### PR TITLE
[AIRFLOW-96] s3_conn_id using environment variable

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -333,7 +333,7 @@ is named ``postgres_master`` the environment variable should be named
 ``AIRFLOW_CONN_POSTGRES_MASTER`` (note that the environment variable must be
 all uppercase). Airflow assumes the value returned from the environment
 variable to be in a URI format (e.g.
-``postgres://user:password@localhost:5432/master``).
+``postgres://user:password@localhost:5432/master`` or ``s3://accesskey:secretkey@S3``).
 
 Queues
 ======


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- [AIRFLOW-96](https://issues.apache.org/jira/browse/AIRFLOW-96) : allow parameter "s3_conn_id" of S3KeySensor and S3PrefixSensor to be defined using an environment variable.

Actually, S3KeySensor and S3PrefixSensor use the S3hook, which extends BaseHook. BaseHook has get_connection, which looks a connection up : 
- in environment variables first
- and then in the database
