### PR TITLE
[AIRFLOW-220] Make SchedulerJob's refresh_dags_every parameter externally configurable

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -470,6 +470,7 @@ def scheduler(args):
         dag_id=args.dag_id,
         subdir=process_subdir(args.subdir),
         num_runs=args.num_runs,
+        refresh_dags_every=args.refresh_dags_every,
         do_pickle=args.do_pickle)
 
     if args.daemon:
@@ -837,6 +838,10 @@ class CLIFactory(object):
             ("-n", "--num_runs"),
             default=None, type=int,
             help="Set the number of runs to execute before exiting"),
+        'refresh_dags_every': Arg(
+            ("-r", "--refresh_dags_every"),
+            default=conf.get('scheduler', 'REFRESH_DAGS_EVERY'), type=int,
+            help="Set every how many runs to refresh the DAG definition"),
         # worker
         'do_pickle': Arg(
             ("-p", "--do_pickle"),
@@ -968,8 +973,8 @@ class CLIFactory(object):
         }, {
             'func': scheduler,
             'help': "Start a scheduler instance",
-            'args': ('dag_id_opt', 'subdir', 'num_runs', 'do_pickle',
-                     'pid', 'daemon', 'stdout', 'stderr', 'log_file'),
+            'args': ('dag_id_opt', 'subdir', 'num_runs', 'refresh_dags_every',
+                     'do_pickle', 'pid', 'daemon', 'stdout', 'stderr', 'log_file'),
         }, {
             'func': worker,
             'help': "Start a Celery worker node",

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -135,6 +135,7 @@ defaults = {
         'scheduler_heartbeat_sec': 60,
         'authenticate': False,
         'max_threads': 2,
+        'refresh_dags_every': 10,
     },
     'celery': {
         'broker_url': 'sqla+mysql://airflow:airflow@localhost:3306/airflow',
@@ -369,6 +370,10 @@ scheduler_heartbeat_sec = 5
 # use more threads than the amount of cpu cores available.
 max_threads = 2
 
+# The scheduler reloads the DAG definition from dags_folder for every N runs.
+# This defines the parameter N.
+refresh_dags_every = 10
+
 [mesos]
 # Mesos master address which MesosExecutor will connect to.
 master = localhost:5050
@@ -460,6 +465,7 @@ job_heartbeat_sec = 1
 scheduler_heartbeat_sec = 5
 authenticate = true
 max_threads = 2
+refresh_dags_every = 10
 """
 
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-220

Testing Done:
- confirmed all 87 unit tests in tests.core passed locally (including 1 skipped test)
- confirmed the new command line option and the new property in airflow.cfg worked as expected manually

For now, SchedulerJob refreshes DagBag every 10 run and this parameter is hard-coded.
This patch makes it configurable via command-line option.
