### PR TITLE
[Airflow-161]: New route for 'redirect' and 'Go to QDS' support

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -109,6 +109,9 @@
           <button id="btn_log" type="button" class="btn btn-primary">
             View Log
           </button>
+          <button id="btn_qds" type="button" class="btn btn-primary">
+            Goto QDS
+          </button>
           <hr/>
           <button id="btn_run" type="button" class="btn btn-primary"
             title="Runs a single task instance">
@@ -210,24 +213,27 @@ function updateQueryStringParameter(uri, key, value) {
     var task_id = '';
     var exection_date = '';
     var subdag_id = '';
-    function call_modal(t, d, sd) {
+    function call_modal(t, d, task_type) {
       task_id = t;
       loc = String(window.location);
       $("#btn_filter").on("click", function(){
         window.location = updateQueryStringParameter(loc, "root", task_id);
       });
-      subdag_id = sd;
       execution_date = d;
       $('#task_id').html(t);
       $('#execution_date').html(d);
       $('#myModal').modal({});
+      $("#div_btn_subdag").hide();
+      $('#btn_qds').hide();
       $("#myModal").css("margin-top","0px")
-        if (subdag_id===undefined)
-            $("#div_btn_subdag").hide();
-        else {
+        if (task_type=="SubDagOperator"){
             $("#div_btn_subdag").show();
             subdag_id = "{{ dag.dag_id }}."+t;
         }
+        else if (task_type =="QuboleOperator"){
+          $('#btn_qds').show();
+        }
+
     }
 
     $("#btn_rendered").click(function(){
@@ -251,6 +257,15 @@ function updateQueryStringParameter(uri, key, value) {
         "&dag_id=" + dag_id +
         "&execution_date=" + execution_date;
       window.location = url;
+    });
+
+    $("#btn_qds").click(function(){
+      url = "{{ url_for('airflow.redirect') }}" +
+              "?task_id=" + task_id +
+              "&dag_id=" + dag_id +
+              "&execution_date=" + execution_date +
+              "&redirect_to=qds";
+      window.open(url, '_blank');
     });
 
     $("#btn_task").click(function(){

--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -31,10 +31,11 @@
     $( document ).ready(function() {
       execution_date = '{{ execution_date }}';
       hc = {{ hc|safe }};
+      types = {{ types|safe }};
       hc.plotOptions.series.point = {
         events: {
             click: function(p){
-                call_modal(this.category, execution_date);
+                call_modal(this.category, execution_date, types[this.category]);
             }
         }
       };

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -101,10 +101,7 @@
 
     d3.selectAll("g.node").on("click", function(d){
         task = tasks[d];
-        if (task.task_type == "SubDagOperator")
-            call_modal(d, execution_date, true);
-        else
-            call_modal(d, execution_date);
+        call_modal(d, execution_date, task.task_type);
     });
 
     {% if blur %}

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -218,10 +218,7 @@ function update(source) {
         if(d.task_id === undefined){
           window.location = '/admin/dagrun/edit/?id=' + d.id;
         }
-        else if(nodeobj[d.task_id].operator=='SubDagOperator')
-            call_modal(d.task_id, d.execution_date, true);
-        else
-            call_modal(d.task_id, d.execution_date);
+        call_modal(d.task_id, d.execution_date, nodeobj[d.task_id].operator);
       })
       .attr("class", function(d) {return "state " + d.state})
       .attr("data-toggle", "tooltip")

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -46,6 +46,7 @@ from flask._compat import PY2
 import jinja2
 import markdown
 import json
+import re
 
 from wtforms import (
     Form, SelectField, TextAreaField, PasswordField, StringField)
@@ -60,6 +61,7 @@ from airflow import settings
 from airflow.exceptions import AirflowException
 from airflow.settings import Session
 from airflow.models import XCom
+from airflow.hooks import BaseHook
 
 from airflow.operators import BaseOperator, SubDagOperator
 
@@ -1642,6 +1644,10 @@ class Airflow(BaseView):
                 'color': color,
             })
         height = (len(tis) * 25) + 50
+        types = {}
+        for t in dag.tasks:
+            types[t.task_id] = t.task_type
+
         session.commit()
         session.close()
 
@@ -1651,7 +1657,7 @@ class Airflow(BaseView):
                 'inverted': True,
                 'height': height,
             },
-            'xAxis': {'categories': tasks, 'alternateGridColor': '#FAFAFA'},
+            'xAxis': {'categories': tasks, 'alternateGridColor': '#FAFAFA', 'types': tasks},
             'yAxis': {'type': 'datetime'},
             'title': {
                 'text': None
@@ -1678,7 +1684,62 @@ class Airflow(BaseView):
             height=height,
             demo_mode=demo_mode,
             root=root,
+            types=types
         )
+
+    @expose('/redirect')
+    @login_required
+    @wwwutils.action_logging
+    def redirect(self):
+
+        dag_id = request.args.get('dag_id')
+        task_id = request.args.get('task_id')
+        execution_date =  request.args.get('execution_date')
+        redirect_to = request.args.get('redirect_to')
+        dttm = dateutil.parser.parse(execution_date)
+        dag = dagbag.get_dag(dag_id)
+        if not dag or task_id not in dag.task_ids:
+            flash(
+                "Task [{}.{}] doesn't seem to exist"
+                " at the moment".format(dag_id, task_id),
+                "error")
+            return redirect('/admin/')
+
+        session = Session()
+        url = None
+
+        if redirect_to == 'qds':
+            for t in dag.tasks:
+                if t.task_id == task_id:
+                    task = t
+                    break
+
+            conn = BaseHook.get_connection(task.kwargs['qubole_conn_id'])
+            host = None
+            if conn:
+                host = re.sub(r'api$', 'v2/analyze?command_id=', conn.host)
+            else:
+                host = 'https://api.qubole.com/v2/analyze?command_id?command_id='
+
+            xcom = session.query(XCom).filter(
+                XCom.dag_id == dag_id, XCom.task_id == task_id,
+                XCom.execution_date == dttm, XCom.key == 'qbol_cmd_id').first()
+
+            if xcom:
+                qds_cmd_id = str(xcom.value)
+                url = host + qds_cmd_id
+
+        session.commit()
+        session.close()
+
+        if url:
+            return redirect(url)
+        else:
+            flash(
+                "Couldn't redirect to {} for [{}.{}]"
+                " at the moment".format(redirect_to, dag_id, task_id),
+                "error")
+            return redirect('/admin/')
 
     @expose('/object/task_instances')
     @login_required

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1657,7 +1657,9 @@ class Airflow(BaseView):
                 'inverted': True,
                 'height': height,
             },
-            'xAxis': {'categories': tasks, 'alternateGridColor': '#FAFAFA', 'types': tasks},
+            'xAxis': {'categories': tasks,
+                      'alternateGridColor': '#FAFAFA',
+                      'types': tasks},
             'yAxis': {'type': 'datetime'},
             'title': {
                 'text': None
@@ -1694,7 +1696,7 @@ class Airflow(BaseView):
 
         dag_id = request.args.get('dag_id')
         task_id = request.args.get('task_id')
-        execution_date =  request.args.get('execution_date')
+        execution_date = request.args.get('execution_date')
         redirect_to = request.args.get('redirect_to')
         dttm = dateutil.parser.parse(execution_date)
         dag = dagbag.get_dag(dag_id)
@@ -1713,6 +1715,13 @@ class Airflow(BaseView):
                 if t.task_id == task_id:
                     task = t
                     break
+
+            if task.task_type != 'QuboleOperator':
+                flash(
+                    "Task [{}.{}] doesn't seem to be a QDS task."
+                    .format(dag_id, task_id),
+                    "error")
+                return redirect('/admin/')
 
             conn = BaseHook.get_connection(task.kwargs['qubole_conn_id'])
             host = None

--- a/tests/core.py
+++ b/tests/core.py
@@ -874,6 +874,12 @@ class WebUiTests(unittest.TestCase):
         response = self.app.get(
             "/admin/airflow/paused?"
             "dag_id=example_python_operator&is_paused=false")
+        url = (
+            "/admin/airflow/redirect?task_id=runme_1&"
+            "dag_id=example_bash_operator&redirect_to=qds&"
+            "execution_date={}".format(DEFAULT_DATE_DS))
+        response = self.app.get(url)
+        assert "doesn't seem to be a QDS task" in response.data.decode('utf-8')
 
     def test_charts(self):
         session = Session()


### PR DESCRIPTION
Added a new route `redirect`, which will take dag_id, task_id, execution_date and type of redirection as input and redirects to appropriate external url on the basis of inputs. Currently added redirections to QDS (Qubole) only, but same method can be used for other redirections as well. 

Goto QDS button will appear only for tasks which are of `QuboleOperator` type. 
![screen shot 2016-05-23 at 2 10 32 pm](https://cloud.githubusercontent.com/assets/2018407/15465236/3b8a89fc-20f1-11e6-8964-fe79f83f8291.png)
