### PR TITLE
more informative error message

### DIFF
--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -429,8 +429,9 @@ def import_module_attrs(parent_module_globals, module_attrs_dict):
             for attr in attrs:
                 parent_module_globals[attr] = getattr(module, attr)
                 imported_attrs += [attr]
-        except:
-            logging.debug("Couldn't import module " + mod)
+        except Exception as err:
+            logging.debug("Error importing module {mod}: {err}".format(
+                mod=mod, err=err))
     return imported_attrs
 
 


### PR DESCRIPTION
Especially when adding plugins, the suppressed error messages make it difficult to understand why imports fail -- this makes it a little easier.
