### PR TITLE
Don't warn if start_date is None

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1344,7 +1344,7 @@ class BaseOperator(object):
         self.email_on_retry = email_on_retry
         self.email_on_failure = email_on_failure
         self.start_date = start_date
-        if not isinstance(start_date, datetime):
+        if start_date is not None and not isinstance(start_date, datetime):
             logging.warning(
                 "start_date for {} isn't datetime.datetime".format(self))
         self.end_date = end_date


### PR DESCRIPTION
Tasks are not required to have a `start_date` (the default value is `None` and as long as a DAG has a `start_date`, tasks will run fine), so raising a warning here for non-datetimes is over-eager. If `None` is a valid default parameter, it shouldn't raise a warning. 
