### PR TITLE
AIRFLOW-128 Optimize and refactor process_dag

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -106,6 +106,10 @@ def clear_task_instances(tis, session, activate_dag_runs=True):
             if ti.job_id:
                 ti.state = State.SHUTDOWN
                 job_ids.append(ti.job_id)
+        # todo: this creates an issue with the webui tests
+        #elif ti.state != State.REMOVED:
+        #    ti.state = State.NONE
+        #    session.merge(ti)
         else:
             session.delete(ti)
     if job_ids:
@@ -920,7 +924,6 @@ class TaskInstance(Base):
         else:
             return False
 
-
     def is_premature(self):
         """
         Returns whether a task is in UP_FOR_RETRY state and its retry interval
@@ -1088,6 +1091,9 @@ class TaskInstance(Base):
         if not task.upstream_list or task.trigger_rule == TR.DUMMY:
             return True
 
+        # todo: this query becomes quite expensive with dags that have
+        # many tasks. It should be refactored to let the task report
+        # to the dag run and get the aggregates from there
         qry = (
             session
             .query(
@@ -1112,10 +1118,12 @@ class TaskInstance(Base):
         )
 
         successes, skipped, failed, upstream_failed, done = qry.first()
+
         satisfied = self.evaluate_trigger_rule(
             session=session, successes=successes, skipped=skipped,
             failed=failed, upstream_failed=upstream_failed, done=done,
             flag_upstream_failed=flag_upstream_failed)
+
         if verbose and not satisfied:
             logging.warning("Trigger rule `{}` not satisfied".format(task.trigger_rule))
         return satisfied
@@ -1186,6 +1194,8 @@ class TaskInstance(Base):
 
         if self.state == State.RUNNING:
             logging.warning("Another instance is running, skipping.")
+        elif self.state == State.REMOVED:
+            logging.debug("Task {} was removed from the dag".format(self))
         elif not force and self.state == State.SUCCESS:
             logging.info(
                 "Task {self} previously succeeded"
@@ -1200,6 +1210,7 @@ class TaskInstance(Base):
                     verbose=True)):
             logging.warning("Dependencies not met yet")
         elif (
+            # todo: move this to the scheduler
                 self.state == State.UP_FOR_RETRY and
                 not self.ready_for_retry()):
             next_run = (self.end_date + task.retry_delay).isoformat()
@@ -2652,107 +2663,6 @@ class DAG(LoggingMixin):
                 l += task.subdag.subdags
         return l
 
-    def get_active_runs(self):
-        """
-        Maintains and returns the currently active runs as a list of dates.
-
-        A run is considered a SUCCESS if all of its root tasks either succeeded
-        or were skipped.
-
-        A run is considered a FAILURE if any of its root tasks failed OR if
-        it is deadlocked, meaning no tasks can run.
-        """
-        TI = TaskInstance
-        session = settings.Session()
-        active_dates = []
-        active_runs = (
-            session.query(DagRun)
-            .filter(
-                DagRun.dag_id == self.dag_id,
-                DagRun.state == State.RUNNING)
-            .order_by(DagRun.execution_date)
-            .all())
-
-        task_instances = (
-            session
-            .query(TI)
-            .filter(
-                TI.dag_id == self.dag_id,
-                TI.task_id.in_(self.active_task_ids),
-                TI.execution_date.in_(r.execution_date for r in active_runs)
-            )
-            .all())
-
-        for ti in task_instances:
-            ti.task = self.get_task(ti.task_id)
-
-        # Runs are considered deadlocked if there are unfinished tasks but
-        # none of them can run. First we check across *all* dagruns in case
-        # there are depends_on_past relationships which could make individual
-        # dags look deadlocked incorrectly. Later we will check individual
-        # dagruns, as long as they don't have depends_on_past=True
-        all_deadlocked = (
-            # AND there are unfinished tasks...
-            any(ti.state in State.unfinished() for ti in task_instances) and
-            # AND none of them have dependencies met...
-            all(not ti.are_dependencies_met(session=session)
-                for ti in task_instances
-                if ti.state in State.unfinished()))
-
-        for run in active_runs:
-            self.logger.info("Checking state for {}".format(run))
-
-            tis = [
-                t for t in task_instances
-                if t.execution_date == run.execution_date
-            ]
-
-            if len(tis) == len(self.active_tasks):
-
-                # if any roots failed, the run failed
-                root_ids = [t.task_id for t in self.roots]
-                roots = [t for t in tis if t.task_id in root_ids]
-                if any(
-                        r.state in (State.FAILED,  State.UPSTREAM_FAILED)
-                        for r in roots):
-                    self.logger.info('Marking run {} failed'.format(run))
-                    run.state = State.FAILED
-
-                # if all roots succeeded, the run succeeded
-                elif all(
-                        r.state in (State.SUCCESS, State.SKIPPED)
-                        for r in roots):
-                    self.logger.info('Marking run {} successful'.format(run))
-                    run.state = State.SUCCESS
-
-                # if *the individual dagrun* is deadlocked, the run failed
-                elif (
-                        # there are unfinished tasks
-                        any(t.state in State.unfinished() for t in tis) and
-                        # AND none of them depend on past
-                        all(not t.task.depends_on_past for t in tis
-                            if t.state in State.unfinished()) and
-                        # AND none of their dependencies are met
-                        all(not t.are_dependencies_met() for t in tis
-                            if t.state in State.unfinished())):
-                    self.logger.info(
-                        'Deadlock; marking run {} failed'.format(run))
-                    run.state = State.FAILED
-
-                # if *ALL* dagruns are deadlocked, the run failed
-                elif all_deadlocked:
-                    self.logger.info(
-                        'Deadlock; marking run {} failed'.format(run))
-                    run.state = State.FAILED
-
-                # finally, if the roots aren't done, the dag is still running
-                else:
-                    active_dates.append(run.execution_date)
-            else:
-                active_dates.append(run.execution_date)
-        session.commit()
-        return active_dates
-
     def resolve_template_files(self):
         for t in self.tasks:
             t.resolve_template_files()
@@ -3109,17 +3019,13 @@ class DAG(LoggingMixin):
             state=state
         )
         session.add(run)
+        session.commit()
+
+        run.dag = self
 
         # create the associated taskinstances
         # state is None at the moment of creation
-        for task in self.tasks:
-            if task.adhoc:
-                continue
-
-            ti = TaskInstance(task, execution_date)
-            session.add(ti)
-
-        session.commit()
+        run.verify_integrity(session=session)
 
         run.refresh_from_db()
         return run
@@ -3401,6 +3307,8 @@ class DagRun(Base):
     external_trigger = Column(Boolean, default=True)
     conf = Column(PickleType)
 
+    dag = None
+
     __table_args__ = (
         Index('dr_run_id', dag_id, run_id, unique=True),
     )
@@ -3438,35 +3346,185 @@ class DagRun(Base):
 
     @staticmethod
     @provide_session
-    def find(dag_id, run_id=None, state=None, external_trigger=None, session=None,
-             execution_date=None):
+    def find(dag_id, run_id=None, execution_date=None,
+             state=None, external_trigger=None, session=None):
         """
         Returns a set of dag runs for the given search criteria.
         :param run_id: defines the the run id for this dag run
         :type run_id: string
