### PR TITLE
some fixes 

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -848,11 +848,14 @@ class LocalTaskJob(BaseJob):
             job_id=self.id,
             pool=self.pool,
         )
-        self.process = subprocess.Popen(['bash', '-c', command])
-        return_code = None
-        while return_code is None:
-            self.heartbeat()
-            return_code = self.process.poll()
+        with open(self.task_instance.log_filepath, 'a') as log_file_handle:
+            self.process = subprocess.Popen(['bash', '-c', command],
+                stdout=log_file_handle,
+                stderr=log_file_handle)
+            return_code = None
+            while return_code is None:
+                self.heartbeat()
+                return_code = self.process.poll()
 
     def on_kill(self):
         self.process.terminate()

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -207,7 +207,8 @@ class DagBag(LoggingMixin):
 
             for dag in list(m.__dict__.values()):
                 if isinstance(dag, DAG):
-                    dag.full_filepath = filepath
+                    if dag.full_filepath is None or dag.full_filepath == '':
+                        dag.full_filepath = filepath
                     dag.is_subdag = False
                     self.bag_dag(dag, parent_dag=dag, root_dag=dag)
 
@@ -586,7 +587,8 @@ class TaskInstance(Base):
         cmd += "--raw " if raw else ""
         if task_start_date:
             cmd += "-s " + task_start_date.isoformat() + ' '
-        if not pickle_id and self.task.dag and self.task.dag.full_filepath:
+        if not pickle_id and self.task.dag and \
+                self.task.dag.full_filepath and not os.path.isabs(self.task.dag.full_filepath):
             cmd += "-sd DAGS_FOLDER/{self.task.dag.filepath} "
         return cmd.format(**locals())
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -722,7 +722,7 @@ class Airflow(BaseView):
         task_id = request.args.get('task_id')
         execution_date = request.args.get('execution_date')
         dag = dagbag.get_dag(dag_id)
-        log_relative = "{dag_id}/{task_id}/{execution_date}".format(
+        log_relative = "{dag_id}/{task_id}/{execution_date}.log".format(
             **locals())
         loc = os.path.join(BASE_LOG_FOLDER, log_relative)
         loc = loc.format(**locals())
@@ -746,8 +746,8 @@ class Airflow(BaseView):
                     log += "".join(f.readlines())
                     f.close()
                     log_loaded = True
-                except:
-                    log = "*** Log file isn't where expected.\n".format(loc)
+                except Exception as e:
+                    log = "*** Log file isn't where expected {0}\n {1}.\n".format(loc, str(e))
             else:
                 WORKER_LOG_SERVER_PORT = \
                     configuration.get('celery', 'WORKER_LOG_SERVER_PORT')


### PR DESCRIPTION
full_filepath fixes the usecase with actual file with dag definition is outside the DAGS_FOLDER. 

I have dags defined in our project and a file like 'from our_project.dags import *' in DAGS_FOLDER.
In this setup we steel want source code to be displayed in web interface correctly. So we pass full_filepath parameter, but airflow does not handle it right

The second commit redirects logs to the correct place
