### PR TITLE
No need to expand if not bool(env_var)

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -34,6 +34,8 @@ def expand_env_var(env_var):
     `expandvars` and `expanduser` until interpolation stops having
     any effect.
     """
+    if not env_var:
+        return env_var
     while True:
         interpolated = os.path.expanduser(os.path.expandvars(str(env_var)))
         if interpolated == env_var:


### PR DESCRIPTION
@mistercrunch 

CC: @gwax 

Should fix #642 
The call to `str` is hiding the `None`. I return `env_var` to protect the case where 0 would be a legitimate `int` valued parameter in config. But in that case you don't want to interpolate either.
