### PR TITLE
Don't force run pool tasks. 

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -566,8 +566,7 @@ class SchedulerJob(BaseJob):
                     overloaded_dags.add(dag.dag_id)
                     continue
                 if ti.are_dependencies_met():
-                    executor.queue_task_instance(
-                        ti, force=True, pickle_id=pickle_id)
+                    executor.queue_task_instance(ti, pickle_id=pickle_id)
                     open_slots -= 1
                 else:
                     session.delete(ti)

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -940,7 +940,8 @@ class TaskInstance(Base):
                 self.try_number += 1
             else:
                 self.try_number = 1
-            if not force and (self.pool or self.task.dag.concurrency_reached):
+            if self.state != State.QUEUED and (
+                    self.pool or self.task.dag.concurrency_reached):
                 # If a pool is set for this task, marking the task instance
                 # as QUEUED
                 self.state = State.QUEUED

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -104,7 +104,7 @@ class State(object):
     def runnable(cls):
         return [
             None, cls.FAILED, cls.UP_FOR_RETRY, cls.UPSTREAM_FAILED,
-            cls.SKIPPED]
+            cls.SKIPPED, cls.QUEUED]
 
 
 cron_presets = {


### PR DESCRIPTION
Stop using force=True for pooled tasks to prevent re-running of already successful tasks. This is an edge case.
