### PR TITLE
[AIRFLOW-241] Add testing done section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,8 @@ Dear Airflow Maintainers,
 Please accept this PR that addresses the following issues:
 - *(replace with a link to AIRFLOW-X)*
 
+Testing Done:
+
 Reminders for contributors:
 * Your PR's title must reference an issue on [Airflow's JIRA](https://issues.apache.org/jira/browse/AIRFLOW/). For example, a PR called "[AIRFLOW-1] My Amazing PR" would close JIRA issue #1. Please open a new issue if required!
-* You must add an [Apache License header](http://www.apache.org/legal/src-headers.html) to all new files.
 * Please squash your commits when possible and follow the [7 rules of good Git commits](http://chris.beams.io/posts/git-commit/#seven-rules).


### PR DESCRIPTION
I want contributors to think about testing a little bit more and to explain how their change was tested. I also removed the apache header line since this is enforced by tests now so no need to duplicate this logic.
