### PR TITLE
Add support for BigQuery User Defined Functions in BigQuery operator

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -149,7 +149,7 @@ class BigQueryBaseCursor(object):
         self.service = service
         self.project_id = project_id
 
-    def run_query(self, bql, destination_dataset_table = False, write_disposition = 'WRITE_EMPTY', allow_large_results=False):
+    def run_query(self, bql, destination_dataset_table = False, write_disposition = 'WRITE_EMPTY', allow_large_results=False, udf_config = False):
         """
         Executes a BigQuery SQL query. Optionally persists results in a BigQuery
         table. See here:
@@ -166,6 +166,9 @@ class BigQueryBaseCursor(object):
             BigQuery.
         :param allow_large_results: Whether to allow large results.
         :type allow_large_results: boolean
+        :param udf_config: The User Defined Function configuration for the query.
+            See https://cloud.google.com/bigquery/user-defined-functions for details.
+        :type udf_config: list
         """
         configuration = {
             'query': {
@@ -185,6 +188,11 @@ class BigQueryBaseCursor(object):
                     'datasetId': destination_dataset,
                     'tableId': destination_table,
                 }
+            })
+        if udf_config:
+            assert isinstance(udf_config, list)
+            configuration['query'].update({
+                'userDefinedFunctionResources': udf_config
             })
 
         return self.run_with_configuration(configuration)

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -20,6 +20,7 @@ class BigQueryOperator(BaseOperator):
                  allow_large_results=False,
                  bigquery_conn_id='bigquery_default',
                  delegate_to=None,
+                 udf_config=False,
                  *args,
                  **kwargs):
         """
@@ -37,6 +38,9 @@ class BigQueryOperator(BaseOperator):
         :param delegate_to: The account to impersonate, if any.
             For this to work, the service account making the request must have domain-wide delegation enabled.
         :type delegate_to: string
+        :param udf_config: The User Defined Function configuration for the query.
+            See https://cloud.google.com/bigquery/user-defined-functions for details.
+        :type udf_config: list
         """
         super(BigQueryOperator, self).__init__(*args, **kwargs)
         self.bql = bql
@@ -45,10 +49,11 @@ class BigQueryOperator(BaseOperator):
         self.allow_large_results = allow_large_results
         self.bigquery_conn_id = bigquery_conn_id
         self.delegate_to = delegate_to
+        self.udf_config = udf_config
 
     def execute(self, context):
         logging.info('Executing: %s', str(self.bql))
         hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id, delegate_to=self.delegate_to)
         conn = hook.get_conn()
         cursor = conn.cursor()
-        cursor.run_query(self.bql, self.destination_dataset_table, self.write_disposition, self.allow_large_results)
+        cursor.run_query(self.bql, self.destination_dataset_table, self.write_disposition, self.allow_large_results, self.udf_config)


### PR DESCRIPTION
User Defined Functions let a BigQuery user do data transformations on query results. If you are using BigQuery for ELT, then UDFs let you do the Transform step entirely in BigQuery, using javascript functions on a per-row basis.

This pull request allows an Airflow DAG to pass a UDF config to the BigQuery operator, and have that UDF config be included in the query API call.

See https://cloud.google.com/bigquery/user-defined-functions for more details on UDFs.
