### PR TITLE
Add BaseSensorOperator to __init__

### DIFF
--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -28,6 +28,7 @@ _operators = {
     'mysql_to_hive': ['MySqlToHiveTransfer'],
     'postgres_operator': ['PostgresOperator'],
     'sensors': [
+        'BaseSensorOperator',
         'SqlSensor',
         'ExternalTaskSensor',
         'HivePartitionSensor',


### PR DESCRIPTION
@mistercrunch to allow custom sensors in contrib (currently building a datadog sensor)
