### PR TITLE
Refresh border coloring in graph view without having to refresh the entire page

### DIFF
--- a/airflow/www/static/graph.css
+++ b/airflow/www/static/graph.css
@@ -43,3 +43,11 @@ div#svg_container {
     right: 15px;
     position: relative;
 }
+
+#loading {
+    margin: auto;
+    display: none;
+    position: relative;
+    width: 100px;
+    top: -550px;
+}

--- a/airflow/www/static/graph.css
+++ b/airflow/www/static/graph.css
@@ -37,3 +37,9 @@ div#svg_container {
  background-color: #EEE;
  cursor: move;
 }
+
+#refresh_button {
+    top: 15px;
+    right: 15px;
+    position: relative;
+}

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -54,6 +54,10 @@
     </div>
     <div style="clear:both;"></div>
 </div>
+<div id="error" style="display: none; margin-top: 10px;" class="alert alert-danger" role="alert">
+        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+        <span id="error_msg">Oops.</span>
+</div>
 <hr style="margin-bottom: 0px;"/>
 <button class="btn btn-default pull-right" id="refresh_button">
     <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
@@ -66,6 +70,7 @@
         <feGaussianBlur stdDeviation="3" />
         </filter>
     </svg>
+    <img id="loading" alt="spinner" src="{{ url_for('static', filename='loading.gif') }}">
 </div>
 <hr>
 {% endblock %}
@@ -274,17 +279,35 @@
         return false
     }
 
+    function error(msg){
+      $('#error_msg').html(msg);
+      $('#error').show();
+      $('#loading').hide();
+      $('#chart_section').hide(1000);
+      $('#datatable_section').hide(1000);
+    }
+
     d3.select("#refresh_button").on("click",
         function() {
+            $("#loading").css("display", "block");
+            $("div#svg_container").css("opacity", "0.2");
             $.get(
                 "/admin/airflow/object/task_instances",
-                {dag_id : "{{ dag.dag_id }}", execution_date : "{{ execution_date }}"},
+                {dag_id : "{{ dag.dag_id }}", execution_date : "{{ execution_date }}"})
+            .done(
                 function(task_instances) {
                     update_nodes_states(JSON.parse(task_instances));
+                    $("#loading").hide();
+                    $("div#svg_container").css("opacity", "1");
+                    $('#error').hide();
                 }
-            );
+            ).fail(function(jqxhr, textStatus, err) {
+                error(textStatus + ': ' + err);
+            });
         }
     );
 
     </script>
+
+
 {% endblock %}

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -30,8 +30,6 @@
             <input type="submit" value="Go" class="btn btn-default"
             action="" method="get">
         </form>
-
-            <button class="btn btn-default" id="refreshButton" style="float: left;">Refresh Tasks</button>
             <div class="input-group" style="float: right;">
               <input type="text" id="searchbox" class="form-control" placeholder="Search for..." onenter="null">
             </div><!-- /input-group -->
@@ -57,13 +55,17 @@
     <div style="clear:both;"></div>
 </div>
 <hr style="margin-bottom: 0px;"/>
+<button class="btn btn-default pull-right" id="refresh_button">
+    <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
+</button>
 <div id="svg_container">
+
     <svg width="{{ width }}" height="{{ height }}">
-      <g id='dig' transform="translate(20,20)"/>
-      <filter id="blur-effect-1">
+        <g id='dig' transform="translate(20,20)"/>
+        <filter id="blur-effect-1">
         <feGaussianBlur stdDeviation="3" />
-      </filter>
-  </svg>
+        </filter>
+    </svg>
 </div>
 <hr>
 {% endblock %}
@@ -272,7 +274,7 @@
         return false
     }
 
