### PR TITLE
add a simple index view to extend

### DIFF
--- a/airflow/www/static/main.css
+++ b/airflow/www/static/main.css
@@ -54,9 +54,6 @@ span.queued{
 input#execution_date {
     margin-bottom: 0px;
 }
-.modal{
-    margin-top:5000px;
-}
 table.highlighttable{
     width: 100%;
     table-layout:fixed;

--- a/airflow/www/templates/airflow/master.html
+++ b/airflow/www/templates/airflow/master.html
@@ -1,1 +1,1 @@
-{% extends "admin/master.html" %}
+{% extends "index.html" %}

--- a/airflow/www/templates/index.html
+++ b/airflow/www/templates/index.html
@@ -1,0 +1,5 @@
+{% extends 'airflow/master.html' %}
+
+{% block body %}
+{{ content }}
+{% endblock %}

--- a/airflow/www/templates/index.html
+++ b/airflow/www/templates/index.html
@@ -1,5 +1,1 @@
-{% extends 'airflow/master.html' %}
-
-{% block body %}
-{{ content }}
-{% endblock %}
+{% extends 'admin/master.html' %}


### PR DESCRIPTION
@mistercrunch adds a simple index page that can be extended to import airflows css into a plugin app.  It seems to work for my app.
