### PR TITLE
Allow MesosExecutor to re-register with Mesos

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -224,6 +224,12 @@ task_memory = 256
 # See http://mesos.apache.org/documentation/latest/slave-recovery/
 checkpoint = False
 
+# Failover timeout in milliseconds.
+# When checkpointing is enabled and this option is set, Mesos waits until the configured timeout for
+# the MesosExecutor framework to re-register after a failover. Mesos shuts down running tasks if the
+# MesosExecutor framework fails to re-register within this timeframe.
+# failover_timeout = 604800
+
 # Enable framework authentication for mesos
 # See http://mesos.apache.org/documentation/latest/configuration/
 authenticate = False

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1732,6 +1732,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
             ('samba', 'Samba',),
             ('sqlite', 'Sqlite',),
             ('mssql', 'Microsoft SQL Server'),
+            ('mesos_framework-id', 'Mesos Framework ID'),
         ]
     }
 


### PR DESCRIPTION
This PR adds the ability to re-register the framework of the
MesosExecutor with Mesos. That way tasks on Mesos keep running while
the Scheduler is being restarted.

It also fixes some PEP8 style issues in `mesos_executor.py`.
