### PR TITLE
Adding ssh connection type to webform

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2110,6 +2110,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
             ('s3', 'S3',),
             ('samba', 'Samba',),
             ('sqlite', 'Sqlite',),
+            ('ssh', 'SSH',),
             ('mssql', 'Microsoft SQL Server'),
             ('mesos_framework-id', 'Mesos Framework ID'),
         ]


### PR DESCRIPTION
Adding ssh connection type to the webworm as discussed in https://github.com/airbnb/airflow/pull/697. Would still be great to have this extendable by plugin or configuration, but that will need to come in another pull request.
