### PR TITLE
OracleHook: Add Oracle SQL Support

### DIFF
--- a/airflow/hooks/__init__.py
+++ b/airflow/hooks/__init__.py
@@ -23,6 +23,7 @@ _hooks = {
     'jdbc_hook': ['JdbcHook'],
     'dbapi_hook': ['DbApiHook'],
     'mssql_hook': ['MsSqlHook'],
+    'oracle_hook': ['OracleHook'],
 }
 
 _import_module_attrs(globals(), _hooks)

--- a/airflow/hooks/oracle_hook.py
+++ b/airflow/hooks/oracle_hook.py
@@ -1,0 +1,95 @@
+import cx_Oracle
+
+from airflow.hooks.dbapi_hook import DbApiHook
+
+class OracleHook(DbApiHook):
+    """
+    Interact with Oracle SQL Server.
+    """
+    conn_name_attr = 'oracle_conn_id'
+    default_conn_name = 'oracle_default'
+    supports_autocommit = False
+
+    def get_conn(self):
+        """
+        Returns a oracle connection object
+        """
+        conn = self.get_connection(self.oracle_conn_id)
+        try:
+            conn = cx_Oracle.connect(conn.login, conn.password, conn.host)
+        except:
+            dsn = conn.extra_dejson.get('dsn', None)
+            service_name = conn.extra_dejson.get('service_name', None)
+            dsn = cx_Oracle.makedsn(dsn, conn.port, service_name=service_name)
+            conn = cx_Oracle.connect(conn.login, conn.password, dsn=dsn)
+
+        return conn
+
+    def run(self, sql, autocommit = False, parameters = None):
+        """
+        Runs a command
+        """
+        conn = self.get_conn()
+        if self.supports_autocommit:
+            self.set_autocommit(conn, autocommit)
+        cur = conn.cursor()
+        cur.callproc('dbms_output.enable')
+        logging.info('Executing query {sql}'.format(**locals()))
+        cur.execute(sql)
+        conn.commit()
+        cur.close()
+        conn.close()
+
+    def get_pandas_df(self, sql, parameters = None):
+        """
+        Executes the sql and returns a pandas dataframe
+        """
+        import pandas.io.sql as psql
+        conn = self.get_conn()
+        df = psql.read_sql(sql, con=conn)
+        df.columns = df.columns.map(lambda x: x.lower())
+        conn.close()
+        return df
+
+    def insert_rows(self, table, rows, target_fields = None, commit_every = 1000):
+        """
+        A generic way to insert a set of tuples into a table,
+        the whole set of inserts is treated as one transaction
+        """
+        if target_fields:
+            target_fields = ', '.join(target_fields)
+            target_fields = '({})'.format(target_fields)
+        else:
+            target_fields = ''
+        conn = self.get_conn()
+        cur = conn.cursor()
+        if self.supports_autocommit:
+            cur.execute('SET autocommit = 0')
+        conn.commit()
+        i = 0
+        for row in rows:
+            i += 1
+            l = []
+            for cell in row:
+                if isinstance(cell, basestring):
+                    l.append("'" + str(cell).replace("'", "''") + "'")
+                elif cell is None:
+                    l.append('NULL')
+                elif isinstance(cell, numpy.datetime64):
+                    l.append("'" + str(cell) + "'")
+                elif isinstance(cell, datetime):
+                    l.append("'" + cell.isoformat() + "'")
+                else:
+                    l.append(str(cell))
+
+            values = tuple(l)
+            sql = 'INSERT /*+ APPEND */ INTO {0} {1} VALUES ({2})'.format(table, target_fields, ','.join(values))
+            cur.execute(sql)
+            if i % commit_every == 0:
+                conn.commit()
+                logging.info('Loaded {i} into {table} rows so far'.format(**locals()))
+
+        conn.commit()
+        cur.close()
+        conn.close()
+        logging.info('Done loading. Loaded a total of {i} rows'.format(**locals()))

--- a/airflow/hooks/oracle_hook.py
+++ b/airflow/hooks/oracle_hook.py
@@ -19,26 +19,12 @@ class OracleHook(DbApiHook):
         try:
             conn = cx_Oracle.connect(conn.login, conn.password, conn.host)
         except:
