### PR TITLE
Fixing a broken example dag, example_skip_dag.py

### DIFF
--- a/airflow/example_dags/example_skip_dag.py
+++ b/airflow/example_dags/example_skip_dag.py
@@ -44,12 +44,6 @@ def create_test_pipeline(suffix, trigger_rule, dag):
 
     join = DummyOperator(task_id=trigger_rule, dag=dag, trigger_rule=trigger_rule)
 
-
-    op = MyEmrOperator(task_id='my_task_id', dag=dag,
-                       template='my_jinja_template.conf',
-                       params={ 'param1': '{{ ti.xcom_pull(...) }}' }
-    )
-
     join.set_upstream(skip_operator)
     join.set_upstream(always_true)
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -35,7 +35,7 @@ from airflow.configuration import AirflowConfigException
 
 import six
 
-NUM_EXAMPLE_DAGS = 14
+NUM_EXAMPLE_DAGS = 15
 DEV_NULL = '/dev/null'
 TEST_DAG_FOLDER = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), 'dags')


### PR DESCRIPTION
This is a fix for https://github.com/airbnb/airflow/issues/1313 that was introduced in https://github.com/airbnb/airflow/pull/1292
