### PR TITLE
exclude timestamp column from the dimensions

### DIFF
--- a/airflow/hooks/druid_hook.py
+++ b/airflow/hooks/druid_hook.py
@@ -61,7 +61,7 @@ class DruidHook(BaseHook):
         """
         metric_names = [
             m['fieldName'] for m in metric_spec if m['type'] != 'count']
-        dimensions = [c for c in columns if c not in metric_names]
+        dimensions = [c for c in columns if c not in metric_names and c != ts_dim]
         ingest_query_dict = {
             "type": "index_hadoop",
             "spec": {


### PR DESCRIPTION
it's not necessary and it obviously has a huge cardinality, making the ingestion hard to handle

@mistercrunch @coleslaw @aeon @krishnap
