### PR TITLE
AIRFLOW-51 && AIRFLOW-71 docker_operator improvements

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -62,8 +62,8 @@ class DockerOperator(BaseOperator):
     :type xcom_all: bool
     :param dockercfg_path: Path for the .dockercfg file
     :type dockercfg_path: str
-    :param username: username to the docker-registry.
-    :type username: str
+    :param registry_username: username to the docker-registry.
+    :type registry_username: str
     """
     template_fields = ('command',)
     template_ext = ('.sh', '.bash',)
@@ -91,7 +91,7 @@ class DockerOperator(BaseOperator):
             xcom_push=False,
             xcom_all=False,
             dockercfg_path=None,
-            username=None,
+            registry_username=None,
             *args,
             **kwargs):
 
@@ -116,7 +116,7 @@ class DockerOperator(BaseOperator):
         self.xcom_push = xcom_push
         self.xcom_all = xcom_all
         self.dockercfg_path = dockercfg_path
-        self.username = username
+        self.registry_username = registry_username
 
         self.cli = None
         self.container = None
@@ -189,8 +189,8 @@ class DockerOperator(BaseOperator):
 
     def get_auth_config(self):
         auth_config = None
-        if self.username is not None and "/" in self.image:
+        if self.registry_username is not None and "/" in self.image:
             registry = self.image.split("/")[0]
-            auth_config = self.cli.login(registry=registry, username=self.username,
+            auth_config = self.cli.login(registry=registry, username=self.registry_username,
                                          dockercfg_path=self.dockercfg_path)
         return auth_config

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -6,7 +6,7 @@ from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory
 from docker import Client, tls
 import ast
-
+import warnings
 
 class DockerOperator(BaseOperator):
     """
@@ -22,6 +22,8 @@ class DockerOperator(BaseOperator):
     :type api_version: str
     :param command: Command to be run in the container.
     :type command: str or list
+    :param cpus: deprecated use cpu_shares instead.
+    :type cpus: float
     :param cpu_shares: CPU shares (relative weight)
         https://docs.docker.com/engine/reference/run/#cpu-share-constraint
     :type cpu_shares: int
@@ -74,6 +76,7 @@ class DockerOperator(BaseOperator):
             image,
             api_version=None,
             command=None,
+            cpus=None,
             cpu_shares=None,
             docker_url='unix://var/run/docker.sock',
             environment=None,
@@ -121,8 +124,13 @@ class DockerOperator(BaseOperator):
         self.cli = None
         self.container = None
 
+        warnings.warn(
+            "Don't use cpus anymore! use cpu_shares instead.",
+            DeprecationWarning
+        )
+
     def execute(self, context):
-        logging.info('Starting docker container from image ' + self.image)
+        logging.info("Starting docker container from image " + self.image)
 
         tls_config = None
         if self.tls_ca_cert and self.tls_client_cert and self.tls_client_key:

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -22,10 +22,9 @@ class DockerOperator(BaseOperator):
     :type api_version: str
     :param command: Command to be run in the container.
     :type command: str or list
-    :param cpus: Number of CPUs to assign to the container.
-        This value gets multiplied with 1024. See
+    :param cpu_shares: CPU shares (relative weight)
         https://docs.docker.com/engine/reference/run/#cpu-share-constraint
-    :type cpus: float
+    :type cpu_shares: int
     :param docker_url: URL of the host running the docker daemon.
     :type docker_url: str
     :param environment: Environment variables to set in the container.
@@ -71,7 +70,7 @@ class DockerOperator(BaseOperator):
             image,
             api_version=None,
             command=None,
-            cpus=1.0,
+            cpu_shares=None,
             docker_url='unix://var/run/docker.sock',
             environment=None,
             force_pull=False,
@@ -93,7 +92,7 @@ class DockerOperator(BaseOperator):
         super(DockerOperator, self).__init__(*args, **kwargs)
         self.api_version = api_version
         self.command = command
-        self.cpus = cpus
+        self.cpu_shares = cpu_shares
         self.docker_url = docker_url
         self.environment = environment or {}
         self.force_pull = force_pull
@@ -120,11 +119,11 @@ class DockerOperator(BaseOperator):
         tls_config = None
         if self.tls_ca_cert and self.tls_client_cert and self.tls_client_key:
             tls_config = tls.TLSConfig(
-                    ca_cert=self.tls_ca_cert,
-                    client_cert=(self.tls_client_cert, self.tls_client_key),
-                    verify=True,
-                    ssl_version=self.tls_ssl_version,
-                    assert_hostname=self.tls_hostname
+                ca_cert=self.tls_ca_cert,
+                client_cert=(self.tls_client_cert, self.tls_client_key),
+                verify=True,
+                ssl_version=self.tls_ssl_version,
+                assert_hostname=self.tls_hostname
             )
             self.docker_url = self.docker_url.replace('tcp://', 'https://')
 
