### PR TITLE
[AIRFLOW-594] Load plugins and workflows from packages

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -102,6 +102,9 @@ dags_folder = {AIRFLOW_HOME}/dags
 # This path must be absolute
 base_log_folder = {AIRFLOW_HOME}/logs
 
+# The entrypoint group from which plugins and dags are loaded
+entrypoint_group = airflow
+
 # Airflow can store logs remotely in AWS S3 or Google Cloud Storage. Users
 # must supply a remote location URL (starting with either 's3://...' or
 # 'gs://...') and an Airflow connection id that provides access to the storage
@@ -428,6 +431,7 @@ airflow_home = {AIRFLOW_HOME}
 dags_folder = {TEST_DAGS_FOLDER}
 plugins_folder = {TEST_PLUGINS_FOLDER}
 base_log_folder = {AIRFLOW_HOME}/logs
+entrypoint_group = {TEST_ENTRYPOINT_GROUP}
 executor = SequentialExecutor
 sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/unittests.db
 load_examples = True
@@ -726,6 +730,8 @@ if os.path.exists(_TEST_PLUGINS_FOLDER):
     TEST_PLUGINS_FOLDER = _TEST_PLUGINS_FOLDER
 else:
     TEST_PLUGINS_FOLDER = os.path.join(AIRFLOW_HOME, 'plugins')
+
+TEST_ENTRYPOINT_GROUP = 'airflow_test'
 
 
 def parameterized_config(template):

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -45,6 +45,8 @@ import warnings
 import hashlib
 
 from urllib.parse import urlparse
+from pkg_resources import iter_entry_points
+
 
 from sqlalchemy import (
     Column, Integer, String, DateTime, Text, Boolean, ForeignKey, PickleType,
@@ -82,6 +84,7 @@ Base = declarative_base()
 ID_LEN = 250
 SQL_ALCHEMY_CONN = configuration.get('core', 'SQL_ALCHEMY_CONN')
 DAGS_FOLDER = os.path.expanduser(configuration.get('core', 'DAGS_FOLDER'))
+ENTRYPOINT_GROUP = configuration.get('core', 'ENTRYPOINT_GROUP')
 XCOM_RETURN_KEY = 'return_value'
 
 Stats = settings.Stats
@@ -161,12 +164,16 @@ class DagBag(BaseDagBag, LoggingMixin):
     def __init__(
             self,
             dag_folder=None,
+            entrypoint_group=None,
             executor=DEFAULT_EXECUTOR,
             include_examples=configuration.getboolean('core', 'LOAD_EXAMPLES')):
 
         dag_folder = dag_folder or DAGS_FOLDER
-        self.logger.info("Filling up the DagBag from {}".format(dag_folder))
+        entrypoint_group = entrypoint_group or ENTRYPOINT_GROUP
+        logging.info("Filling up the DagBag from %s and "
+                     "entrypoint group %s", dag_folder, entrypoint_group)
         self.dag_folder = dag_folder
+        self.entrypoint_group = entrypoint_group
         self.dags = {}
         # the file's last modified timestamp when we last read it
         self.file_last_changed = {}
@@ -179,6 +186,7 @@ class DagBag(BaseDagBag, LoggingMixin):
                 'example_dags')
             self.collect_dags(example_dag_folder)
         self.collect_dags(dag_folder)
