### PR TITLE
Raise deep scheduler exceptions to force a process restart.

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -716,6 +716,7 @@ class SchedulerJob(BaseJob):
                     self.logger.error("Tachycardia!")
             except Exception as deep_e:
                 self.logger.exception(deep_e)
+                raise
             finally:
                 settings.Session.remove()
         executor.end()


### PR DESCRIPTION
Our database got into a weird state the other day after we saw this:

```
[2016-04-03 09:23:55.105269] ERROR:airflow.jobs.SchedulerJob:(psycopg2.OperationalError) terminating connection due to administrator command
[2016-04-03 09:23:55.105312] SSL connection has been closed unexpectedly
```

That's unfortunate, but we can deal. However, due to the scheduler loop swallowing all exceptions, our scheduler was dead for hours looping over this error:

```
[2016-04-03 19:31:57.721295] ERROR:airflow.jobs.SchedulerJob:(sqlalchemy.exc.InvalidRequestError) Can't reconnect until invalid transaction is rolled back [SQL: '...']
```

I know there's a param to restart the scheduler every N loops, but we don't have that turned on because we found that the scheduler would reboot and schedule the same tasks many times over, leading to a large celery queue depth.

I'm proposing this patch that lets the exception propagate so the scheduler can die and restart fresh. If the scheduler is hitting some kind of persistent error, dying quickly is still desirable since that can let us detect a flapping process.
