### PR TITLE
Fix SAWarning from sqlalchemy queries

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -17,6 +17,7 @@ import traceback
 
 import sqlalchemy as sqla
 from sqlalchemy import or_
+from sqlalchemy.sql.expression import text
 
 
 from flask import redirect, url_for, request, Markup, Response, current_app, render_template
@@ -1247,7 +1248,7 @@ class Airflow(BaseView):
             dttm = dag.latest_execution_date or datetime.now().date()
 
         DR = models.DagRun
-        drs = session.query(DR).filter_by(dag_id=dag_id).order_by('execution_date desc').all()
+        drs = session.query(DR).filter_by(dag_id=dag_id).order_by(text('execution_date desc')).all()
         dr_choices = []
         dr_state = None
         for dr in drs:


### PR DESCRIPTION
After an fresh install on master, I had the following error when I started the webserver:

`/Users/mlu/.virtualenvs/airflow-dev/lib/python2.7/site-packages/sqlalchemy/sql/compiler.py:575: SAWarning: Can't resolve label reference 'execution_date desc'; converting to text() (this warning may be suppressed after 10 occurrences)
  util.ellipses_string(element.element))`

It is not critical but annoying. This PR fixed it.

Here is some details from sqlalchemy docs: http://docs.sqlalchemy.org/en/latest/changelog/migration_10.html#order-by-and-group-by-are-special-cases
