### PR TITLE
Add XCom (cross-communication) functionality

### DIFF
--- a/airflow/example_dags/example_xcom.py
+++ b/airflow/example_dags/example_xcom.py
@@ -1,0 +1,55 @@
+from __future__ import print_function
+import airflow
+import datetime
+
+dag = airflow.DAG(
+    'example_xcom',
+    start_date=datetime.datetime(2015, 1, 1),
+    default_args={'owner': 'airflow', 'provide_context': True})
+
+value_1 = [1, 2, 3]
+value_2 = {'a': 'b'}
+value_3 = set([4, 5, 6])
+
+def push(**kwargs):
+    # pushes an XCom without a specific target
+    kwargs['ti'].xcom_push(key='value from pusher 1', value=value_1)
+
+def push_to_target(**kwargs):
+    # pushes an XCom to a target
+    kwargs['ti'].xcom_push(
+        key='value for puller', value=value_2, to_tasks=['puller'])
+
+def push_by_returning(**kwargs):
+    # pushes an XCom without a specific target, just by returning it
+    return value_3
+
+def puller(**kwargs):
+    ti = kwargs['ti']
+
+    # get value_1 (which must be pulled from the source)
+    v1 = ti.xcom_pull(from_tasks=['push'])
+    assert v1.iloc[0].value == value_1
+
+    # get value 2 (which was pushed to this task)
+    v2 = ti.xcom_pull()
+    assert v2.iloc[0].value == value_2
+
+    # get value_3 (which must be pulled from the source)
+    v3 = ti.xcom_pull(from_tasks=['push_by_returning'])
+    assert v3.iloc[0].value == value_3
+
+push1 = airflow.operators.PythonOperator(
+    task_id='push', dag=dag, python_callable=push)
+
+push2 = airflow.operators.PythonOperator(
+    task_id='push_to_target', dag=dag, python_callable=push_to_target)
+
+push3 = airflow.operators.PythonOperator(
+    task_id='push_by_returning', dag=dag,
+    python_callable=push_by_returning)
+
+pull = airflow.operators.PythonOperator(
+    task_id='puller', dag=dag, python_callable=puller)
+
+pull.set_upstream([push1, push2, push3])

--- a/airflow/example_dags/example_xcom.py
+++ b/airflow/example_dags/example_xcom.py
@@ -22,7 +22,7 @@ def puller(**kwargs):
     ti = kwargs['ti']
 
     # get value_1
-    v1 = ti.xcom_pull(tasks='push')
+    v1 = ti.xcom_pull(task_ids='push')
     assert v1 == value_1
 
     # get value 1 by key
@@ -30,11 +30,11 @@ def puller(**kwargs):
     assert v1 == value_1
 
     # get value_2
-    v2 = ti.xcom_pull(tasks='push_by_returning')
+    v2 = ti.xcom_pull(task_ids='push_by_returning')
     assert v2 == value_2
 
     # get both value_1 and value_2
