### PR TITLE
Fix airflow.utils deprecation warning code being Python 3 incompatible

### DIFF
--- a/airflow/utils/__init__.py
+++ b/airflow/utils/__init__.py
@@ -29,7 +29,7 @@ def apply_defaults(func):
         from airflow.utils.decorators import apply_defaults
         """,
         category=PendingDeprecationWarning,
-        filename=func.func_code.co_filename,
-        lineno=func.func_code.co_firstlineno + 1
+        filename=func.__code__.co_filename,
+        lineno=func.__code__.co_firstlineno + 1
     )
     return _apply_defaults(func)


### PR DESCRIPTION
See https://docs.python.org/3.0/whatsnew/3.0.html#operators-and-special-methods

> The function attributes named `func_X` have been renamed to use the `__X__` form, freeing up these names in the function attribute namespace for user-defined attributes. To wit, `func_closure`, `func_code`, `func_defaults`, `func_dict`, `func_doc`, `func_globals`, `func_name` were renamed to `__closure__`, `__code__`, `__defaults__`, `__dict__`, `__doc__`, `__globals__`, `__name__`, respectively.

`function.__code__` was introduced in Python 2.6 according to https://docs.python.org/2/reference/datamodel.html.
