### PR TITLE
Change inconsistent example DAG owners

### DIFF
--- a/airflow/example_dags/example_passing_params_via_test_command.py
+++ b/airflow/example_dags/example_passing_params_via_test_command.py
@@ -19,7 +19,7 @@ from airflow import DAG
 from airflow.operators import BashOperator, PythonOperator
 
 dag = DAG("example_passing_params_via_test_command",
-          default_args={"owner" : "me",
+          default_args={"owner" : "airflow",
                         "start_date":datetime.now()},
           schedule_interval='*/1 * * * *',
           dagrun_timeout=timedelta(minutes=4)

--- a/airflow/example_dags/example_trigger_controller_dag.py
+++ b/airflow/example_dags/example_trigger_controller_dag.py
@@ -37,7 +37,7 @@ def conditionally_trigger(context, dag_run_obj):
 
 # Define the DAG
 dag = DAG(dag_id='example_trigger_controller_dag',
-          default_args={"owner": "me",
+          default_args={"owner": "airflow",
                         "start_date": datetime.now()},
           schedule_interval='@once')
 


### PR DESCRIPTION
Change two example DAG owners from 'me' to 'airflow'
in order to
1. Be consistent with other example DAGs
2. Avoid confusing users, who may misinterpret "me"

This resolves #1295 
