### PR TITLE
Use os.execvp instead of subprocess.Popen for the webserver

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -405,14 +405,23 @@ def webserver(args):
             'Running the Gunicorn server with {workers} {args.workerclass}'
             'workers on host {args.hostname} and port '
             '{args.port} with a timeout of {worker_timeout}...'.format(**locals()))
-        sp = subprocess.Popen([
-            'gunicorn', '-w', str(args.workers), '-k', str(args.workerclass),
-            '-t', str(args.worker_timeout), '-b', args.hostname + ':' + str(args.port),
-            '-n', 'airflow-webserver', '--pid', pid,
-            'airflow.www.app:cached_app()']
+
+        run_args = ['gunicorn',
+                    '-w ' + str(args.workers),
+                    '-k ' + str(args.workerclass),
+                    '-t ' + str(args.worker_timeout),
+                    '-b ' + args.hostname + ':' + str(args.port),
+                    '-n ' + 'airflow-webserver',
+                    '-p ' + str(pid)]
+
+        if not args.foreground:
+            run_args.append("-D")
+
+        module = "airflow.www.app:cached_app()".encode()
+        run_args.append(module)
+        os.execvp(
+            'gunicorn', run_args
         )
-        if args.foreground:
-            sp.wait()
 
 
 def scheduler(args):


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept the following PR that
- Addresses the following issues (links to issues addressed by this PR) : #852 

Reminder to contributors:
- You must add an Apache License header to all new files
- Please squash your commits when possible and follow the [7 rules of good Git commits](http://chris.beams.io/posts/git-commit/#seven-rules)

subprocess.Popen forks before doing execv. This makes it difficult
for some manager daemons (like supervisord) to send kill signals.
This patch uses os.execve directly. os.execve takes over the current
process and thus responds correctly to signals
- Resolves residue in ISSUE-#852
