### PR TITLE
Http protocol sensor

### DIFF
--- a/airflow/example_dags/example_http_operator.py
+++ b/airflow/example_dags/example_http_operator.py
@@ -1,0 +1,77 @@
+"""
+### Example HTTP operator and sensor
+"""
+from airflow import DAG
+from airflow.operators import SimpleHttpOperator, HttpSensor
+from datetime import datetime, timedelta
+import json
+
+seven_days_ago = datetime.combine(datetime.today() - timedelta(7),
+                                  datetime.min.time())
+
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': seven_days_ago,
+    'email': ['airflow@airflow.com'],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'retry_interval': timedelta(minutes=5),
+}
+
+dag = DAG('http_test', default_args=default_args)
+
+# t1, t2 and t3 are examples of tasks created by instatiating operators
+t1 = SimpleHttpOperator(
+    task_id='post_op',
+    url='nodes/refresh',
+    data=json.dumps({"priority":5}),
+    headers={"Content-Type":"application/json"},
+    dag=dag)
+
+t5 = SimpleHttpOperator(
+    task_id='post_op_formenc',
+    url='nodes/url',
+    data="name=Joe",
+    headers={"Content-Type":"application/x-www-form-urlencoded"},
+    dag=dag)
+
+dag.doc_md = __doc__
+
+t2 = SimpleHttpOperator(
+    task_id='get_op',
+    method='GET',
+    url='jobs/',
+    data={"param1":"value1","param2":"value2"},
+    headers={},
+    dag=dag)
+
+t3 = SimpleHttpOperator(
+    task_id='put_op',
+    method='PUT',
+    url='jobs/2',
+    data=json.dumps({"priority":5}),
+    headers={"Content-Type":"application/json"},
+    dag=dag)
+
+t4 = SimpleHttpOperator(
+    task_id='del_op',
+    method='DELETE',
+    url='nodes/5',
+    data="some=data",
+    headers={"Content-Type":"application/x-www-form-urlencoded"},
+    dag=dag)
+
+sensor = HttpSensor(
+    task_id='http_sensor_check',
+    conn_id='http_default',
+    url='apps2',
+    dag=dag)
+
+t1.set_upstream(sensor)
+t2.set_upstream(t1)
+t3.set_upstream(t2)
+t4.set_upstream(t3)
+t5.set_upstream(t4)
+

--- a/airflow/example_dags/example_http_operator.py
+++ b/airflow/example_dags/example_http_operator.py
@@ -20,29 +20,29 @@ default_args = {
     'retry_interval': timedelta(minutes=5),
 }
 
-dag = DAG('http_test', default_args=default_args)
+dag = DAG('example_http_operator', default_args=default_args)
+
+dag.doc_md = __doc__
 
 # t1, t2 and t3 are examples of tasks created by instatiating operators
 t1 = SimpleHttpOperator(
     task_id='post_op',
-    url='nodes/refresh',
+    endpoint='api/v1.0/nodes',
     data=json.dumps({"priority":5}),
     headers={"Content-Type":"application/json"},
     dag=dag)
 
 t5 = SimpleHttpOperator(
     task_id='post_op_formenc',
-    url='nodes/url',
+    endpoint='nodes/url',
     data="name=Joe",
     headers={"Content-Type":"application/x-www-form-urlencoded"},
     dag=dag)
 
-dag.doc_md = __doc__
-
 t2 = SimpleHttpOperator(
     task_id='get_op',
     method='GET',
-    url='jobs/',
+    endpoint='api/v1.0/nodes',
     data={"param1":"value1","param2":"value2"},
     headers={},
     dag=dag)
