### PR TITLE
Added no authentication possibility for Hive Client Hook

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -85,7 +85,7 @@ class HiveCliHook(BaseHook):
                             proxy_user = "hive.server2.proxy.user={0}".format(self.run_as)
 
                         jdbc_url += ";principal={template};{proxy_user}"
-                    elif self.auth:
+                    elif self.auth and self.auth != "none":
                         jdbc_url += ";auth=" + self.auth
 
                     jdbc_url = jdbc_url.format(**locals())


### PR DESCRIPTION
On some clients, if authentication is not needed, this can be a problem because you can't connect with Hive Client.

I just added the possibility to not include this parameter if the value is set to none in the extra connection parameter.
