### PR TITLE
Fixed issue 1012: pool not used with celery executor

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -222,7 +222,8 @@ def run(args):
             mark_success=args.mark_success,
             pickle_id=pickle_id,
             ignore_dependencies=args.ignore_dependencies,
-            force=args.force)
+            force=args.force,
+            pool=args.pool)
         executor.heartbeat()
         executor.end()
 


### PR DESCRIPTION
args.pool was not being propagated in the else clause

Thanks to r39132 for pointing me in the right direction.
