### PR TITLE
Log front-end Web UI actions

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1186,13 +1186,13 @@ class Log(Base):
     execution_date = Column(DateTime)
     owner = Column(String(500))
 
-    def __init__(self, event, task_instance):
+    def __init__(self, event, task_instance, owner=None):
         self.dttm = datetime.now()
         self.dag_id = task_instance.dag_id
         self.task_id = task_instance.task_id
         self.execution_date = task_instance.execution_date
         self.event = event
-        self.owner = task_instance.task.owner
+        self.owner = owner or task_instance.task.owner
 
 
 @functools.total_ordering


### PR DESCRIPTION
For diagnostics in larger teams when a certain member might be marking things success without others knowledge (etc.)

I think current_user.get_id() works though in my test env it returns null since no creds are needed.

@mistercrunch still some open questions:
- I need to access which TIs have been cleared, though current dag.clear() returns a simple count. Would anything break if I changed that to return a list of cleared TIs that I could use to add logging? Assuming I can't add logging without the class definitions themselves unless I add a current_user variable to them. Let me know what feels cleaner.
