### PR TITLE
Properly handle BigQuery booleans in BigQuery hook.

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -782,6 +782,7 @@ def _bq_cast(string_field, bq_type):
     elif bq_type == 'FLOAT':
         return float(string_field)
     elif bq_type == 'BOOLEAN':
-        return bool(string_field)
+        assert string_field in set(['true', 'false'])
+        return string_field == 'true'
     else:
         return string_field


### PR DESCRIPTION
I discovered a pretty nasty bug with BigQuery type handling. BigQuery returns JSON for boolean fields as `'true'` and `'false'`, not `true` and `false`. Our code was doing `bool('false')`, which was evaluating everything to `True`.
