### PR TITLE
New CLI param for initializing DB without connection examples

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -512,7 +512,7 @@ def worker(args):
 
 def initdb(args):  # noqa
     print("DB: " + repr(settings.engine.url))
-    db_utils.initdb()
+    db_utils.initdb(args.load_examples)
     print("Done.")
 
 
@@ -523,7 +523,7 @@ def resetdb(args):
             "Proceed? (y/n)").upper() == "Y":
         logging.basicConfig(level=settings.LOGGING_LEVEL,
                             format=settings.SIMPLE_LOG_FORMAT)
-        db_utils.resetdb()
+        db_utils.resetdb(args.load_examples)
     else:
         print("Bail.")
 
@@ -760,6 +760,12 @@ class CLIFactory(object):
             ("-d", "--debug"),
             "Use the server that ships with Flask in debug mode",
             "store_true"),
+        # initdb
+        'load_examples': Arg(
+            ("-l", "--load-examples"),
+            "Load examples when initializing metadata database",
+            "store_true",
+            default=False),
         # resetdb
         'yes': Arg(
             ("-y", "--yes"),
@@ -856,7 +862,7 @@ class CLIFactory(object):
         }, {
             'func': initdb,
             'help': "Initialize the metadata database",
-            'args': tuple(),
+            'args': ('load_examples',),
         }, {
             'func': list_dags,
             'help': "List all the DAGs",
@@ -886,7 +892,7 @@ class CLIFactory(object):
         }, {
             'func': resetdb,
             'help': "Burn down and rebuild the metadata database",
-            'args': ('yes',),
+            'args': ('load_examples', 'yes',),
         }, {
             'func': upgradedb,
             'help': "Upgrade metadata database to latest version",

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -83,89 +83,90 @@ def merge_conn(conn, session=None):
         session.commit()
 
 
-def initdb():
+def initdb(load_examples=False):
     session = settings.Session()
 
     from airflow import models
     upgradedb()
 
-    merge_conn(
-        models.Connection(
-            conn_id='airflow_db', conn_type='mysql',
-            host='localhost', login='root', password='',
-            schema='airflow'))
-    merge_conn(
-        models.Connection(
-            conn_id='airflow_ci', conn_type='mysql',
-            host='localhost', login='root',
-            schema='airflow_ci'))
-    merge_conn(
-        models.Connection(
-            conn_id='beeline_default', conn_type='beeline', port="10000",
-            host='localhost', extra="{\"use_beeline\": true, \"auth\": \"\"}",
-            schema='default'))
-    merge_conn(
-        models.Connection(
-            conn_id='bigquery_default', conn_type='bigquery'))
-    merge_conn(
-        models.Connection(
-            conn_id='local_mysql', conn_type='mysql',
-            host='localhost', login='airflow', password='airflow',
-            schema='airflow'))
-    merge_conn(
-        models.Connection(
-            conn_id='presto_default', conn_type='presto',
-            host='localhost',
-            schema='hive', port=3400))
-    merge_conn(
-        models.Connection(
-            conn_id='hive_cli_default', conn_type='hive_cli',
-            schema='default',))
-    merge_conn(
-        models.Connection(
-            conn_id='hiveserver2_default', conn_type='hiveserver2',
-            host='localhost',
-            schema='default', port=10000))
-    merge_conn(
-        models.Connection(
-            conn_id='metastore_default', conn_type='hive_metastore',
-            host='localhost', extra="{\"authMechanism\": \"PLAIN\"}",
-            port=9083))
-    merge_conn(
-        models.Connection(
-            conn_id='mysql_default', conn_type='mysql',
-            login='root',
-            host='localhost'))
-    merge_conn(
-        models.Connection(
-            conn_id='postgres_default', conn_type='postgres',
-            login='postgres',
-            schema='airflow',
-            host='localhost'))
-    merge_conn(
-        models.Connection(
-            conn_id='sqlite_default', conn_type='sqlite',
-            host='/tmp/sqlite_default.db'))
-    merge_conn(
-        models.Connection(
-            conn_id='http_default', conn_type='http',
-            host='https://www.google.com/'))
-    merge_conn(
-        models.Connection(
-            conn_id='mssql_default', conn_type='mssql',
-            host='localhost', port=1433))
-    merge_conn(
-        models.Connection(
-            conn_id='vertica_default', conn_type='vertica',
-            host='localhost', port=5433))
-    merge_conn(
-        models.Connection(
-            conn_id='webhdfs_default', conn_type='hdfs',
-            host='localhost', port=50070))
-    merge_conn(
-        models.Connection(
-            conn_id='ssh_default', conn_type='ssh',
-            host='localhost'))
+    if load_examples:
+        merge_conn(
+            models.Connection(
+                conn_id='airflow_db', conn_type='mysql',
+                host='localhost', login='root', password='',
+                schema='airflow'))
+        merge_conn(
+            models.Connection(
+                conn_id='airflow_ci', conn_type='mysql',
+                host='localhost', login='root',
+                schema='airflow_ci'))
+        merge_conn(
+            models.Connection(
+                conn_id='beeline_default', conn_type='beeline', port="10000",
+                host='localhost', extra="{\"use_beeline\": true, \"auth\": \"\"}",
+                schema='default'))
+        merge_conn(
+            models.Connection(
+                conn_id='bigquery_default', conn_type='bigquery'))
+        merge_conn(
+            models.Connection(
+                conn_id='local_mysql', conn_type='mysql',
+                host='localhost', login='airflow', password='airflow',
+                schema='airflow'))
+        merge_conn(
+            models.Connection(
+                conn_id='presto_default', conn_type='presto',
+                host='localhost',
+                schema='hive', port=3400))
+        merge_conn(
+            models.Connection(
+                conn_id='hive_cli_default', conn_type='hive_cli',
+                schema='default',))
+        merge_conn(
+            models.Connection(
+                conn_id='hiveserver2_default', conn_type='hiveserver2',
+                host='localhost',
+                schema='default', port=10000))
+        merge_conn(
+            models.Connection(
+                conn_id='metastore_default', conn_type='hive_metastore',
+                host='localhost', extra="{\"authMechanism\": \"PLAIN\"}",
+                port=9083))
+        merge_conn(
+            models.Connection(
+                conn_id='mysql_default', conn_type='mysql',
+                login='root',
+                host='localhost'))
+        merge_conn(
+            models.Connection(
+                conn_id='postgres_default', conn_type='postgres',
+                login='postgres',
+                schema='airflow',
+                host='localhost'))
+        merge_conn(
+            models.Connection(
+                conn_id='sqlite_default', conn_type='sqlite',
+                host='/tmp/sqlite_default.db'))
+        merge_conn(
+            models.Connection(
+                conn_id='http_default', conn_type='http',
+                host='https://www.google.com/'))
+        merge_conn(
+            models.Connection(
+                conn_id='mssql_default', conn_type='mssql',
+                host='localhost', port=1433))
+        merge_conn(
+            models.Connection(
+                conn_id='vertica_default', conn_type='vertica',
+                host='localhost', port=5433))
+        merge_conn(
+            models.Connection(
+                conn_id='webhdfs_default', conn_type='hdfs',
+                host='localhost', port=50070))
+        merge_conn(
+            models.Connection(
+                conn_id='ssh_default', conn_type='ssh',
+                host='localhost'))
 
     # Known event types
     KET = models.KnownEventType
@@ -214,7 +215,7 @@ def upgradedb():
     command.upgrade(config, 'heads')
 
 
-def resetdb():
+def resetdb(load_examples):
     '''
     Clear out the database
     '''
@@ -225,4 +226,4 @@ def resetdb():
     mc = MigrationContext.configure(settings.engine)
     if mc._version.exists(settings.engine):
         mc._version.drop(settings.engine)
-    initdb()
+    initdb(load_examples)

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -27,8 +27,8 @@ fi
 which airflow > /dev/null || python setup.py develop
 
 echo "Initializing the DB"
-yes | airflow resetdb
-airflow initdb
+yes | airflow resetdb --load-examples
+airflow initdb --load-examples
 
 echo "Starting the unit tests with the following nose arguments: "$nose_args
 nosetests $nose_args


### PR DESCRIPTION
Hi,

When running Airflow into a non development environment, I have found out that it could be a good idea to not initialize the metadata DB with the default connections that are added when you run `airflow initdb`.

With this PR, the DB is initialized without the connection examples and they are only added if you explicit it in the CLI as follows: `airflow initdb -l` or `airflow initdb --load-examples`. The same applies when running resetdb: `airflow resetdb -l` or `airflow resetdb --load-examples`.

If this functionality is covered with some features that I haven't heard of so far, please, forgive me, I am still quite new using the platform. If not, and you consider that it could be useful for other people, I'd be glad to see it merged.

Thanks in advance!
