### PR TITLE
AIRFLOW-20: Improving the scheduler by making dag runs more coherent

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -868,6 +868,7 @@ class TaskInstance(Base):
         self.start_date = datetime.now()
         self.end_date = datetime.now()
         session.merge(self)
+        session.commit()
 
     def is_queueable(
             self,
@@ -1106,7 +1107,6 @@ class TaskInstance(Base):
             session=session, successes=successes, skipped=skipped,
             failed=failed, upstream_failed=upstream_failed, done=done,
             flag_upstream_failed=flag_upstream_failed)
-        session.commit()
         if verbose and not satisfied:
             logging.warning("Trigger rule `{}` not satisfied".format(task.trigger_rule))
         return satisfied


### PR DESCRIPTION
This particular issue arises because of an alignment issue between
start_date and schedule_interval. This can only happen with cron-based
schedule_intervals that describe absolute points in time (like “1am”) as
opposed to time deltas (like “every hour”)

In the past (and in the docs) we have simply said that users must make
sure the two params agree. But this is counter intuitive. As in these
cases, start_date is sort of like telling the scheduler to
“start paying attention” as opposed to “this is my first execution date”.

This patch changes the behavior of the scheduler. The next run date of
the dag will be treated as "start_date + interval" unless the start_date
is on the (previous) interval in which case the start_date will be the
next run date.
- Supersedes #1428
- Resolves #1427
