### PR TITLE
AIRFLOW-156 Add date option to trigger_dag

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -124,7 +124,7 @@ def trigger_dag(args):
         logging.error("Cannot find dag {}".format(args.dag_id))
         sys.exit(1)
 
-    execution_date = datetime.now()
+    execution_date = args.execution_date if args.execution_date else datetime.now()
     run_id = args.run_id or "manual__{0}".format(execution_date.isoformat())
 
     dr = DagRun.find(dag_id=args.dag_id, run_id=run_id)
@@ -707,6 +707,9 @@ class CLIFactory(object):
         'conf': Arg(
             ('-c', '--conf'),
             "JSON string that gets pickled into the DagRun's conf attribute"),
+        'date': Arg(
+            ("-d", "--execution_date"), "Override execution_date YYYY-MM-DD",
+            type=parsedate),
         # variables
         'set': Arg(
             ("-s", "--set"),
@@ -855,7 +858,7 @@ class CLIFactory(object):
         }, {
             'func': trigger_dag,
             'help': "Trigger a DAG run",
-            'args': ('dag_id', 'subdir', 'run_id', 'conf'),
+            'args': ('dag_id', 'subdir', 'run_id', 'conf', 'date'),
         }, {
             'func': variables,
             'help': "List all variables",

--- a/airflow/example_dags/example_trigger_date_dag.py
+++ b/airflow/example_dags/example_trigger_date_dag.py
@@ -1,0 +1,55 @@
+
+"""This example illustrates the use of the TriggerDagRunOperator. There are 2
+entities at work in this scenario:
+1. The Controller DAG - the DAG that conditionally executes the trigger
+2. The Target DAG - DAG being triggered (in example_trigger_target_dag.py)
+
+This example illustrates the following features :
+1. A TriggerDagRunOperator that takes:
+  a. A python callable that decides whether or not to trigger the Target DAG
+  b. An optional params dict passed to the python callable to help in
+     evaluating whether or not to trigger the Target DAG
+  c. The id (name) of the Target DAG
+  d. The python callable can add contextual info to the DagRun created by
+     way of adding a Pickleable payload (e.g. dictionary of primitives). This
+     state is then made available to the TargetDag
+2. A Target DAG : c.f. example_trigger_target_dag.py
+"""
+
+from airflow import DAG
+from airflow.operators import TriggerDagRunOperator
+from datetime import datetime
+
+import pprint
+
+pp = pprint.PrettyPrinter(indent=4)
+
+
+def conditionally_trigger(context, dag_run_obj):
+    """This function decides whether or not to Trigger the remote DAG"""
+    # Demonstrates use of the custom execution date in the conditional trigger
+    if dag_run_obj.execution_date < datetime(2016, 1, 1):
+        dag_run_obj.payload = {'message': context['params']['message']}
+        return dag_run_obj
+    return None
+
+# Define the DAG
+dag = DAG(dag_id='example_trigger_date_dag',
+          default_args={"owner": "airflow",
+                        "start_date": datetime.now()},
+          schedule_interval='@once')
+
+trigger = TriggerDagRunOperator(task_id='test_trigger_date_dagrun',
+                                trigger_dag_id="example_trigger_target_dag",
+                                python_callable=conditionally_trigger,
+                                execution_date="2015-01-01",
+                                params={'condition_param': True,
+                                        'message': 'Hello World'},
+                                dag=dag)
+
+no_trigger = TriggerDagRunOperator(task_id='test_no_trigger_date_dagrun',
+                                trigger_dag_id="example_trigger_target_dag",
+                                python_callable=conditionally_trigger,
+                                params={'condition_param': True,
+                                        'message': 'Hello World'},
+                                dag=dag)


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-156

Currently the trigger_dag command always sets the execution date to
datetime.now(). This seems like a rather arbitrary restriction and there
are use cases when running dags ad-hoc where one may wish to set a
different execution date.
