### PR TITLE
Add "search_scope" as a configuration variable for LDAP

### DIFF
--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -91,7 +91,11 @@ class LdapUser(models.User):
             username
         )
 
-        search_scope = SUBTREE if configuration.has_option("ldap", "search_scope") == "SUBTREE" else LEVEL
+        search_scope = LEVEL
+        if configuration.has_option("ldap", "search_scope"):
+            search_scope = SUBTREE if configuration.get("ldap", "search_scope") == "SUBTREE" else LEVEL
+
+        LOG.info("Search scope is: %s " % search_scope)
 
         # todo: BASE or ONELEVEL?
 

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -97,10 +97,9 @@ class LdapUser(models.User):
             "BASE": BASE
         }
 
-        search_scope = search_scopes.get(configuration.get("ldap", "search_scope").upper(), None) \
-            if configuration.has_option("ldap", "search_scope") else LEVEL
-
-        LOG.info("Search scope is: %s " % search_scope)
+        search_scope = LEVEL
+        if configuration.has_option("ldap", "search_scope"):
+            search_scope = SUBTREE if configuration.get("ldap", "search_scope") == "SUBTREE" else LEVEL
 
         # todo: BASE or ONELEVEL?
 
@@ -206,7 +205,7 @@ def login(self, request):
 
         return redirect(request.args.get("next") or url_for("admin.index"))
     except (LdapException, AuthenticationError) as e:
-        if e:
+        if type(e) == LdapException:
             flash(e, "error")
         else:
             flash("Incorrect login details")

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -17,6 +17,8 @@ from airflow.configuration import AirflowConfigException
 
 import logging
 
+import traceback
+
 login_manager = flask_login.LoginManager()
 login_manager.login_view = 'airflow.login'  # Calls login() bellow
 login_manager.login_message = None
@@ -25,6 +27,9 @@ LOG = logging.getLogger(__name__)
 
 
 class AuthenticationError(Exception):
+    pass
+
+class LdapException(Exception):
     pass
 
 
@@ -86,9 +91,12 @@ class LdapUser(models.User):
             username
         )
 
+        search_scope = configuration.get("ldap", "search_scope") \
+            if configuration.has_option("ldap", "search_scope") else "LEVEL"
+
         # todo: BASE or ONELEVEL?
 
-        res = conn.search(configuration.get("ldap", "basedn"), search_filter)
+        res = conn.search(configuration.get("ldap", "basedn"), search_filter, search_scope=search_scope)
 
         # todo: use list or result?
         if not res:
@@ -98,7 +106,14 @@ class LdapUser(models.User):
         entry = conn.response[0]
 
         conn.unbind()
-        conn = get_ldap_connection(entry['dn'], password)
+        try:
+            conn = get_ldap_connection(entry['dn'], password)
+        except KeyError as e:
+            LOG.error("""
+            Unable to parse LDAP structure. If you're using Active Directory and not specifying an OU, you must set search_scope=SUBTREE in airflow.cfg.
+            %s
+            """ % traceback.format_exc())
+            raise LdapException("Could not parse LDAP structure. Try setting search_scope in airflow.cfg, or check logs")
 
         if not conn:
             LOG.info("Password incorrect for user %s", username)
@@ -182,8 +197,11 @@ def login(self, request):
         session.close()
 
         return redirect(request.args.get("next") or url_for("admin.index"))
-    except AuthenticationError:
-        flash("Incorrect login details")
+    except (LdapException, AuthenticationError) as e:
+        if e:
+            flash(e, "error")
+        else:
+            flash("Incorrect login details")
         return self.render('airflow/login.html',
                            title="Airflow - Login",
                            form=form)

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -5,7 +5,7 @@ from wtforms import (
     Form, PasswordField, StringField)
 from wtforms.validators import InputRequired
 
-from ldap3 import Server, Connection, Tls, LEVEL
+from ldap3 import Server, Connection, Tls, LEVEL, SUBTREE
 import ssl
 
 from flask import url_for, redirect
@@ -91,8 +91,7 @@ class LdapUser(models.User):
             username
         )
 
-        search_scope = configuration.get("ldap", "search_scope") \
-            if configuration.has_option("ldap", "search_scope") else "LEVEL"
+        search_scope = SUBTREE if configuration.has_option("ldap", "search_scope") == "SUBTREE" else LEVEL
 
         # todo: BASE or ONELEVEL?
 

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -5,7 +5,7 @@ from wtforms import (
     Form, PasswordField, StringField)
 from wtforms.validators import InputRequired
 
-from ldap3 import Server, Connection, Tls, LEVEL, SUBTREE
+from ldap3 import Server, Connection, Tls, LEVEL, SUBTREE, BASE
 import ssl
 
 from flask import url_for, redirect
@@ -91,9 +91,14 @@ class LdapUser(models.User):
             username
         )
 
-        search_scope = LEVEL
-        if configuration.has_option("ldap", "search_scope"):
-            search_scope = SUBTREE if configuration.get("ldap", "search_scope") == "SUBTREE" else LEVEL
+        search_scopes = {
+            "LEVEL": LEVEL,
+            "SUBTREE": SUBTREE,
+            "BASE": BASE
+        }
+
+        search_scope = search_scopes.get(configuration.get("ldap", "search_scope").upper(), None) \
+            if configuration.has_option("ldap", "search_scope") else LEVEL
 
         LOG.info("Search scope is: %s " % search_scope)
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -55,6 +55,9 @@ To turn on LDAP authentication configure your ``airflow.cfg`` as follows. Please
 an encrypted connection to the ldap server as you probably do not want passwords be readable on the network level.
 It is however possible to configure without encryption if you really want to.
 
+Additionally, if you are using Active Directory, and are not explicitly specifying an OU that your users are in,
+you will need to change ``search_scope`` to "SUBTREE".
+
 .. code-block:: bash
 
     [webserver]
@@ -71,6 +74,7 @@ It is however possible to configure without encryption if you really want to.
     bind_password = insecure
     basedn = dc=example,dc=com
     cacert = /etc/ca/ldap_ca.crt
+    search_scope = LEVEL # Set this to SUBTREE if using Active Directory, and not specifying an Organizational Unit
 
 The superuser_filter and data_profiler_filter are optional. If defined, these configurations allow you to specify LDAP groups that users must belong to in order to have superuser (admin) and data-profiler permissions. If undefined, all users will be superusers and data profilers.
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -58,6 +58,8 @@ It is however possible to configure without encryption if you really want to.
 Additionally, if you are using Active Directory, and are not explicitly specifying an OU that your users are in,
 you will need to change ``search_scope`` to "SUBTREE".
 
+Valid search_scope options can be found in the `ldap3 Documentation <http://ldap3.readthedocs.org/searches.html?highlight=search_scope>`_
+
 .. code-block:: bash
 
     [webserver]


### PR DESCRIPTION
This is the correct solution to #796 -- instead of completely dropping
the variable all together.

Added a bit of "pretty" failure for this error as well--including
specifying what is happening in the webserver log, and how it can be
fixed.

Comments appreciated. I hope the coding style is acceptable. I tried to match what was already in the ldap auth backend.
