### PR TITLE
#317 Multi-tenant web UI

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -38,6 +38,7 @@ defaults = {
         'web_server_host': '0.0.0.0',
         'web_server_port': '8080',
         'authenticate': False,
+        'filter_by_owner': False,
         'demo_mode': False,
         'secret_key': 'airflowified',
         'expose_config': False,
@@ -115,6 +116,11 @@ secret_key = temporary_key
 # Expose the configuration file in the web server
 expose_config = true
 
+# Set to true to turn on authentication : http://pythonhosted.org/airflow/installation.html#web-authentication
+authenticate = False
+
+# Filter the list of dags by owner name (requires authentication to be enabled)
+filter_by_owner = False
 
 [smtp]
 # If you want airflow to send emails on retries, failure, and you want to

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -152,3 +152,15 @@ exposes a set of hooks in the ``airflow.default_login`` module. You can
 alter the content of this module by overriding it as a ``airflow_login``
 module. To do this, you would typically copy/paste ``airflow.default_login``
 in a ``airflow_login.py`` and put it directly in your ``PYTHONPATH``.
+You also need to set webserver.authenticate as true in your ``airflow.cfg``
+
+
+Multi-tenancy
+'''''''''''''
+
+You can filter the list of dags in webserver by owner name, when authentication
+is turned on, by setting webserver.filter_by_owner as true in your ``airflow.cfg``
+With this, when a user authenticates and logs into webserver, it will see only the dags 
+which it is owner of. A super_user, will be able to see all the dags although.
+This makes the web UI a multi-tenant UI, where a user will only be able to see dags
+created by itself.


### PR DESCRIPTION
Added a flag filter_by_owner in [webserver] section of airflow.cfg.
If it's set, and authentication is turned on, the UI filters the list of dags, to show only the ones which current_user is owner of.
This makes the web UI suitable for multi-tenant environment.
