### PR TITLE
Making force a task instance member, so it becomes available for

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -568,6 +568,7 @@ class TaskInstance(Base):
         self.priority_weight = task.priority_weight_total
         self.try_number = 1
         self.test_mode = False  # can be changed when calling 'run'
+        self.force = False  # can be changed when calling 'run'
         self.unixname = getpass.getuser()
         if state:
             self.state = state
@@ -926,6 +927,7 @@ class TaskInstance(Base):
         task = self.task
         self.pool = pool or task.pool
         self.test_mode = test_mode
+        self.force = force
         session = settings.Session()
         self.refresh_from_db(session)
         session.commit()


### PR DESCRIPTION
operators in runtime.

The use-case was explained and discussed in Airflow's google group topic: https://groups.google.com/forum/#!topic/airbnb_airflow/VsE9YdL2mF4
@mistercrunch suggested to address the issue by this implementation approach.
