### PR TITLE
Remote log storage in GCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ sftp-config.json
 unittests.cfg
 error.log
 unittests.db
+rat-results.txt

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -1,0 +1,16 @@
+.gitignore
+.gitattributes
+.coverage
+.coveragerc
+.coveralls.yml
+.rat-excludes
+requirements.txt
+.*log
+.travis.yml
+.*pyc
+docs
+.*md
+dist
+build
+airflow.egg-info
+.idea

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ As the Airflow community grows, we'd like to keep track of who is using
 the platform. Please send a PR with your company name and @githubhandle
 if you may.
 
+Committers:
+
+* [@mistercrunch](https://github.com/mistercrunch) ([Airbnb](http://airbnb.io/))
+* [@r39132](https://github.com/r39132) ([Agari](https://github.com/agaridata))
+* [@criccomini](https://github.com/criccomini) ([WePay](http://www.wepay.com))
+* [@bolkedebruin](https://github.com/bolkedebruin) ([ING](http://www.ing.com/))
+
 Currently **officially** using Airflow:
 
 * [Airbnb](http://airbnb.io/) [[@mistercrunch](https://github.com/mistercrunch), [@artwr](https://github.com/artwr)]
@@ -64,7 +71,7 @@ Currently **officially** using Airflow:
 * [Handy](http://www.handy.com/careers/73115?gh_jid=73115&gh_src=o5qcxn) [[@marcintustin](https://github.com/marcintustin) / [@mtustin-handy](https://github.com/mtustin-handy)]
 * [Holimetrix](http://holimetrix.com/) [[@thibault-ketterer](https://github.com/thibault-ketterer)]
 * [Hootsuite](https://github.com/hootsuite)
-* ING
+* [ING](http://www.ing.com/)
 * [Jampp](https://github.com/jampp)
 * [Kogan.com](https://github.com/kogan) [[@geeknam](https://github.com/geeknam)]
 * [LendUp](https://www.lendup.com/) [[@lendup](https://github.com/lendup)]
@@ -79,6 +86,7 @@ Currently **officially** using Airflow:
 * [WeTransfer](https://github.com/WeTransfer) [[@jochem](https://github.com/jochem)]
 * Wooga
 * Xoom [[@gepser](https://github.com/gepser) & [@omarvides](https://github.com/omarvides)]
+* [WePay](http://www.wepay.com) [[@criccomini](https://github.com/criccomini) & [@mtagle](https://github.com/mtagle)]
 * Yahoo!
 
 ## Links

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -332,7 +332,7 @@ def store_gcs_log(log, remote_log_location):
             old_log = gcs_blob.download_as_string().decode()
             log = old_log + '\n' + log
         # upload to gcs
-        gcs_hook.upload_from_string(log, remote_log_location)
+        gcs_hook.upload_from_string(log, remote_log_location, replace=True)
 
     # use airflow[gcp_api]
     else:

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -138,8 +138,8 @@ def run(args):
     utils.pessimistic_connection_handling()
 
     # Setting up logging
-    log = os.path.expanduser(configuration.get('core', 'BASE_LOG_FOLDER'))
-    directory = log + "/{args.dag_id}/{args.task_id}".format(args=args)
+    log_base = os.path.expanduser(configuration.get('core', 'BASE_LOG_FOLDER'))
+    directory = log_base + "/{args.dag_id}/{args.task_id}".format(args=args)
     if not os.path.exists(directory):
         os.makedirs(directory)
     args.execution_date = dateutil.parser.parse(args.execution_date)
@@ -251,7 +251,7 @@ def run(args):
         with open(filename, 'r') as logfile:
             log = logfile.read().replace(old_log, '')
 
-        remote_log_location = filename.replace(log_location, remote_base)
+        remote_log_location = filename.replace(log_base, remote_base)
         # S3
         if remote_base.startswith('s3:/'):
             try:

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -151,7 +151,7 @@ def run(args):
         with open(filename, 'r') as logfile:
             old_log = logfile.read()
     else:
-        old_log = None
+        old_log = ''
 
     subdir = process_subdir(args.subdir)
     logging.root.handlers = []

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -78,6 +78,7 @@ defaults = {
         'dags_are_paused_at_creation': False,
         'sql_alchemy_pool_size': 5,
         'sql_alchemy_pool_recycle': 3600,
+        'dagbag_import_timeout': 30,
     },
     'webserver': {
         'base_url': 'http://localhost:8080',
@@ -182,6 +183,9 @@ fernet_key = {FERNET_KEY}
 
 # Whether to disable pickling dags
 donot_pickle = False
+
+# How long before timing out a python file import while filing the DagBag
+dagbag_import_timeout = 30
 
 [webserver]
 # The base url of your website as airflow cannot guess what domain or

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -184,7 +184,7 @@ fernet_key = {FERNET_KEY}
 # Whether to disable pickling dags
 donot_pickle = False
 
-# How long before timing out a python file import while filing the DagBag
+# How long before timing out a python file import while filling the DagBag
 dagbag_import_timeout = 30
 
 [webserver]

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -4,8 +4,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from future import standard_library
-
 standard_library.install_aliases()
+
 from builtins import str
 from configparser import ConfigParser
 import errno
@@ -70,8 +70,10 @@ defaults = {
         'plugins_folder': None,
         'security': None,
         'donot_pickle': False,
-        's3_log_folder': '',
+        'remote_base_log_folder': '',
+        'remote_log_conn_id': '',
         'encrypt_s3_logs': False,
+        's3_log_folder': '', # deprecated!
         'dag_concurrency': 16,
         'max_active_runs_per_dag': 16,
         'executor': 'SequentialExecutor',
@@ -134,9 +136,17 @@ dags_folder = {AIRFLOW_HOME}/dags
 
 # The folder where airflow should store its log files. This location
 base_log_folder = {AIRFLOW_HOME}/logs
-# An S3 location can be provided for log backups
-# For S3, use the full URL to the base folder (starting with "s3://...")
-s3_log_folder = None
+
+# Airflow can store logs remotely in AWS S3 or Google Cloud Storage. Users
+# must supply a remote location URL (starting with either 's3://...' or
+# 'gs://...') and an Airflow connection id that provides access to the storage
+# location.
+remote_base_log_folder = None
+remote_log_conn_id = None
+# options for configuring remote log storage
+encrypt_s3_logs = False
+# deprecated option for remote log storage, use remote_base_log_folder instead!
+# s3_log_folder = None
 
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -143,7 +143,7 @@ base_log_folder = {AIRFLOW_HOME}/logs
 # location.
 remote_base_log_folder = None
 remote_log_conn_id = None
-# options for configuring remote log storage
+# Use server-side encryption for logs stored in S3
 encrypt_s3_logs = False
 # deprecated option for remote log storage, use remote_base_log_folder instead!
 # s3_log_folder = None

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -4,8 +4,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from future import standard_library
-
 standard_library.install_aliases()
+
 from builtins import str
 from configparser import ConfigParser
 import errno
@@ -70,8 +70,10 @@ defaults = {
         'plugins_folder': None,
         'security': None,
         'donot_pickle': False,
-        's3_log_folder': '',
+        'remote_base_log_folder': '',
+        'remote_log_conn_id': '',
         'encrypt_s3_logs': False,
+        's3_log_folder': '', # deprecated!
         'dag_concurrency': 16,
         'max_active_runs_per_dag': 16,
         'executor': 'SequentialExecutor',
@@ -133,9 +135,17 @@ dags_folder = {AIRFLOW_HOME}/dags
 
 # The folder where airflow should store its log files. This location
 base_log_folder = {AIRFLOW_HOME}/logs
-# An S3 location can be provided for log backups
-# For S3, use the full URL to the base folder (starting with "s3://...")
-s3_log_folder = None
+
+# Airflow can store logs remotely in AWS S3 or Google Cloud Storage. Users
+# must supply a remote location URL (starting with either 's3://...' or
+# 'gs://...') and an Airflow connection id that provides access to the storage
+# location.
+remote_base_log_folder = None
+remote_log_conn_id = None
+# options for configuring remote log storage
+encrypt_s3_logs = False
+# deprecated option for remote log storage, use remote_base_log_folder instead!
+# s3_log_folder = None
 
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -142,7 +142,7 @@ base_log_folder = {AIRFLOW_HOME}/logs
 # location.
 remote_base_log_folder = None
 remote_log_conn_id = None
-# options for configuring remote log storage
+# Use server-side encryption for logs stored in S3
 encrypt_s3_logs = False
 # deprecated option for remote log storage, use remote_base_log_folder instead!
 # s3_log_folder = None

--- a/airflow/contrib/hooks/__init__.py
+++ b/airflow/contrib/hooks/__init__.py
@@ -5,6 +5,7 @@ from airflow.utils import import_module_attrs as _import_module_attrs
 _hooks = {
     'ftp_hook': ['FTPHook'],
     'ftps_hook': ['FTPSHook'],
+    'gcloud/gcs_hook': ['GCSHook'],
     'vertica_hook': ['VerticaHook'],
     'ssh_hook': ['SSHHook'],
     'bigquery_hook': ['BigQueryHook'],

--- a/airflow/contrib/hooks/gcloud/base_hook.py
+++ b/airflow/contrib/hooks/gcloud/base_hook.py
@@ -1,0 +1,107 @@
+from airflow.hooks import BaseHook
+import gcloud
+
+class GCPBaseHook(BaseHook):
+    """
+    A hook for working wth Google Cloud Platform via the gcloud library.
+
+    A GCP connection ID can be provided. If it is provided, its "extra" values
+    will OVERRIDE any argments passed to GCSHook. The following precendance is
+    observed:
+        GCP connection "extra"
+        GCPBaseHook initialization arguments
+        host environment
+
+    Extras should be JSON and take the form:
+    {
+        "project": "<google cloud project id>",
+        "key_path": "<path to service account keyfile, either JSON or P12>"
+        "service_account": "<google service account email, required for P12>"
+        "scope": "<google service scopes>"
+    }
+
+    service_account is only required if the key_path points to a P12 file.
+
+    scope is only used if key_path is provided. Scopes can include:
+        https://www.googleapis.com/auth/devstorage.full_control
+        https://www.googleapis.com/auth/devstorage.read_only
+        https://www.googleapis.com/auth/devstorage.read_write
+
+    If fields are not provided, either as arguments or extras, they can be set
+    in the host environment.
+
+    To set a default project, use:
+        gcloud config set project <project-id>
+
+    To log in:
+        gcloud auth
+
+    """
+
+    client_class = None
+
+    def __init__(
+            self,
+            gcp_conn_id=None,
+            project=None,
+            key_path=None,
+            service_account=None,
+            scope=None,
+            *args,
+            **kwargs):
+
+        if not self.client_class:
+            raise NotImplementedError(
+                'The GCPBaseHook must be extended by providing a client_class.')
+
+        # compatibility with GoogleCloudStorageHook
+        if 'google_cloud_storage_conn_id' in kwargs and not gcp_conn_id:
+            gcp_conn_id = kwargs.pop('google_cloud_storage_conn_id')
+
+        self.gcp_conn_id = gcp_conn_id
+        self.project = project
+        self.key_path = key_path
+        self.service_account = service_account
+        self.scope = scope
+
+        self.client = self.get_conn()
+
+    def get_conn(self):
+        # parse arguments and connection extras
+        if self.gcp_conn_id:
+            extras = self.get_connection(self.gcp_conn_id).extra_dejson
+        else:
+            extras = {}
+        project = extras.get('project', self.project)
+        key_path = extras.get('key_path', self.key_path)
+        service_account = extras.get('service_account', self.service_account)
+        scope = extras.get('scope', self.scope)
+
+        # guess project, if possible
+        if not project:
+            project = gcloud._helpers._determine_default_project()
+            # workaround for
+            # https://github.com/GoogleCloudPlatform/gcloud-python/issues/1470
+            if isinstance(project, bytes):
+                project = project.decode()
+
+        # load credentials/scope
+        if key_path:
+            if key_path.endswith('.json') or key_path.endswith('.JSON'):
+                credentials = gcloud.credentials.get_for_service_account_json(
+                    json_credentials_path=key_path,
+                    scope=scope)
+            elif key_path.endswith('.p12') or key_path.endswith('.P12'):
+                credentials = gcloud.credentials.get_for_service_account_p12(
+                    client_email=service_account,
+                    private_key_path=key_path,
+                    scope=scope)
+            else:
+                raise ValueError('Unrecognized keyfile: {}'.format(key_path))
+            client = self.client_class(
+                credentials=credentials,
+                project=project)
+        else:
+            client = self.client_class(project=project)
+
+        return client

--- a/airflow/contrib/hooks/gcloud/base_hook.py
+++ b/airflow/contrib/hooks/gcloud/base_hook.py
@@ -91,9 +91,7 @@ class GCPBaseHook(BaseHook):
         scope = load_field('scope')
         if scope:
             scope = scope.split(',')
-
-        import ipdb; ipdb.set_trace()
-        
+            
         # guess project, if possible
         if not project:
             project = gcloud._helpers._determine_default_project()

--- a/airflow/contrib/hooks/gcloud/gcs_hook.py
+++ b/airflow/contrib/hooks/gcloud/gcs_hook.py
@@ -1,0 +1,181 @@
+from future.standard_library import install_aliases
+install_aliases()
+
+from urllib.parse import urlparse
+from airflow.hooks import BaseHook
+from airflow.utils import AirflowException
+
+import gcloud.storage as gcs
+
+def parse_gcs_url(gsurl):
+    """
+    Given a Google Cloud Storage URL (gs://<bucket>/<blob>), returns a
+    tuple containing the corresponding bucket and blob.
+    """
+    parsed_url = urlparse(gsurl)
+    if not parsed_url.netloc:
+        raise AirflowException('Please provide a bucket name')
+    else:
+        bucket = parsed_url.netloc
+        if parsed_url.path.startswith('/'):
+            blob = parsed_url.path[1:]
+        else:
+            blob = parsed_url.path
+        return (bucket, blob)
+
+class GCSHook(BaseHook):
+    """
+    A hook for working wth Google Cloud Storage via the gcloud library.
+
+    GCS Connections can contain two optional fields in "extras":
+    {
+        "project": "<google cloud project id>",
+        "keyfile_path": "<path to service account JSON keyfile>"
+    }
+
+    If the project field is missing, the project will be inferred from the host
+    environment (if possible). To set a default project, use:
+        gcloud config set project <project-id>
+
+    If the keyfile_path is missing, the host authorization credentials will be
+    used (if possible). To log in, use:
+        gcloud auth
+    """
+    def __init__(self, gcs_conn_id=None):
+        self.gcs_conn_id = gcs_conn_id
+        self.gcs_conn = self.get_conn()
+
+    def get_conn(self):
+        project, keyfile_path = None, None
+        if self.gcs_conn_id:
+            conn = self.get_connection(self.gcs_conn_id)
+            extras = conn.extra_dejson
+            project = extras.get('project', None)
+            keyfile_path = extras.get('keyfile_path', None)
+
+        if not project:
+            project = gcloud._helpers._determine_default_project()
+            # workaround for
+            # https://github.com/GoogleCloudPlatform/gcloud-python/issues/1470
+            if isinstance(project, bytes):
+                project = project.decode()
+
+        if keyfile_path:
+            client = gcs.Client.from_service_account_json(
+                keyfile_path, project=project)
+        else:
+            client = gcs.Client(project=project)
+
+        return client
+
+    def bucket_exists(self, bucket):
+        return self.get_conn().bucket(bucket).exists()
+
+    def get_bucket(self, bucket):
+        return self.get_conn().get_bucket(bucket)
+
+    def list_blobs(
+            self,
+            bucket,
+            max_results=None,
+            page_token=None,
+            prefix=None,
+            delimiter=None):
+        return self.get_conn().bucket(bucket).list_blobs(
+            max_results=max_results,
+            page_token=page_token,
+            prefix=prefix,
+            delimiter=delimiter)
+
+    def get_blob(self, blob, bucket=None):
+        """
+        Returns None if the blob does not exist
+        """
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        return self.get_conn().bucket(bucket).get_blob(blob)
+
+    def blob_exists(self, blob, bucket=None):
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        return self.get_conn().bucket(bucket).blob(blob).exists()
+
+    def upload_from_file(
+            self,
+            file_obj,
+            blob,
+            bucket=None,
+            replace=False):
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        gcs_blob = self.get_conn().bucket(bucket).blob(blob)
+        if gcs_blob.exists() and not replace:
+            raise ValueError(
+                'The blob {bucket}/{blob} already exists.'.format(**locals()))
+        gcs_blob.upload_from_file(file_obj)
+
+    def upload_from_filename(
+            self,
+            filename,
+            blob,
+            bucket=None,
+            replace=False):
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        gcs_blob = self.get_conn().bucket(bucket).blob(blob)
+        if gcs_blob.exists() and not replace:
+            raise ValueError(
+                'The blob {bucket}/{blob} already exists.'.format(**locals()))
+        gcs_blob.upload_from_filename(filename)
+
+    def upload_from_string(
+            self,
+            string,
+            blob,
+            bucket=None,
+            replace=False):
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        gcs_blob = self.get_conn().bucket(bucket).blob(blob)
+        if gcs_blob.exists() and not replace:
+            raise ValueError(
+                'The blob {bucket}/{blob} already exists.'.format(**locals()))
+        gcs_blob.upload_from_string(string)
+
+    def download_as_string(
+            self,
+            blob,
+            bucket=None):
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        gcs_blob = self.get_conn().bucket(bucket).get_blob(blob)
+        if not gcs_blob:
+            raise ValueError(
+                'Blob does not exist: {bucket}/{blob}'.format(**locals()))
+        return gcs_blob.download_as_string()
+
+    def download_to_file(
+            self,
+            file_obj,
+            blob,
+            bucket=None):
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        gcs_blob = self.get_conn().bucket(bucket).get_blob(blob)
+        if not gcs_blob:
+            raise ValueError(
+                'Blob does not exist: {bucket}/{blob}'.format(**locals()))
+        return gcs_blob.download_to_file(file_obj)
+
+    def download_to_filename(
+            self,
+            filename,
+            blob,
+            bucket=None):
+        if not bucket:
+            bucket, blob = parse_gcs_url(blob)
+        gcs_blob = self.get_conn().bucket(bucket).get_blob(blob)
+        if not gcs_blob:
+            raise ValueError(
+                'Blob does not exist: {bucket}/{blob}'.format(**locals()))
+        return gcs_blob.download_to_filename(filename)

--- a/airflow/contrib/hooks/gcloud/gcs_hook.py
+++ b/airflow/contrib/hooks/gcloud/gcs_hook.py
@@ -82,10 +82,10 @@ class GCSHook(BaseHook):
         return client
 
     def bucket_exists(self, bucket):
-        return self.get_conn().bucket(bucket).exists()
+        return self.gcs_conn.bucket(bucket).exists()
 
     def get_bucket(self, bucket):
-        return self.get_conn().get_bucket(bucket)
+        return self.gcs_conn.get_bucket(bucket)
 
     def list_blobs(
             self,
@@ -94,7 +94,7 @@ class GCSHook(BaseHook):
             page_token=None,
             prefix=None,
             delimiter=None):
-        return self.get_conn().bucket(bucket).list_blobs(
+        return self.gcs_conn.bucket(bucket).list_blobs(
             max_results=max_results,
             page_token=page_token,
             prefix=prefix,
@@ -106,12 +106,12 @@ class GCSHook(BaseHook):
         """
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        return self.get_conn().bucket(bucket).get_blob(blob)
+        return self.gcs_conn.bucket(bucket).get_blob(blob)
 
     def blob_exists(self, blob, bucket=None):
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        return self.get_conn().bucket(bucket).blob(blob).exists()
+        return self.gcs_conn.bucket(bucket).blob(blob).exists()
 
     def upload_from_file(
             self,
@@ -121,7 +121,7 @@ class GCSHook(BaseHook):
             replace=False):
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        gcs_blob = self.get_conn().bucket(bucket).blob(blob)
+        gcs_blob = self.gcs_conn.bucket(bucket).blob(blob)
         if gcs_blob.exists() and not replace:
             raise ValueError(
                 'The blob {bucket}/{blob} already exists.'.format(**locals()))
@@ -135,7 +135,7 @@ class GCSHook(BaseHook):
             replace=False):
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        gcs_blob = self.get_conn().bucket(bucket).blob(blob)
+        gcs_blob = self.gcs_conn.bucket(bucket).blob(blob)
         if gcs_blob.exists() and not replace:
             raise ValueError(
                 'The blob {bucket}/{blob} already exists.'.format(**locals()))
@@ -149,7 +149,7 @@ class GCSHook(BaseHook):
             replace=False):
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        gcs_blob = self.get_conn().bucket(bucket).blob(blob)
+        gcs_blob = self.gcs_conn.bucket(bucket).blob(blob)
         if gcs_blob.exists() and not replace:
             raise ValueError(
                 'The blob {bucket}/{blob} already exists.'.format(**locals()))
@@ -161,7 +161,7 @@ class GCSHook(BaseHook):
             bucket=None):
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        gcs_blob = self.get_conn().bucket(bucket).get_blob(blob)
+        gcs_blob = self.gcs_conn.bucket(bucket).get_blob(blob)
         if not gcs_blob:
             raise ValueError(
                 'Blob does not exist: {bucket}/{blob}'.format(**locals()))
@@ -174,7 +174,7 @@ class GCSHook(BaseHook):
             bucket=None):
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        gcs_blob = self.get_conn().bucket(bucket).get_blob(blob)
+        gcs_blob = self.gcs_conn.bucket(bucket).get_blob(blob)
         if not gcs_blob:
             raise ValueError(
                 'Blob does not exist: {bucket}/{blob}'.format(**locals()))
@@ -187,7 +187,7 @@ class GCSHook(BaseHook):
             bucket=None):
         if not bucket:
             bucket, blob = parse_gcs_url(blob)
-        gcs_blob = self.get_conn().bucket(bucket).get_blob(blob)
+        gcs_blob = self.gcs_conn.bucket(bucket).get_blob(blob)
         if not gcs_blob:
             raise ValueError(
                 'Blob does not exist: {bucket}/{blob}'.format(**locals()))

--- a/airflow/contrib/hooks/gcloud/gcs_hook.py
+++ b/airflow/contrib/hooks/gcloud/gcs_hook.py
@@ -192,3 +192,33 @@ class GCSHook(BaseHook):
             raise ValueError(
                 'Blob does not exist: {bucket}/{blob}'.format(**locals()))
         return gcs_blob.download_to_filename(filename)
+
+    def download(
+            self,
+            bucket,
+            object,
+            filename=False):
+        """
+        This method is provided for compatibility with
+        contrib/GoogleCloudStorageHook.
+        """
+        if filename:
+            return self.download_to_filename(
+                filename=filename, blob=object, bucket=bucket)
+        else:
+            return self.download_as_string(blob=object, bucket=bucket)
+
+    def upload(
+            self,
+            bucket,
+            object,
+            filename,
+            mime_type='application/octet-stream'):
+        """
+        This method is provided for compatibility with
+        contrib/GoogleCloudStorageHook.
+
+        Warning: acts as if replace == True!
+        """
+        self.upload_from_filename(
+                filename=filename, blob=object, bucket=bucket, replace=True)

--- a/airflow/contrib/hooks/gcloud/gcs_hook.py
+++ b/airflow/contrib/hooks/gcloud/gcs_hook.py
@@ -69,6 +69,10 @@ class GCSHook(BaseHook):
             scope=None,
             *args,
             **kwargs):
+            
+        # compatibility with GoogleCloudStorageHook
+        if 'google_cloud_storage_conn_id' in kwargs and not gcp_conn_id:
+            gcp_conn_id = kwargs.pop('google_cloud_storage_conn_id')
 
         self.gcp_conn_id = gcp_conn_id
         self.project = project

--- a/airflow/contrib/hooks/gcloud/gcs_hook.py
+++ b/airflow/contrib/hooks/gcloud/gcs_hook.py
@@ -25,42 +25,7 @@ def parse_gcs_url(gsurl):
         return (bucket, blob)
 
 class GCSHook(GCPBaseHook):
-    """
-    A hook for working wth Google Cloud Storage via the gcloud library.
-
-    A GCP connection ID can be provided. If it is provided, its "extra" values
-    will OVERRIDE any argments passed to GCSHook. The following precendance is
-    observed:
-        GCP connection "extra"
-        GCSHook initialization arguments
-        host environment
-
-    Extras should be JSON and take the form:
-    {
-        "project": "<google cloud project id>",
-        "key_path": "<path to service account keyfile, either JSON or P12>"
-        "service_account": "<google service account email, required for P12>"
-        "scope": "<google service scopes>"
-    }
-
-    service_account is only required if the key_path points to a P12 file.
-
-    scope is only used if key_path is provided. Scopes can include:
-        https://www.googleapis.com/auth/devstorage.full_control
-        https://www.googleapis.com/auth/devstorage.read_only
-        https://www.googleapis.com/auth/devstorage.read_write
-
-    If fields are not provided, either as arguments or extras, they can be set
-    in the host environment.
-
-    To set a default project, use:
-        gcloud config set project <project-id>
-
-    To log in:
-        gcloud auth
-
-    """
-
+    
     client_class = gcloud.storage.Client
 
     def bucket_exists(self, bucket):

--- a/airflow/contrib/hooks/gcloud/readme.md
+++ b/airflow/contrib/hooks/gcloud/readme.md
@@ -1,0 +1,20 @@
+## GCP interfaces for Airflow
+
+Please note: Airflow currently has two sets of hooks/operators for interacting with the Google Cloud Platform. At this time (March 2016), they are not compatible with each other due to reliance on different versions of the `oauth2client` library (which introduced breaking changes with version 2.0 in February 2016). Therefore, users have to install them explicitly.
+
+##### The `gcp_api` package
+The first set is based on a version of the [Google API Client](https://github.com/google/google-api-python-client) (`google-api-python-client`) that requires `oauth2client < 2.0`. It includes a large number of hooks/operators covering GCS, DataStore, and BigQuery.
+
+To use this set, install `airflow[gcp_api]`.
+
+##### The `gcloud` package
+The second set is based on the [`gcloud` Python library](https://googlecloudplatform.github.io/gcloud-python/) and requires `oauth2client >= 2.0`. At this time it only includes a hook for GCS. Note that the hooks/operators in this set live in `gcloud/` directories, for clarity.
+
+To use this set, install `airflow[gcloud]`.
+
+##### Which should I use?
+New users should probably build on the `gcloud` set because the `gcloud` library is the recommended way for Python apps to interact with the Google Cloud Platform. The interface is easier to extend than the API approach.  
+
+More pragmatically, if your existing code (hooks/operators/DAGs) depends on EITHER `gcloud >= 0.10` OR `google-api-python-client >= 1.5` (which both require `oauth2client >= 2.0`), then you won't be able to use `airflow[gcp_api]` due to compatibility issues. 
+
+However, if the hooks/operators in the `gcp_api` set meet your needs and you do not have other dependencies, then by all means use them!

--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -338,7 +338,8 @@ class S3Hook(BaseHook):
 
     def load_string(self, string_data,
                     key, bucket_name=None,
-                    replace=False):
+                    replace=False,
+                    encrypt=False):
         """
         Loads a local file to S3
 
@@ -366,6 +367,7 @@ class S3Hook(BaseHook):
         if not key_obj:
             key_obj = bucket.new_key(key_name=key)
         key_size = key_obj.set_contents_from_string(string_data,
-                                                    replace=replace)
+                                                    replace=replace,
+                                                    encrypt_key=encrypt)
         logging.info("The key {key} now contains"
                      " {key_size} bytes".format(**locals()))

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -204,7 +204,8 @@ class DagBag(LoggingMixin):
                 self.logger.info("Importing " + filepath)
                 if mod_name in sys.modules:
                     del sys.modules[mod_name]
-                with utils.timeout(30):
+                with utils.timeout(
+                        configuration.getint('core', "DAGBAG_IMPORT_TIMEOUT")):
                     m = imp.load_source(mod_name, filepath)
             except Exception as e:
                 self.logger.exception("Failed to import: " + filepath)

--- a/airflow/operators/slack_operator.py
+++ b/airflow/operators/slack_operator.py
@@ -51,8 +51,8 @@ class SlackAPIOperator(BaseOperator):
         sc = SlackClient(self.token)
         rc = json.loads(sc.api_call(self.method, **self.api_params).decode('utf-8'))
         if not rc['ok']:
-            raise AirflowException("Slack API call failed: ({})".format(rc['error']))
             logging.error("Slack API call failed ({})".format(rc['error']))
+            raise AirflowException("Slack API call failed: ({})".format(rc['error']))
 
 
 class SlackAPIPostOperator(SlackAPIOperator):

--- a/airflow/operators/slack_operator.py
+++ b/airflow/operators/slack_operator.py
@@ -1,7 +1,8 @@
 from slackclient import SlackClient
 from airflow.models import BaseOperator
-from airflow.utils import apply_defaults
+from airflow.utils import apply_defaults, AirflowException
 import json
+import logging
 
 
 class SlackAPIOperator(BaseOperator):
@@ -48,7 +49,10 @@ class SlackAPIOperator(BaseOperator):
         if not self.api_params:
             self.construct_api_call_params()
         sc = SlackClient(self.token)
-        sc.api_call(self.method, **self.api_params)
+        rc = json.loads(sc.api_call(self.method, **self.api_params).decode('utf-8'))
+        if not rc['ok']:
+            raise AirflowException("Slack API call failed: ({})".format(rc['error']))
+            logging.error("Slack API call failed ({})".format(rc['error']))
 
 
 class SlackAPIPostOperator(SlackAPIOperator):

--- a/airflow/www/static/connection_form.js
+++ b/airflow/www/static/connection_form.js
@@ -7,7 +7,12 @@
         jdbc: {
             hidden_fields: ['port', 'schema', 'extra'],
             relabeling: {'host': 'Connection URL'},
+        },
+        google_cloud_platform: {
+            hidden_fields: ['host', 'schema', 'login', 'password', 'port', 'extra'],
+            relabeling: {},
         }
+
       }
       function connTypeChange(connectionType) {
         $("div.form_group").removeClass("hide");

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2110,6 +2110,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
             ('s3', 'S3',),
             ('samba', 'Samba',),
             ('sqlite', 'Sqlite',),
+            ('ssh', 'SSH',),
             ('mssql', 'Microsoft SQL Server'),
             ('mesos_framework-id', 'Mesos Framework ID'),
         ]

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2096,6 +2096,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
             ('datastore', 'Google Datastore'),
             ('ftp', 'FTP',),
             ('google_cloud_storage', 'Google Cloud Storage'),
+            ('gcp', 'Google Cloud Platform'),
             ('hdfs', 'HDFS',),
             ('http', 'HTTP',),
             ('hive_cli', 'Hive Client Wrapper',),

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2071,6 +2071,10 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
         'extra',
         'extra__jdbc__drv_path',
         'extra__jdbc__drv_clsname',
+        'extra__google_cloud_platform__project',
+        'extra__google_cloud_platform__key_path',
+        'extra__google_cloud_platform__service_account',
+        'extra__google_cloud_platform__scope',
     )
     verbose_name = "Connection"
     verbose_name_plural = "Connections"
@@ -2089,6 +2093,11 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
     form_extra_fields = {
         'extra__jdbc__drv_path' : StringField('Driver Path'),
         'extra__jdbc__drv_clsname': StringField('Driver Class'),
+        'extra__google_cloud_platform__project': StringField('Project'),
+        'extra__google_cloud_platform__key_path': StringField('Keyfile Path'),
+        'extra__google_cloud_platform__service_account': StringField('Service Account'),
+        'extra__google_cloud_platform__scope': StringField('Scopes (comma seperated)'),
+
     }
     form_choices = {
         'conn_type': [
@@ -2096,7 +2105,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
             ('datastore', 'Google Datastore'),
             ('ftp', 'FTP',),
             ('google_cloud_storage', 'Google Cloud Storage'),
-            ('gcp', 'Google Cloud Platform'),
+            ('google_cloud_platform', 'Google Cloud Platform'),
             ('hdfs', 'HDFS',),
             ('http', 'HTTP',),
             ('hive_cli', 'Hive Client Wrapper',),
@@ -2118,7 +2127,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
 
     def on_model_change(self, form, model, is_created):
         formdata = form.data
-        if formdata['conn_type'] in ['jdbc']:
+        if formdata['conn_type'] in ['jdbc', 'google_cloud_platform']:
             extra = {
                 key:formdata[key]
                 for key in self.form_extra_fields.keys() if key in formdata}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -826,7 +826,7 @@ class Airflow(BaseView):
         log += ('*** Note: remote logs are only available once '
                 'tasks have completed.\n')
         s3_key = s3_hook.get_key(remote_log_location)
-        if s3_key.exists():
+        if s3_key:
             log += '\n' + s3_key.get_contents_as_string().decode()
         else:
             log += '*** No log found on S3.\n'
@@ -859,7 +859,7 @@ class Airflow(BaseView):
         # use airflow[gcloud]
         if GCLOUD_PACKAGE:
             gcs_blob = gcs_hook.get_blob(remote_log_location)
-            if gcs_blob.exists():
+            if gcs_blob:
                 log += '\n' + gcs_blob.download_as_string().decode()
             else:
                 log += '*** No log found on GCS.\n'

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -782,13 +782,15 @@ class Airflow(BaseView):
                 try:
                     log = self.read_s3_log(log, remote_log_location)
                 except:
-                    log += '*** Could not read logs from S3.\n'
+                    log += '*** Could not read logs from S3 at {}.\n'.format(
+                        remote_log_location)
             # GCS
             elif not log_loaded and remote_log_location.startswith('gs:/'):
                 try:
                     log = self.read_gcs_log(log, remote_log_location)
                 except:
-                    log += '*** Could not read logs from GCS.\n'
+                    log += '*** Could not read logs from GCS at {}.\n'.format(
+                        remote_log_location)
 
             elif not log_loaded and remote_log_location:
                 log += '*** Unsupported remote log location: {}'.format(

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -810,7 +810,7 @@ class Airflow(BaseView):
             execution_date=execution_date, form=form)
 
     def read_s3_log(self, log, remote_log_location):
-        remote_conn_id = configuration.get('core', 'REMOTE_LOG_CONN_ID')
+        remote_conn_id = conf.get('core', 'REMOTE_LOG_CONN_ID')
         try:
             from airflow.hooks import S3Hook
             s3_hook = S3Hook(remote_conn_id)
@@ -833,7 +833,7 @@ class Airflow(BaseView):
         return log
 
     def read_gcs_log(self, log, remote_log_location):
-        remote_conn_id = configuration.get('core', 'REMOTE_LOG_CONN_ID')
+        remote_conn_id = conf.get('core', 'REMOTE_LOG_CONN_ID')
         try:
             from airflow.contrib.hooks import GCSHook
             gcs_hook = GCSHook(remote_conn_id)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -259,3 +259,23 @@ Environment configuration is picked up from ``/etc/sysconfig/airflow``.
 An example file is supplied. Make sure to specify the ``SCHEDULER_RUNS``
 variable in this file when you run the scheduler. You
 can also define here, for example, ``AIRFLOW_HOME`` or ``AIRFLOW_CONFIG``.
+
+Integration with upstart
+''''''''''''''''''''''''
+Airflow can integrate with upstart based systems. Upstart automatically starts all airflow services for which you
+have a corresponding *.conf file in ``/etc/init`` upon system boot. On failure, upstart automatically restarts
+the process (until it reaches re-spawn limit set in a *.conf file).
+
+You can find sample upstart job files in the ``scripts/upstart`` directory. These files have been tested on
+Ubuntu 14.04 LTS. You may have to adjust ``start on`` and ``stop on`` stanzas to make it work on other upstart
+systems. Some of the possible options are listed in ``scripts/upstart/README``.
+
+Modify *.conf files as needed and copy to ``/etc/init`` directory. It is assumed that airflow will run
+under ``airflow:airflow``. Change ``setuid`` and ``setgid`` in *.conf files if you use other user/group
+
+You can use ``initctl`` to manually start, stop, view status of the airflow process that has been
+integrated with upstart
+
+.. code-block:: bash
+
+    initctl airflow-webserver status

--- a/scripts/ci/check-license.sh
+++ b/scripts/ci/check-license.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+acquire_rat_jar () {
+
+  URL="http://repo1.maven.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
+
+  JAR="$rat_jar"
+
+  # Download rat launch jar if it hasn't been downloaded yet
+  if [ ! -f "$JAR" ]; then
+    # Download
+    printf "Attempting to fetch rat\n"
+    JAR_DL="${JAR}.part"
+    if [ $(command -v curl) ]; then
+      curl -L --silent "${URL}" > "$JAR_DL" && mv "$JAR_DL" "$JAR"
+    elif [ $(command -v wget) ]; then
+      wget --quiet ${URL} -O "$JAR_DL" && mv "$JAR_DL" "$JAR"
+    else
+      printf "You do not have curl or wget installed, please install rat manually.\n"
+      exit -1
+    fi
+  fi
+
+  unzip -tq "$JAR" &> /dev/null
+  if [ $? -ne 0 ]; then
+    # We failed to download
+    rm "$JAR"
+    printf "Our attempt to download rat locally to ${JAR} failed. Please install rat manually.\n"
+    exit -1
+  fi
+}
+
+# Go to the Airflow project root directory
+FWDIR="$(cd "`dirname "$0"`"/../..; pwd)"
+cd "$FWDIR"
+
+if [ -z "${TRAVIS_CACHE}" ]; then
+    TRAVIS_CACHE=/tmp
+fi
+
+if test -x "$JAVA_HOME/bin/java"; then
+    declare java_cmd="$JAVA_HOME/bin/java"
+else
+    declare java_cmd=java
+fi
+
+export RAT_VERSION=0.11
+export rat_jar="${TRAVIS_CACHE}"/lib/apache-rat-${RAT_VERSION}.jar
+mkdir -p ${TRAVIS_CACHE}/lib
+
+
+[[ -f "$rat_jar" ]] || acquire_rat_jar || {
+    echo "Download failed. Obtain the rat jar manually and place it at $rat_jar"
+    exit 1
+}
+
+$java_cmd -jar "$rat_jar" -E "$FWDIR"/.rat-excludes  -d "$FWDIR" > rat-results.txt
+
+if [ $? -ne 0 ]; then
+   echo "RAT exited abnormally"
+   exit 1
+fi
+
+ERRORS="$(cat rat-results.txt | grep -e "??")"
+
+if test ! -z "$ERRORS"; then
+    echo "Could not find Apache license headers in the following files:"
+    echo "$ERRORS"
+    COUNT=`echo "${ERRORS}" | wc -l`
+    if [ ! -f ${TRAVIS_CACHE}/rat-error-count ]; then
+        echo ${COUNT} > ${TRAVIS_CACHE}/rat-error-count
+    fi
+    typeset -i OLD_COUNT=$(cat ${TRAVIS_CACHE}/rat-error-count)
+    if [ ${COUNT} -gt ${OLD_COUNT} ]; then
+        echo "New missing licenses detected. Please correct them by adding them to to header of your files"
+        exit 1
+    else
+        echo ${COUNT} > ${TRAVIS_CACHE}/rat-error-count
+    fi
+    exit 0
+else
+    echo -e "RAT checks passed."
+fi

--- a/scripts/upstart/README
+++ b/scripts/upstart/README
@@ -1,0 +1,33 @@
+The upstart files in this directory are tested on Ubuntu 14.04 LTS based systems running in VPC on AWS.
+
+Copy *.conf files to /etc/init.
+
+You can then start airflow services by using initctl start <service>. Where <service> is airflow-worker,
+airflow-webserver, airflow-scheduler, etc.
+
+Upstart automatically starts all airflow services for which you have a corresponding *.conf file in /etc/init
+upon system boot. If service process dies, upstart will automatically re-spawn it (until it hits re-spawn limit
+set in a *.conf file)
+
+You may have to adjust `start on` & `stop on` stanzas to make it work on other upstart systems. Some of the possible
+options are listed bellow
+
+# This should work on most Linux distributions that support upstart
+start on started network-services
+
+# This is for Ubuntu based systems which lack generic network-services job
+# Wait for a non-loopback interface before starting airflow services
+start on (local-filesystems and net-device-up IFACE!=lo)
+
+# This should work on Ubuntu 11.10 based systems
+# Start after all network interfaces are up
+start on static-network-up
+
+# If nothing else works, use this
+start on runlevel [2345]
+
+It is assumed that airflow will run under `airflow:airflow`. Change `setuid` and `setgid` in *.conf files
+if you use other user/group
+
+You can use `initctl` to manually start, stop, view status of the airflow process.  For example
+`initctl status airflow-webserver`

--- a/scripts/upstart/airflow-flower.conf
+++ b/scripts/upstart/airflow-flower.conf
@@ -1,0 +1,29 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description "Airflow celery flower"
+
+start on started networking
+stop on (deconfiguring-networking or runlevel [016])
+
+respawn
+respawn limit 5 30
+
+setuid airflow
+setgid airflow
+
+# env AIRFLOW_CONFIG=
+# env AIRFLOW_HOME=
+# export AIRFLOW_CONFIG
+# export AIRFLOW_HOME
+
+exec usr/local/bin/airflow flower

--- a/scripts/upstart/airflow-scheduler.conf
+++ b/scripts/upstart/airflow-scheduler.conf
@@ -1,0 +1,33 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description "Airflow scheduler daemon"
+
+start on started networking
+stop on (deconfiguring-networking or runlevel [016])
+
+respawn
+respawn limit 5 10
+
+setuid airflow
+setgid airflow
+
+# env AIRFLOW_CONFIG=
+# env AIRFLOW_HOME=
+# export AIRFLOW_CONFIG
+# export AIRFLOW_HOME
+
+# required setting, 0 sets it to unlimited. Scheduler will restart after every X runs
+env SCHEDULER_RUNS=5
+export SCHEDULER_RUNS
+
+exec usr/local/bin/airflow scheduler -n ${SCHEDULER_RUNS}

--- a/scripts/upstart/airflow-webserver.conf
+++ b/scripts/upstart/airflow-webserver.conf
@@ -1,0 +1,29 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description "Airflow webserver daemon"
+
+start on started networking
+stop on (deconfiguring-networking or runlevel [016])
+
+respawn
+respawn limit 5 30
+
+setuid airflow
+setgid airflow
+
+# env AIRFLOW_CONFIG=
+# env AIRFLOW_HOME=
+# export AIRFLOW_CONFIG
+# export AIRFLOW_HOME
+
+exec usr/local/bin/airflow webserver

--- a/scripts/upstart/airflow-worker.conf
+++ b/scripts/upstart/airflow-worker.conf
@@ -1,0 +1,29 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description "Airflow celery worker daemon"
+
+start on started networking
+stop on (deconfiguring-networking or runlevel [016])
+
+respawn
+respawn limit 5 30
+
+setuid airflow
+setgid airflow
+
+# env AIRFLOW_CONFIG=
+# env AIRFLOW_HOME=
+# export AIRFLOW_CONFIG
+# export AIRFLOW_HOME
+
+exec usr/local/bin/airflow worker

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ doc = [
 ]
 docker = ['docker-py>=1.6.0']
 druid = ['pydruid>=0.2.1']
+gcp = [
+    'gcloud>=1.1.0',
+]
 gcp_api = [
     'oauth2client>=1.5.2, <2.0.0',
     'httplib2',
@@ -133,6 +136,7 @@ setup(
         'doc': doc,
         'docker': docker,
         'druid': druid,
+        'gcp': gcp,
         'gcp_api': gcp_api,
         'hdfs': hdfs,
         'hive': hive,

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ doc = [
 ]
 docker = ['docker-py>=1.6.0']
 druid = ['pydruid>=0.2.1']
-gcp = [
+gcloud = [
     'gcloud>=1.1.0',
 ]
 gcp_api = [
@@ -136,7 +136,7 @@ setup(
         'doc': doc,
         'docker': docker,
         'druid': druid,
-        'gcp': gcp,
+        'gcloud': gcloud,
         'gcp_api': gcp_api,
         'hdfs': hdfs,
         'hive': hive,

--- a/tox.ini
+++ b/tox.ini
@@ -46,4 +46,5 @@ commands =
   {toxinidir}/scripts/ci/ldap.sh
   {toxinidir}/scripts/ci/load_fixtures.sh
   {toxinidir}/scripts/ci/run_tests.sh []
+  {toxinidir}/scripts/ci/check-license.sh
   coveralls


### PR DESCRIPTION
Builds on top of (and replaces) #1109. Depends on the GCSHook in #1119.

This extends the remote log storage to include Google Cloud Storage in addition to S3. It uses either of the two GCP packages, as available (see discussion in #1109, #1118, #1119).

In addition, per @criccomini's suggestion, it refactors the existing (and new) functionality to use hooks. This allows more fine-grained control over the log writing behavior/access.
