### PR TITLE
Set Postgres autocommit as supported only if server version is < 7.4

### DIFF
--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -11,7 +11,7 @@ class PostgresHook(DbApiHook):
     '''
     conn_name_attr = 'postgres_conn_id'
     default_conn_name = 'postgres_default'
-    supports_autocommit = True
+    supports_autocommit = False
 
     def get_conn(self):
         conn = self.get_connection(self.postgres_conn_id)
@@ -25,4 +25,7 @@ class PostgresHook(DbApiHook):
         for arg_name, arg_val in conn.extra_dejson.items():
             if arg_name in ['sslmode', 'sslcert', 'sslkey', 'sslrootcert', 'sslcrl']:
                 conn_args[arg_name] = arg_val
-        return psycopg2.connect(**conn_args)
+        psycopg2_conn = psycopg2.connect(**conn_args)
+        if psycopg2_conn.server_version < 70400:
+            self.supports_autocommit = True
+        return psycopg2_conn


### PR DESCRIPTION
Fixes #690.

The server-side autocommit setting was removed here http://www.postgresql.org/docs/7.4/static/release-7-4.html
