### PR TITLE
print traceback for internal server error

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -14,6 +14,7 @@ import os
 import socket
 import sys
 import time
+import traceback
 
 from flask._compat import PY2
 from flask import (
@@ -716,6 +717,11 @@ class Airflow(BaseView):
     @app.errorhandler(404)
     def circles(self):
         return render_template('airflow/circles.html'), 404
+
+    @app.errorhandler(500)
+    def show_traceback(self):
+        return render_template(
+            'airflow/traceback.html', info=traceback.format_exc()), 500
 
     @expose('/sandbox')
     @login_required

--- a/airflow/www/templates/airflow/traceback.html
+++ b/airflow/www/templates/airflow/traceback.html
@@ -1,0 +1,5 @@
+<h1> Internal Server Error </h1>
+
+<div>
+    <pre>{{ info }}</pre>
+</div>


### PR DESCRIPTION
@mistercrunch adds a simple view to show the traceback for an internal server error when running the webserver in production mode.
