### PR TITLE
Make foreground default and use os.execvp in specific cases

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -17,13 +17,6 @@ Previously, new DAGs would be scheduled immediately. To retain the old behavior,
 dags_are_paused_at_creation = False
 ```
 
-### Worker, Scheduler, Webserver, Kerberos, Flower now detach by default
-
-The different daemons have been reworked to behave like traditional Unix daemons. This allows
-you to set PID file locations, log file locations including stdin and stderr.
-
-If you want to retain the old behavior specify ```-f``` or ```--foreground``` on the command line.
-
 ### Deprecated Features
 These features are marked for deprecation. They may still work (and raise a `DeprecationWarning`), but are no longer supported and will be removed entirely in Airflow 2.0
 

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -411,7 +411,7 @@ def webserver(args):
             '-n', 'airflow-webserver', '--pid', pid,
             'airflow.www.app:cached_app()']
         )
-        if args.foreground:
+        if args.daemon:
             sp.wait()
 
 
@@ -423,7 +423,7 @@ def scheduler(args):
         num_runs=args.num_runs,
         do_pickle=args.do_pickle)
 
-    if not args.foreground:
+    if args.daemon:
         pid, stdout, stderr, log_file = setup_locations("scheduler", args.pid, args.stdout, args.stderr, args.log_file)
         handle = setup_logging(log_file)
         stdout = open(stdout, 'w+')
@@ -481,7 +481,7 @@ def worker(args):
         'concurrency': args.concurrency,
     }
 
-    if not args.foreground:
+    if args.daemon:
         pid, stdout, stderr, log_file = setup_locations("worker", args.pid, args.stdout, args.stderr, args.log_file)
         handle = setup_logging(log_file)
         stdout = open(stdout, 'w+')
@@ -539,13 +539,12 @@ def version(args):  # noqa
 
 def flower(args):
     broka = conf.get('celery', 'BROKER_URL')
-    args.port = args.port
-    port = '--port=' + args.port
+    port = '--port={}'.format(args.port)
     api = ''
     if args.broker_api:
         api = '--broker_api=' + args.broker_api
 
-    if not args.foreground:
+    if args.daemon:
         pid, stdout, stderr, log_file = setup_locations("flower", args.pid, args.stdout, args.stderr, args.log_file)
         stdout = open(stdout, 'w+')
         stderr = open(stderr, 'w+')
@@ -557,8 +556,7 @@ def flower(args):
         )
 
         with ctx:
-            sp = subprocess.Popen(['flower', '-b', broka, port, api])
-            sp.wait()
+            os.execvp("flower", ['flower', '-b', broka, port, api])
 
         stdout.close()
         stderr.close()
@@ -566,15 +564,14 @@ def flower(args):
         signal.signal(signal.SIGINT, sigint_handler)
         signal.signal(signal.SIGTERM, sigint_handler)
 
-        sp = subprocess.Popen(['flower', '-b', broka, port, api])
-        sp.wait()
+        os.execvp("flower", ['flower', '-b', broka, port, api])
 
 
 def kerberos(args):  # noqa
     print(settings.HEADER)
     import airflow.security.kerberos
 
-    if not args.foreground:
+    if args.daemon:
         pid, stdout, stderr, log_file = setup_locations("kerberos", args.pid, args.stdout, args.stderr, args.log_file)
         stdout = open(stdout, 'w+')
         stderr = open(stderr, 'w+')
@@ -625,8 +622,8 @@ class CLIFactory(object):
         'pid': Arg(
             ("--pid", ), "PID file location",
             nargs='?'),
-        'foreground': Arg(
-            ("-f", "--foreground"), "Do not detach. Run in foreground", "store_true"),
+        'daemon': Arg(
+            ("-D", "--daemon"), "Daemonize instead of running on the foreground", "store_true"),
         'stderr': Arg(
             ("--stderr", ), "Redirect stderr to this file"),
         'stdout': Arg(
@@ -841,7 +838,7 @@ class CLIFactory(object):
             'func': kerberos,
             'help': "Start a kerberos ticket renewer",
             'args': ('principal', 'keytab', 'pid',
-                     'foreground', 'stdout', 'stderr', 'log_file'),
+                     'daemon', 'stdout', 'stderr', 'log_file'),
         }, {
             'func': render,
             'help': "Render a task instance's template(s)",
@@ -882,7 +879,7 @@ class CLIFactory(object):
             'func': webserver,
             'help': "Start a Airflow webserver instance",
             'args': ('port', 'workers', 'workerclass', 'worker_timeout', 'hostname',
-                     'pid', 'foreground', 'stdout', 'stderr', 'log_file',
+                     'pid', 'daemon', 'stdout', 'stderr', 'log_file',
                      'debug'),
         }, {
             'func': resetdb,
@@ -896,17 +893,17 @@ class CLIFactory(object):
             'func': scheduler,
             'help': "Start a scheduler scheduler instance",
             'args': ('dag_id_opt', 'subdir', 'num_runs', 'do_pickle',
-                     'pid', 'foreground', 'stdout', 'stderr', 'log_file'),
+                     'pid', 'daemon', 'stdout', 'stderr', 'log_file'),
         }, {
             'func': worker,
             'help': "Start a Celery worker node",
             'args': ('do_pickle', 'queues', 'concurrency',
-                     'pid', 'foreground', 'stdout', 'stderr', 'log_file'),
+                     'pid', 'daemon', 'stdout', 'stderr', 'log_file'),
         }, {
             'func': flower,
             'help': "Start a Celery Flower",
             'args': ('flower_port', 'broker_api',
-                     'pid', 'foreground', 'stdout', 'stderr', 'log_file'),
+                     'pid', 'daemon', 'stdout', 'stderr', 'log_file'),
         }, {
             'func': version,
             'help': "Show the version",


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept the following PR that
- Addresses the following issues (links to issues addressed by this PR) : #852 

Reminder to contributors:
- You must add an Apache License header to all new files
- Please squash your commits when possible and follow the [7 rules of good Git commits](http://chris.beams.io/posts/git-commit/#seven-rules)

subprocess.Popen forks before doing execv. This makes it difficult
for some manager daemons (like supervisord) to send kill signals.
This patch uses os.execve directly. os.execve takes over the current
process and thus responds correctly to signals

It also reverts detaching from the console by default. You can still enable this by using "-D" or "--daemon"
