### PR TITLE
Add SimilarWeb to the who uses airflow section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Currently **officially** using Airflow:
 * Lyft
 * [Sense360](https://github.com/Sense360) [[@kamilmroczek](https://github.com/KamilMroczek)]
 * [Sidecar](https://hello.getsidecar.com/) [[@getsidecar](https://github.com/getsidecar)]
+* [SimilarWeb](https://www.similarweb.com/) [[@similarweb](https://github.com/similarweb)]
 * Stripe [@jbalogh]
 * [WeTransfer](https://github.com/WeTransfer) [[@jochem](https://github.com/jochem)]
 * Wooga


### PR DESCRIPTION
Hi
We moved the majority of our production orchestration workloads to Airflow with the intention of becoming an active member and contributor in the Airflow community. 
