### PR TITLE
[AIRFLOW-111] DAG concurrency is not honored

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1247,7 +1247,7 @@ class TaskInstance(Base):
                 logging.info("Queuing into pool {}".format(self.pool))
                 return
 
-            if concurrency_reached:
+            if not mark_success and self.state == State.QUEUED and concurrency_reached:
                 logging.warning('Job_id={} has to wait, since dag concurrency limit [{}] is reached'
                                 .format(self.job_id, self.task.dag.concurrency))
                 return

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1230,8 +1230,9 @@ class TaskInstance(Base):
                 total=task.retries + 1)
             self.start_date = datetime.now()
 
+            concurrency_reached = self.task.dag.concurrency_reached
             if not mark_success and self.state != State.QUEUED and (
-                    self.pool or self.task.dag.concurrency_reached):
+                    self.pool or concurrency_reached):
                 # If a pool is set for this task, marking the task instance
                 # as QUEUED
                 self.state = State.QUEUED
@@ -1244,6 +1245,11 @@ class TaskInstance(Base):
                 session.merge(self)
                 session.commit()
                 logging.info("Queuing into pool {}".format(self.pool))
+                return
+
+            if concurrency_reached:
+                logging.warning('Job_id={} has to wait, since dag concurrency limit [{}] is reached'
+                                .format(self.job_id, self.task.dag.concurrency))
                 return
 
             # print status message


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- _https://issues.apache.org/jira/browse/AIRFLOW-111_

The issue was that once a task is in QUEUED state, then it wont be checked against concurrency_reached for its dag, hence it will be set to RUNNING status. By adding this one more concurrency_reached check for all the QUEUED tasks, dag concurrency setting is now honored.

@mistercrunch 
