### PR TITLE
consolidate base_date rounding in tree view

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1073,11 +1073,13 @@ class Airflow(BaseView):
         if not start_date and 'start_date' in dag.default_args:
             start_date = dag.default_args['start_date']
 
-        if start_date:
-            base_date = utils.round_time(
-                base_date, dag.schedule_interval, start_date)
-        else:
-            base_date = utils.round_time(base_date, dag.schedule_interval)
+        # if a specific base_date is requested, don't round it
+        if not request.args.get('base_date'):
+            if start_date:
+                base_date = utils.round_time(
+                    base_date, dag.schedule_interval, start_date)
+            else:
+                base_date = utils.round_time(base_date, dag.schedule_interval)
 
         form = TreeForm(data={'base_date': base_date, 'num_runs': num_runs})
 

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1068,18 +1068,18 @@ class Airflow(BaseView):
                 base_date = datetime.now()
         else:
             base_date = dateutil.parser.parse(base_date)
-        base_date = utils.round_time(base_date, dag.schedule_interval)
-        form = TreeForm(data={'base_date': base_date, 'num_runs': num_runs})
 
         start_date = dag.start_date
         if not start_date and 'start_date' in dag.default_args:
             start_date = dag.default_args['start_date']
 
         if start_date:
-            base_date = utils.round_time(base_date, dag.schedule_interval, start_date)
+            base_date = utils.round_time(
+                base_date, dag.schedule_interval, start_date)
         else:
             base_date = utils.round_time(base_date, dag.schedule_interval)
 
+        form = TreeForm(data={'base_date': base_date, 'num_runs': num_runs})
 
         from_date = (base_date - (num_runs * dag.schedule_interval))
 


### PR DESCRIPTION
It looks like `base_date` is getting rounded a little more (and a little earlier) than necessary.

This also impacts any base_dates that are passed directly (as url args) -- they are rounded and potentially won't match the requested date.
