### PR TITLE
[AIRFLOW-283] Make store_to_xcom_key a templated field in GoogleCloudStorageDownloadOperator

### DIFF
--- a/airflow/contrib/operators/gcs_download_operator.py
+++ b/airflow/contrib/operators/gcs_download_operator.py
@@ -23,7 +23,7 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
     """
     Downloads a file from Google Cloud Storage.
     """
-    template_fields = ('bucket','object','filename',)
+    template_fields = ('bucket','object','filename','store_to_xcom_key',)
     template_ext = ('.sql',)
     ui_color = '#f0eee4'
 
@@ -53,7 +53,7 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
         :type filename: string
         :param store_to_xcom_key: If this param is set, the operator will push
             the contents of the downloaded file to XCom with the key set in this
-            paramater. If false, the downloaded data will not be pushed to XCom.
+            parameter. If false, the downloaded data will not be pushed to XCom.
         :type store_to_xcom_key: string
         :param google_cloud_storage_conn_id: The connection ID to use when
             connecting to Google cloud storage.


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-283

Testing Done: 

Reminders for contributors:
- Your PR's title must reference an issue on [Airflow's JIRA](https://issues.apache.org/jira/browse/AIRFLOW/). For example, a PR called "[AIRFLOW-1] My Amazing PR" would close JIRA issue #1. Please open a new issue if required!
- Please squash your commits when possible and follow the [7 rules of good Git commits](http://chris.beams.io/posts/git-commit/#seven-rules).
