### PR TITLE
add a parameter for number of shard in batch ingestion

### DIFF
--- a/airflow/hooks/druid_hook.py
+++ b/airflow/hooks/druid_hook.py
@@ -100,8 +100,8 @@ class DruidHook(BaseHook):
                     },
                     "partitionsSpec" : {
                         "type" : "hashed",
-                        "targetPartitionSize" : -1
-                        "numShards" : num_shards
+                        "targetPartitionSize" : -1,
+                        "numShards" : num_shards,
                     },
                 },
                 "ioConfig": {

--- a/airflow/hooks/druid_hook.py
+++ b/airflow/hooks/druid_hook.py
@@ -52,7 +52,7 @@ class DruidHook(BaseHook):
 
     def construct_ingest_query(
             self, datasource, static_path, ts_dim, columns, metric_spec,
-            intervals, hadoop_dependency_coordinates=None):
+            intervals, num_shards, hadoop_dependency_coordinates=None):
         """
         Builds an ingest query for an HDFS TSV load.
 
@@ -98,6 +98,11 @@ class DruidHook(BaseHook):
                         "mapreduce.map.output.compress": "false",
                         "mapreduce.output.fileoutputformat.compress": "false",
                     },
+                    "partitionsSpec" : {
+                        "type" : "hashed",
+                        "targetPartitionSize" : -1
+                        "numShards" : num_shards
+                    },
                 },
                 "ioConfig": {
                     "inputSpec": {
@@ -116,10 +121,10 @@ class DruidHook(BaseHook):
 
     def send_ingest_query(
             self, datasource, static_path, ts_dim, columns, metric_spec,
-            intervals, hadoop_dependency_coordinates=None):
+            intervals, num_shards, hadoop_dependency_coordinates=None):
         query = self.construct_ingest_query(
             datasource, static_path, ts_dim, columns,
-            metric_spec, intervals, hadoop_dependency_coordinates)
+            metric_spec, intervals, num_shards, hadoop_dependency_coordinates)
         r = requests.post(
             self.ingest_post_url, headers=self.header, data=query)
         logging.info(self.ingest_post_url)
@@ -133,7 +138,7 @@ class DruidHook(BaseHook):
 
     def load_from_hdfs(
             self, datasource, static_path,  ts_dim, columns,
-            intervals, metric_spec=None, hadoop_dependency_coordinates=None):
+            intervals, num_shards, metric_spec=None, hadoop_dependency_coordinates=None):
         """
         load data to druid from hdfs
         :params ts_dim: The column name to use as a timestamp
@@ -141,7 +146,7 @@ class DruidHook(BaseHook):
         """
         task_id = self.send_ingest_query(
             datasource, static_path, ts_dim, columns, metric_spec,
-            intervals, hadoop_dependency_coordinates)
+            intervals, num_shards, hadoop_dependency_coordinates)
         status_url = self.get_ingest_status_url(task_id)
         while True:
             r = requests.get(status_url)

--- a/airflow/operators/hive_to_druid.py
+++ b/airflow/operators/hive_to_druid.py
@@ -49,12 +49,14 @@ class HiveToDruidTransfer(BaseOperator):
             metastore_conn_id='metastore_default',
             hadoop_dependency_coordinates=None,
             intervals=None,
+            num_shards=1,
             *args, **kwargs):
         super(HiveToDruidTransfer, self).__init__(*args, **kwargs)
         self.sql = sql
         self.druid_datasource = druid_datasource
         self.ts_dim = ts_dim
         self.intervals = intervals or ['{{ ds }}/{{ tomorrow_ds }}']
+        self.num_shards = num_shards
         self.metric_spec = metric_spec or [{
             "name": "count",
             "type": "count"}]
@@ -101,7 +103,7 @@ class HiveToDruidTransfer(BaseOperator):
             datasource=self.druid_datasource,
             intervals=self.intervals,
             static_path=static_path, ts_dim=self.ts_dim,
-            columns=columns, metric_spec=self.metric_spec,
+            columns=columns, num_shards=self.num_shards, metric_spec=self.metric_spec,
             hadoop_dependency_coordinates=self.hadoop_dependency_coordinates)
         logging.info("Load seems to have succeeded!")
 


### PR DESCRIPTION
some druid batch index job failed because one reducer can't take all the data and runs out of memory

@mistercrunch @krishnap
