### PR TITLE
Normalize plugin paths that include both slashes and dots

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -8,6 +8,7 @@ import imp
 import inspect
 import logging
 import os
+import re
 import sys
 from itertools import chain
 merge = chain.from_iterable
@@ -43,6 +44,8 @@ if plugins_folder not in sys.path:
 
 plugins = []
 
+norm_pattern = re.compile(r'[/|.]')
+
 # Crawl through the plugins folder to find AirflowPlugin derivatives
 for root, dirs, files in os.walk(plugins_folder, followlinks=True):
     for f in files:
@@ -54,7 +57,10 @@ for root, dirs, files in os.walk(plugins_folder, followlinks=True):
                 os.path.split(filepath)[-1])
             if file_ext != '.py':
                 continue
-            namespace = root.replace('/', '__') + '_' + mod_name
+
+            # normalize root path as namespace
+            namespace = '_'.join([re.sub(norm_pattern, '__', root), mod_name])
+
             m = imp.load_source(namespace, filepath)
             for obj in list(m.__dict__.values()):
                 if (


### PR DESCRIPTION
If the path to AIRFLOW_HOME contains a dot (e.g. `/home/user/foo.bar`), the plugins manager will fail to load the source properly due to the dot demarcating a parent module.  Sample error output:

`RuntimeWarning: Parent module '__user__foo' not found ...`

The line where the normalization occurs is: https://github.com/airbnb/airflow/blob/master/airflow/plugins_manager.py#L57

This changeset applies a regex to account for both slashes and dots when normalizing the namespace.
