### PR TITLE
Enable schedule_interval to support dateutil.relativedelta.relativedelta (monthly DAGs!)

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1768,8 +1768,11 @@ class DAG(object):
 
     :param dag_id: The id of the DAG
     :type dag_id: string
-    :param schedule_interval: Defines how often that DAG runs
-    :type schedule_interval: datetime.timedelta
+    :param schedule_interval: Defines how often that DAG runs, this
+        timedelta object gets added to your latest task instance's
+        execution_date to figure out the next schedule
+    :type schedule_interval: datetime.timedelta or
+        dateutil.relativedelta.relativedelta
     :param start_date: The timestamp from which the scheduler will
         attempt to backfill
     :type start_date: datetime.datetime

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -558,7 +558,7 @@ def round_time(dt, delta, start_date=datetime.min):
         if start_date + (lower + 1)*delta > dt:
             # Check if start_date + (lower + 1)*delta or
             # start_date + lower*delta is closer to dt and return the solution
-            if (start_date + (lower + 1)*delta) - dt < dt - (start_date + lower*delta):
+            if (start_date + (lower + 1)*delta) - dt <= dt - (start_date + lower*delta):
                 return start_date + (lower + 1)*delta
             else:
                 return start_date + lower*delta

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -521,8 +521,24 @@ def as_tuple(obj):
         return tuple([obj])
 
 
-def round_time(dt, delta):
-    delta = delta.total_seconds()
-    seconds = (dt - dt.min).seconds
-    rounding = (seconds + delta / 2) // delta * delta
-    return dt + timedelta(0, rounding - seconds, -dt.microsecond)
+def round_time(dt, delta, start_date=datetime.min):
+    dt -= timedelta(microseconds = dt.microsecond)
+
+    upper = 1
+    while start_date + upper*delta < dt:
+        upper *= 2
+
+    lower = upper // 2
+
+    while True:
+        if start_date + (lower + 1)*delta > dt:
+            if (start_date + (lower + 1)*delta) - dt < dt - (start_date + lower*delta):
+                return start_date + (lower + 1)*delta
+            else:
+                return start_date + lower*delta
+
+        candidate = lower + (upper - lower) // 2
+        if start_date + candidate*delta > dt:
+            upper = candidate
+        else:
+            lower = candidate

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -522,23 +522,55 @@ def as_tuple(obj):
 
 
 def round_time(dt, delta, start_date=datetime.min):
+    """
+    Returns the datetime of the form start_date + i * delta
+    which is closest to dt for any non-negative integer i.
+    """
+    # Ignore the microseconds of dt
     dt -= timedelta(microseconds = dt.microsecond)
 
+    # We are looking for a datetime in the form start_date + i * delta
+    # which is as close as possible to dt. Since delta could be a relative
+    # delta we don't know it's exact length in seconds so we cannot rely on
+    # division to find i. Instead we employ a binary search algorithm, first
+    # finding an upper and lower limit and then disecting the interval until
+    # we have found the closest match.
+
+    # We first search an upper limit for i for which start_date + upper * delta
+    # exceeds dt.
     upper = 1
     while start_date + upper*delta < dt:
+        # To speed up finding an upper limit we grow this exponentially by a
+        # factor of 2
         upper *= 2
 
+    # Since upper is the first value for which start_date + upper * delta
+    # exceeds dt, upper // 2 is below dt and therefore forms a lower limited
+    # for the i we are looking for
     lower = upper // 2
 
+    # We now continue to intersect the interval between
+    # start_date + lower * delta and start_date + upper * delta
+    # until we find the closest value
     while True:
+        # If start_date + (lower + 1)*delta exceeds dt, then either lower or
+        # lower+1 has to be the solution we are searching for
         if start_date + (lower + 1)*delta > dt:
+            # Check if start_date + (lower + 1)*delta or
+            # start_date + lower*delta is closer to dt and return the solution
             if (start_date + (lower + 1)*delta) - dt < dt - (start_date + lower*delta):
                 return start_date + (lower + 1)*delta
             else:
                 return start_date + lower*delta
 
+        # We intersect the interval and either replace the lower or upper
+        # limit with the candidate
         candidate = lower + (upper - lower) // 2
         if start_date + candidate*delta > dt:
             upper = candidate
         else:
             lower = candidate
+
+    # in the special case when start_date > dt the search for upper will
+    # immediately stop for upper == 1 which results in lower = upper // 2 = 0
+    # and this function returns start_date.

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -3,6 +3,7 @@ from builtins import str, input, object
 from past.builtins import basestring
 from copy import copy
 from datetime import datetime, timedelta
+from dateutil.relativedelta import relativedelta  # for doctest
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.mime.application import MIMEApplication
@@ -525,6 +526,13 @@ def round_time(dt, delta, start_date=datetime.min):
     """
     Returns the datetime of the form start_date + i * delta
     which is closest to dt for any non-negative integer i.
+
+    Note that delta may be a datetime.timedelta or a dateutil.relativedelta
+
+    >>> round_time(datetime(2015, 1, 1, 6), timedelta(days=1))
+    datetime.datetime(2015, 1, 1, 0, 0)
+    >>> round_time(datetime(2015, 1, 2), relativedelta(months=1))
+    datetime.datetime(2015, 1, 1, 0, 0)
     """
     # Ignore the microseconds of dt
     dt -= timedelta(microseconds = dt.microsecond)

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1047,6 +1047,10 @@ class Airflow(BaseView):
 
         session = settings.Session()
 
+        start_date = dag.start_date
+        if not start_date and 'start_date' in dag.default_args:
+            start_date = dag.default_args['start_date']
+
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
         num_runs = int(num_runs) if num_runs else 25
@@ -1063,10 +1067,10 @@ class Airflow(BaseView):
             start_date = dag.default_args['start_date']
 
         if start_date:
-            difference = base_date - start_date
-            offset = timedelta(seconds=int(difference.total_seconds() % dag.schedule_interval.total_seconds()))
-            base_date -= offset
-            base_date -= timedelta(microseconds=base_date.microsecond)
+            base_date = utils.round_time(base_date, dag.schedule_interval, start_date)
+        else:
+            base_date = utils.round_time(base_date, dag.schedule_interval)
+
 
         from_date = (base_date - (num_runs * dag.schedule_interval))
 

--- a/airflow/www/templates/airflow/ti_code.html
+++ b/airflow/www/templates/airflow/ti_code.html
@@ -8,7 +8,7 @@
         {{ html_code|safe }}
     {% endif %}
     {% if code %}
-        <pre>{{ code }}</pre>
+        <pre>{{ code.decode('utf8') }}</pre>
     {% endif %}
 
     {% if code_dict %}

--- a/airflow/www/templates/airflow/ti_code.html
+++ b/airflow/www/templates/airflow/ti_code.html
@@ -8,7 +8,7 @@
         {{ html_code|safe }}
     {% endif %}
     {% if code %}
-        <pre>{{ code.decode('utf8') }}</pre>
+        <pre>{{ code }}</pre>
     {% endif %}
 
     {% if code_dict %}


### PR DESCRIPTION
This is a local version of
https://github.com/airbnb/airflow/pull/345

It enables relative schedule_interval, as in "the first of the month" or "the first of the year"

Thanks @markusschmaus!
