### PR TITLE
set celery_executor to use queue name as exchange

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -28,6 +28,7 @@ class CeleryConfig(object):
     CELERY_RESULT_BACKEND = configuration.get('celery', 'CELERY_RESULT_BACKEND')
     CELERYD_CONCURRENCY = configuration.getint('celery', 'CELERYD_CONCURRENCY')
     CELERY_DEFAULT_QUEUE = DEFAULT_QUEUE
+    CELERY_DEFAULT_EXCHANGE = DEFAULT_QUEUE
 
 app = Celery(
     configuration.get('celery', 'CELERY_APP_NAME'),


### PR DESCRIPTION
This PR is for issue https://github.com/airbnb/airflow/issues/1030

In an environment where you're using celery executors with RabbitMQ as the broker, workers will receive work from the default queue because they connect to the default exchange.  This change fixes that.

I haven't tested the implications of this change on other brokers but I'm happy to revisit this PR if needed.
