### PR TITLE
Add gcloud-based GCSHook

### DIFF
--- a/airflow/contrib/hooks/__init__.py
+++ b/airflow/contrib/hooks/__init__.py
@@ -5,6 +5,7 @@ from airflow.utils import import_module_attrs as _import_module_attrs
 _hooks = {
     'ftp_hook': ['FTPHook'],
     'ftps_hook': ['FTPSHook'],
+    'gcloud/gcs_hook': ['GCSHook'],
     'vertica_hook': ['VerticaHook'],
     'ssh_hook': ['SSHHook'],
     'bigquery_hook': ['BigQueryHook'],

--- a/airflow/contrib/hooks/gcloud/base_hook.py
+++ b/airflow/contrib/hooks/gcloud/base_hook.py
@@ -1,0 +1,107 @@
+from airflow.hooks import BaseHook
+import gcloud
+
+class GCPBaseHook(BaseHook):
+    """
+    A hook for working wth Google Cloud Platform via the gcloud library.
+
+    A GCP connection ID can be provided. If it is provided, its "extra" values
+    will OVERRIDE any argments passed to GCSHook. The following precendance is
+    observed:
+        GCP connection "extra"
+        GCPBaseHook initialization arguments
+        host environment
+
+    Extras should be JSON and take the form:
+    {
+        "project": "<google cloud project id>",
+        "key_path": "<path to service account keyfile, either JSON or P12>"
+        "service_account": "<google service account email, required for P12>"
+        "scope": "<google service scopes>"
+    }
+
+    service_account is only required if the key_path points to a P12 file.
+
+    scope is only used if key_path is provided. Scopes can include:
+        https://www.googleapis.com/auth/devstorage.full_control
+        https://www.googleapis.com/auth/devstorage.read_only
+        https://www.googleapis.com/auth/devstorage.read_write
+
+    If fields are not provided, either as arguments or extras, they can be set
+    in the host environment.
+
+    To set a default project, use:
+        gcloud config set project <project-id>
+
+    To log in:
+        gcloud auth
+
+    """
+
+    client_class = None
+
+    def __init__(
+            self,
+            gcp_conn_id=None,
+            project=None,
+            key_path=None,
+            service_account=None,
+            scope=None,
+            *args,
+            **kwargs):
+
+        if not self.client_class:
+            raise NotImplementedError(
+                'The GCPBaseHook must be extended by providing a client_class.')
+
+        # compatibility with GoogleCloudStorageHook
+        if 'google_cloud_storage_conn_id' in kwargs and not gcp_conn_id:
+            gcp_conn_id = kwargs.pop('google_cloud_storage_conn_id')
+
+        self.gcp_conn_id = gcp_conn_id
+        self.project = project
+        self.key_path = key_path
+        self.service_account = service_account
+        self.scope = scope
+
+        self.client = self.get_conn()
+
+    def get_conn(self):
+        # parse arguments and connection extras
+        if self.gcp_conn_id:
+            extras = self.get_connection(self.gcp_conn_id).extra_dejson
+        else:
+            extras = {}
+        project = extras.get('project', self.project)
+        key_path = extras.get('key_path', self.key_path)
+        service_account = extras.get('service_account', self.service_account)
+        scope = extras.get('scope', self.scope)
+
+        # guess project, if possible
+        if not project:
+            project = gcloud._helpers._determine_default_project()
+            # workaround for
+            # https://github.com/GoogleCloudPlatform/gcloud-python/issues/1470
+            if isinstance(project, bytes):
+                project = project.decode()
+
+        # load credentials/scope
+        if key_path:
+            if key_path.endswith('.json') or key_path.endswith('.JSON'):
+                credentials = gcloud.credentials.get_for_service_account_json(
+                    json_credentials_path=key_path,
+                    scope=scope)
+            elif key_path.endswith('.p12') or key_path.endswith('.P12'):
+                credentials = gcloud.credentials.get_for_service_account_p12(
+                    client_email=service_account,
+                    private_key_path=key_path,
+                    scope=scope)
+            else:
+                raise ValueError('Unrecognized keyfile: {}'.format(key_path))
+            client = self.client_class(
+                credentials=credentials,
+                project=project)
+        else:
+            client = self.client_class(project=project)
+
+        return client

--- a/airflow/contrib/hooks/gcloud/base_hook.py
+++ b/airflow/contrib/hooks/gcloud/base_hook.py
@@ -91,9 +91,7 @@ class GCPBaseHook(BaseHook):
         scope = load_field('scope')
         if scope:
             scope = scope.split(',')
-
-        import ipdb; ipdb.set_trace()
-        
+            
         # guess project, if possible
         if not project:
             project = gcloud._helpers._determine_default_project()

--- a/airflow/contrib/hooks/gcloud/gcs_hook.py
+++ b/airflow/contrib/hooks/gcloud/gcs_hook.py
@@ -1,0 +1,181 @@
+from future.standard_library import install_aliases
+install_aliases()
+
+from urllib.parse import urlparse
+from airflow.hooks import BaseHook
+from airflow.utils import AirflowException
+
+import gcloud.storage as gcs
+
+def parse_gcs_url(gsurl):
+    """
+    Given a Google Cloud Storage URL (gs://<bucket>/<blob>), returns a
+    tuple containing the corresponding bucket and blob.
+    """
+    parsed_url = urlparse(gsurl)
+    if not parsed_url.netloc:
+        raise AirflowException('Please provide a bucket name')
+    else:
+        bucket = parsed_url.netloc
+        if parsed_url.path.startswith('/'):
+            blob = parsed_url.path[1:]
+        else:
+            blob = parsed_url.path
+        return (bucket, blob)
+
+class GCSHook(BaseHook):
+    """
+    A hook for working wth Google Cloud Storage via the gcloud library.
+
+    GCS Connections can contain two optional fields in "extras":
+    {
+        "project": "<google cloud project id>",
+        "keyfile_path": "<path to service account JSON keyfile>"
+    }
+
+    If the project field is missing, the project will be inferred from the host
+    environment (if possible). To set a default project, use:
+        gcloud config set project <project-id>
+
+    If the keyfile_path is missing, the host authorization credentials will be
+    used (if possible). To log in, use:
+        gcloud auth
+    """
+    def __init__(self, gcs_conn_id=None):
+        self.gcs_conn_id = gcs_conn_id
+        self.gcs_conn = self.get_conn()
+
+    def get_conn(self):
+        project, keyfile_path = None, None
+        if self.gcs_conn_id:
+            conn = self.get_connection(self.gcs_conn_id)
+            extras = conn.extra_dejson
+            project = extras.get('project', None)
+            keyfile_path = extras.get('keyfile_path', None)
+
+        if not project:
+            project = gcloud._helpers._determine_default_project()
+            # workaround for
+            # https://github.com/GoogleCloudPlatform/gcloud-python/issues/1470
+            if isinstance(project, bytes):
+                project = project.decode()
+
+        if keyfile_path:
+            client = gcs.Client.from_service_account_json(
+                keyfile_path, project=project)
+        else:
+            client = gcs.Client(project=project)
+
+        return client
+
+    def bucket_exists(self, bucket):
+        return self.get_conn().bucket(bucket).exists()
+
+    def get_bucket(self, bucket):
+        return self.get_conn().get_bucket(bucket)
+
+    def list_blobs(
+            self,
+            bucket,
+            max_results=None,
+            page_token=None,
+            prefix=None,
+            delimiter=None):
+        return self.get_conn().bucket(bucket).list_blobs(
+            max_results=max_results,
+            page_token=page_token,
+            prefix=prefix,
+            delimiter=delimiter)
+
+    def get_blob(self, blob, bucket=None):
+        """
+        Returns None if the blob does not exist
+        """
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        return self.get_conn().bucket(bucket).get_blob(blob)
+
+    def blob_exists(self, blob, bucket=None):
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        return self.get_conn().bucket(bucket).blob(blob).exists()
+
+    def upload_from_file(
+            self,
+            file_obj,
+            blob,
+            bucket=None,
+            replace=False):
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        gcs_blob = self.get_conn().bucket(bucket).blob(blob)
+        if gcs_blob.exists() and not replace:
+            raise ValueError(
+                'The blob {bucket}/{blob} already exists.'.format(**locals()))
+        gcs_blob.upload_from_file(file_obj)
+
+    def upload_from_filename(
+            self,
+            filename,
+            blob,
+            bucket=None,
+            replace=False):
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        gcs_blob = self.get_conn().bucket(bucket).blob(blob)
+        if gcs_blob.exists() and not replace:
+            raise ValueError(
+                'The blob {bucket}/{blob} already exists.'.format(**locals()))
+        gcs_blob.upload_from_filename(filename)
+
+    def upload_from_string(
+            self,
+            string,
+            blob,
+            bucket=None,
+            replace=False):
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        gcs_blob = self.get_conn().bucket(bucket).blob(blob)
+        if gcs_blob.exists() and not replace:
+            raise ValueError(
+                'The blob {bucket}/{blob} already exists.'.format(**locals()))
+        gcs_blob.upload_from_string(string)
+
+    def download_as_string(
+            self,
+            blob,
+            bucket=None):
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        gcs_blob = self.get_conn().bucket(bucket).get_blob(blob)
+        if not gcs_blob:
+            raise ValueError(
+                'Blob does not exist: {bucket}/{blob}'.format(**locals()))
+        return gcs_blob.download_as_string()
+
+    def download_to_file(
+            self,
+            file_obj,
+            blob,
+            bucket=None):
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        gcs_blob = self.get_conn().bucket(bucket).get_blob(blob)
+        if not gcs_blob:
+            raise ValueError(
+                'Blob does not exist: {bucket}/{blob}'.format(**locals()))
+        return gcs_blob.download_to_file(file_obj)
+
+    def download_to_filename(
+            self,
+            filename,
+            blob,
+            bucket=None):
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        gcs_blob = self.get_conn().bucket(bucket).get_blob(blob)
+        if not gcs_blob:
+            raise ValueError(
+                'Blob does not exist: {bucket}/{blob}'.format(**locals()))
+        return gcs_blob.download_to_filename(filename)

--- a/airflow/contrib/hooks/gcloud/gcs_hook.py
+++ b/airflow/contrib/hooks/gcloud/gcs_hook.py
@@ -82,10 +82,10 @@ class GCSHook(BaseHook):
         return client
 
     def bucket_exists(self, bucket):
-        return self.get_conn().bucket(bucket).exists()
+        return self.gcs_conn.bucket(bucket).exists()
 
     def get_bucket(self, bucket):
-        return self.get_conn().get_bucket(bucket)
+        return self.gcs_conn.get_bucket(bucket)
 
     def list_blobs(
             self,
@@ -94,7 +94,7 @@ class GCSHook(BaseHook):
             page_token=None,
             prefix=None,
             delimiter=None):
-        return self.get_conn().bucket(bucket).list_blobs(
+        return self.gcs_conn.bucket(bucket).list_blobs(
             max_results=max_results,
             page_token=page_token,
             prefix=prefix,
@@ -106,12 +106,12 @@ class GCSHook(BaseHook):
         """
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        return self.get_conn().bucket(bucket).get_blob(blob)
+        return self.gcs_conn.bucket(bucket).get_blob(blob)
 
     def blob_exists(self, blob, bucket=None):
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        return self.get_conn().bucket(bucket).blob(blob).exists()
+        return self.gcs_conn.bucket(bucket).blob(blob).exists()
 
     def upload_from_file(
             self,
@@ -121,7 +121,7 @@ class GCSHook(BaseHook):
             replace=False):
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        gcs_blob = self.get_conn().bucket(bucket).blob(blob)
+        gcs_blob = self.gcs_conn.bucket(bucket).blob(blob)
         if gcs_blob.exists() and not replace:
             raise ValueError(
                 'The blob {bucket}/{blob} already exists.'.format(**locals()))
@@ -135,7 +135,7 @@ class GCSHook(BaseHook):
             replace=False):
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        gcs_blob = self.get_conn().bucket(bucket).blob(blob)
+        gcs_blob = self.gcs_conn.bucket(bucket).blob(blob)
         if gcs_blob.exists() and not replace:
             raise ValueError(
                 'The blob {bucket}/{blob} already exists.'.format(**locals()))
@@ -149,7 +149,7 @@ class GCSHook(BaseHook):
             replace=False):
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        gcs_blob = self.get_conn().bucket(bucket).blob(blob)
+        gcs_blob = self.gcs_conn.bucket(bucket).blob(blob)
         if gcs_blob.exists() and not replace:
             raise ValueError(
                 'The blob {bucket}/{blob} already exists.'.format(**locals()))
@@ -161,7 +161,7 @@ class GCSHook(BaseHook):
             bucket=None):
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        gcs_blob = self.get_conn().bucket(bucket).get_blob(blob)
+        gcs_blob = self.gcs_conn.bucket(bucket).get_blob(blob)
         if not gcs_blob:
             raise ValueError(
                 'Blob does not exist: {bucket}/{blob}'.format(**locals()))
@@ -174,7 +174,7 @@ class GCSHook(BaseHook):
             bucket=None):
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        gcs_blob = self.get_conn().bucket(bucket).get_blob(blob)
+        gcs_blob = self.gcs_conn.bucket(bucket).get_blob(blob)
         if not gcs_blob:
             raise ValueError(
                 'Blob does not exist: {bucket}/{blob}'.format(**locals()))
@@ -187,7 +187,7 @@ class GCSHook(BaseHook):
             bucket=None):
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        gcs_blob = self.get_conn().bucket(bucket).get_blob(blob)
+        gcs_blob = self.gcs_conn.bucket(bucket).get_blob(blob)
         if not gcs_blob:
             raise ValueError(
                 'Blob does not exist: {bucket}/{blob}'.format(**locals()))

--- a/airflow/contrib/hooks/gcloud/gcs_hook.py
+++ b/airflow/contrib/hooks/gcloud/gcs_hook.py
@@ -192,3 +192,33 @@ class GCSHook(BaseHook):
             raise ValueError(
                 'Blob does not exist: {bucket}/{blob}'.format(**locals()))
         return gcs_blob.download_to_filename(filename)
+
+    def download(
+            self,
+            bucket,
+            object,
+            filename=False):
+        """
+        This method is provided for compatibility with
+        contrib/GoogleCloudStorageHook.
+        """
+        if filename:
+            return self.download_to_filename(
+                filename=filename, blob=object, bucket=bucket)
+        else:
+            return self.download_as_string(blob=object, bucket=bucket)
+
+    def upload(
+            self,
+            bucket,
+            object,
+            filename,
+            mime_type='application/octet-stream'):
+        """
+        This method is provided for compatibility with
+        contrib/GoogleCloudStorageHook.
+
+        Warning: acts as if replace == True!
+        """
+        self.upload_from_filename(
+                filename=filename, blob=object, bucket=bucket, replace=True)

--- a/airflow/contrib/hooks/gcloud/gcs_hook.py
+++ b/airflow/contrib/hooks/gcloud/gcs_hook.py
@@ -69,6 +69,10 @@ class GCSHook(BaseHook):
             scope=None,
             *args,
             **kwargs):
+            
+        # compatibility with GoogleCloudStorageHook
+        if 'google_cloud_storage_conn_id' in kwargs and not gcp_conn_id:
+            gcp_conn_id = kwargs.pop('google_cloud_storage_conn_id')
 
         self.gcp_conn_id = gcp_conn_id
         self.project = project

--- a/airflow/contrib/hooks/gcloud/gcs_hook.py
+++ b/airflow/contrib/hooks/gcloud/gcs_hook.py
@@ -25,42 +25,7 @@ def parse_gcs_url(gsurl):
         return (bucket, blob)
 
 class GCSHook(GCPBaseHook):
-    """
-    A hook for working wth Google Cloud Storage via the gcloud library.
-
-    A GCP connection ID can be provided. If it is provided, its "extra" values
-    will OVERRIDE any argments passed to GCSHook. The following precendance is
-    observed:
-        GCP connection "extra"
-        GCSHook initialization arguments
-        host environment
-
-    Extras should be JSON and take the form:
-    {
-        "project": "<google cloud project id>",
-        "key_path": "<path to service account keyfile, either JSON or P12>"
-        "service_account": "<google service account email, required for P12>"
-        "scope": "<google service scopes>"
-    }
-
-    service_account is only required if the key_path points to a P12 file.
-
-    scope is only used if key_path is provided. Scopes can include:
-        https://www.googleapis.com/auth/devstorage.full_control
-        https://www.googleapis.com/auth/devstorage.read_only
-        https://www.googleapis.com/auth/devstorage.read_write
-
-    If fields are not provided, either as arguments or extras, they can be set
-    in the host environment.
-
-    To set a default project, use:
-        gcloud config set project <project-id>
-
-    To log in:
-        gcloud auth
-
-    """
-
+    
     client_class = gcloud.storage.Client
 
     def bucket_exists(self, bucket):

--- a/airflow/contrib/hooks/gcloud/readme.md
+++ b/airflow/contrib/hooks/gcloud/readme.md
@@ -1,0 +1,20 @@
+## GCP interfaces for Airflow
+
+Please note: Airflow currently has two sets of hooks/operators for interacting with the Google Cloud Platform. At this time (March 2016), they are not compatible with each other due to reliance on different versions of the `oauth2client` library (which introduced breaking changes with version 2.0 in February 2016). Therefore, users have to install them explicitly.
+
+##### The `gcp_api` package
+The first set is based on a version of the [Google API Client](https://github.com/google/google-api-python-client) (`google-api-python-client`) that requires `oauth2client < 2.0`. It includes a large number of hooks/operators covering GCS, DataStore, and BigQuery.
+
+To use this set, install `airflow[gcp_api]`.
+
+##### The `gcloud` package
+The second set is based on the [`gcloud` Python library](https://googlecloudplatform.github.io/gcloud-python/) and requires `oauth2client >= 2.0`. At this time it only includes a hook for GCS. Note that the hooks/operators in this set live in `gcloud/` directories, for clarity.
+
+To use this set, install `airflow[gcloud]`.
+
+##### Which should I use?
+New users should probably build on the `gcloud` set because the `gcloud` library is the recommended way for Python apps to interact with the Google Cloud Platform. The interface is easier to extend than the API approach.  
+
+More pragmatically, if your existing code (hooks/operators/DAGs) depends on EITHER `gcloud >= 0.10` OR `google-api-python-client >= 1.5` (which both require `oauth2client >= 2.0`), then you won't be able to use `airflow[gcp_api]` due to compatibility issues. 
+
+However, if the hooks/operators in the `gcp_api` set meet your needs and you do not have other dependencies, then by all means use them!

--- a/airflow/www/static/connection_form.js
+++ b/airflow/www/static/connection_form.js
@@ -7,7 +7,12 @@
         jdbc: {
             hidden_fields: ['port', 'schema', 'extra'],
             relabeling: {'host': 'Connection URL'},
+        },
+        google_cloud_platform: {
+            hidden_fields: ['host', 'schema', 'login', 'password', 'port', 'extra'],
+            relabeling: {},
         }
+
       }
       function connTypeChange(connectionType) {
         $("div.form_group").removeClass("hide");

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2096,6 +2096,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
             ('datastore', 'Google Datastore'),
             ('ftp', 'FTP',),
             ('google_cloud_storage', 'Google Cloud Storage'),
+            ('gcp', 'Google Cloud Platform'),
             ('hdfs', 'HDFS',),
             ('http', 'HTTP',),
             ('hive_cli', 'Hive Client Wrapper',),

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2071,6 +2071,10 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
         'extra',
         'extra__jdbc__drv_path',
         'extra__jdbc__drv_clsname',
+        'extra__google_cloud_platform__project',
+        'extra__google_cloud_platform__key_path',
+        'extra__google_cloud_platform__service_account',
+        'extra__google_cloud_platform__scope',
     )
     verbose_name = "Connection"
     verbose_name_plural = "Connections"
@@ -2089,6 +2093,11 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
     form_extra_fields = {
         'extra__jdbc__drv_path' : StringField('Driver Path'),
         'extra__jdbc__drv_clsname': StringField('Driver Class'),
+        'extra__google_cloud_platform__project': StringField('Project'),
+        'extra__google_cloud_platform__key_path': StringField('Keyfile Path'),
+        'extra__google_cloud_platform__service_account': StringField('Service Account'),
+        'extra__google_cloud_platform__scope': StringField('Scopes (comma seperated)'),
+
     }
     form_choices = {
         'conn_type': [
@@ -2096,7 +2105,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
             ('datastore', 'Google Datastore'),
             ('ftp', 'FTP',),
             ('google_cloud_storage', 'Google Cloud Storage'),
-            ('gcp', 'Google Cloud Platform'),
+            ('google_cloud_platform', 'Google Cloud Platform'),
             ('hdfs', 'HDFS',),
             ('http', 'HTTP',),
             ('hive_cli', 'Hive Client Wrapper',),
@@ -2118,7 +2127,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
 
     def on_model_change(self, form, model, is_created):
         formdata = form.data
-        if formdata['conn_type'] in ['jdbc']:
+        if formdata['conn_type'] in ['jdbc', 'google_cloud_platform']:
             extra = {
                 key:formdata[key]
                 for key in self.form_extra_fields.keys() if key in formdata}

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ flask-cache
 flask-login
 flower
 future
-google-api-python-client
 gunicorn
 hive-thrift-py
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,13 +19,11 @@ future
 google-api-python-client
 gunicorn
 hive-thrift-py
-httplib2
 ipython
 jinja2
 markdown
 nose
 nose-exclude
-oauth2client
 pandas
 pygments
 pyhive

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ doc = [
 ]
 docker = ['docker-py>=1.6.0']
 druid = ['pydruid>=0.2.1']
+gcp = [
+    'gcloud>=1.1.0',
+]
 gcp_api = [
     'oauth2client>=1.5.2, <2.0.0',
     'httplib2',
@@ -133,6 +136,7 @@ setup(
         'doc': doc,
         'docker': docker,
         'druid': druid,
+        'gcp': gcp,
         'gcp_api': gcp_api,
         'hdfs': hdfs,
         'hive': hive,

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ doc = [
 ]
 docker = ['docker-py>=1.6.0']
 druid = ['pydruid>=0.2.1']
-gcp = [
+gcloud = [
     'gcloud>=1.1.0',
 ]
 gcp_api = [
@@ -136,7 +136,7 @@ setup(
         'doc': doc,
         'docker': docker,
         'druid': druid,
-        'gcp': gcp,
+        'gcloud': gcloud,
         'gcp_api': gcp_api,
         'hdfs': hdfs,
         'hive': hive,

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,10 @@ doc = [
 ]
 docker = ['docker-py>=1.6.0']
 druid = ['pydruid>=0.2.1']
+gcp_api = [
+    'oauth2client>=1.5.2, <2.0.0',
+    'httplib2',
+]
 hdfs = ['snakebite>=2.4.13']
 webhdfs = ['hdfs[dataframe,avro,kerberos]>=2.0.4']
 hive = [
@@ -110,7 +114,6 @@ setup(
         'gunicorn>=19.3.0, <19.4.0',  # 19.4.? seemed to have issues
         'jinja2>=2.7.3, <3.0',
         'markdown>=2.5.2, <3.0',
-        'oauth2client>=1.5.2, <2.0.0',
         'pandas>=0.15.2, <1.0.0',
         'pygments>=2.0.1, <3.0',
         'python-dateutil>=2.3, <3',
@@ -130,6 +133,7 @@ setup(
         'doc': doc,
         'docker': docker,
         'druid': druid,
+        'gcp_api': gcp_api,
         'hdfs': hdfs,
         'hive': hive,
         'jdbc': jdbc,

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,9 @@ doc = [
 docker = ['docker-py>=1.6.0']
 druid = ['pydruid>=0.2.1']
 gcp_api = [
-    'oauth2client>=1.5.2, <2.0.0',
     'httplib2',
+    'google-api-python-client',
+    'oauth2client>=1.5.2, <2.0.0',
 ]
 hdfs = ['snakebite>=2.4.13']
 webhdfs = ['hdfs[dataframe,avro,kerberos]>=2.0.4']


### PR DESCRIPTION
A GCSHook based on the `gcloud` library, analogous to the `S3Hook` in the main airflow package.

see conversation in #1109

The file itself lives in `contrib/gcloud/` to clearly identify it as different from the current GCSHook.
