### PR TITLE
Support worker logs on S3

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -173,13 +173,15 @@ def run(args):
         s3_log = filename.replace(log, conf.get('core', 'BASE_LOG_FOLDER'))
         bucket, key = s3_log.lstrip('s3:/').split('/', 1)
         s3_key = boto.s3.key.Key(s3.get_bucket(bucket), key)
-        s3_key.set_contents_from_filename(filename)
-        try:
-            # try to clean up tmp files
-            os.remove(filename)
-            os.removedirs(os.path.dirname(filename))
-        except:
-            pass
+        if os.path.exists(filename):
+            s3_key.set_contents_from_filename(filename)
+            try:
+                # load log file to s3, if it exists
+                # try to clean up tmp files
+                os.remove(filename)
+                os.removedirs(os.path.dirname(filename))
+            except:
+                pass
 
 
 def task_state(args):

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -174,6 +174,12 @@ def run(args):
         bucket, key = s3_log.lstrip('s3:/').split('/', 1)
         s3_key = boto.s3.key.Key(s3.get_bucket(bucket), key)
         s3_key.set_contents_from_filename(filename)
+        try:
+            # try to clean up tmp files
+            os.remove(filename)
+            os.removedirs(os.path.dirname(filename))
+        except:
+            pass
 
 
 def task_state(args):

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -90,6 +90,8 @@ def run(args):
     if os.path.exists(filename):
         with open(filename, 'r') as logfile:
             old_log = logfile.read()
+    else:
+        old_log = None
 
     subdir = None
     if args.subdir:
@@ -182,7 +184,8 @@ def run(args):
                 new_log = logfile.read()
 
             # remove old logs (since they are already in S3)
-            new_log.replace(old_log, '')
+            if old_log:
+                new_log.replace(old_log, '')
 
             try:
                 s3 = boto.connect_s3()

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -95,6 +95,7 @@ airflow_home = {AIRFLOW_HOME}
 dags_folder = {AIRFLOW_HOME}/dags
 
 # The folder where airflow should store its log files
