### PR TITLE
Removed logging sql query that exposes credentials

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -102,7 +102,6 @@ class DbApiHook(BaseHook):
 
         cur = conn.cursor()
         for s in sql:
-            logging.info(s)
             if parameters is not None:
                 cur.execute(s, parameters)
             else:


### PR DESCRIPTION
# Purpose

Although most of the time, logs are only exposed to internal systems/people, it is unsafe to show credentials in plain text anywhere. Technologies that only allow passing credentials with a query could potentially pose a problem in this context when all the sql queries executed are shown in logs. Maybe this could be added back when airflow has a debug mode, but definitely a security risk.

For example, AWS redshift authenticates with aws credentials with their COPY command which looks like this in logs:

```
[2015-12-09 21:12:21,228] {dbapi_hook.py:97} INFO - COPY some_table_name from 's3://airflow/folder/table' credentials 'aws_access_key_id=XXXX;aws_secret_access_key=YYYY';
```
