### PR TITLE
Small change to fix a crash when reading log files from remote workers

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -748,7 +748,7 @@ class Airflow(BaseView):
             host = ti.hostname
             log_loaded = False
 
-            if socket.gethostname() == host:
+            if socket.gethostname() == ' bla': #host:
                 try:
                     f = open(loc)
                     log += "".join(f.readlines())
@@ -791,7 +791,9 @@ class Airflow(BaseView):
 
             session.commit()
             session.close()
-        log = log.decode('utf-8') if PY2 else log
+
+        if PY2 and not isinstance(log, unicode):
+            log = log.decode('utf-8')
 
         title = "Log"
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -748,7 +748,7 @@ class Airflow(BaseView):
             host = ti.hostname
             log_loaded = False
 
-            if socket.gethostname() == ' bla': #host:
+            if socket.gethostname() == host:
                 try:
                     f = open(loc)
                     log += "".join(f.readlines())


### PR DESCRIPTION
Noticed a small encoding issue when opening a log from the failed task from example_http_operator which was retrieved from another worker. This little change fixes it for the situations I've been able to test. Unfortunately I have not been able to verify this with Amazon S3. 
