### PR TITLE
Fix context bug

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -808,9 +808,11 @@ class TaskInstance(Base):
                     msg = "Executing "
                 msg += "{self.task} on {self.execution_date}"
 
+            context = {}
             try:
                 logging.info(msg.format(self=self))
                 if not mark_success:
+                    context = self.get_template_context()
 
                     task_copy = copy.copy(task)
                     self.task = task_copy
@@ -823,7 +825,6 @@ class TaskInstance(Base):
                     signal.signal(signal.SIGTERM, signal_handler)
 
                     self.render_templates()
-                    context = self.get_template_context()
                     settings.policy(task_copy)
                     task_copy.pre_execute(context=context)
 


### PR DESCRIPTION
If the try block would fail before the assignment was made to `context`, the expect block would also fail, dawg.
