### PR TITLE
[AIRFLOW-129] Allow CELERYD_PREFETCH_MULTIPLIER to be configured via settings /configuration.

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -810,6 +810,11 @@ class CLIFactory(object):
             type=int,
             help="The number of worker processes",
             default=conf.get('celery', 'celeryd_concurrency')),
+        'prefetch_limit': Arg(
+            ("-pm", "--prefetch_limit"),
+            type=int,
+            help="The number of messages to prefetch at a time",
+            default=conf.get('celery', 'celeryd_prefetch_multiplier')),
         # flower
         'broker_api': Arg(("-a", "--broker_api"), help="Broker api"),
         'flower_port': Arg(

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -291,6 +291,11 @@ celery_app_name = airflow.executors.celery_executor
 # your worker box and the nature of your tasks
 celeryd_concurrency = 16
 
+# How many messages to prefetch at a time multiplied by the number of
+# concurrent processes
+# http://docs.celeryproject.org/en/latest/userguide/optimizing.html#optimizing-prefetch-limit
+celeryd_prefetch_multiplier = 1
+
 # When you start an airflow worker, airflow starts a tiny web server
 # subprocess to serve the workers local log files to the airflow main
 # web server, who then builds pages and sends them to users. This defines
@@ -410,6 +415,7 @@ smtp_mail_from = airflow@airflow.com
 [celery]
 celery_app_name = airflow.executors.celery_executor
 celeryd_concurrency = 16
+celeryd_prefetch_multiplier = 1
 worker_log_server_port = 8793
 broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
 celery_result_backend = db+mysql://airflow:airflow@localhost:3306/airflow

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -22,10 +22,14 @@ DEFAULT_QUEUE = configuration.get('celery', 'DEFAULT_QUEUE')
 
 class CeleryConfig(object):
     CELERY_ACCEPT_CONTENT = ['json', 'pickle']
-    CELERYD_PREFETCH_MULTIPLIER = 1
+    CELERYD_PREFETCH_MULTIPLIER = configuration.getint(
+        'celery', 'CELERYD_PREFETCH_MULTIPLIER'
+    )
     CELERY_ACKS_LATE = True
     BROKER_URL = configuration.get('celery', 'BROKER_URL')
-    CELERY_RESULT_BACKEND = configuration.get('celery', 'CELERY_RESULT_BACKEND')
+    CELERY_RESULT_BACKEND = configuration.get(
+        'celery', 'CELERY_RESULT_BACKEND'
+    )
     CELERYD_CONCURRENCY = configuration.getint('celery', 'CELERYD_CONCURRENCY')
     CELERY_DEFAULT_QUEUE = DEFAULT_QUEUE
     CELERY_DEFAULT_EXCHANGE = DEFAULT_QUEUE

--- a/scripts/ci/airflow_travis.cfg
+++ b/scripts/ci/airflow_travis.cfg
@@ -29,6 +29,7 @@ smtp_mail_from = airflow@airflow.com
 [celery]
 celery_app_name = airflow.executors.celery_executor
 celeryd_concurrency = 16
+celeryd_prefetch_multiplier = 1
 worker_log_server_port = 8793
 broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
 celery_result_backend = db+mysql://airflow:airflow@localhost:3306/airflow


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-129

Give users the choice to configure prefetch limits: http://docs.celeryproject.org/en/latest/userguide/optimizing.html#optimizing-prefetch-limit
