### PR TITLE
[AIRFLOW-127] Makes filter_by_owner aware of multi-owner DAG

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1733,7 +1733,7 @@ class HomeView(AdminIndexView):
                 session.query(DM)
                     .filter(
                     ~DM.is_subdag, DM.is_active,
-                    DM.owners == current_user.username)
+                    DM.owners.like('%' + current_user.username + '%'))
                     .all()
             )
         else:


### PR DESCRIPTION
Hello.

When enabling the _webserver.filter_by_owner_ setting, Airflow issues a request like this one :

 `SELECT * FROM dag WHERE NOT dag.is_subdag AND dag.is_active AND dag.owners = username`

Unfortunately that doesn't account for DAG authored by multiple users.

https://issues.apache.org/jira/browse/AIRFLOW-127

dud
