### PR TITLE
Hive Metastore Browser plugin

### DIFF
--- a/airflow/contrib/plugins/metastore_browser/main.py
+++ b/airflow/contrib/plugins/metastore_browser/main.py
@@ -1,0 +1,157 @@
+from datetime import datetime
+import json
+
+from flask import Blueprint, request
+from flask.ext.admin import BaseView, expose
+import pandas as pd
+
+from airflow.hooks import HiveMetastoreHook, MySqlHook, PrestoHook, HiveCliHook
+from airflow.plugins_manager import AirflowPlugin
+from airflow.www import utils as wwwutils
+
+METASTORE_CONN_ID = 'metastore_default'
+METASTORE_MYSQL_CONN_ID = 'metastore_mysql'
+PRESTO_CONN_ID = 'presto_default'
+HIVE_CLI_CONN_ID = 'hive_default'
+DEFAULT_DB = 'default'
+DB_WHITELIST = None
+DB_BLACKLIST = ['tmp']
+TABLE_SELECTOR_LIMIT = 2000
+
+# Keeping pandas from truncating long strings
+pd.set_option('display.max_colwidth', -1)
+
+
+# Creating a flask admin BaseView
+class MetastoreBrowserView(BaseView, wwwutils.DataProfilingMixin):
+
+    @expose('/')
+    def index(self):
+        sql = """
+        SELECT
+            a.name as db, db_location_uri as location,
+            count(1) as object_count, a.desc as description
+        FROM DBS a
+        JOIN TBLS b ON a.DB_ID = b.DB_ID
+        GROUP BY a.name, db_location_uri, a.desc
+        """.format(**locals())
+        h = MySqlHook(METASTORE_MYSQL_CONN_ID)
+        df = h.get_pandas_df(sql)
+        df.db = (
+            '<a href="/admin/metastorebrowserview/db/?db=' +
+            df.db + '">' + df.db + '</a>')
+        table = df.to_html(
+            classes="table table-striped table-bordered table-hover",
+            index=False,
+            escape=False,
+            na_rep='',)
+        return self.render(
+            "metastore_browser/dbs.html", table=table)
+
+    @expose('/table/')
+    def table(self):
+        table_name = request.args.get("table")
+        m = HiveMetastoreHook(METASTORE_CONN_ID)
+        table = m.get_table(table_name)
+        return self.render(
+            "metastore_browser/table.html",
+            table=table, table_name=table_name, datetime=datetime, int=int)
+
+    @expose('/db/')
+    def db(self):
+        db = request.args.get("db")
+        m = HiveMetastoreHook(METASTORE_CONN_ID)
+        tables = sorted(m.get_tables(db=db), key=lambda x: x.tableName)
+        return self.render(
+            "metastore_browser/db.html", tables=tables, db=db)
+
+    @wwwutils.gzipped
+    @expose('/partitions/')
+    def partitions(self):
+        schema, table = request.args.get("table").split('.')
+        sql = """
+        SELECT
+            a.PART_NAME,
+            a.CREATE_TIME,
+            c.LOCATION,
+            c.IS_COMPRESSED,
+            c.INPUT_FORMAT,
+            c.OUTPUT_FORMAT
+        FROM PARTITIONS a
+        JOIN TBLS b ON a.TBL_ID = b.TBL_ID
+        JOIN DBS d ON b.DB_ID = d.DB_ID
+        JOIN SDS c ON a.SD_ID = c.SD_ID
+        WHERE
+            b.TBL_NAME like '{table}' AND
+            d.NAME like '{schema}'
+        ORDER BY PART_NAME DESC
+        """.format(**locals())
+        h = MySqlHook(METASTORE_MYSQL_CONN_ID)
+        df = h.get_pandas_df(sql)
+        return df.to_html(
+            classes="table table-striped table-bordered table-hover",
+            index=False,
+            na_rep='',)
+
+    @wwwutils.gzipped
+    @expose('/objects/')
+    def objects(self):
+        where_clause = ''
+        if DB_WHITELIST:
+            dbs = ",".join(["'" + db + "'" for db in DB_WHITELIST])
+            where_clause = "AND b.name IN ({})".format(dbs)
+        if DB_BLACKLIST:
+            dbs = ",".join(["'" + db + "'" for db in DB_BLACKLIST])
+            where_clause = "AND b.name NOT IN ({})".format(dbs)
+        sql = """
+        SELECT CONCAT(b.NAME, '.', a.TBL_NAME), TBL_TYPE
+        FROM TBLS a
+        JOIN DBS b ON a.DB_ID = b.DB_ID
+        WHERE
+            a.TBL_NAME NOT LIKE '%tmp%' AND
+            a.TBL_NAME NOT LIKE '%temp%' AND
+            b.NAME NOT LIKE '%tmp%' AND
+            b.NAME NOT LIKE '%temp%'
+        {where_clause}
+        LIMIT {LIMIT};
+        """.format(where_clause=where_clause, LIMIT=TABLE_SELECTOR_LIMIT)
+        h = MySqlHook(METASTORE_MYSQL_CONN_ID)
+        d = [
+                {'id': row[0], 'text': row[0]}
+            for row in h.get_records(sql)]
+        return json.dumps(d)
+
+    @wwwutils.gzipped
+    @expose('/data/')
+    def data(self):
+        table = request.args.get("table")
+        sql = "SELECT * FROM {table} LIMIT 1000;".format(table=table)
+        h = PrestoHook(PRESTO_CONN_ID)
+        df = h.get_pandas_df(sql)
+        return df.to_html(
+            classes="table table-striped table-bordered table-hover",
+            index=False,
+            na_rep='',)
+
+    @expose('/ddl/')
+    def ddl(self):
+        table = request.args.get("table")
+        sql = "SHOW CREATE TABLE {table};".format(table=table)
+        h = HiveCliHook(HIVE_CLI_CONN_ID)
+        return h.run_cli(sql)
+
+v = MetastoreBrowserView(category="Plugins", name="Hive Metadata Browser")
+
+# Creating a flask blueprint to intergrate the templates and static folder
+bp = Blueprint(
+    "metastore_browser", __name__,
+    template_folder='templates',
+    static_folder='static',
+    static_url_path='/static/metastore_browser')
+
+
+# Defining the plugin class
+class MetastoreBrowserPlugin(AirflowPlugin):
+    name = "metastore_browser"
+    flask_blueprints = [bp]
+    admin_views = [v]

