### PR TITLE
Allow for domain-wide delegation in google cloud apps

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -27,12 +27,15 @@ class BigQueryHook(GoogleCloudBaseHook):
     """
     conn_name_attr = 'bigquery_conn_id'
 
-    def __init__(self, scope='https://www.googleapis.com/auth/bigquery', bigquery_conn_id='bigquery_default'):
+    def __init__(self,
+                 scope='https://www.googleapis.com/auth/bigquery',
+                 bigquery_conn_id='bigquery_default',
+                 sub=None):
         """
         :param scope: The scope of the hook.
         :type scope: string
         """
-        super(BigQueryHook, self).__init__(scope, bigquery_conn_id)
+        super(BigQueryHook, self).__init__(scope, bigquery_conn_id, sub)
 
     def get_conn(self):
         """

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -30,12 +30,12 @@ class BigQueryHook(GoogleCloudBaseHook):
     def __init__(self,
                  scope='https://www.googleapis.com/auth/bigquery',
                  bigquery_conn_id='bigquery_default',
-                 sub=None):
+                 delegate_to=None):
         """
         :param scope: The scope of the hook.
         :type scope: string
         """
-        super(BigQueryHook, self).__init__(scope, bigquery_conn_id, sub)
+        super(BigQueryHook, self).__init__(scope, bigquery_conn_id, delegate_to)
 
     def get_conn(self):
         """

--- a/airflow/contrib/hooks/gc_base_hook.py
+++ b/airflow/contrib/hooks/gc_base_hook.py
@@ -16,15 +16,18 @@ class GoogleCloudBaseHook(BaseHook):
     The class also contains some miscellaneous helper functions.
     """
 
-    def __init__(self, scope, conn_id):
+    def __init__(self, scope, conn_id, sub=None):
         """
         :param scope: The scope of the hook.
         :type scope: string
         :param conn_id: The connection ID to use when fetching connection info.
+        :param sub: The account to impersonate, if any.
+            For this to work, the service account making the request must have domain-wide delegation enabled.
         :type conn_id: string
         """
         self.scope = scope
         self.conn_id = conn_id
+        self.sub = sub
 
     def _authorize(self):
         """
@@ -36,6 +39,10 @@ class GoogleCloudBaseHook(BaseHook):
         service_account = connection_extras.get('service_account', False)
         key_path = connection_extras.get('key_path', False)
 
+        kwargs = {}
+        if self.sub:
+            kwargs['sub'] = self.sub
+
         if not key_path or not service_account:
             logging.info('Getting connection using `gcloud auth` user, since no service_account/key_path are defined for hook.')
             credentials = GoogleCredentials.get_application_default()
@@ -45,10 +52,8 @@ class GoogleCloudBaseHook(BaseHook):
                 credentials = SignedJwtAssertionCredentials(
                     service_account,
                     key,
-                    scope=self.scope)
-                    # TODO Support domain delegation, which will allow us to set a sub-account to execute as. We can then
-                    # pass DAG owner emails into the connection_info, and use it here.
-                    # sub='some@email.com')
+                    scope=self.scope,
+                    **kwargs)
         else:
             raise AirflowException('Scope undefined, or either key_path/service_account config was missing.')
 

--- a/airflow/contrib/hooks/gc_base_hook.py
+++ b/airflow/contrib/hooks/gc_base_hook.py
@@ -16,18 +16,20 @@ class GoogleCloudBaseHook(BaseHook):
     The class also contains some miscellaneous helper functions.
     """
 
-    def __init__(self, scope, conn_id, sub=None):
+    def __init__(self, scope, conn_id, delegate_to=None):
         """
         :param scope: The scope of the hook.
         :type scope: string
         :param conn_id: The connection ID to use when fetching connection info.
-        :param sub: The account to impersonate, if any.
-            For this to work, the service account making the request must have domain-wide delegation enabled.
         :type conn_id: string
+        :param delegate_to: The account to impersonate, if any.
+            For this to work, the service account making the request must have domain-wide delegation enabled.
+        :type delegate_to: string
+
         """
         self.scope = scope
         self.conn_id = conn_id
-        self.sub = sub
+        self.delegate_to = delegate_to
 
     def _authorize(self):
         """
@@ -40,8 +42,8 @@ class GoogleCloudBaseHook(BaseHook):
         key_path = connection_extras.get('key_path', False)
 
         kwargs = {}
-        if self.sub:
-            kwargs['sub'] = self.sub
+        if self.delegate_to:
+            kwargs['sub'] = self.delegate_to
 
         if not key_path or not service_account:
             logging.info('Getting connection using `gcloud auth` user, since no service_account/key_path are defined for hook.')

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -25,13 +25,16 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
     """
     conn_name_attr = 'google_cloud_storage_conn_id'
 
