### PR TITLE
Added yesterday_ds_nodash and tommorow_ds_nodash

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1149,11 +1149,17 @@ class TaskInstance(Base):
         tables = None
         if 'tables' in task.params:
             tables = task.params['tables']
+
         ds = self.execution_date.isoformat()[:10]
+        ts = self.execution_date.isoformat()
         yesterday_ds = (self.execution_date - timedelta(1)).isoformat()[:10]
         tomorrow_ds = (self.execution_date + timedelta(1)).isoformat()[:10]
+
         ds_nodash = ds.replace('-', '')
-        iso = self.execution_date.isoformat()
+        ts_nodash = ts.replace('-', '').replace(':', '')
+        yesterday_ds_nodash = yesterday_ds.replace('-', '')
+        tomorrow_ds_nodash = tomorrow_ds.replace('-', '')
+
         ti_key_str = "{task.dag_id}__{task.task_id}__{ds_nodash}"
         ti_key_str = ti_key_str.format(**locals())
 
@@ -1180,8 +1186,8 @@ class TaskInstance(Base):
         return {
             'dag': task.dag,
             'ds': ds,
-            'ts': iso,
-            'ts_nodash': iso.replace('-', '').replace(':', ''),
+            'ts': ts,
+            'ts_nodash': ts_nodash,
             'yesterday_ds': yesterday_ds,
             'tomorrow_ds': tomorrow_ds,
             'END_DATE': ds,

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -112,8 +112,11 @@ in all templates
 Variable                            Description
 =================================   ====================================
 ``{{ ds }}``                        the execution date as ``YYYY-MM-DD``
-``{{ yesterday_ds }}``              yesterday's date as  ``YYYY-MM-DD``
-``{{ tomorrow_ds }}``               tomorrow's date as  ``YYYY-MM-DD``
+``{{ ds_nodash }}``                 the execution date as ``YYYYMMDD``
+``{{ yesterday_ds }}``              yesterday's date as ``YYYY-MM-DD``
+``{{ yesterday_ds_nodash }}``       yesterday's date as ``YYYYMMDD``
+``{{ tomorrow_ds }}``               tomorrow's date as ``YYYY-MM-DD``
+``{{ tomorrow_ds_nodash }}``        tomorrow's date as ``YYYYMMDD``
 ``{{ ts }}``                        same as ``execution_date.isoformat()``
 ``{{ ts_nodash }}``                 same as ``ts`` without ``-`` and ``:``
 ``{{ execution_date }}``            the execution_date, (datetime.datetime)
@@ -121,7 +124,6 @@ Variable                            Description
 ``{{ task }}``                      the Task object
 ``{{ macros }}``                    a reference to the macros package, described below
 ``{{ task_instance }}``             the task_instance object
-``{{ ds_nodash }}``                 the execution date as ``YYYYMMDD``
 ``{{ end_date }}``                  same as ``{{ ds }}``
 ``{{ latest_date }}``               same as ``{{ ds }}``
 ``{{ ti }}``                        same as ``{{ task_instance }}``


### PR DESCRIPTION
The goal is to avoid too much logic in templates, the current workaround is to
write `{{ macros.ds_format(yesterday_ds, '%Y-%m-%d', '%Y%m%d') }}` which is too
verbose.
