### PR TITLE
Fixing the function headers for decorated functions in the docs

### DIFF
--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -448,6 +448,9 @@ def apply_defaults(func):
         return result
     return wrapper
 
+if 'BUILDING_AIRFLOW_DOCS' in os.environ:
+    # Monkey patch hook to get good function headers while building docs
+    apply_defaults = lambda x: x
 
 def ask_yesno(question):
     yes = set(['yes', 'y'])

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,9 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
+import os
 import sys
+os.environ['BUILDING_AIRFLOW_DOCS'] = 'TRUE'
 from airflow import settings
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
@artwr  functools.wraps does preserve headers starting in 3.4, but in the meantime we have to use `decorator.decorator` 

This makes the docs looks much better, especially the operators section.
