### PR TITLE
Better logging

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -342,6 +342,9 @@ class ConfigParserWithDefaults(ConfigParser):
             return expand_env_var(d[section][key])
 
         else:
+            logging.warn("section/key [{section}/{key}] not found "
+                         "in config".format(**locals()))
+
             raise AirflowConfigException(
                 "section/key [{section}/{key}] not found "
                 "in config".format(**locals()))

--- a/airflow/executors/__init__.py
+++ b/airflow/executors/__init__.py
@@ -5,16 +5,6 @@ from airflow.executors.base_executor import BaseExecutor
 from airflow.executors.local_executor import LocalExecutor
 from airflow.executors.sequential_executor import SequentialExecutor
 
-# TODO Fix this emergency fix
-try:
-    from airflow.executors.celery_executor import CeleryExecutor
-except:
-    pass
-try:
-    from airflow.contrib.executors.mesos_executor import MesosExecutor
-except:
-    pass
-
 from airflow.utils import AirflowException
 
 _EXECUTOR = configuration.get('core', 'EXECUTOR')
@@ -22,10 +12,12 @@ _EXECUTOR = configuration.get('core', 'EXECUTOR')
 if _EXECUTOR == 'LocalExecutor':
     DEFAULT_EXECUTOR = LocalExecutor()
 elif _EXECUTOR == 'CeleryExecutor':
+    from airflow.executors.celery_executor import CeleryExecutor
     DEFAULT_EXECUTOR = CeleryExecutor()
 elif _EXECUTOR == 'SequentialExecutor':
     DEFAULT_EXECUTOR = SequentialExecutor()
 elif _EXECUTOR == 'MesosExecutor':
+    from airflow.contrib.executors.mesos_executor import MesosExecutor
     DEFAULT_EXECUTOR = MesosExecutor()
 else:
     # Loading plugins

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -835,11 +835,17 @@ class Airflow(BaseView):
         force = request.args.get('force') == "true"
         deps = request.args.get('deps') == "true"
 
-        from airflow.executors import DEFAULT_EXECUTOR as executor
-        from airflow.executors import CeleryExecutor
-        if not isinstance(executor, CeleryExecutor):
+        try:
+            from airflow.executors import DEFAULT_EXECUTOR as executor
+            from airflow.executors import CeleryExecutor
+            if not isinstance(executor, CeleryExecutor):
+                flash("Only works with the CeleryExecutor, sorry", "error")
+                return redirect(origin)
+        except ImportError:
+            # in case CeleryExecutor cannot be imported it is not active either
             flash("Only works with the CeleryExecutor, sorry", "error")
             return redirect(origin)
+
         ti = models.TaskInstance(task=task, execution_date=execution_date)
         executor.start()
         executor.queue_task_instance(


### PR DESCRIPTION
This PR removes the hack in the executors/**init**.py by only importing executors when specified to do so. It is assumed (in views.py) that a failure to import CeleryExecutor means it is not active anyway and thus a run() fails accordingly. Furthermore it adds logging to sections/keys that are non existent in a config so debugging config issues becomes easier.
