### PR TITLE
[BUG 1015] Ensure airflow database is created with timezone set to UTC

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2719,7 +2719,6 @@ class Variable(Base):
         session.flush()
 
 
-
 class XCom(Base):
     """
     Base class for XCom objects.
@@ -2894,6 +2893,7 @@ class DagRun(Base):
     @classmethod
     def id_for_date(klass, date, prefix=ID_FORMAT_PREFIX):
         return prefix.format(date.isoformat()[:19])
+
 
 class Pool(Base):
     __tablename__ = "slot_pool"

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -42,7 +42,7 @@ from airflow.executors import DEFAULT_EXECUTOR, LocalExecutor
 from airflow import configuration
 from airflow.utils import (
     AirflowException, State, apply_defaults, provide_session,
-    is_container, as_tuple, TriggerRule, LoggingMixin)
+    is_container, as_tuple, TriggerRule, LoggingMixin, utcnow)
 
 Base = declarative_base()
 ID_LEN = 250
@@ -530,7 +530,7 @@ class DagPickle(Base):
     """
     id = Column(Integer, primary_key=True)
     pickle = Column(PickleType(pickler=dill))
-    created_dttm = Column(DateTime, default=func.now())
+    created_dttm = Column(DateTime, server_default=utcnow())
     pickle_hash = Column(Text)
 
     __tablename__ = "dag_pickle"
@@ -2619,7 +2619,7 @@ class Chart(Base):
         "User", cascade=False, cascade_backrefs=False, backref='charts')
     x_is_date = Column(Boolean, default=True)
     iteration_no = Column(Integer, default=0)
-    last_modified = Column(DateTime, default=func.now())
+    last_modified = Column(DateTime, server_default=utcnow())
 
     def __repr__(self):
         return self.label
@@ -2729,7 +2729,7 @@ class XCom(Base):
     key = Column(String(512))
     value = Column(PickleType(pickler=dill))
     timestamp = Column(
-        DateTime, default=func.now(), nullable=False)
+        DateTime, server_default=utcnow(), nullable=False)
     execution_date = Column(DateTime, nullable=False)
 
     # source information
@@ -2868,8 +2868,8 @@ class DagRun(Base):
 
     id = Column(Integer, primary_key=True)
     dag_id = Column(String(ID_LEN))
-    execution_date = Column(DateTime, default=func.now())
-    start_date = Column(DateTime, default=func.now())
+    execution_date = Column(DateTime, server_default=utcnow())
+    start_date = Column(DateTime, server_default=utcnow())
     end_date = Column(DateTime)
     state = Column(String(50), default=State.RUNNING)
     run_id = Column(String(ID_LEN))

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -790,7 +790,7 @@ class LoggingMixin(object):
 
 class utcnow(expression.FunctionElement):
     key = 'utcnow'
-    type = DateTime(timezone=True)
+    type = DateTime()
 
 
 @compiles(utcnow)

--- a/airflow/utils.py
+++ b/airflow/utils.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import sys
 from builtins import str, input, object
 from past.builtins import basestring
 from copy import copy
@@ -482,8 +481,8 @@ if 'BUILDING_AIRFLOW_DOCS' in os.environ:
 
 
 def ask_yesno(question):
-    yes = set(['yes', 'y'])
-    no = set(['no', 'n'])
+    yes = {'yes', 'y'}
+    no = {'no', 'n'}
 
     done = False
     print(question)
@@ -793,6 +792,7 @@ class utcnow(expression.FunctionElement):
     key = 'utcnow'
     type = DateTime(timezone=True)
 
+
 @compiles(utcnow)
 def _default_utcnow(element, compiler, **kw):
     """
@@ -804,15 +804,18 @@ def _default_utcnow(element, compiler, **kw):
     """
     return "utcnow()"
 
+
 @compiles(utcnow, 'postgresql')
 def _pg_utcnow(element, compiler, **kw):
     """Postgresql-specific compilation handler."""
     return "TIMEZONE('utc', CURRENT_TIMESTAMP)"
 
+
 @compiles(utcnow, 'mssql')
 def _ms_utcnow(element, compiler, **kw):
     """MySQL-specific compilation handler."""
     return "GETUTCDATE()"
+
 
 @compiles(utcnow, 'sqlite')
 def _sl_utcnow(element, compiler, **kw):

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -112,7 +112,8 @@ setting up a real database backend and switching to the LocalExecutor.
 
 As Airflow was built to interact with its metadata using the great SqlAlchemy
 library, you should be able to use any database backend supported as a
-SqlAlchemy backend. We recommend using **MySQL** or **Postgres**.
+SqlAlchemy backend. We recommend using **MySQL** or **Postgres**. Also make sure
+the database timezone is set to GMT.
 
 .. note:: If you decide to use **Postgres**, we recommend using the ``psycopg2``
    driver and specifying it in your SqlAlchemy connection string.


### PR DESCRIPTION
FIXIT https://github.com/airbnb/airflow/issues/1015

From sqlalchemy doc, `utcnow()` here is:

`A function that works like “CURRENT_TIMESTAMP” except applies the appropriate conversions so that the time is in UTC time.`
