### PR TITLE
Removing QUEUED from runnable states list

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -343,7 +343,7 @@ class SchedulerJob(BaseJob):
                         logging.error("Queued task {} seems gone".format(ti))
                     if task:
                         ti.task = task
-                        executor.queue_task_instance(ti)
+                        executor.queue_task_instance(ti, force=True)
 
     def _execute(self):
         dag_id = self.dag_id

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -57,9 +57,7 @@ class State(object):
 
     @classmethod
     def runnable(cls):
-        return [
-            None, cls.FAILED, cls.UP_FOR_RETRY,
-            cls.QUEUED, cls.UPSTREAM_FAILED]
+        return [None, cls.FAILED, cls.UP_FOR_RETRY, cls.UPSTREAM_FAILED]
 
 
 def pessimistic_connection_handling():


### PR DESCRIPTION
This forces the execution of queued task instances to go through the prioritization process in all cases, except for force runs from the UI and/or CLI.
