### PR TITLE
use getboolean in jobs.py

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -23,7 +23,7 @@ ID_LEN = models.ID_LEN
 
 # Setting up a statsd client if needed
 statsd = None
-if conf.get('scheduler', 'statsd_on'):
+if conf.getboolean('scheduler', 'statsd_on'):
     from statsd import StatsClient
     statsd = StatsClient(
         host=conf.get('scheduler', 'statsd_host'),


### PR DESCRIPTION
Not using this, but I think it should be `getboolean`. Otherwise typing False in `airflow.cfg` will still trigger it.
