### PR TITLE
[AIRFLOW-269] Add some unit tests for PostgreSQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
       - slapd
       - ldap-utils
       - openssh-server
+  postgresql: "9.2"
 python:
   - "2.7"
   - "3.4"


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-269

Testing Done:
- ran `./run_unit_tests.sh tests.operators:PostgresTest` and confirmed all 4 tests passed

There is only one unit test for PostgreSQL for now.
This patch add some tests as well as MySQL.
