### PR TITLE
More instructions/warnings about using cryptography

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -12,6 +12,14 @@ except:
     pass
 
 
+def generate_fernet_key():
+    try:
+        FERNET_KEY = Fernet.generate_key()
+    except NameError:
+        FERNET_KEY = "cryptography_not_found_storing_passwords_in_plain_text"
+    return FERNET_KEY
+
+
 class AirflowConfigException(Exception):
     pass
 
@@ -287,11 +295,7 @@ if not os.path.isfile(AIRFLOW_CONFIG):
     when it is missing. The right way to change your configuration is to alter
     your configuration file, not this code.
     """
-    try:
-        FERNET_KEY = Fernet.generate_key()
-    except NameError:
-        FERNET_KEY = "storing_passwords_in_plain_text"
-
+    FERNET_KEY = generate_fernet_key()
     logging.info("Creating new config file in: " + AIRFLOW_CONFIG)
     f = open(AIRFLOW_CONFIG, 'w')
     f.write(DEFAULT_CONFIG.format(**locals()))

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -5,6 +5,9 @@ from configparser import ConfigParser
 import errno
 import logging
 import os
+import sys
+import textwrap
+
 
 try:
     from cryptography.fernet import Fernet
@@ -317,3 +320,21 @@ def test_mode():
 
 conf = ConfigParserWithDefaults(defaults)
 conf.read(AIRFLOW_CONFIG)
+if 'cryptography' in sys.modules and not conf.has_option('core', 'fernet_key'):
+    logging.warning(textwrap.dedent("""
+
+        Your system supports encrypted passwords for Airflow connections but is
+        currently storing them in plaintext! To turn on encryption, add a
+        "fernet_key" option to the "core" section of your airflow.cfg file,
+        like this:
+
+            [core]
+            fernet_key = <YOUR FERNET KEY>
+
+        Your airflow.cfg file is located at: {cfg}.
+        If you need to generate a fernet key, you can run this code:
+
+            from airflow.configuration import generate_fernet_key
+            generate_fernet_key()
+
+        """.format(cfg=AIRFLOW_CONFIG)))

--- a/airflow/www/templates/airflow/conn_list.html
+++ b/airflow/www/templates/airflow/conn_list.html
@@ -2,7 +2,7 @@
 
 {% block model_menu_bar %}
 {% if not admin_view.is_secure() %}
-<div class="alert alert-danger"><b>Warning:</b> Connection password are stored in clear until you install the Python "cryptography" library. Find the instructions on how to install it here:  https://cryptography.io/en/latest/installation/</div>
+<div class="alert alert-danger"><b>Warning:</b> Connection passwords are stored in plaintext until you install the Python "cryptography" library. You can find installation instructions here: <a href=https://cryptography.io/en/latest/installation/>https://cryptography.io/en/latest/installation/</a>. Once installed, instructions for creating an encryption key will be displayed the next time you import Airflow. </div>
 {% endif %}
   {{ super() }}
 {% endblock %}


### PR DESCRIPTION
This PR is about making it easier for users to take advantage of @neovintage's great work in #267!

The problem is that existing users aren't given a clear path to enable encryption. The warning in #279 suggests that they should install the `cryptography` library, but that's not enough -- encryption only works if they also put a `fernet_key` in their `airflow.cfg` files. Airflow will create a default key for a fresh install, but anyone with an existing `airflow.cfg` file is out of luck unless they change it themselves -- and by definition, anyone seeing #279 already has an `airflow.cfg`!

So this PR does two things: if the user has `cryptography` installed but no `fernet_key` option, it prompts them to create an encryption key at import (and provides a helper function `generate_fernet_key()`). It also expands the warning from #279 to explain that just installing `cryptography` isn't enough, users must add the key.

New warning message:

```
In [1]: import airflow
WARNING:root:

Your system supports encrypted passwords for Airflow connections but is
currently storing them in plaintext! To turn on encryption, add a
"fernet_key" option to the "core" section of your airflow.cfg file,
like this:

    [core]
    fernet_key = <YOUR FERNET KEY>

Your airflow.cfg file is located at: /Users/jlowin/airflow/airflow.cfg.
If you need to generate a fernet key, you can run this code:

    from airflow.configuration import generate_fernet_key
    generate_fernet_key()
```

Updated UI message:
![screen shot 2015-08-25 at 4 04 48 pm](https://cloud.githubusercontent.com/assets/153965/9477960/16fc39de-4b43-11e5-8699-cf8a4e72c342.png)
