### PR TITLE
AIRFLOW-124 Implement create_dagrun

### DIFF
--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -252,9 +252,9 @@ class SchedulerJobTest(unittest.TestCase):
 
     def test_dagrun_deadlock(self):
         """
-        Deadlocked DagRun is marked a failure
+        Do not deadlock
 
-        Test that a deadlocked dagrun is marked as a failure by having
+        Test that a dagrun is marked as a running by having
         depends_on_past and an execution_date after the start_date
         """
         self.evaluate_dagrun(
@@ -263,7 +263,7 @@ class SchedulerJobTest(unittest.TestCase):
                 'test_depends_on_past': None,
                 'test_depends_on_past_2': None,
             },
-            dagrun_state=State.FAILED,
+            dagrun_state=State.RUNNING,
             advance_execution_date=True)
 
     def test_scheduler_pooled_tasks(self):


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-124

This PR forms the basis for the roadmap (https://drive.google.com/open?id=0B_Y7S4YFVWvYM1o0aDhKMjJhNzg) . It is one of the initial commits from https://github.com/apache/incubator-airflow/compare/master...bolkedebruin:AIRFLOW_SCHEDULER .

**DAG.create_dagrun (please review: @aoen, @jlowin, @mistercrunch, @artwr )**

This creates dagrun from a Dag. It also creates the TaskInstances from the tasks known at instantiation time. By having taskinstances created at dagrun instantiation time, deadlocks that were tested for will not take place anymore (@jlowin, correct? different test required?). For now, the visual consequence of having these taskinstances already there is that they will be black in the tree view.

Tests in core.py were adjusted as they were supposedly creating a dagrun with tasks, while they were actually creating dagruns and orphaned TaskInstances (ie. the dag_id was not matching the dag_id from the dagrun). This was discussed with @artwr, who said these were remnants from the past.

By doing this I also fixed an issue in models.py that a dag was not set for a task if called from dag.add_task (@aoen, @jlowin).

**DagRun.find is a convenience function that returns the DagRuns for a given dag. It makes sure to have a single place how to find dagruns**

DagRun.find does not work for all cases yet (ie multiple execution dates etc). My aim is to limit the ORM required in sub functions that implement somethings just a bit differently creating compatibility issues.
