### PR TITLE
Added the dst filename to template_fields GoogleCloudStorageDownloadOperator

### DIFF
--- a/airflow/contrib/operators/gcs_download_operator.py
+++ b/airflow/contrib/operators/gcs_download_operator.py
@@ -8,7 +8,7 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
     """
     Downloads a file from Google Cloud Storage.
     """
-    template_fields = ('bucket','object',)
+    template_fields = ('bucket','object','filename',)
     template_ext = ('.sql',)
     ui_color = '#f0eee4'
 


### PR DESCRIPTION
If you can template the object (src file) you should definately be able to template filename (dst file)
