### PR TITLE
Py3 compatibility: BashOperator sentinel

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -57,7 +57,7 @@ class BashOperator(BaseOperator):
                 self.sp = sp
 
                 logging.info("Output:")
-                for line in iter(sp.stdout.readline, ''):
+                for line in iter(sp.stdout.readline, b''):
                     logging.info(line.strip())
                 sp.wait()
                 logging.info("Command exited with "


### PR DESCRIPTION
Without explicit bytes, this line can cause an infinite loop in Py3. Should not impact Py2 since 
`('' is b'') == True` in Py2
