### PR TITLE
Don't force installation of GCP API client dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ flask-cache
 flask-login
 flower
 future
-google-api-python-client
 gunicorn
 hive-thrift-py
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,13 +19,11 @@ future
 google-api-python-client
 gunicorn
 hive-thrift-py
-httplib2
 ipython
 jinja2
 markdown
 nose
 nose-exclude
-oauth2client
 pandas
 pygments
 pyhive

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,10 @@ doc = [
 ]
 docker = ['docker-py>=1.6.0']
 druid = ['pydruid>=0.2.1']
+gcp_api = [
+    'oauth2client>=1.5.2, <2.0.0',
+    'httplib2',
+]
 hdfs = ['snakebite>=2.4.13']
 webhdfs = ['hdfs[dataframe,avro,kerberos]>=2.0.4']
 hive = [
@@ -110,7 +114,6 @@ setup(
         'gunicorn>=19.3.0, <19.4.0',  # 19.4.? seemed to have issues
         'jinja2>=2.7.3, <3.0',
         'markdown>=2.5.2, <3.0',
-        'oauth2client>=1.5.2, <2.0.0',
         'pandas>=0.15.2, <1.0.0',
         'pygments>=2.0.1, <3.0',
         'python-dateutil>=2.3, <3',
@@ -130,6 +133,7 @@ setup(
         'doc': doc,
         'docker': docker,
         'druid': druid,
+        'gcp_api': gcp_api,
         'hdfs': hdfs,
         'hive': hive,
         'jdbc': jdbc,

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,9 @@ doc = [
 docker = ['docker-py>=1.6.0']
 druid = ['pydruid>=0.2.1']
 gcp_api = [
-    'oauth2client>=1.5.2, <2.0.0',
     'httplib2',
+    'google-api-python-client',
+    'oauth2client>=1.5.2, <2.0.0',
 ]
 hdfs = ['snakebite>=2.4.13']
 webhdfs = ['hdfs[dataframe,avro,kerberos]>=2.0.4']


### PR DESCRIPTION
See https://github.com/airbnb/airflow/pull/1109#issuecomment-192461854

tl;dr currently all users must install dependencies for an old version of the Google Cloud Platform API. This is a big problem because pinning `oauth2client<2.0` breaks `gcloud`,  the recommended approach to accessing the Google Cloud Platform. This PR moves the dependencies to a `gcp_api` airflow package, so that it doesn’t impact all users. Users who want to use the GCP API hooks and operators can still do so by installing `airflow[gcp_api]`.
