### PR TITLE
To csv delimiter

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -428,11 +428,11 @@ class HiveServer2Hook(BaseHook):
                 cur.execute(hql)
                 schema = cur.getSchema()
                 with open(csv_filepath, 'w') as f:
-                    writer = csv.writer(f, delimiter)
+                    writer = csv.writer(f, delimiter=delimiter)
                     writer.writerow([c['columnName'] for c in cur.getSchema()])
                     i = 0
                     while cur.hasMoreRows:
-                        rows = [row for row in cur.fetchmany() if row]
+                        rows = [row for row in cur.fetchmany(size=10000) if row]
                         writer.writerows(rows)
                         i += len(rows)
                         logging.info("Written {0} rows so far.".format(i))

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -420,7 +420,14 @@ class HiveServer2Hook(BaseHook):
                         }
             return results
 
-    def to_csv(self, hql, csv_filepath, schema='default', delimiter=','):
+    def to_csv(
+            self,
+            hql,
+            csv_filepath,
+            schema='default',
+            delimiter=',',
+            lineterminator='\r\n',
+            output_header=True):
         schema = schema or 'default'
         with self.get_conn() as conn:
             with conn.cursor() as cur:
@@ -429,8 +436,10 @@ class HiveServer2Hook(BaseHook):
                 schema = cur.getSchema()
                 with open(csv_filepath, 'w') as f:
                     writer = csv.writer(f, delimiter=delimiter,
-                        lineterminator='\n')
-                    writer.writerow([c['columnName'] for c in cur.getSchema()])
+                        lineterminator=lineterminator)
+                    if output_header:
+                        writer.writerow([c['columnName']
+                            for c in cur.getSchema()])
                     i = 0
                     while cur.hasMoreRows:
                         rows = [row for row in cur.fetchmany() if row]

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -432,7 +432,7 @@ class HiveServer2Hook(BaseHook):
                     writer.writerow([c['columnName'] for c in cur.getSchema()])
                     i = 0
                     while cur.hasMoreRows:
-                        rows = [row for row in cur.fetchmany(size=10000) if row]
+                        rows = [row for row in cur.fetchmany() if row]
                         writer.writerows(rows)
                         i += len(rows)
                         logging.info("Written {0} rows so far.".format(i))

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -428,7 +428,8 @@ class HiveServer2Hook(BaseHook):
                 cur.execute(hql)
                 schema = cur.getSchema()
                 with open(csv_filepath, 'w') as f:
-                    writer = csv.writer(f, delimiter=delimiter)
+                    writer = csv.writer(f, delimiter=delimiter,
+                        lineterminator='\n')
                     writer.writerow([c['columnName'] for c in cur.getSchema()])
                     i = 0
                     while cur.hasMoreRows:

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -420,7 +420,7 @@ class HiveServer2Hook(BaseHook):
                         }
             return results
 
-    def to_csv(self, hql, csv_filepath, schema='default'):
+    def to_csv(self, hql, csv_filepath, schema='default', delimiter=','):
         schema = schema or 'default'
         with self.get_conn() as conn:
             with conn.cursor() as cur:
@@ -428,7 +428,7 @@ class HiveServer2Hook(BaseHook):
                 cur.execute(hql)
                 schema = cur.getSchema()
                 with open(csv_filepath, 'w') as f:
-                    writer = csv.writer(f)
+                    writer = csv.writer(f, delimiter)
                     writer.writerow([c['columnName'] for c in cur.getSchema()])
                     i = 0
                     while cur.hasMoreRows:

--- a/airflow/operators/hive_to_mysql.py
+++ b/airflow/operators/hive_to_mysql.py
@@ -68,7 +68,7 @@ class HiveToMySqlTransfer(BaseOperator):
 
         if self.bulk_load:
             tmpfile = NamedTemporaryFile()
-            hive.to_csv(self.sql, tmpfile.name)
+            hive.to_csv(self.sql, tmpfile.name, delimiter='\\t')
         else:
             results = hive.get_records(self.sql)
 

--- a/airflow/operators/hive_to_mysql.py
+++ b/airflow/operators/hive_to_mysql.py
@@ -68,7 +68,8 @@ class HiveToMySqlTransfer(BaseOperator):
 
         if self.bulk_load:
             tmpfile = NamedTemporaryFile()
-            hive.to_csv(self.sql, tmpfile.name, delimiter='\t')
+            hive.to_csv(self.sql, tmpfile.name, delimiter='\t',
+                lineterminator='\n', output_header=False)
         else:
             results = hive.get_records(self.sql)
 

--- a/airflow/operators/hive_to_mysql.py
+++ b/airflow/operators/hive_to_mysql.py
@@ -68,7 +68,7 @@ class HiveToMySqlTransfer(BaseOperator):
 
         if self.bulk_load:
             tmpfile = NamedTemporaryFile()
-            hive.to_csv(self.sql, tmpfile.name, delimiter='\\t')
+            hive.to_csv(self.sql, tmpfile.name, delimiter='\t')
         else:
             results = hive.get_records(self.sql)
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -184,14 +184,18 @@ class HivePrestoTest(unittest.TestCase):
             task_id='hive_to_mysql_bulk_check',
             create=True,
             sql="""
-            SELECT name
+            SELECT name, gender
             FROM airflow.static_babynames
             LIMIT 100
             """,
             mysql_table='test_static_babynames',
             mysql_preoperator=[
                 'DROP TABLE IF EXISTS test_static_babynames;',
-                'CREATE TABLE test_static_babynames (name VARCHAR(500))',
+                """
+                CREATE TABLE test_static_babynames (
+                    name VARCHAR(500),
+                    gender VARCHAR(500)
+                )""",
             ],
             bulk_load=True,
             dag=self.dag)


### PR DESCRIPTION
@mistercrunch:

Adding additional options for csv export (field delimiter, line terminator).  This was necessary for properly importing data to MySQL using bulk method.

*\* Ideally, I'd rather use a bulk export option (`hive -e "" > output` or `INSERT OVERWRITE LOCAL DIRECTORY '' SELECT FROM ...`) , but I couldn't get these options to work.  Perhaps we can explore this at a later time when someone has more time..
