### PR TITLE
[AIRFLOW-147] Added fetch_size parameter to HiveServer2Hook.to_csv()

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -489,7 +489,8 @@ class HiveServer2Hook(BaseHook):
             schema='default',
             delimiter=',',
             lineterminator='\r\n',
-            output_header=True):
+            output_header=True,
+            fetch_size=1000):
         schema = schema or 'default'
         with self.get_conn() as conn:
             with conn.cursor() as cur:
@@ -504,7 +505,7 @@ class HiveServer2Hook(BaseHook):
                             for c in cur.description])
                     i = 0
                     while True:
-                        rows = [row for row in cur.fetchmany() if row]
+                        rows = [row for row in cur.fetchmany(fetch_size) if row]
                         if not rows:
                             break
 


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-147

In short, the default behavior for the new impala dbapi which is used for the HiveServer2Hook reads a single line at a time when fetchall() is called. This PR provides the option to specify the row batch size in to_csv() and sets the default to 1000. 
