### PR TITLE
Now supporting branching using a BranchPythonOperator

### DIFF
--- a/airflow/example_dags/example_branch_operator.py
+++ b/airflow/example_dags/example_branch_operator.py
@@ -1,0 +1,30 @@
+from airflow.operators import BranchPythonOperator, DummyOperator
+from airflow.models import DAG
+from datetime import datetime, timedelta
+import random
+
+seven_days_ago = datetime.combine(datetime.today() - timedelta(7),
+                                  datetime.min.time())
+args = {
+    'owner': 'airflow',
+    'start_date': seven_days_ago,
+}
+
+dag = DAG(dag_id='example_branch_operator', default_args=args)
+
+cmd = 'ls -l'
+run_this_first = DummyOperator(task_id='run_this_first', dag=dag)
+
+options = ['branch_a', 'branch_b', 'branch_c', 'branch_d']
+
+branching = BranchPythonOperator(
+    task_id='branching',
+    python_callable=lambda: random.choice(options),
+    dag=dag)
+branching.set_upstream(run_this_first)
+
+for option in options:
+    t = DummyOperator(task_id=option, dag=dag)
+    t.set_upstream(branching)
+    dummy_follow = DummyOperator(task_id='follow_' + option, dag=dag)
+    t.set_downstream(dummy_follow)

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -267,7 +267,7 @@ class SchedulerJob(BaseJob):
                 # Brand new task, let's get started
                 ti = TI(task, task.start_date)
                 ti.refresh_from_db()
-                if ti.is_runnable():
+                if ti.is_queueable(flag_upstream_failed=True):
                     logging.info(
                         'First run for {ti}'.format(**locals()))
                     executor.queue_task_instance(ti)

