### PR TITLE
Fix cursor execution with None parameters in cx_Oracle (dbapi_hook)

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -1,3 +1,4 @@
+
 from builtins import str
 from past.builtins import basestring
 from datetime import datetime
@@ -57,7 +58,10 @@ class DbApiHook(BaseHook):
         '''
         conn = self.get_conn()
         cur = self.get_cursor()
-        cur.execute(sql, parameters)
+        if parameters is not None:
+            cur.execute(sql, parameters)
+        else:
+            cur.execute(sql)
         rows = cur.fetchall()
         cur.close()
         conn.close()
@@ -69,7 +73,10 @@ class DbApiHook(BaseHook):
         '''
         conn = self.get_conn()
         cur = conn.cursor()
-        cur.execute(sql, parameters)
+        if parameters is not None:
+            cur.execute(sql, parameters)
+        else:
+            cur.execute(sql)
         rows = cur.fetchone()
         cur.close()
         conn.close()
@@ -80,7 +87,6 @@ class DbApiHook(BaseHook):
         Runs a command or a list of commands. Pass a list of sql
         statements to the sql parameter to get them to execute
         sequentially
-
         :param sql: the sql statement to be executed (str) or a list of
             sql statements to execute
         :type sql: str or list
@@ -95,7 +101,10 @@ class DbApiHook(BaseHook):
         cur = conn.cursor()
         for s in sql:
             logging.info(s)
-            cur.execute(s, parameters)
+            if parameters is not None:
+                cur.execute(s, parameters)
+            else:
+                cur.execute(s)
         cur.close()
         conn.commit()
         conn.close()


### PR DESCRIPTION
cx_Oracle doesn't like None parameters, so I changed all cursor execution lines to check if parameters are given or not
If not, the parameters are left out completely from the cursor execution
