### PR TITLE
[AIRFLOW-131] Only clear XCOM when the task instance is actually runn…

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1186,7 +1186,6 @@ class TaskInstance(Base):
         self.test_mode = test_mode
         self.force = force
         self.refresh_from_db(session=session, lock_for_update=True)
-        self.clear_xcom_data()
         self.job_id = job_id
         iso = datetime.now().isoformat()
         self.hostname = socket.getfqdn()
@@ -1195,6 +1194,7 @@ class TaskInstance(Base):
         if self.state == State.RUNNING:
             logging.warning("Another instance is running, skipping.")
         elif self.state == State.REMOVED:
+            self.clear_xcom_data()
             logging.debug("Task {} was removed from the dag".format(self))
         elif not force and self.state == State.SUCCESS:
             logging.info(
@@ -1219,6 +1219,7 @@ class TaskInstance(Base):
                 "Next run after {0}".format(next_run)
             )
         elif force or self.state in State.runnable():
+            self.clear_xcom_data()
             HR = "\n" + ("-" * 80) + "\n"  # Line break
 
             # For reporting purposes, we report based on 1-indexed,


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-131

Simple refactor of XCOM clear placement to push it down to the conditional when a DAG is going to actually run and also the removal case for tidiness purposes (although functionally probably a no-op).
