### PR TITLE
dag_details was causing mushroom cloud page

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -58,7 +58,7 @@
         </a>
       </li>
       <li>
-      <a href="{{ url_for("airflow.dag_details", dag_id=dag.dag_id) }}">
+      <a href="{{ url_for("airflow.dag_stats", dag_id=dag.dag_id) }}">
           <span class="glyphicon glyphicon-list" aria-hidden="true"></span>
           Details 
         </a>


### PR DESCRIPTION
The line as before this change was causing the mushroom cloud page. This change fixes it.

@mistercrunch 
