### PR TITLE
Disable auto-sorting on query view

### DIFF
--- a/airflow/www/templates/airflow/query.html
+++ b/airflow/www/templates/airflow/query.html
@@ -51,6 +51,7 @@
         $('table.dataframe').dataTable({
             "scrollX": true,
             "iDisplayLength": 100,
+            "aaSorting": [],
         });
         $('select').addClass("form-control");
         sync();


### PR DESCRIPTION
As per http://stackoverflow.com/questions/12124746/disable-automatic-sorting-on-the-first-column-when-using-jquery-datatables

Tested and it works 
@mistercrunch 

Perhaps we should add this to other places as well?
