### PR TITLE
Making `airflow run` not use a db connection pool

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -20,7 +20,6 @@ in their PYTHONPATH. airflow_login should be based off the
 `airflow.www.login`
 """
 from builtins import object
-__version__ = "1.6.2"
 
 import logging
 import os
@@ -34,6 +33,8 @@ from flask_admin import BaseView
 from importlib import import_module
 from airflow.utils import AirflowException, get_sqla_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
+
+__version__ = "1.6.2"
 
 DAGS_FOLDER = os.path.expanduser(conf.get('core', 'DAGS_FOLDER'))
 if DAGS_FOLDER not in sys.path:

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -28,16 +28,23 @@ import sys
 
 from airflow import configuration as conf
 
-from airflow.models import DAG
+from airflow.models import DAG  # noqa
 from flask_admin import BaseView
 from importlib import import_module
-from airflow.utils import AirflowException
+from airflow.utils import AirflowException, get_sqla_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 DAGS_FOLDER = os.path.expanduser(conf.get('core', 'DAGS_FOLDER'))
 if DAGS_FOLDER not in sys.path:
     sys.path.append(DAGS_FOLDER)
 
 login = None
+engine = get_sqla_engine(
+    pool_size=conf.getint('core', 'SQL_ALCHEMY_POOL_SIZE'),
+    pool_recycle=conf.getint('core', 'SQL_ALCHEMY_POOL_RECYCLE'))
+
+Session = scoped_session(
+    sessionmaker(autocommit=False, autoflush=False, bind=engine))
 
 
 def load_login():

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -27,6 +27,7 @@ import os
 import sys
 
 from airflow import configuration as conf
+from airflow import settings
 
 from airflow.models import DAG  # noqa
 from flask_admin import BaseView
@@ -45,6 +46,8 @@ engine = get_sqla_engine(
 
 Session = scoped_session(
     sessionmaker(autocommit=False, autoflush=False, bind=engine))
+settings.Session = Session
+settings.engine = engine
 
 
 def load_login():

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -155,7 +155,7 @@ encrypt_s3_logs = False
 
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor
-executor = SequentialExecutor
+executor = LocalExecutor
 
 # The SqlAlchemy connection string to the metadata database.
 # SqlAlchemy supports many different database engine, more information

--- a/airflow/contrib/auth/backends/github_enterprise_auth.py
+++ b/airflow/contrib/auth/backends/github_enterprise_auth.py
@@ -20,6 +20,7 @@ from flask import url_for, redirect, request
 
 from flask_oauthlib.client import OAuth
 
+import airflow
 from airflow import models, configuration, settings
 from airflow.configuration import AirflowConfigException
 
@@ -161,7 +162,7 @@ class GHEAuthBackend(object):
         if not userid or userid == 'None':
             return None
 
-        session = settings.Session()
+        session = airflow.Session()
         user = session.query(models.User).filter(
             models.User.id == int(userid)).first()
         session.expunge_all()
@@ -193,7 +194,7 @@ class GHEAuthBackend(object):
             _log.exception('')
             return redirect(url_for('airflow.noaccess'))
 
-        session = settings.Session()
+        session = airflow.Session()
 
         user = session.query(models.User).filter(
             models.User.username == username).first()

--- a/airflow/contrib/auth/backends/github_enterprise_auth.py
+++ b/airflow/contrib/auth/backends/github_enterprise_auth.py
@@ -21,7 +21,7 @@ from flask import url_for, redirect, request
 from flask_oauthlib.client import OAuth
 
 import airflow
-from airflow import models, configuration, settings
+from airflow import models, configuration
 from airflow.configuration import AirflowConfigException
 
 _log = logging.getLogger(__name__)

--- a/airflow/contrib/auth/backends/kerberos_auth.py
+++ b/airflow/contrib/auth/backends/kerberos_auth.py
@@ -12,9 +12,8 @@ import airflow.security.utils as utils
 
 from flask import url_for, redirect
 
-from airflow import settings
-from airflow import models
-from airflow import configuration
+import airflow
+from airflow import settings, models, configuration
 
 import logging
 
@@ -77,7 +76,7 @@ def load_user(userid):
     if not userid or userid == 'None':
         return None
 
-    session = settings.Session()
+    session = airflow.Session()
     user = session.query(models.User).filter(models.User.id == int(userid)).first()
     session.expunge_all()
     session.commit()

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -1,5 +1,5 @@
 import flask_login
-from flask_login import login_required, current_user, logout_user
+from flask_login import current_user
 from flask import flash
 from wtforms import (
     Form, PasswordField, StringField)
@@ -10,9 +10,8 @@ import ssl
 
 from flask import url_for, redirect
 
-from airflow import settings
-from airflow import models
-from airflow import configuration
+import airflow
+from airflow import settings, models, configuration
 from airflow.configuration import AirflowConfigException
 
 import logging
@@ -172,7 +171,7 @@ def load_user(userid):
     if not userid or userid == 'None':
         return None
 
-    session = settings.Session()
+    session = airflow.Session()
     user = session.query(models.User).filter(models.User.id == int(userid)).first()
     session.expunge_all()
     session.commit()
@@ -203,7 +202,7 @@ def login(self, request):
         LdapUser.try_login(username, password)
         LOG.info("User %s successfully authenticated", username)
 
-        session = settings.Session()
+        session = airflow.Session()
         user = session.query(models.User).filter(
             models.User.username == username).first()
 

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -11,7 +11,7 @@ import ssl
 from flask import url_for, redirect
 
 import airflow
-from airflow import settings, models, configuration
+from airflow import models, configuration
 from airflow.configuration import AirflowConfigException
 
 import logging

--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from sys import version_info
 
 import flask_login
-from flask_login import login_required, current_user, logout_user
+from flask_login import current_user
 from flask import flash
 from wtforms import (
     Form, PasswordField, StringField)
@@ -16,9 +16,8 @@ from sqlalchemy import (
     Column, String, DateTime)
 from sqlalchemy.ext.hybrid import hybrid_property
 
-from airflow import settings
-from airflow import models
-from airflow import configuration
+import airflow
+from airflow import settings, models
 
 import logging
 
@@ -83,7 +82,7 @@ def load_user(userid):
     if not userid or userid == 'None':
         return None
 
-    session = settings.Session()
+    session = airflow.Session()
     user = session.query(models.User).filter(models.User.id == int(userid)).first()
     session.expunge_all()
     session.commit()
@@ -111,7 +110,7 @@ def login(self, request):
                            form=form)
 
     try:
-        session = settings.Session()
+        session = airflow.Session()
         user = session.query(PasswordUser).filter(
             PasswordUser.username == username).first()
 

--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -12,12 +12,11 @@ from wtforms.validators import InputRequired
 from flask import url_for, redirect
 from flask_bcrypt import generate_password_hash, check_password_hash
 
-from sqlalchemy import (
-    Column, String, DateTime)
+from sqlalchemy import Column, String
 from sqlalchemy.ext.hybrid import hybrid_property
 
 import airflow
-from airflow import settings, models
+from airflow import models
 
 import logging
 

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -8,7 +8,7 @@ import logging
 import os
 import random
 
-from airflow import settings
+import airflow
 from airflow.models import Connection
 from airflow.utils import AirflowException
 
@@ -28,7 +28,7 @@ class BaseHook(object):
 
     @classmethod
     def get_connections(cls, conn_id):
-        session = settings.Session()
+        session = airflow.Session()
         db = (
             session.query(Connection)
             .filter(Connection.conn_id == conn_id)

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -33,6 +33,7 @@ from time import sleep
 from sqlalchemy import Column, Integer, String, DateTime, func, Index, or_
 from sqlalchemy.orm.session import make_transient
 
+import airflow
 from airflow import executors, models, settings, utils
 from airflow import configuration as conf
 from airflow.utils import AirflowException, State, LoggingMixin
@@ -94,7 +95,7 @@ class BaseJob(Base, LoggingMixin):
         )
 
     def kill(self):
-        session = settings.Session()
+        session = airflow.Session()
         job = session.query(BaseJob).filter(BaseJob.id == self.id).first()
         job.end_date = datetime.now()
         try:
@@ -134,7 +135,7 @@ class BaseJob(Base, LoggingMixin):
         heart rate. If you go over 60 seconds before calling it, it won't
         sleep at all.
         '''
-        session = settings.Session()
+        session = airflow.Session()
         job = session.query(BaseJob).filter(BaseJob.id == self.id).first()
 
         if job.state == State.SHUTDOWN:
@@ -158,7 +159,7 @@ class BaseJob(Base, LoggingMixin):
     def run(self):
         Stats.incr(self.__class__.__name__.lower()+'_start', 1, 1)
         # Adding an entry in the DB
-        session = settings.Session()
+        session = airflow.Session()
         self.state = State.RUNNING
         session.add(self)
         session.commit()
@@ -357,7 +358,7 @@ class SchedulerJob(BaseJob):
             session.close()
 
     def import_errors(self, dagbag):
-        session = settings.Session()
+        session = airflow.Session()
         session.query(models.ImportError).delete()
         for filename, stacktrace in list(dagbag.import_errors.items()):
             session.add(models.ImportError(
@@ -373,7 +374,7 @@ class SchedulerJob(BaseJob):
         """
         if dag.schedule_interval:
             DagRun = models.DagRun
