### PR TITLE
[AIRFLOW-65] Support child rows to show extra information for AirflowModelView

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,17 @@
+Apache Airflow
+Copyright 2011-2016 The Apache Software Foundation
+
+This product includes software developed at The Apache Software
+Foundation (http://www.apache.org/).
+
+This product includes jQuery (http://jquery.org - MIT license), Copyright © 2016, John Resig.
+This product includes Parallel Coordinates (https://syntagmatic.github.io/parallel-coordinates), Copyright (c) 2012, Kai Chang.
+This product includes WebGL-2D.js (https://github.com/gameclosure/webgl-2d), Copyright (c) 2010 Corban Brook.
+This product includes Bootstrap (http://getbootstrap.com - MIT license), Copyright (c) 2011-2016 Twitter, Inc.
+This product includes Bootstrap Toggle (http://www.bootstraptoggle.com - MIT license), Copyright 2014 Min Hur, The New York Times Company.
+This product includes Highcharts (http://www.bootstraptoggle.com - www.highcharts.com/license), Copyright (c) 2011-2014 Torstein Honsi
+This product includes Clock plugin (https://github.com/Lwangaman/jQuery-Clock-Plugin - Dual licensed under the MIT and GPL licenses), Copyright (c) 2010 John R D'Orazio (donjohn.fmmi@gmail.com)
+This product includes DataTables (datatables.net - datatables.net/license), Copyright © 2008-2015 SpryMedia Ltd.
+This product includes Underscore.js (http://underscorejs.org - MIT license), Copyright (c) 2011-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors.
+This product includes dagre (https://github.com/cpettitt/dagre - MIT license), Copyright (c) 2012-2014 Chris Pettitt.
+This product includes d3js (https://d3js.org/ - https://github.com/mbostock/d3/blob/master/LICENSE), Copyright (c) 2010-2016, Michael Bostock.

--- a/airflow/www/static/main.css
+++ b/airflow/www/static/main.css
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 body { padding-top: 70px; }
 a.navbar-brand span {
     color: white;
@@ -238,3 +252,43 @@ div.square {
 .sc { color: #BA2121 } /* Literal.String.Char */
 .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
 .s2 { color: #BA2121 } /* Literal.String.Double */
+
+/* === Connection List Style Starts === */
+.model-list td.detail-row {
+    -moz-box-shadow: 0 2px 2px #eee inset;
+    -webkit-box-shadow: 0 2px 2px #eee inset;
+    box-shadow: 0 2px 2px #eee inset;
+
+    background: #fcfcfc;
+}
+
+.model-list [data-hide] {
+    display: none;
+}
+
+.model-list [data-toggle] {
+    font-family: 'Glyphicons Halflings';
+    color: #000;
+}
+
+.model-list [data-toggle]:before {
+    content: '';
+}
+
+.model-list .not-empty[data-toggle]:before {
+    content: "\002b";
+}
+
+.model-list .shown .not-empty[data-toggle]:before {
+    content: "\2212";
+}
+
+.model-list td pre {
+    background: transparent;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font-size: 0.8em;
+}
+
+/* === Connection List Style Ends === */

--- a/airflow/www/templates/airflow/conn_create.html
+++ b/airflow/www/templates/airflow/conn_create.html
@@ -1,3 +1,19 @@
+{#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#}
+
 {% extends 'airflow/model_create.html' %}
 
 {% block tail %}

--- a/airflow/www/templates/airflow/conn_edit.html
+++ b/airflow/www/templates/airflow/conn_edit.html
@@ -1,3 +1,19 @@
+{#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#}
+
 {% extends 'airflow/model_edit.html' %}
 
 {% block tail %}

--- a/airflow/www/templates/airflow/conn_list.html
+++ b/airflow/www/templates/airflow/conn_list.html
@@ -1,3 +1,19 @@
+{#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#}
+
 {% extends 'airflow/model_list.html' %}
 
 {% block model_menu_bar %}
@@ -15,4 +31,3 @@
   {% endif %}
   {{ super() }}
 {% endblock %}
-

--- a/airflow/www/templates/airflow/model_list.html
+++ b/airflow/www/templates/airflow/model_list.html
@@ -1,3 +1,19 @@
+{#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#}
+
 {% extends 'admin/model/list.html' %}
 
 {% block model_menu_bar %}
@@ -6,4 +22,59 @@
     <hr/>
   {% endif %}
   {{ super() }}
+{% endblock %}
+
+{% block list_header scoped %}
+    {{ super() }}
+    {% if admin_view.extra_column %}
+        <th>{{ admin_view.extra_column_toggle or 'Extra' }}</th>
+        <th data-hide="true"></th>
+    {% endif %}
+{% endblock %}
+
+{% block list_row scoped %}
+    {{ super() }}
+    {% if admin_view.extra_column %}
+        <td data-toggle="true" class="{{ 'not-empty' if get_value(row, admin_view.extra_column) else 'empty' }}">
+        </td>
+        <td data-hide="true" class="extra-content">
+            {{ get_value(row, admin_view.extra_column) }}
+        </td>
+    {% endif %}
+{% endblock %}
+
+{% block tail_js %}
+    {{ super() }}
+    <!-- enhances the table with "DataTable" -->
+    <script src="{{ url_for('static', filename='jquery.dataTables.min.js') }}" type="text/javascript"></script>
+    <script>
+        $(function () {
+            // initialize the table
+            var table = $('.table.model-list').DataTable({
+                "paging": false,
+                "ordering": false,
+                "info": false,
+                "filter": false
+            });
+
+            $('.table.model-list tbody').on(
+                    'click', 'td[data-toggle]',
+                    function(ev) {
+                        var rowElem = $(ev.currentTarget).closest('tr');
+                        var row = table.row(rowElem);
+
+                        if (row.child.isShown()) {
+                            row.child.hide();
+                            rowElem.removeClass('shown');
+                        }
+                        else {
+                            var content = $('.extra-content', rowElem).html();
+                            console.log(row);
+                            row.child(content, 'detail-row').show();
+                            rowElem.addClass('shown');
+                        }
+                    })
+
+        });
+</script>
 {% endblock %}


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept the following PR that
- Support child rows to show extra information for AirflowModelView using DataTable

It's an update for #1422 in that it solely uses the existing DataTable plugin and extends the detail row feature to all AirflowModelViews.
### DagRun conf

![snip20160427_78](https://cloud.githubusercontent.com/assets/705367/14865286/c961ce40-0c72-11e6-862d-316f968a03ee.png)
### Connection Extra

![snip20160427_80](https://cloud.githubusercontent.com/assets/705367/14865304/e6b3be0e-0c72-11e6-9067-acd5a9fe1f7e.png)

Reminder to contributors:
- You must add an Apache License header to all new files
- Please squash your commits when possible and follow the [7 rules of good Git commits](http://chris.beams.io/posts/git-commit/#seven-rules)
