### PR TITLE
[AIRFLOW-244] Modify hive operator to inject analysis data

### DIFF
--- a/airflow/operators/hive_operator.py
+++ b/airflow/operators/hive_operator.py
@@ -18,6 +18,7 @@ import re
 from airflow.hooks.hive_hooks import HiveCliHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.operator_helpers import context_to_airflow_vars
 
 
 class HiveOperator(BaseOperator):
@@ -76,7 +77,8 @@ class HiveOperator(BaseOperator):
     def execute(self, context):
         logging.info('Executing: ' + self.hql)
         self.hook = self.get_hook()
-        self.hook.run_cli(hql=self.hql, schema=self.schema)
+        self.hook.run_cli(hql=self.hql, schema=self.schema,
+                          hive_conf=context_to_airflow_vars(context))
 
     def dry_run(self):
         self.hook = self.get_hook()

--- a/airflow/utils/operator_helpers.py
+++ b/airflow/utils/operator_helpers.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def context_to_airflow_vars(context):
+    """
+    Given a context, this function provides a dictionary of values that can be used to
+    externally reconstruct relations between dags, dag_runs, tasks and task_instances.
+
+    :param context: The context for the task_instance of interest
+    :type successes: dict
+    """
+    params = dict()
+    dag = context['dag']
+    if dag and dag.dag_id:
+        params['airflow.ctx.dag.dag_id'] = dag.dag_id
+    dag_run = context['dag_run']
+    if dag_run and dag_run.execution_date:
+        params['airflow.ctx.dag_run.execution_date'] = dag_run.execution_date.isoformat()
+    task = context['task']
+    if task and task.task_id:
+        params['airflow.ctx.task.task_id'] = task.task_id
+    task_instance = context['task_instance']
+    if task_instance and task_instance.execution_date:
+        params['airflow.ctx.task_instance.execution_date'] = \
+            task_instance.execution_date.isoformat()
+    return params


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-244

Testing Done:
Test dags were run as backfills on an Airbnb Airflow dev box.

This PR exposes task/dag id/run data through the HiveOperator for ingestion by performance analysis tools like Dr. Elephant.

As per discussion this supersedes #1594 

@krishnap @artwr @aoen @mistercrunch 
