### PR TITLE
[cli] improved datetime parsing for the "clear" command

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -212,9 +212,9 @@ def clear(args):
     dag = dagbag.dags[args.dag_id]
 
     if args.start_date:
-        args.start_date = datetime.strptime(args.start_date, '%Y-%m-%d')
+        args.start_date = dateutil.parser.parse(args.start_date)
     if args.end_date:
-        args.end_date = datetime.strptime(args.end_date, '%Y-%m-%d')
+        args.end_date = dateutil.parser.parse(args.end_date)
 
     if args.task_regex:
         dag = dag.sub_dag(


### PR DESCRIPTION
Test plan:
- Create a dag and a dummy task with schedule_interval 1 hour.
- Let it run for a couple of hours
- Clear tasks with the following command:
  airflow clear test_dag -s "2015-07-24 15:00" -e "2015-07-24 18:00"
- Check that the tasks are cleared as expected.
