### PR TITLE
Sync dags from S3 location

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -46,6 +46,7 @@ defaults = {
         'parallelism': 32,
         'load_examples': True,
         'plugins_folder': None,
+        's3_dags_folder': None,
     },
     'webserver': {
         'base_url': 'http://localhost:8080',
@@ -84,6 +85,11 @@ airflow_home = {AIRFLOW_HOME}
 # The folder where your airflow pipelines live, most likely a
 # subfolder in a code repository
 dags_folder = {AIRFLOW_HOME}/dags
+
+# Dags can also be stored in S3. The S3 dags folder must begin with 's3://'.
+# An airflow S3 Connection is required to access the S3 location.
+# s3_dags_folder = s3://<s3 dags folder>
+# s3_dags_folder_conn_id = S3
 
 # The folder where airflow should store its log files
 base_log_folder = {AIRFLOW_HOME}/logs

--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -173,7 +173,8 @@ class S3Hook(BaseHook):
         """
         return self.connection.get_bucket(bucket_name)
 
-    def list_keys(self, bucket_name, prefix='', delimiter=''):
+    def list_keys(
+            self, bucket_name, prefix='', delimiter='', return_names=True):
         """
         Lists keys in a bucket under prefix and not containing delimiter
 
@@ -183,10 +184,16 @@ class S3Hook(BaseHook):
         :type prefix: str
         :param delimiter: the delimiter marks key hierarchy.
         :type delimiter: str
+        :param return_names: if True, a list of key names is returned. If False,
+            a list of key objects is returned.
+        :type return_names: bool
         """
         b = self.get_bucket(bucket_name)
         keylist = list(b.list(prefix=prefix, delimiter=delimiter))
-        return [k.name for k in keylist] if keylist != [] else None
+        if return_names:
+            return [k.name for k in keylist] if keylist != [] else None
+        else:
+            return keylist
 
     def list_prefixes(self, bucket_name, prefix='', delimiter=''):
         """
@@ -329,4 +336,3 @@ class S3Hook(BaseHook):
                                                       replace=replace)
         logging.info("The key {key} now contains"
                      " {key_size} bytes".format(**locals()))
-

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -215,8 +215,8 @@ class SchedulerJob(BaseJob):
             self.num_runs = 1
         else:
             self.num_runs = num_runs
-        self.refresh_dags_every = refresh_dags_every	
-        self.do_pickle = do_pickle	
+        self.refresh_dags_every = refresh_dags_every
+        self.do_pickle = do_pickle
         super(SchedulerJob, self).__init__(*args, **kwargs)
 
         self.heartrate = conf.getint('scheduler', 'SCHEDULER_HEARTBEAT_SEC')

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -1068,18 +1068,18 @@ class Airflow(BaseView):
                 base_date = datetime.now()
         else:
             base_date = dateutil.parser.parse(base_date)
-        base_date = utils.round_time(base_date, dag.schedule_interval)
-        form = TreeForm(data={'base_date': base_date, 'num_runs': num_runs})
 
         start_date = dag.start_date
         if not start_date and 'start_date' in dag.default_args:
             start_date = dag.default_args['start_date']
 
         if start_date:
-            base_date = utils.round_time(base_date, dag.schedule_interval, start_date)
+            base_date = utils.round_time(
+                base_date, dag.schedule_interval, start_date)
         else:
             base_date = utils.round_time(base_date, dag.schedule_interval)
 
+        form = TreeForm(data={'base_date': base_date, 'num_runs': num_runs})
 
         from_date = (base_date - (num_runs * dag.schedule_interval))
 

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -51,7 +51,7 @@
                         <span class="glyphicon glyphicon-info-sign" class="info" aria-hidden="true" title="This DAG isn't available in the web server's DagBag object. It shows up in this list because the scheduler marked it as active in the metdata database."></span>
                     {% endif %}
                     {% if dag_id not in orm_dags and False %}
-                        <span class="glyphicon glyphicon-info-sign" class="info" aria-hidden="true" title="This DAG seems to be existing only locally. The master scheduler doesn't seem to be aware of its existence."></span>
+                        <span class="glyphicon glyphicon-info-sign" class="info" aria-hidden="true" title="This DAG  exists only locally. The master scheduler doesn't seem to be aware of it."></span>
                     {% endif %}
                 </td>
                     <td>{{ dag.owner if dag else orm_dags[dag_id].owners }}</td>


### PR DESCRIPTION
I've seen this request floating around... this PR lets users store dags in an S3 location.

Users need to add two lines to their `airflow.cfg` files:

```
[core]
s3_dags_folder = s3://<s3 dags location>
s3_dags_folder_conn_id = <conn id>
```

Any `.py` files found in the `s3_dags_folder` (and its subdirectories) are synced to an `__s3_dags__` subdirectory of the main airflow dags folder. Syncing is done through an `S3Hook`, which is why the `conn_id` is required. The folder is synced every 10 times that the DagBag's `collect_dags` method is called (so roughly once a minute with a default scheduler, but guaranteed to run every time an airflow command is issued since that creates a new DagBag). Syncing will mirror the S3 location, so new files will be added and old files will be deleted. 

I think for folks running airflow in a distributed manner (with many workers across different machines) but without a sophisticated syncing infrastructure, this will be an appealing alternative.
