### PR TITLE
[AIRFLOW-179] DbApiHook string serialization fails when string contains non-ASCII characters

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -1,8 +1,5 @@
 
-from builtins import str
 from past.builtins import basestring
-from datetime import datetime
-import numpy
 import logging
 
 from airflow.hooks.base_hook import BaseHook
@@ -171,10 +168,7 @@ class DbApiHook(BaseHook):
         i = 0
         for row in rows:
             i += 1
-            l = []
-            for cell in row:
-                l.append(self._serialize_cell(cell))
-            values = tuple(l)
+            values = [conn.literal(cell) for cell in row]
             sql = "INSERT INTO {0} {1} VALUES ({2});".format(
                 table,
                 target_fields,
@@ -189,19 +183,6 @@ class DbApiHook(BaseHook):
         conn.close()
         logging.info(
             "Done loading. Loaded a total of {i} rows".format(**locals()))
-
-    @staticmethod
-    def _serialize_cell(cell):
-        if isinstance(cell, basestring):
-            return "'" + str(cell).replace("'", "''") + "'"
-        elif cell is None:
-            return 'NULL'
-        elif isinstance(cell, numpy.datetime64):
-            return "'" + str(cell) + "'"
-        elif isinstance(cell, datetime):
-            return "'" + cell.isoformat() + "'"
-        else:
-            return str(cell)
 
     def bulk_dump(self, table, tmp_file):
         """


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-179

In addition to correctly serializing non-ASCII characters the literal transformation also corrects an issue with escaping single quotes (').

Note it was my intention to add another unit test to `test_hive_to_mysql` in `tests/core.py` however on inspection the indentations of the various methods seemed wrong, methods are nested and it's not apparent what class they refer to. Additionally it seems a number of the test cases aren't related to the corresponding class.

For testing purposes I simply ran a pipeline which previously failed with the following exception,

```
[2016-05-26 22:03:39,256] {models.py:1286} ERROR - 'ascii' codec can't decode byte 0xc3 in position 230: ordinal not in range(128)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/airflow/models.py", line 1245, in run
result = task_copy.execute(context=context)
  File "/usr/local/lib/python2.7/dist-packages/airflow/operators/hive_to_mysql.py", line 88, in execute
mysql.insert_rows(table=self.mysql_table, rows=results)
  File "/usr/local/lib/python2.7/dist-packages/airflow/hooks/dbapi_hook.py", line 176, in insert_rows
l.append(self._serialize_cell(cell))
  File "/usr/local/lib/python2.7/dist-packages/airflow/hooks/dbapi_hook.py", line 196, in _serialize_cell
return "'" + str(cell).replace("'", "''") + "'"
  File "/usr/local/lib/python2.7/dist-packages/future/types/newstr.py", line 102, in __new__
return super(newstr, cls).__new__(cls, value)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 230: ordinal not in range(128)
```

and verified with the presence of the fix that the task succeeded and the resulting output was correct. Note currently from grokking the code base it seems that only `MySqlHook` objects call the the `insert_rows` method.
