### PR TITLE
Port kerberos authentication to new authentication structure

### DIFF
--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -108,7 +108,7 @@ def load_user(userid):
 def login(self, request):
     if current_user.is_authenticated():
         flash("You are already logged in")
-        return redirect(url_for('index'))
+        return redirect(url_for('admin.index'))
 
     username = None
     password = None

--- a/airflow/contrib/security/__init__.py
+++ b/airflow/contrib/security/__init__.py
@@ -1,1 +1,0 @@
-__author__ = 'bolke'

--- a/airflow/contrib/security/kerberos/__init__.py
+++ b/airflow/contrib/security/kerberos/__init__.py
@@ -1,1 +1,0 @@
-__author__ = 'bolke'

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ slackclient
 ldap3
 Flask-WTF
 lxml
+pykerberos

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ statsd = ['statsd>=3.0.1, <4.0']
 vertica = ['vertica-python>=0.5.1']
 ldap = ['ldap3>=0.9.9.1']
 devel = ['lxml>=3.3.4']
+kerberos = ['pykerberos>=1.1.8']
 
 all_dbs = postgres + mysql + hive + mssql + hdfs + vertica
 devel = all_dbs + doc + samba + s3 + ['nose'] + slack + crypto + oracle
@@ -110,6 +111,7 @@ setup(
         'vertica': vertica,
         'ldap': ldap,
         'webhdfs': webhdfs,
+        'kerberos': kerberos,
     },
     author='Maxime Beauchemin',
     author_email='maximebeauchemin@gmail.com',


### PR DESCRIPTION
This PR ports the kerberos authentication that was lingering around in contrib/security to the new contrib/auth/backend structure.

It is still untested (to test it requires a running kdc which is not too trivial to setup on travis) - but it wasn't anyway.
