### PR TITLE
[AIRFLOW-262] Simplify commands in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include airflow/www/templates *
-recursive-include airflow/www/static *
+graft airflow/www/templates
+graft airflow/www/static
 include airflow/alembic.ini
 include requirements.txt


### PR DESCRIPTION
`recursive-include` command with the wild card pattern can be simplified to use graft command instead.

Complete reference for the MANIFEST.in can be found [here](https://docs.python.org/3/distutils/commandref.html)
