### PR TITLE
[AIRFLOW-31] Add zope dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -199,6 +199,7 @@ def do_setup():
             'setproctitle>=1.1.8, <2',
             'sqlalchemy>=0.9.8',
             'thrift>=0.9.2, <0.10',
+            'zope.deprecation>=4.0, <5.0',
         ],
         extras_require={
             'all': devel_all,
@@ -257,4 +258,3 @@ def do_setup():
 
 if __name__ == "__main__":
     do_setup()
-


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-31

When I rebased #1272, a critical line was lost: the dependency on `zope.deprecation`.
Thanks to @paulbramsen for catching it!
