### PR TITLE
Use a bare raise so the original exception gets propagated.

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -825,7 +825,7 @@ class TaskInstance(Base):
                     task_copy.post_execute(context=context)
             except (Exception, StandardError, KeyboardInterrupt) as e:
                 self.record_failure(e, test_mode)
-                raise e
+                raise
 
             # Recording SUCCESS
             session = settings.Session()


### PR DESCRIPTION
With this change I get full stack traces in the logs. Without it the exception appears to originate from the line with `raise e`.
