### PR TITLE
[Fix] pluggable executor needs to be instantiated

### DIFF
--- a/airflow/executors/__init__.py
+++ b/airflow/executors/__init__.py
@@ -21,7 +21,7 @@ else:
     for _executor in _executors:
         globals()[_executor.__name__] = _executor
     if _EXECUTOR in globals():
-        DEFAULT_EXECUTOR = globals()[_EXECUTOR]
+        DEFAULT_EXECUTOR = globals()[_EXECUTOR]()
     else:
         raise AirflowException("Executor {0} not supported.".format(_EXECUTOR))
 


### PR DESCRIPTION
I was working on a plugin and noticed that an executor class defined in a plugin doesn't get instantiated as the rest of them so I was getting this error when trying to use the executor from my plugin:

Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 10, in <module>
    args.func(args)
  File "/usr/local/lib/python2.7/dist-packages/airflow/bin/cli.py", line 263, in scheduler
    job.run()
  File "/usr/local/lib/python2.7/dist-packages/airflow/jobs.py", line 159, in run
    self._execute()
  File "/usr/local/lib/python2.7/dist-packages/airflow/jobs.py", line 473, in _execute
    executor.start()
TypeError: unbound method start() must be called with ECSExecutor instance as first argument (got nothing instead)

Here's a simple fix for this problem.
