### PR TITLE
[AIRFLOW-183] Fetch log from remote when worker returns 4xx/5xx response

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -856,7 +856,9 @@ class Airflow(BaseView):
                 log += "*** Fetching here: {url}\n".format(**locals())
                 try:
                     import requests
-                    log += '\n' + requests.get(url).text
+                    response = requests.get(url)
+                    response.raise_for_status()
+                    log += '\n' + response.text
                     log_loaded = True
                 except:
                     log += "*** Failed to fetch log file from worker.\n".format(


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-183

This is mainly to make the behavior consistent when some log files have
been deleted from the log folder. Without the change, the remote s3/gcs
fallback will only trigger if the task ran on the local worker.
