### PR TITLE
Add Zendesk as a company using Airflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Currently **officially** using Airflow:
 * Xoom [[@gepser](https://github.com/gepser) & [@omarvides](https://github.com/omarvides)]
 * [WePay](http://www.wepay.com) [[@criccomini](https://github.com/criccomini) & [@mtagle](https://github.com/mtagle)]
 * Yahoo!
+* [Zendesk](https://www.github.com/zendesk)
 
 ## Links
 


### PR DESCRIPTION
We've been using Airflow for a while to help schedule & monitor our nightly Hadoop jobs and to build models for our ML [product features](https://www.zendesk.com/analytics/satisfaction-prediction/). Would be great to be listed as "official using Airflow".

Thanks for open sourcing such a great tool.
