### PR TITLE
Fix infinite retries with pools

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -626,7 +626,7 @@ class TaskInstance(Base):
         return self._key() == other._key()
 
     def __hash__(self):
-        return hash(self.__key())
+        return hash(self._key())
 
    def command(
             self,

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -619,7 +619,16 @@ class TaskInstance(Base):
         if state:
             self.state = state
 
-    def command(
+    def _key(self):
+        return (self.task_id, self.dag_id, self.execution_date)
+
+    def __eq__(self, other):
+        return self._key() == other._key()
+
+    def __hash__(self):
+        return hash(self.__key())
+
+   def command(
             self,
             mark_success=False,
             ignore_dependencies=False,


### PR DESCRIPTION
`SchedulerJob` contains a `set` of `TaskInstance`s called `queued_tis`. `SchedulerJob.process_events` loops through `queued_tis` and tries to remove completed tasks. However, without customizing `__eq__` and `__hash__`, the following two lines in `jobs.py`'s `SchedulerJob.process_events` have no effect, never removing elements from `queued_tis` leading to infinite retries on failure. This is related to my comment on #216. The following code was introduced in the fix to #1225.

```
elif ti in self.queued_tis:
    self.queued_tis.remove(ti)
```
