### PR TITLE
Fix AttributeError when starting scheduler

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -220,7 +220,7 @@ class SchedulerJob(BaseJob):
 
         if test_mode:
             self.num_runs = 1
-        elif num_runs and num_runs > 0:
+        else:
             self.num_runs = num_runs
 
         self.refresh_dags_every = refresh_dags_every


### PR DESCRIPTION
This PR fixes the exception
`AttributeError: 'SchedulerJob' object has no attribute 'num_runs'`
that is thrown when starting the scheduler without setting `-n`.
