### PR TITLE
Added default_var to Variable

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2312,9 +2312,12 @@ class Variable(Base):
 
     @classmethod
     @provide_session
-    def get(cls, key, session, deserialize_json=False):
+    def get(cls, key, session, deserialize_json=False, default_var=None):
         obj = session.query(cls).filter(cls.key == key).first()
-        v = obj.val
+        if obj is None and default_var is not None:
+            v = default_var
+        else:
+            v = obj.val
         if deserialize_json and v:
             v = json.loads(v)
         return v

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2312,10 +2312,13 @@ class Variable(Base):
 
     @classmethod
     @provide_session
-    def get(cls, key, session, deserialize_json=False, default_var=None):
+    def get(cls, key, default_var=None, deserialize_json=False, session=None):
         obj = session.query(cls).filter(cls.key == key).first()
-        if obj is None and default_var is not None:
-            v = default_var
+        if obj is None:
+            if default_var is not None:
+                v = default_var
+            else:
+                raise ValueError('Variable {} does not exist'.format(key))
         else:
             v = obj.val
         if deserialize_json and v:


### PR DESCRIPTION
Added default_var to Variable 'get' method which provides fallback in case if variable does not exist and user want to use default values. It's fully compatible with current behavior of Variable get method. For example, if there is variable 'test' of the form {"a": "b"}, then following code willl output:
- b (current behavior)
- y (default_var behavior)
- Error: 'NoneType' object has no attribute 'val' (current behavior)
- b (default_var ignored)

```
from airflow import DAG
from airflow.operators import PythonOperator
from datetime import datetime
from airflow.models import Variable

import logging

default_args = {
    'owner': 'airflow',
    'start_date': datetime(2015, 10, 6),
}

dag = DAG('check_variables', default_args=default_args)


def test_var():
    var1 = Variable.get('test', deserialize_json=True)
    logging.info('Start test')
    logging.info(var1['a'])  # existing variable
    var2 = Variable.get('test2', deserialize_json=True, default_var='{"x": "y"}')
    logging.info(var2['x'])  # yields value from default_var
    try:
        var3 = Variable.get('test3', deserialize_json=True)  # Error
    except Exception as e:
        logging.error(e)
    var4 = Variable.get('test', deserialize_json=True, default_var='{"a": "c"}')
    logging.info(var4['a'])


t1 = PythonOperator(
    task_id='test',
    python_callable=test_var,
    dag=dag
)
```
