### PR TITLE
[AIRFLOW-31] Use standard imports for hooks/operators

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -79,6 +79,6 @@ from airflow import executors
 from airflow import macros
 from airflow import contrib
 
-operators.integrate_plugins()
-hooks.integrate_plugins()
-macros.integrate_plugins()
+operators._integrate_plugins()
+hooks._integrate_plugins()
+macros._integrate_plugins()

--- a/airflow/contrib/example_dags/example_twitter_dag.py
+++ b/airflow/contrib/example_dags/example_twitter_dag.py
@@ -23,7 +23,8 @@
 # --------------------------------------------------------------------------------
 
 from airflow import DAG
-from airflow.operators import BashOperator, HiveOperator, PythonOperator
+from airflow.operators import BashOperator, PythonOperator
+from airflow.operators.hive_operator import HiveOperator
 from datetime import datetime, date, timedelta
 
 # --------------------------------------------------------------------------------
@@ -180,4 +181,3 @@ for channel in from_channels:
 
     load_to_hive.set_upstream(load_to_hdfs)
     load_to_hive.set_downstream(hive_to_mysql)
-

--- a/airflow/contrib/hooks/__init__.py
+++ b/airflow/contrib/hooks/__init__.py
@@ -11,7 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+
+
+# Contrib hooks are not imported by default. They should be accessed
+# directly: from airflow.contrib.hooks.hook_module import Hook
+
+
+
+
+
+
+
+# ------------------------------------------------------------------------
 #
+# #TODO #FIXME Airflow 2.0
+#
+# Old import machinary below.
+#
+# This is deprecated but should be kept until Airflow 2.0
+# for compatibility.
+#
+# ------------------------------------------------------------------------
 
 # Imports the hooks dynamically while keeping the package API clean,
 # abstracting the underlying modules
@@ -31,4 +52,14 @@ _hooks = {
     'fs_hook': ['FSHook']
 }
 
-_import_module_attrs(globals(), _hooks)
+import os as _os
+if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
+    from zope.deprecation import deprecated as _deprecated
+    _imported = _import_module_attrs(globals(), _hooks)
+    for _i in _imported:
+        _deprecated(
+            _i,
+            "Importing {i} directly from 'contrib.hooks' has been "
+            "deprecated. Please import from "
+            "'contrib.hooks.[hook_module]' instead. Support for direct imports "
+            "will be dropped entirely in Airflow 2.0.".format(i=_i))

--- a/airflow/contrib/operators/__init__.py
+++ b/airflow/contrib/operators/__init__.py
@@ -1,3 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Contrib operators are not imported by default. They should be accessed
+# directly: from airflow.contrib.operators.operator_module import Operator
+
+
+# ------------------------------------------------------------------------
+#
+# #TODO #FIXME Airflow 2.0
+#
+# Old import machinary below.
+#
+# This is deprecated but should be kept until Airflow 2.0
+# for compatibility.
+#
+# ------------------------------------------------------------------------
+
 # Imports the operators dynamically while keeping the package API clean,
 # abstracting the underlying modules
 from airflow.utils.helpers import import_module_attrs as _import_module_attrs
@@ -10,4 +40,14 @@ _operators = {
     'fs': ['FileSensor']
 }
 
-_import_module_attrs(globals(), _operators)
+import os as _os
+if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
+    from zope.deprecation import deprecated as _deprecated
+    _imported = _import_module_attrs(globals(), _operators)
+    for _i in _imported:
+        _deprecated(
+            _i,
+            "Importing {i} directly from 'contrib.operators' has been "
+            "deprecated. Please import from "
+            "'contrib.operators.[operator_module]' instead. Support for direct "
+            "imports will be dropped entirely in Airflow 2.0.".format(i=_i))

--- a/airflow/contrib/operators/fs_operator.py
+++ b/airflow/contrib/operators/fs_operator.py
@@ -17,7 +17,7 @@ from os import walk
 import logging
 
 from airflow.operators.sensors import BaseSensorOperator
-from airflow.contrib.hooks import FSHook
+from airflow.contrib.hooks.fs_hook import FSHook
 from airflow.utils.decorators import apply_defaults
 
 class FileSensor(BaseSensorOperator):
@@ -54,4 +54,3 @@ class FileSensor(BaseSensorOperator):
         except:
             return False
         return True
-

--- a/airflow/contrib/operators/mysql_to_gcs.py
+++ b/airflow/contrib/operators/mysql_to_gcs.py
@@ -3,7 +3,7 @@ import logging
 import time
 
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
-from airflow.hooks import MySqlHook
+from airflow.hooks.mysql_hook import MySqlHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from collections import OrderedDict

--- a/airflow/contrib/operators/vertica_to_hive.py
+++ b/airflow/contrib/operators/vertica_to_hive.py
@@ -4,7 +4,7 @@ import unicodecsv as csv
 import logging
 from tempfile import NamedTemporaryFile
 
-from airflow.hooks import HiveCliHook
+from airflow.hooks.hive_hooks import HiveCliHook
 from airflow.contrib.hooks import VerticaHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults

--- a/airflow/contrib/plugins/metastore_browser/main.py
+++ b/airflow/contrib/plugins/metastore_browser/main.py
@@ -5,7 +5,9 @@ from flask import Blueprint, request
 from flask_admin import BaseView, expose
 import pandas as pd
 
-from airflow.hooks import HiveMetastoreHook, MySqlHook, PrestoHook, HiveCliHook
+from airflow.hooks.hive_hooks import HiveMetastoreHook, HiveCliHook
+from airflow.hooks.mysql_hook import MySqlHook
+from airflow.hooks.presto_hook import PrestoHook
 from airflow.plugins_manager import AirflowPlugin
 from airflow.www import utils as wwwutils
 