-    def __init__(self, scope='https://www.googleapis.com/auth/devstorage.read_only', google_cloud_storage_conn_id='google_cloud_storage_default'):
+    def __init__(self,
+                 scope='https://www.googleapis.com/auth/devstorage.read_only',
+                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 sub=None):
         """
         :param scope: The scope of the hook (read only, read write, etc). See:
             https://cloud.google.com/storage/docs/authentication?hl=en#oauth-scopes
         :type scope: string
         """
-        super(GoogleCloudStorageHook, self).__init__(scope, google_cloud_storage_conn_id)
+        super(GoogleCloudStorageHook, self).__init__(scope, google_cloud_storage_conn_id, sub)
 
     def get_conn(self):
         """

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -28,13 +28,13 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
     def __init__(self,
                  scope='https://www.googleapis.com/auth/devstorage.read_only',
                  google_cloud_storage_conn_id='google_cloud_storage_default',
-                 sub=None):
+                 delegate_to=None):
         """
         :param scope: The scope of the hook (read only, read write, etc). See:
             https://cloud.google.com/storage/docs/authentication?hl=en#oauth-scopes
         :type scope: string
         """
-        super(GoogleCloudStorageHook, self).__init__(scope, google_cloud_storage_conn_id, sub)
+        super(GoogleCloudStorageHook, self).__init__(scope, google_cloud_storage_conn_id, delegate_to)
 
     def get_conn(self):
         """

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -13,7 +13,14 @@ class BigQueryOperator(BaseOperator):
     ui_color = '#e4f0e8'
 
     @apply_defaults
-    def __init__(self, bql, destination_dataset_table = False, write_disposition = 'WRITE_EMPTY', bigquery_conn_id='bigquery_default', *args, **kwargs):
+    def __init__(self,
+                 bql,
+                 destination_dataset_table = False,
+                 write_disposition = 'WRITE_EMPTY',
+                 bigquery_conn_id='bigquery_default',
+                 sub=None,
+                 *args,
+                 **kwargs):
         """
         Create a new BigQueryOperator.
 
@@ -32,8 +39,9 @@ class BigQueryOperator(BaseOperator):
         self.destination_dataset_table = destination_dataset_table
         self.write_disposition = write_disposition
         self.bigquery_conn_id = bigquery_conn_id
+        self.sub = sub
 
     def execute(self, context):
         logging.info('Executing: %s', str(self.bql))
-        hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id)
+        hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id, sub=self.sub)
         hook.run(self.bql, self.destination_dataset_table, self.write_disposition)

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -18,7 +18,7 @@ class BigQueryOperator(BaseOperator):
                  destination_dataset_table = False,
                  write_disposition = 'WRITE_EMPTY',
                  bigquery_conn_id='bigquery_default',
-                 sub=None,
+                 delegate_to=None,
                  *args,
                  **kwargs):
         """
@@ -33,15 +33,18 @@ class BigQueryOperator(BaseOperator):
         :type destination_dataset_table: string
         :param bigquery_conn_id: reference to a specific BigQuery hook.
         :type bigquery_conn_id: string
+        :param delegate_to: The account to impersonate, if any.
+            For this to work, the service account making the request must have domain-wide delegation enabled.
+        :type delegate_to: string
         """
         super(BigQueryOperator, self).__init__(*args, **kwargs)
         self.bql = bql
         self.destination_dataset_table = destination_dataset_table
         self.write_disposition = write_disposition
         self.bigquery_conn_id = bigquery_conn_id
-        self.sub = sub
+        self.delegate_to = delegate_to
 
     def execute(self, context):
         logging.info('Executing: %s', str(self.bql))
-        hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id, sub=self.sub)
+        hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id, delegate_to=self.delegate_to)
         hook.run(self.bql, self.destination_dataset_table, self.write_disposition)

--- a/airflow/contrib/operators/bigquery_to_gcs.py
+++ b/airflow/contrib/operators/bigquery_to_gcs.py
@@ -22,7 +22,7 @@ class BigQueryToCloudStorageOperator(BaseOperator):
         field_delimiter=',', 
         print_header=True, 
         bigquery_conn_id='bigquery_default',
-        sub=None,
+        delegate_to=None,
         *args, 
         **kwargs):
         """
