### PR TITLE
Use proper signal handling and cascade signals to children (Fix #852)

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -17,6 +17,13 @@ Previously, new DAGs would be scheduled immediately. To retain the old behavior,
 dags_are_paused_at_creation = False
 ```
 
+### Worker, Scheduler, Webserver, Kerberos, Flower now detach by default
+
+The different daemons have been reworked to behave like traditional Unix daemons. This allows
+you to set PID file locations, log file locations including stdin and stderr.
+
+If you want to retain the old behavior specify ```-f``` or ```--foreground``` on the command line.
+
 ### Deprecated Features
 These features are marked for deprecation. They may still work (and raise a `DeprecationWarning`), but are no longer supported and will be removed entirely in Airflow 2.0
 

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -122,3 +122,9 @@ class BaseExecutor(LoggingMixin):
         all done.
         """
         raise NotImplementedError()
+
+    def terminate(self):
+        """
+        This method is called when the daemon receives a SIGTERM
+        """
+        raise NotImplementedError()

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -18,6 +18,7 @@ class LocalWorker(multiprocessing.Process, LoggingMixin):
         multiprocessing.Process.__init__(self)
         self.task_queue = task_queue
         self.result_queue = result_queue
+        self.daemon = True
 
     def run(self):
         while True:
@@ -34,7 +35,7 @@ class LocalWorker(multiprocessing.Process, LoggingMixin):
                 state = State.SUCCESS
             except subprocess.CalledProcessError as e:
                 state = State.FAILED
-                self.logger.error("Failed to execute task {}:".format(str(e)))
+                self.logger.error("failed to execute task {}:".format(str(e)))
                 # raise e
             self.result_queue.put((key, state))
             self.task_queue.task_done()
@@ -72,3 +73,4 @@ class LocalExecutor(BaseExecutor):
         [self.queue.put((None, None)) for w in self.workers]
         # Wait for commands to finish
         self.queue.join()
+

--- a/docs/start.rst
+++ b/docs/start.rst
@@ -22,7 +22,9 @@ The installation is quick and straightforward.
 Upon running these commands, Airflow will create the ``$AIRFLOW_HOME`` folder
 and lay an "airflow.cfg" file with defaults that get you going fast. You can
 inspect the file either in ``$AIRFLOW_HOME/airflow.cfg``, or through the UI in
-the ``Admin->Configuration`` menu.
+the ``Admin->Configuration`` menu. The PID file for the webserver will be stored
+in ``$AIRFLOW_HOME/airflow-webserver.pid`` or in ``/run/airflow/webserver.pid``
+if started by systemd.
 
 Out of the box, Airflow uses a sqlite database, which you should outgrow
 fairly quickly since no parallelization is possible using this database

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -7,6 +7,7 @@ coverage
 coveralls
 croniter
 dill
+python-daemon
 docker-py
 filechunkio
 flake8

--- a/scripts/systemd/README
+++ b/scripts/systemd/README
@@ -1,8 +1,11 @@
-The systemd files in this directory are tested on RedHat based systems. Copy (or link) them to /usr/lib/systemd/system.
+The systemd files in this directory are tested on RedHat based systems. Copy (or link) them to /usr/lib/systemd/system
+and copy the airflow.conf to /etc/tmpfiles.d/ or /usr/lib/tmpfiles.d/. Copying airflow.conf ensures /run/airflow is
+created with the right owner and permissions (0755 airflow airflow)
+
 You can then start the different servers by using systemctl start <service>. Enabling services can be done by issuing
  systemctl enable <service>.
 
 By default the environment configuration points to /etc/sysconfig/airflow . You can copy the "airflow" file in this
-directory and adjust it to yout liking. Make sure to specify the SCHEDULER_RUNS variabl.
+directory and adjust it to your liking. Make sure to specify the SCHEDULER_RUNS variable.
 
 With some minor changes they probably work on other systemd systems.

--- a/scripts/systemd/airflow-webserver.service
+++ b/scripts/systemd/airflow-webserver.service
@@ -4,13 +4,17 @@ After=network.target postgresql.service mysql.service redis.service rabbitmq-ser
 Wants=postgresql.service mysql.service redis.service rabbitmq-server.service
 
 [Service]
+PIDFile=/run/airflow/webserver.pid
 EnvironmentFile=/etc/sysconfig/airflow
 User=airflow
 Group=airflow
-Type=simple
-ExecStart=/bin/airflow webserver
+Type=forking
+ExecStart=/bin/airflow webserver --pid /run/airflow/webserver.pid
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s TERM $MAINPID
 Restart=on-failure
 RestartSec=42s
+PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/systemd/airflow.conf
+++ b/scripts/systemd/airflow.conf
@@ -1,0 +1,1 @@
+D /run/airflow 0755 airflow airflow

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ setup(
         'chartkick>=0.4.2, < 0.5',
         'croniter>=0.3.8, <0.4',
         'dill>=0.2.2, <0.3',
+        'python-daemon>=2.1.1, <2.2',
         'flask>=0.10.1, <0.11',
         'flask-admin>=1.4.0, <2.0.0',
         'flask-cache>=0.13.1, <0.14',


### PR DESCRIPTION
This fixes ISSUE-#852 by starting gunicorn with a pid file and to exit immediately after that. This makes airflow's webserver behave more standard. To retain old behavior you can specify "-f" or "--foreground". 
- the pid file is placed in AIRFLOW_HOME/airflow-webserver.pid or if you are running systemd in /run/airflow/webserver.pid. If you want to store it somewhere else please use "--pid" as an argument.
- systemd profile for the webserver is now a bit more secure 
- if you are running systemd make sure to follow the instructions otherwise you might have some write permission issues for storing the pid file.
