### PR TITLE
Fix reading strings from conf for remote logging

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -246,7 +246,7 @@ def run(args, dag=None):
                 remote_log_location,
                 append=True)
         # Other
-        elif remote_base:
+        elif remote_base and remote_base != 'None':
             logging.error(
                 'Unsupported remote log location: {}'.format(remote_base))
 

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -150,12 +150,12 @@ base_log_folder = {AIRFLOW_HOME}/logs
 # must supply a remote location URL (starting with either 's3://...' or
 # 'gs://...') and an Airflow connection id that provides access to the storage
 # location.
-remote_base_log_folder = None
-remote_log_conn_id = None
+remote_base_log_folder =
+remote_log_conn_id =
 # Use server-side encryption for logs stored in S3
 encrypt_s3_logs = False
 # deprecated option for remote log storage, use remote_base_log_folder instead!
-# s3_log_folder = None
+# s3_log_folder =
 
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor

--- a/airflow/utils/logging.py
+++ b/airflow/utils/logging.py
@@ -105,7 +105,7 @@ class S3Log(object):
                     log,
                     key=remote_log_location,
                     replace=True,
-                    encrypt=configuration.get('core', 'ENCRYPT_S3_LOGS'))
+                    encrypt=configuration.get_bool('core', 'ENCRYPT_S3_LOGS'))
                 return
             except:
                 pass


### PR DESCRIPTION
The default remote_logging values of None and False were being read as
strings rather than Python objects and therefore misinterpreted
