### PR TITLE
(Py3) implement comparison operators

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1341,7 +1341,8 @@ class BaseOperator(object):
     def __eq__(self, other):
         return (
             type(self) == type(other) and
-            all(self.__dict__[c] == other.__dict__[c] for c in self._comps))
+            all(self.__dict__.get(c, None) == other.__dict__.get(c, None)
+                for c in self._comps))
 
     def __neq__(self, other):
         return not self == other
@@ -1777,7 +1778,8 @@ class DAG(object):
     def __eq__(self, other):
         return (
             type(self) == type(other) and
-            all(self.__dict__[c] == other.__dict__[c] for c in self._comps))
+            all(self.__dict__.get(c, None) == other.__dict__.get(c, None)
+                for c in self._comps))
 
     def __neq__(self, other):
         return not self == other

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1348,7 +1348,7 @@ class BaseOperator(object):
         return not self == other
 
     def __lt__(self, other):
-        return (type(self) == type(other) and self.task_id < other.task_id)
+        return self.task_id < other.task_id
 
     def __hash__(self):
         return hash(tuple(getattr(self, c, None) for c in self._comps))
@@ -1785,7 +1785,7 @@ class DAG(object):
         return not self == other
 
     def __lt__(self, other):
-        return (type(self) == type(other) and self.dag_id < other.dag_id)
+        return self.dag_id < other.dag_id
 
     def __hash__(self):
         return hash(tuple(getattr(self, c, None) for c in self._comps))

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1351,7 +1351,15 @@ class BaseOperator(object):
         return self.task_id < other.task_id
 
     def __hash__(self):
-        return hash(tuple(getattr(self, c, None) for c in self._comps))
+        hash_components = [type(self)]
+        for c in self._comps:
+            val = getattr(self, c, None)
+            try:
+                hash(val)
+                hash_components.append(val)
+            except TypeError:
+                hash_components.append(repr(val))
+        return hash(tuple(hash_components))
 
     @property
     def schedule_interval(self):
@@ -1788,7 +1796,15 @@ class DAG(object):
         return self.dag_id < other.dag_id
 
     def __hash__(self):
-        return hash(tuple(getattr(self, c, None) for c in self._comps))
+        hash_components = [type(self)]
+        for c in self._comps:
+            val = getattr(self, c, None)
+            try:
+                hash(val)
+                hash_components.append(val)
+            except TypeError:
+                hash_components.append(repr(val))
+        return hash(tuple(hash_components))
 
     @property
     def task_ids(self):

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1766,7 +1766,7 @@ class DAG(object):
             'tasks',
             'parent_dag',
             'start_date',
-            'schedule_interval'
+            'schedule_interval',
             'full_filepath',
             'template_searchpath',
             'last_loaded',


### PR DESCRIPTION
Something strange happened to my last PR -- a bad reset wiped it out -- so I'm splitting out the necessary functionality from the wishful ones. 

This PR makes tasks and dags comparable in Python 3 (Py3 ignores `__cmp__`, so it's impossible for two DAGs to be equal to each other in the `==` sense, much less any other comparison). It also supplies a `__hash__` implementation, which is required when providing a custom `__eq__` (otherwise both are based on `is`).
