### PR TITLE
Update some datetime column default args for consistent treatment

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2536,7 +2536,7 @@ class Chart(Base):
         "User", cascade=False, cascade_backrefs=False, backref='charts')
     x_is_date = Column(Boolean, default=True)
     iteration_no = Column(Integer, default=0)
-    last_modified = Column(DateTime, default=datetime.now())
+    last_modified = Column(DateTime, default=func.now())
 
     def __repr__(self):
         return self.label
@@ -2762,8 +2762,8 @@ class DagRun(Base):
 
     id = Column(Integer, primary_key=True)
     dag_id = Column(String(ID_LEN))
-    execution_date = Column(DateTime, default=datetime.now())
-    start_date = Column(DateTime, default=datetime.now())
+    execution_date = Column(DateTime, default=func.now())
+    start_date = Column(DateTime, default=func.now())
     end_date = Column(DateTime)
     state = Column(String(50), default=State.RUNNING)
     run_id = Column(String(ID_LEN))


### PR DESCRIPTION
Three model columns used datetime.now() as a default argument.  According to the sqlalchemy docs, http://docs.sqlalchemy.org/en/latest/core/defaults.html, when using datetime, you want to pass the function itself without parens (see quote below).

Additionally, elsewhere in models.py, the convention is to use func.now().  This SO comment, http://stackoverflow.com/a/33532154/1812329, leads me to believe this is probably best practice, so I changed the 3 instances where datetime.now() is passed as default into func.now() calls.  

from sqlalchemy docs:

> Note that when using func functions, unlike when using Python datetime functions we do call the function, i.e. with parenthesis “()” - this is because what we want in this case is the return value of the function, which is the SQL expression construct that will be rendered into the INSERT or UPDATE statement.
