### PR TITLE
AIRFLOW-168 Correct evaluation of @once schedule

### DIFF
--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -398,3 +398,20 @@ class SchedulerJobTest(unittest.TestCase):
         session = settings.Session()
         self.assertEqual(
             len(session.query(TI).filter(TI.dag_id == dag_id).all()), 0)
+
+    def test_scheduler_dagrun_once(self):
+        """
+        Test if the scheduler does not create multiple dagruns
+        if a dag is scheduled with @once and a start_date
+        """
+        dag = DAG(
+            'test_scheduler_dagrun_once',
+            start_date=datetime.datetime(2015, 1, 1),
+            schedule_interval="@once")
+
+        scheduler = SchedulerJob()
+        dag.clear()
+        dr = scheduler.schedule_dag(dag)
+        self.assertIsNotNone(dr)
+        dr = scheduler.schedule_dag(dag)
+        self.assertIsNone(dr)


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-168

If the schedule @once was used with a start_date two dagruns
would be created as next_run_date would be none and compared
against dag.start_date. This patch fixes that by returning
immediately if a dagrun has already occured with an @once
schedule.

@aoen @mistercrunch @jlowin: this is actually a bug in the 1.7.1.2 scheduler but only gets exhibited after AIRFLOW-124 due to eager creation of tasks. See also Jira.
