### PR TITLE
[AIRFLOW-251] Add option SQL_ALCHEMY_SCHEMA parameter to use SQL Server for metadata.

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -106,6 +106,7 @@ defaults = {
         'dags_are_paused_at_creation': True,
         'sql_alchemy_pool_size': 5,
         'sql_alchemy_pool_recycle': 3600,
+        'sql_alchemy_schema': None,
         'dagbag_import_timeout': 30,
         'non_pooled_task_slot_count': 128,
     },
@@ -209,6 +210,10 @@ executor = SequentialExecutor
 # SqlAlchemy supports many different database engine, more information
 # their website
 sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/airflow.db
+
+# The schema to use for the metadata database
+# SqlAlchemy supports databases with the concept of multiple schemas.
+sql_alchemy_schema =
 
 # The SqlAlchemy pool size is the maximum number of database connections
 # in the pool.

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -47,7 +47,7 @@ from urllib.parse import urlparse
 from sqlalchemy import (
     Column, Integer, String, DateTime, Text, Boolean, ForeignKey, PickleType,
     Index, Float)
-from sqlalchemy import case, func, or_, and_
+from sqlalchemy import case, func, or_, and_, MetaData
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.dialects.mysql import LONGTEXT
 from sqlalchemy.orm import relationship, synonym
@@ -71,7 +71,11 @@ from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 from airflow.utils.trigger_rule import TriggerRule
 
-Base = declarative_base()
+SQL_ALCHEMY_SCHEMA = configuration.get('core', 'SQL_ALCHEMY_SCHEMA')
+if SQL_ALCHEMY_SCHEMA is None or SQL_ALCHEMY_SCHEMA.isspace():
+    Base = declarative_base()
+else:
+    Base = declarative_base(metadata=MetaData(schema=SQL_ALCHEMY_SCHEMA))
 ID_LEN = 250
 SQL_ALCHEMY_CONN = configuration.get('core', 'SQL_ALCHEMY_CONN')
 DAGS_FOLDER = os.path.expanduser(configuration.get('core', 'DAGS_FOLDER'))


### PR DESCRIPTION
The attached pull request adds an optional parameter SQL_ALCHEMY_SCHEMA, which can be used to specify a schema. This is particularly useful when using SQL Server for metadata storage, to separate Airflow tables out of the default dbo schema.

This is in the Airflow JIRA: https://issues.apache.org/jira/browse/AIRFLOW-251
