### PR TITLE
Use internal table. Using external was leading to duplicates.

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -110,7 +110,7 @@ class HiveCliHook(BaseHook):
         if create or recreate:
             fields = ",\n    ".join(
                 [k + ' ' + v for k, v in field_dict.items()])
-            hql += "CREATE EXTERNAL TABLE IF NOT EXISTS {table} (\n{fields})\n"
+            hql += "CREATE TABLE IF NOT EXISTS {table} (\n{fields})\n"
             if partition:
                 pfields = ",\n    ".join(
                     [p + " STRING" for p in partition])


### PR DESCRIPTION
@mistercrunch 
We were running into an interesting issue even with an insert overwrite which would not clear previous data. This should fix it. 