+        self.collect_dags_from_entrypoint_group(entrypoint_group)
 
     def size(self):
         """
@@ -454,6 +462,41 @@ class DagBag(BaseDagBag, LoggingMixin):
             task_num=sum([o.dag_num for o in stats]),
             table=pprinttable(stats),
         )
+
+    def collect_dags_from_entrypoint_group(self, entrypoint_group=None):
+        """
+        Given an entry point group, this method takes all entry points in the group that
+        are DAGs and adds them to the dagbag collection.
+
+        Note that the entry point group will be formatted as '{entrypoint_group}.dags'.
+        """
+        entrypoint_group = entrypoint_group or self.entrypoint_group
+        if entrypoint_group is None:
+            return
+
+        for entry_point in iter_entry_points(group=entrypoint_group + '.dags', name=None):
+            dist = entry_point.dist
+            self.logger.info("Importing package " + dist.project_name)
+            try:
+                self.logger.info("Importing DAG from module " + entry_point.module_name)
+                dag = entry_point.load()
+                logging.info(dag)
+                if isinstance(dag, DAG):
+                    # Get the file defining the dag to display it in the ui
+                    module_path = sys.modules[entry_point.module_name].__file__
+
+                    # Do not use pyc files for reloading
+                    if module_path.endswith(".pyc"):
+                        module_path = module_path[:-1]
+
+                    dag.full_filepath = module_path
+
+                    dag.is_subdag = False
+                    self.bag_dag(dag, parent_dag=dag, root_dag=dag)
+
+            except Exception as e:
+                self.logger.exception(e)
+                self.logger.error('Failed to import DAG ' + entry_point.module_name)
 
     def deactivate_inactive_dags(self):
         active_dag_ids = [dag.dag_id for dag in list(self.dags.values())]

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -24,6 +24,7 @@ import logging
 import os
 import re
 import sys
+from pkg_resources import iter_entry_points
 
 from airflow import configuration
 
@@ -48,6 +49,7 @@ class AirflowPlugin(object):
             raise AirflowPluginException("Your plugin needs a name.")
 
 
+entrypoint_group = configuration.get('core', 'entrypoint_group')
 plugins_folder = configuration.get('core', 'plugins_folder')
 if not plugins_folder:
     plugins_folder = configuration.get('core', 'airflow_home') + '/plugins'
@@ -89,6 +91,22 @@ for root, dirs, files in os.walk(plugins_folder, followlinks=True):
         except Exception as e:
             logging.exception(e)
             logging.error('Failed to import plugin ' + filepath)
+
+if entrypoint_group is not None:
+    # Allow for plugin classes also to be registered as entry points in packages
+    for entry_point in iter_entry_points(group=entrypoint_group + '.plugins', name=None):
+        dist = entry_point.dist
+        try:
+            logging.info('Importing plugin module ' + entry_point.module_name)
+            obj = entry_point.load()
+            if issubclass(obj, AirflowPlugin) and obj is not AirflowPlugin:
+                obj.validate()
+                if obj not in plugins:
+
+                    plugins.append(obj)
+        except Exception as e:
+            logging.exception(e)
+            logging.error('Failed to import plugin ' + entry_point.module_name)
 
 
 def make_module(name, objects):

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -832,3 +832,26 @@ do the same, but then it is more to use a virtualenv and pip.
    to be available on the system if a module needs those. In other words only
    pure python modules can be packaged.
 
+Dags as Python packages
+'''''''''''''''''''''''
+
+It is possible to load dags via setuptools' entrypoint mechanism. To do this link
+your dag using an entrypoint in your package. If the package is installed, airflow
+will automatically load the registered dags from the entrypoint list.
+
+.. code-block:: python
+
+    from setuptools import setup
+
+    setup(
+        name="my-package",
+        ...
+        entry_points = {
+            'airflow.dags': [
+                'my_dag = my_package.my_dag:dag'
+            ]
+        }
+    )
+
+.. note:: The default entrypoint group ``airflow`` can be changed in the configuration
+   file.

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -142,3 +142,28 @@ definitions in Airflow.
         admin_views = [v]
         flask_blueprints = [bp]
         menu_links = [ml]
+
+
+Plugins as Python packages
+--------------------------
+
+It is possible to load plugins via setuptools' entrypoint mechanism. To do this link
+your plugin using an entrypoint in your package. If the package is installed, airflow
+will automatically load the registered plugins from the entrypoint list.
+
+.. code-block:: python
+
+    from setuptools import setup
+
+    setup(
+        name="my-package",
+        ...
+        entry_points = {
+            'airflow.plugins': [
+                'my_plugin = my_package.my_plugin:MyAirflowPlugin'
+            ]
+        }
+    )
+
+.. note:: The default entrypoint group ``airflow`` can be changed in the configuration
+   file.

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -39,6 +39,8 @@ if [ -z "$nose_args" ]; then
 --logging-level=DEBUG "
 fi
 
+pip install -e tests/airflow_test_load_via_pkg
+
 #--with-doctest
 
 # Generate the `airflow` executable if needed
@@ -48,8 +50,13 @@ echo "Initializing the DB"
 yes | airflow resetdb
 airflow initdb
 
+
+
 echo "Starting the unit tests with the following nose arguments: "$nose_args
 nosetests $nose_args
 
 # To run individual tests:
 # nosetests tests.core:CoreTest.test_scheduler_job
+
+# Remove the egg info from the local install of the test package
+rm -r tests/airflow_test_load_via_pkg/airflow_test_load_via_pkg.egg-info

--- a/tests/airflow_test_load_via_pkg/airflow_test_load_via_pkg/__init__.py
+++ b/tests/airflow_test_load_via_pkg/airflow_test_load_via_pkg/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -10,8 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-set -o verbose
-
-
-python setup.py test --tox-args="-v -e $TOX_ENV"

--- a/tests/airflow_test_load_via_pkg/airflow_test_load_via_pkg/another_test_plugin.py
+++ b/tests/airflow_test_load_via_pkg/airflow_test_load_via_pkg/another_test_plugin.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the class you derive to create a plugin
+from airflow.plugins_manager import AirflowPlugin
+
+from flask_admin.base import MenuLink
+
+# Importing base classes that we need to derive
+from airflow.hooks.base_hook import BaseHook
+from airflow.models import  BaseOperator
+from airflow.executors.base_executor import BaseExecutor
+
+# Will show up under airflow.hooks.another_test_plugin.AnotherPluginHook
+class AnotherPluginHook(BaseHook):
+    pass
+
+# Will show up under airflow.operators.another_test_plugin.AnotherPluginOperator
+class AnotherPluginOperator(BaseOperator):
+    pass
+
+# Will show up under airflow.executors.another_test_plugin.AnotherPluginExecutor
+class AnotherPluginExecutor(BaseExecutor):
+    pass
+
+# Will show up under airflow.macros.another_test_plugin.plugin_macro
+def another_plugin_macro():
+    pass
+
+ml = MenuLink(
+    category='Another Test Plugin',
+    name='Another Test Menu Link',
+    url='http://pythonhosted.org/airflow/')
+
+# Defining the plugin class
+class AnotherAirflowTestPlugin(AirflowPlugin):
+    name = "another_test_plugin"
+    operators = [AnotherPluginOperator]
+    hooks = [AnotherPluginHook]
+    executors = [AnotherPluginExecutor]
+    macros = [another_plugin_macro]
+    menu_links = [ml]

--- a/tests/airflow_test_load_via_pkg/airflow_test_load_via_pkg/test_dag.py
+++ b/tests/airflow_test_load_via_pkg/airflow_test_load_via_pkg/test_dag.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o verbose
+from datetime import datetime
 
+from airflow.models import DAG
+from airflow.operators.dummy_operator import DummyOperator
 
-python setup.py test --tox-args="-v -e $TOX_ENV"
+entrypoint_test_dag = DAG(
+    dag_id='entrypoint_test_dag',
+    start_date=datetime(2100, 1, 1)
+)
+
+dag1_task1 = DummyOperator(
+    task_id='dummy',
+    dag=entrypoint_test_dag,
+    owner='airflow')

--- a/tests/airflow_test_load_via_pkg/setup.py
+++ b/tests/airflow_test_load_via_pkg/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o verbose
+from setuptools import setup
 
-
-python setup.py test --tox-args="-v -e $TOX_ENV"
+setup(
+    name="airflow-test-load-via-pkg",
+    version="1.0.0",
+    long_description=__doc__,
+    packages=["airflow_test_load_via_pkg"],
+    entry_points = {
+        'airflow_test.dags': [
+            'test_dag = airflow_test_load_via_pkg.test_dag:entrypoint_test_dag'
+        ],
+        'airflow_test.plugins': [
+            'test_plugin = airflow_test_load_via_pkg.another_test_plugin:AnotherAirflowTestPlugin'
+        ]
+      },
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/tests/core.py
+++ b/tests/core.py
@@ -62,7 +62,7 @@ from airflow.configuration import AirflowConfigException
 
 import six
 
-NUM_EXAMPLE_DAGS = 18
+NUM_EXAMPLE_DAGS = 19
 DEV_NULL = '/dev/null'
 TEST_DAG_FOLDER = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), 'dags')

--- a/tests/models.py
+++ b/tests/models.py
@@ -134,7 +134,8 @@ class DagBagTest(unittest.TestCase):
         dagbag = models.DagBag(include_examples=True)
 
         some_expected_dag_ids = ["example_bash_operator",
-                                 "example_branch_operator"]
+                                 "example_branch_operator",
+                                 "entrypoint_test_dag"]
 
         for dag_id in some_expected_dag_ids:
             dag = dagbag.get_dag(dag_id)

--- a/tests/plugins_manager.py
+++ b/tests/plugins_manager.py
@@ -68,3 +68,21 @@ class PluginsTest(unittest.TestCase):
         [menu_link] = [ml for ml in category.get_children()
                        if isinstance(ml, MenuLink)]
         assert menu_link.name == 'Test Menu Link'
+
+
+class EntrypointPluginsTest(unittest.TestCase):
+    def test_operators(self):
+        from airflow.operators.another_test_plugin import AnotherPluginOperator
+        assert issubclass(AnotherPluginOperator, BaseOperator)
+
+    def test_hooks(self):
+        from airflow.hooks.another_test_plugin import AnotherPluginHook
+        assert issubclass(AnotherPluginHook, BaseHook)
+
+    def test_executors(self):
+        from airflow.executors.another_test_plugin import AnotherPluginExecutor
+        assert issubclass(AnotherPluginExecutor, BaseExecutor)
+
+    def test_macros(self):
+        from airflow.macros.another_test_plugin import another_plugin_macro
+        assert callable(another_plugin_macro)


### PR DESCRIPTION
This pull request adds capabilities to load plugins and workflows from other packages via the setuptools entry point mechanism.

Within my company (http://blue-yonder.com) we are currently evaluating whether we could use airflow. As our infrastructure is suited towards the deployment of python packages we would need a way to load workflows from installed packages. Also for plugins the entry point mechanism seems very natural.

If you have any ideas or comments on this feature (or how to properly test it) we are happy to discuss it here!
