### PR TITLE
Fixes for SQLite support

### DIFF
--- a/airflow/migrations/versions/2e541a1dcfed_task_duration.py
+++ b/airflow/migrations/versions/2e541a1dcfed_task_duration.py
@@ -18,10 +18,12 @@ from sqlalchemy.dialects import mysql
 
 
 def upgrade():
-    op.alter_column('task_instance', 'duration',
-               existing_type=mysql.INTEGER(display_width=11),
-               type_=sa.Float(),
-               existing_nullable=True)
+    # use batch_alter_table to support SQLite workaround
+    with op.batch_alter_table("task_instance") as batch_op:
+        batch_op.alter_column('duration',
+                              existing_type=mysql.INTEGER(display_width=11),
+                              type_=sa.Float(),
+                              existing_nullable=True)
 
 
 def downgrade():

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2056,7 +2056,7 @@ class DAG(object):
         has been reached
         """
         TI = TaskInstance
-        qry = session.query(func.count(TI)).filter(
+        qry = session.query(func.count(TI.task_id)).filter(
             TI.dag_id == self.dag_id,
             TI.task_id.in_(self.task_ids),
             TI.state == State.RUNNING,


### PR DESCRIPTION
Linked to issue https://github.com/airbnb/airflow/issues/621
- I fixed the migration script to allow alambic to use SQLite workarounds
- I fixed `DAG.concurrency_reached` to also work with SQLite