+        :param execution_date: the execution date
+        :type execution_date: datetime
         :param state: the state of the dag run
         :type state: State
         :param external_trigger: whether this dag run is externally triggered
         :type external_trigger: bool
         :param session: database session
         :type session: Session
-        :param execution_date: execution date for the dag
-        :type execution_date: string
         """
         DR = DagRun
 
         qry = session.query(DR).filter(DR.dag_id == dag_id)
         if run_id:
             qry = qry.filter(DR.run_id == run_id)
+        if execution_date:
+            qry = qry.filter(DR.execution_date == execution_date)
         if state:
             qry = qry.filter(DR.state == state)
         if external_trigger:
             qry = qry.filter(DR.external_trigger == external_trigger)
-        if execution_date:
-            qry = qry.filter(DR.execution_date == execution_date)
-        dr = qry.all()
+
+        dr = qry.order_by(DR.execution_date).all()
 
         return dr
+
+    @provide_session
+    def get_task_instances(self, state=None, session=None):
+        """
+        Returns the task instances for this dag run
+        """
+        TI = TaskInstance
+        tis = session.query(TI).filter(
+            TI.dag_id == self.dag_id,
+            TI.execution_date == self.execution_date,
+        )
+        if state:
+            if isinstance(state, six.string_types):
+                tis = tis.filter(TI.state == state)
+            else:
+                # this is required to deal with NULL values
+                if None in state:
+                    tis = tis.filter(or_(
+                        TI.state.in_(state),
+                        TI.state.is_(None))
+                    )
+                else:
+                    tis = tis.filter(TI.state.in_(state))
+
+        return tis.all()
+
+    @provide_session
+    def get_task_instance(self, task_id, session=None):
+        """
+        Returns the task instance specified by task_id for this dag run
+        :param task_id: the task id
+        """
+
+        TI = TaskInstance
+        ti = session.query(TI).filter(
+            TI.dag_id == self.dag_id,
+            TI.execution_date == self.execution_date,
+            TI.task_id == task_id
+        ).one()
+
+        return ti
+
+    def get_dag(self):
+        """
+        Returns the Dag associated with this DagRun
+        :param session: database session
+        :return: DAG
+        """
+        if not self.dag:
+            raise AirflowException("The DAG (.dag) for {} needs to be set"
+                                   .format(self))
+
+        return self.dag
+
+    @provide_session
+    def update_state(self, session=None):
+        """
+        Determines the overall state of the DagRun based on the state
+        of its TaskInstances.
+        :returns State:
+        """
+
+        dag = self.get_dag()
+        tis = self.get_task_instances(session=session)
+
+        logging.info("Updating state for {} considering {} task(s)"
+                     .format(self, len(tis)))
+
+        for ti in tis:
+            ti.task = dag.get_task(ti.task_id)
+
+        # pre-calculate
+        # db is faster
+        start_dttm = datetime.now()
+        unfinished_tasks = self.get_task_instances(
+            state=State.unfinished(),
+            session=session
+        )
+        none_depends_on_past = all(t.task.depends_on_past for t in unfinished_tasks)
+
+        # small speed up
+        if unfinished_tasks and none_depends_on_past:
+            # todo: this can actually get pretty slow: one task costs between 0.01-015s
+            no_dependencies_met = all(not t.are_dependencies_met(session=session)
+                                      for t in unfinished_tasks)
+
+        duration = (datetime.now() - start_dttm).total_seconds() * 1000
+        Stats.timing("dagrun.dependency-check.{}.{}".
+                     format(self.dag_id, self.execution_date), duration)
+
+        # future: remove the check on adhoc tasks (=active_tasks)
+        if len(tis) == len(dag.active_tasks):
+            # if any roots failed, the run failed
+            root_ids = [t.task_id for t in dag.roots]
+            roots = [t for t in tis if t.task_id in root_ids]
+
+            if any(r.state in (State.FAILED,  State.UPSTREAM_FAILED)
+                   for r in roots):
+                logging.info('Marking run {} failed'.format(self))
+                self.state = State.FAILED
+
+            # if all roots succeeded, the run succeeded
+            elif all(r.state in (State.SUCCESS, State.SKIPPED)
+                     for r in roots):
+                logging.info('Marking run {} successful'.format(self))
+                self.state = State.SUCCESS
+
+            # if *all tasks* are deadlocked, the run failed
+            elif unfinished_tasks and none_depends_on_past and no_dependencies_met:
+                logging.info(
+                    'Deadlock; marking run {} failed'.format(self))
+                self.state = State.FAILED
+
+            # finally, if the roots aren't done, the dag is still running
+            else:
+                self.state = State.RUNNING
+
+        # todo: determine we want to use with_for_update to make sure to lock the run
+        session.merge(self)
+        session.commit()
+
+        return self.state
+
+    @provide_session
+    def verify_integrity(self, session=None):
+        """
+        Verifies the DagRun by checking for removed tasks or tasks that are not in the
+        database yet. It will set state to removed or add the task if required.
+        """
+        dag = self.get_dag()
+        tis = self.get_task_instances(session=session)
+
+        # check for removed tasks
+        task_ids = []
+        for ti in tis:
+            task_ids.append(ti.task_id)
+            if not dag.get_task(ti.task_id) and self.state not in State.unfinished():
+                ti.state = State.REMOVED
+
+        # check for missing tasks
+        for task in dag.tasks:
+            if task.adhoc:
+                continue
+
+            if task.task_id not in task_ids:
+                ti = TaskInstance(task, self.execution_date)
+                session.add(ti)
+
+        session.commit()
 
 
 class Pool(Base):

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -37,6 +37,9 @@ class DummyStatsLogger(object):
     @classmethod
     def gauge(cls, stat, value, rate=1, delta=False):
         pass
+    @classmethod
+    def timing(cls, stat, dt):
+        pass
 
 Stats = DummyStatsLogger
 

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -22,7 +22,16 @@ class State(object):
     Static class with task instance states constants and color method to
     avoid hardcoding.
     """
