### PR TITLE
[AIRFLOW-222] Running task instances should show duration in UI

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1295,10 +1295,16 @@ class Airflow(BaseView):
             elif children:
                 children_key = "_children"
 
+            def set_duration(tid):
+                if isinstance(tid, dict) and tid.get("state") == State.RUNNING:
+                    d = datetime.now() - dateutil.parser.parse(tid["start_date"])
+                    tid["duration"] = d.total_seconds()
+                return tid
+
             return {
                 'name': task.task_id,
                 'instances': [
-                        task_instances.get((task.task_id, d)) or {
+                        set_duration(task_instances.get((task.task_id, d))) or {
                             'execution_date': d.isoformat(),
                             'task_id': task.task_id
                         }


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-222

At the moment mousing over a task instance (square) in the Airflow tree view
only shows the duration for completed task, and shows "Duration: null"
for running tasks.
Instead the UI should show the current task instance's duration
(given by datetime.datetime.now() - ti.start_date) for running tasks.
