### PR TITLE
Increase version for alembic due to bug in alembic < 0.8.3 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     zip_safe=False,
     scripts=['airflow/bin/airflow'],
     install_requires=[
-        'alembic>=0.8.0, <0.9',
+        'alembic>=0.8.3, <0.9',
         'chartkick>=0.4.2, < 0.5',
         'croniter>=0.3.8, <0.4',
         'dill>=0.2.2, <0.3',


### PR DESCRIPTION
Alembic versions < 0.8.3 have an issue that try to recreate table indexes with the same name on sqlite. This fixes migrations on sqlite.

https://bitbucket.org/zzzeek/alembic/issues/333/batch-fails-on-tables-that-have-indexes
