### PR TITLE
[AIRFLOW-181] Fix failing unpacking of hadoop by redownloading

### DIFF
--- a/scripts/ci/setup_env.sh
+++ b/scripts/ci/setup_env.sh
@@ -94,7 +94,14 @@ tar zxf ${TRAVIS_CACHE}/${HADOOP_DISTRO}/hadoop.tar.gz --strip-components 1 -C $
 
 if [ $? != 0 ]; then
     echo "Failed to extract Hadoop from ${HADOOP_HOME}/hadoop.tar.gz to ${HADOOP_HOME} - abort" >&2
-    exit 1
+    echo "Trying again..." >&2
+    # dont use cache
+    curl -o ${TRAVIS_CACHE}/${HADOOP_DISTRO}/hadoop.tar.gz -L $URL
+    tar zxf ${TRAVIS_CACHE}/${HADOOP_DISTRO}/hadoop.tar.gz --strip-components 1 -C $HADOOP_HOME
+    if [ $? != 0 ]; then
+        echo "Failed twice in downloading and unpacking hadoop!" >&2
+        exit 1
+    fi
 fi
 
 echo "Downloading and unpacking hive"
@@ -108,4 +115,4 @@ unzip ${TRAVIS_CACHE}/minicluster/minicluster.zip -d /tmp
 
 echo "Path = ${PATH}"
 
-java -cp "/tmp/minicluster-1.1-SNAPSHOT/*" com.ing.minicluster.MiniCluster &
+java -cp "/tmp/minicluster-1.1-SNAPSHOT/*" com.ing.minicluster.MiniCluster > /dev/null &


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-181

curl compares timestamps, but if the file is corrupt this can
result in hadoop tars that are never updated. This adds a retry
without using the cache.
