### PR TITLE
Fix parsing file that contains multi byte char

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -192,9 +192,9 @@ class DagBag(LoggingMixin):
 
         if safe_mode and os.path.isfile(filepath):
             # Skip file if no obvious references to airflow or DAG are found.
-            with open(filepath, 'r') as f:
+            with open(filepath, 'rb') as f:
                 content = f.read()
-                if not all([s in content for s in ('DAG', 'airflow')]):
+                if not all([s in content for s in (b'DAG', b'airflow')]):
                     return found_dags
 
         if (not only_if_updated or

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -45,6 +46,18 @@ class DagBagTest(unittest.TestCase):
 
         non_existing_dag_id = "non_existing_dag_id"
         assert dagbag.get_dag(non_existing_dag_id) is None
+
+    def test_process_file_that_contains_multi_bytes_char(self):
+        """
+        test that we're able to parse file that contains multi-byte char
+        """
+        from tempfile import NamedTemporaryFile
+        f = NamedTemporaryFile()
+        f.write('\u3042'.encode('utf8'))  # write multi-byte char (hiragana)
+        f.flush()
+
+        dagbag = models.DagBag(include_examples=True)
+        assert dagbag.process_file(f.name) == []
 
 
 class TaskInstanceTest(unittest.TestCase):


### PR DESCRIPTION
Fix https://github.com/airbnb/airflow/issues/721

Writing mutli byte character in source file is very usual case in some languages, like Japanese, but this bug prevents that.
