### PR TITLE
Add ShortCircuitOperator

### DIFF
--- a/airflow/example_dags/example_short_circuit_operator.py
+++ b/airflow/example_dags/example_short_circuit_operator.py
@@ -1,0 +1,25 @@
+from airflow.operators import ShortCircuitOperator, DummyOperator
+from airflow.models import DAG
+import airflow.utils
+from datetime import datetime, timedelta
+
+seven_days_ago = datetime.combine(datetime.today() - timedelta(7),
+                                  datetime.min.time())
+args = {
+    'owner': 'airflow',
+    'start_date': seven_days_ago,
+}
+
+dag = DAG(dag_id='example_short_circuit_operator', default_args=args)
+
+cond_true = ShortCircuitOperator(
+    task_id='condition_is_True', python_callable=lambda: True, dag=dag)
+
+cond_false = ShortCircuitOperator(
+    task_id='condition_is_False', python_callable=lambda: False, dag=dag)
+
+ds_true = [DummyOperator(task_id='true_' + str(i), dag=dag) for i in [1, 2]]
+ds_false = [DummyOperator(task_id='false_' + str(i), dag=dag) for i in [1, 2]]
+
+airflow.utils.chain(cond_true, *ds_true)
+airflow.utils.chain(cond_false, *ds_false)

--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -13,7 +13,11 @@ _import_module_attrs(globals(), {
 
 _operators = {
     'bash_operator': ['BashOperator'],
-    'python_operator': ['PythonOperator', 'BranchPythonOperator'],
+    'python_operator': [
+        'PythonOperator',
+        'BranchPythonOperator',
+        'ShortCircuitOperator',
+    ],
     'hive_operator': ['HiveOperator'],
     'presto_check_operator': [
         'PrestoCheckOperator',

--- a/tests/core.py
+++ b/tests/core.py
@@ -9,7 +9,7 @@ from airflow.configuration import conf
 from airflow.www.app import app
 from airflow.settings import Session
 
-NUM_EXAMPLE_DAGS = 6
+NUM_EXAMPLE_DAGS = 7
 DEV_NULL = '/dev/null'
 DEFAULT_DATE = datetime(2015, 1, 1)
 TEST_DAG_ID = 'unit_tests'


### PR DESCRIPTION
A common idiom here is to use a PythonBranchOperator to check if a condition has been met and short circuit the DAG's execution if it hasn't. We started using this ShortCircuitOperator instead because it's much simpler to implement and (critically) to understand: if the condition returns False, DAG execution stops.

This makes it simple to gently introduce non-Task dependencies (file not available, table not updated, don't run on weekends, don't run on holidays, don't run if some metric isn't at a critical level).
