### PR TITLE
[AIRFLOW-179] DbApiHook string serialization fails when string contains non-ASCII characters"

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -191,7 +191,7 @@ class DbApiHook(BaseHook):
             "Done loading. Loaded a total of {i} rows".format(**locals()))
 
     @staticmethod
-    def _serialize_cell(cell, conn):
+    def _serialize_cell(cell, conn=None):
         """
         Returns the SQL literal of the cell as a string.
 

--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -173,7 +173,7 @@ class DbApiHook(BaseHook):
             i += 1
             l = []
             for cell in row:
-                l.append(self._serialize_cell(cell))
+                l.append(self._serialize_cell(cell, conn))
             values = tuple(l)
             sql = "INSERT INTO {0} {1} VALUES ({2});".format(
                 table,
@@ -191,7 +191,18 @@ class DbApiHook(BaseHook):
             "Done loading. Loaded a total of {i} rows".format(**locals()))
 
     @staticmethod
-    def _serialize_cell(cell):
+    def _serialize_cell(cell, conn):
+        """
+        Returns the SQL literal of the cell as a string.
+
+        :param cell: The cell to insert into the table
+        :type cell: object
+        :param conn: The database connection
+        :type conn: connection object
+        :return: The serialized cell
+        :rtype: str
+        """
+
         if isinstance(cell, basestring):
             return "'" + str(cell).replace("'", "''") + "'"
         elif cell is None:

--- a/airflow/hooks/mysql_hook.py
+++ b/airflow/hooks/mysql_hook.py
@@ -65,3 +65,18 @@ class MySqlHook(DbApiHook):
             INTO TABLE {table}
             """.format(**locals()))
         conn.commit()
+
+    @staticmethod
+    def _serialize_cell(cell, conn):
+        """
+        Returns the MySQL literal of the cell as a string.
+
+        :param cell: The cell to insert into the table
+        :type cell: object
+        :param conn: The database connection
+        :type conn: connection object
+        :return: The serialized cell
+        :rtype: str
+        """
+
+        return conn.literal(cell)

--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -32,5 +32,16 @@ class PostgresHook(DbApiHook):
         return psycopg2_conn
 
     @staticmethod
-    def _serialize_cell(cell):
+    def _serialize_cell(cell, conn):
+        """
+        Returns the Postgres literal of the cell as a string.
+
+        :param cell: The cell to insert into the table
+        :type cell: object
+        :param conn: The database connection
+        :type conn: connection object
+        :return: The serialized cell
+        :rtype: str
+        """
+
         return psycopg2.extensions.adapt(cell).getquoted().decode('utf-8')


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-179

This PR adds MySQL specific logic for serializing a cell leveraging the `literal` method which applies the necessary encoding specific to the connection. 

Note an alternative approach would have to made `_serialize_cell` a non-static method allowing for more flexibility and thus one could do, 

```
 self.get_conn().literal(cell)
```

however it is extremely inefficient to get the connection for every value being injected into the table.

Given that `HivePrestoTest` is disabled within Travis which provides the necessary test coverage, I tested  this change locally and verified that non-ASCII characters where correctly injected into MySQL. 
