### PR TITLE
Adding support for beeline as part of HiveCliHook

### DIFF
--- a/tests/core.py
+++ b/tests/core.py
@@ -54,9 +54,7 @@ class HivePrestoTest(unittest.TestCase):
         args = {'owner': 'airflow', 'start_date': datetime(2015, 1, 1)}
         dag = DAG('hive_test', default_args=args)
         self.dag = dag
-
-    def test_hive(self):
-        hql = """
+        self.hql = """
         USE airflow;
         DROP TABLE IF EXISTS static_babynames_partitioned;
         CREATE TABLE IF NOT EXISTS static_babynames_partitioned (
@@ -70,7 +68,16 @@ class HivePrestoTest(unittest.TestCase):
             PARTITION(ds='{{ ds }}')
         SELECT state, year, name, gender, num FROM static_babynames;
         """
-        t = operators.HiveOperator(task_id='basic_hql', hql=hql, dag=self.dag)
+
+    def test_hive(self):
+        t = operators.HiveOperator(
+            task_id='basic_hql', hql=self.hql, dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+    def test_beeline(self):
+        t = operators.HiveOperator(
+            task_id='beeline_hql', hive_cli_conn_id='beeline_default',
+            hql=self.hql, dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
 
     def test_presto(self):


### PR DESCRIPTION
@askeys @artwr 

beeline is a new lightweight Hive client that goes over JDBC to talk to HiveServer2 that is supposed to be able to replace the old Hive CLI.
