### PR TITLE
Import CeleryExecutor only when available

### DIFF
--- a/airflow/executors/__init__.py
+++ b/airflow/executors/__init__.py
@@ -3,10 +3,13 @@ import logging
 from airflow.configuration import conf
 from airflow.executors.base_executor import BaseExecutor
 from airflow.executors.local_executor import LocalExecutor
-from airflow.executors.celery_executor import CeleryExecutor
 from airflow.executors.sequential_executor import SequentialExecutor
 
 # TODO Fix this emergency fix
+try:
+    from airflow.executors.celery_executor import CeleryExecutor
+except:
+    pass
 try:
     from airflow.contrib.executors.mesos_executor import MesosExecutor
 except:


### PR DESCRIPTION
According to setup.py Celery should be optional, so I applied the 'emergy fix' that was present for the MesosExecutor again.
