### PR TITLE
[AIRFLOW-254] Refresh all workers of the webserver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,6 @@ install:
   - pip install tox
   - pip install codecov
 before_script:
-  - sudo service apparmor stop
   - sudo service apparmor teardown
   - mysql -e 'drop database if exists airflow; create database airflow' -u root
   - psql -c 'create database airflow;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+sudo: required
+dist: trusty
 language: python
 jdk: oraclejdk7
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ install:
   - pip install codecov
 before_script:
   - sudo service apparmor stop
+  - sudo service apparmor teardown
   - mysql -e 'drop database if exists airflow; create database airflow' -u root
   - psql -c 'create database airflow;' -U postgres
   - export PATH=${PATH}:/tmp/hive/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,7 @@ install:
   - pip install tox
   - pip install codecov
 before_script:
-  - sudo invoke-rc.d apparmor teardown
-  - sudo update-rc.d -f apparmor remove
+  - sudo service apparmor stop
   - mysql -e 'drop database if exists airflow; create database airflow' -u root
   - psql -c 'create database airflow;' -U postgres
   - export PATH=${PATH}:/tmp/hive/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 jdk: oraclejdk7
 services:
-  - mysql
   - postgresql
 addons:
   apt:
@@ -10,9 +9,6 @@ addons:
       - slapd
       - ldap-utils
       - openssh-server
-      - mysql-server-5.6
-      - mysql-client-core-5.6
-      - mysql-client-5.6
     postgresql: "9.4"
 python:
   - "2.7"
@@ -69,6 +65,9 @@ before_install:
   - ln -s ~/.ssh/authorized_keys ~/.ssh/authorized_keys2
   - chmod 600 ~/.ssh/*
 install:
+  - apt-get remove mysql-common mysql-server-5.5 mysql-server-core-5.5 mysql-client-5.5 mysql-client-core-5.5
+  - apt-get autoremove
+  - apt-get install libaio1
   - pip install --upgrade pip
   - pip install tox
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: required
-dist: trusty
+sudo: false
 language: python
 jdk: oraclejdk7
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ addons:
       - slapd
       - ldap-utils
       - openssh-server
+      - mysql-server-5.6
+      - mysql-client-core-5.6
+      - mysql-client-5.6
+    postgresql: "9.4"
 python:
   - "2.7"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
-sudo: false
+sudo: required
+dist: trusty
 language: python
 jdk: oraclejdk7
 services:
+  - mysql
   - postgresql
 addons:
   apt:
@@ -9,6 +11,9 @@ addons:
       - slapd
       - ldap-utils
       - openssh-server
+      - mysql-server-5.6
+      - mysql-client-core-5.6
+      - mysql-client-5.6
     postgresql: "9.4"
 python:
   - "2.7"
@@ -65,9 +70,6 @@ before_install:
   - ln -s ~/.ssh/authorized_keys ~/.ssh/authorized_keys2
   - chmod 600 ~/.ssh/*
 install:
-  - apt-get remove mysql-common mysql-server-5.5 mysql-server-core-5.5 mysql-client-5.5 mysql-client-core-5.5
-  - apt-get autoremove
-  - apt-get install libaio1
   - pip install --upgrade pip
   - pip install tox
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,8 @@ install:
   - pip install tox
   - pip install codecov
 before_script:
+  - sudo invoke-rc.d apparmor teardown
+  - sudo update-rc.d -f apparmor remove
   - mysql -e 'drop database if exists airflow; create database airflow' -u root
   - psql -c 'create database airflow;' -U postgres
   - export PATH=${PATH}:/tmp/hive/bin

--- a/airflow/migrations/versions/1cf9cf73bea6_add_last_modified_field_to_dag.py
+++ b/airflow/migrations/versions/1cf9cf73bea6_add_last_modified_field_to_dag.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Add last_modified field to dag
+
+Revision ID: 1cf9cf73bea6
+Revises: 2e82aab8ef20
+Create Date: 2016-06-17 13:32:09.035886
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1cf9cf73bea6'
+down_revision = '2e82aab8ef20'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('dag', sa.Column('last_modified', sa.DateTime,
+                                   server_default=sa.func.current_timestamp(),
+                                   nullable=False))
+
+
+def downgrade():
+    op.drop_column('dag', 'last_modified')

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -361,6 +361,7 @@ class DagBag(LoggingMixin):
             orm_dag.is_subdag = dag.is_subdag
             orm_dag.owners = root_dag.owner
             orm_dag.is_active = True
+            orm_dag.last_modified = datetime.now()
             session.merge(orm_dag)
             session.commit()
             session.close()
@@ -2375,6 +2376,8 @@ class DagModel(Base):
     fileloc = Column(String(2000))
     # String representing the owners
     owners = Column(String(2000))
+    # Last modified
+    last_modified = Column(DateTime, nullable=False)
 
     def __repr__(self):
         return "<DAG: {self.dag_id}>".format(self=self)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -70,12 +70,11 @@ from airflow.utils.db import provide_session
 from airflow.utils.helpers import alchemy_to_dict
 from airflow.utils import logging as log_utils
 from airflow.www import utils as wwwutils
+from airflow.www.app import dagbag
 from airflow.www.forms import DateTimeForm, DateTimeWithNumRunsForm
 
 QUERY_LIMIT = 100000
 CHART_LIMIT = 200000
-
-dagbag = models.DagBag(os.path.expanduser(conf.get('core', 'DAGS_FOLDER')))
 
 login_required = airflow.login.login_required
 current_user = airflow.login.current_user
@@ -1619,6 +1618,7 @@ class Airflow(BaseView):
 
         if orm_dag:
             orm_dag.last_expired = datetime.now()
+            orm_dag.last_modified = datetime.now()
             session.merge(orm_dag)
         session.commit()
         session.close()

--- a/scripts/ci/load_data.sh
+++ b/scripts/ci/load_data.sh
@@ -24,5 +24,7 @@ DATABASE=airflow_ci
 
 mysqladmin -u root create ${DATABASE}
 mysql -u root < ${DATA_DIR}/mysql_schema.sql
+ls -l ${DATA_FILE}
+whoami
 mysqlimport -u root --fields-optionally-enclosed-by="\"" --fields-terminated-by=, --ignore-lines=1 ${DATABASE} ${DATA_FILE}
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- _(replace with a link to AIRFLOW-254)_

Testing Done: Tested by hand.

The webserver only refreshes one process in case a
dag refresh is demanded or an update is made to a dag.
This is annoying as you might end up with old code in
the views or the dreaded "scheduler has put this in the
db, but the webserver hasnt got it yet.

By maintaining a last_modified field in the db and
comparing this to what the individual workers know,
the dagbag will now be updated.
