### PR TITLE
Fix travis caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - "3.4"
 env:
   global:
-    - CACHE=$HOME/.cache/
+    - TRAVIS_CACHE=$HOME/.travis_cache/
   matrix:
     - TOX_ENV=py27-cdh
     - TOX_ENV=py27-hdp
@@ -28,12 +28,12 @@ matrix:
 cache:
   directories:
     - $HOME/.wheelhouse/
-    - $HOME/.cache/
+    - $HOME/.travis_cache/
 install:
   - pip install --upgrade pip
   - pip install tox
 before_script:
-  - mysql -e 'create database airflow'
+  - mysql -e 'drop database if exists airflow; create database airflow' -u root
   - psql -c 'create database airflow;' -U postgres
 script:
   - pip --version

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -2,6 +2,7 @@ import socket
 
 from flask import Flask
 from flask.ext.admin import Admin, base
+from flask.ext.cache import Cache
 
 from airflow import login
 from airflow import models
@@ -18,6 +19,9 @@ def create_app(config=None):
     app.secret_key = conf.get('webserver', 'SECRET_KEY')
     #app.config = config
     login.login_manager.init_app(app)
+
+    cache = Cache(
+        app=app, config={'CACHE_TYPE': 'filesystem', 'CACHE_DIR': '/tmp'})
 
     app.register_blueprint(ck, url_prefix='/ck')
     app.register_blueprint(routes)

--- a/scripts/ci/setup_env.sh
+++ b/scripts/ci/setup_env.sh
@@ -51,7 +51,7 @@ if $ONLY_DOWNLOAD && $ONLY_EXTRACT; then
 fi
 
 mkdir -p ${HADOOP_HOME}
-mkdir -p ${CACHE}/${HADOOP_DISTRO}
+mkdir -p ${TRAVIS_CACHE}/${HADOOP_DISTRO}
 
 if [ $HADOOP_DISTRO = "cdh" ]; then
     URL="http://archive.cloudera.com/cdh5/cdh/5/hadoop-latest.tar.gz"
@@ -63,8 +63,8 @@ else
 fi
 
 if ! $ONLY_EXTRACT; then
-    echo "Downloading Hadoop from $URL to ${CACHE}/${HADOOP_DISTRO}/hadoop.tar.gz"
-    curl -z ${CACHE}/${HADOOP_DISTRO}/hadoop.tar.gz -o ${CACHE}/${HADOOP_DISTRO}/hadoop.tar.gz -L $URL
+    echo "Downloading Hadoop from $URL to ${TRAVIS_CACHE}/${HADOOP_DISTRO}/hadoop.tar.gz"
+    curl -z ${TRAVIS_CACHE}/${HADOOP_DISTRO}/hadoop.tar.gz -o ${TRAVIS_CACHE}/${HADOOP_DISTRO}/hadoop.tar.gz -L $URL
 
     if [ $? != 0 ]; then
         echo "Failed to download Hadoop from $URL - abort" >&2
@@ -77,7 +77,7 @@ if $ONLY_DOWNLOAD; then
 fi
 
 echo "Extracting ${HADOOP_HOME}/hadoop.tar.gz into $HADOOP_HOME"
-tar zxf ${CACHE}/${HADOOP_DISTRO}/hadoop.tar.gz --strip-components 1 -C $HADOOP_HOME
+tar zxf ${TRAVIS_CACHE}/${HADOOP_DISTRO}/hadoop.tar.gz --strip-components 1 -C $HADOOP_HOME
 
 if [ $? != 0 ]; then
     echo "Failed to extract Hadoop from ${HADOOP_HOME}/hadoop.tar.gz to ${HADOOP_HOME} - abort" >&2

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ passenv =
     TRAVIS_BUILD_DIR
     TRAVIS_JOB_ID
     USER
-    CACHE
+    TRAVIS_CACHE
 commands =
   pip wheel -w {homedir}/.wheelhouse -f {homedir}/.wheelhouse -r requirements.txt
   pip install --find-links={homedir}/.wheelhouse --no-index -rrequirements.txt


### PR DESCRIPTION
This actually fixes the travis caching and speeds up the builds. Previously ~/.cache was used for caching travis build requirements but this was also populated by other tools and thus changed every build. I moved the cache for travis to ~/.travis_cache.

I re-added the the Cache to app.py which was missing from my earlier commit (sorry for putting these unrelated changes together, it's a minor one hope you don't mind).
