### PR TITLE
Fixed a blocker bug in the scheduler: num_runs used where runs intended

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -718,7 +718,7 @@ class SchedulerJob(BaseJob):
 
                 self.runs += 1
                 try:
-                    if self.num_runs % self.refresh_dags_every == 0:
+                    if self.runs % self.refresh_dags_every == 0:
                         dagbag = models.DagBag(self.subdir, sync_to_db=True)
                     else:
                         dagbag.collect_dags(only_if_updated=True)


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept the following PR that
- Addresses the following issues (links to issues addressed by this PR) : https://github.com/airbnb/airflow/issues/1395

Reminder to contributors:
- You must add an Apache License header to all new files
- Please squash your commits when possible and follow the [7 rules of good Git commits](http://chris.beams.io/posts/git-commit/#seven-rules)

In a nutshell, `num_runs` used where `runs` intended, leading to a failure to load the dag bag.
