### PR TITLE
Make smtp_user and smtp_password optional

### DIFF
--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -41,6 +41,7 @@ from croniter import croniter
 from airflow import settings
 from airflow import configuration
 from airflow.settings import LOGGING_LEVEL
+from airflow.configuration import AirflowConfigException
 
 
 class AirflowException(Exception):
@@ -520,9 +521,12 @@ def send_email(to, subject, html_content, files=None, dryrun=False):
 def send_MIME_email(e_from, e_to, mime_msg, dryrun=False):
     SMTP_HOST = configuration.get('smtp', 'SMTP_HOST')
     SMTP_PORT = configuration.getint('smtp', 'SMTP_PORT')
-    SMTP_USER = configuration.get('smtp', 'SMTP_USER')
-    SMTP_PASSWORD = configuration.get('smtp', 'SMTP_PASSWORD')
     SMTP_STARTTLS = configuration.getboolean('smtp', 'SMTP_STARTTLS')
+    try:
+        SMTP_USER = configuration.get('smtp', 'SMTP_USER')
+        SMTP_PASSWORD = configuration.get('smtp', 'SMTP_PASSWORD')
+    except AirflowConfigException:
+        SMTP_USER = None
 
     if not dryrun:
         s = smtplib.SMTP(SMTP_HOST, SMTP_PORT)


### PR DESCRIPTION
Not all SMTP servers require authentication (e.g. those on localhost) so make this optional.
