### PR TITLE
Revert "Fixing referential integrity"

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1719,7 +1719,8 @@ class Chart(Base):
 
     id = Column(Integer, primary_key=True)
     label = Column(String(200))
-    conn_id = Column(String(ID_LEN), nullable=False)
+    conn_id = Column(
+        String(ID_LEN), ForeignKey('connection.conn_id'), nullable=False)
     user_id = Column(Integer(), ForeignKey('user.id'),)
     chart_type = Column(String(100), default="line")
     sql_layout = Column(String(50), default="series")
@@ -1732,9 +1733,7 @@ class Chart(Base):
     owner = relationship(
         "User", cascade=False, cascade_backrefs=False, backref='charts')
     x_is_date = Column(Boolean, default=True)
-    db = relationship(
-        "Connection",
-        primaryjoin='Chart.conn_id == foreign(Connection.conn_id)')
+    db = relationship("Connection")
     iteration_no = Column(Integer, default=0)
     last_modified = Column(DateTime, default=datetime.now())
 


### PR DESCRIPTION
This reverts commit f27d20f48f60b3a4421e3676f32a8686bca8ff9a.

This commit introduced a bug that can be see in in Issue https://github.com/airbnb/airflow/issues/27

The bug happens when the `conn_id` is not passed to the back-end
database.

I'm not sure of the original reason for the change, so there may be a subsequent fix that needs to happen, but this revert appears to fix functionality with the web interface.
