### PR TITLE
Bugfix for TriggerDagRunOperator

### DIFF
--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -35,12 +35,12 @@ class TriggerDagRunOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            dag_id,
+            trigger_dag_id,
             python_callable,
             *args, **kwargs):
         super(TriggerDagRunOperator, self).__init__(*args, **kwargs)
         self.python_callable = python_callable
-        self.dag_id = dag_id
+        self.trigger_dag_id = trigger_dag_id
 
     def execute(self, context):
         dro = DagRunOrder(run_id='trig__' + datetime.now().isoformat())
@@ -48,7 +48,7 @@ class TriggerDagRunOperator(BaseOperator):
         if dro:
             session = settings.Session()
             dr = DagRun(
-                dag_id=self.dag_id,
+                dag_id=self.trigger_dag_id,
                 run_id=dro.run_id,
                 conf=dro.payload,
                 external_trigger=True)

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -16,8 +16,8 @@ class TriggerDagRunOperator(BaseOperator):
     """
     Triggers a DAG run for a specified ``dag_id`` if a criteria is met
 
-    :param dag_id: the dag_id to trigger
-    :type dag_id: str
+    :param trigger_dag_id: the dag_id to trigger
+    :type trigger_dag_id: str
     :param python_callable: a reference to a python function that will be
         called while passing it the ``context`` object and a placeholder
         object ``obj`` for your callable to fill and return if you want

--- a/tests/core.py
+++ b/tests/core.py
@@ -251,7 +251,7 @@ class CoreTest(unittest.TestCase):
                 return obj
         t = operators.TriggerDagRunOperator(
             task_id='test_trigger_dagrun',
-            dag_id='example_bash_operator',
+            trigger_dag_id='example_bash_operator',
             python_callable=trigga,
             dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)


### PR DESCRIPTION
This fixes Issue #687.  Using dag_id as the attribute name for the dag-to-trigger conflicts with the use of dag_id in BaseOperator which is the id of the parent dag. 
