### PR TITLE
[AIRFLOW-274] Add XCom functionality to GoogleCloudStorageDownloadOperator

### DIFF
--- a/airflow/contrib/operators/gcs_download_operator.py
+++ b/airflow/contrib/operators/gcs_download_operator.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.models import BaseOperator
@@ -17,7 +18,8 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
         self,
         bucket,
         object,
-        filename,
+        filename=False,
+        store_to_xcom_key=False,
         google_cloud_storage_conn_id='google_cloud_storage_default',
         delegate_to=None,
         *args,
@@ -32,7 +34,13 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
         :type object: string
         :param filename: The file path on the local file system (where the
             operator is being executed) that the file should be downloaded to.
+            If false, the downloaded data will not be stored on the local file
+            system.
         :type filename: string
+        :param store_to_xcom_key: If this param is set, the operator will push
+            the contents of the downloaded file to XCom with the key set in this
+            paramater. If false, the downloaded data will not be pushed to XCom.
+        :type store_to_xcom_key: string
         :param google_cloud_storage_conn_id: The connection ID to use when
             connecting to Google cloud storage.
         :type google_cloud_storage_conn_id: string
@@ -44,6 +52,7 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
         self.bucket = bucket
         self.object = object
         self.filename = filename
+        self.store_to_xcom_key = store_to_xcom_key
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
         self.delegate_to = delegate_to
 
@@ -51,4 +60,10 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
         logging.info('Executing download: %s, %s, %s', self.bucket, self.object, self.filename)
         hook = GoogleCloudStorageHook(google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
                                       delegate_to=self.delegate_to)
-        print(hook.download(self.bucket, self.object, self.filename))
+        file_bytes = hook.download(self.bucket, self.object, self.filename)
+        if self.store_to_xcom_key:
+            if sys.getsizeof(file_bytes) < 48000:
+                context['ti'].xcom_push(key=self.store_to_xcom_key, value=file_bytes)
+            else:
+                raise RuntimeError('The size of the downloaded file is too large to push to XCom!')
+        print(file_bytes)


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
[AIRFLOW-274]: I have updated GoogleCloudStorageDownloadOperator so that it has the option to store the downloaded file's contents in an XCom instead of saving to disk. It now also takes filename as an optional argument instead of a required argument, so it is not necessary to save to disk if you do not need to. 

Testing Done: I ran a DAG that relies on this functionality and it ran correctly.
