### PR TITLE
Update plugins.rst for clarity on the example

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -112,17 +112,17 @@ definitions in Airflow.
     class TestView(BaseView):
         @expose('/')
         def test(self):
+            # in this example, put your test_plugin/test.html template at airflow/plugins/templates/test_plugin/test.html
             return self.render("test_plugin/test.html", content="Hello galaxy!")
     v = TestView(category="Test Plugin", name="Test View")
 
     # Creating a flask blueprint to intergrate the templates and static folder
     bp = Blueprint(
         "test_plugin", __name__,
-        template_folder='templates',
+        template_folder='templates', # registers airflow/plugins/templates as a Jinja template folder 
         static_folder='static',
         static_url_path='/static/test_plugin')
-
-
+        
     ml = MenuLink(
         category='Test Plugin',
         name='Test Menu Link',


### PR DESCRIPTION
The plugins tutorial was lacking in the following ways:
1. I wasn't sure where my template should live
2. I wasn't aware that both the TestView and Blueprint were necessary

In lieu of a code refactor, here's my suggestion on how to make the documentation more helpful from the perspective of someone who doesn't have experience with Flask Blueprints and Flask Admin, which can prevent the deep-dive into the code and supporting libs that I just did!
