### PR TITLE
[AIRFLOW-25] Configuration for Celery always required

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -135,8 +135,13 @@ defaults = {
         'max_threads': 2,
     },
     'celery': {
+        'broker_url': 'sqla+mysql://airflow:airflow@localhost:3306/airflow',
+        'celery_app_name': 'airflow.executors.celery_executor',
+        'celery_result_backend': 'db+mysql://airflow:airflow@localhost:3306/airflow',
+        'celeryd_concurrency': 16,
         'default_queue': 'default',
-        'flower_port': '5555'
+        'flower_port': '5555',
+        'worker_log_server_port': '8793',
     },
     'email': {
         'email_backend': 'airflow.utils.email.send_email_smtp',


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-25

For now, if airflow.cfg has no [celery] section, all subcommands fail.
This patch adds the default values for Celery-related properties
as well as existing 'default_queue' and 'flower_port',
so as to make all subcommands work and suppress "not found in config"
warnings even if [celery] section is omitted.