+            # add support for custom DSN connections
             dsn = conn.extra_dejson.get('dsn', None)
             service_name = conn.extra_dejson.get('service_name', None)
             dsn = cx_Oracle.makedsn(dsn, conn.port, service_name=service_name)
             conn = cx_Oracle.connect(conn.login, conn.password, dsn=dsn)
         return conn
-
-    def run(self, sql, autocommit = False, parameters = None):
-        """
-        Runs a command
-        """
-        conn = self.get_conn()
-        if self.supports_autocommit:
-            self.set_autocommit(conn, autocommit)
-        cur = conn.cursor()
-        cur.callproc('dbms_output.enable')
-        logging.info('Executing query {sql}'.format(**locals()))
-        cur.execute(sql)
-        conn.commit()
-        cur.close()
-        conn.close()
 
     def get_pandas_df(self, sql, parameters = None):
         """
@@ -47,7 +33,7 @@ class OracleHook(DbApiHook):
         import pandas.io.sql as psql
         conn = self.get_conn()
         df = psql.read_sql(sql, con=conn)
-        df.columns = df.columns.map(lambda x: x.lower())
+        df.columns = df.columns.map(lambda x: x.lower()) # lower column names to have same output as other hooks
         conn.close()
         return df
 

--- a/airflow/hooks/oracle_hook.py
+++ b/airflow/hooks/oracle_hook.py
@@ -1,11 +1,15 @@
 import cx_Oracle
-import logging
 
 from airflow.hooks.dbapi_hook import DbApiHook
+from builtins import str
+from past.builtins import basestring
+from datetime import datetime
+import numpy
+import logging
 
 class OracleHook(DbApiHook):
     """
-    Interact with Oracle SQL Server.
+    Interact with Oracle SQL.
     """
     conn_name_attr = 'oracle_conn_id'
     default_conn_name = 'oracle_default'
@@ -14,33 +18,32 @@ class OracleHook(DbApiHook):
     def get_conn(self):
         """
         Returns a oracle connection object
+        Optional parameters for using a custom DSN connection (instead of using a server alias from tnsnames.ora)
+        The dsn (data source name) is the TNS entry (from the Oracle names server or tnsnames.ora file) 
+        or is a string like the one returned from makedsn().
+        :param dsn: the host address for the Oracle server
+        :param service_name: the db_unique_name of the database that you are connecting to (CONNECT_DATA part of TNS)
+        You can set these parameters in the extra fields of your connection 
+        as in ``{ "dsn":"some.host.address" , "service_name":"some.service.name" }``
         """
         conn = self.get_connection(self.oracle_conn_id)
-        try:
-            conn = cx_Oracle.connect(conn.login, conn.password, conn.host)
-        except:
-            # add support for custom DSN connections
-            dsn = conn.extra_dejson.get('dsn', None)
-            service_name = conn.extra_dejson.get('service_name', None)
+        dsn = conn.extra_dejson.get('dsn', None)
+        service_name = conn.extra_dejson.get('service_name', None)
+        if dsn and service_name:            
             dsn = cx_Oracle.makedsn(dsn, conn.port, service_name=service_name)
             conn = cx_Oracle.connect(conn.login, conn.password, dsn=dsn)
+        else:
+            conn = cx_Oracle.connect(conn.login, conn.password, conn.host)
         return conn
-
-    def get_pandas_df(self, sql, parameters = None):
-        """
-        Executes the sql and returns a pandas dataframe
-        """
-        import pandas.io.sql as psql
-        conn = self.get_conn()
-        df = psql.read_sql(sql, con=conn)
-        df.columns = df.columns.map(lambda x: x.lower()) # lower column names to have same output as other hooks
-        conn.close()
-        return df
 
     def insert_rows(self, table, rows, target_fields = None, commit_every = 1000):
         """
         A generic way to insert a set of tuples into a table,
         the whole set of inserts is treated as one transaction
