### PR TITLE
Making the end of celery_executor async by default

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -87,8 +87,9 @@ class CeleryExecutor(BaseExecutor):
                     logging.info("Unexpected state: " + async.state)
                 self.last_state[key] = async.state
 
-    def end(self):
-        while any([
-                async.state not in celery_states.READY_STATES
-                for async in self.tasks.values()]):
-            time.sleep(5)
+    def end(self, synchronous=False):
+        if synchronous:
+            while any([
+                    async.state not in celery_states.READY_STATES
+                    for async in self.tasks.values()]):
+                time.sleep(5)


### PR DESCRIPTION
Firefighting fix to let the scheduler restart every N run without waiting for all tasks to finish.

I can make `synchronous_end` a param of `airflow scheduler` tomorrow until we fix the scheduler

@artwr 
