### PR TITLE
Improve [Hide/Show all series] perforamce

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Currently **officially** using Airflow:
 * [Hootsuite](https://github.com/hootsuite)
 * ING
 * [Jampp](https://github.com/jampp)
-* [LendUp](https://www.lendup.com/) [[@lendup](https://github.com/lendup)]
 * [LingoChamp](http://www.liulishuo.com/) [[@haitaoyao](https://github.com/haitaoyao)]
 * Lyft
 * [Sense360](https://github.com/Sense360) [[@kamilmroczek](https://github.com/KamilMroczek)]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Currently **officially** using Airflow:
 * [Hootsuite](https://github.com/hootsuite)
 * ING
 * [Jampp](https://github.com/jampp)
+* [LendUp](https://www.lendup.com/)[[@lendup](https://github.com/lendup)]
 * [LingoChamp](http://www.liulishuo.com/) [[@haitaoyao](https://github.com/haitaoyao)]
 * Lyft
 * [Sense360](https://github.com/Sense360) [[@kamilmroczek](https://github.com/KamilMroczek)]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Currently **officially** using Airflow:
 * [Hootsuite](https://github.com/hootsuite)
 * ING
 * [Jampp](https://github.com/jampp)
-* [LendUp](https://www.lendup.com/)[[@lendup](https://github.com/lendup)]
+* [LendUp](https://www.lendup.com/) [[@lendup](https://github.com/lendup)]
 * [LingoChamp](http://www.liulishuo.com/) [[@haitaoyao](https://github.com/haitaoyao)]
 * Lyft
 * [Sense360](https://github.com/Sense360) [[@kamilmroczek](https://github.com/KamilMroczek)]

--- a/airflow/www/templates/airflow/chart.html
+++ b/airflow/www/templates/airflow/chart.html
@@ -43,15 +43,17 @@
       }
       $('#uncheck').click(function(){
           chart = Highcharts.charts[0];
-          for(i=0; i < chart.series.length; i++) {
-            chart.series[i].hide();
-          }
+          $(chart.series).each(function(){
+              this.setVisible(false, false);
+          });
+          chart.redraw();
       });
       $('#check').click(function(){
           chart = Highcharts.charts[0];
-          for(i=0; i < chart.series.length; i++) {
-            chart.series[i].show();
-          }
+          $(chart.series).each(function(){
+              this.setVisible(true, false);
+          });
+          chart.redraw();
       });
     });
     </script>


### PR DESCRIPTION
At LendUp we have DAGs with over 50+ auto-generated tasks, `Hide/Show all series` is very slow and sometimes broke the browser. 

The problem is that iterating `chart.series` and call `.hide()` function is very slow, because it will trigger a `chart.redraw()` after every `.hide()` operation. `setVisible` is a better choice in this case.

jsfiddle demo (with both current and new implementations): http://jsfiddle.net/q04qfgac/1/
