### PR TITLE
Use LocalExecutor on Travis if possible

### DIFF
--- a/scripts/ci/airflow_travis.cfg
+++ b/scripts/ci/airflow_travis.cfg
@@ -7,13 +7,17 @@ sql_alchemy_conn = mysql://root@localhost/airflow
 unit_test_mode = True
 load_examples = True
 donot_pickle = False
-parallelism = 2
+dag_concurrency = 16
+dags_are_paused_at_creation = False
 fernet_key = af7CN0q6ag5U3g08IsPsw3K45U7Xa0axgVFhoh-3zB8=
 
 [webserver]
 base_url = http://localhost:8080
 web_server_host = 0.0.0.0
 web_server_port = 8080
+
+[email]
+email_backend = airflow.utils.send_email_smtp
 
 [smtp]
 smtp_host = localhost

--- a/scripts/ci/run_tests.sh
+++ b/scripts/ci/run_tests.sh
@@ -11,5 +11,12 @@ echo "Using ${HADOOP_DISTRO} distribution of Hadoop from ${HADOOP_HOME}"
 pwd
 
 mkdir ~/airflow/
+
+if [ "${TRAVIS}" ]; then
+    echo "Using travis airflow.cfg"
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    cp -f ${DIR}/airflow_travis.cfg ~/airflow/unittests.cfg
+fi
+
 echo Backend: $AIRFLOW__CORE__SQL_ALCHEMY_CONN
 ./run_unit_tests.sh


### PR DESCRIPTION
Travis was only using the SequentialExecutor, which is suboptimal as the
SequentialExecutor is not geared for production. This change enables
the LocalExecutor if possible, ie. when not using sqllite.
