### PR TITLE
[AIRFLOW-56] Airflow's scheduler can "lose" queued tasks

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -30,10 +30,11 @@ class BaseExecutor(LoggingMixin):
         """
         pass
 
-    def queue_command(self, key, command, priority=1, queue=None):
+    def queue_command(self, task_instance, command, priority=1, queue=None):
+        key = task_instance.key
         if key not in self.queued_tasks and key not in self.running:
             self.logger.info("Adding to queue: {}".format(command))
-            self.queued_tasks[key] = (command, priority, queue)
+            self.queued_tasks[key] = (command, priority, queue, task_instance)
 
     def queue_task_instance(
             self,
@@ -54,7 +55,7 @@ class BaseExecutor(LoggingMixin):
             pool=pool,
             pickle_id=pickle_id)
         self.queue_command(
-            task_instance.key,
+            task_instance,
             command,
             priority=task_instance.task.priority_weight_total,
             queue=task_instance.task.queue)
@@ -67,9 +68,6 @@ class BaseExecutor(LoggingMixin):
         pass
 
     def heartbeat(self):
-        # Calling child class sync method
-        self.logger.debug("Calling the {} sync method".format(self.__class__))
-        self.sync()
 
         # Triggering new jobs
         if not self.parallelism:
@@ -86,10 +84,27 @@ class BaseExecutor(LoggingMixin):
             key=lambda x: x[1][1],
             reverse=True)
         for i in range(min((open_slots, len(self.queued_tasks)))):
-            key, (command, priority, queue) = sorted_queue.pop(0)
-            self.running[key] = command
+            key, (command, _, queue, ti) = sorted_queue.pop(0)
+            # TODO(jlowin) without a way to know what Job ran which tasks,
+            # there is a danger that another Job started running a task
+            # that was also queued to this executor. This is the last chance
+            # to check if that hapened. The most probable way is that a
+            # Scheduler tried to run a task that was originally queued by a
+            # Backfill. This fix reduces the probability of a collision but
+            # does NOT eliminate it.
             self.queued_tasks.pop(key)
-            self.execute_async(key, command=command, queue=queue)
+            ti.refresh_from_db()
+            if ti.state != State.RUNNING:
+                self.running[key] = command
+                self.execute_async(key, command=command, queue=queue)
+            else:
+                self.logger.debug(
+                    'Task is already running, not sending to '
+                    'executor: {}'.format(key))
+
+        # Calling child class sync method
+        self.logger.debug("Calling the {} sync method".format(self.__class__))
+        self.sync()
 
     def change_state(self, key, state):
         self.running.pop(key)

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -95,3 +95,4 @@ class CeleryExecutor(BaseExecutor):
                     async.state not in celery_states.READY_STATES
                     for async in self.tasks.values()]):
                 time.sleep(5)
+        self.sync()

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -73,4 +73,4 @@ class LocalExecutor(BaseExecutor):
         [self.queue.put((None, None)) for w in self.workers]
         # Wait for commands to finish
         self.queue.join()
-
+        self.sync()

--- a/tests/dags/test_issue_1225.py
+++ b/tests/dags/test_issue_1225.py
@@ -23,12 +23,24 @@ from datetime import datetime
 from airflow.models import DAG
 from airflow.operators import DummyOperator, PythonOperator, SubDagOperator
 from airflow.utils.trigger_rule import TriggerRule
+import time
+
 DEFAULT_DATE = datetime(2016, 1, 1)
 default_args = dict(
     start_date=DEFAULT_DATE,
     owner='airflow')
 
 def fail():
+    raise ValueError('Expected failure.')
+
+def delayed_fail():
+    """
+    Delayed failure to make sure that processes are running before the error
+    is raised.
+    
+    TODO handle more directly (without sleeping)
+    """
+    time.sleep(5)
     raise ValueError('Expected failure.')
 
 # DAG tests backfill with pooled tasks
@@ -123,7 +135,9 @@ dag8 = DAG(
     end_date=DEFAULT_DATE,
     default_args=default_args)
 dag8_task1 = PythonOperator(
-    python_callable=fail,
+    # use delayed_fail because otherwise LocalExecutor will have a chance to
+    # complete the task
+    python_callable=delayed_fail,
     task_id='test_queued_task',
     dag=dag8,
     pool='test_queued_pool')


### PR DESCRIPTION
When Scheduler is run with `—num-runs`, there can be multiple
Schedulers and Executors all trying to run tasks. For queued tasks,
Scheduler was previously only trying to run tasks that it itself had
queued — but that doesn’t work if the Scheduler is restarting. This PR
reverts that behavior and adds two types of “best effort” executions —
before running a TI, executors check if it is already running, and
before ending executors call sync() one last time

Closes https://issues.apache.org/jira/browse/AIRFLOW-56
