### PR TITLE
Fix submodule label for Druid

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ mysql = ['mysql-python>=1.2.5']
 postgres = ['psycopg2>=2.6']
 optional = ['librabbitmq>=1.6.1']
 samba = ['pysmbclient>=0.1.3']
-pydruid = ['pydruid>=0.2.1']
+druid = ['pydruid>=0.2.1']
 s3 = ['boto>=2.36.0']
 
 all_dbs = postgres + mysql + hive


### PR DESCRIPTION
Fix for `NameError: name 'druid' is not defined` exception when installing with Pip via Git url.

---

```
16:02 $ mkvirtualenv airflow
New python executable in airflow/bin/python
Installing Setuptools..............................................................................................................................................................................................................................done.
Installing Pip.....................................................................................................................................................................................................................................................................................................................................done.
pip install git+https://github.com/airbnb/airflow.git@master
Downloading/unpacking git+https://github.com/airbnb/airflow.git@master
  Cloning https://github.com/airbnb/airflow.git (to master) to /var/folders/sg/ncfblr6d6bzd0q3wyz7tf5vw0000gp/T/pip-zHt3UD-build
remote: Counting objects: 5988, done.
remote: Compressing objects: 100% (16/16), done.
remote: Total 5988 (delta 8), reused 0 (delta 0), pack-reused 5972
Receiving objects: 100% (5988/5988), 5.20 MiB | 253.00 KiB/s, done.
Resolving deltas: 100% (4157/4157), done.
  Running setup.py egg_info for package from git+https://github.com/airbnb/airflow.git@master
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/var/folders/sg/ncfblr6d6bzd0q3wyz7tf5vw0000gp/T/pip-zHt3UD-build/setup.py", line 67, in <module>
        'druid': druid,
    NameError: name 'druid' is not defined
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/var/folders/sg/ncfblr6d6bzd0q3wyz7tf5vw0000gp/T/pip-zHt3UD-build/setup.py", line 67, in <module>

    'druid': druid,

NameError: name 'druid' is not defined

----------------------------------------
Cleaning up...
Command python setup.py egg_info failed with error code 1 in /var/folders/sg/ncfblr6d6bzd0q3wyz7tf5vw0000gp/T/pip-zHt3UD-build
Storing complete log in /Users/robb/.pip/pip.log
```
