### PR TITLE
Fix SSHExecuteOperator crash when using a custom ssh port

### DIFF
--- a/airflow/contrib/hooks/ssh_hook.py
+++ b/airflow/contrib/hooks/ssh_hook.py
@@ -20,7 +20,7 @@ import subprocess
 from contextlib import contextmanager
 
 from airflow.hooks.base_hook import BaseHook
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 
 import logging
 

--- a/airflow/contrib/hooks/ssh_hook.py
+++ b/airflow/contrib/hooks/ssh_hook.py
@@ -20,7 +20,7 @@ import subprocess
 from contextlib import contextmanager
 
 from airflow.hooks.base_hook import BaseHook
-from airflow.exceptions import AirflowException
+from airflow import AirflowException
 
 import logging
 
@@ -76,7 +76,7 @@ class SSHHook(BaseHook):
             connection_cmd += ["-o", "BatchMode=yes"] # no password prompts
 
         if self.conn.port:
-            connection_cmd += ["-p", self.conn.port]
+            connection_cmd += ["-p", str(self.conn.port)]
 
         if self.connect_timeout:
             connection_cmd += ["-o", "ConnectionTimeout={}".format(self.connect_timeout)]


### PR DESCRIPTION
The ssh port, if not converted to a string, makes the SSHExecuteOperator crash.
This patch converts the port number to string and fixes problem.