+
+    # scheduler
     NONE = None
+    REMOVED = "removed"
+    SCHEDULED = "scheduled"
+
+    # set by the executor (t.b.d.)
+    # LAUNCHED = "launched"
+
+    # set by a task
     QUEUED = "queued"
     RUNNING = "running"
     SUCCESS = "success"
@@ -41,6 +50,8 @@ class State(object):
         UP_FOR_RETRY: 'gold',
         UPSTREAM_FAILED: 'orange',
         SKIPPED: 'pink',
+        REMOVED: 'lightgrey',
+        SCHEDULED: 'white',
     }
 
     @classmethod
@@ -66,7 +77,8 @@ class State(object):
             cls.UP_FOR_RETRY,
             cls.UPSTREAM_FAILED,
             cls.SKIPPED,
-            cls.QUEUED
+            cls.QUEUED,
+            cls.SCHEDULED
         ]
 
     @classmethod
@@ -91,6 +103,7 @@ class State(object):
         """
         return [
             cls.NONE,
+            cls.SCHEDULED,
             cls.QUEUED,
             cls.RUNNING,
             cls.UP_FOR_RETRY


### PR DESCRIPTION
This addresses _AIRFLOW-128_.

@aoen @artwr @mistercrunch @r39132 @jlowin : ready for review.

**Goals:**
- Improve readability of the code and generic assumptions (getters should not change a state) for DagRuns
- Improve robustness and lower risk of race conditions in the scheduler
- Reduce amount of calls to the database, limit connections in the scheduler
- Identify speed optimizations possibilities

**What has changed:**
- Two new TaskInstance states have been introduced. "REMOVED" and "SCHEDULED". REMOVED will be set when taskinstances are encountered that do no exist anymore in the DAG. This happens when a DAG is changed (ie. a new version). The "REMOVED" state exists for lineage purposes. "SCHEDULED" is used when a Task that did not have a state before is sent to the executor. It is used by both the scheduler and backfills. This state almost removes the race condition that exists if using multiple schedulers: due to the fact UP_FOR_RETRY is being managed by the TaskInstance (I think that is the wrong place) is still exists for that state.
- get_active_runs was a getter that was also updating to the database. This patch refactors get_active_runs into two different functions that are now part of DagRun. 1) update_state updates the state of the dagrun based on the taskinstances of the dagrun. 2) verify_integrity checks and updates the dag run based on if the dag contains new or missing tasks. 
- DagRun.update_state has been updated to not call the database twice for the same functions. This reduces the time spent here by 50% in certain occasions when having many tasks in a Dag that need to be evaluated. Still this needs to be faster: for those Dags with many tasks the aggregation query in TaskInstance.are_dependencies_met is very expensive. It should be refactored.
- process_dag has been updated to use the functions and cleaned up, making it much more readable. Tasks are now properly locked by the database. I have played with multiprocessing here (on dagruns and taskinstances) but left it out for now. Fixing the above will help more I think.

**Stats:**
- New scheduler time spent at earlier stages is a bit more, due to eager creation of TaskIntances
- Old scheduler MAX is higher due to "are_dependencies_met()" called twice
- New scheduler fluctuates a bit more due to database locking and "are_dependencies_met" scanning the table (needs to wait for lock). 

Old:

``` bash
2016-05-23 11:17:39,031 INFO - Loop took: 0.018685 seconds
2016-05-23 11:17:44,022 INFO - Loop took: 0.013455 seconds
2016-05-23 11:17:49,033 INFO - Loop took: 0.018868 seconds
2016-05-23 11:17:54,031 INFO - Loop took: 0.019578 seconds
2016-05-23 11:17:59,024 INFO - Loop took: 0.013051 seconds
2016-05-23 11:18:05,026 INFO - Loop took: 1.010049 seconds
2016-05-23 11:18:10,399 INFO - Loop took: 1.390761 seconds
2016-05-23 11:18:32,112 INFO - Loop took: 18.104715 seconds
2016-05-23 11:19:03,432 INFO - Loop took: 31.089109 seconds
2016-05-23 11:19:14,140 INFO - Loop took: 10.492135 seconds
2016-05-23 11:19:38,339 INFO - Loop took: 24.05553 seconds
2016-05-23 11:20:06,281 INFO - Loop took: 27.887196 seconds
2016-05-23 11:20:30,215 INFO - Loop took: 23.9155 seconds
2016-05-23 11:20:53,953 INFO - Loop took: 23.375444 seconds
2016-05-23 11:21:29,168 INFO - Loop took: 35.191994 seconds
2016-05-23 11:22:42,276 INFO - Loop took: 72.384736 seconds
2016-05-23 11:23:06,276 INFO - Loop took: 23.831495 seconds
2016-05-23 11:23:38,852 INFO - Loop took: 32.333608 seconds
```

New:

``` bash
2016-05-23 11:26:12,021 INFO - Loop took: 0.011257 seconds
2016-05-23 11:26:17,031 INFO - Loop took: 0.018259 seconds
2016-05-23 11:26:22,021 INFO - Loop took: 0.01233 seconds
2016-05-23 11:26:27,026 INFO - Loop took: 0.017952 seconds
2016-05-23 11:26:32,031 INFO - Loop took: 0.017606 seconds
2016-05-23 11:26:37,707 INFO - Loop took: 0.697367 seconds
2016-05-23 11:26:43,268 INFO - Loop took: 1.255278 seconds
2016-05-23 11:27:01,234 INFO - Loop took: 14.225399 seconds
2016-05-23 11:27:03,832 INFO - Loop took: 2.580292 seconds
2016-05-23 11:27:35,556 INFO - Loop took: 29.534056 seconds
2016-05-23 11:27:55,896 INFO - Loop took: 20.321862 seconds
2016-05-23 11:28:10,192 INFO - Loop took: 14.250471 seconds
2016-05-23 11:28:40,778 INFO - Loop took: 30.337702 seconds
2016-05-23 11:28:49,003 INFO - Loop took: 8.135393 seconds
2016-05-23 11:29:09,132 INFO - Loop took: 19.923375 seconds
2016-05-23 11:29:46,856 INFO - Loop took: 37.393256 seconds
2016-05-23 11:30:30,984 INFO - Loop took: 43.79019 seconds
2016-05-23 11:31:09,856 INFO - Loop took: 38.444254 seconds
2016-05-23 11:31:31,164 INFO - Loop took: 21.061177 seconds
2016-05-23 11:32:29,776 INFO - Loop took: 58.153763 seconds
2016-05-23 11:33:12,128 INFO - Loop took: 42.105758 seconds
2016-05-23 11:33:50,796 INFO - Loop took: 38.137385 seconds
2016-05-23 11:34:40,290 INFO - Loop took: 49.115855 seconds
2016-05-23 11:35:22,900 INFO - Loop took: 42.269646 seconds
2016-05-23 11:35:38,456 INFO - Loop took: 15.453262 seconds
```

*\* Note: unittests have been added to cover process_dag **

**Dag used for testing:**
- Please note that both schedulers this Dag does not even finish. It only finished properly with the fully implemented new scheduler (including connecting dagruns by using previous ids)

``` python
from datetime import timedelta, datetime
from airflow.models import DAG, Pool
from airflow.operators import BashOperator, SubDagOperator, DummyOperator
from airflow.executors import SequentialExecutor
import airflow


# -----------------------------------------------------------------\
# DEFINE THE POOLS
# -----------------------------------------------------------------/
session = airflow.settings.Session()
for p in ['test_pool_1', 'test_pool_2', 'test_pool_3']:
    pool = (
        session.query(Pool)
        .filter(Pool.pool == p)
        .first())
    if not pool:
        session.add(Pool(pool=p, slots=8))
        session.commit()


# -----------------------------------------------------------------\
# DEFINE THE DAG
# -----------------------------------------------------------------/

# Define the Dag Name. This must be unique.
dag_name = 'hanging_subdags_n16_sqe'

# Default args are passed to each task
default_args = {
    'owner': 'Airflow',
    'depends_on_past': False,
    'start_date': datetime(2016, 04, 10),
    'retries': 0,
    'retry_interval': timedelta(minutes=5),
    'email': ['your@email.com'],
    'email_on_failure': True,
    'email_on_retry': True,
    'wait_for_downstream': False,
}

# Create the dag object
dag = DAG(dag_name,
          default_args=default_args,
          schedule_interval='0 0 * * *'
          )

# -----------------------------------------------------------------\
# DEFINE THE TASKS
# -----------------------------------------------------------------/


def get_subdag(dag, sd_id, pool=None):
    subdag = DAG(
        dag_id='{parent_dag}.{sd_id}'.format(
            parent_dag=dag.dag_id,
            sd_id=sd_id),
        params=dag.params,
        default_args=dag.default_args,
        template_searchpath=dag.template_searchpath,
        user_defined_macros=dag.user_defined_macros,
    )

    t1 = BashOperator(
        task_id='{sd_id}_step_1'.format(
            sd_id=sd_id
        ),
        bash_command='echo "hello" && sleep 1',
        dag=subdag,
        pool=pool
    )

    t2 = BashOperator(
        task_id='{sd_id}_step_two'.format(
            sd_id=sd_id
        ),
        bash_command='echo "hello" && sleep 2',
        dag=subdag,
        pool=pool
    )

    t2.set_upstream(t1)

    sdo = SubDagOperator(
        task_id=sd_id,
        subdag=subdag,
        retries=0,
        retry_delay=timedelta(seconds=5),
        dag=dag,
        depends_on_past=False,
        executor=SequentialExecutor()
    )

    return sdo

start_task = DummyOperator(
    task_id='start',
    dag=dag
)

for n in range(1, 17):
    sd_i = get_subdag(dag=dag, sd_id='level_1_{n}'.format(n=n), pool='test_pool_1')
    sd_ii = get_subdag(dag=dag, sd_id='level_2_{n}'.format(n=n), pool='test_pool_2')
    sd_iii = get_subdag(dag=dag, sd_id='level_3_{n}'.format(n=n), pool='test_pool_3')

    sd_i.set_upstream(start_task)
    sd_ii.set_upstream(sd_i)
    sd_iii.set_upstream(sd_ii)
```
