### PR TITLE
Add templating support for data field in SimpleHttpOperator

### DIFF
--- a/airflow/operators/http_operator.py
+++ b/airflow/operators/http_operator.py
@@ -30,7 +30,7 @@ class SimpleHttpOperator(BaseOperator):
         depends on the option that's being modified.
     """
 
-    template_fields = ('endpoint',)
+    template_fields = ('endpoint','data',)
     template_ext = ()
     ui_color = '#f4a460'
 


### PR DESCRIPTION
SimpleHttpOperator has templating for endpoints. It a good idea adding templating for data which we want to send through HTTP.