--- a/airflow/contrib/plugins/metastore_browser/templates/metastore_browser/base.html
+++ b/airflow/contrib/plugins/metastore_browser/templates/metastore_browser/base.html
@@ -1,0 +1,38 @@
+{% extends 'airflow/master.html' %}
+
+{% block body %}
+<div>
+    <h3 style="float: left"> 
+        {% block page_header %}Hive Metastore Browser{% endblock%}
+    </h3>
+    <div id="object" class="select2-drop-mask" style="margin-top: 25px; width: 400px;float: right"></div>
+    <div style="clear: both"></div>
+</div>
+{% block plugin_content %}{% endblock %}
+{% endblock %}
+
+{% block head %}
+{{ super() }}
+<link rel="stylesheet" type="text/css" href="{{ url_for("static", filename="dataTables.bootstrap.css") }}">
+<link href="/admin/static/vendor/select2/select2.css" rel="stylesheet">
+{% endblock %}
+
+{% block tail %}
+{{ super() }}
+<script src="{{ url_for('static', filename='jquery.dataTables.min.js') }}"></script>
+<script src="{{ url_for('static', filename='dataTables.bootstrap.js') }}"></script>
+<script src="/admin/static/vendor/select2/select2.min.js" type="text/javascript"></script>
+<script>
+    // Filling up the table selector
+    url = "{{ url_for('.objects') }}";
+    $.get(url, function( data ) {
+        $("#object").select2({
+            data: data,
+            placeholder: "Table Selector",
+        })
+        .on("change", function(e){
+            window.location = "{{ url_for('.table') }}?table=" + e.val;
+        });
+    }, "json");
+</script>
+{% endblock %}

