### PR TITLE
Fix logging

### DIFF
--- a/airflow/bin/airflow
+++ b/airflow/bin/airflow
@@ -6,8 +6,6 @@ from airflow.bin.cli import get_parser
 
 if __name__ == '__main__':
 
-    logging.root.handlers = []
-
     if configuration.get("core", "security") == 'kerberos':
         os.environ['KRB5CCNAME'] = configuration.get('kerberos', 'ccache')
         os.environ['KRB5_KTNAME'] = configuration.get('kerberos', 'keytab')

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -10,7 +10,6 @@ import argparse
 import dateutil.parser
 
 import airflow
-print ("ABOUT TO IMPORT SETTINGS")
 from airflow import jobs, settings, utils
 from airflow import configuration
 from airflow.executors import DEFAULT_EXECUTOR

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -10,6 +10,7 @@ import argparse
 import dateutil.parser
 
 import airflow
+print ("ABOUT TO IMPORT SETTINGS")
 from airflow import jobs, settings, utils
 from airflow import configuration
 from airflow.executors import DEFAULT_EXECUTOR
@@ -80,7 +81,7 @@ def backfill(args):
 
 
 def trigger_dag(args):
-    utils.log_to_stdout()
+    
     session = settings.Session()
     # TODO: verify dag_id
     execution_date = datetime.now()
@@ -261,7 +262,7 @@ def list_tasks(args):
 
 
 def test(args):
-    utils.log_to_stdout()
+    
     args.execution_date = dateutil.parser.parse(args.execution_date)
     dagbag = DagBag(process_subdir(args.subdir))
     if args.dag_id not in dagbag.dags:
@@ -307,7 +308,7 @@ def clear(args):
 
 def webserver(args):
     print(settings.HEADER)
-    utils.log_to_stdout()
+    
     from airflow.www.app import cached_app
     app = cached_app(configuration)
     workers = args.workers or configuration.get('webserver', 'workers')
@@ -330,7 +331,7 @@ def webserver(args):
 
 def scheduler(args):
     print(settings.HEADER)
