### PR TITLE
added os.environ to the config parser

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -338,7 +338,7 @@ def test_mode():
     conf = ConfigParserWithDefaults(defaults)
     conf.read(TEST_CONFIG)
 
-conf = ConfigParserWithDefaults(defaults)
+conf = ConfigParserWithDefaults(defaults, os.environ)
 conf.read(AIRFLOW_CONFIG)
 if 'cryptography' in sys.modules and not conf.has_option('core', 'fernet_key'):
     logging.warning(textwrap.dedent("""


### PR DESCRIPTION
For some of the variables in the config file, this pull request will allow users to interpolate env variables. For example in airflow.cfg:

```
[core]
sql_alchemy_conn = %(DATABASE_URL)s
```
