### PR TITLE
small improvements to slack operator. fixed templating.

### DIFF
--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -48,7 +48,7 @@ _operators = {
     'jdbc_operator': ['JdbcOperator'],
     'mssql_operator': ['MsSqlOperator'],
     'mssql_to_hive': ['MsSqlToHiveTransfer'],
-    'slack_operator': ['SlackAPIPostOperator', 'SlackAPIOperator'],
+    'slack_operator': ['SlackAPIOperator', 'SlackAPIPostOperator'],
     'generic_transfer': ['GenericTransfer'],
 }
 

--- a/airflow/operators/slack_operator.py
+++ b/airflow/operators/slack_operator.py
@@ -13,20 +13,20 @@ class SlackAPIOperator(BaseOperator):
     :type token: string
     :param method: The Slack API Method to Call (https://api.slack.com/methods)
     :type method: string
-    :param api_call_params: API Method call parameters (https://api.slack.com/methods)
-    :type api_call_params: dict
+    :param params: API Method call parameters (https://api.slack.com/methods)
+    :type params: dict
     """
 
     @apply_defaults
     def __init__(self,
                  token='unset',
                  method='unset',
-                 api_call_params=None,
+                 params=None,
                  *args, **kwargs):
         super(SlackAPIOperator, self).__init__(*args, **kwargs)
         self.token = token
         self.method = method
-        self.api_call_params = api_call_params
+        self.params = params
 
     def construct_api_call_params(self):
         """
@@ -44,14 +44,10 @@ class SlackAPIOperator(BaseOperator):
         SlackAPIOperator calls will not fail even if the call is not unsuccessful.
         It should not prevent a DAG from completing in success
         """
-
-        try:
-            if not self.api_call_params:
-                self.construct_api_call_params()
-            sc = SlackClient(self.token)
-            sc.api_call(self.method, **self.api_call_params)
-        except Exception:
-            pass
+        if not self.params:
+            self.construct_api_call_params()
+        sc = SlackClient(self.token)
+        sc.api_call(self.method, **self.params)
 
 
 class SlackAPIPostOperator(SlackAPIOperator):
@@ -89,7 +85,7 @@ class SlackAPIPostOperator(SlackAPIOperator):
                                                    *args, **kwargs)
 
     def construct_api_call_params(self):
-        self.api_call_params = {
+        self.params = {
             'channel': self.channel,
             'username': self.username,
             'text': self.text,

--- a/airflow/operators/slack_operator.py
+++ b/airflow/operators/slack_operator.py
@@ -1,5 +1,6 @@
 from slackclient import SlackClient
 from airflow.models import BaseOperator
+from airflow.utils import apply_defaults
 
 
 class SlackAPIOperator(BaseOperator):
@@ -8,26 +9,49 @@ class SlackAPIOperator(BaseOperator):
     The SlackAPIPostOperator is derived from this operator.
     In the future additional Slack API Operators will be derived from this class as well
 
-    :param token: Slack api token
-    :type token: String
+    :param token: Slack API token (https://api.slack.com/web)
+    :type token: string
     :param method: The Slack API Method to Call (https://api.slack.com/methods)
-    :type method: String
-    :param param: API Method call parameters (https://api.slack.com/methods)
-    :type param: dict
+    :type method: string
+    :param api_call_params: API Method call parameters (https://api.slack.com/methods)
+    :type api_call_params: dict
     """
+
+    @apply_defaults
     def __init__(self,
                  token='unset',
                  method='unset',
-                 params=None,
+                 api_call_params=None,
                  *args, **kwargs):
         super(SlackAPIOperator, self).__init__(*args, **kwargs)
         self.token = token
         self.method = method
-        self.params = params
+        self.api_call_params = api_call_params
+
+    def construct_api_call_params(self):
+        """
+        Used by the execute function. Allows templating on the source fields of the api_call_params dict before construction
+
+        Override in child classes.
+        Each SlackAPIOperator child class is responsible for having a construct_api_call_params function
+        which sets self.api_call_params with a dict of API call parameters (https://api.slack.com/methods)
+        """
+
+        pass
 
     def execute(self, **kwargs):
-        sc = SlackClient(self.token)
-        sc.api_call(self.method, **self.params)
+        """
+        SlackAPIOperator calls will not fail even if the call is not unsuccessful.
+        It should not prevent a DAG from completing in success
+        """
+
+        try:
+            if not self.api_call_params:
+                self.construct_api_call_params()
+            sc = SlackClient(self.token)
+            sc.api_call(self.method, **self.api_call_params)
+        except Exception:
+            pass
 
 
 class SlackAPIPostOperator(SlackAPIOperator):
@@ -43,9 +67,11 @@ class SlackAPIPostOperator(SlackAPIOperator):
     :param icon_url: url to icon used for this message
     :type icon_url: string
     """
+
     template_fields = ('username', 'text')
     ui_color = '#FFBA40'
 
+    @apply_defaults
     def __init__(self,
                  channel='#general',
                  username='Airflow',
@@ -59,13 +85,13 @@ class SlackAPIPostOperator(SlackAPIOperator):
         self.username = username
         self.text = text
         self.icon_url = icon_url
-        self.params = {
+        super(SlackAPIPostOperator, self).__init__(method=self.method,
+                                                   *args, **kwargs)
+
+    def construct_api_call_params(self):
+        self.api_call_params = {
             'channel': self.channel,
             'username': self.username,
             'text': self.text,
             'icon_url': self.icon_url,
         }
-        super(SlackAPIPostOperator, self).__init__(method=self.method,
-                                                   params=self.params,
-                                                   *args, **kwargs)
-


### PR DESCRIPTION
cleaned up docstring types

renamed params attribute to api_call_params to avoid conflicts/confusion with task_instance params

moved the building of the api_call_params dict to it's own function which is run by the execute function.

execute method will pass on failure. Notification should not cause a DAG to fail
