### PR TITLE
Add BigQuery PEP 249 support

### DIFF
--- a/airflow/contrib/operators/bigquery_check_operator.py
+++ b/airflow/contrib/operators/bigquery_check_operator.py
@@ -1,0 +1,52 @@
+from airflow.contrib.hooks.bigquery_hook import BigQueryHook
+from airflow.operators import CheckOperator, ValueCheckOperator, IntervalCheckOperator
+from airflow.utils import apply_defaults
+
+
+class BigQueryCheckOperator(CheckOperator):
+    # TODO pydocs
+    @apply_defaults
+    def __init__(
+            self,
+            sql,
+            bigquery_conn_id='bigquery_default',
+            *args,
+            **kwargs):
+        super(BigQueryCheckOperator, self).__init__(sql=sql, *args, **kwargs)
+        self.bigquery_conn_id = bigquery_conn_id
+        self.sql = sql
+
+    def get_db_hook(self):
+        return BigQueryHook(bigquery_conn_id=self.bigquery_conn_id)
+
+class BigQueryValueCheckOperator(ValueCheckOperator):
+    # TODO pydocs
+
+    @apply_defaults
+    def __init__(
+            self, sql, pass_value, tolerance=None,
+            bigquery_conn_id='bigquery_default',
+            *args, **kwargs):
+        super(BigQueryValueCheckOperator, self).__init__(sql=sql, pass_value=pass_value, tolerance=tolerance, *args, **kwargs)
+        self.bigquery_conn_id = bigquery_conn_id
+
+    def get_db_hook(self):
+        return BigQueryHook(bigquery_conn_id=self.bigquery_conn_id)
+
+
+class BigQueryIntervalCheckOperator(IntervalCheckOperator):
+    # TODO pydocs
+
+    @apply_defaults
+    def __init__(
+            self, table, metrics_thresholds,
+            date_filter_column='ds', days_back=-7,
+            bigquery_conn_id='bigquery_default',
+            *args, **kwargs):
+        super(BigQueryIntervalCheckOperator, self).__init__(
+            table=table, metrics_thresholds=metrics_thresholds, date_filter_column=date_filter_column, days_back=days_back,
+            *args, **kwargs)
+        self.bigquery_conn_id = bigquery_conn_id
+
+    def get_db_hook(self):
+        return BigQueryHook(bigquery_conn_id=self.bigquery_conn_id)

--- a/airflow/contrib/operators/bigquery_check_operator.py
+++ b/airflow/contrib/operators/bigquery_check_operator.py
@@ -4,7 +4,38 @@ from airflow.utils import apply_defaults
 
 
 class BigQueryCheckOperator(CheckOperator):
-    # TODO pydocs
+    """
+    Performs checks against Presto. The ``BigQueryCheckOperator`` expects
+    a sql query that will return a single row. Each value on that
+    first row is evaluated using python ``bool`` casting. If any of the
+    values return ``False`` the check is failed and errors out.
+
+    Note that Python bool casting evals the following as ``False``:
+    * False
+    * 0
+    * Empty string (``""``)
+    * Empty list (``[]``)
+    * Empty dictionary or set (``{}``)
+
+    Given a query like ``SELECT COUNT(*) FROM foo``, it will fail only if
+    the count ``== 0``. You can craft much more complex query that could,
+    for instance, check that the table has the same number of rows as
+    the source table upstream, or that the count of today's partition is
+    greater than yesterday's partition, or that a set of metrics are less
+    than 3 standard deviation for the 7 day average.
+
+    This operator can be used as a data quality check in your pipeline, and
+    depending on where you put it in your DAG, you have the choice to
+    stop the critical path, preventing from
+    publishing dubious data, or on the side and receive email alterts
+    without stopping the progress of the DAG.
+
+    :param sql: the sql to be executed
+    :type sql: string
+    :param bigquery_conn_id: reference to the BigQuery database
+    :type presto_conn_id: string
+    """
+
     @apply_defaults
     def __init__(
             self,
@@ -20,7 +51,12 @@ class BigQueryCheckOperator(CheckOperator):
         return BigQueryHook(bigquery_conn_id=self.bigquery_conn_id)
 
 class BigQueryValueCheckOperator(ValueCheckOperator):
-    # TODO pydocs
+    """
+    Performs a simple value check using sql code.
+
+    :param sql: the sql to be executed
+    :type sql: string
+    """
 
     @apply_defaults
     def __init__(
@@ -33,9 +69,26 @@ class BigQueryValueCheckOperator(ValueCheckOperator):
     def get_db_hook(self):
         return BigQueryHook(bigquery_conn_id=self.bigquery_conn_id)
 
-
 class BigQueryIntervalCheckOperator(IntervalCheckOperator):
-    # TODO pydocs
+    """
+    Checks that the values of metrics given as SQL expressions are within
+    a certain tolerance of the ones from days_back before.
+
+    This method constructs a query like so:
+
+    SELECT {metrics_threshold_dict_key} FROM {table}
+        WHERE {date_filter_column}=<date>
+
+    :param table: the table name
+    :type table: str
+    :param days_back: number of days between ds and the ds we want to check
+        against. Defaults to 7 days
+    :type days_back: int
+    :param metrics_threshold: a dictionary of ratios indexed by metrics, for
+        example 'COUNT(*)': 1.5 would require a 50 percent or less difference
+        between the current day, and the prior days_back.
+    :type metrics_threshold: dict
+    """
 
     @apply_defaults
     def __init__(

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -47,4 +47,6 @@ class BigQueryOperator(BaseOperator):
     def execute(self, context):
         logging.info('Executing: %s', str(self.bql))
         hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id, delegate_to=self.delegate_to)
-        hook.run(self.bql, self.destination_dataset_table, self.write_disposition)
+        conn = hook.get_conn()
+        cursor = conn.cursor()
+        cursor.run_query(self.bql, self.destination_dataset_table, self.write_disposition)

--- a/airflow/contrib/operators/bigquery_to_gcs.py
+++ b/airflow/contrib/operators/bigquery_to_gcs.py
@@ -67,7 +67,9 @@ class BigQueryToCloudStorageOperator(BaseOperator):
     def execute(self, context):
         logging.info('Executing extract of %s into: %s', self.source_dataset_table, self.destination_cloud_storage_uris)
         hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id, delegate_to=self.delegate_to)
-        hook.run_extract(
+        conn = hook.get_conn()
+        cursor = conn.cursor()
+        cursor.run_extract(
             self.source_dataset_table,
             self.destination_cloud_storage_uris,
             self.compression,


### PR DESCRIPTION
While trying to use the check_operator with BigQuery, I discovered that we need PEP 249 support for BigQuery in order to make it work. I've added PEP 249 support for BQ, and added a BigQuery check operator.

This patch looks large, but is mostly just cruft. The core BigQuery run methods remain basically untouched.

I have validated that these changes work with our DAGs. I also validated the Data Profiler queries. I'm still unaware of anyone else using this stuff. There is one backwards incompatible change--I moved the run methods for BQ into the cursor.
