### PR TITLE
[AIRFLOW-238] fix flask-admin==1.4.1 breaks the build

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -20,7 +20,7 @@ in their PYTHONPATH. airflow_login should be based off the
 `airflow.www.login`
 """
 from builtins import object
-__version__ = "1.7.1.2"
+__version__ = "1.7.1.3"
 
 import logging
 import os

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -106,14 +106,9 @@ def dag_link(v, c, m, p):
         '<a href="{url}">{m.dag_id}</a>'.format(**locals()))
 
 
-def log_link(v, c, m, p):
-    url = url_for(
-        'airflow.log',
-        dag_id=m.dag_id,
-        task_id=m.task_id,
-        execution_date=m.execution_date.isoformat())
+def log_url_formatter(v, c, m, p):
     return Markup(
-        '<a href="{url}">'
+        '<a href="{m.log_url}">'
         '    <span class="glyphicon glyphicon-book" aria-hidden="true">'
         '</span></a>').format(**locals())
 
@@ -837,7 +832,7 @@ class Airflow(BaseView):
         if ti:
             host = ti.hostname
             log_loaded = False
-            
+
             if os.path.exists(loc):
                 try:
                     f = open(loc)
@@ -2156,7 +2151,8 @@ class TaskInstanceModelView(ModelViewOnly):
         'queue', 'pool', 'operator', 'start_date', 'end_date')
     named_filter_urls = True
     column_formatters = dict(
-        log=log_link, task_id=task_instance_link,
+        log_url=log_url_formatter,
+        task_id=task_instance_link,
         hostname=nobr_f,
         state=state_f,
         execution_date=datetime_f,
@@ -2177,7 +2173,7 @@ class TaskInstanceModelView(ModelViewOnly):
         'state', 'dag_id', 'task_id', 'execution_date', 'operator',
         'start_date', 'end_date', 'duration', 'job_id', 'hostname',
         'unixname', 'priority_weight', 'queue', 'queued_dttm', 'try_number',
-        'pool', 'log')
+        'pool', 'log_url')
     can_delete = True
     page_size = 500
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import sys
 logger = logging.getLogger(__name__)
 
 # Kept manually in sync with airflow.__version__
-version = '1.7.1.2'
+version = '1.7.1.3'
 
 
 class Tox(TestCommand):
@@ -168,7 +168,7 @@ def do_setup():
             'dill>=0.2.2, <0.3',
             'python-daemon>=2.1.1, <2.2',
             'flask>=0.10.1, <0.11',
-            'flask-admin>=1.4.0, <2.0.0',
+            'flask-admin==1.4.1',
             'flask-cache>=0.13.1, <0.14',
             'flask-login==0.2.11',
             'future>=0.15.0, <0.16',


### PR DESCRIPTION
The new flask-admin==1.4.1 release on 2016-06-13 breaks the Airflow
release currently in Pypi (1.7.1.2). This fixes the edge case triggered
by this new release.

Note that 1.7.1.3 was fixed by pinning flask-admin to 1.4.0.
