### PR TITLE
Adding the upstream_failed state to allow the scheduler to move forward

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -299,7 +299,7 @@ class SchedulerJob(BaseJob):
                         execution_date=next_schedule,
                     )
                     ti.refresh_from_db()
-                    if ti.is_queueable():
+                    if ti.is_queueable(flag_upstream_failed=True):
                         logging.debug('Queuing next run: ' + str(ti))
                         executor.queue_task_instance(ti)
         # Releasing the lock

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -38,6 +38,8 @@ class State(object):
     SHUTDOWN = "shutdown"  # External request to shut down
     FAILED = "failed"
     UP_FOR_RETRY = "up_for_retry"
+    UPSTREAM_FAILED = "upstream_failed"
+    SKIPPED = "skipped"
 
     state_color = {
         QUEUED: 'gray',
@@ -46,6 +48,7 @@ class State(object):
         SHUTDOWN: 'orange',
         FAILED: 'red',
         UP_FOR_RETRY: 'yellow',
+        UPSTREAM_FAILED: 'blue',
     }
 
     @classmethod
@@ -54,7 +57,9 @@ class State(object):
 
     @classmethod
     def runnable(cls):
-        return [None, cls.FAILED, cls.UP_FOR_RETRY, cls.QUEUED]
+        return [
+            None, cls.FAILED, cls.UP_FOR_RETRY,
+            cls.QUEUED, cls.UPSTREAM_FAILED]
 
 
 def pessimistic_connection_handling():

--- a/airflow/www/static/graph.css
+++ b/airflow/www/static/graph.css
@@ -21,6 +21,9 @@ g.node.failed rect {
 g.node.shutdown rect{
     stroke: orange;
 }
+g.node.upstream_failed rect{
+    stroke: #FFB400;
+}
 div#svg_container {
  border: 1px solid black;
  background-color: #EEE;

--- a/airflow/www/static/main.css
+++ b/airflow/www/static/main.css
@@ -41,19 +41,22 @@ div.squares{
 div.task_row{
 }
 span.success{
-    background-color:green;
+    background-color: green;
 }
 span.up_for_retry{
-    background-color:yellow;
+    background-color: yellow;
 }
 span.started{
-    background-color:lime;
+    background-color: lime;
 }
 span.error{
-    background-color:red;
+    background-color: red;
 }
 span.queued{
-    background-color:gray;
+    background-color: gray;
+}
+span.upstream_failed{
+    background-color: #FFB400;
 }
 .tooltip-inner {
     text-align:left !important;

--- a/airflow/www/static/tree.css
+++ b/airflow/www/static/tree.css
@@ -37,6 +37,9 @@ rect.queued {
 rect.shutdown {
     fill: orange;
 }
+rect.upstream_failed {
+    fill: #FFB400;
+}
 .tooltip.in {
     opacity: 1;
     filter: alpha(opacity=100);


### PR DESCRIPTION
This new task state `upstream_failed` allows the scheduler to move forward for dependencies of tasks that have failed. I made sure that it still respects the `depends_on_past` flag.

This also means that the scheduler will now leave more holes that will need to get filled in. This is probably a call for the upcoming "backfill wizard" feature to be added to the UI.

@askeys @artwr 

![screen shot 2015-06-26 at 11 11 59 am](https://cloud.githubusercontent.com/assets/487433/8384192/34b4a4f8-1bf4-11e5-88e5-549f37edd51b.png)
