### PR TITLE
Fix for missing edit actions

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1754,6 +1754,7 @@ class AirflowModelView(ModelView):
     list_template = 'airflow/model_list.html'
     edit_template = 'airflow/model_edit.html'
     create_template = 'airflow/model_create.html'
+    column_display_actions = True
     page_size = 500
 
 


### PR DESCRIPTION
Edit actions vanished after upgrading to flask-admin 1.4.0 . Fix for bringing those back.

![edit](https://cloud.githubusercontent.com/assets/802149/14380533/a0b19a64-fd88-11e5-8683-9da303829b70.png)
