### PR TITLE
Adding base date and run number form to Task Duration and Landing Times views

### DIFF
--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -15,7 +15,9 @@ class DateTimeForm(Form):
         "Execution date", widget=DateTimePickerWidget())
 
 
-class TreeForm(Form):
+class DateTimeWithNumRunsForm(Form):
+    # Date time and number of runs form for tree view, task duration
+    # and landing times
     base_date = DateTimeField(
         "Anchor date", widget=DateTimePickerWidget(), default=datetime.now())
     num_runs = SelectField("Number of runs", default=25, choices=(

--- a/airflow/www/templates/airflow/chart.html
+++ b/airflow/www/templates/airflow/chart.html
@@ -1,6 +1,30 @@
 {% extends "airflow/dag.html" %}
 {% block title %}Airflow - DAGs{% endblock %}
 
+{% block head_css %}
+{{ super() }}
+<link rel="stylesheet" type="text/css"
+    href="{{ url_for('static', filename='tree.css') }}">
+<link href="{{ admin_static.url(filename='vendor/bootstrap-daterangepicker/daterangepicker-bs2.css') }}" rel="stylesheet">
+{% endblock %}
+
+{% block body %}
+{{ super() }}
+<div style="float: left" class="form-inline">
+    <form method="get" style="float:left;">
+        Base date: {{ form.base_date(class_="form-control") }}
+        Number of runs: {{ form.num_runs(class_="form-control") }}
+        <input type="hidden" name="root" value="{{ root if root else '' }}">
+        <input type="hidden" value="{{ dag.dag_id }}" name="dag_id">
+        <input type="submit" value="Go" class="btn btn-default"
+         action="" method="get">
+        <input name="_csrf_token" type="hidden" value="{{ csrf_token() }}">
+    </form>
+</div>
+<div style="clear: both;"></div>
+<hr/>
+{% endblock %}
+
 {% block tail %}
     {{ super() }}
     <script src="{{ url_for('static', filename='d3.v3.min.js') }}"></script>
@@ -31,6 +55,7 @@
       });
     });
     </script>
+
     <div class="container">
       {% line_chart data with height=height library=chart_options%}
       <div class="text-center">
@@ -39,4 +64,9 @@
       </div>
     </div>
 
