### PR TITLE
handle default option for extra_options argument in HttpHook.run method

### DIFF
--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -40,6 +40,8 @@ class HttpHook(BaseHook):
         """
         Performs the request
         """
+        extra_options = extra_options or {}
+
         session = self.get_conn(headers)
 
         url = self.base_url + endpoint


### PR DESCRIPTION
The default option None will fail because later in the code the "get" method is called on the variable extra_options expecting a dictionary.

I am willing to add a test covering this if you can point me out the proper location.
