### PR TITLE
Fix issue with expand_env_var

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -29,6 +29,8 @@ def expand_env_var(env_var):
     `expandvars` and `expanduser` until interpolation stops having
     any effect.
     """
+    if not isinstance(env_var, str):
+        return env_var
     while True:
         interpolated = os.path.expanduser(os.path.expandvars(str(env_var)))
         if interpolated == env_var:

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -1,5 +1,6 @@
 from future import standard_library
 standard_library.install_aliases()
+from past.builtins import basestring
 from builtins import str
 from configparser import ConfigParser
 import errno
@@ -29,7 +30,7 @@ def expand_env_var(env_var):
     `expandvars` and `expanduser` until interpolation stops having
     any effect.
     """
-    if not isinstance(env_var, str):
+    if not isinstance(env_var, basestring):
         return env_var
     while True:
         interpolated = os.path.expanduser(os.path.expandvars(str(env_var)))


### PR DESCRIPTION
Should only attempt to expand objects that are strings
