### PR TITLE
[AIRFLOW-218] Added option to enable webserver gunicorn access/err logs

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -98,7 +98,7 @@ defaults = {
         'remote_base_log_folder': '',
         'remote_log_conn_id': '',
         'encrypt_s3_logs': False,
-        's3_log_folder': '', # deprecated!
+        's3_log_folder': '',  # deprecated!
         'dag_concurrency': 16,
         'max_active_runs_per_dag': 16,
         'executor': 'SequentialExecutor',
@@ -122,7 +122,9 @@ defaults = {
         'secret_key': 'airflowified',
         'expose_config': False,
         'workers': 4,
-        'worker_class': 'sync'
+        'worker_class': 'sync',
+        'access_logfile': '',
+        'error_logfile': '',
     },
     'scheduler': {
         'statsd_on': False,
@@ -276,6 +278,10 @@ workers = 4
 # The worker class gunicorn should use. Choices include
 # sync (default), eventlet, gevent
 worker_class = sync
+
+# Log files for the gunicorn webserver. '-' means log to stderr.
+access_logfile = -
+error_logfile = -
 
 # Expose the configuration file in the web server
 expose_config = true

--- a/airflow/www/templates/airflow/circles.html
+++ b/airflow/www/templates/airflow/circles.html
@@ -1,6 +1,6 @@
 <div style="font-family: verdana;">
     <h1>Airflow 404 = lots of circles</h1>
-    <div style="color: white">{{ hostname }}</div>
+    <div>{{ hostname }}</div>
 <div
             id="div_svg"
             class="content"


### PR DESCRIPTION
Added an option to enable gunicorn access/error logs.
The default airflow.cfg will now log webserver errors/accesses to stderr.

Also made the 404 page hostname text default page color instead of
white, since white text is pretty hard to see against a white
background.

Tested:
- '-' argument value logs appeared in stderr
- placing the setting in the config file/the command line/omitting it and making sure the logs appeared in the correct place

@mistercrunch
