### PR TITLE
Fix conn_type parsing from uris.

### DIFF
--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -46,7 +46,7 @@ class BaseHook(object):
         environment_uri = os.environ.get(CONN_ENV_PREFIX + conn_id.upper())
         conn = None
         if environment_uri:
-            conn = Connection(uri=environment_uri)
+            conn = Connection(conn_id=conn_id, uri=environment_uri)
         else:
             conn = random.choice(cls.get_connections(conn_id))
         if conn.host:

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -377,10 +377,10 @@ class Connection(Base):
             schema=None, port=None, extra=None,
             uri=None):
         self.conn_id = conn_id
-        self.conn_type = conn_type
         if uri:
             self.parse_from_uri(uri)
         else:
+            self.conn_type = conn_type
             self.host = host
             self.login = login
             self.password = password
@@ -393,6 +393,10 @@ class Connection(Base):
         hostname = temp_uri.hostname or ''
         if '%2f' in hostname:
             hostname = hostname.replace('%2f', '/').replace('%2F', '/')
+        conn_type = temp_uri.scheme
+        if conn_type == 'postgresql':
+            conn_type = 'postgres'
+        self.conn_type = conn_type
         self.host = hostname
         self.schema = temp_uri.path[1:]
         self.login = temp_uri.username


### PR DESCRIPTION
When reading connections from the environment as uri, the conn_type was getting set to None. This results in get_hook always returning None. Instead, we can parse the conn_type as the scheme in the uri.
