### PR TITLE
Improved error message when converting columns in charts

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -348,7 +348,14 @@ class Airflow(BaseView):
                     df[df.columns[x_col]] = pd.to_datetime(
                         df[df.columns[x_col]])
                 except Exception as e:
-                    raise AirflowException(str(e))
+                    error_format_str = ("Error in chart ID {} while converting " +
+                                        "X column {} to datetime. Please verify " +
+                                        "that the X values are valid and can be " +
+                                        "converted to datetime. Exception was: {}")
+                    payload['error'] += error_format_str.format(chart_id,
+                                                                x_col,
+                                                                str(e))
+                    return wwwutils.json_response(payload)
                 df[df.columns[x_col]] = df[df.columns[x_col]].apply(
                     lambda x: int(x.strftime("%s")) * 1000)
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept the following PR that addresses an issue related to the following situation:
1. A user creates a Airflow chart using a SQL query.
2. The checkbox that specifies that the X column is a datetime is checked.
3. The X column generated by the SQL query can't be converted into a datetime.
4. The user sees a cryptic `INTERNAL ERROR` message.

This PR adds more details to the error message so that the user has a hint that the X column may have an issue.
