### PR TITLE
correct missed arg.foreground to arg.daemon in cli

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -414,7 +414,7 @@ def webserver(args):
                     '-n ' + 'airflow-webserver',
                     '-p ' + str(pid)]
 
-        if not args.foreground:
+        if args.daemon:
             run_args.append("-D")
 
         module = "airflow.www.app:cached_app()".encode()


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept the following PR that
- Addresses the following issues (links to issues addressed by this PR) : cli bug fix

Reminder to contributors:
- You must add an Apache License header to all new files
- Please squash your commits when possible and follow the [7 rules of good Git commits](http://chris.beams.io/posts/git-commit/#seven-rules)
