### PR TITLE
Added charset and cursor functionality to mysql hook

### DIFF
--- a/airflow/hooks/mysql_hook.py
+++ b/airflow/hooks/mysql_hook.py
@@ -1,4 +1,5 @@
 import MySQLdb
+import MySQLdb.cursors
 
 from airflow.hooks.dbapi_hook import DbApiHook
 
@@ -6,6 +7,10 @@ from airflow.hooks.dbapi_hook import DbApiHook
 class MySqlHook(DbApiHook):
     '''
     Interact with MySQL.
+
+    You can specify charset in the extra field of your connection
+    as ``{"charset": "utf8"}``. Also you can choose cursor as
+    ``{"cursor": "SSCursor"}``. Refer to the MySQLdb.cursors for more details.
     '''
 
     conn_name_attr = 'mysql_conn_id'
@@ -17,14 +22,30 @@ class MySqlHook(DbApiHook):
         Returns a mysql connection object
         """
         conn = self.get_connection(self.mysql_conn_id)
+        conn_config = {
+            "user": conn.login,
+            "passwd": conn.password
+        }
+
+        conn_config["host"] = conn.host or 'localhost'
         if not conn.port:
-            port = 3306
+            conn_config["port"] = 3306
         else:
-            port = int(conn.port)
-        conn = MySQLdb.connect(
-            host=conn.host,
-            port=port,
-            user=conn.login,
-            passwd=conn.password,
-            db=conn.schema)
+            conn_config["port"] = int(conn.port)
+        if conn.schema:
+            conn_config["db"] = conn.schema
+        if conn.extra_dejson.get('charset', False):
+            conn_config["charset"] = conn.extra_dejson["charset"]
+            if (conn_config["charset"]).lower() == 'utf8' or\
+                    (conn_config["charset"]).lower() == 'utf-8':
+                conn_config["use_unicode"] = True
+        if conn.extra_dejson.get('cursor', False):
+            if (conn.extra_dejson["cursor"]).lower() == 'sscursor':
+                conn_config["cursorclass"] = MySQLdb.cursors.SSCursor
+            elif (conn.extra_dejson["cursor"]).lower() == 'dictcursor':
+                conn_config["cursorclass"] = MySQLdb.cursors.DictCursor
+            elif (conn.extra_dejson["cursor"]).lower() == 'ssdictcursor':
+                conn_config["cursorclass"] = MySQLdb.cursors.SSDictCursor
+
+        conn = MySQLdb.connect(**conn_config)
         return conn


### PR DESCRIPTION
Added some functionality to mysql_hook.
- Relaxed requirements for connection, only user and password is needed. Default host is localhost, default port 3306, default db is unnecessary.
- Added charset support, specifically 'utf-8', through extra field in connection.
- Added cursor selection through "extra" field in connection. SSCursor is especially important, when dealing with large datasets.
