### PR TITLE
Fix typo preventing launching webserver from CLI

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -677,7 +677,7 @@ class CLIFactory(object):
                 'dag_id', 'task_id', 'execution_date', 'subdir', 'dry_run',
                 'task_params'),
         }, {
-            'func': scheduler,
+            'func': webserver,
             'help': "Start a Airflow webserver instance",
             'args': ('port', 'workers', 'workerclass', 'hostname', 'debug'),
         }, {


### PR DESCRIPTION
I think it is a typo introduced by the CLI refactor.
