### PR TITLE
Setting 10 seconds timeout on HiveServer2Hook connect

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -14,6 +14,8 @@ from airflow.utils import AirflowException
 from airflow.hooks.base_hook import BaseHook
 from airflow.utils import TemporaryDirectory
 
+HS2_TIMEOUT = 10000  # HiveServer2 timeout is 10 seconds
+
 
 class HiveCliHook(BaseHook):
     """
@@ -325,7 +327,8 @@ class HiveServer2Hook(BaseHook):
             port=db.port,
             authMechanism=db.extra_dejson.get('authMechanism', 'NOSASL'),
             user=db.login,
-            database=db.schema or 'default')
+            database=db.schema or 'default',
+            timeout=HS2_TIMEOUT)
 
     def get_results(self, hql, schema='default', arraysize=1000):
         with self.get_conn() as conn:


### PR DESCRIPTION
Otherwise it just hangs forever. This way it can fail, retry and most likely get wired to an node that isn't busted.
