### PR TITLE
Fix process_subdir bug

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -28,9 +28,9 @@ def process_subdir(subdir):
     dags_folder = configuration.get("core", "DAGS_FOLDER")
     dags_folder = os.path.expanduser(dags_folder)
     if subdir:
-        subdir = os.path.abspath(os.path.expanduser(subdir))
         if "DAGS_FOLDER" in subdir:
             subdir = subdir.replace("DAGS_FOLDER", dags_folder)
+        subdir = os.path.abspath(os.path.expanduser(subdir))
         if dags_folder not in subdir:
             raise AirflowException(
                 "subdir has to be part of your DAGS_FOLDER as defined in your "

--- a/tests/core.py
+++ b/tests/core.py
@@ -618,6 +618,9 @@ class CliTests(unittest.TestCase):
             'backfill', 'example_bash_operator', '-l',
             '-s', DEFAULT_DATE.isoformat()]))
 
+    def test_process_subdir_path_with_placeholder(self):
+        assert cli.process_subdir('DAGS_FOLDER/abc') == os.path.join(configuration.get_dags_folder(), 'abc')
+
 
 class WebUiTests(unittest.TestCase):
 


### PR DESCRIPTION
If subdir parameter (`airflow run` command)  contains `DAGS_FOLDER` and the subdir is relative path, `cli.process_subdir` failed to parse correclty, and could not find dag file.

For example, if `DAGS_FOLDER` is `/var/lib/airflow` and current directory is also `/var/lib/airflow`, `DAGS_FOLDER/abc` become `/var/lib/airflow/var/lib/airflow/abc`.

This is because `os.path.abspath` is called before replace `DAGS_FOLDER` palceholder.
https://github.com/airbnb/airflow/blob/master/airflow/models.py#L630

This bug is critical because `TaskInstance.commad` specify `DAGS_FOLDER/{dag.filepath}` as default suddir value.
