### PR TITLE
[AIRFLOW-227] Show environmentally defined configs in the config view

### DIFF
--- a/airflow/www/templates/airflow/config.html
+++ b/airflow/www/templates/airflow/config.html
@@ -1,0 +1,69 @@
+{#
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+#}
+{% extends "airflow/master.html" %}
+
+{% block title %}
+    {{ title }}
+{% endblock %}
+
+{% block body %}
+    {{ super() }}
+    <h2>{{ title }}</h2>
+
+    {% if pre_subtitle %}
+        <pre>{{ pre_subtitle }}</pre>
+    {% endif %}
+
+    {% if subtitle %}
+        <h5>{{ subtitle }}</h5>
+    {% endif %}
+
+    {% if code %}
+        <pre>{{ code }}</pre>
+    {% endif %}
+
+    {% if code_html %}
+        {{ code_html|safe }}
+    {% endif %}
+
+    <hr>
+
+    {% if table %}
+        <br>
+        <h3>Running Configuration</h3>
+        <br>
+        <div>
+            <table class="table table-striped table-bordered">
+                <tr>
+                    <th>Section</th>
+                    <th>Key</th>
+                    <th>Value</th>
+                    <th>Source</th>
+                </tr>
+                {% for section, key, value, source in table %}
+                    <tr>
+                        <td>{{ section }}</td>
+                        <td>{{ key }}</td>
+                        <td class='code'>{{ value }}</td>
+                        <td>{{ source }}</td>
+                    </tr>
+                {% endfor %}
+            </table>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2511,10 +2511,15 @@ class ConfigurationView(wwwutils.SuperUserMixin, BaseView):
         if conf.getboolean("webserver", "expose_config"):
             with open(conf.AIRFLOW_CONFIG, 'r') as f:
                 config = f.read()
+            table = [(section, key, value, source)
+                     for section, parameters in conf.as_dict(True, True).items()
+                     for key, (value, source) in parameters.items()]
+
         else:
             config = (
                 "# You Airflow administrator chose not to expose the "
                 "configuration, most likely for security reasons.")
+            table = None
         if raw:
             return Response(
                 response=config,
@@ -2527,9 +2532,10 @@ class ConfigurationView(wwwutils.SuperUserMixin, BaseView):
                 HtmlFormatter(noclasses=True))
             )
             return self.render(
-                'airflow/code.html',
+                'airflow/config.html',
                 pre_subtitle=settings.HEADER + "  v" + airflow.__version__,
-                code_html=code_html, title=title, subtitle=subtitle)
+                code_html=code_html, title=title, subtitle=subtitle,
+                table=table)
 
 
 class DagModelView(wwwutils.SuperUserMixin, ModelView):

--- a/tests/core.py
+++ b/tests/core.py
@@ -1272,6 +1272,7 @@ class WebUiTests(unittest.TestCase):
     def setUp(self):
         configuration.load_test_config()
         configuration.conf.set("webserver", "authenticate", "False")
+        configuration.conf.set("webserver", "expose_config", "True")
         app = application.create_app()
         app.config['TESTING'] = True
         self.app = app.test_client()
@@ -1327,6 +1328,7 @@ class WebUiTests(unittest.TestCase):
         response = self.app.get(
             '/admin/configurationview/')
         assert "Airflow Configuration" in response.data.decode('utf-8')
+        assert "Running Configuration" in response.data.decode('utf-8')
         response = self.app.get(
             '/admin/airflow/rendered?'
             'task_id=runme_1&dag_id=example_bash_operator&'
@@ -1435,6 +1437,7 @@ class WebUiTests(unittest.TestCase):
         assert "runme_0" in response.data.decode('utf-8')
 
     def tearDown(self):
+        configuration.conf.set("webserver", "expose_config", "False")
         self.dag_bash.clear(start_date=DEFAULT_DATE, end_date=datetime.now())
 
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-227

Testing Done:
- executed run_unit_tests.sh and confirmed all 175 tests passed
- confirmed that the new page:
  - shows no parameter if expose_config is false
  - shows all parameters if expose_config is true, including environment variables such as AIRFLOW__CORE__FOO=bar

Right now the config page (when set to display) just loads the airflow.cfg and lists that,
so any configuration values that are set via an environment variable are not shown.
This patch add a new page that shows all configuration values which are loaded via any means,
only if expose_config is set to true.
