### PR TITLE
Fix logic in Airflow scheduler to prevent DAGs from being reloaded on…

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -65,7 +65,6 @@ from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 from airflow.utils.trigger_rule import TriggerRule
 
-
 Base = declarative_base()
 ID_LEN = 250
 SQL_ALCHEMY_CONN = configuration.get('core', 'SQL_ALCHEMY_CONN')
@@ -181,11 +180,12 @@ class DagBag(LoggingMixin):
         # If the root_dag_id is absent or expired
         orm_dag = DagModel.get_current(root_dag_id)
         if orm_dag and (
-                root_dag_id not in self.dags or (
-                    dag.last_loaded < (
-                    orm_dag.last_expired or datetime(2100, 1, 1)
+                root_dag_id not in self.dags or
+                (
+                    orm_dag.last_expired and
+                    dag.last_loaded < orm_dag.last_expired
                 )
-        )):
+        ):
             # Reprocessing source file
             found_dags = self.process_file(
                 filepath=orm_dag.fileloc, only_if_updated=False)

--- a/tests/models.py
+++ b/tests/models.py
@@ -26,8 +26,10 @@ from airflow import models, AirflowException
 from airflow.exceptions import AirflowSkipException
 from airflow.models import TaskInstance as TI
 from airflow.models import State as ST
+from airflow.models import DagModel
 from airflow.operators import DummyOperator, BashOperator, PythonOperator
 from airflow.utils.state import State
+from mock import patch
 from nose_parameterized import parameterized
 
 DEFAULT_DATE = datetime.datetime(2016, 1, 1)
@@ -113,6 +115,32 @@ class DagBagTest(unittest.TestCase):
         dagbag = models.DagBag(include_examples=True)
         assert dagbag.process_file(f.name) == []
 
+    @patch.object(DagModel,'get_current')
+    def test_get_dag_without_refresh(self, mock_dagmodel):
+        """
+        Test that, once a DAG is loaded, it doesn't get refreshed again if it
+        hasn't been expired.
+        """
+        dag_id = 'example_bash_operator'
+
+        mock_dagmodel.return_value = DagModel()
+        mock_dagmodel.return_value.last_expired = None
+        mock_dagmodel.return_value.fileloc = 'foo'
+
+        class TestDagBag(models.DagBag):
+            process_file_calls = 0
+            def process_file(self, filepath, only_if_updated=True, safe_mode=True):
+                if 'example_bash_operator.py' in filepath:
+                    TestDagBag.process_file_calls += 1
+                super(TestDagBag, self).process_file(filepath, only_if_updated, safe_mode)
+
+        dagbag = TestDagBag(include_examples=True)
+        processed_files = dagbag.process_file_calls
+
+        # Should not call process_file agani, since it's already loaded during init.
+        assert dagbag.process_file_calls == 1
+        assert dagbag.get_dag(dag_id) != None
+        assert dagbag.process_file_calls == 1
 
 class TaskInstanceTest(unittest.TestCase):
 


### PR DESCRIPTION
I have been observing strange behavior from the Airflow scheduler lately. The behavior manifests itself as having a lot of active DAG runs with very few task instances being executed. Then, every two minutes, or so, a bunch of task instances would get scheduled. They'd then finish up pretty quickly (< 30s), and there would be no activity for 1m30s until more tasks were added.

Upon investigation, it appears that the Airflow scheduler was taking more than 2 minutes to complete a single loop. We put in profiling in the jobs.py _execute method, and it became apparent that this loop was the culprit:

```
            for dag in dags:
                self.logger.debug("Scheduling {}".format(dag.dag_id))
                dag = dagbag.get_dag(dag.dag_id)
                if not dag or (dag.dag_id in paused_dag_ids):
                    continue
                try:
                    self.schedule_dag(dag)
                    self.process_dag(dag, executor)
                    self.manage_slas(dag)
                except Exception as e:
                    self.logger.exception(e)
```

The dagbag.get_dag(dag.dag_id) invocation was taking about 500ms per-DAG. I have 270 DAGs. 270 \* .5 = ~2 minutes.

The get_dag method has an if-statement to determine if the DAG should be refreshed. Every DAG was getting refreshed on every iteration. This was happening because orm_dag.last_expired is None for all DAGs, which resulted in a check of `dag.last_loaded < datetime(2100, 1, 1)`, which it always is.

The fix appears to only check if last_expired is not None. If it's None, the UI hasn't been clicked, and we shouldn't bother checking if it needs to be refreshed (unless it's not in self.dags).

This dropped the scheduler loop from ~2 minutes to 16 seconds. This is still not great, but it's better. Now, each iteration of the for loop takes .05s. Still, .05_270 = 13.5 seconds. Ideally, I'd like this loop to be even lower. 270 DAGs aren't *that_ many.

I think the scheduler's loop might need to be re-thought a bit, but I'll leave that for a different issue.
