### PR TITLE
Fix typo when returning VerticaHook

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -496,7 +496,7 @@ class Connection(Base):
             elif self.conn_type == 'oracle':
                 return hooks.OracleHook(oracle_conn_id=self.conn_id)
             elif self.conn_type == 'vertica':
-                return hooks.VerticaHook(vertica_conn_id=self.conn_id)
+                return contrib_hooks.VerticaHook(vertica_conn_id=self.conn_id)
         except:
             return None
 


### PR DESCRIPTION
It looks like the get_hook method in the Connections class is trying to retrieve VerticaHook from the hooks module, but it is currently living in the contrib_hooks module.
