### PR TITLE
Reduce logger verbosity

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -850,7 +850,6 @@ class BackfillJob(BaseJob):
 
                 # Mark the task as not ready to run
                 elif ti.state in (State.NONE, State.UPSTREAM_FAILED):
-                    self.logger.debug('Added {} to not_ready'.format(ti))
                     not_ready.add(key)
 
             self.heartbeat()

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -223,7 +223,7 @@ class DagBag(LoggingMixin):
                 filepath not in self.file_last_changed or
                 dttm != self.file_last_changed[filepath]):
             try:
-                self.logger.info("Importing " + filepath)
+                self.logger.debug("Importing " + filepath)
                 if mod_name in sys.modules:
                     del sys.modules[mod_name]
                 with timeout(
@@ -315,7 +315,7 @@ class DagBag(LoggingMixin):
             subdag.fileloc = root_dag.full_filepath
             subdag.is_subdag = True
             self.bag_dag(subdag, parent_dag=dag, root_dag=root_dag)
-        self.logger.info('Loaded DAG {dag}'.format(**locals()))
+        self.logger.debug('Loaded DAG {dag}'.format(**locals()))
 
     def collect_dags(
             self,


### PR DESCRIPTION
Move two very common DagBag logging messages from `INFO` to `DEBUG`; remove one old debugging log that doesn’t add much value (since it is printed almost every loop).
