### PR TITLE
[AIRFLOW-109] Move presto.execute inside try catch to handle error

### DIFF
--- a/airflow/hooks/presto_hook.py
+++ b/airflow/hooks/presto_hook.py
@@ -74,8 +74,8 @@ class PrestoHook(DbApiHook):
         """
         import pandas
         cursor = self.get_cursor()
-        cursor.execute(self._strip_sql(hql), parameters)
         try:
+            cursor.execute(self._strip_sql(hql), parameters)
             data = cursor.fetchall()
         except DatabaseError as e:
             obj = eval(str(e))


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-109

This commit fixes an issue where malformed SQL would raise a
DatabaseError outside of the try catch block in the hook. This
should now raise a PrestoException as expected.
