### PR TITLE
Small chance to concepts docs

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -41,7 +41,7 @@ Hooks
 Hooks are interfaces to external platforms and databases like Hive, S3,
 MySQL, Postgres, HDFS, and Pig. Hooks implement a common interface when
 possible, and act as a building block for operators. They also use
-the ``airflow.connection.Connection`` model to retrieve hostnames
+the ``airflow.models.Connection`` model to retrieve hostnames
 and authentication information. Hooks keep authentication code and
 information out of pipelines, centralized in the metadata database.
 


### PR DESCRIPTION
`airflow.connection.Connection` should be `airflow.models.Connection`
