### PR TITLE
Improving the check for an existing session in the provide_session decorator

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -42,10 +42,14 @@ def provide_session(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         needs_session = False
-        if 'session' not in kwargs:
+        arg_session = 'session'
+        func_params = func.__code__.co_varnames
+        session_in_args = arg_session in func_params and \
+            func_params.index(arg_session) < len(args)
+        if not (arg_session in kwargs or session_in_args):
             needs_session = True
             session = settings.Session()
-            kwargs['session'] = session
+            kwargs[arg_session] = session
         result = func(*args, **kwargs)
         if needs_session:
             session.expunge_all()


### PR DESCRIPTION
Checking positional arguments as well as keyword arguments for an
existing session, so as to accommodate both styles of argument
passing in decorated functions.

This fixes https://github.com/airbnb/airflow/issues/1234.
