### PR TITLE
Support new configuration dags_are_paused_at_creation that, when True…

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -75,6 +75,7 @@ defaults = {
         'dag_concurrency': 16,
         'max_active_runs_per_dag': 16,
         'executor': 'SequentialExecutor',
+        'dags_are_paused_at_creation': False,
     },
     'webserver': {
         'base_url': 'http://localhost:8080',
@@ -149,6 +150,9 @@ parallelism = 32
 
 # The number of task instances allowed to run concurrently by the scheduler
 dag_concurrency = 16
+
+# Are DAGs paused by default at creation
+dags_are_paused_at_creation = False
 
 # The maximum number of active DAG runs per DAG
 max_active_runs_per_dag = 16
@@ -309,6 +313,7 @@ unit_test_mode = True
 load_examples = True
 donot_pickle = False
 dag_concurrency = 16
+dags_are_paused_at_creation = False
 fernet_key = {FERNET_KEY}
 
 [webserver]

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1932,7 +1932,9 @@ class DagModel(Base):
     """
     dag_id = Column(String(ID_LEN), primary_key=True)
     # A DAG can be paused from the UI / DB
-    is_paused = Column(Boolean, default=False)
+    # Set this default value of is_paused based on a configuration value!
+    is_paused_at_creation = configuration.getboolean('core', 'dags_are_paused_at_creation')
+    is_paused = Column(Boolean, default=is_paused_at_creation)
     # Whether the DAG is a subdag
     is_subdag = Column(Boolean, default=False)
     # Whether that DAG was seen on the last DagBag load


### PR DESCRIPTION
…, will cause a new DAG to be created and loaded in a paused state. The default value is False, in line with current expected behavior

This is in response to https://github.com/airbnb/airflow/issues/954
