### PR TITLE
Allow http response checks to return values

### DIFF
--- a/airflow/operators/http_operator.py
+++ b/airflow/operators/http_operator.py
@@ -60,5 +60,8 @@ class SimpleHttpOperator(BaseOperator):
                             self.headers,
                             self.extra_options)
         if self.response_check:
-            if not self.response_check(response):
-                raise AirflowException("Response check returned False.")
+            resp = self.response_check(response)
+            if resp is None:
+                raise AirflowException("Response check returned None.")
+            else:
+                return resp


### PR DESCRIPTION
This would be useful in situations where subsequent HTTP requests need to use values from upstream ones.
