### PR TITLE
[AIRFLOW-92] Avoid unneeded upstream_failed session commits

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -859,6 +859,7 @@ class TaskInstance(Base):
         self.start_date = datetime.now()
         self.end_date = datetime.now()
         session.merge(self)
+        session.commit()
 
     def is_queueable(
             self,
@@ -1097,7 +1098,6 @@ class TaskInstance(Base):
             session=session, successes=successes, skipped=skipped,
             failed=failed, upstream_failed=upstream_failed, done=done,
             flag_upstream_failed=flag_upstream_failed)
-        session.commit()
         if verbose and not satisfied:
             logging.warning("Trigger rule `{}` not satisfied".format(task.trigger_rule))
         return satisfied


### PR DESCRIPTION
Resolves: https://issues.apache.org/jira/browse/AIRFLOW-92

It looks like this is the only place where `set_state` is used, so it should be safe to move the commit there I think. If the commit is done where it was before, then there will be a commit even if state updates are disabled (`flag_upstream_failed=False`), expiring objects in the session, and causing the issue referenced in the Jira ticket.