--- a/airflow/contrib/plugins/metastore_browser/templates/metastore_browser/db.html
+++ b/airflow/contrib/plugins/metastore_browser/templates/metastore_browser/db.html
@@ -1,0 +1,28 @@
+{% extends 'metastore_browser/base.html' %}
+
+{% block plugin_content %}
+    <h3 style="float: left"> 
+        <span style="color:#AAA;">Database: </span>
+        <span>{{ db }}</span>
+    </h3>
+    <table class="table table-striped table-bordered table-hover">
+        <thead>
+            <tr>
+                <th>Table</th>
+                <th>Owner</th>
+            </tr>
+        </thead>
+        <tbody>
+        {%for table in tables %}
+            <tr>
+                <td>
+                    <a href="{{ url_for('.table', table=table.dbName + '.' + table.tableName) }}">
+                        {{ table.tableName }}
+                    </a>
+                </td>
+                <td>{{ table.owner }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% endblock %}

--- a/airflow/contrib/plugins/metastore_browser/templates/metastore_browser/dbs.html
+++ b/airflow/contrib/plugins/metastore_browser/templates/metastore_browser/dbs.html
@@ -1,0 +1,8 @@
+{% extends 'metastore_browser/base.html' %}
+
+{% block plugin_content %}
+    <h4> 
+        <span>Hive Databases</span>
+    </h4>
+    {{ table|safe }}
+{% endblock %}

