### PR TITLE
Correct logged state in BranchPythonOperator

### DIFF
--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -81,7 +81,7 @@ class BranchPythonOperator(PythonOperator):
     def execute(self, context):
         branch = super(BranchPythonOperator, self).execute(context)
         logging.info("Following branch " + branch)
-        logging.info("Marking other directly downstream tasks as failed")
+        logging.info("Marking other directly downstream tasks as skipped")
         session = settings.Session()
         for task in context['task'].downstream_list:
             if task.task_id != branch:


### PR DESCRIPTION
The logs were stating that the other directly downstream tasks were being set as `failed` while they are actually being set as `skipped`.
