### PR TITLE
Add ssl extra arguments to postgres hook

### DIFF
--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -6,6 +6,8 @@ from airflow.hooks.dbapi_hook import DbApiHook
 class PostgresHook(DbApiHook):
     '''
     Interact with Postgres.
+    You can specify ssl parameters in the extra field of your connection
+    as ``{"sslmode": "require", "sslcert": "/path/to/cert.pem", etc}``.
     '''
     conn_name_attr = 'postgres_conn_id'
     default_conn_name = 'postgres_default'
@@ -13,9 +15,14 @@ class PostgresHook(DbApiHook):
 
     def get_conn(self):
         conn = self.get_connection(self.postgres_conn_id)
-        return psycopg2.connect(
+        conn_args = dict(
             host=conn.host,
             user=conn.login,
             password=conn.password,
             dbname=conn.schema,
             port=conn.port)
+        # check for ssl parameters in conn.extra
+        for arg_name, arg_val in conn.extra_dejson.iteritems():
+            if arg_name in ['sslmode', 'sslcert', 'sslkey', 'sslrootcert', 'sslcrl']:
+                conn_args[arg_name] = arg_val
+        return psycopg2.connect(**conn_args)


### PR DESCRIPTION
This enables one to specify items such as ssl certificate paths in the extra field of a postgres connection object. Rather than simply pass-through everything from the extra field, I followed the existing code pattern of selecting for specific arguments, as demonstrated in other hooks. I tested this in Python 2.7.6 and Python 2.7.10.
