### PR TITLE
Beware of negative pool slots.

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -559,12 +559,12 @@ class SchedulerJob(BaseJob):
             queue_size = len(tis)
             self.logger.info("Pool {pool} has {open_slots} slots, {queue_size} "
                           "task instances in queue".format(**locals()))
-            if not open_slots:
+            if open_slots <= 0:
                 continue
             tis = sorted(
                 tis, key=lambda ti: (-ti.priority_weight, ti.start_date))
             for ti in tis:
-                if not open_slots:
+                if open_slots <= 0:
                     continue
                 task = None
                 try:


### PR DESCRIPTION
Sometimes the scheduler over-allocates tasks in a pool. When that happens the
number of open slot counts will go negative. The `not open_slots` code only
works if the scheduler observes the pool going to zero. If it has gone negative
the previous logic will schedule an unlimited number of pool tasks.
