### PR TITLE
Use urljoin to join endpoint to base URL

### DIFF
--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -14,6 +14,10 @@
 #
 from builtins import str
 import logging
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
 
 import requests
 
@@ -58,7 +62,7 @@ class HttpHook(BaseHook):
 
         session = self.get_conn(headers)
 
-        url = self.base_url + endpoint
+        url = urljoin(self.base_url, endpoint)
         req = None
         if self.method == 'GET':
             # GET uses params

--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -62,7 +62,7 @@ class HttpHook(BaseHook):
 
         session = self.get_conn(headers)
 
-        url = urljoin(self.base_url, endpoint)
+        url = urljoin(str(self.base_url), str(endpoint))
         req = None
         if self.method == 'GET':
             # GET uses params


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept the following PR that adds robustness against various combinations of trailing and leading slashes.
