### PR TITLE
Don't require unittests.cfg to avoid overwriting airflow.cfg

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -410,7 +410,7 @@ TEST_CONFIG_FILE = AIRFLOW_HOME + '/unittests.cfg'
 if not os.path.isfile(TEST_CONFIG_FILE):
     logging.info("Creating new airflow config file for unit tests in: " +
                  TEST_CONFIG_FILE)
-    with open(AIRFLOW_CONFIG, 'w') as f:
+    with open(TEST_CONFIG_FILE, 'w') as f:
         f.write(parameterized_config(TEST_CONFIG))
 
 if not os.path.isfile(AIRFLOW_CONFIG):

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -220,7 +220,7 @@ class SchedulerJob(BaseJob):
 
         if test_mode:
             self.num_runs = 1
-        elif num_runs and num_runs > 0:
+        else:
             self.num_runs = num_runs
 
         self.refresh_dags_every = refresh_dags_every


### PR DESCRIPTION
@mistercrunch Found this bug - without unittests.cfg airflow will overwrite airflow.cfg
