### PR TITLE
Add KafkaConsumerHook and KafkaSensor

### DIFF
--- a/airflow/contrib/hooks/kafka_hook.py
+++ b/airflow/contrib/hooks/kafka_hook.py
@@ -1,0 +1,29 @@
+from airflow.hooks import BaseHook
+from kafka import KafkaConsumer
+
+
+class KafkaConsumerHook(BaseHook):
+
+    default_host = 'localhost'
+    default_port = 9092
+
+    def __init__(self, conn_id):
+        super(KafkaConsumerHook, self).__init__(None)
+        self.conn = self.get_connection(conn_id)
+        self.consumer = None
+
+    def get_conn(self):
+        if not self.consumer:
+            conf = self.conn.extra_dejson
+            host = self.conn.host or self.default_host
+            port = self.conn.port or self.default_port
+
+            server = '{host}:{port}'.format(**locals())
+            self.consumer = KafkaConsumer(
+                bootstrap_servers=server, **conf)
+
+        return self.consumer
+
+    def get_message(self):
+        consumer = self.get_conn()
+        return next(consumer)

--- a/airflow/contrib/hooks/kafka_hook.py
+++ b/airflow/contrib/hooks/kafka_hook.py
@@ -28,8 +28,35 @@ class KafkaConsumerHook(BaseHook):
         return self.consumer
 
     def get_message(self):
+        """
+        Get one single message, blocks for a period
+        of timeout set by`consumer_timeout_ms`, then commit
+        the offset.
+
+        :return:
+            The message
+        """
         consumer = self.get_conn()
