### PR TITLE
Fix run_unit_tests.sh

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ jinja2
 librabbitmq
 markdown
 mysql-python
+nose
 pandas
 pygments
 pyhive

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -1,6 +1,6 @@
 export AIRFLOW_HOME=${AIRFLOW_HOME:=~/airflow}
 export AIRFLOW_CONFIG=$AIRFLOW_HOME/unittests.cfg
-rm airflow/www/static/coverage/*
+
 nosetests --with-doctest --with-coverage --cover-html --cover-package=airflow -v --cover-html-dir=airflow/www/static/coverage
 # To run individual tests:
 # nosetests tests.core:CoreTest.test_scheduler_job


### PR DESCRIPTION
I don't know if it's a mistake, but the airflow/www/static/coverage does not exist. So, if anyone want to try run_unit_tests.sh, he will have an error from rm and he will not able to use it.

Moreover, in https://github.com/airbnb/airflow/blob/master/CONTRIBUTING.md#testing you don't specify to install nose so you can add it to your requierements.txt or specify it in your CONTRIBUTING.md

To finish, are you interested by the output of the test ?
