### PR TITLE
Improve process_file in model.py.

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -235,7 +235,7 @@ class DagBag(LoggingMixin):
             if safe_mode and os.path.isfile(filepath):
                 with open(filepath, 'rb') as f:
                     content = f.read()
-                    if not all([s in content for s in (b'DAG', b'airflow')]):
+                    if not all([s in content for s in (b'DAG', b'dag', b'airflow')]):
                         return found_dags
 
             self.logger.debug("Importing {}".format(filepath))
@@ -269,7 +269,7 @@ class DagBag(LoggingMixin):
                             self.logger.debug("Reading {} from {}".
                                               format(mod.filename, filepath))
                             content = zf.read()
-                            if not all([s in content for s in (b'DAG', b'airflow')]):
+                            if not all([s in content for s in (b'DAG', b'dag', b'airflow')]):
                                 # todo: create ignore list
                                 return found_dags
 


### PR DESCRIPTION
In some use cases, we define the actual DAG and its dag tasks in separate files. And in the task file(s), there is no really keyword "DAG", but has keyword "dag". e.g. BashOperator(dag="my_dag", command="...").
So this small diff will make process_file more flexible.  
