### PR TITLE
(Py3) Explicit bytes transformation for Fernet

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -17,7 +17,7 @@ except:
 
 def generate_fernet_key():
     try:
-        FERNET_KEY = Fernet.generate_key()
+        FERNET_KEY = Fernet.generate_key().decode()
     except NameError:
         FERNET_KEY = "cryptography_not_found_storing_passwords_in_plain_text"
     return FERNET_KEY

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -44,7 +44,7 @@ XCOM_RETURN_KEY = 'return_value'
 ENCRYPTION_ON = False
 try:
     from cryptography.fernet import Fernet
-    FERNET = Fernet(conf.get('core', 'FERNET_KEY'))
+    FERNET = Fernet(conf.get('core', 'FERNET_KEY').encode('utf-8'))
     ENCRYPTION_ON = True
 except:
     pass


### PR DESCRIPTION
Fixes a Py3 corner case when the Fernet key is generated automatically by a fresh install; it gets written as a literal bytes string in airflow.cfg (`’b”…”`). Fixed by explicitly converting to/from string.