--- a/airflow/contrib/plugins/metastore_browser/templates/metastore_browser/table.html
+++ b/airflow/contrib/plugins/metastore_browser/templates/metastore_browser/table.html
@@ -1,0 +1,134 @@
+{% extends 'metastore_browser/base.html' %}
+
+{% block plugin_content %}
+<div>
+    <h4> 
+        <span style="color:#AAA;">Table:</span>
+        <span>{{ table.dbName }}.{{ table.tableName }}</span>
+    </h4>
+</div>
+<ul class="nav nav-tabs" id="tabs" style="clear: both">
+    <li role="presentation" class="active"><a href="#home" aria-controls="fields" role="tab" data-toggle="tab">Fields</a></li>
+    <li role="presentation"><a href="#data" aria-controls="data" role="tab" data-toggle="tab">Sample Data</a></li>
+    <li role="presentation"><a href="#partitions" aria-controls="partitions" role="tab" data-toggle="tab">Partitions</a></li>
+    <li role="presentation"><a href="#attributes" aria-controls="attributes" role="tab" data-toggle="tab">Atributes</a></li>
+    <li role="presentation"><a href="#parameters" aria-controls="parameters" role="tab" data-toggle="tab">Parameters</a></li>
+    <li role="presentation"><a href="#ddl" aria-controls="ddl" role="tab" data-toggle="tab">DDL</a></li>
+</ul>
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane fade in active" id="home">
+    <table class="table table-striped table-bordered table-hover">
+        <thead>
+            <tr>
+                <th>Column</th>
+                <th>Type</th>
+                <th>Comment</th>
+            </tr>
+        </thead>
+        <tbody>
+        {%for col in table.partitionKeys %}
+            <tr>
+                <td><b>{{ col.name }}</b> (PARTITION)</td>
+                <td>{{ col.type }}</td>
+                <td>{{ col.comment or '' }}</td>
+            </tr>
+        {% endfor %}
+        {%for col in table.sd.cols %}
+            <tr>
+                <td>{{ col.name }}</td>
+                <td>{{ col.type }}</td>
+                <td>{{ col.comment or '' }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+  </div>
+  <div role="tabpanel" class="tab-pane fade" id="data" style="white-space:nowrap; margin-top: 10px;">
+      <img src="{{ url_for('static', filename='loading.gif') }}" width="50" style="margin: 20px">
+  </div>
+  <div role="tabpanel" class="tab-pane fade" id="partitions" style="white-space:nowrap; margin-top: 10px;">
+      <img src="{{ url_for('static', filename='loading.gif') }}" width="50" style="margin: 20px">
+  </div>
+  <div role="tabpanel" class="tab-pane fade" id="attributes">
+    <table class="table table-striped table-bordered table-hover">
+        <thead>
+            <tr>
+                <th>Attribute</th>
+                <th>Value</th>
+            </tr>
+        </thead>
+        <tbody>
+        {%for k, v in table.__dict__.items() %}
+            {% if v and k not in ('sd', 'partitionKeys', 'tableName', 'parameters') %}
+            <tr>
+                <td>{{ k }}</td>
+                {% if k.endswith('Time') %}
+                    <td>{{ datetime.fromtimestamp(int(v)).isoformat() }}</td>
+                {% else %}
+                    <td>{{ v }}</td>
+                {% endif %}
+            </tr>
+            {% endif %}
+        {% endfor %}
+        </tbody>
+    </table>
+  </div>
+  <div role="tabpanel" class="tab-pane fade" id="parameters">
+    <table class="table table-striped table-bordered table-hover">
+        <thead>
+            <tr>
+                <th>Parameter</th>
+                <th>Value</th>
+            </tr>
+        </thead>
+        <tbody>
+        {%for k, v in table.parameters.items() %}
+            {% if v and k not in [] %}
+            <tr>
+                <td>{{ k }}</td>
+                {% if k.endswith('Time') %}
+                    <td>{{ datetime.fromtimestamp(int(v)).isoformat() }}</td>
+                {% else %}
+                    <td>{{ v }}</td>
+                {% endif %}
+            </tr>
+            {% endif %}
+        {% endfor %}
+        </tbody>
+    </table>
+  </div>
+  <div role="tabpanel" class="tab-pane fade" id="ddl">
+      <pre id="ddl_content">
+        <img src="{{ url_for('static', filename='loading.gif') }}" width="50" style="margin: 20px">
+      </pre>
+  </div>
+</div>
+{% endblock %}
+
+{% block tail %}
+{{ super() }}
+<script>
+$('#tabs a').click(function (e) {
+    //e.preventDefault();
+    $(this).tab('show');
+});
+
+$.get("{{ url_for(".data" , table=table_name) }}", function( data ) {
+    $("#data").html(data);        
+    $('#data table.dataframe').dataTable({
+        "iDisplayLength": 30,
+    });
+});
+
+$.get("{{ url_for(".partitions" , table=table_name) }}", function( data ) {
+    $("#partitions").html(data);        
+    $('#partitions table.dataframe').dataTable({
+        "iDisplayLength": 30,
+    });
+});
+
+$.get("{{ url_for(".ddl" , table=table_name) }}", function( data ) {
+    $("#ddl_content").html(data);        
+});
+</script>
+{% endblock %}

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -172,14 +172,6 @@ def shutdown_session(exception=None):
     settings.Session.remove()
 
 
-class SuperUserMixin(object):
-    def is_accessible(self):
-        return (
-            not AUTHENTICATE or
-            (not current_user.is_anonymous() and current_user.is_superuser())
-        )
-
-
 def dag_link(v, c, m, p):
     url = url_for(
         'airflow.graph',
@@ -188,7 +180,7 @@ def dag_link(v, c, m, p):
         '<a href="{url}">{m.dag_id}</a>'.format(**locals()))
 
 
-class DagModelView(SuperUserMixin, ModelView):
+class DagModelView(wwwutils.SuperUserMixin, ModelView):
     column_list = ('dag_id', 'owners')
     column_editable_list = ('is_paused',)
     form_excluded_columns = ('is_subdag', 'is_active')
@@ -1329,25 +1321,7 @@ class Airflow(BaseView):
 admin.add_view(Airflow(name='DAGs'))
 
 
-class LoginMixin(object):
-    def is_accessible(self):
-        return (
-            not AUTHENTICATE or (
-                not current_user.is_anonymous() and
-                current_user.is_authenticated()
-            )
-        )
-
-
-class DataProfilingMixin(object):
-    def is_accessible(self):
-        return (
-            not AUTHENTICATE or
-            (not current_user.is_anonymous() and current_user.data_profiling())
-        )
-
-
-class QueryView(DataProfilingMixin, BaseView):
+class QueryView(wwwutils.DataProfilingMixin, BaseView):
     @expose('/')
     @wwwutils.gzipped
     def query(self):
@@ -1413,7 +1387,7 @@ class QueryView(DataProfilingMixin, BaseView):
 admin.add_view(QueryView(name='Ad Hoc Query', category="Data Profiling"))
 
 
-class ModelViewOnly(LoginMixin, ModelView):
+class ModelViewOnly(wwwutils.LoginMixin, ModelView):
     """
     Modifying the base ModelView class for non edit, browse only operations
     """
@@ -1520,7 +1494,7 @@ mv = DagModelView(
 admin.add_view(mv)
 
 
-class ConnectionModelView(SuperUserMixin, ModelView):
+class ConnectionModelView(wwwutils.SuperUserMixin, ModelView):
     column_default_sort = ('conn_id', False)
     column_list = ('conn_id', 'conn_type', 'host', 'port')
     form_overrides = dict(password=VisiblePasswordField)
@@ -1546,13 +1520,13 @@ mv = ConnectionModelView(
 admin.add_view(mv)
 
 
-class UserModelView(SuperUserMixin, ModelView):
+class UserModelView(wwwutils.SuperUserMixin, ModelView):
     column_default_sort = 'username'
 mv = UserModelView(models.User, Session, name="Users", category="Admin")
 admin.add_view(mv)
 
 
-class ConfigurationView(SuperUserMixin, BaseView):
+class ConfigurationView(wwwutils.SuperUserMixin, BaseView):
     @expose('/')
     def conf(self):
         from airflow import configuration
@@ -1592,7 +1566,7 @@ def label_link(v, c, m, p):
     return Markup("<a href='{url}'>{m.label}</a>".format(**locals()))
 
 
-class ChartModelView(DataProfilingMixin, ModelView):
+class ChartModelView(wwwutils.DataProfilingMixin, ModelView):
     form_columns = (
         'label',
         'owner',
@@ -1705,7 +1679,7 @@ admin.add_link(
         url='https://github.com/airbnb/airflow'))
 
 
-class KnowEventView(DataProfilingMixin, ModelView):
+class KnowEventView(wwwutils.DataProfilingMixin, ModelView):
     form_columns = (
         'label',
         'event_type',
@@ -1721,7 +1695,7 @@ mv = KnowEventView(
 admin.add_view(mv)
 
 
-class KnowEventTypeView(DataProfilingMixin, ModelView):
+class KnowEventTypeView(wwwutils.DataProfilingMixin, ModelView):
     pass
 
 '''
@@ -1739,7 +1713,7 @@ admin.add_view(mv)
 '''
 
 
-class VariableView(LoginMixin, ModelView):
+class VariableView(wwwutils.LoginMixin, ModelView):
     column_list = ('key',)
     column_filters = ('key', 'val')
     column_searchable_list = ('key', 'val')
@@ -1775,7 +1749,7 @@ def fqueued_slots(v, c, m, p):
     return Markup("<a href='{0}'>{1}</a>".format(url, m.queued_slots()))
 
 
-class PoolModelView(SuperUserMixin, ModelView):
+class PoolModelView(wwwutils.SuperUserMixin, ModelView):
     column_list = ('pool', 'slots', 'used_slots', 'queued_slots')
     column_formatters = dict(
         pool=pool_link, used_slots=fused_slots, queued_slots=fqueued_slots)

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -4,8 +4,38 @@ import gzip
 import functools
 
 from flask import after_this_request, request
+from flask_login import current_user
 import wtforms
 from wtforms.compat import text_type
+
+from airflow.configuration import conf
+AUTHENTICATE = conf.getboolean('webserver', 'AUTHENTICATE')
+
+
+class LoginMixin(object):
+    def is_accessible(self):
+        return (
+            not AUTHENTICATE or (
+                not current_user.is_anonymous() and
+                current_user.is_authenticated()
+            )
+        )
+
+
+class SuperUserMixin(object):
+    def is_accessible(self):
+        return (
+            not AUTHENTICATE or
+            (not current_user.is_anonymous() and current_user.is_superuser())
+        )
+
+
+class DataProfilingMixin(object):
+    def is_accessible(self):
+        return (
+            not AUTHENTICATE or
+            (not current_user.is_anonymous() and current_user.data_profiling())
+        )
 
 
 def limit_sql(sql, limit):


### PR DESCRIPTION
The first official Airflow plugin, it was mostly written as an example on how to build an Airflow plugin. 

It allows you to browse the Hive metastore's metadata from the Airflow UI and see:
- A list of the databases in the metastore,
- For a database, a list of all tables
- For each table:
  - Column definition
  - Sample data
  - Partitions list
  - Table attributes and params
  - DDL
  - ...

![screen shot 2015-06-22 at 3 42 16 pm](https://cloud.githubusercontent.com/assets/487433/8294983/54af0eb2-18f5-11e5-9fc3-7b568877fc6c.png)
