### PR TITLE
Call `Session.remove` after each run, to survive DB restart

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -650,6 +650,8 @@ class SchedulerJob(BaseJob):
                     self.logger.error("Tachycardia!")
             except Exception as deep_e:
                 self.logger.exception(deep_e)
+            finally:
+                settings.Session.remove()
         executor.end()
 
     def heartbeat_callback(self):


### PR DESCRIPTION
Without this, we get the following exception for subsequent runs after a
DB restart, indefinitely:

```
sqlalchemy.exc.InvalidRequestError: This Session's transaction has
been rolled back due to a previous exception during flush. To begin
a new transaction with this Session, first issue Session.rollback().
Original exception was: (psycopg2.OperationalError) terminating
connection due to administrator command
```
