### PR TITLE
[documentation] document that max_active_runs can prevent a DAG from running

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -44,6 +44,9 @@ Here are some of the common causes:
   how many ``running`` task instances a DAG is allowed to have, beyond which
   point things get queued. 
 
+- Is the ``max_active_runs`` parameter of your DAG reached? ``max_active_runs`` defines
+  how many ``running`` concurrent instances of a DAG there are allowed to be.
+
 You may also want to read the Scheduler section of the docs and make
 sure you fully understand how it proceeds.
 


### PR DESCRIPTION
@mistercrunch 
