### PR TITLE
SLA Miss Alert Callbacks : Allow DAGs to specify a callback function for SLA miss handling

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -327,6 +327,9 @@ class SchedulerJob(BaseJob):
                         if email not in emails:
                             emails.append(email)
             if emails and len(slas):
+                if dag.sla_miss_callback:
+                    dag.sla_miss_callback(dag, task_list, blocking_task_list, slas, blocking_tis)
+                # Send email
                 utils.send_email(
                     emails,
                     "[airflow] SLA miss on DAG=" + dag.dag_id,

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -277,7 +277,7 @@ class SchedulerJob(BaseJob):
         slas = (
             session
             .query(SlaMiss)
-            .filter(SlaMiss.email_sent == False)
+            .filter(SlaMiss.email_sent == False or SlaMiss.notification_sent == False)
             .filter(SlaMiss.dag_id == dag.dag_id)
             .all()
         )
@@ -309,6 +309,15 @@ class SchedulerJob(BaseJob):
             blocking_task_list = "\n".join([
                 ti.task_id + ' on ' + ti.execution_date.isoformat()
                 for ti in blocking_tis])
+            # Track whether email or any alert notification sent
+            # We consider email or the alert callback as notifications
+            email_sent = False
+            notification_sent = False
+            if dag.sla_miss_callback:
+                # Execute the alert callback
+                self.logger.info(' --------------> ABOUT TO CALL SLA MISS CALL BACK ')
+                dag.sla_miss_callback(dag, task_list, blocking_task_list, slas, blocking_tis)
+                notification_sent = True
             from airflow import ascii
             email_content = """\
             Here's a list of tasks thas missed their SLAs:
@@ -327,15 +336,18 @@ class SchedulerJob(BaseJob):
                         if email not in emails:
                             emails.append(email)
             if emails and len(slas):
-                if dag.sla_miss_callback:
-                    dag.sla_miss_callback(dag, task_list, blocking_task_list, slas, blocking_tis)
-                # Send email
                 utils.send_email(
                     emails,
                     "[airflow] SLA miss on DAG=" + dag.dag_id,
                     email_content)
+                email_sent = True
+                notification_sent = True
+            # If we sent any notification, update the sla_miss table
+            if notification_sent:
                 for sla in slas:
-                    sla.email_sent = True
+                    if email_sent:
+                        sla.email_sent = True
+                    sla.notification_sent = True
                     session.merge(sla)
             session.commit()
             session.close()

--- a/airflow/migrations/versions/bbc73705a13e_add_notification_sent_column_to_sla_miss.py
+++ b/airflow/migrations/versions/bbc73705a13e_add_notification_sent_column_to_sla_miss.py
@@ -1,0 +1,24 @@
+"""Add notification_sent column to sla_miss
+
+Revision ID: bbc73705a13e
+Revises: 4446e08588
+Create Date: 2016-01-14 18:05:54.871682
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'bbc73705a13e'
+down_revision = '4446e08588'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('sla_miss', sa.Column('notification_sent', sa.Boolean,default=False))
+
+
+def downgrade():
+    op.drop_column('sla_miss', 'notification_sent')

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2850,6 +2850,7 @@ class SlaMiss(Base):
     email_sent = Column(Boolean, default=False)
     timestamp = Column(DateTime)
     description = Column(Text)
+    notification_sent = Column(Boolean, default=False)
 
     def __repr__(self):
         return str((

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1998,6 +1998,9 @@ class DAG(LoggingMixin):
     :param dagrun_timeout: specify how long a DagRun should be up before
         timing out / failing, so that new DagRuns can be created
     :type dagrun_timeout: datetime.timedelta
+    :param sla_miss_callback: specify a function to call when reporting SLA
+        timeouts.
+    :type sla_miss_callback: types.FunctionType
     """
 
     def __init__(
@@ -2012,6 +2015,7 @@ class DAG(LoggingMixin):
             max_active_runs=configuration.getint(
                 'core', 'max_active_runs_per_dag'),
             dagrun_timeout=None,
+            sla_miss_callback=None,
             params=None):
 
         self.user_defined_macros = user_defined_macros
@@ -2039,6 +2043,7 @@ class DAG(LoggingMixin):
         self.concurrency = concurrency
         self.max_active_runs = max_active_runs
         self.dagrun_timeout = dagrun_timeout
+        self.sla_miss_callback = sla_miss_callback
 
         self._comps = {
             'dag_id',


### PR DESCRIPTION
This is in response to https://github.com/airbnb/airflow/issues/873

Essentially, I would like to add a callback function to SLA miss handling. In the callback function, I can decide whether to post to Slack and to VictorOps/PagerDuty, or some other 3rd party ops solution. Email is too limiting. 

I've added another column to the table to track SLA notifications in general. Not in this PR is a fix for a general problem which can occur is SLAs were enabled on a task but no emails or sla alert call back were provided. In this case, the query to return all SLA misses would progressively return more and more data, slowing down the Scheduler. We need a separate fix to place a window on the max number of sla misses queried.