+# For S3, use the full URL to the base folder (starting with "s3://...")
 base_log_folder = {AIRFLOW_HOME}/logs
 
 # The executor class that airflow should use. Choices include

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -48,6 +48,7 @@ defaults = {
         'plugins_folder': None,
         'security': None,
         'donot_pickle': False,
+        's3_log_folder': ''
     },
     'webserver': {
         'base_url': 'http://localhost:8080',
@@ -94,9 +95,11 @@ airflow_home = {AIRFLOW_HOME}
 # subfolder in a code repository
 dags_folder = {AIRFLOW_HOME}/dags
 
-# The folder where airflow should store its log files
-# For S3, use the full URL to the base folder (starting with "s3://...")
+# The folder where airflow should store its log files. This location
 base_log_folder = {AIRFLOW_HOME}/logs
+# An S3 location can be provided for log backups
+# For S3, use the full URL to the base folder (starting with "s3://...")
+s3_log_folder = None
 
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -826,7 +826,14 @@ class Airflow(BaseView):
         form = DateTimeForm(data={'execution_date': dttm})
         if ti:
             host = ti.hostname
-            if socket.gethostname() == host:
+
+            if loc.startswith('s3:'):
+                import boto
+                s3 = boto.connect_s3()
+                bucket, key = loc.lstrip('s3:/').split('/', 1)
+                s3_key = boto.s3.key.Key(s3.get_bucket(bucket), key)
+                log = s3_key.get_contents_as_string().decode()
+            elif socket.gethostname() == host:
                 try:
                     f = open(loc)
                     log += "".join(f.readlines())

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -811,9 +811,9 @@ class Airflow(BaseView):
         task_id = request.args.get('task_id')
         execution_date = request.args.get('execution_date')
         dag = dagbag.get_dag(dag_id)
-        log_relative = "/{dag_id}/{task_id}/{execution_date}".format(
+        log_relative = "{dag_id}/{task_id}/{execution_date}".format(
             **locals())
-        loc = BASE_LOG_FOLDER + log_relative
+        loc = os.path.join(BASE_LOG_FOLDER, log_relative)
         loc = loc.format(**locals())
         log = ""
         TI = models.TaskInstance
@@ -836,9 +836,9 @@ class Airflow(BaseView):
             else:
                 WORKER_LOG_SERVER_PORT = \
                     conf.get('celery', 'WORKER_LOG_SERVER_PORT')
-                url = (
-                    "http://{host}:{WORKER_LOG_SERVER_PORT}/log"
-                    "{log_relative}").format(**locals())
+                url = os.path.join(
+                    "http://{host}:{WORKER_LOG_SERVER_PORT}/log", log_relative
+                    ).format(**locals())
                 log += "Log file isn't local.\n"
                 log += "Fetching here: {url}\n".format(**locals())
                 try:

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -832,7 +832,11 @@ class Airflow(BaseView):
                 s3 = boto.connect_s3()
                 bucket, key = loc.lstrip('s3:/').split('/', 1)
                 s3_key = boto.s3.key.Key(s3.get_bucket(bucket), key)
-                log = s3_key.get_contents_as_string().decode()
+                if not s3_key.exists():
+                    log = 'No log available on S3.'
+                else:
+                    log = s3_key.get_contents_as_string().decode()
+
             elif socket.gethostname() == host:
                 try:
                     f = open(loc)

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -847,7 +847,7 @@ class Airflow(BaseView):
                 log += "*** Fetching here: {url}\n".format(**locals())
                 try:
                     import requests
-                    log += requests.get(url).text
+                    log += '\n' + requests.get(url).text
                     log_loaded = True
                 except:
                     log += "*** Failed to fetch log file from worker.\n".format(
@@ -856,13 +856,13 @@ class Airflow(BaseView):
             # try to load log backup from S3
             s3_log_folder = conf.get('core', 'S3_LOG_FOLDER')
             if not log_loaded and s3_log_folder.startswith('s3:'):
-                log += '*** Fetching log from S3.\n'
-                log += ('*** Note: S3 logs are only available once '
-                        'tasks have completed.\n')
                 import boto
                 s3 = boto.connect_s3()
                 s3_log_loc = os.path.join(
                     conf.get('core', 'S3_LOG_FOLDER'), log_relative)
+                log += '*** Fetching log from S3: {}\n'.format(s3_log_loc)
+                log += ('*** Note: S3 logs are only available once '
+                        'tasks have completed.\n')
                 bucket, key = s3_log_loc.lstrip('s3:/').split('/', 1)
                 s3_key = boto.s3.key.Key(s3.get_bucket(bucket), key)
                 if s3_key.exists():

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -151,6 +151,17 @@ its direction.
 Note that you can also run "Celery Flower", a web UI built on top of Celery,
 to monitor your workers.
 
+Logs
+''''
+Users can specify a logs folder in ``airflow.cfg``. By default, it is in the ``AIRFLOW_HOME`` directory.
+
+In addition, users can supply an S3 location for storing log backups. If logs are not found in the local filesystem (for example, if a worker is lost or reset), the S3 logs will be displayed in the Airflow UI. Note that logs are only sent to S3 once a task completes (including failure).
+
+.. code-block:: bash
+
+    [core]
+    base_log_folder = {AIRFLOW_HOME}/logs
+    s3_log_folder = s3://{YOUR S3 LOG PATH}
 
 Scaling Out on Mesos (community contributed)
 ''''''''''''''''''''''''''''''''''''''''''''
@@ -161,21 +172,21 @@ steps -
 1. Install airflow on a machine where webserver and scheduler will run,
    let's refer this as Airflow server.
 2. On Airflow server, install mesos python eggs from `mesos downloads <http://open.mesosphere.com/downloads/mesos/>`_.
-3. On Airflow server, use a database which can be accessed from mesos 
+3. On Airflow server, use a database which can be accessed from mesos
    slave machines, for example mysql, and configure in ``airflow.cfg``.
-4. Change your ``airflow.cfg`` to point executor parameter to 
+4. Change your ``airflow.cfg`` to point executor parameter to
    MesosExecutor and provide related Mesos settings.
-5. On all mesos slaves, install airflow. Copy the ``airflow.cfg`` from 
+5. On all mesos slaves, install airflow. Copy the ``airflow.cfg`` from
    Airflow server (so that it uses same sql alchemy connection).
-6. On all mesos slaves, run 
+6. On all mesos slaves, run
 
 .. code-block:: bash
-   
+
     airflow serve_logs
 
 for serving logs.
 
-7. On Airflow server, run 
+7. On Airflow server, run
 
 .. code-block:: bash
 
@@ -188,7 +199,7 @@ The logs for airflow tasks can be seen in airflow UI as usual.
 
 For more information about mesos, refer `mesos documentation <http://mesos.apache.org/documentation/latest/>`_.
 For any queries/bugs on MesosExecutor, please contact `@kapil-malik <https://github.com/kapil-malik>`_.
- 
+
 
 Web Authentication
 ''''''''''''''''''
@@ -212,7 +223,7 @@ Multi-tenancy
 
 You can filter the list of dags in webserver by owner name, when authentication
 is turned on, by setting webserver.filter_by_owner as true in your ``airflow.cfg``
-With this, when a user authenticates and logs into webserver, it will see only the dags 
+With this, when a user authenticates and logs into webserver, it will see only the dags
 which it is owner of. A super_user, will be able to see all the dags although.
 This makes the web UI a multi-tenant UI, where a user will only be able to see dags
 created by itself.


### PR DESCRIPTION
Pursuant to #346, we have an environment with dockerized (and ephemeral) workers, meaning that having workers host logs from their own mini-webservers is infeasible because 1) the filesystem can be destroyed at any time and 2) the host address can change at any time. In the absence of a "grand" logging interface, this is a quick adjustment that ships (reads) logs to (from) S3 if the `base_logs_folders` begins with `s3:`. Workers will need to be able to write to the requested S3 bucket (via boto). In testing, this has been a valuable addition to our infrastructure -- debugging failed tasks without logs is no fun at all!

This shouldn't change any existing functionality. All it really does is look for the `s3:` url clue and, if found, uses boto to read/write the log files appropriately. Everything else is as-is, using a temporary directory for the local log files.
