### PR TITLE
Show only Airflow's deprecation warnings

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -17,9 +17,11 @@ from builtins import str
 from collections import OrderedDict
 from configparser import ConfigParser
 
-# show DeprecationWarning and PendingDeprecationWarning
-warnings.simplefilter('default', DeprecationWarning)
-warnings.simplefilter('default', PendingDeprecationWarning)
+# show Airflow's deprecation warnings
+warnings.filterwarnings(
+    action='default', category=DeprecationWarning, module='airflow')
+warnings.filterwarnings(
+    action='default', category=PendingDeprecationWarning, module='airflow')
 
 class AirflowConfigException(Exception):
     pass

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1602,7 +1602,7 @@ class BaseOperator(object):
             # TODO remove *args and **kwargs in Airflow 2.0
             warnings.warn(
                 'Invalid arguments were passed to {c}. Support for '
-                'passing such arguments will be dropped in Airflow 2.0.'
+                'passing such arguments will be dropped in Airflow 2.0. '
                 'Invalid arguments were:'
                 '\n*args: {a}\n**kwargs: {k}'.format(
                     c=self.__class__.__name__, a=args, k=kwargs),


### PR DESCRIPTION
Previous filter was too lenient and showed deprecation warnings from
ALL modules.
