### PR TITLE
MySQLDB falls back on pymysql

### DIFF
--- a/airflow/hooks/mysql_hook.py
+++ b/airflow/hooks/mysql_hook.py
@@ -1,7 +1,13 @@
-import pymysql
-import pymysql.cursors
-
 from airflow.hooks.dbapi_hook import DbApiHook
+try:
+    import MySQLdb as mysql
+    import MySQLdb.cursors as cursors
+except ImportError as e:
+    logging.debug("MySQLdb not installed, falling back on pymysql")
+    import pymysql as mysql
+    import pymysql.cursors as cursors
+
+
 
 class MySqlHook(DbApiHook):
     '''
@@ -9,7 +15,7 @@ class MySqlHook(DbApiHook):
 
     You can specify charset in the extra field of your connection
     as ``{"charset": "utf8"}``. Also you can choose cursor as
-    ``{"cursor": "SSCursor"}``. Refer to the pymysql.cursors for more details.
+    ``{"cursor": "SSCursor"}``. Refer to the driver's doc for more details.
     '''
 
     conn_name_attr = 'mysql_conn_id'
@@ -40,11 +46,11 @@ class MySqlHook(DbApiHook):
                 conn_config["use_unicode"] = True
         if conn.extra_dejson.get('cursor', False):
             if (conn.extra_dejson["cursor"]).lower() == 'sscursor':
-                conn_config["cursorclass"] = pymysql.cursors.SSCursor
+                conn_config["cursorclass"] = cursors.SSCursor
             elif (conn.extra_dejson["cursor"]).lower() == 'dictcursor':
-                conn_config["cursorclass"] = pymysql.cursors.DictCursor
+                conn_config["cursorclass"] = cursors.DictCursor
             elif (conn.extra_dejson["cursor"]).lower() == 'ssdictcursor':
-                conn_config["cursorclass"] = pymysql.cursors.SSDictCursor
+                conn_config["cursorclass"] = cursors.SSDictCursor
 
-        conn = pymysql.connect(**conn_config)
+        conn = mysql.connect(**conn_config)
         return conn

--- a/airflow/hooks/mysql_hook.py
+++ b/airflow/hooks/mysql_hook.py
@@ -1,8 +1,7 @@
-import MySQLdb
-import MySQLdb.cursors
+import pymysql
+import pymysql.cursors
 
 from airflow.hooks.dbapi_hook import DbApiHook
-
 
 class MySqlHook(DbApiHook):
     '''
@@ -10,7 +9,7 @@ class MySqlHook(DbApiHook):
 
     You can specify charset in the extra field of your connection
     as ``{"charset": "utf8"}``. Also you can choose cursor as
-    ``{"cursor": "SSCursor"}``. Refer to the MySQLdb.cursors for more details.
+    ``{"cursor": "SSCursor"}``. Refer to the pymysql.cursors for more details.
     '''
 
     conn_name_attr = 'mysql_conn_id'
@@ -41,11 +40,11 @@ class MySqlHook(DbApiHook):
                 conn_config["use_unicode"] = True
         if conn.extra_dejson.get('cursor', False):
             if (conn.extra_dejson["cursor"]).lower() == 'sscursor':
-                conn_config["cursorclass"] = MySQLdb.cursors.SSCursor
+                conn_config["cursorclass"] = pymysql.cursors.SSCursor
             elif (conn.extra_dejson["cursor"]).lower() == 'dictcursor':
-                conn_config["cursorclass"] = MySQLdb.cursors.DictCursor
+                conn_config["cursorclass"] = pymysql.cursors.DictCursor
             elif (conn.extra_dejson["cursor"]).lower() == 'ssdictcursor':
-                conn_config["cursorclass"] = MySQLdb.cursors.SSDictCursor
+                conn_config["cursorclass"] = pymysql.cursors.SSDictCursor
 
-        conn = MySQLdb.connect(**conn_config)
+        conn = pymysql.connect(**conn_config)
         return conn

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,12 +18,12 @@ ipython
 jinja2
 librabbitmq
 markdown
-mysql-python
 nose
 pandas
 pygments
 pyhive
 pydruid
+pymysql
 PySmbClient
 python-dateutil
 #pyhs2

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ hive = [
     'pyhive>=0.1.3',
     'pyhs2>=0.6.0',
 ]
-mysql = ['mysql-python>=1.2.5']
+mysql = ['pymysql>=0.6.6']
 postgres = ['psycopg2>=2.6']
 optional = ['librabbitmq>=1.6.1']
 samba = ['pysmbclient>=0.1.3']


### PR DESCRIPTION
@LilithWittmann , I decided to privilege MySQLDB over pymysql since it's written in C and probably is more optimized and less disruptive overall to keep it as deps in `extras_require` don't get applied unless specified.

I still left `pymysql` in `setup.py` though for py3 compatibility, people can install MySQLDB if they prefer it for some reason.

Original PR: https://github.com/airbnb/airflow/pull/424
