### PR TITLE
[AIRFLOW-38] Gracefully fail unit tests when docker-py isn't installed

### DIFF
--- a/tests/operators/docker_operator.py
+++ b/tests/operators/docker_operator.py
@@ -1,7 +1,10 @@
 import unittest
 
-from airflow.operators.docker_operator import DockerOperator
-from docker.client import Client
+try:
+    from airflow.operators.docker_operator import DockerOperator
+    from docker.client import Client
+except ImportError:
+    pass
 
 from airflow.exceptions import AirflowException
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept the following PR that
- Addresses the following issues (links to issues addressed by this PR):
  https://issues.apache.org/jira/browse/AIRFLOW-38

Reminder to contributors:
- You must add an Apache License header to all new files
- Please squash your commits when possible and follow the [7 rules of good Git commits](http://chris.beams.io/posts/git-commit/#seven-rules)
