### PR TITLE
Allow env variables to be passed to PigCliHook

### DIFF
--- a/airflow/hooks/pig_hook.py
+++ b/airflow/hooks/pig_hook.py
@@ -31,10 +31,12 @@ class PigCliHook(BaseHook):
     def __init__(
             self,
             pig_cli_conn_id="pig_cli_default",
-            env={}):
+            env=None):
         conn = self.get_connection(pig_cli_conn_id)
         self.pig_properties = conn.extra_dejson.get('pig_properties', '')
-        self.env = dict(conn.extra_dejson.get('env', {}), **env)
+        self.env = conn.extra_dejson.get('env', {})
+        if env is not None:
+            self.env = dict(self.env, **env)
         self.conn = conn
 
     def run_cli(self, pig, verbose=True):

--- a/airflow/hooks/pig_hook.py
+++ b/airflow/hooks/pig_hook.py
@@ -17,20 +17,24 @@ class PigCliHook(BaseHook):
     Note that you can also set default pig CLI properties using the
     ``pig_properties`` to be used in your connection as in
     ``{"pig_properties": "-Dpig.tmpfilecompression=true"}``
-    
+
     Environment variables can be passed using the ``env`` property
     in the connection. This should be a dict that maps variable
     names to values, for example:
     ``{"env": {"PIG_OPTS": "-Xmx512M"}}``
 
+    Environment variables defined in the connection can be overriden
+    by passing the ``env`` keyword argument to the constructor.
+
     """
 
     def __init__(
             self,
-            pig_cli_conn_id="pig_cli_default"):
+            pig_cli_conn_id="pig_cli_default",
+            env={}):
         conn = self.get_connection(pig_cli_conn_id)
         self.pig_properties = conn.extra_dejson.get('pig_properties', '')
-        self.env = conn.extra_dejson.get('env', {})
+        self.env = dict(conn.extra_dejson.get('env', {}), **env)
         self.conn = conn
 
     def run_cli(self, pig, verbose=True):

--- a/airflow/operators/pig_operator.py
+++ b/airflow/operators/pig_operator.py
@@ -33,13 +33,13 @@ class PigOperator(BaseOperator):
             self, pig,
             pig_cli_conn_id='pig_cli_default',
             pigparams_jinja_translate=False,
-            env={},
+            env=None,
             *args, **kwargs):
 
         super(PigOperator, self).__init__(*args, **kwargs)
         self.pigparams_jinja_translate = pigparams_jinja_translate
         self.pig = pig
-        self.env = env
+        self.env = env or {}
         self.pig_cli_conn_id = pig_cli_conn_id
 
     def get_hook(self):

--- a/airflow/operators/pig_operator.py
+++ b/airflow/operators/pig_operator.py
@@ -20,6 +20,8 @@ class PigOperator(BaseOperator):
         ``DAG(user_defined_macros=myargs)`` parameter. View the DAG
         object documentation for more details.
     :type pigparams_jinja_translate: boolean
+    :param env: environment variables to pass to the Pig CLI
+    :type env: dict
     """
 
     template_fields = ('pig',)
@@ -31,15 +33,17 @@ class PigOperator(BaseOperator):
             self, pig,
             pig_cli_conn_id='pig_cli_default',
             pigparams_jinja_translate=False,
+            env={},
             *args, **kwargs):
 
         super(PigOperator, self).__init__(*args, **kwargs)
         self.pigparams_jinja_translate = pigparams_jinja_translate
         self.pig = pig
+        self.env = env
         self.pig_cli_conn_id = pig_cli_conn_id
 
     def get_hook(self):
-        return PigCliHook(pig_cli_conn_id=self.pig_cli_conn_id)
+        return PigCliHook(pig_cli_conn_id=self.pig_cli_conn_id, env=self.env)
 
     def prepare_template(self):
         if self.pigparams_jinja_translate:


### PR DESCRIPTION
We need a way to be able to specify environment variables at runtime. Specifically, we want to set the heap space available to our pig cli. We would ordinarily do this by prepending these variables before the pig executable, for example:

``` bash
PIG_OPTS="$PIG_OPTS -Xmx512M" pig -useHCatalog script.pig
```

The `subprocess.Popen` method allows you to pass environment variables in, so I figured that would be the best interface. You can just define a dict in your connection option that maps environment variable names to values. At runtime, the hook will add these to the existing environment variables from `os.environ` and make them available when the pig command is executed.