@@ -50,7 +50,7 @@ t2 = SimpleHttpOperator(
 t3 = SimpleHttpOperator(
     task_id='put_op',
     method='PUT',
-    url='jobs/2',
+    endpoint='api/v1.0/nodes',
     data=json.dumps({"priority":5}),
     headers={"Content-Type":"application/json"},
     dag=dag)
@@ -58,7 +58,7 @@ t3 = SimpleHttpOperator(
 t4 = SimpleHttpOperator(
     task_id='del_op',
     method='DELETE',
-    url='nodes/5',
+    endpoint='api/v1.0/nodes',
     data="some=data",
     headers={"Content-Type":"application/x-www-form-urlencoded"},
     dag=dag)
@@ -66,7 +66,8 @@ t4 = SimpleHttpOperator(
 sensor = HttpSensor(
     task_id='http_sensor_check',
     conn_id='http_default',
-    url='apps2',
+    endpoint='api/v1.0/apps',
+    poke_interval=5,
     dag=dag)
 
 t1.set_upstream(sensor)

--- a/airflow/example_dags/example_http_operator.py
+++ b/airflow/example_dags/example_http_operator.py
@@ -30,6 +30,7 @@ t1 = SimpleHttpOperator(
     endpoint='api/v1.0/nodes',
     data=json.dumps({"priority":5}),
     headers={"Content-Type":"application/json"},
+    response_check=lambda response: True if len(response.json()) == 0 else False,
     dag=dag)
 
 t5 = SimpleHttpOperator(
@@ -67,6 +68,8 @@ sensor = HttpSensor(
     task_id='http_sensor_check',
     conn_id='http_default',
     endpoint='api/v1.0/apps',
+    headers={"Content-Type":"application/json"},
+    response_check=lambda response: True if "collation" in response.content else False,
     poke_interval=5,
     dag=dag)
 
@@ -75,4 +78,3 @@ t2.set_upstream(t1)
 t3.set_upstream(t2)
 t4.set_upstream(t3)
 t5.set_upstream(t4)
-

--- a/airflow/hooks/__init__.py
+++ b/airflow/hooks/__init__.py
@@ -18,6 +18,7 @@ _hooks = {
     'samba_hook': ['SambaHook'],
     'sqlite_hook': ['SqliteHook'],
     'S3_hook': ['S3Hook'],
+    'http_hook': [ 'HttpHook' ]
 }
 
 _import_module_attrs(globals(), _hooks)

--- a/airflow/hooks/__init__.py
+++ b/airflow/hooks/__init__.py
@@ -18,7 +18,7 @@ _hooks = {
     'samba_hook': ['SambaHook'],
     'sqlite_hook': ['SqliteHook'],
     'S3_hook': ['S3Hook'],
-    'http_hook': [ 'HttpHook' ]
+    'http_hook': ['HttpHook'],
 }
 
 _import_module_attrs(globals(), _hooks)

--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -77,7 +77,8 @@ class HttpHook(BaseHook):
         )
         if response.status_code != requests.codes.ok:
             logging.error("HTTP call failed: %d[%s]"%( response.status_code, response.reason ))
-            logging.error( response.text )
+            if self.method != 'GET':
+                logging.error( response.text )
             return False, response.reason
         return True, response.content
 

--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -1,0 +1,102 @@
+import logging
+
+import requests
+
+from airflow import utils
+from airflow.hooks.base_hook import BaseHook
+
+
+class HttpHook(BaseHook):
+
+    """
+    Interact with HTTP servers.
+    """
+
+    def __init__(
+            self, http_conn_id='http_default'):
+        self.http_conn_id = http_conn_id
+
+    def get_conn(self, headers):
+        """
+        Returns http session for use with requests
+        """
+        conn = self.get_connection(self.http_conn_id)
+        session = requests.Session()
+        if len(conn.login) > 0:
+            session.auth = (conn.login, conn.password)
+        if headers != None:
+            s.headers.update(headers)
+
+        return session
+
+    def execute_and_check( self, s, prepped, context ):
+        stream = utils.get_val_or_default( context, "stream", False )
+        verify = utils.get_val_or_default( context, "verify", False )
+        proxies= utils.get_val_or_default( context, "proxies", {} )
+        cert = utils.get_val_or_default( context, "cert", None )
+        timeout = utils.get_val_or_default( context, "timeout", None )
+
+        s.send(prepped,
+            stream=stream,
+            verify=verify,
+            proxies=proxies,
+            cert=cert,
+            timeout=timeout
+        )
+        if resp.status_code != requests.codes.ok:
+            raise AirflowException("%s failed. %d [%s]"%( op, resp.status_code, resp.reason ))
+
+        return resp.content
+
+    def get(self, url, params={}, headers=None, context={}):
+        """
+        Performs a GET request
+        """
+        s = get_conn( headers )
+        req = Request('GET',  url,
+            data=params
+            headers=headers
+        )
+        prepped = s.prepare_request( req )
+        logging.info("Getting url: " + url)
+        self.execute_and_check( s, prepped, context )
+
+    def post(self, url, data, headers=None, context={}):
+        """
+        Performs a POST request
+        """
+        s = get_conn( headers )
+        req = Request('POST',  url,
+            data=data
+            headers=headers
+        )
+        prepped = s.prepare_request( req )
+        logging.info("Posting to url: " + url)
+        self.execute_and_check( s, prepped, context )
+
+    def put(self, url, data, headers=None, context={}):
+        """
+        Performs a PUT request
+        """
+        s = get_conn( headers )
+        req = Request('PUT',  url,
+            data=data
+            headers=headers
+        )
+        prepped = s.prepare_request( req )
+        logging.info("Putting to url: " + url)
+        self.execute_and_check( s, prepped, context )
+
+    def delete(self, url, data, headers=None, context={}):
+        """
+        Performs a PUT request
+        """
+        s = get_conn( headers )
+        req = Request('DELETE',  url,
+            data=data
+            headers=headers
+        )
+        prepped = s.prepare_request( req )
+        logging.info("Deleting from url: " + url)
+        self.execute_and_check( s, prepped, context )
+

--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -92,4 +92,4 @@ class HttpHook(BaseHook):
                 # all data should be visible in the log (no post data)
                 logging.error(response.text)
             raise AirflowException(str(response.status_code)+":"+response.reason)
-        return response.content
+        return response

--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -2,21 +2,20 @@ import logging
 
 import requests
 
-from airflow import utils
 from airflow.hooks.base_hook import BaseHook
+from airflow.utils import AirflowException
 
 
 class HttpHook(BaseHook):
-
     """
     Interact with HTTP servers.
     """
 
-    def __init__(
-            self, method='POST', http_conn_id='http_default'):
+    def __init__(self, method='POST', http_conn_id='http_default'):
         self.http_conn_id = http_conn_id
         self.method = method
 
+    # headers is required to make it required
     def get_conn(self, headers):
         """
         Returns http session for use with requests
@@ -25,60 +24,72 @@ class HttpHook(BaseHook):
         session = requests.Session()
         self.base_url = conn.host
 
-        if conn.port != None and conn.port > 0:
-            self.base_url = self.base_url + ":%d/"%( conn.port )
-
-        if len(conn.login) > 0:
+        if conn.port:
+            self.base_url = self.base_url + ":" + str(conn.port) + "/"
+        if conn.login:
             session.auth = (conn.login, conn.password)
-        if headers != None:
+        if headers:
             session.headers.update(headers)
 
         return session
 
-    def run(self, url, data=None, headers=None, extra_options={}):
+    def run(self, endpoint, data=None, headers=None, extra_options={}):
         """
         Performs the request
         """
-        s = self.get_conn( headers )
+        session = self.get_conn(headers)
 
-        url = self.base_url + url
+        url = self.base_url + endpoint
         req = None
         if self.method == 'GET':
-            req = requests.Request( self.method, 
-                url,
-                params=data,
-                headers=headers
-            )
+            # GET uses params
+            req = requests.Request(self.method,
+                                   url,
+                                   params=data,
+                                   headers=headers)
         else:
-            req = requests.Request( self.method, 
-                url,
-                data=data,
-                headers=headers
-            )
-        prepped = s.prepare_request( req )
-        logging.info("Posting to url: " + url)
-        return self.run_and_check( s, prepped, extra_options )    
+            # Others use data
+            req = requests.Request(self.method,
+                                   url,
+                                   data=data,
+                                   headers=headers)
 
-    def run_and_check( self, s, prepped, extra_options ):
-        stream = utils.get_val_or_default( extra_options, "stream", False )
-        verify = utils.get_val_or_default( extra_options, "verify", False )
-        proxies= utils.get_val_or_default( extra_options, "proxies", {} )
-        cert = utils.get_val_or_default( extra_options, "cert", None )
-        timeout = utils.get_val_or_default( extra_options, "timeout", None )
-        allow_redirects = utils.get_val_or_default( extra_options, "allow_redirects", True )
+        preppedRequest = session.prepare_request(req)
+        logging.info("Sending '" + self.method + "' to url: " + url)
+        return self.run_and_check(session, preppedRequest, extra_options)
 
-        response = s.send(prepped,
-            stream=stream,
-            verify=verify,
-            proxies=proxies,
-            cert=cert,
-            timeout=timeout,
-            allow_redirects=allow_redirects
-        )
-        if response.status_code != requests.codes.ok:
-            logging.error("HTTP call failed: %d[%s]"%( response.status_code, response.reason ))
+    def run_and_check(self, session, preppedRequest, extra_options):
+        """
+        Grabs extra options like timeout and actually runs the request,
+        checking for the result
+        """
+        stream = extra_options.get("stream", False)
+        verify = extra_options.get("verify", False)
+        proxies = extra_options.get("proxies", {})
+        cert = extra_options.get("cert", None)
+        timeout = extra_options.get("timeout", None)
+        allow_redirects = extra_options.get("allow_redirects", True)
+
+        response = session.send(preppedRequest,
+                                stream=stream,
+                                verify=verify,
+                                proxies=proxies,
+                                cert=cert,
+                                timeout=timeout,
+                                allow_redirects=allow_redirects)
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError:
+            # Tried rewrapping, but not supported. This way, it's possible
+            # to get reason and code for failure by checking first 3 chars
+            # for the code, or do a split on ':'
+            logging.error("HTTP error: " + response.reason)
             if self.method != 'GET':
-                logging.error( response.text )
-            return False, response.reason
-        return True, response.content
-
+                # The sensor uses GET, so this prevents filling up the log
+                # with the body every time the GET 'misses'.
+                # That's ok to do, because GETs should be repeatable and
+                # all data should be visible in the log (no post data)
+                logging.error(response.text)
+            raise AirflowException(str(response.status_code)+":"+response.reason)
+        return response.content

--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -29,12 +29,14 @@ _operators = {
         'S3PrefixSensor',
         'HdfsSensor',
         'TimeSensor',
+        'HttpSensor'
     ],
     'subdag_operator': ['SubDagOperator'],
     'hive_stats_operator': ['HiveStatsCollectionOperator'],
     's3_to_hive_operator': ['S3ToHiveTransfer'],
     'hive_to_mysql': ['HiveToMySqlTransfer'],
     's3_file_transform_operator': ['S3FileTransformOperator'],
+    'http_operator': ['SimpleHttpOperator']
     }
 
 _import_module_attrs(globals(), _operators)

--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -41,6 +41,7 @@ _operators = {
 
 _import_module_attrs(globals(), _operators)
 
+
 def integrate_plugins():
     """Integrate plugins to the context"""
     from airflow.plugins_manager import operators as _operators

--- a/airflow/operators/http_operator.py
+++ b/airflow/operators/http_operator.py
@@ -3,31 +3,36 @@ import logging
 from airflow.hooks import HttpHook
 from airflow.models import BaseOperator
 from airflow.utils import apply_defaults
-from airflow.utils import AirflowException
+
 
 class SimpleHttpOperator(BaseOperator):
     """
-    Calls a url 
+    Calls an endpoint on an HTTP system to execute an action
     """
 
-    template_fields = ('url',)
+    template_fields = ('endpoint',)
     template_ext = ()
     ui_color = '#f4a460'
 
     @apply_defaults
-    def __init__(self, url, method='POST', data=None, headers={}, http_conn_id='http_default', *args, **kwargs):
+    def __init__(self,
+                 endpoint,
+                 method='POST',
+                 data=None,
+                 headers={},
+                 regex=None,
+                 http_conn_id='http_default', *args, **kwargs):
         super(SimpleHttpOperator, self).__init__(*args, **kwargs)
         self.http_conn_id = http_conn_id
         self.method = method
-        self.url = url
+        self.endpoint = endpoint
         self.data = data
         self.headers = headers
+        self.regex = regex
 
     def execute(self, context):
         http = HttpHook(self.method, http_conn_id=self.http_conn_id)
         logging.info("Calling HTTP method")
-        result, content = http.run( self.url, self.data, self.headers )
-        if not result:
-            raise AirflowException( "HTTP call failed" )
-
-
+        content = http.run(self.endpoint, self.data, self.headers)
+        if self.regex:
+            pass

--- a/airflow/operators/http_operator.py
+++ b/airflow/operators/http_operator.py
@@ -1,0 +1,33 @@
+import logging
+
+from airflow.hooks import HttpHook
+from airflow.models import BaseOperator
+from airflow.utils import apply_defaults
+from airflow.utils import AirflowException
+
+class SimpleHttpOperator(BaseOperator):
+    """
+    Calls a url 
+    """
+
+    template_fields = ('url',)
+    template_ext = ()
+    ui_color = '#f4a460'
+
+    @apply_defaults
+    def __init__(self, method, url, data, headers, http_conn_id='http_default', *args, **kwargs):
+        super(SimpleHttpOperator, self).__init__(*args, **kwargs)
+        self.http_conn_id = http_conn_id
+        self.method = method
+        self.url = url
+        self.data = data
+        self.headers = headers
+
+    def execute(self, context):
+        http = HttpHook(http_conn_id=self.http_conn_id)
+        logging.info("Calling HTTP method")
+        result, content = http.run( self.url, self.data, self.headers )
+        if not result:
+            raise AirflowException( "HTTP call failed" )
+
+

--- a/airflow/operators/http_operator.py
+++ b/airflow/operators/http_operator.py
@@ -15,7 +15,7 @@ class SimpleHttpOperator(BaseOperator):
     ui_color = '#f4a460'
 
     @apply_defaults
-    def __init__(self, method, url, data, headers, http_conn_id='http_default', *args, **kwargs):
+    def __init__(self, url, method='POST', data=None, headers={}, http_conn_id='http_default', *args, **kwargs):
         super(SimpleHttpOperator, self).__init__(*args, **kwargs)
         self.http_conn_id = http_conn_id
         self.method = method
@@ -24,7 +24,7 @@ class SimpleHttpOperator(BaseOperator):
         self.headers = headers
 
     def execute(self, context):
-        http = HttpHook(http_conn_id=self.http_conn_id)
+        http = HttpHook(self.method, http_conn_id=self.http_conn_id)
         logging.info("Calling HTTP method")
         result, content = http.run( self.url, self.data, self.headers )
         if not result:

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -359,11 +359,15 @@ class HttpSensor(BaseSensorOperator):
         session.commit()
         session.close()
 
-    def poke(self, context):
+    def poke(self, regex=None):
         logging.info('Poking: ' + self.url)
-        records = self.hook.get( self.url, params=self.params, headers=self.headers, context=self.context )
-        if not records:
+        result, content = self.hook.get( self.url, params=self.params, headers=self.headers, context=self.context )
+        if not result:
             return False
-        else:
-            return True
+
+        if regex != None:
+            # run regex for fail condition
+            pass
+
+        return result
 

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -332,20 +332,26 @@ class TimeSensor(BaseSensorOperator):
             'Checking if the time ({0}) has come'.format(self.target_time))
         return datetime.now().time() > self.target_time
 
+
 class HttpSensor(BaseSensorOperator):
     """
     Executes an HTTP get statement until the specified criteria is met.
 
     :param conn_id: The connection to run the sensor against
     :type conn_id: string
-    :param url: To pass, the url must respond with 
+    :param url: To pass, the url must respond with
     """
 
     @apply_defaults
-    def __init__(self, conn_id, url, params={}, headers=None, extra_options={}, *args, **kwargs):
+    def __init__(self,
+                 conn_id,
+                 endpoint,
+                 params={},
+                 headers=None,
+                 extra_options={}, *args, **kwargs):
         super(HttpSensor, self).__init__(*args, **kwargs)
 
-        self.url = url
+        self.endpoint = endpoint
         self.conn_id = conn_id
         self.params = params
         self.headers = headers
@@ -356,19 +362,25 @@ class HttpSensor(BaseSensorOperator):
         if not site:
             raise AirflowException("conn_id doesn't exist in the repository")
         self.conn_id = conn_id
-        self.hook = hooks.HttpHook( method='GET', http_conn_id=self.conn_id )
+        self.hook = hooks.HttpHook(method='GET', http_conn_id=self.conn_id)
         session.commit()
         session.close()
 
     def poke(self, regex=None):
-        logging.info('Poking: ' + self.url)
-        result, content = self.hook.run( self.url, data=self.params, headers=self.headers, extra_options=self.extra_options )
-        if not result:
-            return False
+        logging.info('Poking: ' + self.endpoint)
 
-        if regex != None:
-            # run regex for fail condition
+        try:
+            response = self.hook.run(self.endpoint,
+                                     data=self.params,
+                                     headers=self.headers,
+                                     extra_options=self.extra_options)
+        except AirflowException as ae:
+            if ae.message.startswith("404"):
+                return False
+            raise
+
+        if regex:
+            # run regex on response for fail condition
             pass
 
-        return result
-
+        return True

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -400,6 +400,11 @@ def is_in(obj, l):
     return False
 
 
+def get_val_or_default( self, context, key, default ):
+    if key in context:
+        return context[key]
+    return default
+
 @contextmanager
 def TemporaryDirectory(suffix='', prefix=None, dir=None):
     name = mkdtemp(suffix=suffix, prefix=prefix, dir=dir)

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -400,7 +400,7 @@ def is_in(obj, l):
     return False
 
 
-def get_val_or_default( self, context, key, default ):
+def get_val_or_default( context, key, default ):
     if key in context:
         return context[key]
     return default

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -403,11 +403,6 @@ def is_in(obj, l):
     return False
 
 
-def get_val_or_default( context, key, default ):
-    if key in context:
-        return context[key]
-    return default
-
 @contextmanager
 def TemporaryDirectory(suffix='', prefix=None, dir=None):
     name = mkdtemp(suffix=suffix, prefix=prefix, dir=dir)

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -403,6 +403,11 @@ def is_in(obj, l):
     return False
 
 
+def get_val_or_default( self, context, key, default ):
+    if key in context:
+        return context[key]
+    return default
+
 @contextmanager
 def TemporaryDirectory(suffix='', prefix=None, dir=None):
     name = mkdtemp(suffix=suffix, prefix=prefix, dir=dir)

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -403,7 +403,7 @@ def is_in(obj, l):
     return False
 
 
-def get_val_or_default( self, context, key, default ):
+def get_val_or_default( context, key, default ):
     if key in context:
         return context[key]
     return default

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1524,6 +1524,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, ModelView):
         'conn_type': [
             ('ftp', 'FTP',),
             ('hdfs', 'HDFS',),
+            ('http', 'HTTP',),
             ('hive_cli', 'Hive Client Wrapper',),
             ('hive_metastore', 'Hive Metastore Thrift',),
             ('hiveserver2', 'Hive Server 2 Thrift',),

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1525,6 +1525,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, ModelView):
         'conn_type': [
             ('ftp', 'FTP',),
             ('hdfs', 'HDFS',),
+            ('http', 'HTTP',),
             ('hive_cli', 'Hive Client Wrapper',),
             ('hive_metastore', 'Hive Metastore Thrift',),
             ('hiveserver2', 'Hive Server 2 Thrift',),


### PR DESCRIPTION
This is the approach chosen for the HTTP hook and includes a very simple SimpleHttpOperator. This op only checks if the response status code is 20x or a failure. The sensor calls a simple GET and if the response code is 20x, it flows through. (regex is not implemented there, yet, to check on object status). 

The most important bit is the hook, which is a wrapper around HTTP operations and which other, more complex operators can use to interact with other systems over HTTP. 

The example http dag demonstrates how this appears to an end user.

Gotcha: for the Simple operator, the code in the dag must ensure that the data is of the right type and the correct content-type header is included, or the request will fail. This is because it's not viable to parse the header and know how to work with the input data to make it sensible.

If this simple interaction doesn't cut it, a specific operator for that system should be built. The simple op is not intended to be more generic nor clever than this, it probably serves more as an example of how to build your own http operators than useful in many use cases.

Obviously, more specific operators would reduce the amount of input parameters in the task instance declaration.
