### PR TITLE
Cleanup Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,19 +85,26 @@ Generate the documentation with:
 Before you submit a pull request from your forked repo, check that it
 meets these guidelines:
 
-1. The pull request should include tests, either as doctests, unit tests, or both.
-1. If the pull request adds functionality, the docs should be updated as part of the same PR. Doc string are often sufficient.  Make sure to follow the sphinx compatible standards.
-1. The pull request should work for Python 2.6, 2.7, and 3.3. If you need help writing code that works in both Python 2 and 3, see the documentation at the [Python-Future project](http://python-future.org) (the future package is an Airflow requirement and should be used where possible).
-1.  Code will be reviewed by re running the unittests and flake8. Syntax should be as rigorous as the core Python project.
-1.  Please rebase and resolve all conflicts before submitting.
+1. The pull request should include tests, either as doctests, unit tests, or
+both.
+2. If the pull request adds functionality, the docs should be updated as part
+of the same PR. Doc string are often sufficient.  Make sure to follow the
+sphinx compatible standards.
+3. The pull request should work for Python 2.6, 2.7, and 3.3. If you need help
+writing code that works in both Python 2 and 3, see the documentation at the
+[Python-Future project](http://python-future.org) (the future package is an
+Airflow requirement and should be used where possible).
+4. Code will be reviewed by re running the unittests and `flake8`. Syntax should
+be as rigorous as the core Python project.
+5. Please rebase and resolve all conflicts before submitting.
 
 ## Running unit tests
 
 Here are loose guidelines on how to get your environment to run the unit tests.
-We do understand that no one out there can run the full test suite since 
-Airflow is meant to connect to virtually any external system and that you most likely 
-have only a subset of these in your environment. You should run the CoreTests and
-tests related to things you touched in your PR.
+We do understand that no one out there can run the full test suite since
+Airflow is meant to connect to virtually any external system and that you most
+likely have only a subset of these in your environment. You should run the
+CoreTests and tests related to things you touched in your PR.
 
 To set up a unit test environment, first take a look at `run_unit_tests.sh` and
 understand that your ``AIRFLOW_CONFIG`` points to an alternate config file
@@ -111,29 +118,31 @@ should already have been created, you just need to point them to the systems
 where you want your tests to run.
 
 Once your unit test environment is setup, you should be able to simply run
-``./run_unit_tests.sh`` at will. 
+``./run_unit_tests.sh`` at will.
 
-For example, in order to just execute the "core" unit tests, run the following: 
+For example, in order to just execute the "core" unit tests, run the following:
 
 ```
 ./run_unit_tests.sh tests.core:CoreTest -s --logging-level=DEBUG
 ```
 
-or a single test method: 
+or a single test method:
 
-``` 
+```
 ./run_unit_tests.sh tests.core:CoreTest.test_check_operators -s --logging-level=DEBUG
 ```
 
-For more information on how to run a subset of the tests, take a look at the nosetests docs.
+For more information on how to run a subset of the tests, take a look at the
+nosetests docs.
 
 See also the the list of test classes and methods in `tests/code.py`.
 
 ## Changing Metadata Database
 
 When developing features the need may arise to persist information to the the
-metadata database. Airflow has alembic built-in to handle all schema changes.
-Alembic must be installed on your development machine before continuing.
+metadata database. Airflow has [Alembic](https://bitbucket.org/zzzeek/alembic)
+built-in to handle all schema changes. Alembic must be installed on your
+development machine before continuing.
 
 ```
 # starting at the root of the project


### PR DESCRIPTION
Hyperlinked Alembic reference. Also cleaned up whitespace and wrapped lines at ~80 characters since it's a Python project.

Originally I was only going to cleanup the Alembic reference, by thought while I was in there I might as well fix whitespace and line wrapping. If that's too pedantic, I'm happy to revert those portions of the change. 
