### PR TITLE
Fix DagBag.get_dag() for non existing dag_id

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -158,8 +158,9 @@ class DagBag(object):
                 dag = self.dags[dag_id]
         else:
             orm_dag = DagModel.get_current(dag_id)
-            self.process_file(
-                filepath=orm_dag.fileloc, only_if_updated=False)
+            if orm_dag:
+                self.process_file(filepath=orm_dag.fileloc,
+                                  only_if_updated=False)
             if dag_id in self.dags:
                 dag = self.dags[dag_id]
             else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,3 @@
 from __future__ import absolute_import
 from .core import *
+from .models import *

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,9 +3,37 @@ import datetime
 
 from airflow import models
 
+
 class DagRunTest(unittest.TestCase):
     def test_id_for_date(self):
-        run_id = models.DagRun.id_for_date(datetime.datetime(2015, 01, 02, 03, 04, 05, 06, None))
+        run_id = models.DagRun.id_for_date(
+            datetime.datetime(2015, 01, 02, 03, 04, 05, 06, None))
         assert run_id == 'scheduled__2015-01-02T03:04:05', (
-                'Generated run_id did not match expections: {0}'.format(run_id))
+            'Generated run_id did not match expectations: {0}'.format(run_id))
 
+
+class DagBagTest(unittest.TestCase):
+
+    def test_get_existing_dag(self):
+        """
+        test that were're able to parse some example DAGs and retrieve them
+        """
+        dagbag = models.DagBag(include_examples=True)
+
+        some_expected_dag_ids = ["example_bash_operator",
+                                 "example_branch_operator"]
+
+        for dag_id in some_expected_dag_ids:
+            dag = dagbag.get_dag(dag_id)
+
+            assert dag is not None
+            assert dag.dag_id == dag_id
+
+    def test_get_non_existing_dag(self):
+        """
+        test that retrieving a non existing dag id returns None without crashing
+        """
+        dagbag = models.DagBag(include_examples=True)
+
+        non_existing_dag_id = "non_existing_dag_id"
+        assert dagbag.get_dag(non_existing_dag_id) is None

--- a/tests/models.py
+++ b/tests/models.py
@@ -7,7 +7,7 @@ from airflow import models
 class DagRunTest(unittest.TestCase):
     def test_id_for_date(self):
         run_id = models.DagRun.id_for_date(
-            datetime.datetime(2015, 01, 02, 03, 04, 05, 06, None))
+            datetime.datetime(2015, 1, 2, 3, 4, 5, 6, None))
         assert run_id == 'scheduled__2015-01-02T03:04:05', (
             'Generated run_id did not match expectations: {0}'.format(run_id))
 


### PR DESCRIPTION
Calling `.get_dag("non_existing_dag_id")` was previously leading to a crash related to a call to `None.fileloc`. We've fixed the bug by allowing the code to return None when the DAG isn't found, following the existing logic that is already returning `None` in other cases where the Dag isn't found.

We've also added unit tests to validate the behavior
