### PR TITLE
Take 2 on more explicit plugins

### DIFF
--- a/airflow/executors/__init__.py
+++ b/airflow/executors/__init__.py
@@ -17,10 +17,9 @@ elif _EXECUTOR == 'SequentialExecutor':
     DEFAULT_EXECUTOR = SequentialExecutor()
 else:
     # Loading plugins
-    from airflow.plugins_manager import get_plugins
-    executor_plugins = {}
-    for _plugin in get_plugins(BaseExecutor):
-        globals()[_plugin.__name__] = _plugin
+    from airflow.plugins_manager import executors as _executors
+    for _executor in _executors:
+        globals()[_executor.__name__] = _executor
     if _EXECUTOR in globals():
         DEFAULT_EXECUTOR = globals()[_EXECUTOR]
     else:

--- a/airflow/hooks/__init__.py
+++ b/airflow/hooks/__init__.py
@@ -25,6 +25,6 @@ _import_module_attrs(globals(), _hooks)
 
 def integrate_plugins():
     """Integrate plugins to the context"""
-    from airflow.plugins_manager import get_plugins
-    for _plugin in get_plugins(_BaseHook):
-        globals()[_plugin.__name__] = _plugin
+    from airflow.plugins_manager import hooks as _hooks
+    for _h in _hooks:
+        globals()[_h.__name__] = _h

--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -48,7 +48,4 @@ def ds_format(ds, input_format, output_format):
 
 def integrate_plugins():
     """Integrate plugins to the context"""
-    from airflow.plugins_manager import get_plugins
-    from airflow import AirflowMacroPlugin
-    for _plugin in get_plugins(AirflowMacroPlugin, expect_class=False):
-        globals()[_plugin.namespace] = _plugin
+    pass

--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -41,6 +41,6 @@ _import_module_attrs(globals(), _operators)
 
 def integrate_plugins():
     """Integrate plugins to the context"""
-    from airflow.plugins_manager import get_plugins
-    for _plugin in get_plugins(_BaseOperator):
-        globals()[_plugin.__name__] = _plugin
+    from airflow.plugins_manager import operators as _operators
+    for _operator in _operators:
+        globals()[_operator.__name__] = _operator

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1780,9 +1780,14 @@ admin.add_view(mv)
 
 def integrate_plugins():
     """Integrate plugins to the context"""
-    from airflow.plugins_manager import get_plugins, register_templates_folders
-    from airflow import AirflowViewPlugin
-    for view in get_plugins(AirflowViewPlugin, expect_class=False):
-        admin.add_view(view)
-    register_templates_folders(app)
+    from airflow.plugins_manager import (
+        admin_views, flask_blueprints, menu_links)
+    for v in admin_views:
+        admin.add_view(v)
+    for bp in flask_blueprints:
+        print bp
+        app.register_blueprint(bp)
+    for ml in menu_links:
+        admin.add_link(ml)
+
 integrate_plugins()


### PR DESCRIPTION
This approach is much more explicit and contains less magic. It also supports plugging in flask blueprints, which is the right way to go to package `static` and `templates` folders.

@askeys 
