### PR TITLE
Minor fix: path conflict with trailing /

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -32,7 +32,7 @@ def process_subdir(subdir):
         if "DAGS_FOLDER" in subdir:
             subdir = subdir.replace("DAGS_FOLDER", dags_folder)
         subdir = os.path.abspath(os.path.expanduser(subdir))
-        if dags_folder not in subdir:
+        if dags_folder.rstrip('/') not in subdir.rstrip('/'):
             raise AirflowException(
                 "subdir has to be part of your DAGS_FOLDER as defined in your "
                 "airflow.cfg")

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -35,7 +35,8 @@ def process_subdir(subdir):
         if dags_folder.rstrip('/') not in subdir.rstrip('/'):
             raise AirflowException(
                 "subdir has to be part of your DAGS_FOLDER as defined in your "
-                "airflow.cfg")
+                "airflow.cfg. DAGS_FOLDER is {df} and subdir is {sd}".format(
+                    df=dags_folder, sd=subdir))
         return subdir
 
 


### PR DESCRIPTION
Got bit by this small issue last night using an `airflow.cfg` that had `dags_folder = /path/with/trailing/slash/`

Changing it to `dags_folder = /path/without/trailing/slash` worked perfectly well, but it was difficult to debug and easy enough to fix automatically. This is a tiny but helpful fix!
