### PR TITLE
Add tests around schedule_dag. Make run_unit_tests.sh idempotent. Fix a bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Currently **officially** using Airflow:
 * Chartboost [[@cgelman](https://github.com/cgelman) & [@dclubb](https://github.com/dclubb)]
 * [Cotap](https://github.com/cotap/) [[@maraca](https://github.com/maraca) & [@richardchew](https://github.com/richardchew)]
 * Easy Taxi [[@caique-lima](https://github.com/caique-lima)]
+* [Handy](http://www.handy.com/careers/73115?gh_jid=73115&gh_src=o5qcxn) [[@marcintustin](https://github.com/marcintustin) / [@mtustin-handy](https://github.com/mtustin-handy)]
 * [Jampp](https://github.com/jampp)
 * [LingoChamp](http://www.liulishuo.com/) [[@haitaoyao](https://github.com/haitaoyao)]
 * Lyft

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -398,7 +398,7 @@ def initdb(args):
 
 def resetdb(args):
     print("DB: " + configuration.get('core', 'SQL_ALCHEMY_CONN'))
-    if input(
+    if args.yes or input(
             "This will drop existing tables if they exist. "
             "Proceed? (y/n)").upper() == "Y":
         logging.basicConfig(level=settings.LOGGING_LEVEL,
@@ -641,6 +641,11 @@ def get_parser():
 
     ht = "Burn down and rebuild the metadata database"
     parser_resetdb = subparsers.add_parser('resetdb', help=ht)
+    parser_resetdb.add_argument(
+            "-y", "--yes",
+            default=False,
+            help="Do not prompt to confirm reset. Use with care!",
+            action="store_true")
     parser_resetdb.set_defaults(func=resetdb)
 
     ht = "Upgrade metadata database to latest version"

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2672,7 +2672,7 @@ class DagRun(Base):
     __tablename__ = "dag_run"
     
     ID_PREFIX = 'scheduled__' 
-    ID_FORMAT_PREFIX = ID_PREFIX+'%s'
+    ID_FORMAT_PREFIX = ID_PREFIX + '{0}'
     
     id = Column(Integer, primary_key=True)
     dag_id = Column(String(ID_LEN))
@@ -2698,7 +2698,7 @@ class DagRun(Base):
 
     @classmethod
     def id_for_date(klass, date, prefix=ID_FORMAT_PREFIX):
-        return prefix % date.isoformat()[:19]
+        return prefix.format(date.isoformat()[:19])
 
 class Pool(Base):
     __tablename__ = "slot_pool"

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2670,7 +2670,10 @@ class DagRun(Base):
     by the scheduler (for regular runs) or by an external trigger
     """
     __tablename__ = "dag_run"
-
+    
+    ID_PREFIX = 'scheduled__' 
+    ID_FORMAT_PREFIX = ID_PREFIX+'%s'
+    
     id = Column(Integer, primary_key=True)
     dag_id = Column(String(ID_LEN))
     execution_date = Column(DateTime, default=datetime.now())
@@ -2693,6 +2696,9 @@ class DagRun(Base):
             run_id=self.run_id,
             external_trigger=self.external_trigger)
 
+    @classmethod
+    def id_for_date(klass, date, prefix=ID_FORMAT_PREFIX):
+        return prefix % date.isoformat()[:19]
 
 class Pool(Base):
     __tablename__ = "slot_pool"

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -22,6 +22,7 @@ fi
 which airflow > /dev/null || python setup.py develop
 
 echo "Initializing the DB"
+rm $AIRFLOW_HOME/unittests.db
 airflow initdb
 
 echo "Starting the unit tests with the following nose arguments: "$nose_args

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -22,8 +22,7 @@ fi
 which airflow > /dev/null || python setup.py develop
 
 echo "Initializing the DB"
-rm $AIRFLOW_HOME/unittests.db
-airflow initdb
+airflow resetdb -y
 
 echo "Starting the unit tests with the following nose arguments: "$nose_args
 nosetests $nose_args

--- a/tests/core.py
+++ b/tests/core.py
@@ -1,9 +1,11 @@
+import copy
 from datetime import datetime, time, timedelta
 import doctest
+import json
 import os
+import re
 from time import sleep
 import unittest
-import re
 
 from airflow import configuration
 configuration.test_mode()
@@ -49,6 +51,31 @@ class CoreTest(unittest.TestCase):
         self.dag = dag
         self.dag_bash = self.dagbag.dags['example_bash_operator']
         self.runme_0 = self.dag_bash.get_task('runme_0')
+
+    def test_schedule_dag_no_previous_runs(self):
+        dag = DAG(TEST_DAG_ID+'test_schedule_dag_no_previous_runs') 
+        dag.tasks = [models.BaseOperator(task_id="faketastic", owner='Also fake',
+            start_date=datetime(2015, 1, 2, 0, 0))]
+        dag_run = jobs.SchedulerJob(test_mode=True).schedule_dag(dag)
+        assert dag_run is not None
+        assert dag_run.dag_id == dag.dag_id
+        assert dag_run.run_id is not None
+        assert dag_run.run_id != ''
+        assert dag_run.execution_date == datetime(2015, 1, 2, 0, 0), (
+                'dag_run.execution_date did not match expectation: %s' % dag_run.execution_date)        
+        assert dag_run.state == models.State.RUNNING
+        assert dag_run.external_trigger == False
+
+    def test_schedule_dag_once(self):
+        dag = DAG(TEST_DAG_ID+'test_schedule_dag_once') 
+        dag.schedule_interval = '@once'
+        dag.tasks = [models.BaseOperator(task_id="faketastic", owner='Also fake',
+            start_date=datetime(2015, 1, 2, 0, 0))]
+        dag_run = jobs.SchedulerJob(test_mode=True).schedule_dag(dag)
+        dag_run2 = jobs.SchedulerJob(test_mode=True).schedule_dag(dag)
+
+        assert dag_run is not None
+        assert dag_run2 is None
 
     def test_confirm_unittest_mod(self):
         assert configuration.get('core', 'unit_test_mode')
@@ -382,13 +409,25 @@ class WebUiTests(unittest.TestCase):
         response = self.app.get(
             '/admin/airflow/tree?num_runs=25&dag_id=example_bash_operator')
         assert "runme_0" in response.data.decode('utf-8')
-        chartkick_regexp = 'new Chartkick.LineChart\(document.getElementById\(\"chart-\d+\"\),\s+\[["\w\:\s,\{\}\[\]]*\],\s+\{["\w\:\s,\{\}]+\)\;'
+        # new Chartkick.LineChart(document.getElementById("chart-0"), [{"data": [["2015-11-17T16:53:08.652950", 9.866944444444444e-06]], "name": "run_after_loop"}, {"data": [["2015-11-17T16:53:08.652950", 0.0002858047222222222], ["2015-11-17T16:56:09.698921", 0.00028737944444444445]], "name": "runme_0"}, {"data": [["2015-11-17T16:53:08.652950", 0.0002863941666666666], ["2015-11-17T16:56:09.698921", 0.00029015249999999996]], "name": "runme_1"}, {"data": [["2015-11-17T16:53:08.652950", 0.0002860847222222222], ["2015-11-17T16:56:09.698921", 0.00029001583333333335]], "name": "runme_2"}, {"data": [["2015-11-17T16:53:08.652950", 8.166944444444444e-06], ["2015-11-17T16:56:09.698921", 1.2806944444444445e-05]], "name": "also_run_this"}], {"library": {"yAxis": {"title": {"text": "hours"}}}, "height": "700px"}); 
+
+        chartkick_regexp = 'new Chartkick.LineChart\(document.getElementById\("chart-\d+"\),(.+)\)\;' 
         response = self.app.get(
             '/admin/airflow/duration?days=30&dag_id=example_bash_operator')
         assert "example_bash_operator" in response.data.decode('utf-8')
+
         chartkick_matched = re.search(chartkick_regexp,
                                       response.data.decode('utf-8'))
-        assert chartkick_matched is not None
+        assert chartkick_matched is not None, "chartkick_matched was none. Expected regex is: %s\nResponse was: %s" % (
+                chartkick_regexp,
+                response.data.decode('utf-8'))
+
+        # test that parameters to LineChart are well-formed json
+        try:
+            json.loads('[%s]' % chartkick_matched.group(1))
+        except e:
+            assert False, "Exception while json parsing LineChart parameters: %s" % e
+
         response = self.app.get(
             '/admin/airflow/landing_times?'
             'days=30&dag_id=example_bash_operator')

--- a/tests/models.py
+++ b/tests/models.py
@@ -6,5 +6,6 @@ from airflow import models
 class DagRunTest(unittest.TestCase):
     def test_id_for_date(self):
         run_id = models.DagRun.id_for_date(datetime.datetime(2015, 01, 02, 03, 04, 05, 06, None))
-        assert run_id == 'scheduled__2015-01-02T03:04:05', 'Generated run_id did not match expections: %s' % run_id
+        assert run_id == 'scheduled__2015-01-02T03:04:05', (
+                'Generated run_id did not match expections: {0}'.format(run_id))
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,10 @@
+import unittest
+import datetime
+
+from airflow import models
+
+class DagRunTest(unittest.TestCase):
+    def test_id_for_date(self):
+        run_id = models.DagRun.id_for_date(datetime.datetime(2015, 01, 02, 03, 04, 05, 06, None))
+        assert run_id == 'scheduled__2015-01-02T03:04:05', 'Generated run_id did not match expections: %s' % run_id
+


### PR DESCRIPTION
@mistercrunch This is not the other bug I alluded to. The bug is one where the second attempt to trigger an `@once` dag caused a TypeError through concatenating with a `None` value.

Also adds a `-y` option to `reset_db` to suppress the confirmation prompt. This is needed to use `reset_db` in the `run_unit_tests.sh` script.

Also has an update to the readme.

I'm going to open a second PR with a test for the other bug. 