--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -7,7 +7,7 @@ from airflow.models import BaseOperator as _BaseOperator
 
 _operators = {
     'bash_operator': ['BashOperator'],
-    'python_operator': ['PythonOperator'],
+    'python_operator': ['PythonOperator', 'BranchPythonOperator'],
     'hive_operator': ['HiveOperator'],
     'presto_check_operator': [
         'PrestoCheckOperator',

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -1,11 +1,13 @@
+from datetime import datetime
 import logging
 
-from airflow.models import BaseOperator
-from airflow.utils import apply_defaults
+from airflow.models import BaseOperator, TaskInstance
+from airflow.utils import apply_defaults, State
+from airflow import settings
 
 
 class PythonOperator(BaseOperator):
-    '''
+    """
     Executes a Python callable
 
     :param python_callable: A reference to an object that is callable
@@ -22,7 +24,7 @@ class PythonOperator(BaseOperator):
         templates. For this to work, you need to define `**kwargs` in your
         funciton header.
     :type provide_context: bool
-    '''
+    """
     template_fields = tuple()
     ui_color = '#ffefeb'
 
@@ -47,3 +49,33 @@ class PythonOperator(BaseOperator):
 
         return_value = self.python_callable(*self.op_args, **self.op_kwargs)
         logging.info("Done. Returned value was: " + str(return_value))
+        return return_value
+
+
+class BranchPythonOperator(PythonOperator):
+    """
+    Allows a workflow to "branch" or follow a single path following the
+    execution of this task.
+
+    It derives the PythonOperator and expects a Python function that returns
+    the task_id to follow. The task_id returned should point to a task
+    directely downstream from {self}. All other "branches" or
+    directly downstream tasks are marked wit a state of "skipped" so that
+    these paths can't move forward.
+    """
+    def execute(self, context):
+        branch = super(BranchPythonOperator, self).execute(context)
+        logging.info("Following branch " + branch)
+        logging.info("Marking other directly downstream tasks as failed")
+        session = settings.Session()
+        for task in context['task'].downstream_list:
+            if task.task_id != branch:
+                ti = TaskInstance(
+                    task, execution_date=context['ti'].execution_date)
+                ti.state = State.SKIPPED
+                ti.start_date = datetime.now()
+                ti.end_date = datetime.now()
+                session.merge(ti)
+        session.commit()
+        session.close()
+        logging.info("Done.")

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -49,6 +49,7 @@ class State(object):
         FAILED: 'red',
         UP_FOR_RETRY: 'yellow',
         UPSTREAM_FAILED: 'blue',
+        SKIPPED: 'pink',
     }
 
     @classmethod
@@ -57,7 +58,9 @@ class State(object):
 
     @classmethod
     def runnable(cls):
-        return [None, cls.FAILED, cls.UP_FOR_RETRY, cls.UPSTREAM_FAILED]
+        return [
+            None, cls.FAILED, cls.UP_FOR_RETRY, cls.UPSTREAM_FAILED,
+            cls.SKIPPED]
 
 
 def pessimistic_connection_handling():
@@ -425,11 +428,14 @@ class timeout:
     def __init__(self, seconds=1, error_message='Timeout'):
         self.seconds = seconds
         self.error_message = error_message
+
     def handle_timeout(self, signum, frame):
         logging.error("Process timed out")
         raise TimeoutError(self.error_message)
+
     def __enter__(self):
         signal.signal(signal.SIGALRM, self.handle_timeout)
         signal.alarm(self.seconds)
+
     def __exit__(self, type, value, traceback):
         signal.alarm(0)

--- a/airflow/www/static/graph.css
+++ b/airflow/www/static/graph.css
@@ -24,6 +24,9 @@ g.node.shutdown rect{
 g.node.upstream_failed rect{
     stroke: #FFB400;
 }
+g.node.skipped rect{
+    stroke: pink;
+}
 div#svg_container {
  border: 1px solid black;
  background-color: #EEE;

--- a/airflow/www/static/main.css
+++ b/airflow/www/static/main.css
@@ -58,6 +58,9 @@ span.queued{
 span.upstream_failed{
     background-color: #FFB400;
 }
+span.skipped{
+    background-color:pink;
+}
 .tooltip-inner {
     text-align:left !important;
     font-size: 12px;

--- a/airflow/www/static/tree.css
+++ b/airflow/www/static/tree.css
@@ -40,6 +40,9 @@ rect.shutdown {
 rect.upstream_failed {
     fill: #FFB400;
 }
+rect.skipped {
+    fill: pink;
+}
 .tooltip.in {
     opacity: 1;
     filter: alpha(opacity=100);

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -23,6 +23,7 @@ There are 3 main types of operators:
     :show-inheritance:
     :members:
         BashOperator,
+        BranchPythonOperator,
         DummyOperator,
         EmailOperator,
         ExternalTaskSensor,

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -137,3 +137,18 @@ accessible and modifiable through the UI.
 The second call assumes ``json`` content and will be deserialized into
 ``bar``. Note that ``Variable`` is a sqlalchemy model and can be used
 as such.
+
+
+Branching
+'''''''''
+
+Sometimes you need a workflow to branch, or only go down a certain path
+based on an arbitrary condition which is typically related to something
+that happened in an upstream task. One way to do this is by using the
+``BranchPythonOperator``.
+
+The ``BranchPythonOperator`` is much like the PythonOperator except that it
+expects a python_callable that returns a task_id. The task_id returned
+is followed, and all of the other paths are skipped.
+The task_id returned by the Python function has to be referencing a task 
+directly downstream from the BranchPythonOperator task.


### PR DESCRIPTION
![screen shot 2015-06-30 at 10 17 21 am](https://cloud.githubusercontent.com/assets/487433/8437070/8c486946-1f11-11e5-8ab9-43139e406de9.png)

The BranchPythonOperator is much like the PythonOperator except that it expects a `python_callable` that returns a `task_id`. The `task_id` returned is followed, all other paths are skipped using the new `skipped` state. The `task_id` returned has to be referencing a task directly downstream from the BranchPythonOperator task.
