### PR TITLE
add tags text field to known_events table

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -4,7 +4,7 @@ implement their own login mechanisms by providing an `airflow_login` module
 in their PYTHONPATH. airflow_login should be based off the
 `airflow.www.login`
 """
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 import logging
 from airflow.configuration import conf

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1948,6 +1948,7 @@ class KnownEvent(Base):
     end_date = Column(DateTime)
     user_id = Column(Integer(), ForeignKey('user.id'),)
     known_event_type_id = Column(Integer(), ForeignKey('known_event_type.id'),)
+    event_tags = Column(String(200))
     reported_by = relationship(
         "User", cascade=False, cascade_backrefs=False, backref='known_events')
     event_type = relationship(

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1781,13 +1781,18 @@ class KnowEventView(wwwutils.DataProfilingMixin, AirflowModelView):
     form_columns = (
         'label',
         'event_type',
+        'event_tags',
         'start_date',
         'end_date',
         'reported_by',
         'description')
     column_list = (
-        'label', 'event_type', 'start_date', 'end_date', 'reported_by')
+        'label', 'event_type', 'event_tags', 
+        'start_date', 'end_date', 'reported_by')
     column_default_sort = ("start_date", True)
+    column_labels = {
+        'event_tags': 'Tags',
+    }
 mv = KnowEventView(
     models.KnownEvent, Session, name="Known Events", category="Data Profiling")
 admin.add_view(mv)

--- a/migrations.sql
+++ b/migrations.sql
@@ -3,3 +3,5 @@ alter table task_instance add column queue varchar(50) NULL;
 alter table task_instance add column pool varchar(50) NULL;
 alter table task_instance add column priority_weight INT NULL;
 create index ti_pool on task_instance (pool, state) using btree;
+// To 1.3
+alter table known_events add column event_tags TEXT(200) NULL;


### PR DESCRIPTION
@mistercrunch 

Adds tags to the known event table as a simple text field.  This is flexible but maybe not super robust.  Since I modified the models very slightly, I bumped the minor version.
