### PR TITLE
Run docker containers

### DIFF
--- a/airflow/example_dags/example_docker_operator.py
+++ b/airflow/example_dags/example_docker_operator.py
@@ -1,0 +1,48 @@
+from airflow import DAG
+from airflow.operators import BashOperator
+from datetime import datetime, timedelta
+from airflow.operators.docker_operator import DockerOperator
+
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': datetime.now(),
+    'email': ['airflow@airflow.com'],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5)    
+}
+
+dag = DAG(
+    'docker_sample', default_args=default_args, schedule_interval=timedelta(minutes=10))
+
+t1 = BashOperator(
+    task_id='print_date',
+    bash_command='date',
+    dag=dag)
+
+t2 = BashOperator(
+    task_id='sleep',
+    bash_command='sleep 5',
+    retries=3,
+    dag=dag)
+
+t3 = DockerOperator(api_version='1.19',
+    docker_url='tcp://localhost:2375', #Set your docker URL
+    command='/bin/sleep 30',
+    image='centos:latest',
+    network_mode='bridge',
+    task_id='docker_op_tester',
+    dag=dag)
+
+
+t4 = BashOperator(
+    task_id='print_hello',
+    bash_command='echo "hello world!!!"',
+    dag=dag)
+
+
+t1.set_downstream(t2)
+t1.set_downstream(t3)
+t3.set_downstream(t4)

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -16,7 +16,7 @@ class DockerOperator(BaseOperator):
     :param image: Docker image from which to create the container.
     :type image: str
     :param api_version: Remote API version.
