### PR TITLE
[AIRFLOW-284] Fx for cursor scope for get_results

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -487,22 +487,22 @@ class HiveServer2Hook(BaseHook):
                 'data': [],
                 'header': [],
             }
+            cur = conn.cursor()
             for statement in hql:
-                with conn.cursor() as cur:
-                    cur.execute(statement)
-                    records = []
-                    try:
-                        # impala Lib raises when no results are returned
-                        # we're silencing here as some statements in the list
-                        # may be `SET` or DDL
-                        records = cur.fetchall()
-                    except ProgrammingError:
-                        logging.debug("get_results returned no records")
-                    if records:
-                        results = {
-                            'data': records,
-                            'header': cur.description,
-                        }
+                cur.execute(statement)
+                records = []
+                try:
+                    # impala Lib raises when no results are returned
+                    # we're silencing here as some statements in the list
+                    # may be `SET` or DDL
+                    records = cur.fetchall()
+                except ProgrammingError:
+                    logging.debug("get_results returned no records")
+                if records:
+                    results = {
+                        'data': records,
+                        'header': cur.description,
+                    }
             return results
 
     def to_csv(


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- _(replace with a link to AIRFLOW-X)_

Detail:
The function `get_results` implemented in the `HiveServer2Hook` does not execute multiple commands passed to it in a list, in the singular cursor scope. This has caused SQL statements that depend on the execution of `add jar` and `set` commands to fail as they are being executed in different cursor scopes which are not persistent.
The code has been updated to have the cursor object persistent.

Testing Done:

Reminders for contributors:
- Your PR's title must reference an issue on [Airflow's JIRA](https://issues.apache.org/jira/browse/AIRFLOW/). For example, a PR called "[AIRFLOW-1] My Amazing PR" would close JIRA issue #1. Please open a new issue if required!
- Please squash your commits when possible and follow the [7 rules of good Git commits](http://chris.beams.io/posts/git-commit/#seven-rules).

@mistercrunch
