### PR TITLE
Enhancements to ExternalTaskSensor

### DIFF
--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -105,6 +105,12 @@ class ExternalTaskSensor(BaseSensorOperator):
     :param external_task_id: The task_id that contains the task you want to
         wait for
     :type external_task_id: string
+    :param allowed_states: list of allowed states, default is ``['success']``
+    :type allowed_states: list
+    :param execution_delta: time difference with the previous execution to
+        look at, the default is the same execution_date as the current task.
+        For yesterday, use [positive!] datetime.timedelta(days=1)
+    :type execution_delta: datetime.timedelta
     """
 
     @apply_defaults
@@ -112,9 +118,12 @@ class ExternalTaskSensor(BaseSensorOperator):
             self,
             external_dag_id,
             external_task_id,
-            allowed_state=None,
+            allowed_states=None,
+            execution_delta=None,
             *args, **kwargs):
         super(ExternalTaskSensor, self).__init__(*args, **kwargs)
+        self.allowed_states = allowed_states or [State.SUCCESS]
+        self.execution_delta = execution_delta
         self.external_dag_id = external_dag_id
         self.external_task_id = external_task_id
 
@@ -125,12 +134,18 @@ class ExternalTaskSensor(BaseSensorOperator):
             '{self.external_task_id} on '
             '{context[execution_date]} ... '.format(**locals()))
         TI = TaskInstance
+
+        if self.execution_delta:
+            dttm = context['execution_date'] - self.execution_delta
+        else:
+            dttm = context['execution_date']
+
         session = settings.Session()
         count = session.query(TI).filter(
             TI.dag_id == self.external_dag_id,
             TI.task_id == self.external_task_id,
-            TI.state == State.SUCCESS,
-            TI.execution_date == context['execution_date'],
+            TI.state.in_(self.allowed_states),
+            TI.execution_date == dttm,
         ).count()
         session.commit()
         session.close()

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -108,7 +108,12 @@ class ExternalTaskSensor(BaseSensorOperator):
     """
 
     @apply_defaults
-    def __init__(self, external_dag_id, external_task_id, *args, **kwargs):
+    def __init__(
+            self,
+            external_dag_id,
+            external_task_id,
+            allowed_state=None,
+            *args, **kwargs):
         super(ExternalTaskSensor, self).__init__(*args, **kwargs)
         self.external_dag_id = external_dag_id
         self.external_task_id = external_task_id

--- a/tests/core.py
+++ b/tests/core.py
@@ -167,6 +167,24 @@ class CoreTest(unittest.TestCase):
             dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
 
+    def test_external_task_sensor(self):
+        t = operators.ExternalTaskSensor(
+            task_id='test_external_task_sensor_check',
+            external_dag_id='core_test',
+            external_task_id='time_sensor_check',
+            dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+    def test_external_task_sensor_delta(self):
+        t = operators.ExternalTaskSensor(
+            task_id='test_external_task_sensor_check_delta',
+            external_dag_id='core_test',
+            external_task_id='time_sensor_check',
+            execution_delta=timedelta(0),
+            allowed_states=['success'],
+            dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
     def test_timeout(self):
         t = operators.PythonOperator(
             task_id='test_timeout',


### PR DESCRIPTION
- param allowed_states: list of allowed states, default is `['success']`
- param execution_delta: time difference with the previous execution to look at, the default is the same execution_date as the current task. For yesterday, use [positive!] datetime.timedelta(days=1)