-    :type api_version: float
+    :type api_version: str
     :param command: Command to be run in the container.
     :type command: str or list
     :param cpus: Number of CPUs to assign to the container.

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -1,0 +1,156 @@
+import json
+import logging
+from airflow.models import BaseOperator
+from airflow.utils import apply_defaults, AirflowException, TemporaryDirectory
+from docker import Client, tls
+
+
+class DockerOperator(BaseOperator):
+    """
+    Execute a command inside a docker container.
+
+    A temporary directory is created on the host and mounted into a container to allow storing files
+    that together exceed the default disk size of 10GB in a container. The path to the mounted
+    directory can be accessed via the environment variable ``AIRFLOW_TMP_DIR``.
+
+    :param image: Docker image from which to create the container.
+    :type image: str
+    :param api_version: Remote API version.
+    :type api_version: float
+    :param command: Command to be run in the container.
+    :type command: str or list
+    :param cpus: Number of CPUs to assign to the container.
+        This value gets multiplied with 1024. See
+        https://docs.docker.com/engine/reference/run/#cpu-share-constraint
+    :type cpus: float
+    :param docker_url: URL of the host running the docker daemon.
+    :type docker_url: str
+    :param environment: Environment variables to set in the container.
+    :type environment: dict
+    :param force_pull: Pull the docker image on every run.
+    :type force_pull: bool
+    :param mem_limit: Maximum amount of memory the container can use. Either a float value, which
+        represents the limit in bytes, or a string like ``128m`` or ``1g``.
+    :type mem_limit: float or str
+    :param network_mode: Network mode for the container.
+    :type network_mode: str
+    :param tls_ca_cert: Path to a PEM-encoded certificate authority to secure the docker connection.
+    :type tls_ca_cert: str
+    :param tls_client_cert: Path to the PEM-encoded certificate used to authenticate docker client.
+    :type tls_client_cert: str
+    :param tls_client_key: Path to the PEM-encoded key used to authenticate docker client.
+    :type tls_client_key: str
+    :param tls_hostname: Hostname to match against the docker server certificate or False to
+        disable the check.
+    :type tls_hostname: str or bool
+    :param tls_ssl_version: Version of SSL to use when communicating with docker daemon.
+    :type tls_ssl_version: str
+    :param tmp_dir: Mount point inside the container to a temporary directory created on the host by
+        the operator. The path is also made available via the environment variable
+        ``AIRFLOW_TMP_DIR`` inside the container.
+    :type tmp_dir: str
+    :param user: Default user inside the docker container.
+    :type user: int or str
+    :param volumes: List of volumes to mount into the container, e.g.
+        ``['/host/path:/container/path', '/host/path2:/container/path2:ro']``.
+    """
+    @apply_defaults
+    def __init__(
+            self,
+            image,
+            api_version=None,
+            command=None,
+            cpus=1.0,
+            docker_url='unix://var/run/docker.sock',
+            environment=None,
+            force_pull=False,
+            mem_limit=None,
+            network_mode=None,
+            tls_ca_cert=None,
+            tls_client_cert=None,
+            tls_client_key=None,
+            tls_hostname=None,
+            tls_ssl_version=None,
+            tmp_dir='/tmp/airflow',
+            user=None,
+            volumes=None,
+            *args,
+            **kwargs):
+
+        super(DockerOperator, self).__init__(*args, **kwargs)
+        self.api_version = api_version
+        self.command = command
+        self.cpus = cpus
+        self.docker_url = docker_url
+        self.environment = environment or {}
+        self.force_pull = force_pull
+        self.image = image
+        self.mem_limit = mem_limit
+        self.network_mode = network_mode
+        self.tls_ca_cert = tls_ca_cert
+        self.tls_client_cert = tls_client_cert
+        self.tls_client_key = tls_client_key
+        self.tls_hostname = tls_hostname
+        self.tls_ssl_version = tls_ssl_version
+        self.tmp_dir = tmp_dir
+        self.user = user
+        self.volumes = volumes or []
+
+        self.cli = None
+        self.container = None
+
+    def execute(self, context):
+        logging.info('Starting docker container from image ' + self.image)
+
+        tls_config = None
+        if self.tls_ca_cert and self.tls_client_cert and self.tls_client_key:
+            tls_config = tls.TLSConfig(
+                ca_cert=self.tls_ca_cert,
+                client_cert=(self.tls_client_cert, self.tls_client_key),
+                verify=True,
+                ssl_version=self.tls_ssl_version,
+                assert_hostname=self.tls_hostname
+            )
+            self.docker_url = self.docker_url.replace('tcp://', 'https://')
+
+        self.cli = Client(base_url=self.docker_url, version=self.api_version, tls=tls_config)
+
+        if ':' not in self.image:
+            image = self.image + ':latest'
+        else:
+            image = self.image
+
+        if self.force_pull or len(self.cli.images(name=image)) == 0:
+            logging.info('Pulling docker image ' + image)
+            for l in self.cli.pull(image, stream=True):
+                output = json.loads(l)
+                logging.info("{}".format(output['status']))
+
+        cpu_shares = int(round(self.cpus * 1024))
+
+        with TemporaryDirectory(prefix='airflowtmp') as host_tmp_dir:
+            self.environment['AIRFLOW_TMP_DIR'] = self.tmp_dir
+            self.volumes.append('{0}:{1}'.format(host_tmp_dir, self.tmp_dir))
+
+            self.container = self.cli.create_container(
+                command=self.command,
+                cpu_shares=cpu_shares,
+                environment=self.environment,
+                host_config=self.cli.create_host_config(binds=self.volumes,
+                                                        network_mode=self.network_mode),
+                image=image,
+                mem_limit=self.mem_limit,
+                user=self.user
+            )
+            self.cli.start(self.container['Id'])
+
+            for l in self.cli.logs(container=self.container['Id'], stream=True):
+                logging.info("{}".format(l.strip()))
+
+            exit_code = self.cli.wait(self.container['Id'])
+            if exit_code != 0:
+                raise AirflowException('docker container failed')
+
+    def on_kill(self):
+        logging.info('Stopping docker container')
+        self.cli.stop(self.container['Id'])

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -152,5 +152,6 @@ class DockerOperator(BaseOperator):
                 raise AirflowException('docker container failed')
 
     def on_kill(self):
-        logging.info('Stopping docker container')
-        self.cli.stop(self.container['Id'])
+        if self.cli is not None:
+            logging.info('Stopping docker container')
+            self.cli.stop(self.container['Id'])

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -49,6 +49,7 @@ Operator API
         BashOperator,
         BranchPythonOperator,
         TriggerDagRunOperator,
