### PR TITLE
[AIRFLOW-112] Change default DAG view from graph to tree

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,6 @@
 * Test and migrate to use beeline instead of the Hive CLI
 * Run Hive / Hadoop / HDFS tests in Travis-CI
 
-
 #### UI
 * Backfill form
 * Better task filtering int duration and landing time charts (operator toggle, task regex, uncheck all button)

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -45,7 +45,7 @@
                 </td>
                 <td>
                     {% if dag %}
-                    <a href="{{ url_for('airflow.graph', dag_id=dag.dag_id) }}">
+                    <a href="{{ url_for('airflow.tree', dag_id=dag.dag_id) }}">
                         {{ dag_id }}
                     </a>
                     {% else %}


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-112

The number of task instances shown is the default (25).

Testing Done:
Tried a link in a local airflow server
