### PR TITLE
Fix handling of executor crashes

### DIFF
--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -14,10 +14,11 @@ PARALLELISM = conf.get('core', 'PARALLELISM')
 
 class LocalWorker(multiprocessing.Process):
 
-    def __init__(self, task_queue, result_queue):
+    def __init__(self, task_queue, result_queue, in_progress):
         multiprocessing.Process.__init__(self)
         self.task_queue = task_queue
         self.result_queue = result_queue
+        self.in_progress = in_progress
 
     def run(self):
         while True:
@@ -26,6 +27,9 @@ class LocalWorker(multiprocessing.Process):
                 # Received poison pill, no more tasks to run
                 self.task_queue.task_done()
                 break
+
+            self.in_progress[str(self)] = (key, command)
+
             logging.info("%s running %s", self.__class__.__name__, command)
             command = "exec bash -c '{0}'".format(command)
             try:
@@ -36,6 +40,7 @@ class LocalWorker(multiprocessing.Process):
                 logging.error(str(e))
                 # raise e
             self.result_queue.put((key, state))
+            self.in_progress.pop(str(self))
             self.task_queue.task_done()
             time.sleep(1)
 
@@ -50,8 +55,9 @@ class LocalExecutor(BaseExecutor):
     def start(self):
         self.queue = multiprocessing.JoinableQueue()
         self.result_queue = multiprocessing.Queue()
+        self.in_progress = multiprocessing.Manager().dict()
         self.workers = [
-            LocalWorker(self.queue, self.result_queue)
+            LocalWorker(self.queue, self.result_queue, self.in_progress)
             for i in range(self.parallelism)
         ]
 
@@ -62,6 +68,16 @@ class LocalExecutor(BaseExecutor):
         self.queue.put((key, command))
 
     def sync(self):
+        for w in list(self.workers):
+            if not w.is_alive():
+                self.workers.remove(w)
+                if str(w) in self.in_progress:
+                    key, command = self.in_progress.pop(str(w))
+                    self.fail(key)
+                self.workers.append(LocalWorker(
+                    self.queue, self.result_queue, self.in_progress))
+                self.workers[-1].start()
+
         while not self.result_queue.empty():
             results = self.result_queue.get()
             self.change_state(*results)

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -215,8 +215,8 @@ class SchedulerJob(BaseJob):
             self.num_runs = 1
         else:
             self.num_runs = num_runs
-        self.refresh_dags_every = refresh_dags_every	
-        self.do_pickle = do_pickle	
+        self.refresh_dags_every = refresh_dags_every
+        self.do_pickle = do_pickle
         super(SchedulerJob, self).__init__(*args, **kwargs)
 
         self.heartrate = conf.getint('scheduler', 'SCHEDULER_HEARTBEAT_SEC')

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -713,7 +713,7 @@ class BackfillJob(BaseJob):
                 # If the executor has a problem independent of the task, the
                 # task state could be 'running' even though the executor says
                 # 'failed'
-                elif ti.state == State.RUNNING and state == State.FAILED:
+                elif ti.state == State.RUNNING and state != ti.state:
 
                     # try/except is a hack for Python 3 because
                     # handle_failure() calls logging.exception(),

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -969,7 +969,12 @@ class TaskInstance(Base):
         task_copy.dry_run()
 
 
-    def handle_failure(self, error, test_mode, context):
+    def handle_failure(
+                self,
+                error,
+                test_mode,
+                context,
+                force_retry=False):
         logging.exception(error)
         task = self.task
         session = settings.Session()
@@ -980,7 +985,7 @@ class TaskInstance(Base):
 
         # Let's go deeper
         try:
-            if self.try_number <= task.retries:
+            if force_retry or self.try_number <= task.retries:
                 self.state = State.UP_FOR_RETRY
                 if task.email_on_retry and task.email:
                     self.email_alert(error, is_retry=True)


### PR DESCRIPTION
This week we found a rare but repeatable situation where `airflow backfill` would hang forever, insisting a number of tasks were running even though there was no visible activity. This was really nasty to debug. Finally determined that workers were crashing for non-task related reasons (in one case, a memory problem; in another, airflowdb was temporarily unavailable). When the worker disappeared, the task died but no action was ever taken because as far as the `BackfillJob` knew, the task was still `running` (the last recorded TI state).

Broadly: `TaskInstances` are responsible for maintaining their own state. However, `Executors` can also track state (via the `change_state()` method). This means it is possible for the `TaskInstance` state and `Executor` state to disagree. In this case, a CeleryWorker was dying in the middle of task execution, which meant that the TaskInstance couldn't update itself to say it hadn't completed. Mechanically, the `CeleryExecutor.event_buffer` was properly reporting a failed task, but the `TaskInstance` itself was reporting that it was `running`. `BackfillJob` only checks the TaskInstance, not the executor, so it would wait forever for the nonexistent task to complete.

This PR changes both `SchedulerJob` and `BackfillJob` to check if tasks that claim to be `running` are ACTUALLY running (according to the executor). If not, there must have been a non-task related problem  and the tasks are restarted.
