### PR TITLE
Handle both SubDagOperator classes

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2255,11 +2255,13 @@ class DAG(LoggingMixin):
         """
         Returns a list of the subdag objects associated to this DAG
         """
-        # Late import to prevent circular imports
-        from airflow.operators import SubDagOperator
+        # Check SubDag for class but don't check class directly, see
+        # https://github.com/airbnb/airflow/issues/1168
         l = []
         for task in self.tasks:
-            if isinstance(task, SubDagOperator):
+            if (
+                    task.__class__.__name__ == 'SubDagOperator' and
+                    hasattr(task, 'subdag')):
                 l.append(task.subdag)
                 l += task.subdag.subdags
         return l


### PR DESCRIPTION
As described in #1168, Airflow validates subdags against `airflow.operators.SubDagOperator`, which is NOT the same as `airflow.operators.subdag_operator.SubDagOperator`. Users who used the latter class got unexpected errors. 

Since this is a piece of Airflow’s internals, we can handle both cases explicitly (with this PR), but this isn’t a good long term fix for the many other cases where users could be using either of two possible Operator/Hook classes. See #1194.
