### PR TITLE
Fix infinite retries with pools

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -619,6 +619,15 @@ class TaskInstance(Base):
         if state:
             self.state = state
 
+    def __key(self):
+        return (self.task_id, self.dag_id, self.execution_date)
+
+    def __eq__(self, other):
+        return  self.__key() == other.__key()
+
+    def __hash__(self):
+        return hash(self.__key())
+
     def command(
             self,
             mark_success=False,

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -623,7 +623,7 @@ class TaskInstance(Base):
         return (self.task_id, self.dag_id, self.execution_date)
 
     def __eq__(self, other):
-        return  self.__key() == other.__key()
+        return self.__key() == other.__key()
 
     def __hash__(self):
         return hash(self.__key())


### PR DESCRIPTION
`SchedulerJob` contains a `set` of `TaskInstance`s called `queued_tis`. `SchedulerJob.process_events` loops through `queued_tis` and tries to remove completed tasks. However, without customizing `__eq__` and `__hash__`, the following two lines have no effect, never removing elements from `queued_tis` leading to infinite retries on failure. This is related to my comment on #216. The following code was introduced in the fix to #1225.

```
elif ti in self.queued_tis:
    self.queued_tis.remove(ti)
```
