### PR TITLE
Allow user principals (without host part) as well as service principals

### DIFF
--- a/airflow/security/kerberos.py
+++ b/airflow/security/kerberos.py
@@ -32,7 +32,7 @@ def renew_from_kt():
     # The config is specified in seconds. But we ask for that same amount in
     # minutes to give ourselves a large renewal buffer.
     renewal_lifetime = "%sm" % conf.getint('kerberos', 'reinit_frequency')
-    principal = "%s/%s" % (conf.get('kerberos', 'principal'), socket.getfqdn())
+    principal = conf.get('kerberos', 'principal').replace("_HOST", socket.getfqdn())
     cmdv = [conf.get('kerberos', 'kinit_path'),
             "-r", renewal_lifetime,
             "-k", # host ticket


### PR DESCRIPTION
- This allows teh configuration for the principal of the keytab to look like "principal/_HOST@MYREALM.COM"
- where _HOST is replaced by the fqdn of the current host

Its important for distributed setups (ie. celery or mesos) but allows also a user principal at the same time
