### PR TITLE
set default smtp_user, smtp_password so they are not needed in user config

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -84,6 +84,8 @@ defaults = {
     },
     'smtp': {
         'smtp_starttls': True,
+        'smtp_user': '',
+        'smtp_password': '',
     },
     'kerberos': {
         'ccache': '/tmp/airflow_krb5_ccache',


### PR DESCRIPTION
currently if you use email and don't set these an exception is raised in utils.py:send_MIME_email
