### PR TITLE
Fix typo in comment in prioritize_queued method

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -603,7 +603,7 @@ class SchedulerJob(BaseJob):
         for pool, tis in list(d.items()):
             if not pool:
                 # Arbitrary:
-                # If queued outside of a pool, trigger no more than 32 per run
+                # If queued outside of a pool, trigger no more than 128 per run
                 open_slots = 128
             else:
                 open_slots = pools[pool].open_slots(session=session)


### PR DESCRIPTION
This PR fixes the comment to match code: open_slots = 128.

I am wondering what is the thought process behind setting open_slots to 128. Since the function is trying to prioritizing queues for an executor, it would make sense to derive the value of open_slots according to the the config flag 'parallelism' when no pools are created, and then subtract the number of running TIs that are not in any pools. And if we want to set a hard cap of 128 during prioritization, perhaps we can also document it somewhere to prevent surprises.

Perhaps I am missing something here, so just want to clarify. 
