### PR TITLE
Don't lstrip remote storage URL because it could strip the bucket name

### DIFF
--- a/airflow/contrib/hooks/gcloud/base_hook.py
+++ b/airflow/contrib/hooks/gcloud/base_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from airflow.hooks import BaseHook
 import gcloud
 
@@ -91,7 +105,7 @@ class GCPBaseHook(BaseHook):
         scope = load_field('scope')
         if scope:
             scope = scope.split(',')
-            
+
         # guess project, if possible
         if not project:
             project = gcloud._helpers._determine_default_project()

--- a/airflow/contrib/hooks/gcloud/gcs_hook.py
+++ b/airflow/contrib/hooks/gcloud/gcs_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from future.standard_library import install_aliases
 install_aliases()
 
@@ -18,14 +32,11 @@ def parse_gcs_url(gsurl):
         raise AirflowException('Please provide a bucket name')
     else:
         bucket = parsed_url.netloc
-        if parsed_url.path.startswith('/'):
-            blob = parsed_url.path[1:]
-        else:
-            blob = parsed_url.path
+        blob = parsed_url.path.strip('/')
         return (bucket, blob)
 
 class GCSHook(GCPBaseHook):
-    
+
     client_class = gcloud.storage.Client
 
     def bucket_exists(self, bucket):

--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from future import standard_library
 standard_library.install_aliases()
 import logging
@@ -126,10 +140,7 @@ class S3Hook(BaseHook):
             raise AirflowException('Please provide a bucket_name')
         else:
             bucket_name = parsed_url.netloc
-            if parsed_url.path[0] == '/':
-                key = parsed_url.path[1:]
-            else:
-                key = parsed_url.path
+            key = parsed_url.path.strip('/')
             return (bucket_name, key)
 
     def get_conn(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,3 +4,4 @@ from .models import *
 from .operators import *
 from .configuration import *
 from .contrib import *
+from .utils import *

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+import unittest
+
+import airflow.utils.logging
+from airflow.exceptions import AirflowException
+
+
+class LogUtilsTest(unittest.TestCase):
+
+    def test_gcs_url_parse(self):
+        logging.info(
+            'About to create a GCSLog object without a connection. This will '
+            'log an error but testing will proceed.')
+        glog = airflow.utils.logging.GCSLog()
+
+        self.assertEqual(
+            glog.parse_gcs_url('gs://bucket/path/to/blob'),
+            ('bucket', 'path/to/blob'))
+
+        # invalid URI
+        self.assertRaises(
+            AirflowException,
+            glog.parse_gcs_url,
+            'gs:/bucket/path/to/blob')
+
+        # trailing slash
+        self.assertEqual(
+            glog.parse_gcs_url('gs://bucket/path/to/blob/'),
+            ('bucket', 'path/to/blob'))
+
+        # bucket only
+        self.assertEqual(
+            glog.parse_gcs_url('gs://bucket/'),
+            ('bucket', ''))


### PR DESCRIPTION
It’s conceivable that the bucket starts with g or s, in which case this
lstrip would remove characters from the bucket name. Instead, remove
the URI protocol explicitly, then strip the /, then split the remainder.

I think this is the issue that was being described in #767 and should supersede that PR.
