### PR TITLE
AIRFLOW-162 Allow variable to be accessible into templates

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1446,6 +1446,24 @@ class TaskInstance(Base):
         if task.params:
             params.update(task.params)
 
+        class VariableAccessor:
+            """
+            Wrapper around Variable. This way you can get variables in templates by using
+            {var.variable_name}.
+            """
+            def __init__(self):
+                pass
+
+            def __getattr__(self, item):
+                return Variable.get(item)
+
+        class VariableJsonAccessor:
+            def __init__(self):
+                pass
+
+            def __getattr__(self, item):
+                return Variable.get(item, deserialize_json=True)
+
         return {
             'dag': task.dag,
             'ds': ds,
@@ -1471,6 +1489,10 @@ class TaskInstance(Base):
             'task_instance_key_str': ti_key_str,
             'conf': configuration,
             'test_mode': self.test_mode,
+            'var': {
+                'value': VariableAccessor(),
+                'json': VariableJsonAccessor()
+            }
         }
 
     def render_templates(self):

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -133,6 +133,10 @@ Variable                            Description
 ``{{ latest_date }}``               same as ``{{ ds }}``
 ``{{ ti }}``                        same as ``{{ task_instance }}``
 ``{{ params }}``                    a reference to the user-defined params dictionary
+``{{ var.value.my_var }}``          global defined variables represented as a dictionary
+``{{ var.json.my_var.path }}``      global defined variables represented as a dictionary
+                                    with deserialized JSON object, append the path to the
+                                    key within the JSON object
 ``{{ task_instance_key_str }}``     a unique, human-readable key to the task instance
                                     formatted ``{dag_id}_{task_id}_{ds}``
 ``conf``                            the full configuration object located at
@@ -150,6 +154,11 @@ dot notation. Here are some examples of what is possible:
 ``{{ task.owner }}``, ``{{ task.task_id }}``, ``{{ ti.hostname }}``, ...
 Refer to the models documentation for more information on the objects'
 attributes and methods.
+
+The ``var`` template variable allows you to access variables defined in Airflow's
+UI. You can access them as either plain-text or JSON. If you use JSON, you are
+also able to walk nested structures, such as dictionaries like:
+``{{ var.json.my_dict_var.key1 }}``
 
 Macros
 ''''''


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
AIRFLOW-162

```
Allow variables to be used in tempates (see tests/core.py) for test
Variable.set("a_variable", {'foo': 'bar'}, serialize_json=True) => '{{ var.json.a_variable.foo }}'
```

Added Doc+Test, could use some feedback
