### PR TITLE
Py3.4: Pass ConfigParser's extra kwargs through

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -302,7 +302,7 @@ class ConfigParserWithDefaults(ConfigParser):
         self.defaults = defaults
         ConfigParser.__init__(self, *args, **kwargs)
 
-    def get(self, section, key):
+    def get(self, section, key, **kwargs):
         section = str(section).lower()
         key = str(key).lower()
         d = self.defaults
@@ -315,7 +315,7 @@ class ConfigParserWithDefaults(ConfigParser):
 
         # ...then the config file
         elif self.has_option(section, key):
-            return expand_env_var(ConfigParser.get(self, section, key))
+            return expand_env_var(ConfigParser.get(self, section, key, **kwargs))
 
         # ...then the defaults
         elif section in d and key in d[section]:


### PR DESCRIPTION
In Python 3.4 ConfigParser has it's own string interpolation which recursively
calls get, but with extra kwargs, raw and fallback.

Accept these and pass them straight on to ConfigParser.

Apart from this, airflow seems fine under Python 3.4.
