### PR TITLE
Set effective user of (web)hdfs hooks using connection config, optionally overridden by constructor

### DIFF
--- a/airflow/hooks/hdfs_hook.py
+++ b/airflow/hooks/hdfs_hook.py
@@ -18,7 +18,7 @@ class HDFSHook(BaseHook):
     '''
     Interact with HDFS. This class is a wrapper around the snakebite library.
     '''
-    def __init__(self, hdfs_conn_id='hdfs_default'):
+    def __init__(self, hdfs_conn_id='hdfs_default', proxy_user=None):
         if not snakebite_imported:
             raise ImportError(
                 'This HDFSHook implementation requires snakebite, but '
@@ -26,6 +26,7 @@ class HDFSHook(BaseHook):
                 '(as of August 2015). Please use Python 2 if you require '
                 'this hook  -- or help by submitting a PR!')
         self.hdfs_conn_id = hdfs_conn_id
+        self.proxy_user = proxy_user
 
     def get_conn(self):
         '''
@@ -37,11 +38,13 @@ class HDFSHook(BaseHook):
 
         connections = self.get_connections(self.hdfs_conn_id)
         client = None
+	''' When using HAClient, proxy_user must be the same, so is ok to always take the first '''
+	effective_user = self.proxy_user or connections[0].login
         if len(connections) == 1:
-            client = Client(connections[0].host, connections[0].port,use_sasl=use_sasl)
+            client = Client(connections[0].host, connections[0].port, use_sasl=use_sasl, effective_user=effective_user)
         elif len(connections) > 1:
             nn = [Namenode(conn.host, conn.port) for conn in connections]
-            client = HAClient(nn, use_sasl=use_sasl)
+            client = HAClient(nn, use_sasl=use_sasl, effective_user=effective_user)
         else:
             raise HDFSHookException("conn_id doesn't exist in the repository")
         return client

--- a/airflow/hooks/webhdfs_hook.py
+++ b/airflow/hooks/webhdfs_hook.py
@@ -22,8 +22,9 @@ class WebHDFSHook(BaseHook):
     """
     Interact with HDFS. This class is a wrapper around the hdfscli library.
     """
-    def __init__(self, webhdfs_conn_id='webhdfs_default'):
+    def __init__(self, webhdfs_conn_id='webhdfs_default', proxy_user=None):
         self.webhdfs_conn_id = webhdfs_conn_id
+        self.proxy_user = proxy_user
 
     def get_conn(self):
         """
@@ -37,8 +38,9 @@ class WebHDFSHook(BaseHook):
                 if _kerberos_security_mode:
                   client = KerberosClient(connection_str)
                 else:
-                  client = InsecureClient(connection_str)
-                client.content('/')
+                  proxy_user = self.proxy_user or nn.login
+                  client = InsecureClient(connection_str, user=proxy_user)
+                client.status('/')
                 logging.debug('Using namenode {} for hook'.format(nn.host))
                 return client
             except HdfsError as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,4 @@ pykerberos
 bcrypt
 flask-bcrypt
 mock
+hdfs

--- a/tests/core.py
+++ b/tests/core.py
@@ -1101,6 +1101,21 @@ class ConnectionTest(unittest.TestCase):
         del os.environ['AIRFLOW_CONN_AIRFLOW_DB']
 
 
+class WebHDFSHookTest(unittest.TestCase):
+    def setUp(self):
+        configuration.test_mode()
+    
+    def test_simple_init(self):
+        from airflow.hooks.webhdfs_hook import WebHDFSHook
+        c = WebHDFSHook()
+        assert c.proxy_user == None
+
+    def test_init_proxy_user(self):
+        from airflow.hooks.webhdfs_hook import WebHDFSHook
+        c = WebHDFSHook(proxy_user='someone')
+        assert c.proxy_user == 'someone'
+
+
 @unittest.skipUnless("S3Hook" in dir(hooks),
                      "Skipping test because S3Hook is not installed")
 class S3HookTest(unittest.TestCase):


### PR DESCRIPTION
Sometimes is needed to do hdfs operations on behalf of other users (like creating dirs or setting permissions), so this PR adds a simple method to do that (optionally, without breaking compatibility).
