### PR TITLE
AIRFLOW-152 Allow task parameters to be set when using the run command.

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -217,6 +217,11 @@ def run(args, dag=None):
         dag = dag_pickle.pickle
     task = dag.get_task(task_id=args.task_id)
 
+    # Add CLI provided task_params to task.params
+    if args.task_params:
+        passed_in_params = json.loads(args.task_params)
+        task.params.update(passed_in_params)
+
     ti = TaskInstance(task, args.execution_date)
 
     if args.local:
@@ -876,7 +881,8 @@ class CLIFactory(object):
                 'dag_id', 'task_id', 'execution_date', 'subdir',
                 'mark_success', 'force', 'pool',
                 'local', 'raw', 'ignore_dependencies',
-                'ignore_depends_on_past', 'ship_dag', 'pickle', 'job_id'),
+                'ignore_depends_on_past', 'ship_dag', 'pickle', 'job_id',
+                'task_params'),
         }, {
             'func': initdb,
             'help': "Initialize the metadata database",

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -738,6 +738,7 @@ class TaskInstance(Base):
         """
         dag = self.task.dag
         iso = self.execution_date.isoformat()
+        tp = json.dumps(self.task.params) if self.task.params else None
         cmd = "airflow run {self.dag_id} {self.task_id} {iso} "
         cmd += "--mark_success " if mark_success else ""
         cmd += "--pickle {pickle_id} " if pickle_id else ""
@@ -748,6 +749,7 @@ class TaskInstance(Base):
         cmd += "--local " if local else ""
         cmd += "--pool {pool} " if pool else ""
         cmd += "--raw " if raw else ""
+        cmd += "-tp '{tp}' " if tp else ""
         if not pickle_id and dag:
             if dag.full_filepath != dag.filepath:
                 cmd += "-sd DAGS_FOLDER/{dag.filepath} "


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-152

Currently there is a 'task_params' option which can add to or override
values in the params dictionary for a task, but it is only available
when running a task with 'airflow test'.

By accepting this parameter in 'airflow run' and then passing it to the
subprocess through the command method in the TaskInstance class this
option can be supported.

This has use cases in running tasks in an ad-hoc manner where a
parameter may define an environment (i.e. testing vs. production) or
input / output locations and a developer may want to tweak them on the
fly.
