### PR TITLE
Fixing the DAGRUN_TIMEOUT check

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -370,8 +370,8 @@ class SchedulerJob(BaseJob):
                 return
             for dr in active_runs:
                 if (
-                        dr.start_date and dag.dagrun_timeout and
-                        dr.start_date < datetime.now() - dag.dagrun_timeout):
+                        dr.execution_date and dag.dagrun_timeout and
+                        dr.execution_date < datetime.now() - dag.dagrun_timeout):
                     dr.state = State.FAILED
                     dr.end_date = datetime.now()
             session.commit()


### PR DESCRIPTION
This is a fix for https://github.com/airbnb/airflow/issues/990
