### PR TITLE
adding pymssql because it's used in MsSql Hook

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,4 @@ bcrypt
 flask-bcrypt
 mock
 hdfs
+pymssql


### PR DESCRIPTION
pymssql is imported in mssql_hook (https://github.com/airbnb/airflow/blob/master/airflow/hooks/mssql_hook.py) but this package is missing from requirements.