-            session = settings.Session()
+            session = airflow.Session()
             qry = session.query(DagRun).filter(
                 DagRun.dag_id == dag.dag_id,
                 DagRun.external_trigger == False,
@@ -450,7 +451,7 @@ class SchedulerJob(BaseJob):
         """
         TI = models.TaskInstance
         DagModel = models.DagModel
-        session = settings.Session()
+        session = airflow.Session()
 
         # picklin'
         pickle_id = None
@@ -676,7 +677,7 @@ class SchedulerJob(BaseJob):
             except Exception as deep_e:
                 self.logger.exception(deep_e)
             finally:
-                settings.Session.remove()
+                airflow.Session.remove()
         executor.end()
 
     def heartbeat_callback(self):
@@ -718,7 +719,7 @@ class BackfillJob(BaseJob):
         """
         Runs a dag for a specified date range.
         """
-        session = settings.Session()
+        session = airflow.Session()
 
         start_date = self.bf_start_date
         end_date = self.bf_end_date
@@ -889,7 +890,7 @@ class LocalTaskJob(BaseJob):
         # Suicide pill
         TI = models.TaskInstance
         ti = self.task_instance
-        session = settings.Session()
+        session = airflow.Session()
         state = session.query(TI.state).filter(
             TI.dag_id==ti.dag_id, TI.task_id==ti.task_id,
             TI.execution_date==ti.execution_date).scalar()

--- a/airflow/migrations/env.py
+++ b/airflow/migrations/env.py
@@ -2,9 +2,8 @@ from __future__ import with_statement
 from alembic import context
 from logging.config import fileConfig
 
-from airflow import settings
-from airflow import configuration
-from airflow.jobs import models
+import airflow
+from airflow import configuration, models
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -56,7 +55,7 @@ def run_migrations_online():
     and associate a connection with the context.
 
     """
-    connectable = settings.engine
+    connectable = airflow.engine
 
     with connectable.connect() as connection:
         context.configure(

--- a/airflow/migrations/versions/1507a7289a2f_create_is_encrypted.py
+++ b/airflow/migrations/versions/1507a7289a2f_create_is_encrypted.py
@@ -15,7 +15,7 @@ depends_on = None
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.engine.reflection import Inspector
-from airflow import settings
+import airflow
 
 
 connectionhelper = sa.Table(
@@ -30,7 +30,7 @@ def upgrade():
     # first check if the user already has this done. This should only be
     # true for users who are upgrading from a previous version of Airflow
     # that predates Alembic integration
-    inspector = Inspector.from_engine(settings.engine)
+    inspector = Inspector.from_engine(airflow.engine)
 
     # this will only be true if 'connection' already exists in the db,
     # but not if alembic created it in a previous migration

--- a/airflow/migrations/versions/e3a246e0dc1_current_schema.py
+++ b/airflow/migrations/versions/e3a246e0dc1_current_schema.py
@@ -17,11 +17,11 @@ import sqlalchemy as sa
 from sqlalchemy import func
 from sqlalchemy.engine.reflection import Inspector
 
-from airflow import settings
+import airflow
 
 
 def upgrade():
-    inspector = Inspector.from_engine(settings.engine)
+    inspector = Inspector.from_engine(airflow.engine)
     tables = inspector.get_table_names()
     if 'connection' not in tables:
         op.create_table(

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -18,7 +18,6 @@ from __future__ import unicode_literals
 
 from future.standard_library import install_aliases
 
-install_aliases()
 from builtins import str
 from builtins import object, bytes
 import copy
@@ -56,6 +55,8 @@ from airflow.executors import DEFAULT_EXECUTOR, LocalExecutor
 from airflow.utils import (
     AirflowException, State, apply_defaults, provide_session,
     is_container, as_tuple, TriggerRule, LoggingMixin)
+
+install_aliases()
 
 Base = declarative_base()
 ID_LEN = 250
@@ -976,7 +977,7 @@ class TaskInstance(Base):
         self.pool = pool or task.pool
         self.test_mode = test_mode
         self.force = force
-        self.refresh_from_db(session)
+        self.refresh_from_db()
         session.commit()
         self.clear_xcom_data()
         self.job_id = job_id

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 import logging
 
+import airflow
 from airflow.models import BaseOperator, DagRun
-from airflow.utils import apply_defaults, State
-from airflow import settings
+from airflow.utils import apply_defaults
 
 
 class DagRunOrder(object):
@@ -46,7 +46,7 @@ class TriggerDagRunOperator(BaseOperator):
         dro = DagRunOrder(run_id='trig__' + datetime.now().isoformat())
         dro = self.python_callable(context, dro)
         if dro:
-            session = settings.Session()
+            session = airflow.Session()
             dr = DagRun(
                 dag_id=self.trigger_dag_id,
                 run_id=dro.run_id,

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -7,6 +7,7 @@ import logging
 from urllib.parse import urlparse
 from time import sleep
 
+import airflow
 from airflow import hooks, settings
 from airflow.models import BaseOperator, TaskInstance, Connection as DB
 from airflow.hooks import BaseHook
@@ -188,7 +189,7 @@ class ExternalTaskSensor(BaseSensorOperator):
             '{dttm} ... '.format(**locals()))
         TI = TaskInstance
 
-        session = settings.Session()
+        session = airflow.Session()
         count = session.query(TI).filter(
             TI.dag_id == self.external_dag_id,
             TI.task_id == self.external_task_id,
@@ -326,7 +327,7 @@ class S3KeySensor(BaseSensorOperator):
             s3_conn_id='s3_default',
             *args, **kwargs):
         super(S3KeySensor, self).__init__(*args, **kwargs)
-        session = settings.Session()
+        session = airflow.Session()
         db = session.query(DB).filter(DB.conn_id == s3_conn_id).first()
         if not db:
             raise AirflowException("conn_id doesn't exist in the repository")
@@ -385,7 +386,7 @@ class S3PrefixSensor(BaseSensorOperator):
             s3_conn_id='s3_default',
             *args, **kwargs):
         super(S3PrefixSensor, self).__init__(*args, **kwargs)
-        session = settings.Session()
+        session = airflow.Session()
         db = session.query(DB).filter(DB.conn_id == s3_conn_id).first()
         if not db:
             raise AirflowException("conn_id doesn't exist in the repository")

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -106,3 +106,4 @@ except:
     pass
 
 configure_logging()
+

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -21,9 +21,6 @@ import logging
 import os
 import sys
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import scoped_session, sessionmaker
-
 from airflow import configuration as conf
 
 
@@ -50,8 +47,6 @@ if conf.getboolean('scheduler', 'statsd_on'):
 else:
     Stats = DummyStatsLogger
 
-
-
 HEADER = """\
   ____________       _____________
  ____    |__( )_________  __/__  /________      __
@@ -66,16 +61,6 @@ SQL_ALCHEMY_CONN = conf.get('core', 'SQL_ALCHEMY_CONN')
 LOGGING_LEVEL = logging.INFO
 DAGS_FOLDER = os.path.expanduser(conf.get('core', 'DAGS_FOLDER'))
 
-engine_args = {}
-if 'sqlite' not in SQL_ALCHEMY_CONN:
-    # Engine args not supported by sqlite
-    engine_args['pool_size'] = conf.getint('core', 'SQL_ALCHEMY_POOL_SIZE')
-    engine_args['pool_recycle'] = conf.getint('core',
-                                              'SQL_ALCHEMY_POOL_RECYCLE')
-
-engine = create_engine(SQL_ALCHEMY_CONN, **engine_args)
-Session = scoped_session(
-    sessionmaker(autocommit=False, autoflush=False, bind=engine))
 
 # can't move this to conf due to ConfigParser interpolation
 LOG_FORMAT = (

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -640,8 +640,10 @@ class timeout(object):
             signal.signal(signal.SIGALRM, self.handle_timeout)
             signal.alarm(self.seconds)
         except ValueError as e:
-            logging.warning("timeout can't be used in the current context")
-            logging.exception(e)
+            logging.warning(
+                "timeout could not be activated, it doens't work within "
+                "threads. Most likely you are using a LocalExecutor. "
+                "Timeouts aren't compatible with LocalExecutor")
 
     def __exit__(self, type, value, traceback):
         try:

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -8,7 +8,7 @@ from builtins import str, input, object
 from past.builtins import basestring
 from copy import copy
 from datetime import datetime, date, timedelta
-from dateutil.relativedelta import relativedelta  # for doctest
+from dateutil.relativedelta import relativedelta  # noqa for doctest
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.mime.application import MIMEApplication
@@ -42,7 +42,6 @@ from croniter import croniter
 
 import airflow
 from airflow import configuration, settings
-
 
 
 class AirflowException(Exception):
@@ -639,7 +638,7 @@ class timeout(object):
         try:
             signal.signal(signal.SIGALRM, self.handle_timeout)
             signal.alarm(self.seconds)
-        except ValueError as e:
+        except ValueError:
             logging.warning(
                 "timeout could not be activated, it doens't work within "
                 "threads. Most likely you are using a LocalExecutor. "

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -7,7 +7,7 @@ from flask_wtf.csrf import CsrfProtect
 
 import airflow
 from airflow import models
-from airflow.settings import Session
+from airflow import Session
 
 from airflow.www.blueprints import ck, routes
 from airflow import jobs
@@ -108,7 +108,7 @@ def create_app(config=None):
 
         @app.teardown_appcontext
         def shutdown_session(exception=None):
-            settings.Session.remove()
+            airflow.Session.remove()
 
         return app
 

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -15,6 +15,7 @@ from jinja2 import Template
 import wtforms
 from wtforms.compat import text_type
 
+import airflow
 from airflow import configuration, models, settings, utils
 AUTHENTICATE = configuration.getboolean('webserver', 'AUTHENTICATE')
 
@@ -78,7 +79,7 @@ def action_logging(f):
     '''
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        session = settings.Session()
+        session = airflow.Session()
 
         if current_user and hasattr(current_user, 'username'):
             user = current_user.username

--- a/tests/contrib/operators/ssh_execute_operator.py
+++ b/tests/contrib/operators/ssh_execute_operator.py
@@ -2,7 +2,7 @@ import unittest
 from datetime import datetime
 
 from airflow import configuration
-from airflow.settings import Session
+from airflow import Session
 from airflow import models, DAG
 from airflow.contrib.operators.ssh_execute_operator import SSHExecuteOperator
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -21,11 +21,11 @@ from airflow.executors import SequentialExecutor, LocalExecutor
 from airflow.models import Variable
 
 configuration.test_mode()
-from airflow import jobs, models, DAG, utils, operators, hooks, macros, settings
+from airflow import (
+    jobs, models, DAG, utils, operators, hooks, macros, settings, Session)
 from airflow.hooks import BaseHook
 from airflow.bin import cli
 from airflow.www import app as application
-from airflow.settings import Session
 from airflow.utils import LoggingMixin, round_time
 from lxml import html
 from airflow.utils import AirflowException

--- a/tests/core.py
+++ b/tests/core.py
@@ -21,11 +21,11 @@ from airflow.executors import SequentialExecutor, LocalExecutor
 from airflow.models import Variable
 
 configuration.test_mode()
-from airflow import (
-    jobs, models, DAG, utils, operators, hooks, macros, settings, Session)
+from airflow import jobs, models, DAG, utils, operators, hooks, macros, settings
 from airflow.hooks import BaseHook
 from airflow.bin import cli
 from airflow.www import app as application
+from airflow.settings import Session
 from airflow.utils import LoggingMixin, round_time
 from lxml import html
 from airflow.utils import AirflowException

--- a/tests/operators/__init__.py
+++ b/tests/operators/__init__.py
@@ -1,1 +1,0 @@
-from .docker_operator import *


### PR DESCRIPTION
The goal here is to reduce the number of active database sessions on the metadata database. Note that sqla create database connection pools and that when we have thousands of tasks emitting heartbeats it can lead to way too many connections, ultimately maxing out on the MySQL side. #1002 describes the issue.

This PR includes:
- A refactor where `Session` and `engine` sqla objects live in `airflow` instead of `airflow.settings` (those objects really aren't settings, they're just widely used objects)
- Some `airflow.utils` functions to set a NullPool engine in place of the QueuePool engine
- call for `airflow run` to use the NullPool
- Fixing the unit tests to run with LocalExecutor (had to disable the timeout feature)
