### PR TITLE
improve SQLAlchemy session management in models.py

### DIFF
--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -6,7 +6,7 @@ export AIRFLOW_CONFIG=$AIRFLOW_HOME/unittests.cfg
 # any argument received is overriding the default nose execution arguments: 
 
 nose_args=$@
-if [ -a $nose_args ]; then
+if [ -z "$nose_args" ]; then
   nose_args="--with-coverage \
 --cover-erase \
 --cover-html \


### PR DESCRIPTION
- the optional creation and closing of local session in case no main_session is present is now encapsulated in a class that can be invoked via a simple with statement
- local sessions are now correctly closed in case of Exception during the method execution: previous load of try/except statement could potentially lead to un-closed sessions
- 4 supplementary UT to validate all that
- slightly more concise code :D 
