### PR TITLE
added log, to at least to show possible exception in searching for DAGs

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -311,7 +311,8 @@ class DagBag(object):
                                 [re.findall(p, filepath) for p in patterns]):
                             self.process_file(
                                 filepath, only_if_updated=only_if_updated)
-                    except:
+                    except Exception as e:
+                        logging.warning(e)
                         pass
 
     def deactivate_inactive_dags(self):

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -313,7 +313,6 @@ class DagBag(object):
                                 filepath, only_if_updated=only_if_updated)
                     except Exception as e:
                         logging.warning(e)
-                        pass
 
     def deactivate_inactive_dags(self):
         active_dag_ids = [dag.dag_id for dag in list(self.dags.values())]


### PR DESCRIPTION
There was added `logging.warning` in order to fix bug described in #714
