### PR TITLE
Revert "[AIRFLOW-179] DbApiHook string serialization fails when strin…

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -1,5 +1,8 @@
 
+from builtins import str
 from past.builtins import basestring
+from datetime import datetime
+import numpy
 import logging
 
 from airflow.hooks.base_hook import BaseHook
@@ -168,7 +171,10 @@ class DbApiHook(BaseHook):
         i = 0
         for row in rows:
             i += 1
-            values = [conn.literal(cell) for cell in row]
+            l = []
+            for cell in row:
+                l.append(self._serialize_cell(cell))
+            values = tuple(l)
             sql = "INSERT INTO {0} {1} VALUES ({2});".format(
                 table,
                 target_fields,
@@ -183,6 +189,19 @@ class DbApiHook(BaseHook):
         conn.close()
         logging.info(
             "Done loading. Loaded a total of {i} rows".format(**locals()))
+
+    @staticmethod
+    def _serialize_cell(cell):
+        if isinstance(cell, basestring):
+            return "'" + str(cell).replace("'", "''") + "'"
+        elif cell is None:
+            return 'NULL'
+        elif isinstance(cell, numpy.datetime64):
+            return "'" + str(cell) + "'"
+        elif isinstance(cell, datetime):
+            return "'" + cell.isoformat() + "'"
+        else:
+            return str(cell)
 
     def bulk_dump(self, table, tmp_file):
         """


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-186

This reverts commit 87b4b8fa19cb660317198d74f6d51fdde0a7e067.

Reverting as the method used in the dbapi hook is actually package
specific to MySQLdb and would break the sqlite and mssql hooks.

More work still needs to be done to refactor this correctly, but this should prevent breakage.

CC: @johnbodley @criccomini 
