### PR TITLE
Patching ExternalTaskSensor for non mysql DBs

### DIFF
--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -122,6 +122,8 @@ class ExternalTaskSensor(BaseSensorOperator):
             '{self.execution_date} ... '.format(**locals()))
         TI = TaskInstance
         session = settings.Session()
+        import dateutil.parser
+        dttm = dateutil.parser.parse(dttm)
         count = session.query(TI).filter(
             TI.dag_id == self.external_dag_id,
             TI.task_id == self.external_task_id,

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -123,7 +123,7 @@ class ExternalTaskSensor(BaseSensorOperator):
         TI = TaskInstance
         session = settings.Session()
         import dateutil.parser
-        dttm = dateutil.parser.parse(dttm)
+        self.execution_date = dateutil.parser.parse(self.execution_date)
         count = session.query(TI).filter(
             TI.dag_id == self.external_dag_id,
             TI.task_id == self.external_task_id,


### PR DESCRIPTION
Proposed patch, date casting in SqlAlchemy may be behaving differently on different backends, this should address it.