+        Changes from standard DbApiHook implementation:
+        - Oracle SQL queries in cx_Oracle can not be terminated with a semicolon (';')
+        - Replace NaN values with NULL using numpy.nan_to_num (not using is_nan() because of input types error for strings)
+        - Coerce datetime cells to Oracle DATETIME format during insert
         """
         if target_fields:
             target_fields = ', '.join(target_fields)
@@ -61,10 +64,12 @@ class OracleHook(DbApiHook):
                     l.append("'" + str(cell).replace("'", "''") + "'")
                 elif cell is None:
                     l.append('NULL')
+                elif type(cell) == float and numpy.isnan(cell): #coerce numpy NaN to NULL
+                    l.append('NULL')
                 elif isinstance(cell, numpy.datetime64):
                     l.append("'" + str(cell) + "'")
                 elif isinstance(cell, datetime):
-                    l.append("'" + cell.isoformat() + "'")
+                    l.append("to_date('" + cell.strftime('%Y-%m-%d %H:%M:%S') + "','YYYY-MM-DD HH24:MI:SS')")
                 else:
                     l.append(str(cell))
             values = tuple(l)

--- a/airflow/hooks/oracle_hook.py
+++ b/airflow/hooks/oracle_hook.py
@@ -1,4 +1,5 @@
 import cx_Oracle
+import logging
 
 from airflow.hooks.dbapi_hook import DbApiHook
 
@@ -22,7 +23,6 @@ class OracleHook(DbApiHook):
             service_name = conn.extra_dejson.get('service_name', None)
             dsn = cx_Oracle.makedsn(dsn, conn.port, service_name=service_name)
             conn = cx_Oracle.connect(conn.login, conn.password, dsn=dsn)
-
         return conn
 
     def run(self, sql, autocommit = False, parameters = None):
@@ -81,14 +81,12 @@ class OracleHook(DbApiHook):
                     l.append("'" + cell.isoformat() + "'")
                 else:
                     l.append(str(cell))
-
             values = tuple(l)
             sql = 'INSERT /*+ APPEND */ INTO {0} {1} VALUES ({2})'.format(table, target_fields, ','.join(values))
             cur.execute(sql)
             if i % commit_every == 0:
                 conn.commit()
                 logging.info('Loaded {i} into {table} rows so far'.format(**locals()))
-
         conn.commit()
         cur.close()
         conn.close()

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -388,6 +388,8 @@ class Connection(Base):
                 return hooks.JdbcHook(jdbc_conn_id=self.conn_id)
             elif self.conn_type == 'mssql':
                 return hooks.MsSqlHook(mssql_conn_id=self.conn_id)
+            elif self.conn_type == 'oracle':
+                return hooks.OracleHook(oracle_conn_id=self.conn_id)
         except:
             return None
 

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -52,6 +52,13 @@ def limit_sql(sql, limit, conn_type):
             {sql}
             ) qry
             """.format(**locals())
+        elif conn_type in ['oracle']:
+            sql = """\
+            SELECT * FROM (
+            {sql}
+            ) qry
+            WHERE ROWNUM <= {limit}
+            """.format(**locals())
         else:
             sql = """\
             SELECT * FROM (

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,10 @@ mssql = ['pymssql>=2.1.1', 'unicodecsv>=0.13.0']
 hdfs = ['snakebite>=2.4.13']
 slack = ['slackclient>=0.15']
 crypto = ['cryptography>=0.9.3']
+oracle = ['cx_Oracle>=5.1.2']
 
 all_dbs = postgres + mysql + hive + mssql + hdfs
-devel = all_dbs + doc + samba + s3 + ['nose'] + slack + crypto
+devel = all_dbs + doc + samba + s3 + ['nose'] + slack + crypto + oracle
 
 setup(
     name='airflow',
@@ -78,6 +79,7 @@ setup(
         'samba': samba,
         'slack': slack,
         'crypto': crypto,
+        'oracle': oracle,
     },
     author='Maxime Beauchemin',
     author_email='maximebeauchemin@gmail.com',


### PR DESCRIPTION
Basic set-up to add Oracle SQL support to Airflow as a Hook + additional code to make sure insert_rows, Data Profiling and Charts work