@@ -50,6 +50,9 @@ class BigQueryToCloudStorageOperator(BaseOperator):
         :type print_header: boolean
         :param bigquery_conn_id: reference to a specific BigQuery hook.
         :type bigquery_conn_id: string
+        :param delegate_to: The account to impersonate, if any.
+            For this to work, the service account making the request must have domain-wide delegation enabled.
+        :type delegate_to: string
         """
         super(BigQueryToCloudStorageOperator, self).__init__(*args, **kwargs)
         self.source_dataset_table = source_dataset_table 
@@ -59,11 +62,11 @@ class BigQueryToCloudStorageOperator(BaseOperator):
         self.field_delimiter = field_delimiter
         self.print_header = print_header
         self.bigquery_conn_id = bigquery_conn_id
-        self.sub = sub
+        self.delegate_to = delegate_to
 
     def execute(self, context):
         logging.info('Executing extract of %s into: %s', self.source_dataset_table, self.destination_cloud_storage_uris)
-        hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id, sub=self.sub)
+        hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id, delegate_to=self.delegate_to)
         hook.run_extract(
             self.source_dataset_table,
             self.destination_cloud_storage_uris,

--- a/airflow/contrib/operators/bigquery_to_gcs.py
+++ b/airflow/contrib/operators/bigquery_to_gcs.py
@@ -21,7 +21,8 @@ class BigQueryToCloudStorageOperator(BaseOperator):
         export_format='CSV', 
         field_delimiter=',', 
         print_header=True, 
-        bigquery_conn_id='bigquery_default', 
+        bigquery_conn_id='bigquery_default',
+        sub=None,
         *args, 
         **kwargs):
         """
@@ -58,10 +59,11 @@ class BigQueryToCloudStorageOperator(BaseOperator):
         self.field_delimiter = field_delimiter
         self.print_header = print_header
         self.bigquery_conn_id = bigquery_conn_id
+        self.sub = sub
 
     def execute(self, context):
         logging.info('Executing extract of %s into: %s', self.source_dataset_table, self.destination_cloud_storage_uris)
-        hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id)
+        hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id, sub=self.sub)
         hook.run_extract(
             self.source_dataset_table,
             self.destination_cloud_storage_uris,

--- a/airflow/contrib/operators/gcs_download_operator.py
+++ b/airflow/contrib/operators/gcs_download_operator.py
@@ -19,6 +19,7 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
         object,
         filename,
         google_cloud_storage_conn_id='google_cloud_storage_default',
+        sub=None,
         *args,
         **kwargs):
         """
@@ -41,8 +42,9 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
         self.object = object
         self.filename = filename
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.sub = sub
 
     def execute(self, context):
         logging.info('Executing download: %s, %s, %s', self.bucket, self.object, self.filename)
-        hook = GoogleCloudStorageHook(google_cloud_storage_conn_id=self.google_cloud_storage_conn_id)
+        hook = GoogleCloudStorageHook(google_cloud_storage_conn_id=self.google_cloud_storage_conn_id, sub=self.sub)
         print(hook.download(self.bucket, self.object, self.filename))

--- a/airflow/contrib/operators/gcs_download_operator.py
+++ b/airflow/contrib/operators/gcs_download_operator.py
@@ -19,7 +19,7 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
         object,
         filename,
         google_cloud_storage_conn_id='google_cloud_storage_default',
-        sub=None,
+        delegate_to=None,
         *args,
         **kwargs):
         """
@@ -36,15 +36,19 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
         :param google_cloud_storage_conn_id: The connection ID to use when
             connecting to Google cloud storage.
         :type google_cloud_storage_conn_id: string
+        :param delegate_to: The account to impersonate, if any.
+            For this to work, the service account making the request must have domain-wide delegation enabled.
+        :type delegate_to: string
         """
         super(GoogleCloudStorageDownloadOperator, self).__init__(*args, **kwargs)
         self.bucket = bucket
         self.object = object
         self.filename = filename
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
-        self.sub = sub
+        self.delegate_to = delegate_to
 
     def execute(self, context):
         logging.info('Executing download: %s, %s, %s', self.bucket, self.object, self.filename)
-        hook = GoogleCloudStorageHook(google_cloud_storage_conn_id=self.google_cloud_storage_conn_id, sub=self.sub)
+        hook = GoogleCloudStorageHook(google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+                                      delegate_to=self.delegate_to)
         print(hook.download(self.bucket, self.object, self.filename))


### PR DESCRIPTION
add a param on google cloud app hooks and operators to allow passing an account to impersonate.

some documentation from google on the subject: https://developers.google.com/identity/protocols/OAuth2ServiceAccount?hl=en_US
