### PR TITLE
Feature/verify trigger rule

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1460,14 +1460,12 @@ class BaseOperator(object):
             logging.warning(
                 "start_date for {} isn't datetime.datetime".format(self))
         self.end_date = end_date
-        # could add "not callable(attr) "
-        all_triggers = [getattr(TriggerRule, attr) \
-                        for attr in dir(TriggerRule) if not attr.startswith("__")]
-        if trigger_rule not in all_triggers:
+        if not TriggerRule.is_valid(trigger_rule):
             raise AirflowException(
                 "The trigger_rule must be one of {all_triggers},"
-                "'{d}.{t}'; received '{tr}'.".format(all_triggers=all_triggers,
-                                                     d=dag.dag_id, t=task_id, tr = trigger_rule))
+                "'{d}.{t}'; received '{tr}'."
+                .format(all_triggers=TriggerRule.all_triggers,
+                        d=dag.dag_id, t=task_id, tr = trigger_rule))
 
         self.trigger_rule = trigger_rule
         self.depends_on_past = depends_on_past

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1460,6 +1460,15 @@ class BaseOperator(object):
             logging.warning(
                 "start_date for {} isn't datetime.datetime".format(self))
         self.end_date = end_date
+        # could add "not callable(attr) "
+        all_triggers = [getattr(TriggerRule, attr) \
+                        for attr in dir(TriggerRule) if not attr.startswith("__")]
+        if trigger_rule not in all_triggers:
+            raise AirflowException(
+                "The trigger_rule must be one of {all_triggers},"
+                "'{d}.{t}'; received '{tr}'.".format(all_triggers=all_triggers,
+                                                     d=dag.dag_id, t=task_id, tr = trigger_rule))
+
         self.trigger_rule = trigger_rule
         self.depends_on_past = depends_on_past
         self.wait_for_downstream = wait_for_downstream

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -59,6 +59,16 @@ class TriggerRule(object):
     ONE_FAILED = 'one_failed'
     DUMMY = 'dummy'
 
+    @classmethod
+    def is_valid(cls, trigger_rule):
+        return trigger_rule in cls.all_triggers()
+
+    @classmethod
+    def all_triggers(cls):
+        return [getattr(cls, attr)
+                for attr in dir(cls)
+                if not attr.startswith("__") and not callable(getattr(cls, attr))]
+
 
 class State(object):
     """

--- a/tests/core.py
+++ b/tests/core.py
@@ -463,6 +463,12 @@ class CoreTest(unittest.TestCase):
         with self.assertRaisesRegexp(AirflowException, regexp):
             self.run_this_last.set_downstream(self.runme_0)
 
+    def test_bad_trigger_rule(self):
+        with self.assertRaises(AirflowException):
+            operators.DummyOperator(
+            task_id='test_bad_trigger',
+            trigger_rule="non_existant",
+            dag=self.dag)
 
 class CliTests(unittest.TestCase):
 


### PR DESCRIPTION
Make the dag classes verify the syntax on trigger_rule.

Because you can enter text in this field and typo can cost a lot on this, since the scheduler does not complain about unknown statuses.
