### PR TITLE
[AIRFLOW-106] : Fix : Don't treat premature tasks as could_not_run tasks

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -535,7 +535,10 @@ class SchedulerJob(BaseJob):
             elif ti.is_runnable(flag_upstream_failed=True):
                 self.logger.debug('Queuing task: {}'.format(ti))
                 queue.put((ti.key, pickle_id))
+            elif ti.is_premature():
+                continue
             else:
+                self.logger.debug('Adding task: {} to the COULD_NOT_RUN set'.format(ti))
                 could_not_run.add(ti)
 
         # this type of deadlock happens when dagruns can't even start and so

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -898,7 +898,7 @@ class TaskInstance(Base):
         if self.execution_date > datetime.now():
             return False
         # is the task still in the retry waiting period?
-        elif self.state == State.UP_FOR_RETRY and not self.ready_for_retry():
+        elif self.is_premature():
             return False
         # does the task have an end_date prior to the execution date?
         elif self.task.end_date and self.execution_date > self.task.end_date:
@@ -919,6 +919,15 @@ class TaskInstance(Base):
         # anything else
         else:
             return False
+
+
+    def is_premature(self):
+        """
+        Returns whether a task is in UP_FOR_RETRY state and its retry interval
+        has elapsed.
+        """
+        # is the task still in the retry waiting period?
+        return self.state == State.UP_FOR_RETRY and not self.ready_for_retry()
 
     def is_runnable(
             self,


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- _https://issues.apache.org/jira/browse/AIRFLOW-106_

A Picture speaks a 1000 words. 
The first 4 DagRuns in the image below are before the fix, the last DagRun is with the fix.

The bug in the first 4 DagRuns is that the task is forever stuck in the UP_FOR_RETRY state although the DagRun has FAILED. As a consequence, failure callbacks, failure emails, and retries are not executed.

The 5th DagRun has the fix. In this case, all retries were executed. When the retries had been exhausted, full failure handing was executed: failure emails, failure callbacks, etc...

<img width="783" alt="screenshot 2016-05-12 03 42 37" src="https://cloud.githubusercontent.com/assets/581734/15203474/bea73828-17f3-11e6-8284-66a4e0b8c321.png">

This shows that if the failed task is not the first in the DagRun, then the behavior is correct before and after my fix. As above, the first 4 DagRuns are with before my fix and the 5th is with my fix. 

<img width="786" alt="screenshot 2016-05-12 16 34 25" src="https://cloud.githubusercontent.com/assets/581734/15222763/bc07f108-1860-11e6-8a44-d0b83b0760cd.png">
