### PR TITLE
AIRFLOW-77: Enable UI toggle for recursive 'clear' operation

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -148,6 +148,10 @@
               >
               Downstream
             </button>
+            <button id="btn_recursive"
+              type="button" class="btn active" data-toggle="button">
+               Recursive
+            </button>
           </span>
           <hr/>
           <button id="btn_success" type="button" class="btn btn-primary">
@@ -284,6 +288,7 @@ function updateQueryStringParameter(uri, key, value) {
         "&past=" + $('#btn_past').hasClass('active') +
         "&upstream=" + $('#btn_upstream').hasClass('active') +
         "&downstream=" + $('#btn_downstream').hasClass('active') +
+        "&recursive=" + $('#btn_recursive').hasClass('active') +
         "&execution_date=" + execution_date +
         "&origin=" + encodeURIComponent(window.location);
       window.location = url;

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1014,6 +1014,7 @@ class Airflow(BaseView):
         downstream = request.args.get('downstream') == "true"
         future = request.args.get('future') == "true"
         past = request.args.get('past') == "true"
+        recursive = request.args.get('recursive') == "true"
 
         dag = dag.sub_dag(
             task_regex=r"^{0}$".format(task_id),
@@ -1025,7 +1026,8 @@ class Airflow(BaseView):
         if confirmed:
             count = dag.clear(
                 start_date=start_date,
-                end_date=end_date)
+                end_date=end_date,
+                include_subdags=recursive)
 
             flash("{0} task instances have been cleared".format(count))
             return redirect(origin)
@@ -1033,6 +1035,7 @@ class Airflow(BaseView):
             tis = dag.clear(
                 start_date=start_date,
                 end_date=end_date,
+                include_subdags=recursive,
                 dry_run=True)
             if not tis:
                 flash("No task instances to clear", 'error')


### PR DESCRIPTION
@r39132, Follwing our discussion in https://github.com/apache/incubator-airflow/pull/1430, this simple PR adds a UI toggle to determine whether the 'Clear' operation should be applied recursively to sub-DAGs.

The JIRA ticket is here: https://issues.apache.org/jira/browse/AIRFLOW-77