-    utils.log_to_stdout()
+    
     job = jobs.SchedulerJob(
         dag_id=args.dag_id,
         subdir=process_subdir(args.subdir),
@@ -419,7 +420,7 @@ def flower(args):
 
 def kerberos(args):
     print(settings.HEADER)
-    utils.log_to_stdout()
+    
     import airflow.security.kerberos
     airflow.security.kerberos.run()
 

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+print ("IN SETTINGS")
+
 import logging
 import os
 
@@ -67,9 +69,15 @@ def policy(task_instance):
     """
     pass
 
+def configure_logging():
+    logging.basicConfig(format=LOG_FORMAT)
+    print ("configured logging")    
 
 try:
     from airflow_local_settings import *
     logging.info("Loaded airflow_local_settings.")
 except:
     pass
+
+print ("about to configure logging")
+configure_logging()

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -3,10 +3,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-print ("IN SETTINGS")
-
 import logging
 import os
+import sys
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -70,8 +69,8 @@ def policy(task_instance):
     pass
 
 def configure_logging():
-    logging.basicConfig(format=LOG_FORMAT)
-    print ("configured logging")    
+    logging.root.handlers = []
+    logging.basicConfig(format=LOG_FORMAT, stream=sys.stdout, level=LOGGING_LEVEL)
 
 try:
     from airflow_local_settings import *
@@ -79,5 +78,4 @@ try:
 except:
     pass
 
-print ("about to configure logging")
 configure_logging()

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -758,6 +758,9 @@ class LoggingMixin(object):
 
     @property
     def logger(self):
-        if not hasattr(self, "_logger"):
-            self._logger = logging.getLogger().getChild(self.__class__.__name__)
-        return self._logger
+        try:
+            return self._logger
+        except AttributeError:
+            self._logger = logging.getLogger(self.__class__.__name__)
+	    return self._logger
+

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -761,6 +761,6 @@ class LoggingMixin(object):
         try:
             return self._logger
         except AttributeError:
-            self._logger = logging.getLogger(self.__class__.__name__)
-	    return self._logger
+            self._logger = logging.root.getChild(self.__class__.__module__ + '.' +self.__class__.__name__)
+            return self._logger
 

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -751,27 +751,6 @@ class AirflowJsonEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def log_to_stdout():
-
-    root_logger = logging.getLogger()
-
-    # default log level if not set externally (e.g. with --logging-level=DEBUG)
-    if root_logger.level == logging.NOTSET:
-        root_logger.setLevel(LOGGING_LEVEL)
-
-    for handler in root_logger.handlers:
-        if isinstance(handler, logging.StreamHandler):
-            root_logger.warn("not adding a stream handler: already present")
-            return
-
-    logformat = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-
-    ch = logging.StreamHandler(sys.stdout)
-    ch.setFormatter(logformat)
-    root_logger.addHandler(ch)
-
-
 class LoggingMixin(object):
     """
     Convenience super-class to have a logger configured with the class name
@@ -780,5 +759,5 @@ class LoggingMixin(object):
     @property
     def logger(self):
         if not hasattr(self, "_logger"):
-            self._logger = logging.getLogger(self.__class__.__name__)
+            self._logger = logging.getLogger().getChild(self.__class__.__name__)
         return self._logger

--- a/tests/core.py
+++ b/tests/core.py
@@ -408,9 +408,9 @@ class CoreTest(unittest.TestCase):
         class Blah(LoggingMixin):
             pass
 
-        assert Blah().logger.name == "Blah"
-        assert SequentialExecutor().logger.name == "SequentialExecutor"
-        assert LocalExecutor().logger.name == "LocalExecutor"
+        assert Blah().logger.name == "tests.core.Blah"
+        assert SequentialExecutor().logger.name == "airflow.executors.sequential_executor.SequentialExecutor"
+        assert LocalExecutor().logger.name == "airflow.executors.local_executor.LocalExecutor"
 
     def test_round_time(self):
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -401,46 +401,6 @@ class CoreTest(unittest.TestCase):
         assert "{AIRFLOW_HOME}" not in cfg
         assert "{FERNET_KEY}" not in cfg
 
-    def test_calling_log_to_stdout_should_add_one_stream_handler(self):
-
-        # first resetting the logger
-        root_logger = logging.getLogger()
-        for handler in root_logger.handlers:
-            root_logger.removeHandler(handler)
-
-        root_logger.setLevel(logging.NOTSET)
-        assert root_logger.level == logging.NOTSET
-
-        utils.log_to_stdout()
-        stream_handlers = [h for h in root_logger.handlers
-                           if isinstance(h, logging.StreamHandler)]
-
-        assert len(stream_handlers) == 1
-        assert root_logger.level == utils.LOGGING_LEVEL
-
-    def test_calling_log_to_stdout_2X_should_add_only_one_stream_handler(self):
-
-        utils.log_to_stdout()
-        utils.log_to_stdout()
-        root_logger = logging.getLogger()
-
-        stream_handlers = [h for h in root_logger.handlers
-                           if isinstance(h, logging.StreamHandler)]
-
-        assert len(stream_handlers) == 1
-
-    def test_setting_log_level_then_calling_log_should_keep_the_old_value(self):
-
-        # if the log level is set externally, i.e. either through
-        # --logging-level or anything, then its value should not be overridden
-        # by the default "INFO" in log_to_stdout
-
-        root_logger = logging.getLogger()
-        root_logger.setLevel(logging.DEBUG)
-        utils.log_to_stdout()
-
-        assert root_logger.level == logging.DEBUG
-
     def test_class_with_logger_should_have_logger_with_correct_name(self):
 
         # each class should automatically receive a logger with a correct name


### PR DESCRIPTION
@mistercrunch @svendx4f This re-enables logging. It also makes class-based loggers hierarchical. It takes the logging config from airflow.settings, and allows airflow_local_settings to override the format, the log level, and the method which does the configuration.

No unit tests; coverage may drop very slightly. 