--- a/airflow/example_dags/example_http_operator.py
+++ b/airflow/example_dags/example_http_operator.py
@@ -2,7 +2,8 @@
 ### Example HTTP operator and sensor
 """
 from airflow import DAG
-from airflow.operators import SimpleHttpOperator, HttpSensor
+from airflow.operators import SimpleHttpOperator
+from airflow.operators.sensors import HttpSensor
 from datetime import datetime, timedelta
 import json
 

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 from builtins import str
 from past.builtins import basestring

--- a/airflow/hooks/druid_hook.py
+++ b/airflow/hooks/druid_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import print_function
 import logging
 import json

--- a/airflow/hooks/hdfs_hook.py
+++ b/airflow/hooks/hdfs_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from airflow.hooks.base_hook import BaseHook
 from airflow import configuration
 

--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 from builtins import str
 import logging
 

--- a/airflow/hooks/jdbc_hook.py
+++ b/airflow/hooks/jdbc_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from builtins import str
 __author__ = 'janomar'
 

--- a/airflow/hooks/mssql_hook.py
+++ b/airflow/hooks/mssql_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pymssql
 
 from airflow.hooks.dbapi_hook import DbApiHook

--- a/airflow/hooks/mysql_hook.py
+++ b/airflow/hooks/mysql_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import MySQLdb
 import MySQLdb.cursors
 

--- a/airflow/hooks/oracle_hook.py
+++ b/airflow/hooks/oracle_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import cx_Oracle
 
 from airflow.hooks.dbapi_hook import DbApiHook

--- a/airflow/hooks/pig_hook.py
+++ b/airflow/hooks/pig_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import print_function
 import logging
 import subprocess

--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import psycopg2
 import psycopg2.extensions
 

--- a/airflow/hooks/presto_hook.py
+++ b/airflow/hooks/presto_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from builtins import str
 import logging
 

--- a/airflow/hooks/samba_hook.py
+++ b/airflow/hooks/samba_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from smbclient import SambaClient
 import os
 

--- a/airflow/hooks/sqlite_hook.py
+++ b/airflow/hooks/sqlite_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sqlite3
 
 from airflow.hooks.dbapi_hook import DbApiHook

--- a/airflow/hooks/webhdfs_hook.py
+++ b/airflow/hooks/webhdfs_hook.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from airflow.hooks.base_hook import BaseHook
 from airflow import configuration
 import logging

--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import absolute_import
 from random import random
 from datetime import datetime, timedelta
@@ -48,8 +62,26 @@ def ds_format(ds, input_format, output_format):
     return datetime.strptime(ds, input_format).strftime(output_format)
 
 
-def integrate_plugins():
+def _integrate_plugins():
     """Integrate plugins to the context"""
+    import sys
     from airflow.plugins_manager import macros as _macros
-    for _macro in _macros:
-        globals()[_macro.__name__] = _macro
+    for _macro_module in _macros:
+        sys.modules[_macro_module.__name__] = _macro_module
+        globals()[_macro_module._name] = _macro_module
+
+
+        ##########################################################
+        # TODO FIXME Remove in Airflow 2.0
+
+        import os as _os
+        if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
+            from zope.deprecation import deprecated as _deprecated
+            for _macro in _macro_module._objects:
+                globals()[_macro.__name__] = _deprecated(
+                    _macro,
+                    "Importing plugin macro '{i}' directly from "
+                    "'airflow.macros' has been deprecated. Please "
+                    "import from 'airflow.macros.[plugin_module]' "
+                    "instead. Support for direct imports will be dropped "
+                    "entirely in Airflow 2.0.".format(i=_macro))

--- a/airflow/macros/hive.py
+++ b/airflow/macros/hive.py
@@ -25,7 +25,7 @@ def max_partition(
     >>> max_partition('airflow.static_babynames_partitioned')
     '2015-01-01'
     '''
-    from airflow.hooks import HiveMetastoreHook
+    from airflow.hooks.hive_hooks import HiveMetastoreHook
     if '.' in table:
         schema, table = table.split('.')
     hh = HiveMetastoreHook(metastore_conn_id=metastore_conn_id)
@@ -78,7 +78,7 @@ def closest_ds_partition(
     >>> closest_ds_partition(tbl, '2015-01-02')
     '2015-01-01'
     '''
-    from airflow.hooks import HiveMetastoreHook
+    from airflow.hooks.hive_hooks import HiveMetastoreHook
     if '.' in table:
         schema, table = table.split('.')
     hh = HiveMetastoreHook(metastore_conn_id=metastore_conn_id)

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -596,33 +596,43 @@ class Connection(Base):
                        descriptor=property(cls.get_extra, cls.set_extra))
 
     def get_hook(self):
-        from airflow import hooks
-        from airflow.contrib import hooks as contrib_hooks
         try:
             if self.conn_type == 'mysql':
-                return hooks.MySqlHook(mysql_conn_id=self.conn_id)
+                from airflow.hooks.mysql_hook import MySqlHook
+                return MySqlHook(mysql_conn_id=self.conn_id)
             elif self.conn_type == 'google_cloud_platform':
-                return contrib_hooks.BigQueryHook(bigquery_conn_id=self.conn_id)
+                from airflow.contrib.hooks.bigquery_hook import BigQueryHook
+                return BigQueryHook(bigquery_conn_id=self.conn_id)
             elif self.conn_type == 'postgres':
-                return hooks.PostgresHook(postgres_conn_id=self.conn_id)
+                from airflow.hooks.postgres_hook import PostgresHook
+                return PostgresHook(postgres_conn_id=self.conn_id)
             elif self.conn_type == 'hive_cli':
-                return hooks.HiveCliHook(hive_cli_conn_id=self.conn_id)
+                from airflow.hooks.hive_hooks import HiveCliHook
+                return HiveCliHook(hive_cli_conn_id=self.conn_id)
             elif self.conn_type == 'presto':
-                return hooks.PrestoHook(presto_conn_id=self.conn_id)
+                from airflow.hooks.presto_hook import PrestoHook
+                return PrestoHook(presto_conn_id=self.conn_id)
             elif self.conn_type == 'hiveserver2':
-                return hooks.HiveServer2Hook(hiveserver2_conn_id=self.conn_id)
+                from airflow.hooks.hive_hooks import HiveServer2Hook
+                return HiveServer2Hook(hiveserver2_conn_id=self.conn_id)
             elif self.conn_type == 'sqlite':
-                return hooks.SqliteHook(sqlite_conn_id=self.conn_id)
+                from airflow.hooks.sqlite_hook import SqliteHook
+                return SqliteHook(sqlite_conn_id=self.conn_id)
             elif self.conn_type == 'jdbc':
-                return hooks.JdbcHook(jdbc_conn_id=self.conn_id)
+                from airflow.hooks.jdbc_hook import JdbcHook
+                return JdbcHook(jdbc_conn_id=self.conn_id)
             elif self.conn_type == 'mssql':
-                return hooks.MsSqlHook(mssql_conn_id=self.conn_id)
+                from airflow.hooks.mssql_hook import MsSqlHook
+                return MsSqlHook(mssql_conn_id=self.conn_id)
             elif self.conn_type == 'oracle':
-                return hooks.OracleHook(oracle_conn_id=self.conn_id)
+                from airflow.hooks.oracle_hook import OracleHook
+                return OracleHook(oracle_conn_id=self.conn_id)
             elif self.conn_type == 'vertica':
-                return contrib_hooks.VerticaHook(vertica_conn_id=self.conn_id)
+                from airflow.contrib.hooks.vertica_hook import VerticaHook
+                return VerticaHook(vertica_conn_id=self.conn_id)
             elif self.conn_type == 'cloudant':
-                return contrib_hooks.CloudantHook(cloudant_conn_id=self.conn_id)
+                from airflow.contrib.hooks.cloudant_hook import CloudantHook
+                return CloudantHook(cloudant_conn_id=self.conn_id)
         except:
             return None
 

--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -1,23 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Only import Core Airflow Operators that don't have extra requirements.
+# All other operators must be imported directly.
+from airflow.models import BaseOperator
+from .bash_operator import BashOperator
+from .python_operator import (
+    BranchPythonOperator,
+    PythonOperator,
+    ShortCircuitOperator)
+from .check_operator import (
+    CheckOperator,
+    ValueCheckOperator,
+    IntervalCheckOperator)
+from .dagrun_operator import TriggerDagRunOperator
+from .dummy_operator import DummyOperator
+from .email_operator import EmailOperator
+from .http_operator import SimpleHttpOperator
+import airflow.operators.sensors
+from .subdag_operator import SubDagOperator
+
+
+
+
+# ------------------------------------------------------------------------
+#
+# #TODO #FIXME Airflow 2.0
+#
+# Old import machinary below.
+#
+# This is deprecated but should be kept until Airflow 2.0
+# for compatibility.
+#
+# ------------------------------------------------------------------------
+
 # Imports operators dynamically while keeping the package API clean,
 # abstracting the underlying modules
 from airflow.utils.helpers import import_module_attrs as _import_module_attrs
 
 # These need to be integrated first as other operators depend on them
-_import_module_attrs(globals(), {
-    'check_operator': [
-        'CheckOperator',
-        'ValueCheckOperator',
-        'IntervalCheckOperator',
-    ],
-})
+# _import_module_attrs(globals(), {
+#     'check_operator': [
+#         'CheckOperator',
+#         'ValueCheckOperator',
+#         'IntervalCheckOperator',
+#     ],
+# })
 
 _operators = {
-    'bash_operator': ['BashOperator'],
-    'python_operator': [
-        'PythonOperator',
-        'BranchPythonOperator',
-        'ShortCircuitOperator',
-    ],
+    # 'bash_operator': ['BashOperator'],
+    # 'python_operator': [
+    #     'PythonOperator',
+    #     'BranchPythonOperator',
+    #     'ShortCircuitOperator',
+    # ],
     'hive_operator': ['HiveOperator'],
     'pig_operator': ['PigOperator'],
     'presto_check_operator': [
@@ -25,9 +73,9 @@ _operators = {
         'PrestoValueCheckOperator',
         'PrestoIntervalCheckOperator',
     ],
-    'dagrun_operator': ['TriggerDagRunOperator'],
-    'dummy_operator': ['DummyOperator'],
-    'email_operator': ['EmailOperator'],
+    # 'dagrun_operator': ['TriggerDagRunOperator'],
+    # 'dummy_operator': ['DummyOperator'],
+    # 'email_operator': ['EmailOperator'],
     'hive_to_samba_operator': ['Hive2SambaOperator'],
     'mysql_operator': ['MySqlOperator'],
     'sqlite_operator': ['SqliteOperator'],
@@ -47,13 +95,13 @@ _operators = {
         'TimeSensor',
         'WebHdfsSensor',
     ],
-    'subdag_operator': ['SubDagOperator'],
+    # 'subdag_operator': ['SubDagOperator'],
     'hive_stats_operator': ['HiveStatsCollectionOperator'],
     's3_to_hive_operator': ['S3ToHiveTransfer'],
     'hive_to_mysql': ['HiveToMySqlTransfer'],
     'presto_to_mysql': ['PrestoToMySqlTransfer'],
     's3_file_transform_operator': ['S3FileTransformOperator'],
-    'http_operator': ['SimpleHttpOperator'],
+    # 'http_operator': ['SimpleHttpOperator'],
     'hive_to_druid': ['HiveToDruidTransfer'],
     'jdbc_operator': ['JdbcOperator'],
     'mssql_operator': ['MsSqlOperator'],
@@ -63,12 +111,38 @@ _operators = {
     'oracle_operator': ['OracleOperator']
 }
 
-_import_module_attrs(globals(), _operators)
-from airflow.models import BaseOperator
+import os as _os
+if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
+    from zope.deprecation import deprecated as _deprecated
+    _imported = _import_module_attrs(globals(), _operators)
+    for _i in _imported:
+        _deprecated(
+            _i,
+            "Importing {i} directly from 'airflow.operators' has been "
+            "deprecated. Please import from "
+            "'airflow.operators.[operator_module]' instead. Support for direct "
+            "imports will be dropped entirely in Airflow 2.0.".format(i=_i))
 
 
-def integrate_plugins():
+def _integrate_plugins():
     """Integrate plugins to the context"""
+    import sys
     from airflow.plugins_manager import operators as _operators
-    for _operator in _operators:
-        globals()[_operator.__name__] = _operator
+    for _operator_module in _operators:
+        sys.modules[_operator_module.__name__] = _operator_module
+        globals()[_operator_module._name] = _operator_module
+
+
+        ##########################################################
+        # TODO FIXME Remove in Airflow 2.0
+
+        if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
+            from zope.deprecation import deprecated as _deprecated
+            for _operator in _operator_module._objects:
+                globals()[_operator.__name__] = _deprecated(
+                    _operator,
+                    "Importing plugin operator '{i}' directly from "
+                    "'airflow.operators' has been deprecated. Please "
+                    "import from 'airflow.operators.[plugin_module]' "
+                    "instead. Support for direct imports will be dropped "
+                    "entirely in Airflow 2.0.".format(i=_operator))

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 from builtins import bytes
 import logging

--- a/airflow/operators/check_operator.py
+++ b/airflow/operators/check_operator.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from builtins import zip
 from builtins import str
 import logging

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from datetime import datetime
 import logging
 

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import logging
 from airflow.exceptions import AirflowException

--- a/airflow/operators/email_operator.py
+++ b/airflow/operators/email_operator.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from airflow.models import BaseOperator
 from airflow.utils.email import send_email
 from airflow.utils.decorators import apply_defaults

--- a/airflow/operators/generic_transfer.py
+++ b/airflow/operators/generic_transfer.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 
 from airflow.models import BaseOperator

--- a/airflow/operators/hive_operator.py
+++ b/airflow/operators/hive_operator.py
@@ -1,7 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import re
 
-from airflow.hooks import HiveCliHook
+from airflow.hooks.hive_hooks import HiveCliHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/hive_stats_operator.py
+++ b/airflow/operators/hive_stats_operator.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from builtins import str
 from builtins import zip
 from collections import OrderedDict
@@ -5,7 +19,9 @@ import json
 import logging
 
 from airflow.exceptions import AirflowException
-from airflow.hooks import PrestoHook, HiveMetastoreHook, MySqlHook
+from airflow.hooks.mysql_hook import MySqlHook
+from airflow.hooks.presto_hook import PrestoHook
+from airflow.hooks.hive_hooks import HiveMetastoreHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/hive_to_druid.py
+++ b/airflow/operators/hive_to_druid.py
@@ -1,6 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 
-from airflow.hooks import HiveCliHook, DruidHook, HiveMetastoreHook
+from airflow.hooks.hive_hooks import HiveCliHook, HiveMetastoreHook
+from airflow.hooks.druid_hook import DruidHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/hive_to_mysql.py
+++ b/airflow/operators/hive_to_mysql.py
@@ -1,6 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 
-from airflow.hooks import HiveServer2Hook, MySqlHook
+from airflow.hooks.hive_hooks import HiveServer2Hook
+from airflow.hooks.mysql_hook import MySqlHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/hive_to_samba_operator.py
+++ b/airflow/operators/hive_to_samba_operator.py
@@ -1,7 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import tempfile
 
-from airflow.hooks import HiveServer2Hook, SambaHook
+from airflow.hooks.hive_hooks import HiveServer2Hook
+from airflow.hooks.samba_hook import SambaHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/http_operator.py
+++ b/airflow/operators/http_operator.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 
 from airflow.exceptions import AirflowException

--- a/airflow/operators/jdbc_operator.py
+++ b/airflow/operators/jdbc_operator.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 __author__ = 'janomar'
 
 import logging

--- a/airflow/operators/mssql_operator.py
+++ b/airflow/operators/mssql_operator.py
@@ -1,6 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 
-from airflow.hooks import MsSqlHook
+from airflow.hooks.mssql_hook import MsSqlHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/mssql_to_hive.py
+++ b/airflow/operators/mssql_to_hive.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from builtins import chr
 from collections import OrderedDict
 import unicodecsv as csv
@@ -6,7 +20,8 @@ from tempfile import NamedTemporaryFile
 import pymssql
 
 
-from airflow.hooks import HiveCliHook, MsSqlHook
+from airflow.hooks.hive_hooks import HiveCliHook
+from airflow.hooks.mssql_hook import MsSqlHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/mysql_operator.py
+++ b/airflow/operators/mysql_operator.py
@@ -1,6 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 
-from airflow.hooks import MySqlHook
+from airflow.hooks.mysql_hook import MySqlHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/mysql_to_hive.py
+++ b/airflow/operators/mysql_to_hive.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from builtins import chr
 from collections import OrderedDict
 import unicodecsv as csv
@@ -5,7 +19,8 @@ import logging
 from tempfile import NamedTemporaryFile
 import MySQLdb
 
-from airflow.hooks import HiveCliHook, MySqlHook
+from airflow.hooks.hive_hooks import HiveCliHook
+from airflow.hooks.mysql_hook import MySqlHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/oracle_operator.py
+++ b/airflow/operators/oracle_operator.py
@@ -14,7 +14,7 @@
 
 import logging
 
-from airflow.hooks import OracleHook
+from airflow.hooks.oracle_hook import OracleHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/pig_operator.py
+++ b/airflow/operators/pig_operator.py
@@ -1,7 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import re
 
-from airflow.hooks import PigCliHook
+from airflow.hooks.pig_hook import PigCliHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/postgres_operator.py
+++ b/airflow/operators/postgres_operator.py
@@ -1,6 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 
-from airflow.hooks import PostgresHook
+from airflow.hooks.postgres_hook import PostgresHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/presto_check_operator.py
+++ b/airflow/operators/presto_check_operator.py
@@ -1,4 +1,18 @@
-from airflow.hooks import PrestoHook
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.hooks.presto_hook import PrestoHook
 from airflow.operators import CheckOperator, ValueCheckOperator, IntervalCheckOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/presto_to_mysql.py
+++ b/airflow/operators/presto_to_mysql.py
@@ -1,6 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 
-from airflow.hooks import PrestoHook, MySqlHook
+from airflow.hooks.presto_hook import PrestoHook
+from airflow.hooks.mysql_hook import MySqlHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from builtins import str
 from datetime import datetime
 import logging

--- a/airflow/operators/s3_file_transform_operator.py
+++ b/airflow/operators/s3_file_transform_operator.py
@@ -1,9 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 from tempfile import NamedTemporaryFile
 import subprocess
 
 from airflow.exceptions import AirflowException
-from airflow.hooks import S3Hook
+from airflow.hooks.S3_hook import S3Hook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/s3_to_hive_operator.py
+++ b/airflow/operators/s3_to_hive_operator.py
@@ -1,10 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from builtins import next
 from builtins import zip
 import logging
 from tempfile import NamedTemporaryFile
 
 from airflow.exceptions import AirflowException
-from airflow.hooks import HiveCliHook, S3Hook
+from airflow.hooks.S3_hook import S3Hook
+from airflow.hooks.hive_hooks import HiveCliHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -532,7 +532,7 @@ class HttpSensor(BaseSensorOperator):
                 # run content check on response
                 return self.response_check(response)
         except AirflowException as ae:
-            if ae.message.startswith("404"):
+            if str(ae).startswith("404"):
                 return False
 
             raise ae

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()
@@ -7,6 +21,7 @@ import logging
 from urllib.parse import urlparse
 from time import sleep
 
+import airflow
 from airflow import hooks, settings
 from airflow.exceptions import AirflowException, AirflowSensorTimeout, AirflowSkipException
 from airflow.models import BaseOperator, TaskInstance, Connection as DB
@@ -249,7 +264,8 @@ class HivePartitionSensor(BaseSensorOperator):
             'Poking for table {self.schema}.{self.table}, '
             'partition {self.partition}'.format(**locals()))
         if not hasattr(self, 'hook'):
-            self.hook = hooks.HiveMetastoreHook(
+            import airflow.hooks.hive_hooks
+            self.hook = airflow.hooks.hive_hooks.HiveMetastoreHook(
                 metastore_conn_id=self.metastore_conn_id)
         return self.hook.check_for_partition(
             self.schema, self.table, self.partition)
@@ -272,7 +288,8 @@ class HdfsSensor(BaseSensorOperator):
         self.hdfs_conn_id = hdfs_conn_id
 
     def poke(self, context):
-        sb = hooks.HDFSHook(self.hdfs_conn_id).get_conn()
+        import airflow.hooks.hdfs_hook
+        sb = airflow.hooks.hdfs_hook.HDFSHook(self.hdfs_conn_id).get_conn()
         logging.getLogger("snakebite").setLevel(logging.WARNING)
         logging.info(
             'Poking for file {self.filepath} '.format(**locals()))
@@ -300,7 +317,7 @@ class WebHdfsSensor(BaseSensorOperator):
         self.webhdfs_conn_id = webhdfs_conn_id
 
     def poke(self, context):
-        c = hooks.WebHDFSHook(self.webhdfs_conn_id)
+        c = airflow.hooks.webhdfs_hook.WebHDFSHook(self.webhdfs_conn_id)
         logging.info(
             'Poking for file {self.filepath} '.format(**locals()))
         return c.check_for_path(hdfs_path=self.filepath)
@@ -356,7 +373,8 @@ class S3KeySensor(BaseSensorOperator):
         session.close()
 
     def poke(self, context):
-        hook = hooks.S3Hook(s3_conn_id=self.s3_conn_id)
+        import airflow.hooks.S3_hook
+        hook = airflow.hooks.S3_hook.S3Hook(s3_conn_id=self.s3_conn_id)
         full_url = "s3://" + self.bucket_name + "/" + self.bucket_key
         logging.info('Poking for key : {full_url}'.format(**locals()))
         if self.wildcard_match:
@@ -408,7 +426,8 @@ class S3PrefixSensor(BaseSensorOperator):
     def poke(self, context):
         logging.info('Poking for prefix : {self.prefix}\n'
                      'in bucket s3://{self.bucket_name}'.format(**locals()))
-        hook = hooks.S3Hook(s3_conn_id=self.s3_conn_id)
+        import airflow.hooks.S3_hook
+        hook = airflow.hooks.S3_hook.S3Hook(s3_conn_id=self.s3_conn_id)
         return hook.check_for_prefix(
             prefix=self.prefix,
             delimiter=self.delimiter,

--- a/airflow/operators/slack_operator.py
+++ b/airflow/operators/slack_operator.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from slackclient import SlackClient
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults

--- a/airflow/operators/sqlite_operator.py
+++ b/airflow/operators/sqlite_operator.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 
 from airflow.hooks import SqliteHook

--- a/airflow/utils/email.py
+++ b/airflow/utils/email.py
@@ -1,11 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-from builtins import str
-from past.builtins import basestring
-
 # -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +11,15 @@ from past.builtins import basestring
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from builtins import str
+from past.builtins import basestring
+
 import importlib
 import logging
 import os

--- a/airflow/utils/logging.py
+++ b/airflow/utils/logging.py
@@ -47,7 +47,7 @@ class S3Log(object):
     def __init__(self):
         remote_conn_id = configuration.get('core', 'REMOTE_LOG_CONN_ID')
         try:
-            from airflow.hooks import S3Hook
+            from airflow.hooks.S3_hook import S3Hook
             self.hook = S3Hook(remote_conn_id)
         except:
             self.hook = None

--- a/airflow/utils/tests.py
+++ b/airflow/utils/tests.py
@@ -12,22 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from airflow.models import BaseOperator
-from airflow.utils.decorators import apply_defaults
+import unittest
 
-
-class DummyOperator(BaseOperator):
-    """
-    Operator that does literally nothing. It can be used to group tasks in a
-    DAG.
-    """
-
-    template_fields = tuple()
-    ui_color = '#e8f7e4'
-
-    @apply_defaults
-    def __init__(self, *args, **kwargs):
-        super(DummyOperator, self).__init__(*args, **kwargs)
-
-    def execute(self, context):
-        pass
+def skipUnlessImported(module, obj):
+    import importlib
+    m = importlib.import_module(module)
+    return unittest.skipUnless(
+        obj in dir(m),
+        "Skipping test because {} could not be imported from {}".format(
+            obj, module))

--- a/dags/testdruid.py
+++ b/dags/testdruid.py
@@ -1,4 +1,4 @@
-from airflow.operators import HiveToDruidTransfer
+from airflow.operators.hive_to_druid import HiveToDruidTransfer
 from airflow import DAG
 from datetime import datetime
 

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -7,6 +7,9 @@ export AIRFLOW_CONFIG=$AIRFLOW_HOME/unittests.cfg
 # configuration test
 export AIRFLOW__TESTSECTION__TESTKEY=testvalue
 
+# use Airflow 2.0-style imports
+export AIRFLOW_USE_NEW_IMPORTS=1
+
 # any argument received is overriding the default nose execution arguments:
 
 nose_args=$@

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from setuptools import setup, find_packages, Command
 from setuptools.command.test import test as TestCommand
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
 from .configuration import *
+from .contrib import *
 from .core import *
 from .jobs import *
 from .models import *
 from .operators import *
-from .contrib import *
 from .utils import *

--- a/tests/operators/__init__.py
+++ b/tests/operators/__init__.py
@@ -1,2 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .docker_operator import *
 from .subdag_operator import *
+from .operators import *
+from .sensors import *
+from .hive_operator import *

--- a/tests/operators/hive_operator.py
+++ b/tests/operators/hive_operator.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import datetime
+import os
+import unittest
+import six
+
+from airflow import DAG, configuration, operators, utils
+configuration.test_mode()
+
+import os
+import unittest
+
+
+DEFAULT_DATE = datetime.datetime(2015, 1, 1)
+DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
+DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
+
+
+if 'AIRFLOW_RUNALL_TESTS' in os.environ:
+
+    import airflow.hooks.hive_hooks
+    import airflow.operators.presto_to_mysql
+
+    class HiveServer2Test(unittest.TestCase):
+        def setUp(self):
+            configuration.test_mode()
+
+        def test_select_conn(self):
+            from airflow.hooks.hive_hooks import HiveServer2Hook
+            sql = "select 1"
+            hook = HiveServer2Hook()
+            hook.get_records(sql)
+
+        def test_multi_statements(self):
+            from airflow.hooks.hive_hooks import HiveServer2Hook
+            sqls = [
+                "CREATE TABLE IF NOT EXISTS test_multi_statements (i INT)",
+                "DROP TABLE test_multi_statements",
+            ]
+            hook = HiveServer2Hook()
+            hook.get_records(sqls)
+
+        def test_get_metastore_databases(self):
+            if six.PY2:
+                from airflow.hooks.hive_hooks import HiveMetastoreHook
+                hook = HiveMetastoreHook()
+                hook.get_databases()
+
+        def test_to_csv(self):
+            from airflow.hooks.hive_hooks import HiveServer2Hook
+            sql = "select 1"
+            hook = HiveServer2Hook()
+            hook.to_csv(hql=sql, csv_filepath="/tmp/test_to_csv")
+
+    class HivePrestoTest(unittest.TestCase):
+
+        def setUp(self):
+            configuration.test_mode()
+            args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
+            dag = DAG('test_dag_id', default_args=args)
+            self.dag = dag
+            self.hql = """
+            USE airflow;
+            DROP TABLE IF EXISTS static_babynames_partitioned;
+            CREATE TABLE IF NOT EXISTS static_babynames_partitioned (
+                state string,
+                year string,
+                name string,
+                gender string,
+                num int)
+            PARTITIONED BY (ds string);
+            INSERT OVERWRITE TABLE static_babynames_partitioned
+                PARTITION(ds='{{ ds }}')
+            SELECT state, year, name, gender, num FROM static_babynames;
+            """
+
+        def test_hive(self):
+            import airflow.operators.hive_operator
+            t = operators.hive_operator.HiveOperator(
+                task_id='basic_hql', hql=self.hql, dag=self.dag)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+        def test_hive_dryrun(self):
+            import airflow.operators.hive_operator
+            t = operators.hive_operator.HiveOperator(
+                task_id='basic_hql', hql=self.hql, dag=self.dag)
+            t.dry_run()
+
+        def test_beeline(self):
+            import airflow.operators.hive_operator
+            t = operators.hive_operator.HiveOperator(
+                task_id='beeline_hql', hive_cli_conn_id='beeline_default',
+                hql=self.hql, dag=self.dag)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+        def test_presto(self):
+            sql = """
+            SELECT count(1) FROM airflow.static_babynames_partitioned;
+            """
+            import airflow.operators.presto_check_operator
+            t = operators.presto_check_operator.PrestoCheckOperator(
+                task_id='presto_check', sql=sql, dag=self.dag)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+        def test_presto_to_mysql(self):
+            import airflow.operators.presto_to_mysql
+            t = operators.presto_to_mysql.PrestoToMySqlTransfer(
+                task_id='presto_to_mysql_check',
+                sql="""
+                SELECT name, count(*) as ccount
+                FROM airflow.static_babynames
+                GROUP BY name
+                """,
+                mysql_table='test_static_babynames',
+                mysql_preoperator='TRUNCATE TABLE test_static_babynames;',
+                dag=self.dag)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+        def test_hdfs_sensor(self):
+            t = operators.sensors.HdfsSensor(
+                task_id='hdfs_sensor_check',
+                filepath='hdfs://user/hive/warehouse/airflow.db/static_babynames',
+                dag=self.dag)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+        def test_webhdfs_sensor(self):
+            t = operators.sensors.WebHdfsSensor(
+                task_id='webhdfs_sensor_check',
+                filepath='hdfs://user/hive/warehouse/airflow.db/static_babynames',
+                timeout=120,
+                dag=self.dag)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+        def test_sql_sensor(self):
+            t = operators.sensors.SqlSensor(
+                task_id='hdfs_sensor_check',
+                conn_id='presto_default',
+                sql="SELECT 'x' FROM airflow.static_babynames LIMIT 1;",
+                dag=self.dag)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+        def test_hive_stats(self):
+            import airflow.operators.hive_stats_operator
+            t = operators.hive_stats_operator.HiveStatsCollectionOperator(
+                task_id='hive_stats_check',
+                table="airflow.static_babynames_partitioned",
+                partition={'ds': DEFAULT_DATE_DS},
+                dag=self.dag)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+        def test_hive_partition_sensor(self):
+            t = operators.sensors.HivePartitionSensor(
+                task_id='hive_partition_check',
+                table='airflow.static_babynames_partitioned',
+                dag=self.dag)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+        def test_hive_metastore_sql_sensor(self):
+            t = operators.sensors.MetastorePartitionSensor(
+                task_id='hive_partition_check',
+                table='airflow.static_babynames_partitioned',
+                partition_name='ds={}'.format(DEFAULT_DATE_DS),
+                dag=self.dag)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+        def test_hive2samba(self):
+            import airflow.operators.hive_to_samba_operator
+            t = operators.hive_to_samba_operator.Hive2SambaOperator(
+                task_id='hive2samba_check',
+                samba_conn_id='tableau_samba',
+                hql="SELECT * FROM airflow.static_babynames LIMIT 10000",
+                destination_filepath='test_airflow.csv',
+                dag=self.dag)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+        def test_hive_to_mysql(self):
+            import airflow.operators.hive_to_mysql
+            t = operators.hive_to_mysql.HiveToMySqlTransfer(
+                mysql_conn_id='airflow_db',
+                task_id='hive_to_mysql_check',
+                create=True,
+                sql="""
+                SELECT name
+                FROM airflow.static_babynames
+                LIMIT 100
+                """,
+                mysql_table='test_static_babynames',
+                mysql_preoperator=[
+                    'DROP TABLE IF EXISTS test_static_babynames;',
+                    'CREATE TABLE test_static_babynames (name VARCHAR(500))',
+                ],
+                dag=self.dag)
+            t.clear(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)

--- a/tests/operators/operators.py
+++ b/tests/operators/operators.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import datetime
+import os
+import unittest
+import six
+
+from airflow import DAG, configuration, operators, utils
+from airflow.utils.tests import skipUnlessImported
+configuration.test_mode()
+
+import os
+import unittest
+
+
+DEFAULT_DATE = datetime.datetime(2015, 1, 1)
+DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
+DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
+TEST_DAG_ID = 'unit_test_dag'
+
+
+@skipUnlessImported('airflow.operators.mysql_operator', 'MySqlOperator')
+class MySqlTest(unittest.TestCase):
+    def setUp(self):
+        configuration.test_mode()
+        args = {
+            'owner': 'airflow',
+            'mysql_conn_id': 'airflow_db',
+            'start_date': DEFAULT_DATE
+        }
+        dag = DAG(TEST_DAG_ID, default_args=args)
+        self.dag = dag
+
+    def mysql_operator_test(self):
+        sql = """
+        CREATE TABLE IF NOT EXISTS test_airflow (
+            dummy VARCHAR(50)
+        );
+        """
+        import airflow.operators.mysql_operator
+        t = operators.mysql_operator.MySqlOperator(
+            task_id='basic_mysql',
+            sql=sql,
+            mysql_conn_id='airflow_db',
+            dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+    def mysql_operator_test_multi(self):
+        sql = [
+            "TRUNCATE TABLE test_airflow",
+            "INSERT INTO test_airflow VALUES ('X')",
+        ]
+        import airflow.operators.mysql_operator
+        t = operators.mysql_operator.MySqlOperator(
+            task_id='mysql_operator_test_multi',
+            mysql_conn_id='airflow_db',
+            sql=sql, dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+    def test_mysql_to_mysql(self):
+        sql = "SELECT * FROM INFORMATION_SCHEMA.TABLES LIMIT 100;"
+        import airflow.operators.generic_transfer
+        t = operators.generic_transfer.GenericTransfer(
+            task_id='test_m2m',
+            preoperator=[
+                "DROP TABLE IF EXISTS test_mysql_to_mysql",
+                "CREATE TABLE IF NOT EXISTS "
+                "test_mysql_to_mysql LIKE INFORMATION_SCHEMA.TABLES"
+            ],
+            source_conn_id='airflow_db',
+            destination_conn_id='airflow_db',
+            destination_table="test_mysql_to_mysql",
+            sql=sql,
+            dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+    def test_sql_sensor(self):
+        t = operators.sensors.SqlSensor(
+            task_id='sql_sensor_check',
+            conn_id='mysql_default',
+            sql="SELECT count(1) FROM INFORMATION_SCHEMA.TABLES",
+            dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+@skipUnlessImported('airflow.operators.postgres_operator', 'PostgresOperator')
+class PostgresTest(unittest.TestCase):
+    def setUp(self):
+        configuration.test_mode()
+        args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
+        dag = DAG(TEST_DAG_ID, default_args=args)
+        self.dag = dag
+
+    def postgres_operator_test(self):
+        sql = """
+        CREATE TABLE IF NOT EXISTS test_airflow (
+            dummy VARCHAR(50)
+        );
+        """
+        import airflow.operators.postgres_operator
+        t = operators.postgres_operator.PostgresOperator(
+            task_id='basic_postgres', sql=sql, dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+        autocommitTask = operators.postgres_operator.PostgresOperator(
+            task_id='basic_postgres_with_autocommit',
+            sql=sql,
+            dag=self.dag,
+            autocommit=True)
+        autocommitTask.run(
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
+            force=True)
+
+
+@skipUnlessImported('airflow.operators.hive_operator', 'HiveOperator')
+@skipUnlessImported('airflow.operators.postgres_operator', 'PostgresOperator')
+class TransferTests(unittest.TestCase):
+    cluster = None
+
+    def setUp(self):
+        configuration.test_mode()
+        args = {'owner': 'airflow', 'start_date': DEFAULT_DATE_ISO}
+        dag = DAG(TEST_DAG_ID, default_args=args)
+        self.dag = dag
+
+    def test_clear(self):
+        self.dag.clear(
+            start_date=DEFAULT_DATE,
+            end_date=datetime.datetime.now())
+
+    def test_mysql_to_hive(self):
+        # import airflow.operators
+        from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
+        sql = "SELECT * FROM baby_names LIMIT 1000;"
+        t = MySqlToHiveTransfer(
+            task_id='test_m2h',
+            mysql_conn_id='airflow_ci',
+            hive_cli_conn_id='beeline_default',
+            sql=sql,
+            hive_table='test_mysql_to_hive',
+            recreate=True,
+            delimiter=",",
+            dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+
+    def test_mysql_to_hive_partition(self):
+        from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
+        sql = "SELECT * FROM baby_names LIMIT 1000;"
+        t = MySqlToHiveTransfer(
+            task_id='test_m2h',
+            mysql_conn_id='airflow_ci',
+            hive_cli_conn_id='beeline_default',
+            sql=sql,
+            hive_table='test_mysql_to_hive_part',
+            partition={'ds': DEFAULT_DATE_DS},
+            recreate=False,
+            create=True,
+            delimiter=",",
+            dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)

--- a/tests/operators/sensors.py
+++ b/tests/operators/sensors.py
@@ -15,7 +15,7 @@
 import os
 import unittest
 
-from airflow.operators import HttpSensor
+from airflow.operators.sensors import HttpSensor
 from airflow.exceptions import AirflowException
 
 


### PR DESCRIPTION
See #1238 for details.

This PR replaces Airflow's import machinery with standard Python imports. This has an impact in four places:

`airflow.hooks.*`
`airflow.operators.*`
`airflow.contrib.hooks.*`
`airflow.contrib.operators.*`

Operators that could formerly be accessed from these directories must now be accessed explicitly from submodules:

``` python
from airflow.operators import PigOperator # NO
from airflow.operators.pig_operator import PigOperator # YES
```

Old style imports _will still work_ but will warn:

``` bash
In [4]: airflow.operators.PigOperator
/Users/jlowin/anaconda3/bin/ipython:1: DeprecationWarning: PigOperator: Importing 
PigOperator directly from 'airflow.operators' has been deprecated. Please import 
from 'airflow.operators.[operator_module]' instead. Support for direct imports will 
be dropped entirely in Airflow 2.0.
  #!/bin/bash /Users/jlowin/anaconda3/bin/python.app

Out[4]: pig_operator.PigOperator
```

`run_unit_tests.sh` exports an environment variable `AIRFLOW_USE_NEW_IMPORTS` which turns off the old-style (deprecated) imports completely. Therefore, unit tests must use the new style. **I've tried to adjust the tests already but there are some I can't test locally so I will see what Travis has issues with and make adjustments.**

Plugins are handled similarly. Let's say the user creates a plugin `MyPlugin` with some operators. Currently those operators are available at `airflow.operators.*`. Through this PR, that behavior is maintained (through Airflow 2.0) but a new module is dynamically created with the operators at `airflow.operators.myplugin.*`

Lastly, I took advantage of the fact I was going into lots of files to add licenses to all hooks and operators.
