### PR TITLE
Support sync and async gunicorn workers

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -602,6 +602,7 @@ def get_parser():
     parser_webserver.add_argument(
         "-k", "--workerclass",
         default=configuration.get('webserver', 'WORKER_CLASS'),
+        choices=['sync', 'eventlet', 'gevent', 'tornado'],
         help="The worker class to use for gunicorn")
     parser_webserver.add_argument(
         "-hn", "--hostname",

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -329,12 +329,12 @@ def webserver(args):
         app.run(debug=True, port=args.port, host=args.hostname)
     else:
         print(
-            'Running the Gunicorn server with {threads}'
-            'on host {args.hostname} and port '
+            'Running the Gunicorn server with {threads} {args.workerclass}'
+            'workers on host {args.hostname} and port '
             '{args.port}...'.format(**locals()))
         sp = subprocess.Popen([
-            'gunicorn', '-w', str(args.threads), '-t', '120', '-b',
-            args.hostname + ':' + str(args.port),
+            'gunicorn', '-w', str(args.threads), '-k', str(args.workerclass),
+            '-t', '120', '-b', args.hostname + ':' + str(args.port),
             'airflow.www.app:cached_app()'])
         sp.wait()
 
@@ -599,6 +599,10 @@ def get_parser():
         default=configuration.get('webserver', 'THREADS'),
         type=int,
         help="Number of threads to run the webserver on")
+    parser_webserver.add_argument(
+        "-k", "--workerclass",
+        default=configuration.get('webserver', 'WORKER_CLASS'),
+        help="The worker class to use for gunicorn")
     parser_webserver.add_argument(
         "-hn", "--hostname",
         default=configuration.get('webserver', 'WEB_SERVER_HOST'),

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -321,7 +321,7 @@ def webserver(args):
     log_to_stdout()
     from airflow.www.app import cached_app
     app = cached_app(configuration)
-    threads = args.threads or configuration.get('webserver', 'threads')
+    workers = args.workers or configuration.get('webserver', 'workers')
     if args.debug:
         print(
             "Starting the web server on port {0} and host {1}.".format(
@@ -329,11 +329,11 @@ def webserver(args):
         app.run(debug=True, port=args.port, host=args.hostname)
     else:
         print(
-            'Running the Gunicorn server with {threads} {args.workerclass}'
+            'Running the Gunicorn server with {workers} {args.workerclass}'
             'workers on host {args.hostname} and port '
             '{args.port}...'.format(**locals()))
         sp = subprocess.Popen([
-            'gunicorn', '-w', str(args.threads), '-k', str(args.workerclass),
+            'gunicorn', '-w', str(args.workers), '-k', str(args.workerclass),
             '-t', '120', '-b', args.hostname + ':' + str(args.port),
             'airflow.www.app:cached_app()'])
         sp.wait()
@@ -595,10 +595,10 @@ def get_parser():
         type=int,
         help="Set the port on which to run the web server")
     parser_webserver.add_argument(
-        "-w", "--threads",
-        default=configuration.get('webserver', 'THREADS'),
+        "-w", "--workers",
+        default=configuration.get('webserver', 'WORKERS'),
         type=int,
-        help="Number of threads to run the webserver on")
+        help="Number of workers to run the webserver on")
     parser_webserver.add_argument(
         "-k", "--workerclass",
         default=configuration.get('webserver', 'WORKER_CLASS'),

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -158,7 +158,7 @@ web_server_port = 8080
 secret_key = temporary_key
 
 # number of threads to run the Gunicorn web server
-thread = 4
+threads = 4
 
 # Expose the configuration file in the web server
 expose_config = true

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -162,7 +162,7 @@ secret_key = temporary_key
 threads = 4
 
 # The worker class gunicorn should use. Choices include
-# sync (default), eventlet, gevent, tornado
+# sync (default), eventlet, gevent
 worker_class = sync
 
 # Expose the configuration file in the web server

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -67,6 +67,7 @@ defaults = {
         'secret_key': 'airflowified',
         'expose_config': False,
         'threads': 4,
+        'worker_class': 'sync',
     },
     'scheduler': {
         'statsd_on': False,
@@ -157,8 +158,12 @@ web_server_port = 8080
 # Secret key used to run your flask app
 secret_key = temporary_key
 
-# number of threads to run the Gunicorn web server
+# Number of threads to run the Gunicorn web server
 threads = 4
+
+# The worker class gunicorn should use. Choices include
+# sync (default), eventlet, gevent, tornado
+worker_class = sync
 
 # Expose the configuration file in the web server
 expose_config = true

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -66,7 +66,7 @@ defaults = {
         'demo_mode': False,
         'secret_key': 'airflowified',
         'expose_config': False,
-        'threads': 4,
+        'workers': 4,
         'worker_class': 'sync',
     },
     'scheduler': {
@@ -158,8 +158,8 @@ web_server_port = 8080
 # Secret key used to run your flask app
 secret_key = temporary_key
 
-# Number of threads to run the Gunicorn web server
-threads = 4
+# Number of workers to run the Gunicorn web server
+workers = 4
 
 # The worker class gunicorn should use. Choices include
 # sync (default), eventlet, gevent

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,7 +55,10 @@ Here's the list of the subpackages and what they enable:
 +-------------+------------------------------------+------------------------------------------------+
 |  crypto     | ``pip install airflow[crypto]``    | Encrypt passwords in metadata db               |
 +-------------+------------------------------------+------------------------------------------------+
-
+|  celery     | ``pip install airflow[celery]``    | CeleryExecutor                                 |
++-------------+------------------------------------+------------------------------------------------+
+|  async      | ``pip install airflow[async]``     | Async worker classes for gunicorn              |
++-------------+------------------------------------+------------------------------------------------+
 
 Configuration
 '''''''''''''

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,11 @@ class Tox(TestCommand):
         errno = tox.cmdline(args=self.tox_args.split())
         sys.exit(errno)
 
+async = [
+    'greenlet>=0.4.9',
+    'eventlet>= 0.9.7',
+    'gevent>=0.13'
+]
 celery = [
     'celery>=3.1.17',
     'flower>=0.7.3'
@@ -91,6 +96,7 @@ setup(
     extras_require={
         'all': devel + optional,
         'all_dbs': all_dbs,
+        'async': async,
         'celery': celery,
         'crypto': crypto,
         'devel': devel,


### PR DESCRIPTION
When running airflow v1.5.2 on AWS with Elastic Load Balancer (ELb), you experience extreme high latency due to the interplay between gunicorn and  ELB as described here: https://forums.aws.amazon.com/thread.jspa?messageID=419138. To resolve this I added support to airflow to support both sync and async workers.
