### PR TITLE
[webserver] Make webserver worker timeout configurable

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -91,6 +91,7 @@ defaults = {
         'base_url': 'http://localhost:8080',
         'web_server_host': '0.0.0.0',
         'web_server_port': '8080',
+        'web_server_worker_timeout': 120,
         'authenticate': False,
         'filter_by_owner': False,
         'demo_mode': False,
@@ -216,6 +217,9 @@ web_server_host = 0.0.0.0
 
 # The port on which to run the web server
 web_server_port = 8080
+
+# The time the gunicorn webserver waits before timing out on a worker
+web_server_worker_timeout = 120
 
 # Secret key used to run your flask app
 secret_key = temporary_key


### PR DESCRIPTION
Make the webserver worker timeout configurable

**Testing Done:**
-Asserted correct default timeout when no timeout is specified
-Asserted timeout picked up via the CLI
-Asserted timeout picked up via config file
-Made sure gunicorn timeout worked (setting it low and making sure that gunicorn timed out)
