### PR TITLE
Adding a 'force_local_logs' option to the webserver

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -123,6 +123,7 @@ defaults = {
         'expose_config': False,
         'workers': 4,
         'worker_class': 'sync',
+        'force_local_logs': False
     },
     'scheduler': {
         'statsd_on': False,

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -122,8 +122,7 @@ defaults = {
         'secret_key': 'airflowified',
         'expose_config': False,
         'workers': 4,
-        'worker_class': 'sync',
-        'force_local_logs': False
+        'worker_class': 'sync'
     },
     'scheduler': {
         'statsd_on': False,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -838,14 +838,14 @@ class Airflow(BaseView):
             host = ti.hostname
             log_loaded = False
             
-            if conf.get('webserver', 'FORCE_LOCAL_LOGS') or socket.getfqdn() == host:
+            if os.path.exists(loc):
                 try:
                     f = open(loc)
                     log += "".join(f.readlines())
                     f.close()
                     log_loaded = True
                 except:
-                    log = "*** Local log file not found.\n".format(loc)
+                    log = "*** Failed to load local log file: {0}.\n".format(loc)
             else:
                 WORKER_LOG_SERVER_PORT = \
                     conf.get('celery', 'WORKER_LOG_SERVER_PORT')

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -837,8 +837,8 @@ class Airflow(BaseView):
         if ti:
             host = ti.hostname
             log_loaded = False
-
-            if socket.getfqdn() == host:
+            
+            if conf.get('webserver', 'FORCE_LOCAL_LOGS') or socket.getfqdn() == host:
                 try:
                     f = open(loc)
                     log += "".join(f.readlines())


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- [AIRFLOW-206](https://issues.apache.org/jira/browse/AIRFLOW-206) : Support for reading log files locally even if task ran in different host

Added a new configuration option to the webserver named 'force_local_logs' which forces the webserver to try and load the task logs locally (even if the task ran at a different host).
