### PR TITLE
Feature/cli fixes

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -428,7 +428,7 @@ def kerberos(args):
 def get_parser():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(help='sub-command help', dest='subcommand')
-    subparsers.required=True
+    subparsers.required = True
 
     ht = "Run subsections of a DAG for a specified date range"
     parser_backfill = subparsers.add_parser('backfill', help=ht)

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -427,7 +427,8 @@ def kerberos(args):
 
 def get_parser():
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(help='sub-command help')
+    subparsers = parser.add_subparsers(help='sub-command help', dest='subcommand')
+    subparsers.required=True
 
     ht = "Run subsections of a DAG for a specified date range"
     parser_backfill = subparsers.add_parser('backfill', help=ht)

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -496,6 +496,7 @@ def get_parser():
     parser_clear.add_argument(
         "-sd", "--subdir", help=subdir_help,
         default=DAGS_FOLDER)
+    ht = "Do not request confirmation"
     parser_clear.add_argument(
         "-c", "--no_confirm", help=ht, action="store_true")
     parser_clear.set_defaults(func=clear)


### PR DESCRIPTION
Corrected a duplicated help text.
Also pulled a workaround from http://stackoverflow.com/questions/23349349/argparse-with-required-subparser so that "airflow" prints help rather than an ugly help with python3 (Ubuntu 14.04):

Was:

```
[2016-01-05 22:31:02,400] {driver.py:120} INFO - Generating grammar tables from /usr/lib/python3.4/lib2to3/Grammar.txt
[2016-01-05 22:31:02,429] {driver.py:120} INFO - Generating grammar tables from /usr/lib/python3.4/lib2to3/PatternGrammar.txt
[2016-01-05 22:31:02,553] {__init__.py:36} INFO - Using executor CeleryExecutor
Traceback (most recent call last):
  File "/opt/airflow/bin/airflow", line 15, in <module>
    args.func(args)
AttributeError: 'Namespace' object has no attribute 'func'
```

Now

```
2016-01-05 22:14:43,790] {driver.py:120} INFO - Generating grammar tables from /usr/lib/python3.4/lib2to3/Grammar.txt
[2016-01-05 22:14:43,820] {driver.py:120} INFO - Generating grammar tables from /usr/lib/python3.4/lib2to3/PatternGrammar.txt
[2016-01-05 22:14:43,943] {__init__.py:36} INFO - Using executor CeleryExecutor
usage: airflow [-h]
               {backfill,clear,trigger_dag,run,test,task_state,webserver,scheduler,initdb,resetdb,upgradedb,list_dags,list_tasks,worker,serve_logs,flower,version,kerberos}
               ...
airflow: error: the following arguments are required: subcommand
```
