### PR TITLE
Fix running custom pool task with mark-success is not marked success

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -987,7 +987,7 @@ class TaskInstance(Base):
             logging.info(HR + msg + HR)
             self.start_date = datetime.now()
 
-            if self.state != State.QUEUED and (
+            if not mark_success and self.state != State.QUEUED and (
                     self.pool or self.task.dag.concurrency_reached):
                 # If a pool is set for this task, marking the task instance
                 # as QUEUED

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,7 +1,13 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import unittest
 import datetime
 
 from airflow import models
+from airflow.operators.dummy_operator import DummyOperator
 
 
 class DagRunTest(unittest.TestCase):
@@ -39,3 +45,32 @@ class DagBagTest(unittest.TestCase):
 
         non_existing_dag_id = "non_existing_dag_id"
         assert dagbag.get_dag(non_existing_dag_id) is None
+
+
+class TaskInstanceTest(unittest.TestCase):
+
+    def test_run_pooling_task(self):
+        """
+        test that running task with mark_success param update task state as SUCCESS
+        without running task.
+        """
+        dag = models.DAG(dag_id='test_run_pooling_task')
+        task = DummyOperator(task_id='test_run_pooling_task_op', dag=dag,
+                             pool='test_run_pooling_task_pool', owner='airflow',
+                             start_date=datetime.datetime(2016, 2, 1, 0, 0, 0))
+        ti = models.TaskInstance(task=task, execution_date=datetime.datetime.now())
+        ti.run()
+        assert ti.state == models.State.QUEUED
+
+    def test_run_pooling_task_with_mark_success(self):
+        """
+        test that running task with mark_success param update task state as SUCCESS
+        without running task.
+        """
+        dag = models.DAG(dag_id='test_run_pooling_task_with_mark_success')
+        task = DummyOperator(task_id='test_run_pooling_task_with_mark_success_op', dag=dag,
+                             pool='test_run_pooling_task_with_mark_success_pool', owner='airflow',
+                             start_date=datetime.datetime(2016, 2, 1, 0, 0, 0))
+        ti = models.TaskInstance(task=task, execution_date=datetime.datetime.now())
+        ti.run(mark_success=True)
+        assert ti.state == models.State.SUCCESS


### PR DESCRIPTION
`airflow run -m` should mark tasks as success without running them , but when tasks uses custom pool, they are actually being run.

This is because task is queued if custom pool is used, and scheduler run the queued task.

This issue seems to be related to #571 , but I don't know deital.
