### PR TITLE
Use psycopg2's API for serializing postgres cell values

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -140,16 +140,7 @@ class DbApiHook(BaseHook):
             i += 1
             l = []
             for cell in row:
-                if isinstance(cell, basestring):
-                    l.append("'" + str(cell).replace("'", "''") + "'")
-                elif cell is None:
-                    l.append('NULL')
-                elif isinstance(cell, numpy.datetime64):
-                    l.append("'" + str(cell) + "'")
-                elif isinstance(cell, datetime):
-                    l.append("'" + cell.isoformat() + "'")
-                else:
-                    l.append(str(cell))
+                l.append(self._serialize_cell(cell))
             values = tuple(l)
             sql = "INSERT INTO {0} {1} VALUES ({2});".format(
                 table,
@@ -166,6 +157,18 @@ class DbApiHook(BaseHook):
         logging.info(
             "Done loading. Loaded a total of {i} rows".format(**locals()))
 
+    @staticmethod
+    def _serialize_cell(cell):
+        if isinstance(cell, basestring):
+            return "'" + str(cell).replace("'", "''") + "'"
+        elif cell is None:
+            return 'NULL'
+        elif isinstance(cell, numpy.datetime64):
+            return "'" + str(cell) + "'"
+        elif isinstance(cell, datetime):
+            return "'" + cell.isoformat() + "'"
+        else:
+            return str(cell)
 
     def bulk_load(self, table, tmp_file):
         """

--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -1,4 +1,5 @@
 import psycopg2
+import psycopg2.extensions
 
 from airflow.hooks.dbapi_hook import DbApiHook
 
@@ -29,3 +30,7 @@ class PostgresHook(DbApiHook):
         if psycopg2_conn.server_version < 70400:
             self.supports_autocommit = True
         return psycopg2_conn
+
+    @staticmethod
+    def _serialize_cell(cell):
+        return psycopg2.extensions.adapt(cell).getquoted().decode('utf-8')


### PR DESCRIPTION
I bumped into an issue when trying to insert arrays into a PostgreSQL table (represented as Python lists) since the current serialization format didn't support it. This PR makes passes the responsibility of serialization to psycopg2 for psql queries.
