### PR TITLE
add attachments support in EmailOperator

### DIFF
--- a/airflow/operators/email_operator.py
+++ b/airflow/operators/email_operator.py
@@ -28,13 +28,13 @@ class EmailOperator(BaseOperator):
             to,
             subject,
             html_content,
-            files=[],
+            files=None,
             *args, **kwargs):
         super(EmailOperator, self).__init__(*args, **kwargs)
         self.to = to
         self.subject = subject
         self.html_content = html_content
-        self.files = files
+        self.files = files or []
 
     def execute(self, context):
         send_email(self.to, self.subject, self.html_content, files=self.files)

--- a/airflow/operators/email_operator.py
+++ b/airflow/operators/email_operator.py
@@ -14,6 +14,8 @@ class EmailOperator(BaseOperator):
     :param html_content: content of the email (templated), html markup
         is allowed
     :type html_content: string
+    :param files: file names to attach in email
+    :type files: list
     """
 
     template_fields = ('subject', 'html_content')
@@ -26,11 +28,13 @@ class EmailOperator(BaseOperator):
             to,
             subject,
             html_content,
+            files=[],
             *args, **kwargs):
         super(EmailOperator, self).__init__(*args, **kwargs)
         self.to = to
         self.subject = subject
         self.html_content = html_content
+        self.files = files
 
     def execute(self, context):
-        send_email(self.to, self.subject, self.html_content)
+        send_email(self.to, self.subject, self.html_content, files=self.files)

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -354,7 +354,7 @@ def ask_yesno(question):
             print("Please respond by yes or no.")
 
 
-def send_email(to, subject, html_content, files=[]):
+def send_email(to, subject, html_content, files=None):
     SMTP_MAIL_FROM = conf.get('smtp', 'SMTP_MAIL_FROM')
 
     if isinstance(to, basestring):
@@ -372,7 +372,7 @@ def send_email(to, subject, html_content, files=[]):
     mime_text = MIMEText(html_content, 'html')
     msg.attach(mime_text)
 
-    for fname in files:
+    for fname in files or []:
         basename = os.path.basename(fname)
         with open(fname, "rb") as f:
             msg.attach(MIMEApplication(

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -5,6 +5,7 @@ from copy import copy
 from datetime import datetime, timedelta
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+from email.mime.application import MIMEApplication
 import errno
 from functools import wraps
 import imp
@@ -353,7 +354,7 @@ def ask_yesno(question):
             print("Please respond by yes or no.")
 
 
-def send_email(to, subject, html_content):
+def send_email(to, subject, html_content, files=[]):
     SMTP_MAIL_FROM = conf.get('smtp', 'SMTP_MAIL_FROM')
 
     if isinstance(to, basestring):
@@ -370,6 +371,15 @@ def send_email(to, subject, html_content):
     msg['To'] = ", ".join(to)
     mime_text = MIMEText(html_content, 'html')
     msg.attach(mime_text)
+
+    for fname in files:
+        basename = os.path.basename(fname)
+        with open(fname, "rb") as f:
+            msg.attach(MIMEApplication(
+                f.read(),
+                Content_Disposition='attachment; filename="%s"' % basename,
+                Name=basename
+            ))
 
     send_MIME_email(SMTP_MAIL_FROM, to, msg)
 


### PR DESCRIPTION
testcase passed in dag

``` py
from airflow.operators import EmailOperator
from airflow.models import DAG
from datetime import datetime, timedelta

seven_days_ago = datetime.combine(datetime.today() - timedelta(7),
                                  datetime.min.time())
args = {
    'owner': 'airflow',
    'start_date': seven_days_ago,
}

dag = DAG(dag_id='email_operator', default_args=args)

job = EmailOperator(
    to='ohmy@cry.cc',
    subject='Daily Report from Cooper(Data Team)',
    html_content='HelloWorld',
    files=['requirements.txt'],
    task_id='email_me',
    dag=dag,
)
```
