### PR TITLE
[AIRFLOW-35] Enable UI feature to recursively set success for nested DAG operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ unittests.cfg
 error.log
 unittests.db
 rat-results.txt
+/.eggs/
+/.tox/

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -166,6 +166,10 @@
               type="button" class="btn" data-toggle="button">
               Downstream
             </button>
+            <button id="btn_success_recursive"
+              type="button" class="btn" data-toggle="button">
+              Recursive
+            </button>
           </span>
         </div>
         <div class="modal-footer">
@@ -293,6 +297,7 @@ function updateQueryStringParameter(uri, key, value) {
         "&downstream=" + $('#btn_success_downstream').hasClass('active') +
         "&future=" + $('#btn_success_future').hasClass('active') +
         "&past=" + $('#btn_success_past').hasClass('active') +
+        "&recursive=" + $('#btn_success_recursive').hasClass('active') +
         "&execution_date=" + execution_date +
         "&origin=" + encodeURIComponent(window.location);
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -853,6 +853,19 @@ class WebUiTests(unittest.TestCase):
             'origin=/admin'.format(DEFAULT_DATE_DS))
         assert "Wait a minute" in response.data.decode('utf-8')
         url = (
+            "/admin/airflow/success?task_id=section-1&"
+            "dag_id=example_subdag_operator&upstream=true&downstream=true&"
+            "recursive=true&future=false&past=false&execution_date={}&"
+            "origin=/admin".format(DEFAULT_DATE_DS))
+        response = self.app.get(url)
+        assert "Wait a minute" in response.data.decode('utf-8')
+        assert "section-1-task-1" in response.data.decode('utf-8')
+        assert "section-1-task-2" in response.data.decode('utf-8')
+        assert "section-1-task-3" in response.data.decode('utf-8')
+        assert "section-1-task-4" in response.data.decode('utf-8')
+        assert "section-1-task-5" in response.data.decode('utf-8')
+        response = self.app.get(url + "&confirmed=true")
+        url = (
             "/admin/airflow/clear?task_id=runme_1&"
             "dag_id=example_bash_operator&future=false&past=false&"
             "upstream=false&downstream=true&"


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept the following PR:

_Context_
Currently, when **marking the success status** of an operator via the UI, there is no way to **recursively include all operators that are nested within a SubDagOperator**

_Solution_
This PR adds a UI toggle "Recursive" (on the same level as Past/Future/Downstream/Upstream) to recursively set the success status of all operators within a SubDagOperator

![screen shot 2016-04-28 at 12 56 01 pm](https://cloud.githubusercontent.com/assets/2807888/14874138/a63c3c7e-0d40-11e6-87ee-f13743a4453b.png)
