### PR TITLE
import BaseHook in airflow.hooks

### DIFF
--- a/airflow/hooks/__init__.py
+++ b/airflow/hooks/__init__.py
@@ -28,7 +28,7 @@ _hooks = {
 }
 
 _import_module_attrs(globals(), _hooks)
-
+from airflow.hooks.base_hook import BaseHook
 
 def integrate_plugins():
     """Integrate plugins to the context"""


### PR DESCRIPTION
Analogous to how `airflow.operators` exposes `BaseOperator` directly; it's a cleaner and more consistent API for subclassing:

``` python
# existing
class MyOperator(airflow.operators.BaseOperator):
    pass

# this PR
class MyHook(airflow.hooks.BaseHook):
    pass
```
