### PR TITLE
Use refactored utils module in unit test imports

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -21,9 +21,9 @@ import datetime
 import unittest
 import time
 
-from airflow import models
+from airflow import models, AirflowException
 from airflow.operators import DummyOperator, BashOperator
-from airflow.utils import State, AirflowException
+from airflow.utils.state import State
 
 
 class DagTest(unittest.TestCase):


### PR DESCRIPTION
#1230 had a unit test that was written prior to merging the `utils` refactor. This is to update it.
