### PR TITLE
External triggers

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -4,6 +4,7 @@ import logging
 import os
 import subprocess
 import sys
+from datetime import datetime
 
 from builtins import input
 import argparse

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from time import sleep
 
-from sqlalchemy import Column, Integer, String, DateTime, func, Index
+from sqlalchemy import Column, Integer, String, DateTime, func, Index, and_
 from sqlalchemy.orm.session import make_transient
 
 from airflow import executors, models, settings, utils
@@ -215,8 +215,8 @@ class SchedulerJob(BaseJob):
             self.num_runs = 1
         else:
             self.num_runs = num_runs
-        self.refresh_dags_every = refresh_dags_every	
-        self.do_pickle = do_pickle	
+        self.refresh_dags_every = refresh_dags_every
+        self.do_pickle = do_pickle
         super(SchedulerJob, self).__init__(*args, **kwargs)
 
         self.heartrate = conf.getint('scheduler', 'SCHEDULER_HEARTBEAT_SEC')
@@ -329,6 +329,37 @@ class SchedulerJob(BaseJob):
                 filename=filename, stacktrace=stacktrace))
         session.commit()
 
+
+    def schedule_dag(self, dag):
+        """
+        This method checks whether a new DagRun needs to be created
+        for a DAG based on scheduling interval
+        """
+        DagRun = models.DagRun
+        session = settings.Session()
+        qry = session.query(func.max(DagRun.execution_date)).filter(and_(
+            DagRun.dag_id == dag.dag_id,
+            DagRun.external_trigger == False
+        ))
+        last_scheduled_run = qry.scalar()
+        if not last_scheduled_run or last_scheduled_run <= datetime.now():
+            if last_scheduled_run:
+                next_run_date = last_scheduled_run + dag.schedule_interval
+            else:
+                next_run_date = dag.default_args['start_date']
+            if not next_run_date:
+                raise Exception('no next_run_date defined!')
+            next_run = DagRun(
+                dag_id=dag.dag_id,
+                run_id='scheduled',
+                execution_date=next_run_date,
+                external_trigger=False
+            )
+            session.add(next_run)
+            session.commit()
+
+
+
     def process_dag(self, dag, executor):
         """
         This method schedules a single DAG by looking at the latest
@@ -392,6 +423,7 @@ class SchedulerJob(BaseJob):
             if task.adhoc:
                 continue
             if task.task_id not in ti_dict:
+                # TODO: Needs this be changed with DagRun refactoring
                 # Brand new task, let's get started
                 ti = TI(task, task.start_date)
                 ti.refresh_from_db()
@@ -415,13 +447,15 @@ class SchedulerJob(BaseJob):
                     # in self.prioritize_queued
                     continue
                 else:
-                    # Trying to run the next schedule
-                    next_schedule = (
-                        ti.execution_date + task.schedule_interval)
-                    if (
-                            ti.task.end_date and
-                            next_schedule > ti.task.end_date):
+                    # Checking whether there is a dag for which no task exists
+                    # up to now
+                    qry = session.query(func.min(models.DagRun.execution_date)).filter(
+                        and_(models.DagRun.dag_id == dag.dag_id,
+                        models.DagRun.execution_date > ti.execution_date))
+                    next_schedule = qry.scalar()
+                    if not next_schedule:
                         continue
+
                     ti = TI(
                         task=task,
                         execution_date=next_schedule,
@@ -543,6 +577,7 @@ class SchedulerJob(BaseJob):
                     if not dag or (dag.dag_id in paused_dag_ids):
                         continue
                     try:
+                        self.schedule_dag(dag)
                         self.process_dag(dag, executor)
                         self.manage_slas(dag)
                     except Exception as e:

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -423,7 +423,7 @@ class SchedulerJob(BaseJob):
             if task.adhoc:
                 continue
             if task.task_id not in ti_dict:
-                # TODO: Needs this be changed with DagRun refactoring
+                # TODO: Check whether this needs to be changed with DagRun refactoring
                 # Brand new task, let's get started
                 ti = TI(task, task.start_date)
                 ti.refresh_from_db()
@@ -447,8 +447,8 @@ class SchedulerJob(BaseJob):
                     # in self.prioritize_queued
                     continue
                 else:
-                    # Checking whether there is a dag for which no task exists
-                    # up to now
+                    # Checking whether there is a DagRun for which a task
+                    # needs to be created
                     qry = session.query(func.min(models.DagRun.execution_date)).filter(
                         and_(models.DagRun.dag_id == dag.dag_id,
                         models.DagRun.execution_date > ti.execution_date))

--- a/airflow/migrations/versions/19054f4ff36_add_dagrun.py
+++ b/airflow/migrations/versions/19054f4ff36_add_dagrun.py
@@ -21,6 +21,7 @@ def upgrade():
         'dag_run',
         sa.Column('dag_id', sa.String(length=250), nullable=False),
         sa.Column('execution_date', sa.DateTime(), nullable=False),
+        sa.Column('state', sa.String(length=50), nullable=True),
         sa.Column('run_id', sa.String(length=250), nullable=True),
         sa.Column('external_trigger', sa.Boolean(), nullable=True),
         sa.PrimaryKeyConstraint('dag_id', 'execution_date')

--- a/airflow/migrations/versions/19054f4ff36_add_dagrun.py
+++ b/airflow/migrations/versions/19054f4ff36_add_dagrun.py
@@ -21,7 +21,8 @@ def upgrade():
         'dag_run',
         sa.Column('dag_id', sa.String(length=250), nullable=False),
         sa.Column('execution_date', sa.DateTime(), nullable=False),
-        sa.Column('run_id', sa.String(length=250), nullable=False),
+        sa.Column('run_id', sa.String(length=250), nullable=True),
+        sa.Column('external_trigger', sa.Boolean(), nullable=True),
         sa.PrimaryKeyConstraint('dag_id', 'execution_date')
     )
 

--- a/airflow/migrations/versions/19054f4ff36_add_dagrun.py
+++ b/airflow/migrations/versions/19054f4ff36_add_dagrun.py
@@ -1,0 +1,30 @@
+"""add DagRun
+
+Revision ID: 19054f4ff36
+Revises: 338e90f54d61
+Create Date: 2015-10-12 09:55:52.475712
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '19054f4ff36'
+down_revision = '338e90f54d61'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'dag_run',
+        sa.Column('dag_id', sa.String(length=250), nullable=False),
+        sa.Column('execution_date', sa.DateTime(), nullable=False),
+        sa.Column('run_id', sa.String(length=250), nullable=False),
+        sa.PrimaryKeyConstraint('dag_id', 'execution_date')
+    )
+
+
+def downgrade():
+    op.drop_table('dag_run')

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -641,7 +641,7 @@ class TaskInstance(Base):
             path to add the feature
         :type flag_upstream_failed: boolean
         """
-        if self.execution_date > datetime.now() - self.task.schedule_interval:
+        if self.execution_date > datetime.now():
             return False
         elif self.state == State.UP_FOR_RETRY and not self.ready_for_retry():
             return False
@@ -2473,10 +2473,15 @@ class DagRun(Base):
     dag_id = Column(String(ID_LEN), primary_key=True)
     execution_date = Column(DateTime, primary_key=True)
     run_id = Column(String(ID_LEN))
-    timestamp = Column(DateTime)
-    description = Column(Text)
+    external_trigger = Column(Boolean, default=False)
 
     def __repr__(self):
+        return '<DagRun {dag_id} @ {execution_date}: {run_id}, \
+            externally triggered: {external_trigger}>'.format(
+            task_id=self.task_id,
+            execution_date=self.execution_date,
+            run_id=self.run_id,
+            external_trigger=self.external_trigger)
         return str((
             self.dag_id, self.run_id, self.execution_date.isoformat()))
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2463,6 +2463,24 @@ class XCom(Base):
         return query.all()
 
 
+class DagRun(Base):
+    """
+    DagRun describes an instance of a Dag. It can be created
+    by a scheduled of a Dag or by an external trigger
+    """
+    __tablename__ = "dag_run"
+
+    dag_id = Column(String(ID_LEN), primary_key=True)
+    execution_date = Column(DateTime, primary_key=True)
+    run_id = Column(String(ID_LEN))
+    timestamp = Column(DateTime)
+    description = Column(Text)
+
+    def __repr__(self):
+        return str((
+            self.dag_id, self.run_id, self.execution_date.isoformat()))
+
+
 class Pool(Base):
     __tablename__ = "slot_pool"
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2466,7 +2466,7 @@ class XCom(Base):
 class DagRun(Base):
     """
     DagRun describes an instance of a Dag. It can be created
