### PR TITLE
fix bytestring in xcom with python3

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -1,6 +1,5 @@
 
 from builtins import bytes
-from builtins import str
 import logging
 import sys
 from subprocess import Popen, STDOUT, PIPE
@@ -71,7 +70,8 @@ class BashOperator(BaseOperator):
                 logging.info("Output:")
                 line = ''
                 for line in iter(sp.stdout.readline, b''):
-                    logging.info(line.strip())
+                    line = line.decode().strip()
+                    logging.info(line)
                 sp.wait()
                 logging.info("Command exited with "
                              "return code {0}".format(sp.returncode))
@@ -80,7 +80,7 @@ class BashOperator(BaseOperator):
                     raise AirflowException("Bash command failed")
 
         if self.xcom_push:
-            return str(line.strip(), sys.getdefaultencoding())
+            return line
 
     def on_kill(self):
         logging.info('Sending SIGTERM signal to bash subprocess')

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -1,6 +1,8 @@
 
 from builtins import bytes
+from builtins import str
 import logging
+import sys
 from subprocess import Popen, STDOUT, PIPE
 from tempfile import gettempdir, NamedTemporaryFile
 
@@ -78,7 +80,7 @@ class BashOperator(BaseOperator):
                     raise AirflowException("Bash command failed")
 
         if self.xcom_push:
-            return str(line.strip())
+            return str(line.strip(), sys.getdefaultencoding())
 
     def on_kill(self):
         logging.info('Sending SIGTERM signal to bash subprocess')


### PR DESCRIPTION
Hi,
There is an issue with python3 and the `str` function, which translate
`"output_from_bash"` to `b"output_from_bash"`

as stated here https://docs.python.org/3/library/stdtypes.html?highlight=str#str

I had issues with jinja templating and saw "b" string in the rendered template.
