### PR TITLE
[AIRFLOW-75] Fix bug in S3 config file parsing

### DIFF
--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -52,6 +52,8 @@ def _parse_s3_config(config_file_name, config_format='boto', profile=None):
     else:
         raise AirflowException("Couldn't read {0}".format(config_file_name))
     # Setting option names depending on file format
+    if config_format is None:
+        config_format = 'boto'
     conf_format = config_format.lower()
     if conf_format == 'boto':  # pragma: no cover
         if profile is not None and 'profile ' + profile in sections:

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1270,6 +1270,8 @@ class TaskInstance(Base):
 
                     # If the task returns a result, push an XCom containing it
                     if result is not None:
+                        logging.info("XCom pushing key={} value={}".format(
+                            XCOM_RETURN_KEY, value=result))
                         self.xcom_push(key=XCOM_RETURN_KEY, value=result)
 
                     task_copy.post_execute(context=context)

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -32,6 +32,32 @@ from airflow import settings
 from airflow import configuration
 
 
+# def provide_session(func):
+#     """
+#     Function decorator that provides a session if it isn't provided.
+#     If you want to reuse a session or run the function as part of a
+#     database transaction, you pass it to the function, if not this wrapper
+#     will create one and close it for you.
+#     """
+#     @wraps(func)
+#     def wrapper(*args, **kwargs):
+#         needs_session = False
+#         arg_session = 'session'
+#         func_params = func.__code__.co_varnames
+#         session_in_args = arg_session in func_params and \
+#             func_params.index(arg_session) < len(args)
+#         if not (arg_session in kwargs or session_in_args):
+#             needs_session = True
+#             session = settings.Session()
+#             kwargs[arg_session] = session
+#         result = func(*args, **kwargs)
+#         if needs_session:
+#             session.expunge_all()
+#             session.commit()
+#             session.close()
+#         return result
+#     return wrapper
+
 def provide_session(func):
     """
     Function decorator that provides a session if it isn't provided.
@@ -42,14 +68,10 @@ def provide_session(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         needs_session = False
-        arg_session = 'session'
-        func_params = func.__code__.co_varnames
-        session_in_args = arg_session in func_params and \
-            func_params.index(arg_session) < len(args)
-        if not (arg_session in kwargs or session_in_args):
+        if 'session' not in kwargs:
             needs_session = True
             session = settings.Session()
-            kwargs[arg_session] = session
+            kwargs['session'] = session
         result = func(*args, **kwargs)
         if needs_session:
             session.expunge_all()
@@ -57,6 +79,8 @@ def provide_session(func):
             session.close()
         return result
     return wrapper
+
+
 
 
 def pessimistic_connection_handling():


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-75

Adding a quick fix to  `_parse_s3_config`.   Formerly on line 55, `config_format` would call the string method `lower` without ensuring that if `None` was passed, `config_format` would revert to the default boto format.
