### PR TITLE
Fix base_url in http hook to always start with http://

### DIFF
--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -24,6 +24,8 @@ class HttpHook(BaseHook):
         conn = self.get_connection(self.http_conn_id)
         session = requests.Session()
         self.base_url = conn.host
+        if not self.base_url.startswith('http'):
+            self.base_url = 'http://' + self.base_url
 
         if conn.port:
             self.base_url = self.base_url + ":" + str(conn.port) + "/"


### PR DESCRIPTION
When we use environment variables to make Http connections, it reads http:// from string and remove it. This fact made to not be able connecting because cannot find location (even localhost or 127.0.0.1).

Other way to recreate this bug is create an Http connection from webserver-ui without specifying http:// in host field.

This minor check add http:// at the start if host string doen't got it.