-        return next(consumer)
+        message = next(consumer)
+
+        # Commit the message, so that it won't be reprocessed.
+        consumer.commit()
+
+        return message
+
+    def get_messages(self):
+        """
+        Get all the messages haven't been consumed, it doesn't
+        block by default, then commit the offset.
+
+        :return:
+            A list of messages
+        """
+        consumer = self.get_conn()
+        messages = consumer.poll()
+
+        consumer.commit()
+        return messages
 
     def __repr__(self):
         """

--- a/airflow/contrib/hooks/kafka_hook.py
+++ b/airflow/contrib/hooks/kafka_hook.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from airflow.hooks import BaseHook
 from kafka import KafkaConsumer
 
@@ -15,19 +27,18 @@ class KafkaConsumerHook(BaseHook):
         self.topic = topic
 
     def get_conn(self):
-        if not self.consumer:
-            conf = self.conn.extra_dejson
-            host = self.conn.host or self.default_host
-            port = self.conn.port or self.default_port
+        conf = self.conn.extra_dejson
+        host = self.conn.host or self.default_host
+        port = self.conn.port or self.default_port
 
-            # Disable auto commit as the hook will commit right
-            # after polling.
-            conf['enable_auto_commit'] = False
+        # Disable auto commit as the hook will commit right
+        # after polling.
+        conf['enable_auto_commit'] = False
 
-            self.server = '{host}:{port}'.format(**locals())
-            self.consumer = KafkaConsumer(
-                self.topic,
-                bootstrap_servers=self.server, **conf)
+        self.server = '{host}:{port}'.format(**locals())
+        self.consumer = KafkaConsumer(
+            self.topic,
+            bootstrap_servers=self.server, **conf)
 
         return self.consumer
 
@@ -43,7 +54,7 @@ class KafkaConsumerHook(BaseHook):
 
         # `poll` returns a dict where keys are the partitions
         # and values are the corresponding messages.
-        messages = consumer.poll()
+        messages = consumer.poll(timeout_ms=50)
 
         consumer.commit()
         return messages

--- a/airflow/contrib/hooks/kafka_hook.py
+++ b/airflow/contrib/hooks/kafka_hook.py
@@ -7,10 +7,12 @@ class KafkaConsumerHook(BaseHook):
     default_host = 'localhost'
     default_port = 9092
 
-    def __init__(self, conn_id):
+    def __init__(self, conn_id, topic):
         super(KafkaConsumerHook, self).__init__(None)
         self.conn = self.get_connection(conn_id)
+        self.server = None
         self.consumer = None
+        self.topic = topic
 
     def get_conn(self):
         if not self.consumer:
@@ -18,12 +20,22 @@ class KafkaConsumerHook(BaseHook):
             host = self.conn.host or self.default_host
             port = self.conn.port or self.default_port
 
-            server = '{host}:{port}'.format(**locals())
+            self.server = '{host}:{port}'.format(**locals())
             self.consumer = KafkaConsumer(
-                bootstrap_servers=server, **conf)
+                self.topic,
+                bootstrap_servers=self.server, **conf)
 
         return self.consumer
 
     def get_message(self):
         consumer = self.get_conn()
         return next(consumer)
+
+    def __repr__(self):
+        """
+        Pretty the hook with the connection info
+        """
+        connected = self.consumer is not None
+        return '<KafkaConsumerHook ' \
+               'connected?=%s server=%s topic=%s>' % \
+               (connected, self.server, self.topic)

--- a/airflow/contrib/operators/kafka_sensor.py
+++ b/airflow/contrib/operators/kafka_sensor.py
@@ -31,9 +31,9 @@ class KafkaSensor(BaseSensorOperator):
             'Poking topic: %s, using hook: %s',
             self.topic, self.hook)
 
-        message = self.hook.get_message()
+        messages = self.hook.get_messages()
 
         logging.info(
-            'Got message during poking: %s', message)
+            'Got messages during poking: %s', messages)
 
-        return message or False
+        return messages or False

--- a/airflow/contrib/operators/kafka_sensor.py
+++ b/airflow/contrib/operators/kafka_sensor.py
@@ -1,0 +1,39 @@
+import logging
+
+from airflow.contrib.hooks.kafka_hook import KafkaConsumerHook
+from airflow.operators.sensors import BaseSensorOperator
+from airflow.utils import apply_defaults
+
+
+class KafkaSensor(BaseSensorOperator):
+    """
+    Consumes the Kafka message with the specific topic
+    """
+
+    @apply_defaults
+    def __init__(self, conn_id, topic, *args, **kwargs):
+        """
+        Initialize the sensor, the connection establish
+        is put off to it's first time usage.
+
+        :param conn_id:
+            the kafka broker connection whom this sensor
+            subscripts against.
+        :param topic:
+            the subscribed topic
+        """
+        self.topic = topic
+        self.hook = KafkaConsumerHook(conn_id, topic)
+        super(KafkaSensor, self).__init__(*args, **kwargs)
+
+    def poke(self, context):
+        logging.info(
+            'Poking topic: %s, using hook: %s',
+            self.topic, self.hook)
+
+        message = self.hook.get_message()
+
+        logging.info(
+            'Got message during poking: %s', message)
+
+        return message or False

--- a/airflow/contrib/operators/kafka_sensor.py
+++ b/airflow/contrib/operators/kafka_sensor.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 
 from airflow.contrib.hooks.kafka_hook import KafkaConsumerHook

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -58,3 +58,4 @@ mock
 hdfs
 thrift_sasl
 impyla
+kafka-python

--- a/setup.py
+++ b/setup.py
@@ -94,12 +94,13 @@ password = [
 ]
 github_enterprise = ['Flask-OAuthlib>=0.9.1']
 qds = ['qds-sdk>=1.9.0']
+kafka = ['kafka-python>=1.0.2']
 
 all_dbs = postgres + mysql + hive + mssql + hdfs + vertica
 devel = ['lxml>=3.3.4', 'nose', 'nose-parameterized', 'mock']
 devel_minreq = devel + mysql + doc + password + s3
 devel_hadoop = devel_minreq + hive + hdfs + webhdfs + kerberos
-devel_all = devel + all_dbs + doc + samba + s3 + slack + crypto + oracle + docker
+devel_all = devel + all_dbs + doc + samba + s3 + slack + crypto + oracle + docker + kafka
 
 
 setup(
@@ -168,7 +169,8 @@ setup(
         'kerberos': kerberos,
         'password': password,
         'github_enterprise': github_enterprise,
-        'qds': qds
+        'qds': qds,
+        'kafka': kafka
     },
     classifiers={
         'Development Status :: 5 - Production/Stable',

--- a/tests/contrib/hooks/__init__.py
+++ b/tests/contrib/hooks/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/contrib/hooks/__init__.py
+++ b/tests/contrib/hooks/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .kafka_hook import *

--- a/tests/contrib/hooks/kafka_hook.py
+++ b/tests/contrib/hooks/kafka_hook.py
@@ -21,7 +21,8 @@ class KafkaConsumerHookTest(unittest.TestCase):
     @patch('airflow.contrib.hooks.kafka_hook.KafkaConsumer')
     def test_initialize_consumer(self, ConsumerMock):
         hook = KafkaConsumerHook(self.conn_id, 'test-topic')
-        consumer = hook.get_conn()
+        # triggers the consumer initialization
+        hook.get_conn()
 
         ConsumerMock.assert_called_with(
             'test-topic',

--- a/tests/contrib/hooks/kafka_hook.py
+++ b/tests/contrib/hooks/kafka_hook.py
@@ -1,0 +1,39 @@
+import unittest
+
+from airflow import configuration
+from airflow.contrib.hooks.kafka_hook import KafkaConsumerHook
+from airflow.models import Connection
+from airflow.utils.db import resetdb, provide_session
+from mock import patch
+
+
+class KafkaConsumerHookTest(unittest.TestCase):
+    def setUp(self):
+        configuration.test_mode()
+        resetdb()
+
+        self.conn_id = 'test-kafka-conn-id'
+        self.broker_host = 'localhost'
+        self.broker_port = '6666'
+
+        self._prepare_connection()
+
+    @patch('kafka.KafkaConsumer')
+    def test_get_message(self):
+        hook = KafkaConsumerHook(self.conn_id)
+
+        # populate sample message
+        message = {'foo': 'baz'}
+        consumer = hook.get_conn()
+        self.assertDictEqual(
+            message, consumer.get_message())
+
+
+    @provide_session
+    def _prepare_connection(self, session):
+        conn = Connection(
+            self.conn_id,
+            host=self.broker_host, port=self.broker_port)
+
+        session.add(conn)
+        session.commit()

--- a/tests/contrib/hooks/kafka_hook.py
+++ b/tests/contrib/hooks/kafka_hook.py
@@ -18,16 +18,27 @@ class KafkaConsumerHookTest(unittest.TestCase):
 
         self._prepare_connection()
 
-    @patch('kafka.KafkaConsumer')
-    def test_get_message(self):
-        hook = KafkaConsumerHook(self.conn_id)
-
-        # populate sample message
-        message = {'foo': 'baz'}
+    @patch('airflow.contrib.hooks.kafka_hook.KafkaConsumer')
+    def test_initialize_consumer(self, ConsumerMock):
+        hook = KafkaConsumerHook(self.conn_id, 'test-topic')
         consumer = hook.get_conn()
-        self.assertDictEqual(
-            message, consumer.get_message())
 
+        ConsumerMock.assert_called_with(
+            'test-topic',
+            bootstrap_servers='localhost:6666', enable_auto_commit=False)
+
+    def test_get_messages(self):
+        message = {'foo': 'baz'}
+
+        with patch('airflow.contrib.hooks.kafka_hook.KafkaConsumer'):
+            hook = KafkaConsumerHook(self.conn_id, 'test-topic')
+
+            consumer = hook.get_conn()
+            # populate sample message
+            consumer.poll.return_value = {'test-partition': [message]}
+
+            self.assertDictEqual(
+                {'test-partition': [message]}, hook.get_messages())
 
     @provide_session
     def _prepare_connection(self, session):

--- a/tests/contrib/hooks/kafka_hook.py
+++ b/tests/contrib/hooks/kafka_hook.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 
 from airflow import configuration


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept the following PR that
- Add the `KafkaConsumerHook`.
- Add the `KafkaSensor` which listens to messages with the specific topic.

Related Issue:
#1311

Reminder to contributors:
- You must add an Apache License header to all new files
- Please squash your commits when possible and follow the [7 rules of good Git commits](http://chris.beams.io/posts/git-commit/#seven-rules)

I am new to the community, I am not sure the files are at the right place or missing anything. 

The sensor could be used as the first node of a dag where the second node can be a `TriggerDagRunOperator`. The messages are polled in a batch and the dag runs are dynamically generated.  

Thanks!
