### PR TITLE
Added destination_dataset_table to template_fieds of bigquery_operator

### DIFF
--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -8,7 +8,7 @@ class BigQueryOperator(BaseOperator):
     """
     Executes BigQuery SQL queries in a specific BigQuery database
     """
-    template_fields = ('bql',)
+    template_fields = ('bql', 'destination_dataset_table')
     template_ext = ('.sql',)
     ui_color = '#e4f0e8'
 


### PR DESCRIPTION
This makes more sense especially when `BigQueryToCloudStorageOperator` also has `source_dataset_table` and `destination_cloud_storage_uris` in `template_fields`.
