### PR TITLE
Add output encoding option to BashOperator

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -1,7 +1,6 @@
 
 from builtins import bytes
 import logging
-import sys
 from subprocess import Popen, STDOUT, PIPE
 from tempfile import gettempdir, NamedTemporaryFile
 
@@ -22,6 +21,7 @@ class BashOperator(BaseOperator):
         of inheriting the current process environment, which is the default
         behavior.
     :type env: dict
+    :type output_encoding: output encoding of bash command
     """
     template_fields = ('bash_command', 'env')
     template_ext = ('.sh', '.bash',)
@@ -33,6 +33,7 @@ class BashOperator(BaseOperator):
             bash_command,
             xcom_push=False,
             env=None,
+            output_encoding='utf-8',
             *args, **kwargs):
         """
         If xcom_push is True, the last line written to stdout will also
@@ -42,6 +43,7 @@ class BashOperator(BaseOperator):
         self.bash_command = bash_command
         self.env = env
         self.xcom_push_flag = xcom_push
+        self.output_encoding = output_encoding
 
     def execute(self, context):
         """
@@ -70,7 +72,7 @@ class BashOperator(BaseOperator):
                 logging.info("Output:")
                 line = ''
                 for line in iter(sp.stdout.readline, b''):
-                    line = line.decode().strip()
+                    line = line.decode(self.output_encoding).strip()
                     logging.info(line)
                 sp.wait()
                 logging.info("Command exited with "

--- a/tests/core.py
+++ b/tests/core.py
@@ -331,6 +331,14 @@ class CoreTest(unittest.TestCase):
             dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
 
+    def test_bash_operator_multi_byte_output(self):
+        t = operators.BashOperator(
+                task_id='test_multi_byte_bash_operator',
+                bash_command=u"echo \u2600",
+                dag=self.dag,
+                output_encoding='utf-8')
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
     def test_trigger_dagrun(self):
         def trigga(context, obj):
             if True:


### PR DESCRIPTION
Bash command outputs multi byte characters under some locale setting (e.g. date command under ja_JP.UTF-8 locale).

This PR will fix #770 .

Also deleting `import sys` because that is not used.
