### PR TITLE
add mark as success link to failure emails

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -923,6 +923,7 @@ class TaskInstance(Base):
             "Log: <a href='{self.log_url}'>Link</a><br>"
             "Host: {self.hostname}<br>"
             "Log file: {self.log_filepath}<br>"
+            "Mark Success: link to mark success here plz"
         ).format(**locals())
         utils.send_email(task.email, title, body)
 


### PR DESCRIPTION
link format:
https://airflow-brain.d.musta.ch/admin/airflow/action?action=success&task_id=<task name>&dag_id=<dag name>&execution_date=<exec ds>

not final, just showing what I'm proposing. @mistercrunch feel free to just do it since I don't know the right variables here
