### PR TITLE
Adding and instrumenting a validate function to the DAG object

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -9,5 +9,6 @@ pylint:
     - cyclic-import
     - invalid-name
     - super-on-old-class
+    - logging-format-interpolation
   options:
     docstring-min-length: 10

--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, Pool
@@ -86,3 +87,21 @@ class SubDagOperator(BaseOperator):
         self.subdag.run(
             start_date=ed, end_date=ed, donot_pickle=True,
             executor=self.executor)
+
+    def __deepcopy__(self, memo):
+        """
+        Deep copying object except for the attrs in DONT_DEEPCOPY_ATTRS
+        """
+        DONT_DEEPCOPY_ATTRS = ('executor')
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+
+        for k, v in list(self.__dict__.items()):
+            if k not in DONT_DEEPCOPY_ATTRS:
+                setattr(result, k, copy.deepcopy(v, memo))
+
+        for attr in DONT_DEEPCOPY_ATTRS:
+            if hasattr(self, attr):
+                setattr(result, attr, getattr(self, attr))
+        return result


### PR DESCRIPTION
The new DAG.validate function tries to deepcopy the DAG object. The DAG object being deepcopyable is a premise we need to validate. `deepcopy` errors are typically hard to debug, so this function tries to pinpoint the specific task the error is coming from. We can eventually do more checks and provide more information to pinpoint where the issue is coming from, though it is likely to come from tasks or callbacks.

We can instrument more checks in the future in this method as needed.
