### PR TITLE
Correcting misnamed argument for airflow webserver and exposing the ability to run multithreaded

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -66,7 +66,8 @@ defaults = {
         'demo_mode': False,
         'secret_key': 'airflowified',
         'expose_config': False,
-        'threads': 4,
+        'workers': 4,
+        'threads': 1,
     },
     'scheduler': {
         'statsd_on': False,
@@ -157,8 +158,11 @@ web_server_port = 8080
 # Secret key used to run your flask app
 secret_key = temporary_key
 
-# number of threads to run the Gunicorn web server
-thread = 4
+# number of workers to run for the Gunicorn web server
+workers = 4
+
+# number of threads to run for each worker
+threads = 1
 
 # Expose the configuration file in the web server
 expose_config = true
@@ -427,9 +431,10 @@ def getboolean(section, key):
 def getfloat(section, key):
     return conf.getfloat(section, key)
 
+
 def getint(section, key):
     return conf.getint(section, key)
 
+
 def has_option(section, key):
     return conf.has_option(section, key)
-

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -67,6 +67,7 @@ defaults = {
         'secret_key': 'airflowified',
         'expose_config': False,
         'workers': 4,
+        'worker_class': 'sync',
         'threads': 1,
     },
     'scheduler': {
@@ -157,6 +158,9 @@ web_server_port = 8080
 
 # Secret key used to run your flask app
 secret_key = temporary_key
+
+# The type of workers to use for the Gunicorn web server
+worker_class = sync
 
 # number of workers to run for the Gunicorn web server
 workers = 4


### PR DESCRIPTION
@mistercrunch 
This might enable more flexibility in how people run the webserver.
What was named threads before was actually processes, but gunicorn now has the ability to run each of theose processes multithreaded. I kept the defaults as the same as we currently have (I changed the config to reflect to correct names but the default call is the same)

Hopefully this will enable people to be more flexible in how they deploy the webserver. Still needs some testing, but putting it there for feedback.