+        DockerOperator,
         DummyOperator,
         EmailOperator,
         ExternalTaskSensor,
@@ -142,7 +143,7 @@ attributes and methods.
 
 Macros
 ''''''
-Macros are a way to expose objects to your templates and live under the 
+Macros are a way to expose objects to your templates and live under the
 ``macros`` namespace in your templates.
 
 A few commonly used libraries and methods are made available.

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,4 @@ lxml
 pykerberos
 bcrypt
 flask-bcrypt
+mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ coverage
 coveralls
 croniter
 dill
+docker-py
 filechunkio
 flake8
 flask

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ doc = [
     'sphinx-rtd-theme>=0.1.6',
     'Sphinx-PyPI-upload>=0.2.1'
 ]
+docker = ['docker-py>=1.6.0']
 druid = ['pydruid>=0.2.1']
 hdfs = ['snakebite>=2.4.13']
 webhdfs = ['hdfs[dataframe,avro,kerberos]>=2.0.4']
@@ -82,7 +83,7 @@ password = [
 ]
 
 all_dbs = postgres + mysql + hive + mssql + hdfs + vertica
-devel = all_dbs + doc + samba + s3 + ['nose'] + slack + crypto + oracle
+devel = all_dbs + doc + samba + s3 + ['nose'] + slack + crypto + oracle + docker
 
 setup(
     name='airflow',
@@ -123,6 +124,7 @@ setup(
         'crypto': crypto,
         'devel': devel,
         'doc': doc,
+        'docker': docker,
         'druid': druid,
         'hdfs': hdfs,
         'hive': hive,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import absolute_import
 from .core import *
 from .models import *
+from .operators import *

--- a/tests/operators/__init__.py
+++ b/tests/operators/__init__.py
@@ -1,0 +1,1 @@
+from .docker_operator import *

--- a/tests/operators/docker_operator.py
+++ b/tests/operators/docker_operator.py
@@ -1,0 +1,118 @@
+import unittest
+
+from airflow.operators.docker_operator import DockerOperator
+from docker.client import Client
+
+from airflow.utils import AirflowException
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+
+class DockerOperatorTestCase(unittest.TestCase):
+    @unittest.skipIf(mock is None, 'mock package not present')
+    @mock.patch('airflow.utils.mkdtemp')
+    @mock.patch('airflow.operators.docker_operator.Client')
+    def test_execute(self, client_class_mock, mkdtemp_mock):
+        host_config = mock.Mock()
+        mkdtemp_mock.return_value = '/mkdtemp'
+
+        client_mock = mock.Mock(spec=Client)
+        client_mock.create_container.return_value = {'Id': 'some_id'}
+        client_mock.create_host_config.return_value = host_config
+        client_mock.images.return_value = []
+        client_mock.logs.return_value = ['container log']
+        client_mock.pull.return_value = ['{"status":"pull log"}']
+        client_mock.wait.return_value = 0
+
+        client_class_mock.return_value = client_mock
+
+        operator = DockerOperator(api_version=1.19, command='env', environment={'UNIT': 'TEST'},
+                                  image='ubuntu:latest', network_mode='bridge', owner='unittest',
+                                  task_id='unittest', volumes=['/host/path:/container/path'])
+        operator.execute(None)
+
+        client_class_mock.assert_called_with(base_url='unix://var/run/docker.sock', tls=None,
+                                             version=1.19)
+
+        client_mock.create_container.assert_called_with(command='env', cpu_shares=1024,
+                                                        environment={
+                                                            'AIRFLOW_TMP_DIR': '/tmp/airflow',
+                                                            'UNIT': 'TEST'
+                                                        },
+                                                        host_config=host_config,
+                                                        image='ubuntu:latest',
+                                                        mem_limit=None, user=None)
+        client_mock.create_host_config.assert_called_with(binds=['/host/path:/container/path',
+                                                                 '/mkdtemp:/tmp/airflow'],
+                                                          network_mode='bridge')
+        client_mock.images.assert_called_with(name='ubuntu:latest')
+        client_mock.logs.assert_called_with(container='some_id', stream=True)
+        client_mock.pull.assert_called_with('ubuntu:latest', stream=True)
+        client_mock.wait.assert_called_with('some_id')
+
+    @unittest.skipIf(mock is None, 'mock package not present')
+    @mock.patch('airflow.operators.docker_operator.tls.TLSConfig')
+    @mock.patch('airflow.operators.docker_operator.Client')
+    def test_execute_tls(self, client_class_mock, tls_class_mock):
+        client_mock = mock.Mock(spec=Client)
+        client_mock.create_container.return_value = {'Id': 'some_id'}
+        client_mock.create_host_config.return_value = mock.Mock()
+        client_mock.images.return_value = []
+        client_mock.logs.return_value = []
+        client_mock.pull.return_value = []
+        client_mock.wait.return_value = 0
+
+        client_class_mock.return_value = client_mock
+        tls_mock = mock.Mock()
+        tls_class_mock.return_value = tls_mock
+
+        operator = DockerOperator(docker_url='tcp://127.0.0.1:2376', image='ubuntu',
+                                  owner='unittest', task_id='unittest', tls_client_cert='cert.pem',
+                                  tls_ca_cert='ca.pem', tls_client_key='key.pem')
+        operator.execute(None)
+
+        tls_class_mock.assert_called_with(assert_hostname=None, ca_cert='ca.pem',
+                                          client_cert=('cert.pem', 'key.pem'), ssl_version=None,
+                                          verify=True)
+
+        client_class_mock.assert_called_with(base_url='https://127.0.0.1:2376', tls=tls_mock,
+                                             version=None)
+
+    @unittest.skipIf(mock is None, 'mock package not present')
+    @mock.patch('airflow.operators.docker_operator.Client')
+    def test_execute_container_fails(self, client_class_mock):
+        client_mock = mock.Mock(spec=Client)
+        client_mock.create_container.return_value = {'Id': 'some_id'}
+        client_mock.create_host_config.return_value = mock.Mock()
+        client_mock.images.return_value = []
+        client_mock.logs.return_value = []
+        client_mock.pull.return_value = []
+        client_mock.wait.return_value = 1
+
+        client_class_mock.return_value = client_mock
+
+        operator = DockerOperator(image='ubuntu', owner='unittest', task_id='unittest')
+
+        with self.assertRaises(AirflowException):
+            operator.execute(None)
+
+    @unittest.skipIf(mock is None, 'mock package not present')
+    def test_on_kill(self):
+        client_mock = mock.Mock(spec=Client)
+
+        operator = DockerOperator(image='ubuntu', owner='unittest', task_id='unittest')
+        operator.cli = client_mock
+        operator.container = {'Id': 'some_id'}
+
+        operator.on_kill()
+
+        client_mock.stop.assert_called_with('some_id')
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/operators/docker_operator.py
+++ b/tests/operators/docker_operator.py
@@ -32,13 +32,13 @@ class DockerOperatorTestCase(unittest.TestCase):
 
         client_class_mock.return_value = client_mock
 
-        operator = DockerOperator(api_version=1.19, command='env', environment={'UNIT': 'TEST'},
+        operator = DockerOperator(api_version='1.19', command='env', environment={'UNIT': 'TEST'},
                                   image='ubuntu:latest', network_mode='bridge', owner='unittest',
                                   task_id='unittest', volumes=['/host/path:/container/path'])
         operator.execute(None)
 
         client_class_mock.assert_called_with(base_url='unix://var/run/docker.sock', tls=None,
-                                             version=1.19)
+                                             version='1.19')
 
         client_mock.create_container.assert_called_with(command='env', cpu_shares=1024,
                                                         environment={


### PR DESCRIPTION
This PR adds support for running docker containers by adding a
`DockerOperator`.

Besides starting a container, the implementation supports pulling
images, limiting resources, mounting volumes, setting the network
mode and authenticating via TLS.
