### PR TITLE
Add missing args to `airflow clear`

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -819,7 +819,8 @@ class CLIFactory(object):
             'help': "Clear a set of task instance, as if they never ran",
             'args': (
                 'dag_id', 'task_regex', 'start_date', 'end_date', 'subdir',
-                'upstream', 'downstream', 'no_confirm'),
+                'upstream', 'downstream', 'no_confirm', 'only_failed',
+                'only_running'),
         }, {
             'func': pause,
             'help': "Pause a DAG",


### PR DESCRIPTION
Running `airflow clear dag_id` from the CLI fails because the
`only_failed` and `only_running` args weren’t supplied by the factory.
