### PR TITLE
[AIRFLOW-256] Fix test_scheduler_reschedule heartrate

### DIFF
--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -770,6 +770,7 @@ class SchedulerJobTest(unittest.TestCase):
         @mock.patch('airflow.models.DagBag.collect_dags')
         def do_schedule(function, function2):
             scheduler = SchedulerJob(num_runs=1, executor=executor,)
+            scheduler.heartrate = 0
             scheduler.run()
 
         do_schedule()


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- _(replace with a link to AIRFLOW-256)_

test_scheduler_reschedule runs two schedulerjobs quite
fast after one another this sometimes is faster than
the heartrate allows and thus the tasks will not get
rescheduled and the test will fail. Fixed by setting
heartrate to 0.