+    <script src="{{ url_for('static', filename='d3.v3.min.js') }}"></script>
+      <script src="{{ admin_static.url(
+        filename='vendor/bootstrap-daterangepicker/daterangepicker.js') }}"></script>
+      <script src="{{ admin_static.url(filename='admin/js/form-1.0.0.js') }}"></script>
+    <script>
 {% endblock %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -46,7 +46,7 @@ from airflow.www import utils as wwwutils
 from airflow import settings
 from airflow.models import State
 
-from airflow.www.forms import DateTimeForm, TreeForm
+from airflow.www.forms import DateTimeForm, DateTimeWithNumRunsForm
 
 QUERY_LIMIT = 100000
 CHART_LIMIT = 200000
@@ -1179,7 +1179,8 @@ class Airflow(BaseView):
         session.commit()
         session.close()
 
-        form = TreeForm(data={'base_date': max_date, 'num_runs': num_runs})
+        form = DateTimeWithNumRunsForm(data={'base_date': max_date,
+                                             'num_runs': num_runs})
         return self.render(
             'airflow/tree.html',
             operators=sorted(
@@ -1304,10 +1305,18 @@ class Airflow(BaseView):
     def duration(self):
         session = settings.Session()
         dag_id = request.args.get('dag_id')
-        days = int(request.args.get('days', 30))
         dag = dagbag.get_dag(dag_id)
-        from_date = (datetime.today()-timedelta(days)).date()
-        from_date = datetime.combine(from_date, datetime.min.time())
+        base_date = request.args.get('base_date')
+        num_runs = request.args.get('num_runs')
+        num_runs = int(num_runs) if num_runs else 25
+
+        if base_date:
+            base_date = dateutil.parser.parse(base_date)
+        else:
+            base_date = dag.latest_execution_date or datetime.now()
+
+        dates = dag.date_range(base_date, num=-abs(num_runs))
+        min_date = dates[0] if dates else datetime(2000, 1, 1)
 
         root = request.args.get('root')
         if root:
@@ -1319,7 +1328,8 @@ class Airflow(BaseView):
         all_data = []
         for task in dag.tasks:
             data = []
-            for ti in task.get_task_instances(session, from_date):
+            for ti in task.get_task_instances(session, start_date=min_date,
+                                              end_date=base_date):
                 if ti.duration:
                     data.append([
                         ti.execution_date.isoformat(),
@@ -1328,9 +1338,16 @@ class Airflow(BaseView):
             if data:
                 all_data.append({'data': data, 'name': task.task_id})
 
+        tis = dag.get_task_instances(
+                session, start_date=min_date, end_date=base_date)
+        dates = sorted(list({ti.execution_date for ti in tis}))
+        max_date = max([ti.execution_date for ti in tis]) if dates else None
+
         session.commit()
         session.close()
 
+        form = DateTimeWithNumRunsForm(data={'base_date': max_date,
+                                             'num_runs': num_runs})
         return self.render(
             'airflow/chart.html',
             dag=dag,
@@ -1339,6 +1356,7 @@ class Airflow(BaseView):
             height="700px",
             demo_mode=configuration.getboolean('webserver', 'demo_mode'),
             root=root,
+            form=form,
         )
 
     @expose('/landing_times')
@@ -1347,10 +1365,18 @@ class Airflow(BaseView):
     def landing_times(self):
         session = settings.Session()
         dag_id = request.args.get('dag_id')
-        days = int(request.args.get('days', 30))
         dag = dagbag.get_dag(dag_id)
-        from_date = (datetime.today()-timedelta(days)).date()
-        from_date = datetime.combine(from_date, datetime.min.time())
+        base_date = request.args.get('base_date')
+        num_runs = request.args.get('num_runs')
+        num_runs = int(num_runs) if num_runs else 25
+
+        if base_date:
+            base_date = dateutil.parser.parse(base_date)
+        else:
+            base_date = dag.latest_execution_date or datetime.now()
+
+        dates = dag.date_range(base_date, num=-abs(num_runs))
+        min_date = dates[0] if dates else datetime(2000, 1, 1)
 
         root = request.args.get('root')
         if root:
@@ -1362,7 +1388,8 @@ class Airflow(BaseView):
         all_data = []
         for task in dag.tasks:
             data = []
-            for ti in task.get_task_instances(session, from_date):
+            for ti in task.get_task_instances(session, start_date=min_date,
+                                              end_date=base_date):
                 if ti.end_date:
                     ts = ti.execution_date
                     if dag.schedule_interval:
@@ -1371,9 +1398,16 @@ class Airflow(BaseView):
                     data.append([ti.execution_date.isoformat(), secs])
             all_data.append({'data': data, 'name': task.task_id})
 
+        tis = dag.get_task_instances(
+                session, start_date=min_date, end_date=base_date)
+        dates = sorted(list({ti.execution_date for ti in tis}))
+        max_date = max([ti.execution_date for ti in tis]) if dates else None
+
         session.commit()
         session.close()
 
+        form = DateTimeWithNumRunsForm(data={'base_date': max_date,
+                                             'num_runs': num_runs})
         return self.render(
             'airflow/chart.html',
             dag=dag,
@@ -1382,6 +1416,7 @@ class Airflow(BaseView):
             chart_options={'yAxis': {'title': {'text': 'hours after 00:00'}}},
             demo_mode=configuration.getboolean('webserver', 'demo_mode'),
             root=root,
+            form=form,
         )
 
     @expose('/paused')


### PR DESCRIPTION
This adds the possibility to specify the base date and the number of runs displayed, for the Task Duration as well as the Landing Times views.
