### PR TITLE
Extract non_pooled_task_slot_count into a configuration param

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -92,6 +92,7 @@ defaults = {
         'sql_alchemy_pool_size': 5,
         'sql_alchemy_pool_recycle': 3600,
         'dagbag_import_timeout': 30,
+        'non_pooled_task_slot_count': 128,
     },
     'webserver': {
         'base_url': 'http://localhost:8080',
@@ -191,6 +192,10 @@ dag_concurrency = 16
 
 # Are DAGs paused by default at creation
 dags_are_paused_at_creation = True
+
+# When not using pools, tasks are run in the "default pool",
+# whose size is guided by this config element
+non_pooled_task_slot_count = 128
 
 # The maximum number of active DAG runs per DAG
 max_active_runs_per_dag = 16
@@ -366,6 +371,7 @@ donot_pickle = False
 dag_concurrency = 16
 dags_are_paused_at_creation = False
 fernet_key = {FERNET_KEY}
+non_pooled_task_slot_count = 128
 
 [webserver]
 base_url = http://localhost:8080

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -603,8 +603,9 @@ class SchedulerJob(BaseJob):
         for pool, tis in list(d.items()):
             if not pool:
                 # Arbitrary:
-                # If queued outside of a pool, trigger no more than 128 per run
-                open_slots = 128
+                # If queued outside of a pool, trigger no more than
+                # non_pooled_task_slot_count per run
+                open_slots = conf.getint('core', 'non_pooled_task_slot_count')
             else:
                 open_slots = pools[pool].open_slots(session=session)
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept the following PR that

Addresses the following issues (links to issues addressed by this PR) : None. This extracts the non_pooled_task_slot_count in to a configuration param. This param guides the number of concurrent tasks that can be run across all DAGs in the default pool (i.e. non-pooled DAGs). 

Reminder to contributors:

You must add an Apache License header to all new files
Please squash your commits when possible and follow the 7 rules of good Git commits
