### PR TITLE
Py3: urlparse doesn't exist

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+from future.standard_library import install_aliases
+install_aliases()
 from builtins import str
 from past.builtins import basestring
 from builtins import object, bytes
@@ -16,7 +18,7 @@ import re
 import signal
 import socket
 import sys
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 from sqlalchemy import (
     Column, Integer, String, DateTime, Text, Boolean, ForeignKey, PickleType,


### PR DESCRIPTION
Need to use the aliases from `future` to use the `urlparse` library (which is `urllib.parse` in Py3)
