### PR TITLE
Changing the default base date of the Tree View

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1055,7 +1055,7 @@ class Airflow(BaseView):
         num_runs = int(num_runs) if num_runs else 25
 
         if not base_date:
-            base_date = dag.latest_execution_date or datetime.now()
+            base_date = (dag.latest_execution_date + 2 * dag.schedule_interval) or datetime.now()
         else:
             base_date = dateutil.parser.parse(base_date)
         base_date = utils.round_time(base_date, dag.schedule_interval)

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1055,7 +1055,11 @@ class Airflow(BaseView):
         num_runs = int(num_runs) if num_runs else 25
 
         if not base_date:
-            base_date = (dag.latest_execution_date + 2 * dag.schedule_interval) or datetime.now()
+            # New DAGs will not have a latest execution date
+            if dag.latest_execution_date:
+                base_date = dag.latest_execution_date + 2 * dag.schedule_interval
+            else:
+                base_date = datetime.now()
         else:
             base_date = dateutil.parser.parse(base_date)
         base_date = utils.round_time(base_date, dag.schedule_interval)


### PR DESCRIPTION
This PR intends to solve the following pain points:
1. We have a daily DAG with a non-midnight start date. When we click on the Tree View icon on http://myairflowinstance.com/admin/, rightmost DAG instance in the Tree View is not the latest instance of the DAG. It is the second to latest instance.
2. For other DAGs with midnight start dates, the Tree View rightmost DAG instance is often a fully finished DAG instance. It is nice to see at least one column of an un-started DAG instance. This makes it clear what the next DAG instance is and when it will run.

In other words, we currently see this:
![screen shot 2015-09-23 at 2 22 51 pm](https://cloud.githubusercontent.com/assets/1062379/10059401/a2c79a08-61ff-11e5-8cc1-8760e59b5a2e.png)
But this is clearer:
![screen shot 2015-09-23 at 2 30 51 pm](https://cloud.githubusercontent.com/assets/1062379/10059434/cd984cb4-61ff-11e5-9e28-5bac813efc76.png)
