### PR TITLE
state wasn't being saved

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -696,7 +696,6 @@ class TaskInstance(Base):
         """
         return (self.dag_id, self.task_id, self.execution_date)
 
-    @provide_session
     def set_state(self, state, session):
         self.state = state
         self.start_date = datetime.now()
@@ -842,18 +841,18 @@ class TaskInstance(Base):
         if flag_upstream_failed:
             if tr == TR.ALL_SUCCESS:
                 if upstream_failed or failed:
-                    self.set_state(State.UPSTREAM_FAILED)
+                    self.set_state(State.UPSTREAM_FAILED, session)
                 elif skipped:
-                    self.set_state(State.SKIPPED)
+                    self.set_state(State.SKIPPED, session)
             elif tr == TR.ALL_FAILED:
                 if successes or skipped:
-                    self.set_state(State.SKIPPED)
+                    self.set_state(State.SKIPPED, session)
             elif tr == TR.ONE_SUCCESS:
                 if upstream_done and not successes:
-                    self.set_state(State.SKIPPED)
+                    self.set_state(State.SKIPPED, session)
             elif tr == TR.ONE_FAILED:
                 if upstream_done and not(failed or upstream_failed):
-                    self.set_state(State.SKIPPED)
+                    self.set_state(State.SKIPPED, session)
 
         if (
             (tr == TR.ONE_SUCCESS and successes) or


### PR DESCRIPTION
Tasks were not being marked as skipped (they were hitting the set_state line though).

Not sure why I had to remove @provide_session - without it I received this stack trace:

```
[2016-01-15 14:37:59,460] {jobs.py:634} ERROR - set_state() got multiple values
for argument 'session'
Traceback (most recent call last):
  File "/opt/airflow/lib/python3.4/site-packages/airflow/jobs.py", line 631, in
_execute
    self.process_dag(dag, executor)
  File "/opt/airflow/lib/python3.4/site-packages/airflow/jobs.py", line 482, in
process_dag
    elif ti.is_runnable(flag_upstream_failed=True):
  File "/opt/airflow/lib/python3.4/site-packages/airflow/models.py", line 740, i
n is_runnable
    return self.is_queueable(flag_upstream_failed) and not self.pool_full()
  File "/opt/airflow/lib/python3.4/site-packages/airflow/models.py", line 730, i
n is_queueable
    flag_upstream_failed=flag_upstream_failed)):
  File "/opt/airflow/lib/python3.4/site-packages/airflow/models.py", line 859, i
n are_dependencies_met
    self.set_state(State.SKIPPED, session)
  File "/opt/airflow/lib/python3.4/site-packages/airflow/utils.py", line 142, in
 wrapper
    result = func(*args, **kwargs)
TypeError: set_state() got multiple values for argument 'session'
```
