### PR TITLE
Allow XCom push from BashOperator

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -27,10 +27,20 @@ class BashOperator(BaseOperator):
     ui_color = '#f0ede4'
 
     @apply_defaults
-    def __init__(self, bash_command, env=None, *args, **kwargs):
+    def __init__(
+            self,
+            bash_command,
+            xcom_push=False,
+            env=None,
+            *args, **kwargs):
+        """
+        If xcom_push is True, the last line written to stdout will also
+        be pushed to an XCom when the bash command completes.
+        """
         super(BashOperator, self).__init__(*args, **kwargs)
         self.bash_command = bash_command
         self.env = env
+        self.xcom_push = xcom_push
 
     def execute(self, context):
         """
@@ -65,6 +75,9 @@ class BashOperator(BaseOperator):
 
                 if sp.returncode:
                     raise AirflowException("Bash command failed")
+
+        if self.xcom_push:
+            return str(line.strip())
 
     def on_kill(self):
         logging.info('Sending SIGTERM signal to bash subprocess')

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -67,6 +67,7 @@ class BashOperator(BaseOperator):
                 self.sp = sp
 
                 logging.info("Output:")
+                line = ''
                 for line in iter(sp.stdout.readline, b''):
                     logging.info(line.strip())
                 sp.wait()


### PR DESCRIPTION
Simple PR to better leverage XComs in BashOperators.

If `xcom_push=True` is passed to the `BashOperator`, then the last line of stdout is automatically pushed to an XCom. So users can quickly pass information (like a filename, url, last modified date, etc.) to other tasks by `echo`ing it at the end of their scripts.
