### PR TITLE
Fix how we recurse through collection-like template fields.

### DIFF
--- a/tests/core.py
+++ b/tests/core.py
@@ -345,6 +345,28 @@ class CoreTest(unittest.TestCase):
             dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
 
+
+    def test_complex_template(self):
+        class OperatorSubclass(operators.BaseOperator):
+            template_fields = ['some_templated_field']
+            def __init__(self, some_templated_field, *args, **kwargs):
+                super(OperatorSubclass, self).__init__(*args, **kwargs)
+                self.some_templated_field = some_templated_field
+            def execute(*args, **kwargs):
+                pass
+        def test_some_templated_field_template_render(context):
+            self.assertEqual(context['ti'].task.some_templated_field['bar'][1], context['ds'])
+        t = OperatorSubclass(
+            task_id='test_complex_template',
+            provide_context=True,
+            some_templated_field={
+                'foo':'123',
+                'bar':['baz', '{{ ds }}']
+            },
+            on_success_callback=test_some_templated_field_template_render,
+            dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
     def test_import_examples(self):
         self.assertEqual(len(self.dagbag.dags), NUM_EXAMPLE_DAGS)
 


### PR DESCRIPTION
I ran into an issue in `models.py` when using a more complex template field (e.g. `templated_field={'foo':['bar', '{{ ds }}'] }` ) for a new operator I'm working on. The issue manifests itself in the form of jinja getting into an infinite recursion:

```
Traceback (most recent call last):
  File "/Users/kkourtchikov/airflow/airflow/models.py", line 921, in run
    self.render_templates()
  File "/Users/kkourtchikov/airflow/airflow/models.py", line 1069, in render_templates
    for k, v in list(content.items())}
  File "/Users/kkourtchikov/airflow/airflow/models.py", line 1068, in <dictcomp>
    k: rt(v, jinja_context)
  File "/Users/kkourtchikov/airflow/airflow/models.py", line 1532, in render_template
    template = env.from_string(content)
  File "/Library/Python/2.7/site-packages/jinja2/environment.py", line 862, in from_string
    return cls.from_code(self, self.compile(source), globals, None)
  File "/Library/Python/2.7/site-packages/jinja2/environment.py", line 553, in compile
    source = optimize(source, self)
  File "/Library/Python/2.7/site-packages/jinja2/optimizer.py", line 27, in optimize
    return optimizer.visit(node)
  File "/Library/Python/2.7/site-packages/jinja2/visitor.py", line 38, in visit
    return f(node, *args, **kwargs)
...
  File "/Library/Python/2.7/site-packages/jinja2/visitor.py", line 38, in visit
    return f(node, *args, **kwargs)
  File "/Library/Python/2.7/site-packages/jinja2/visitor.py", line 84, in visit_list
    rv = self.visit(node, *args, **kwargs)
  File "/Library/Python/2.7/site-packages/jinja2/visitor.py", line 38, in visit
    return f(node, *args, **kwargs)
  File "/Library/Python/2.7/site-packages/jinja2/visitor.py", line 84, in visit_list
    rv = self.visit(node, *args, **kwargs)
RuntimeError: maximum recursion depth exceeded
root: ERROR: maximum recursion depth exceeded
```

Included is a test case which replicates the issue and tests the change to models.py.
