### PR TITLE
cleanup web auth code and require airflow_login if authenticate is True

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -10,6 +10,7 @@ __version__ = "1.5.1"
 import logging
 import os
 import sys
+
 from airflow.configuration import conf
 from airflow.models import DAG
 from flask.ext.admin import BaseView
@@ -19,19 +20,10 @@ DAGS_FOLDER = os.path.expanduser(conf.get('core', 'DAGS_FOLDER'))
 if DAGS_FOLDER not in sys.path:
     sys.path.append(DAGS_FOLDER)
 
-from airflow import default_login as login
-if conf.getboolean('webserver', 'AUTHENTICATE'):
-    try:
-        # Environment specific login
-        import airflow_login as login
-    except ImportError:
-        logging.error(
-            "authenticate is set to True in airflow.cfg, "
-            "but airflow_login failed to import")
-
 
 class AirflowViewPlugin(BaseView):
     pass
+
 
 class AirflowMacroPlugin(object):
     def __init__(self, namespace):

--- a/airflow/default_login.py
+++ b/airflow/default_login.py
@@ -16,7 +16,7 @@ from airflow import models
 DEFAULT_USERNAME = 'airflow'
 
 login_manager = flask_login.LoginManager()
-login_manager.login_view = 'airflow.login'  # Calls login() bellow
+login_manager.login_view = 'airflow.login'  # Calls login() below
 login_manager.login_message = None
 
 


### PR DESCRIPTION
This code does exactly the same but is a little bit more readable imho, and it prevents the webserver from being started when authenticate is set to True and the airflow_login module can't be imported. (Which is what you probably want when you configure it like that.)

I tried to add a test for the authenticate requirement, but I am under the impression that the tests are using my actual config instead of the test version, is that possible?
