### PR TITLE
ContentEmailOperator: rich HTML emails with Matplotlib graphs as images

### DIFF
--- a/airflow/contrib/operators/content_email_components.py
+++ b/airflow/contrib/operators/content_email_components.py
@@ -1,0 +1,75 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import pandas as pd
+import subprocess
+import os
+import logging
+
+def dataTable(data,dim_name, metric_name):
+	#infer which range of dates is available for width of table
+	date_list = []
+	date_list_formatted = []
+	for row in data:
+		if row['ds'] in date_list:
+			break
+		else:
+			date_list.append(row['ds'])
+			if row['ds'][5] == '0':
+				date_list_formatted.append(row['ds'][6:])
+			else:
+				date_list_formatted.append(row['ds'][5:])
+	
+	cnum = 0 #column number
+	width = len(date_list)
+	output = '''<table 
+					border="1" 
+					style="	border-collapse: collapse;
+							border-top: none;
+							font-family: Tahoma, Arial, Verdana, sans-serif;
+							font-size:12px; " 
+					cellpadding="3" 
+					cellspacing="0" 
+					width='775px'>'''
+	date_options = '''<td align="center" style="font-style: italic;">'''
+	date_headers = ''.join(map(lambda x: date_options + x + '</td>',date_list_formatted))
+	output += '<tr bgcolor="#ccc"><td></td>' + date_headers + '</tr>' #first row
+	for row in data:
+		cnum += 1
+
+		if int(row[metric_name]) == 0:
+			value = '-'
+			align = 'center'
+		else:
+			value = "{:,}".format(int(row[metric_name]))
+			align = 'right'
+
+		if cnum == 1:
+			output += '<tr><td>' + row[dim_name] + '</td>' #dim name on first column
+			output += '<td align="' + align + '">' + value + '</td>'
+		elif cnum == width:
+			output += '<td align="' + align + '"><b>' + value + '</b></td>' #bold last column
+			cnum = 0 #reset counter
+		else:
+			output += '<td align="' + align + '">' + value + '</td>'
+	output += '</table>' 
+	return output
+
+def line_graph(data,metric_name,chart_id,title):
+	#infer which range of dates is available for width of table
+	date_list = []
+	for row in data:
+		if row['ds'] in date_list:
+			break
+		else:
+			date_list.append(row['ds'])
+	rng = pd.date_range(date_list[0], periods=len(date_list), freq='D')
+	logging.info(os.path.dirname(os.path.realpath(__file__)))
+	img_dir = '/tmp/'
+	pd.Series(map(lambda x: int(x[metric_name]),data), index=rng).plot(figsize=(8,3),fontsize=10,style=['k'])
+	plt.title(title,size=10)
+	plt.tight_layout()
+	locs,labels = plt.yticks()
+	plt.yticks(locs, map(lambda x: "{:,}".format(int(x)), locs))	
+	plt.savefig(img_dir + chart_id + '.png')
+	return '<img src="cid:{id}"/>'.format(id=chart_id)

