### PR TITLE
S3Hook: better handling when key isn't replaced

### DIFF
--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -283,7 +283,8 @@ class S3Hook(BaseHook):
         :param bucket_name: Name of the bucket in which to store the file
         :type bucket_name: str
         :param replace: A flag to decide whether or not to overwrite the key
-            if it already exists
+            if it already exists. If replace is False and the key exists, an
+            error will be raised.
         :type replace: bool
         """
         if not bucket_name:
@@ -293,8 +294,8 @@ class S3Hook(BaseHook):
             key_obj = bucket.new_key(key_name=key)
         else:
             if not replace:
-                logging.info("The key {key} already exists.".format(**locals()))
-                return
+                raise ValueError("The key {key} already exists.".format(
+                    **locals()))
             key_obj = bucket.get_key(key)
         key_size = key_obj.set_contents_from_filename(filename,
                                                       replace=replace)

--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -292,6 +292,9 @@ class S3Hook(BaseHook):
         if not self.check_for_key(key, bucket_name):
             key_obj = bucket.new_key(key_name=key)
         else:
+            if not replace:
+                logging.info("The key {key} already exists.".format(**locals()))
+                return
             key_obj = bucket.get_key(key)
         key_size = key_obj.set_contents_from_filename(filename,
                                                       replace=replace)


### PR DESCRIPTION
If `replace` is `False` and the key already exists, then `set_contents_from_string` does nothing and `key_size` is None. The log message shows that the key has been set to "None bytes", which is incorrect.

This exits the function (with a log message) if `replace` is `False` and the key exists.
