### PR TITLE
Add smtp_starttls flag to config

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -34,6 +34,9 @@ defaults = {
     'celery': {
         'default_queue': 'default',
     },
+    'smtp': {
+        'smtp_starttls': True,
+    },
 }
 
 DEFAULT_CONFIG = """\
@@ -92,6 +95,7 @@ secret_key = temporary_key
 # the airflow.utils.send_email function, you have to configure an smtp
 # server here
 smtp_host = localhost
+smtp_starttls = True
 smtp_user = airflow
 smtp_port = 25
 smtp_password = airflow

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -368,9 +368,11 @@ def send_MIME_email(e_from, e_to, mime_msg):
     SMTP_PORT = conf.get('smtp', 'SMTP_PORT')
     SMTP_USER = conf.get('smtp', 'SMTP_USER')
     SMTP_PASSWORD = conf.get('smtp', 'SMTP_PASSWORD')
+    SMTP_STARTTLS = conf.getboolean('smtp', 'SMTP_STARTTLS')
 
     s = smtplib.SMTP(SMTP_HOST, SMTP_PORT)
-    s.starttls()
+    if SMTP_STARTTLS:
+        s.starttls()
     if SMTP_USER and SMTP_PASSWORD:
         s.login(SMTP_USER, SMTP_PASSWORD)
     logging.info("Sent an alert email to " + str(e_to))


### PR DESCRIPTION
I need to work with a mail server that does not support STARTTLS.  This PR adds a config file setting (defaulting to True) to decide when to activate STARTTLS.
