### PR TITLE
Allow specificiation of project in BigQuery Hook methods

### DIFF
--- a/airflow/contrib/operators/bigquery_to_bigquery.py
+++ b/airflow/contrib/operators/bigquery_to_bigquery.py
@@ -8,14 +8,14 @@ class BigQueryToBigQueryOperator(BaseOperator):
     """
     Copy a BigQuery table to another BigQuery table.
     """
-    template_fields = ('source_dataset_tables','destination_project_dataset_table',)
+    template_fields = ('source_project_dataset_tables','destination_project_dataset_table',)
     template_ext = ('.sql',)
     ui_color = '#e6f0e4'
 
     @apply_defaults
     def __init__(
         self, 
-        source_dataset_tables,
+        source_project_dataset_tables,
         destination_project_dataset_table,
         write_disposition='WRITE_EMPTY',
         create_disposition='CREATE_IF_NEEDED',
@@ -30,10 +30,11 @@ class BigQueryToBigQueryOperator(BaseOperator):
 
         For more details about these parameters.
 
-        :param source_dataset_tables: One or more dotted <dataset>.<table>
-            BigQuery tables to use as the source data. Use a list if there are
-            multiple source tables.
-        :type source_dataset_tables: list|string
+        :param source_project_dataset_tables: One or more dotted (<project>.)<dataset>.<table>
+            BigQuery tables to use as the source data.
+            If <project> is not included, project will be the project defined in the connection json.
+            Use a list if there are multiple source tables.
+        :type source_project_dataset_tables: list|string
         :param destination_project_dataset_table: The destination BigQuery
             table. Format is: <project>.<dataset>.<table>
         :type destination_project_dataset_table: string
@@ -48,7 +49,7 @@ class BigQueryToBigQueryOperator(BaseOperator):
         :type delegate_to: string
         """
         super(BigQueryToBigQueryOperator, self).__init__(*args, **kwargs)
-        self.source_dataset_tables = source_dataset_tables
+        self.source_project_dataset_tables = source_project_dataset_tables
         self.destination_project_dataset_table = destination_project_dataset_table
         self.write_disposition = write_disposition
         self.create_disposition = create_disposition
@@ -56,12 +57,12 @@ class BigQueryToBigQueryOperator(BaseOperator):
         self.delegate_to = delegate_to
 
     def execute(self, context):
-        logging.info('Executing copy of %s into: %s', self.source_dataset_tables, self.destination_project_dataset_table)
+        logging.info('Executing copy of %s into: %s', self.source_project_dataset_tables, self.destination_project_dataset_table)
         hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id, delegate_to=self.delegate_to)
         conn = hook.get_conn()
         cursor = conn.cursor()
         cursor.run_copy(
-            self.source_dataset_tables,
+            self.source_project_dataset_tables,
             self.destination_project_dataset_table,
             self.write_disposition,
             self.create_disposition)

--- a/airflow/contrib/operators/bigquery_to_gcs.py
+++ b/airflow/contrib/operators/bigquery_to_gcs.py
@@ -8,14 +8,14 @@ class BigQueryToCloudStorageOperator(BaseOperator):
     """
     Transfers a BigQuery table to a Google Cloud Storage bucket.
     """
-    template_fields = ('source_dataset_table','destination_cloud_storage_uris',)
+    template_fields = ('source_project_dataset_table','destination_cloud_storage_uris',)
     template_ext = ('.sql',)
     ui_color = '#e4e6f0'
 
     @apply_defaults
     def __init__(
         self, 
-        source_dataset_table, 
+        source_project_dataset_table,
         destination_cloud_storage_uris, 
         compression='NONE', 
         export_format='CSV', 
@@ -33,8 +33,9 @@ class BigQueryToCloudStorageOperator(BaseOperator):
 
         For more details about these parameters.
 
-        :param source_dataset_table: The dotted <dataset>.<table> BigQuery table to use as the source data.
-        :type source_dataset_table: string
+        :param source_project_dataset_table: The dotted (<project>.)<dataset>.<table> BigQuery table to use as the
+            source data. If <project> is not included, project will be the project defined in the connection json.
+        :type source_project_dataset_table: string
         :param destination_cloud_storage_uris: The destination Google Cloud 
             Storage URI (e.g. gs://some-bucket/some-file.txt). Follows 
             convention defined here: 
@@ -55,7 +56,7 @@ class BigQueryToCloudStorageOperator(BaseOperator):
         :type delegate_to: string
         """
         super(BigQueryToCloudStorageOperator, self).__init__(*args, **kwargs)
-        self.source_dataset_table = source_dataset_table 
+        self.source_project_dataset_table = source_project_dataset_table
         self.destination_cloud_storage_uris = destination_cloud_storage_uris
         self.compression = compression
         self.export_format = export_format
@@ -65,12 +66,12 @@ class BigQueryToCloudStorageOperator(BaseOperator):
         self.delegate_to = delegate_to
 
     def execute(self, context):
-        logging.info('Executing extract of %s into: %s', self.source_dataset_table, self.destination_cloud_storage_uris)
+        logging.info('Executing extract of %s into: %s', self.source_project_dataset_table, self.destination_cloud_storage_uris)
         hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id, delegate_to=self.delegate_to)
         conn = hook.get_conn()
         cursor = conn.cursor()
         cursor.run_extract(
-            self.source_dataset_table,
+            self.source_project_dataset_table,
             self.destination_cloud_storage_uris,
             self.compression,
             self.export_format,


### PR DESCRIPTION
allow bq base cursor methods run_extract, run_copy, run_load to all take in source or destination table strings that include projects.

For backwards compatibility reasons, the project is not required, and will default to the old behavior if not included.

This allows for a decoupling of these methods from the bq project that they are run on.
