### PR TITLE
slack_operator was using "params" which prevented user-defined params macro from working

### DIFF
--- a/airflow/operators/slack_operator.py
+++ b/airflow/operators/slack_operator.py
@@ -13,20 +13,20 @@ class SlackAPIOperator(BaseOperator):
     :type token: string
     :param method: The Slack API Method to Call (https://api.slack.com/methods)
     :type method: string
-    :param params: API Method call parameters (https://api.slack.com/methods)
-    :type params: dict
+    :param api_params: API Method call parameters (https://api.slack.com/methods)
+    :type api_params: dict
     """
 
     @apply_defaults
     def __init__(self,
                  token='unset',
                  method='unset',
-                 params=None,
+                 api_params=None,
                  *args, **kwargs):
         super(SlackAPIOperator, self).__init__(*args, **kwargs)
         self.token = token
         self.method = method
-        self.params = params
+        self.api_params = api_params
 
     def construct_api_call_params(self):
         """
@@ -44,10 +44,10 @@ class SlackAPIOperator(BaseOperator):
         SlackAPIOperator calls will not fail even if the call is not unsuccessful.
         It should not prevent a DAG from completing in success
         """
-        if not self.params:
+        if not self.api_params:
             self.construct_api_call_params()
         sc = SlackClient(self.token)
-        sc.api_call(self.method, **self.params)
+        sc.api_call(self.method, **self.api_params)
 
 
 class SlackAPIPostOperator(SlackAPIOperator):
@@ -85,7 +85,7 @@ class SlackAPIPostOperator(SlackAPIOperator):
                                                    *args, **kwargs)
 
     def construct_api_call_params(self):
-        self.params = {
+        self.api_params = {
             'channel': self.channel,
             'username': self.username,
             'text': self.text,


### PR DESCRIPTION
BTW HttpSensor behaves the same way.
This causes issues if you want to use params and macros/templates as they have unintended consequences.
