### PR TITLE
Fix systemd scripts

### DIFF
--- a/scripts/systemd/airflow-webserver.service
+++ b/scripts/systemd/airflow-webserver.service
@@ -9,7 +9,6 @@ User=airflow
 Group=airflow
 Type=simple
 ExecStart=/bin/airflow webserver
-KillMode=process
 Restart=on-failure
 RestartSec=42s
 

--- a/scripts/systemd/airflow-worker.service
+++ b/scripts/systemd/airflow-worker.service
@@ -9,7 +9,6 @@ User=airflow
 Group=airflow
 Type=simple
 ExecStart=/bin/airflow worker
-KillMode=process
 Restart=on-failure
 RestartSec=42s
 


### PR DESCRIPTION
Hello,
This PR fixes Systemd scripts for airflow-worker.service and airflow-webservice.service.
When calling "systemctl stop" on those services children processes where not properly shutdown.
By removing the "KillMode" parameter, the systemd default value "control-group" is used which properly send SIGTERM signal to childrens like gunicorn processes or airflow serve_log.
