### PR TITLE
[AIRFLOW-53] Add CLI DagBag loading stats option to list_dags subcommand

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -324,7 +324,16 @@ def task_state(args):
 
 def list_dags(args):
     dagbag = DagBag(process_subdir(args.subdir))
-    print("\n".join(sorted(dagbag.dags)))
+    s = textwrap.dedent("""\n
+    -------------------------------------------------------------------
+    DAGS
+    -------------------------------------------------------------------
+    {dag_list}
+    """)
+    dag_list = "\n".join(sorted(dagbag.dags))
+    print(s.format(dag_list=dag_list))
+    if args.report:
+        print(dagbag.dagbag_report())
 
 
 def list_tasks(args, dag=None):
@@ -673,8 +682,11 @@ class CLIFactory(object):
                 "DO respect depends_on_past)."),
             "store_true"),
         'pool': Arg(("--pool",), "Resource pool to use"),
-        # list_dags
+        # list_tasks
         'tree': Arg(("-t", "--tree"), "Tree view", "store_true"),
+        # list_dags
+        'report': Arg(
+            ("-r", "--report"), "Show DagBag loading report", "store_true"),
         # clear
         'upstream': Arg(
             ("-u", "--upstream"), "Include upstream tasks", "store_true"),
@@ -869,7 +881,7 @@ class CLIFactory(object):
         }, {
             'func': list_dags,
             'help': "List all the DAGs",
-            'args': ('subdir',),
+            'args': ('subdir', 'report'),
         }, {
             'func': task_state,
             'help': "Get the status of a task instance",

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -432,24 +432,28 @@ class DagBag(LoggingMixin):
             'dagbag_size', len(self.dags), 1)
         Stats.gauge(
             'dagbag_import_errors', len(self.import_errors), 1)
-        stats = sorted(stats, key=lambda x: x.duration, reverse=True)
-        dagbag_stats = textwrap.dedent("""\n
+        self.dagbag_stats = sorted(
+            stats, key=lambda x: x.duration, reverse=True)
+
+    def dagbag_report(self):
+        """Prints a report around DagBag loading stats"""
+        report = textwrap.dedent("""\n
         -------------------------------------------------------------------
-        DagBag stats for {dag_folder}
+        DagBag loading stats for {dag_folder}
         -------------------------------------------------------------------
         Number of DAGs: {dag_num}
         Total task number: {task_num}
         DagBag parsing time: {duration}
         {table}
         """)
-        dagbag_stats = dagbag_stats.format(
-            dag_folder=dag_folder,
+        stats = self.dagbag_stats
+        return report.format(
+            dag_folder=self.dag_folder,
             duration=sum([o.duration for o in stats]),
             dag_num=sum([o.dag_num for o in stats]),
             task_num=sum([o.dag_num for o in stats]),
             table=pprinttable(stats),
         )
-        logging.debug(dagbag_stats)
 
     def deactivate_inactive_dags(self):
         active_dag_ids = [dag.dag_id for dag in list(self.dags.values())]

--- a/tests/core.py
+++ b/tests/core.py
@@ -649,7 +649,7 @@ class CliTests(unittest.TestCase):
             dag_folder=DEV_NULL, include_examples=True)
 
     def test_cli_list_dags(self):
-        args = self.parser.parse_args(['list_dags'])
+        args = self.parser.parse_args(['list_dags', '--report'])
         cli.list_dags(args)
 
     def test_cli_list_tasks(self):


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-53

Also shut off the logging.debug call as it was way too verbose in the context of unitests as they load DagBags over and over.
