### PR TITLE
Added manual trigger_rule option

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1061,6 +1061,10 @@ class TaskInstance(Base):
 
         task = self.task
 
+        # If set to manual we will never automatically schedule
+        if task.trigger_rule == TR.MANUAL:
+            return False
+
         # Checking that the depends_on_past is fulfilled
         if (task.depends_on_past and not ignore_depends_on_past and
                 not self.execution_date == task.start_date):

--- a/airflow/utils/trigger_rule.py
+++ b/airflow/utils/trigger_rule.py
@@ -24,6 +24,7 @@ class TriggerRule(object):
     ONE_SUCCESS = 'one_success'
     ONE_FAILED = 'one_failed'
     DUMMY = 'dummy'
+    MANUAL = 'manual'
 
     @classmethod
     def is_valid(cls, trigger_rule):


### PR DESCRIPTION
In some circumstances (mainly during the development of DAGs) you may want to define a DAG such that specific operators are not scheduled automatically.

This defines a new trigger_rule option called 'manual'. When this is specified, the task will never be automatically scheduled. However, it will be available to run by selecting Run with Ignore Dependencies from the GUI (assuming you are using CeleryExecutor)

---

Dear Airflow Maintainers,

Please accept the following PR that
- Addresses the following issues (links to issues addressed by this PR) :

Reminder to contributors:
- You must add an Apache License header to all new files
- Please squash your commits when possible and follow the [7 rules of good Git commits](http://chris.beams.io/posts/git-commit/#seven-rules)