--- a/airflow/contrib/operators/content_email_operator.py
+++ b/airflow/contrib/operators/content_email_operator.py
@@ -1,0 +1,104 @@
+from airflow.models import BaseOperator
+from airflow.utils import send_MIME_email
+from airflow.utils import apply_defaults
+from airflow.hooks import PrestoHook
+from email.MIMEMultipart import MIMEMultipart
+from email.MIMEText import MIMEText
+from email.MIMEImage import MIMEImage
+import logging
+import jinja2
+import os
+import contrib.content_email_components as content_email_components
+import subprocess
+
+class ContentEmailOperator(BaseOperator):
+
+    template_fields = ('data','subject','variables')
+    template_ext = ('.sql')
+    ui_color = '#f0ede4'
+
+    @apply_defaults
+    def __init__(
+            self,
+            to,
+            subject,
+            data,
+            template,
+            variables,
+            presto_conn_id='presto_default',
+            *args, **kwargs):
+        super(ContentEmailOperator, self).__init__(*args, **kwargs)
+        self.to = to
+        self.subject = subject
+        self.presto_conn_id = presto_conn_id
+        self.data = data
+        self.template = template
+        self.variables = variables
+
+
+    def formatData(self,df):
+        output = []
+        for i in range(len(df)):
+            row = {}
+            for col in list(df.columns):
+                row[col] = df[col][i]
+            output.append(row)
+        return output
+
+    def run(self,cmd):
+        subprocess.Popen(cmd, shell=True).wait()
+
+    def mkdir_local(self,name):
+        self.run('mkdir {dir}'.format(dir=name))
+
+    def rmdir_local(self,name):
+        self.run('rm -R {dir}'.format(dir=name))
+
+    def execute(self, context):
+        #data
+        data = {}
+        hook = PrestoHook(presto_conn_id=self.presto_conn_id)
+        for source, query in self.data.iteritems():
+            data[source] = self.formatData(hook.get_pandas_df(query))
+
+        #HTML template rendering
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader(os.path.dirname(self.template)))
+        env.globals['lib'] = content_email_components
+        template = env.get_template(os.path.basename(self.template))
+        cur_dir = '/tmp/'
+        #self.mkdir_local(cur_dir + '/images')
+        logging.info(os.path.dirname(os.path.realpath(__file__)))
+        html = template.render({"data":data,"variables" :self.variables })
+
+        #boilerplate email stuff
+        strFrom = 'alerts@airbnb.com'
+        strTo = ','.join(self.to)
+        msgRoot = MIMEMultipart('related')
+        msgRoot['Subject'] = self.subject
+        msgRoot['From'] = strFrom
+        msgRoot['To'] = strTo
+        msgAlternative = MIMEMultipart('alternative')
+        msgRoot.attach(msgAlternative)
+        msgText = MIMEText('This is the alternative plain text message.')
+        msgAlternative.attach(msgText)
+        msgText = MIMEText(html, 'html')
+        msgAlternative.attach(msgText)
+
+        # attach all images to email
+        
+        for file in os.listdir(cur_dir):
+            if '.png' in file:
+                fp = open(cur_dir + file, 'rb')
+                msgImage = MIMEImage(fp.read())
+                fp.close()
+                msgImage.add_header('Content-ID', '<' + file[:-4] + '>')
+                msgRoot.attach(msgImage)
+
+        #send email
+        send_MIME_email(strFrom,strTo,msgRoot)
+
+        #clean up
+        #self.rmdir_local('images')
+        
+
+


### PR DESCRIPTION
(Intended as an initial draft since the current approach is pretty hacky <- @mistercrunch )

Usage in a DAG:

```
email = ContentEmailOperator(
        task_id='email',
        to=[
            'plt@rdif.me'
        ],
        subject='Report for {{ ds }}',
        template=os.path.join(cur_dir, 'email.html'),
        data={
            'by_type' : 'sql/by_type.sql',
            'all' : 'sql/all.sql'
        },
        variables={
            'ds' : '{{ ds }}'
        },
        default_args=args)
```

In this case email.html is a Jinja template with specific macros to generate the matplotlib images. The data dict is simply Presto queries now (but could be generalized).

e.g. email.html

```
<table>
    <tr bgcolor="ff5a5f" height="50px" width="775px">
        <td align="center" style="font-family: Tahoma, Arial, Verdana, sans-serif;font-size:18px;">
            <font color="white">
                Daily Report for {{ variables['ds'] }}
            </font>
        </td>
    </tr>

    <tr height="5px" ></tr>

    <tr> 
        <td>
            {{ lib.line_graph(data['events'], 'event_count','linechartnew','Events Per Day') }}
        </td>
    </tr>

    <tr height="10px" bgcolor="#ccc" align="right" style="font-family: Tahoma, Arial, Verdana, sans-serif;font-size:12px;">
        <td>
            <font color="white">
                brought to you by #data-engineering
            </font>
        </td>
    </tr>
</table>
```