-    d3.select("#refreshButton").on("click",
+    d3.select("#refresh_button").on("click",
         function() {
             $.get(
                 "/admin/airflow/object/task_instances",

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -92,7 +92,7 @@
     var layout = dagreD3.layout().rankDir(arrange).nodeSep(15).rankSep(15);
     var renderer = new dagreD3.Renderer();
     renderer.layout(layout).run(g, d3.select("#dig"));
-    apply_border_coloring(task_instances);
+    update_nodes_states(task_instances);
 
     d3.selectAll("g.node").on("click", function(d){
         task = tasks[d];
@@ -199,14 +199,14 @@
         }
     });
 
-    // Assigning css classes based on state to nodes for border coloring
-    function apply_border_coloring(task_instances) {
+    // Assigning css classes based on state to nodes
+    function update_nodes_states(task_instances) {
         $.each(task_instances, function(task_id, ti) {
           $('tspan').filter(function(index) { return $(this).text() === task_id; })
             .parent().parent().parent()
             .attr("class", "node enter " + ti.state)
             .attr("data-toggle", "tooltip")
-            .attr("title", function(d) {
+            .attr("data-original-title", function(d) {
               // Tooltip
               task = tasks[task_id];
               tt =  "Task_id: " + ti.task_id + "<br>";
@@ -280,7 +280,7 @@
                 "/admin/airflow/object/task_instances",
                 {dag_id : "{{ dag.dag_id }}", execution_date : "{{ execution_date }}"},
                 function(task_instances) {
-                    apply_border_coloring(JSON.parse(task_instances));
+                    update_nodes_states(JSON.parse(task_instances));
                 }
             );
         }

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -30,11 +30,12 @@
             <input type="submit" value="Go" class="btn btn-default"
             action="" method="get">
         </form>
+
+            <button class="btn btn-default" id="refreshButton" style="float: left;">Refresh Tasks</button>
             <div class="input-group" style="float: right;">
               <input type="text" id="searchbox" class="form-control" placeholder="Search for..." onenter="null">
             </div><!-- /input-group -->
         <div style="clear: both;">
-
     </div>
 <hr/>
 <div>
@@ -82,37 +83,15 @@
     var g = dagreD3.json.decode(nodes, edges);
     var duration = 500;
     var stateFocusMap = {
-        'no status':false, 'failed':false, 'running':false, 
+        'no status':false, 'failed':false, 'running':false,
         'queued': false, 'success': false};
 
 
     var layout = dagreD3.layout().rankDir(arrange).nodeSep(15).rankSep(15);
     var renderer = new dagreD3.Renderer();
     renderer.layout(layout).run(g, d3.select("#dig"));
+    apply_border_coloring(task_instances);
 
-    // Assigning css classes based on state to nodes for border coloring
-    $.each(task_instances, function(task_id, ti) {
-      $('tspan').filter(function(index) { return $(this).text() === task_id; })
-        .parent().parent().parent()
-        .attr("class", "node enter " + ti.state)
-        .attr("data-toggle", "tooltip")
-        .attr("title", function(d) {
-          // Tooltip
-          task = tasks[task_id];
-          tt =  "Task_id: " + ti.task_id + "<br>";
-          tt += "Run: " + ti.execution_date + "<br>";
-          if(ti.run_id != undefined){
-            tt += "run_id: <nobr>" + ti.run_id + "</nobr><br>";
-          }
-          tt += "Operator: " + task.task_type + "<br>";
-          tt += "Started: " + ti.start_date + "<br>";
-          tt += "Ended: " + ti.end_date + "<br>";
-          tt += "Duration: " + ti.duration + "<br>";
-          tt += "State: " + ti.state + "<br>";
-          return tt;
-        });
-    });
-    
     d3.selectAll("g.node").on("click", function(d){
         task = tasks[d];
         if (task.task_type == "SubDagOperator")
@@ -180,7 +159,7 @@
                     .selectAll("rect")
                     .style("stroke-width", "2px");
             }
-            else{ 
+            else{
                 d3.select("g.edgePaths")
                     .transition().duration(duration)
                     .style("opacity", 0.2);
@@ -205,11 +184,11 @@
         if(match) {
             var transform = d3.transform(d3.select(match).attr("transform"));
             transform.translate = [
-                -transform.translate[0] + 520, 
+                -transform.translate[0] + 520,
                 -(transform.translate[1] - 400)
             ];
             transform.scale = [1, 1];
-            
+
             d3.select("g.zoom")
                 .transition()
                 .attr("transform", transform.toString());
@@ -217,6 +196,31 @@
             renderer.zoom_obj.scale(1);
         }
     });
+
+    // Assigning css classes based on state to nodes for border coloring
+    function apply_border_coloring(task_instances) {
+        $.each(task_instances, function(task_id, ti) {
+          $('tspan').filter(function(index) { return $(this).text() === task_id; })
+            .parent().parent().parent()
+            .attr("class", "node enter " + ti.state)
+            .attr("data-toggle", "tooltip")
+            .attr("title", function(d) {
+              // Tooltip
+              task = tasks[task_id];
+              tt =  "Task_id: " + ti.task_id + "<br>";
+              tt += "Run: " + ti.execution_date + "<br>";
+              if(ti.run_id != undefined){
+                tt += "run_id: <nobr>" + ti.run_id + "</nobr><br>";
+              }
+              tt += "Operator: " + task.task_type + "<br>";
+              tt += "Started: " + ti.start_date + "<br>";
+              tt += "Ended: " + ti.end_date + "<br>";
+              tt += "Duration: " + ti.duration + "<br>";
+              tt += "State: " + ti.state + "<br>";
+              return tt;
+            });
+        });
+    }
 
     function clearFocus(){
         d3.selectAll("g.node")
@@ -267,6 +271,18 @@
         }
         return false
     }
+
+    d3.select("#refreshButton").on("click",
+        function() {
+            $.get(
+                "/admin/airflow/object/task_instances",
+                {dag_id : "{{ dag.dag_id }}", execution_date : "{{ execution_date }}"},
+                function(task_instances) {
+                    apply_border_coloring(JSON.parse(task_instances));
+                }
+            );
+        }
+    );
 
     </script>
 {% endblock %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1554,7 +1554,6 @@ class Airflow(BaseView):
     @login_required
     @wwwutils.action_logging
     def task_instances(self):
-        print request.args
         session = settings.Session()
         dag_id = request.args.get('dag_id')
         dag = dagbag.get_dag(dag_id)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1550,6 +1550,27 @@ class Airflow(BaseView):
             root=root,
         )
 
+    @expose('/object/task_instances')
+    @login_required
+    @wwwutils.action_logging
+    def task_instances(self):
+        print request.args
+        session = settings.Session()
+        dag_id = request.args.get('dag_id')
+        dag = dagbag.get_dag(dag_id)
+
+        dttm = request.args.get('execution_date')
+        if dttm:
+            dttm = dateutil.parser.parse(dttm)
+        else:
+            return ("Error: Invalid execution_date")
+
+        task_instances = {
+            ti.task_id: utils.alchemy_to_dict(ti)
+            for ti in dag.get_task_instances(session, dttm, dttm)}
+
+        return json.dumps(task_instances)
+
     @expose('/variables/<form>', methods=["GET", "POST"])
     @login_required
     @wwwutils.action_logging

--- a/tests/core.py
+++ b/tests/core.py
@@ -785,11 +785,8 @@ class WebUiTests(unittest.TestCase):
         response = self.app.get(url)
         assert "runme_0" in response.data.decode('utf-8')
 
-        #clean up
-        self.dag_bash.clear(start_date=DEFAULT_DATE, end_date=datetime.now())
-
     def tearDown(self):
-        pass
+        self.dag_bash.clear(start_date=DEFAULT_DATE, end_date=datetime.now())
 
 
 class WebPasswordAuthTest(unittest.TestCase):

--- a/tests/core.py
+++ b/tests/core.py
@@ -737,6 +737,12 @@ class WebUiTests(unittest.TestCase):
             "dag_id=example_bash_operator&force=true&deps=true&"
             "execution_date={}&origin=/admin".format(DEFAULT_DATE_DS))
         response = self.app.get(url)
+        url = (
+            "/admin/airflow/object/task_instances?"
+            "dag_id=example_bash_operator&"
+            "execution_date={}".format(DEFAULT_DATE_DS))
+        response = self.app.get(url)
+        assert "runme_0" in response.data.decode('utf-8')
         response = self.app.get(
             "/admin/airflow/refresh?dag_id=example_bash_operator")
         response = self.app.get("/admin/airflow/refresh_all")

--- a/tests/core.py
+++ b/tests/core.py
@@ -628,6 +628,11 @@ class WebUiTests(unittest.TestCase):
         app.config['TESTING'] = True
         self.app = app.test_client()
 
+        self.dagbag = models.DagBag(
+            dag_folder=DEV_NULL, include_examples=True)
+        self.dag_bash = self.dagbag.dags['example_bash_operator']
+        self.runme_0 = self.dag_bash.get_task('runme_0')
+
     def test_index(self):
         response = self.app.get('/', follow_redirects=True)
         assert "DAGs" in response.data.decode('utf-8')
@@ -737,12 +742,6 @@ class WebUiTests(unittest.TestCase):
             "dag_id=example_bash_operator&force=true&deps=true&"
             "execution_date={}&origin=/admin".format(DEFAULT_DATE_DS))
         response = self.app.get(url)
-        url = (
-            "/admin/airflow/object/task_instances?"
-            "dag_id=example_bash_operator&"
-            "execution_date={}".format(DEFAULT_DATE_DS))
-        response = self.app.get(url)
-        assert "runme_0" in response.data.decode('utf-8')
         response = self.app.get(
             "/admin/airflow/refresh?dag_id=example_bash_operator")
         response = self.app.get("/admin/airflow/refresh_all")
@@ -768,6 +767,26 @@ class WebUiTests(unittest.TestCase):
         response = self.app.get(
             '/admin/airflow/dag_details?dag_id=example_branch_operator')
         assert "run_this_first" in response.data.decode('utf-8')
+
+    def test_fetch_task_instance(self):
+        url = (
+            "/admin/airflow/object/task_instances?"
+            "dag_id=example_bash_operator&"
+            "execution_date={}".format(DEFAULT_DATE_DS))
+        response = self.app.get(url)
+        assert "{}" in response.data.decode('utf-8')
+
+        TI = models.TaskInstance
+        ti = TI(
+            task=self.runme_0, execution_date=DEFAULT_DATE)
+        job = jobs.LocalTaskJob(task_instance=ti, force=True)
+        job.run()
+
+        response = self.app.get(url)
+        assert "runme_0" in response.data.decode('utf-8')
+
+        #clean up
+        self.dag_bash.clear(start_date=DEFAULT_DATE, end_date=datetime.now())
 
     def tearDown(self):
         pass


### PR DESCRIPTION
**Work in Progress**: Creating PR to get feedback on feature

Currently, the only way to get an updated graph is to refresh the entire page. 
This PR adds a button that on the UI that remove the need to refresh the entire page. 

**Questions:**
Should we have the UI automatically poll the server for update rather then a manual click?
If not, what is the best place to place the button?
Which other view should we expand this feature to first?(ex. gantt, tree, etc...)

**Use Case:**
1. Open dag graph view
2. Run a task
3. Click refresh button and the border colors will be updated to fail/running/succeeded without having to refresh the entire page

<img width="437" alt="screen shot 2016-01-31 at 4 14 57 pm" src="https://cloud.githubusercontent.com/assets/4744103/12705010/ddf0c770-c835-11e5-9bef-215dbed66eb8.png">