@@ -141,21 +140,19 @@ class DockerOperator(BaseOperator):
                 output = json.loads(l)
                 logging.info("{}".format(output['status']))
 
-        cpu_shares = int(round(self.cpus * 1024))
-
         with TemporaryDirectory(prefix='airflowtmp') as host_tmp_dir:
             self.environment['AIRFLOW_TMP_DIR'] = self.tmp_dir
             self.volumes.append('{0}:{1}'.format(host_tmp_dir, self.tmp_dir))
 
             self.container = self.cli.create_container(
-                    command=self.get_command(),
-                    cpu_shares=cpu_shares,
-                    environment=self.environment,
-                    host_config=self.cli.create_host_config(binds=self.volumes,
-                                                            network_mode=self.network_mode),
-                    image=image,
-                    mem_limit=self.mem_limit,
-                    user=self.user
+                command=self.get_command(),
+                cpu_shares=self.cpu_shares,
+                environment=self.environment,
+                host_config=self.cli.create_host_config(binds=self.volumes,
+                                                        network_mode=self.network_mode),
+                image=image,
+                mem_limit=self.mem_limit,
+                user=self.user
             )
             self.cli.start(self.container['Id'])
 

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -60,6 +60,10 @@ class DockerOperator(BaseOperator):
     :type xcom_push: bool
     :param xcom_all: Push all the stdout or just the last line. The default is False (last line).
     :type xcom_all: bool
+    :param dockercfg_path: Path for the .dockercfg file
+    :type dockercfg_path: str
+    :param username: username to the docker-registry.
+    :type username: str
     """
     template_fields = ('command',)
     template_ext = ('.sh', '.bash',)
@@ -86,6 +90,8 @@ class DockerOperator(BaseOperator):
             volumes=None,
             xcom_push=False,
             xcom_all=False,
+            dockercfg_path=None,
+            username=None,
             *args,
             **kwargs):
 
@@ -109,6 +115,8 @@ class DockerOperator(BaseOperator):
         self.volumes = volumes or []
         self.xcom_push = xcom_push
         self.xcom_all = xcom_all
+        self.dockercfg_path = dockercfg_path
+        self.username = username
 
         self.cli = None
         self.container = None
@@ -136,7 +144,7 @@ class DockerOperator(BaseOperator):
 
         if self.force_pull or len(self.cli.images(name=image)) == 0:
             logging.info('Pulling docker image ' + image)
-            for l in self.cli.pull(image, stream=True):
+            for l in self.cli.pull(image, stream=True, auth_config=self.get_auth_config()):
                 output = json.loads(l)
                 logging.info("{}".format(output['status']))
 
@@ -158,7 +166,7 @@ class DockerOperator(BaseOperator):
 
             line = ''
             for line in self.cli.logs(container=self.container['Id'], stream=True):
-                logging.info("{}".format(line.strip()))
+                logging.info("%r", line.strip())
 
             exit_code = self.cli.wait(self.container['Id'])
             if exit_code != 0:
@@ -178,3 +186,11 @@ class DockerOperator(BaseOperator):
         if self.cli is not None:
             logging.info('Stopping docker container')
             self.cli.stop(self.container['Id'])
+
+    def get_auth_config(self):
+        auth_config = None
+        if self.username is not None and "/" in self.image:
+            registry = self.image.split("/")[0]
+            auth_config = self.cli.login(registry=registry, username=self.username,
+                                         dockercfg_path=self.dockercfg_path)
+        return auth_config

--- a/tests/operators/docker_operator.py
+++ b/tests/operators/docker_operator.py
@@ -56,7 +56,7 @@ class DockerOperatorTestCase(unittest.TestCase):
                                                           network_mode='bridge')
         client_mock.images.assert_called_with(name='ubuntu:latest')
         client_mock.logs.assert_called_with(container='some_id', stream=True)
-        client_mock.pull.assert_called_with('ubuntu:latest', stream=True)
+        client_mock.pull.assert_called_with('ubuntu:latest', auth_config=None, stream=True)
         client_mock.wait.assert_called_with('some_id')
 
     @unittest.skipIf(mock is None, 'mock package not present')

--- a/tests/operators/docker_operator.py
+++ b/tests/operators/docker_operator.py
@@ -43,7 +43,7 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_class_mock.assert_called_with(base_url='unix://var/run/docker.sock', tls=None,
                                              version='1.19')
 
-        client_mock.create_container.assert_called_with(command='env', cpu_shares=1024,
+        client_mock.create_container.assert_called_with(command='env', cpu_shares=None,
                                                         environment={
                                                             'AIRFLOW_TMP_DIR': '/tmp/airflow',
                                                             'UNIT': 'TEST'


### PR DESCRIPTION
AIRFLOW-51 Rename param Docker cpus -> cpu_shares
AIRFLOW-71 docker_operator - pulling from private repositories

https://github.com/apache/incubator-airflow/pull/1476
It can be merged at version 1.7