-    by a scheduled of a Dag or by an external trigger
+    by the scheduler (for regular runs) or by an external trigger
     """
     __tablename__ = "dag_run"
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2472,13 +2472,14 @@ class DagRun(Base):
 
     dag_id = Column(String(ID_LEN), primary_key=True)
     execution_date = Column(DateTime, primary_key=True)
+    state = Column(String(50))
     run_id = Column(String(ID_LEN))
     external_trigger = Column(Boolean, default=False)
 
     def __repr__(self):
         return '<DagRun {dag_id} @ {execution_date}: {run_id}, \
             externally triggered: {external_trigger}>'.format(
-            task_id=self.task_id,
+            dag_id=self.dag_id,
             execution_date=self.execution_date,
             run_id=self.run_id,
             external_trigger=self.external_trigger)


### PR DESCRIPTION
I am aware that this pull request is not finished (tests, error handling, documentation). I would like to start a more concrete discussion on the externally triggered DAGs as mentioned in issue #417.

Within my company (http://blue-yonder.com) we are evaluating whether we could use airflow and I would really love to do so. Especially I liked the model you have chosen in the APIs and the possibilies to define the DAGs in Python. 

What we really need is the possibility to trigger DAGs externally. I read the discussion in the roadmap issue #417 and liked the ideas expressed there. I did a first prototype for the DagRun object and using this in the scheduler. Before investing further work in stabilizing this, I would like to get your feedback on whether this approach fits with the existing concepts. Does it make sense from your point of view to further work on that, or do you already have different plans/implementations?