-    v1, v2 = ti.xcom_pull(tasks=['push', 'push_by_returning'])
+    v1, v2 = ti.xcom_pull(task_ids=['push', 'push_by_returning'])
     assert (v1, v2) == (value_1, value_2)
 
 push1 = airflow.operators.PythonOperator(

--- a/airflow/example_dags/example_xcom.py
+++ b/airflow/example_dags/example_xcom.py
@@ -22,11 +22,7 @@ def puller(**kwargs):
     ti = kwargs['ti']
 
     # get value_1
-    v1 = ti.xcom_pull(task_ids='push')
-    assert v1 == value_1
-
-    # get value 1 by key
-    v1 = ti.xcom_pull(key='value from pusher 1')
+    v1 = ti.xcom_pull(key=None, task_ids='push')
     assert v1 == value_1
 
     # get value_2
@@ -34,7 +30,7 @@ def puller(**kwargs):
     assert v2 == value_2
 
     # get both value_1 and value_2
-    v1, v2 = ti.xcom_pull(task_ids=['push', 'push_by_returning'])
+    v1, v2 = ti.xcom_pull(key=None, task_ids=['push', 'push_by_returning'])
     assert (v1, v2) == (value_1, value_2)
 
 push1 = airflow.operators.PythonOperator(

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1519,6 +1519,42 @@ class BaseOperator(object):
         """
         self._set_relatives(task_or_task_list, upstream=True)
 
+    def xcom_push(
+            self,
+            context,
+            key,
+            value,
+            to_tasks=None,
+            to_dags=None,
+            visible_on=None):
+        """
+        See TaskInstance.xcom_push()
+        """
+        context['ti'].xcom_push(
+            key=key,
+            value=value,
+            to_tasks=to_tasks,
+            to_dags=to_dags,
+            visible_on=visible_on)
+
+    def xcom_pull(
+            self,
+            context,
+            key,
+            from_tasks=None,
+            from_dags=None,
+            include_prior_dates=None,
+            limit=100):
+        """
+        See TaskInstance.xcom_pull()
+        """
+        return context['ti'].xcom_pull(
+            key=key,
+            from_tasks=from_tasks,
+            from_dags=from_dags,
+            include_prior_dates=include_prior_dates,
+            limit=limit)
+
 
 class DagModel(Base):
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -679,10 +679,10 @@ class TaskInstance(Base):
             qry = (
                 session
                 .query(
-                    func.sum(
-                        case([(TI.state == State.SUCCESS, 1)], else_=0)),
-                    func.sum(
-                        case([(TI.state == State.SKIPPED, 1)], else_=0)),
+                    func.coalesce(func.sum(
+                        case([(TI.state == State.SUCCESS, 1)], else_=0)), 0),
+                    func.coalesce(func.sum(
+                        case([(TI.state == State.SKIPPED, 1)], else_=0)), 0),
                     func.count(TI.task_id),
                 )
                 .filter(

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2235,6 +2235,11 @@ class XCom(Base):
             index_col='id',
             parse_dates=['timestamp', 'visible_on'])
 
+        result.drop_duplicates(
+            subset=['key', 'visible_on',
+                    'from_task', 'from_dag', 'to_task', 'to_dag'],
+            inplace=True)
+
         if result.empty:
             raise XComException('No XCom values found.')
         return result

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1017,6 +1017,11 @@ class TaskInstance(Base):
             to_tasks=None,
             to_dags=None,
             visible_on=None):
+        if visible_on and visible_on < self.execution_date:
+            raise ValueError(
+                'visible_on can not be in the past (current execution_date '
+                'is {}; received {})'.format(self.execution_date, visible_on))
+
         if to_dags is None:
             to_dags = self.dag_id
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1017,12 +1017,11 @@ class TaskInstance(Base):
             to_tasks=None,
             to_dags=None,
             visible_on=None):
+        if to_dags is None:
+            to_dags = self.dag_id
 
         for to_task_i in as_tuple(to_tasks):
             for to_dag_i in as_tuple(to_dags):
-
-                if to_dag_i is None:
-                    to_dag_i = self.dag_id
 
                 XCom.set(
                     key=key,

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1017,6 +1017,29 @@ class TaskInstance(Base):
             to_tasks=None,
             to_dags=None,
             visible_on=None):
+        """
+        Make an XCom available for tasks to pull.
+
+        :param key: A key for the XCom
+        :type key: string
+        :param value: A value for the XCom. The value is pickled and stored
+            in the database.
+        :type value: any pickleable object
+        :param to_tasks: If provided, only these tasks will be able to pull
+            the XCom. If None (the default), no targets are specified.
+        :type to_tasks: TaskInstance, string (representing task_id), or
+            an iterable of TaskInstances or strings.
+        :param to_dags: If provided, only tasks in these DAGs will be able to
+            pull the XCom. If None (the default), the calling task's DAG is
+            used. To remove the DAG filter entirely, pass [None].
+        :type to_dags: DAG, string (representing dag_id), or an iterable of
+            DAGs or strings.
+        :param visible_on: if provided, the XCom will not be visible until
+            this date. This can be used, for example, to send a message to a
+            task on a future date without it being immediately visible.
+        :type visible_on: datetime
+        """
+
         if visible_on and visible_on < self.execution_date:
             raise ValueError(
                 'visible_on can not be in the past (current execution_date '
@@ -1044,6 +1067,31 @@ class TaskInstance(Base):
             from_dags=None,
             include_prior_dates=False,
             limit=100):
+        """
+        Pull an XCom that meets certain criteria.
+
+        :param key: A key for the XCom. If provided, only XComs with matching
+            keys will be returned. Defaults to None.
+        :type key: string
+        :param from_tasks: If None, only XComs that specifically target the
+            calling task can be pulled. If from_tasks is provided, then XComs
+            pushed by those tasks without targets will also be pulled. To clear
+            the task filter entirely, pass [None].
+        :type from_tasks: TaskInstance, string (representing task_id), or
+            an iterable of TaskInstances or strings.
+        :param from_dags: If provided, only XComs from these DAGs will be
+            pulled. Defaults to the DAG of the calling task. To clear the DAG
+            filter entirely, pass [None]
+        :type from_dags: DAG, string (representing dag_id), or an iterable of
+            DAGs or strings.
+        :param include_prior_dates: If False, only XComs from the current
+            execution_date are returned. If True, XComs from previous dates
+            are returned as well.
+        :type include_prior_dates: bool
+        :param limit: the maximum number of results to return. Pass None for
+            no limit.
+        :type limit: int
+        """
 
         if from_dags is None:
             from_dags = self.dag_id

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -13,7 +13,6 @@ import logging
 import os
 import dill
 import re
-import pandas as pd
 import signal
 import socket
 import sys

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2165,9 +2165,6 @@ class XCom(Base):
         Store an XCom value.
         """
 
-        if not isinstance(task, basestring) or not isinstance(dag, basestring):
-            raise TypeError('Expected string; received {}'.format(type(task)))
-
         session.expunge_all()
         session.add(XCom(
             key=key,

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2166,6 +2166,15 @@ class XCom(Base):
         """
         Store an XCom value.
         """
+
+        # remove any duplicate XComs
+        session.query(cls).filter(
+            cls.key == key,
+            cls.execution_date == execution_date,
+            cls.task_id == task_id,
+            cls.dag_id == dag_id).delete()
+
+        # insert new XCom
         session.add(XCom(
             key=key,
             value=value,

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -36,7 +36,7 @@ Base = declarative_base()
 ID_LEN = 250
 SQL_ALCHEMY_CONN = conf.get('core', 'SQL_ALCHEMY_CONN')
 DAGS_FOLDER = os.path.expanduser(conf.get('core', 'DAGS_FOLDER'))
-RETURN_XCOM = '<Returned XCom>'
+RETURN_XCOM = '__return_value__'
 
 
 if 'mysql' in SQL_ALCHEMY_CONN:

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -29,7 +29,7 @@ from airflow import settings, utils
 from airflow.executors import DEFAULT_EXECUTOR, LocalExecutor
 from airflow.configuration import conf
 from airflow.utils import (
-    AirflowException, XComException, State, apply_defaults, provide_session,
+    AirflowException, State, apply_defaults, provide_session,
     is_container, as_tuple)
 
 Base = declarative_base()
@@ -2214,7 +2214,7 @@ class XCom(Base):
             inplace=True)
 
         if result.empty:
-            raise XComException('No XCom values found.')
+            return None
 
         if limit is None:
             return result.iloc[0].value

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2166,6 +2166,7 @@ class XCom(Base):
         """
         Store an XCom value.
         """
+        session.expunge_all()
 
         # remove any duplicate XComs
         session.query(cls).filter(
@@ -2182,6 +2183,7 @@ class XCom(Base):
             task_id=task_id,
             dag_id=dag_id))
 
+        session.commit()
     @classmethod
     @provide_session
     def get(

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2198,11 +2198,11 @@ class XCom(Base):
         Retrieve an XCom value, optionally meeting certain criteria
         """
         filters = []
-        if key is not None:
+        if key:
             filters.append(cls.key == key)
-        if task_id is not None:
+        if task_id:
             filters.append(cls.task_id == task_id)
-        if dag_id is not None:
+        if dag_id:
             filters.append(cls.dag_id == dag_id)
         if include_prior_dates:
             filters.append(cls.execution_date <= execution_date)

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -36,7 +36,7 @@ Base = declarative_base()
 ID_LEN = 250
 SQL_ALCHEMY_CONN = conf.get('core', 'SQL_ALCHEMY_CONN')
 DAGS_FOLDER = os.path.expanduser(conf.get('core', 'DAGS_FOLDER'))
-RETURN_XCOM = '<XCom from return>'
+RETURN_XCOM = '<Returned XCom>'
 
 
 if 'mysql' in SQL_ALCHEMY_CONN:

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2164,15 +2164,12 @@ class XCom(Base):
         """
         Store an XCom value.
         """
-
-        session.expunge_all()
         session.add(XCom(
             key=key,
             value=value,
             visible_on=visible_on,
             task=task,
             dag=dag))
-        session.commit()
 
     @classmethod
     @provide_session

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2137,7 +2137,7 @@ class XCom(Base):
     __tablename__ = "xcom"
 
     id = Column(Integer, primary_key=True)
-    key = Column(String)
+    key = Column(String(512))
     value = Column(PickleType(pickler=dill))
     timestamp = Column(DateTime, server_default=func.current_timestamp())
     execution_date = Column(DateTime, nullable=False)

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -32,6 +32,10 @@ class AirflowException(Exception):
     pass
 
 
+class XComException(AirflowException):
+    pass
+
+
 class AirflowSensorTimeout(Exception):
     pass
 
@@ -467,3 +471,20 @@ class timeout(object):
 
     def __exit__(self, type, value, traceback):
         signal.alarm(0)
+
+
+def as_tuple(obj):
+    """
+    If obj is a container, returns obj as a tuple.
+    Otherwise, returns a tuple containing obj.
+    """
+    def _inner_gen():
+        try:
+            for i in obj:
+                yield i
+        except:
+            yield obj
+    if isinstance(obj, basestring):
+        return (obj,)
+    else:
+        return tuple(_inner_gen())

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -32,10 +32,6 @@ class AirflowException(Exception):
     pass
 
 
-class XComException(AirflowException):
-    pass
-
-
 class AirflowSensorTimeout(Exception):
     pass
 

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -473,21 +473,22 @@ class timeout(object):
         signal.alarm(0)
 
 
+def is_container(obj):
+    """
+    Test if an object is a container (iterable) but not a string
+    """
+    return hasattr(obj, '__iter__') and not isinstance(obj, basestring)
+
+
 def as_tuple(obj):
     """
     If obj is a container, returns obj as a tuple.
     Otherwise, returns a tuple containing obj.
     """
-    def _inner_gen():
-        try:
-            for i in obj:
-                yield i
-        except:
-            yield obj
-    if isinstance(obj, basestring):
-        return (obj,)
+    if is_container(obj):
+        return tuple(obj)
     else:
-        return tuple(_inner_gen())
+        return tuple([obj])
 
 
 def round_time(dt, delta):

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -115,6 +115,55 @@ could take thousands of tasks without a problem), or from an environment
 perspective (you want a worker running from within the Spark cluster
 itself because it needs a very specific environment and security rights).
 
+XComs
+'''''
+
+XComs let tasks exchange messages, allowing more nuanced forms of control and
+shared state. The name is an abbreviation of "cross-communication". XComs are
+principally defined by a key, value, and timestamp, but also track attributes
+like the task and DAG that created the XComas well as any intended recipients.
+Any object that can be pickled can be used as an XCom value, so users should
+make sure to use objects of appropriate size.
+
+
+XComs can be "pushed" (sent) or "pulled" (received). When a task pushes an
+XCom, it makes it generally available to other tasks (though by default, only
+those in its own DAG). In addition, the task can specify that only certain
+tasks or DAGs can pull the XCom (a "targeted XCom") by providing ``to_tasks``
+or ``to_dags`` to ``xcom_push()``. Lastly, if a task returns a value (either
+from its Operator's ``execute`` method, or from a PythonOperator's
+``python_callable`` function), then an XCom containing the value is
+automatically pushed.
+
+When a task pulls, the default action is to receive any XComs of which the
+pulling task is a target. However, by providing a source task, XComs that were
+broadcast without targets can be pulled as well. Note that if an XCom was pushed to
+specific targets, only the target tasks can pull it.
+
+When XComs are pulled, the result is a pandas ``DataFrame`` of any messages
+that meet the provided criteria. By default, any XComs that 1) target the
+calling task and 2) were sent on the same execution date are pulled. Users can
+provide other criteria to expand or filter the pull.
+
+.. code:: python
+
+    # inside a PythonOperator called pushing_task
+    def push_function(**context)
+        context['ti'].xcom_push(
+            key='targeted XCom',
+            value=v,
+            to_tasks=['pulling_task'])
+
+    # inside a PythonOperator called pulling_task
+    def pull_function(**context):
+        values = context['ti'].xcom_pull()
+        # extract first value from Dataframe
+        v = values.iloc[0].value
+
+
+XComs are similar to Variables, but are specifically designed for inter-task communication rather
+than global settings.
+
 
 Variables
 '''''''''

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -148,7 +148,7 @@ provide other criteria to expand or filter the pull.
 .. code:: python
 
     # inside a PythonOperator called pushing_task
-    def push_function(**context)
+    def push_function(**context):
         context['ti'].xcom_push(
             key='targeted XCom',
             value=v,

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -134,22 +134,24 @@ PythonOperator's ``python_callable`` function), then an XCom containing that
 value is automatically pushed.
 
 Tasks call ``xcom_pull()`` to retrieve XComs, optionally applying filters
-based on criteria like ``key``, source ``tasks``, and source ``dags``. By
-default, the value of the most recent XCom that matches the criteria is
-returned (unless ``tasks`` is a list, in which case a corresponding list of
-values is returned). However, if ``limit`` is greater than 0, a pandas
-``DataFrame`` is returned containing any matching XComs. This is to allow more
-complex filtering on the query result, if necessary.
+based on criteria like ``key``, source ``task_ids``, and source ``dag_id``. By
+default, ``xcom_pull()`` filters for the keys that are automatically given to
+XComs when they are pushed by being returned from execute functions (as
+opposed to XComs that are pushed manually).
+
+If ``xcom_pull`` is passed a single string for ``task_ids``, then the most
+recent XCom value from that task is returned; if a list of ``task_ids`` is
+passed, then a correpsonding list of XCom values is returned.
 
 .. code:: python
 
     # inside a PythonOperator called 'pushing_task'
-    def push_function(**context):
-        context['ti'].xcom_push(key='sample XCom', value=v)
+    def push_function():
+        return value
 
     # inside another PythonOperator
     def pull_function(**context):
-        v = context['ti'].xcom_pull(tasks='pushing_task')
+        value = context['ti'].xcom_pull(task_ids='pushing_task')
 
 
 XComs are similar to Variables, but are specifically designed for inter-task


### PR DESCRIPTION
Supersedes #232. 

Provides XCom objects and methods for passing messages/state between tasks. XCom values can be any pickleable object. Please see the `concepts` doc, `TaskInstance.xcom_push()` and `TaskInstance.xcom_pull()` docstrings, and `example_xcom.py` for more info.

``` python
    # inside a PythonOperator called 'pushing_task'
    def push_function(**context):
        context['ti'].xcom_push(key='sample XCom', value=v)

    # inside another PythonOperator
    def pull_function(**context):
        v = context['ti'].xcom_pull(task_ids='pushing_task')
```
