### PR TITLE
there could be dot in the key string, which is illegal in the hive ta…

### DIFF
--- a/airflow/operators/hive_to_druid.py
+++ b/airflow/operators/hive_to_druid.py
@@ -68,7 +68,7 @@ class HiveToDruidTransfer(BaseOperator):
     def execute(self, context):
         hive = HiveCliHook(hive_cli_conn_id=self.hive_cli_conn_id)
         logging.info("Extracting data from Hive")
-        hive_table = 'druid.' + context['task_instance_key_str']
+        hive_table = 'druid.' + context['task_instance_key_str'].replace('.', '_')
         sql = self.sql.strip().strip(';')
         hql = """\
         set mapred.output.compress=false;


### PR DESCRIPTION
…ble name

an error for example `DROP TABLE IF EXISTS druid.datainfra.hdfs_hive_metadata__hdfs_size_druid_ingestion_gold__20160210;`

@mistercrunch @aoen 
