### PR TITLE
Convert dag.tasks list to dict to avoid slowdown

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2338,7 +2338,7 @@ class DAG(LoggingMixin):
             del self.default_args['params']
 
         validate_key(dag_id)
-        self.tasks = []
+        self.task_dict = dict()
         self.dag_id = dag_id
         self.start_date = start_date
         self.end_date = end_date
@@ -2434,12 +2434,21 @@ class DAG(LoggingMixin):
             return dttm - self._schedule_interval
 
     @property
+    def tasks(self):
+        return list(self.task_dict.values())
+
+    @tasks.setter
+    def tasks(self, val):
+        raise AttributeError(
+            'DAG.tasks can not be modified. Use dag.add_task() instead.')
+
+    @property
     def task_ids(self):
-        return [t.task_id for t in self.tasks]
+        return list(self.task_dict.keys())
 
     @property
     def active_task_ids(self):
-        return [t.task_id for t in self.tasks if not t.adhoc]
+        return list(k for k, v in self.task_dict.items() if not v.adhoc)
 
     @property
     def active_tasks(self):
@@ -2790,7 +2799,7 @@ class DAG(LoggingMixin):
                 also_include += t.get_flat_relatives(upstream=True)
 
         # Compiling the unique list of tasks that made the cut
-        dag.tasks = list(set(regex_match + also_include))
+        dag.task_dict = {t.task_id: t for t in regex_match + also_include}
         for t in dag.tasks:
             # Removing upstream/downstream references to tasks that did not
             # made the cut
@@ -2804,9 +2813,8 @@ class DAG(LoggingMixin):
         return task_id in (t.task_id for t in self.tasks)
 
     def get_task(self, task_id):
-        for task in self.tasks:
-            if task.task_id == task_id:
-                return task
+        if task_id in self.task_dict:
+            return self.task_dict[task_id]
         raise AirflowException("Task {task_id} not found".format(**locals()))
 
     @provide_session
@@ -2872,6 +2880,7 @@ class DAG(LoggingMixin):
                 "to the DAG ".format(task.task_id))
         else:
             self.tasks.append(task)
+            self.task_dict[task.task_id] = task
             task.dag = self
 
         self.task_count = len(self.tasks)

--- a/tests/core.py
+++ b/tests/core.py
@@ -88,8 +88,11 @@ class CoreTest(unittest.TestCase):
         Tests scheduling a dag with no previous runs
         """
         dag = DAG(TEST_DAG_ID + 'test_schedule_dag_no_previous_runs')
-        dag.tasks = [models.BaseOperator(task_id="faketastic", owner='Also fake',
-                                         start_date=datetime(2015, 1, 2, 0, 0))]
+        dag.add_task(models.BaseOperator(
+            task_id="faketastic",
+            owner='Also fake',
+            start_date=datetime(2015, 1, 2, 0, 0)))
+
         dag_run = jobs.SchedulerJob(test_mode=True).schedule_dag(dag)
         assert dag_run is not None
         assert dag_run.dag_id == dag.dag_id
@@ -110,9 +113,10 @@ class CoreTest(unittest.TestCase):
         dag = DAG(TEST_DAG_ID + 'test_schedule_dag_fake_scheduled_previous',
                   schedule_interval=delta,
                   start_date=DEFAULT_DATE)
-        dag.tasks = [models.BaseOperator(task_id="faketastic",
-                                         owner='Also fake',
-                                         start_date=DEFAULT_DATE)]
+        dag.add_task(models.BaseOperator(
+            task_id="faketastic",
+            owner='Also fake',
+            start_date=DEFAULT_DATE))
         scheduler = jobs.SchedulerJob(test_mode=True)
         trigger = models.DagRun(
             dag_id=dag.dag_id,
@@ -140,8 +144,10 @@ class CoreTest(unittest.TestCase):
         """
         dag = DAG(TEST_DAG_ID + 'test_schedule_dag_once')
         dag.schedule_interval = '@once'
-        dag.tasks = [models.BaseOperator(task_id="faketastic", owner='Also fake',
-                                         start_date=datetime(2015, 1, 2, 0, 0))]
+        dag.add_task(models.BaseOperator(
+            task_id="faketastic",
+            owner='Also fake',
+            start_date=datetime(2015, 1, 2, 0, 0)))
         dag_run = jobs.SchedulerJob(test_mode=True).schedule_dag(dag)
         dag_run2 = jobs.SchedulerJob(test_mode=True).schedule_dag(dag)
 
@@ -170,7 +176,7 @@ class CoreTest(unittest.TestCase):
             task = models.BaseOperator(task_id='faketastic__%s' % i,
                                        owner='Also fake',
                                        start_date=date)
-            dag.tasks.append(task)
+            dag.task_dict[task.task_id] = task
             dag_runs.append(scheduler.schedule_dag(dag))
 
         additional_dag_run = scheduler.schedule_dag(dag)
@@ -209,7 +215,8 @@ class CoreTest(unittest.TestCase):
             task = models.BaseOperator(task_id='faketastic__%s' % i,
                                        owner='Also fake',
                                        start_date=date)
-            dag.tasks.append(task)
+
+            dag.task_dict[task.task_id] = task
 
             # Schedule the DagRun
             dag_run = scheduler.schedule_dag(dag)


### PR DESCRIPTION
After discussion with @mistercrunch, looks like #1213 introduced some slowdowns. I believe it's related to increased use of `dag.get_task()` which iterates over all tasks in `dag.tasks`. For example: https://github.com/airbnb/airflow/pull/1213/files#diff-a32a363fa616685db3bfefba947535b2R1767

The solution is to replace the list of tasks with a `{task_id: task}` dict. Adding a `tasks` property that returns a list of the dict's values means all other uses of `dag.tasks` should work.
