### PR TITLE
[AIRFLOW-289] Changed datetime.now() to datetime.utcnow()

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -167,7 +167,7 @@ def trigger_dag(args):
         logging.error("Cannot find dag {}".format(args.dag_id))
         sys.exit(1)
 
-    execution_date = datetime.now()
+    execution_date = datetime.utcnow()
     run_id = args.run_id or "manual__{0}".format(execution_date.isoformat())
 
     dr = DagRun.find(dag_id=args.dag_id, run_id=run_id)

--- a/airflow/example_dags/docker_copy_data.py
+++ b/airflow/example_dags/docker_copy_data.py
@@ -29,7 +29,7 @@ TODO: Review the workflow, change it accordingly to to your environment & enable
 # default_args = {
 #     'owner': 'airflow',
 #     'depends_on_past': False,
-#     'start_date': datetime.now(),
+#     'start_date': datetime.utcnow(),
 #     'email': ['airflow@airflow.com'],
 #     'email_on_failure': False,
 #     'email_on_retry': False,

--- a/airflow/example_dags/example_docker_operator.py
+++ b/airflow/example_dags/example_docker_operator.py
@@ -20,7 +20,7 @@ from airflow.operators.docker_operator import DockerOperator
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': datetime.now(),
+    'start_date': datetime.utcnow(),
     'email': ['airflow@airflow.com'],
     'email_on_failure': False,
     'email_on_retry': False,

--- a/airflow/example_dags/example_passing_params_via_test_command.py
+++ b/airflow/example_dags/example_passing_params_via_test_command.py
@@ -21,7 +21,7 @@ from airflow.operators.python_operator import PythonOperator
 
 dag = DAG("example_passing_params_via_test_command",
           default_args={"owner": "airflow",
-                        "start_date":datetime.now()},
+                        "start_date":datetime.utcnow()},
           schedule_interval='*/1 * * * *',
           dagrun_timeout=timedelta(minutes=4)
           )

--- a/airflow/example_dags/example_trigger_controller_dag.py
+++ b/airflow/example_dags/example_trigger_controller_dag.py
@@ -50,7 +50,7 @@ def conditionally_trigger(context, dag_run_obj):
 # Define the DAG
 dag = DAG(dag_id='example_trigger_controller_dag',
           default_args={"owner": "airflow",
-                        "start_date": datetime.now()},
+                        "start_date": datetime.utcnow()},
           schedule_interval='@once')
 
 

--- a/airflow/example_dags/example_trigger_target_dag.py
+++ b/airflow/example_dags/example_trigger_target_dag.py
@@ -37,7 +37,7 @@ pp = pprint.PrettyPrinter(indent=4)
 # 2. A Target DAG : c.f. example_trigger_target_dag.py
 
 args = {
-    'start_date': datetime.now(),
+    'start_date': datetime.utcnow(),
     'owner': 'airflow',
 }
 

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -101,22 +101,22 @@ class BaseJob(Base, LoggingMixin):
         self.hostname = socket.getfqdn()
         self.executor = executor
         self.executor_class = executor.__class__.__name__
-        self.start_date = datetime.now()
-        self.latest_heartbeat = datetime.now()
+        self.start_date = datetime.utcnow()
+        self.latest_heartbeat = datetime.utcnow()
         self.heartrate = heartrate
         self.unixname = getpass.getuser()
         super(BaseJob, self).__init__(*args, **kwargs)
 
     def is_alive(self):
         return (
-            (datetime.now() - self.latest_heartbeat).seconds <
+            (datetime.utcnow() - self.latest_heartbeat).seconds <
             (conf.getint('scheduler', 'JOB_HEARTBEAT_SEC') * 2.1)
         )
 
     def kill(self):
         session = settings.Session()
         job = session.query(BaseJob).filter(BaseJob.id == self.id).first()
-        job.end_date = datetime.now()
+        job.end_date = datetime.utcnow()
         try:
             self.on_kill()
         except:
@@ -162,11 +162,11 @@ class BaseJob(Base, LoggingMixin):
 
         if job.latest_heartbeat:
             sleep_for = self.heartrate - (
-                datetime.now() - job.latest_heartbeat).total_seconds()
+                datetime.utcnow() - job.latest_heartbeat).total_seconds()
             if sleep_for > 0:
                 sleep(sleep_for)
 
-        job.latest_heartbeat = datetime.now()
+        job.latest_heartbeat = datetime.utcnow()
 
         session.merge(job)
         session.commit()
@@ -190,7 +190,7 @@ class BaseJob(Base, LoggingMixin):
         self._execute()
 
         # Marking the success in the DB
-        self.end_date = datetime.now()
+        self.end_date = datetime.utcnow()
         self.state = State.SUCCESS
         session.merge(self)
         session.commit()
@@ -343,7 +343,7 @@ class DagFileProcessor(AbstractDagFileProcessor):
             self._dag_id_white_list,
             "DagFileProcessor{}".format(self._instance_id),
             self.log_file)
-        self._start_time = datetime.now()
+        self._start_time = datetime.utcnow()
 
     def terminate(self, sigkill=False):
         """
@@ -547,16 +547,16 @@ class SchedulerJob(BaseJob):
             TI.execution_date == sq.c.max_ti,
         ).all()
 
-        ts = datetime.now()
+        ts = datetime.utcnow()
         SlaMiss = models.SlaMiss
         for ti in max_tis:
             task = dag.get_task(ti.task_id)
             dttm = ti.execution_date
             if task.sla:
                 dttm = dag.following_schedule(dttm)
-                while dttm < datetime.now():
+                while dttm < datetime.utcnow():
                     following_schedule = dag.following_schedule(dttm)
-                    if following_schedule + task.sla < datetime.now():
+                    if following_schedule + task.sla < datetime.utcnow():
                         session.merge(models.SlaMiss(
                             task_id=ti.task_id,
                             dag_id=ti.dag_id,
@@ -693,9 +693,9 @@ class SchedulerJob(BaseJob):
             for dr in active_runs:
                 if (
                         dr.start_date and dag.dagrun_timeout and
-                        dr.start_date < datetime.now() - dag.dagrun_timeout):
+                        dr.start_date < datetime.utcnow() - dag.dagrun_timeout):
                     dr.state = State.FAILED
-                    dr.end_date = datetime.now()
+                    dr.end_date = datetime.utcnow()
                     timedout_runs += 1
             session.commit()
             if len(active_runs) - timedout_runs >= dag.max_active_runs:
@@ -764,11 +764,11 @@ class SchedulerJob(BaseJob):
             if next_run_date and min_task_end_date and next_run_date > min_task_end_date:
                 return
 
-            if next_run_date and period_end and period_end <= datetime.now():
+            if next_run_date and period_end and period_end <= datetime.utcnow():
                 next_run = dag.create_dagrun(
                     run_id='scheduled__' + next_run_date.isoformat(),
                     execution_date=next_run_date,
-                    start_date=datetime.now(),
+                    start_date=datetime.utcnow(),
                     state=State.RUNNING,
                     external_trigger=False
                 )
@@ -788,7 +788,7 @@ class SchedulerJob(BaseJob):
         for run in dag_runs:
             self.logger.info("Examining DAG run {}".format(run))
             # don't consider runs that are executed in the future
-            if run.execution_date > datetime.now():
+            if run.execution_date > datetime.utcnow():
                 self.logging.error("Execution date is in future: {}"
                                    .format(run.execution_date))
                 continue
@@ -1032,7 +1032,7 @@ class SchedulerJob(BaseJob):
                 self.logger.info("Setting state of {} to {}".format(
                     task_instance.key, State.QUEUED))
                 task_instance.state = State.QUEUED
-                task_instance.queued_dttm = (datetime.now()
+                task_instance.queued_dttm = (datetime.utcnow()
                                              if not task_instance.queued_dttm
                                              else task_instance.queued_dttm)
                 session.merge(task_instance)
@@ -1142,7 +1142,7 @@ class SchedulerJob(BaseJob):
             last_runtime = processor_manager.get_last_runtime(file_path)
             processor_pid = processor_manager.get_pid(file_path)
             processor_start_time = processor_manager.get_start_time(file_path)
-            runtime = ((datetime.now() - processor_start_time).total_seconds()
+            runtime = ((datetime.utcnow() - processor_start_time).total_seconds()
                        if processor_start_time else None)
             last_run = processor_manager.get_last_finish_time(file_path)
 
@@ -1306,34 +1306,34 @@ class SchedulerJob(BaseJob):
         self.clear_import_errors(session)
         session.close()
 
-        execute_start_time = datetime.now()
+        execute_start_time = datetime.utcnow()
 
         # Last time stats were printed
         last_stat_print_time = datetime(2000, 1, 1)
         # Last time that self.heartbeat() was called.
-        last_self_heartbeat_time = datetime.now()
+        last_self_heartbeat_time = datetime.utcnow()
         # Last time that the DAG dir was traversed to look for files
-        last_dag_dir_refresh_time = datetime.now()
+        last_dag_dir_refresh_time = datetime.utcnow()
 
         # Use this value initially
         known_file_paths = processor_manager.file_paths
 
         # For the execute duration, parse and schedule DAGs
-        while (datetime.now() - execute_start_time).total_seconds() < \
+        while (datetime.utcnow() - execute_start_time).total_seconds() < \
                 self.run_duration:
             self.logger.debug("Starting Loop...")
             loop_start_time = time.time()
 
             # Traverse the DAG directory for Python files containing DAGs
             # periodically
-            elapsed_time_since_refresh = (datetime.now() -
+            elapsed_time_since_refresh = (datetime.utcnow() -
                                           last_dag_dir_refresh_time).total_seconds()
 
             if elapsed_time_since_refresh > self.dag_dir_list_interval:
                 # Build up a list of Python files that could contain DAGs
                 self.logger.info("Searching for files in {}".format(self.subdir))
                 known_file_paths = list_py_file_paths(self.subdir)
-                last_dag_dir_refresh_time = datetime.now()
+                last_dag_dir_refresh_time = datetime.utcnow()
                 self.logger.info("There are {} files in {}"
                                  .format(len(known_file_paths), self.subdir))
                 processor_manager.set_file_paths(known_file_paths)
@@ -1383,20 +1383,20 @@ class SchedulerJob(BaseJob):
             self._process_executor_events()
 
             # Heartbeat the scheduler periodically
-            time_since_last_heartbeat = (datetime.now() -
+            time_since_last_heartbeat = (datetime.utcnow() -
                                          last_self_heartbeat_time).total_seconds()
             if time_since_last_heartbeat > self.heartrate:
                 self.logger.info("Heartbeating the scheduler")
                 self.heartbeat()
-                last_self_heartbeat_time = datetime.now()
+                last_self_heartbeat_time = datetime.utcnow()
 
             # Occasionally print out stats about how fast the files are getting processed
-            if ((datetime.now() - last_stat_print_time).total_seconds() >
+            if ((datetime.utcnow() - last_stat_print_time).total_seconds() >
                     self.print_stats_interval):
                 if len(known_file_paths) > 0:
                     self._log_file_processing_stats(known_file_paths,
                                                     processor_manager)
-                last_stat_print_time = datetime.now()
+                last_stat_print_time = datetime.utcnow()
 
             loop_end_time = time.time()
             self.logger.debug("Ran scheduling loop in {:.2f}s"
@@ -1477,7 +1477,7 @@ class SchedulerJob(BaseJob):
             return []
 
         # Save individual DAGs in the ORM and update DagModel.last_scheduled_time
-        sync_time = datetime.now()
+        sync_time = datetime.utcnow()
         for dag in dagbag.dags.values():
             models.DAG.sync_to_db(dag, dag.owner, sync_time)
 
@@ -1634,7 +1634,7 @@ class BackfillJob(BaseJob):
         # create dag runs
         dr_start_date = start_date or min([t.start_date for t in self.dag.tasks])
         next_run_date = self.dag.normalize_schedule(dr_start_date)
-        end_date = end_date or datetime.now()
+        end_date = end_date or datetime.utcnow()
 
         active_dag_runs = []
         while next_run_date and next_run_date <= end_date:
@@ -1649,7 +1649,7 @@ class BackfillJob(BaseJob):
                 run = self.dag.create_dagrun(
                     run_id=run_id,
                     execution_date=next_run_date,
-                    start_date=datetime.now(),
+                    start_date=datetime.utcnow(),
                     state=State.RUNNING,
                     external_trigger=False,
                     session=session,

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -133,7 +133,7 @@ def clear_task_instances(tis, session, activate_dag_runs=True):
         ).all()
         for dr in drs:
             dr.state = State.RUNNING
-            dr.start_date = datetime.now()
+            dr.start_date = datetime.utcnow()
 
 
 class DagBag(BaseDagBag, LoggingMixin):
@@ -322,7 +322,7 @@ class DagBag(BaseDagBag, LoggingMixin):
         TI = TaskInstance
         secs = (
             configuration.getint('scheduler', 'job_heartbeat_sec') * 3) + 120
-        limit_dttm = datetime.now() - timedelta(seconds=secs)
+        limit_dttm = datetime.utcnow() - timedelta(seconds=secs)
         self.logger.info(
             "Failing jobs without heartbeat after {}".format(limit_dttm))
 
@@ -356,7 +356,7 @@ class DagBag(BaseDagBag, LoggingMixin):
         """
         self.dags[dag.dag_id] = dag
         dag.resolve_template_files()
-        dag.last_loaded = datetime.now()
+        dag.last_loaded = datetime.utcnow()
 
         for task in dag.tasks:
             settings.policy(task)
@@ -382,7 +382,7 @@ class DagBag(BaseDagBag, LoggingMixin):
         ignoring files that match any of the regex patterns specified
         in the file.
         """
-        start_dttm = datetime.now()
+        start_dttm = datetime.utcnow()
         dag_folder = dag_folder or self.dag_folder
 
         # Used to store stats around DagBag processing
@@ -410,11 +410,11 @@ class DagBag(BaseDagBag, LoggingMixin):
                             continue
                         if not any(
                                 [re.findall(p, filepath) for p in patterns]):
-                            ts = datetime.now()
+                            ts = datetime.utcnow()
                             found_dags = self.process_file(
                                 filepath, only_if_updated=only_if_updated)
 
-                            td = datetime.now() - ts
+                            td = datetime.utcnow() - ts
                             td = td.total_seconds() + (
                                 float(td.microseconds) / 1000000)
                             stats.append(FileLoadStat(
@@ -427,7 +427,7 @@ class DagBag(BaseDagBag, LoggingMixin):
                     except Exception as e:
                         logging.warning(e)
         Stats.gauge(
-            'collect_dags', (datetime.now() - start_dttm).total_seconds(), 1)
+            'collect_dags', (datetime.utcnow() - start_dttm).total_seconds(), 1)
         Stats.gauge(
             'dagbag_size', len(self.dags), 1)
         Stats.gauge(
@@ -954,8 +954,8 @@ class TaskInstance(Base):
 
     def set_state(self, state, session):
         self.state = state
-        self.start_date = datetime.now()
-        self.end_date = datetime.now()
+        self.start_date = datetime.utcnow()
+        self.end_date = datetime.utcnow()
         session.merge(self)
         session.commit()
 
@@ -1079,7 +1079,7 @@ class TaskInstance(Base):
         to be retried.
         """
         return (self.state == State.UP_FOR_RETRY and
-                self.next_retry_datetime() < datetime.now())
+                self.next_retry_datetime() < datetime.utcnow())
 
     @provide_session
     def pool_full(self, session):
@@ -1182,7 +1182,7 @@ class TaskInstance(Base):
         msg = "Starting attempt {attempt} of {total}".format(
             attempt=self.try_number % (task.retries + 1) + 1,
             total=task.retries + 1)
-        self.start_date = datetime.now()
+        self.start_date = datetime.utcnow()
 
         dep_context = DepContext(
             deps=RUN_DEPS - QUEUE_DEPS,
@@ -1205,7 +1205,7 @@ class TaskInstance(Base):
                     total=task.retries + 1)
                 logging.info(hr + msg + hr)
 
-                self.queued_dttm = datetime.now()
+                self.queued_dttm = datetime.utcnow()
                 session.merge(self)
                 session.commit()
                 logging.info("Queuing into pool {}".format(self.pool))
@@ -1278,7 +1278,7 @@ class TaskInstance(Base):
             raise
 
         # Recording SUCCESS
-        self.end_date = datetime.now()
+        self.end_date = datetime.utcnow()
         self.set_duration()
         if not test_mode:
             session.add(Log(self.state, self))
@@ -1307,7 +1307,7 @@ class TaskInstance(Base):
         logging.exception(error)
         task = self.task
         session = settings.Session()
-        self.end_date = datetime.now()
+        self.end_date = datetime.utcnow()
         self.set_duration()
         Stats.incr('operator_failures_{}'.format(task.__class__.__name__), 1, 1)
         if not test_mode:
@@ -1609,7 +1609,7 @@ class Log(Base):
     extra = Column(Text)
 
     def __init__(self, event, task_instance, owner=None, extra=None, **kwargs):
-        self.dttm = datetime.now()
+        self.dttm = datetime.utcnow()
         self.event = event
         self.extra = extra
 
@@ -2209,7 +2209,7 @@ class BaseOperator(object):
         range.
         """
         TI = TaskInstance
-        end_date = end_date or datetime.now()
+        end_date = end_date or datetime.utcnow()
         return session.query(TI).filter(
             TI.dag_id == self.dag_id,
             TI.task_id == self.task_id,
@@ -2256,7 +2256,7 @@ class BaseOperator(object):
         Run a set of task instances for a date range.
         """
         start_date = start_date or self.start_date
-        end_date = end_date or self.end_date or datetime.now()
+        end_date = end_date or self.end_date or datetime.utcnow()
 
         for dt in self.dag.date_range(start_date, end_date=end_date):
             TaskInstance(self, dt).run(
@@ -2545,7 +2545,7 @@ class DAG(BaseDag, LoggingMixin):
             template_searchpath = [template_searchpath]
         self.template_searchpath = template_searchpath
         self.parent_dag = None  # Gets set when DAGs are loaded
-        self.last_loaded = datetime.now()
+        self.last_loaded = datetime.utcnow()
         self.safe_dag_id = dag_id.replace('.', '__dot__')
         self.max_active_runs = max_active_runs
         self.dagrun_timeout = dagrun_timeout
@@ -2609,7 +2609,7 @@ class DAG(BaseDag, LoggingMixin):
 
     # /Context Manager ----------------------------------------------
 
-    def date_range(self, start_date, num=None, end_date=datetime.now()):
+    def date_range(self, start_date, num=None, end_date=datetime.utcnow()):
         if num:
             end_date = None
         return utils_date_range(
@@ -2833,7 +2833,7 @@ class DAG(BaseDag, LoggingMixin):
         if not start_date:
             start_date = (datetime.today()-timedelta(30)).date()
             start_date = datetime.combine(start_date, datetime.min.time())
-        end_date = end_date or datetime.now()
+        end_date = end_date or datetime.utcnow()
         tis = session.query(TI).filter(
             TI.dag_id == self.dag_id,
             TI.execution_date >= start_date,
@@ -2982,10 +2982,10 @@ class DAG(BaseDag, LoggingMixin):
         d = {}
         d['is_picklable'] = True
         try:
-            dttm = datetime.now()
+            dttm = datetime.utcnow()
             pickled = pickle.dumps(self)
             d['pickle_len'] = len(pickled)
-            d['pickling_duration'] = "{}".format(datetime.now() - dttm)
+            d['pickling_duration'] = "{}".format(datetime.utcnow() - dttm)
         except Exception as e:
             logging.exception(e)
             d['is_picklable'] = False
@@ -3003,7 +3003,7 @@ class DAG(BaseDag, LoggingMixin):
         if not dp or dp.pickle != self:
             dp = DagPickle(dag=self)
             session.add(dp)
-            self.last_pickled = datetime.now()
+            self.last_pickled = datetime.utcnow()
             session.commit()
             self.pickle_id = dp.id
 
@@ -3738,7 +3738,7 @@ class DagRun(Base):
 
         # pre-calculate
         # db is faster
-        start_dttm = datetime.now()
+        start_dttm = datetime.utcnow()
         unfinished_tasks = self.get_task_instances(
             state=State.unfinished(),
             session=session
@@ -3750,7 +3750,7 @@ class DagRun(Base):
             no_dependencies_met = all(not t.are_dependencies_met(session=session)
                                       for t in unfinished_tasks)
 
-        duration = (datetime.now() - start_dttm).total_seconds() * 1000
+        duration = (datetime.utcnow() - start_dttm).total_seconds() * 1000
         Stats.timing("dagrun.dependency-check.{}.{}".
                      format(self.dag_id, self.execution_date), duration)
 

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -61,7 +61,7 @@ class TriggerDagRunOperator(BaseOperator):
         self.trigger_dag_id = trigger_dag_id
 
     def execute(self, context):
-        dro = DagRunOrder(run_id='trig__' + datetime.now().isoformat())
+        dro = DagRunOrder(run_id='trig__' + datetime.utcnow().isoformat())
         dro = self.python_callable(context, dro)
         if dro:
             session = settings.Session()

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -111,8 +111,8 @@ class BranchPythonOperator(PythonOperator):
                 ti = TaskInstance(
                     task, execution_date=context['ti'].execution_date)
                 ti.state = State.SKIPPED
-                ti.start_date = datetime.now()
-                ti.end_date = datetime.now()
+                ti.start_date = datetime.utcnow()
+                ti.end_date = datetime.utcnow()
                 session.merge(ti)
         session.commit()
         session.close()
@@ -144,8 +144,8 @@ class ShortCircuitOperator(PythonOperator):
                 ti = TaskInstance(
                     task, execution_date=context['ti'].execution_date)
                 ti.state = State.SKIPPED
-                ti.start_date = datetime.now()
-                ti.end_date = datetime.now()
+                ti.start_date = datetime.utcnow()
+                ti.end_date = datetime.utcnow()
                 session.merge(ti)
             session.commit()
             session.close()

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -69,9 +69,9 @@ class BaseSensorOperator(BaseOperator):
         raise AirflowException('Override me.')
 
     def execute(self, context):
-        started_at = datetime.now()
+        started_at = datetime.utcnow()
         while not self.poke(context):
-            if (datetime.now() - started_at).total_seconds() > self.timeout:
+            if (datetime.utcnow() - started_at).total_seconds() > self.timeout:
                 if self.soft_fail:
                     raise AirflowSkipException('Snap. Time is OUT.')
                 else:
@@ -547,7 +547,7 @@ class TimeSensor(BaseSensorOperator):
     def poke(self, context):
         logging.info(
             'Checking if the time ({0}) has come'.format(self.target_time))
-        return datetime.now().time() > self.target_time
+        return datetime.utcnow().time() > self.target_time
 
 
 class TimeDeltaSensor(BaseSensorOperator):
@@ -572,7 +572,7 @@ class TimeDeltaSensor(BaseSensorOperator):
         target_dttm = dag.following_schedule(context['execution_date'])
         target_dttm += self.delta
         logging.info('Checking if the time ({0}) has come'.format(target_dttm))
-        return datetime.now() > target_dttm
+        return datetime.utcnow() > target_dttm
 
 
 class HttpSensor(BaseSensorOperator):

--- a/airflow/ti_deps/deps/not_in_retry_period_dep.py
+++ b/airflow/ti_deps/deps/not_in_retry_period_dep.py
@@ -32,7 +32,7 @@ class NotInRetryPeriodDep(BaseTIDep):
 
         # Calculate the date first so that it is always smaller than the timestamp used by
         # ready_for_retry
-        cur_date = datetime.now()
+        cur_date = datetime.utcnow()
         next_task_retry_date = ti.next_retry_datetime()
         if ti.is_premature:
             yield self._failing_status(

--- a/airflow/ti_deps/deps/runnable_exec_date_dep.py
+++ b/airflow/ti_deps/deps/runnable_exec_date_dep.py
@@ -23,7 +23,7 @@ class RunnableExecDateDep(BaseTIDep):
 
     @provide_session
     def _get_dep_statuses(self, ti, session, dep_context):
-        cur_date = datetime.now()
+        cur_date = datetime.utcnow()
 
         if ti.execution_date > cur_date:
             yield self._failing_status(

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -387,7 +387,7 @@ class DagFileProcessorManager(LoggingMixin):
         being processed
         """
         if file_path in self._processors:
-            return (datetime.now() - self._processors[file_path].start_time)\
+            return (datetime.utcnow() - self._processors[file_path].start_time)\
                 .total_seconds()
         return None
 
@@ -477,7 +477,7 @@ class DagFileProcessorManager(LoggingMixin):
         """
         # General approach is to put the log file under the same relative path
         # under the log directory as the DAG file in the DAG directory
-        now = datetime.now()
+        now = datetime.utcnow()
         log_directory = os.path.join(self._child_process_log_directory,
                                      now.strftime("%Y-%m-%d"))
         relative_dag_file_path = os.path.relpath(dag_file_path, start=self._dag_directory)
@@ -521,7 +521,7 @@ class DagFileProcessorManager(LoggingMixin):
         for file_path, processor in self._processors.items():
             if processor.done:
                 self.logger.info("Processor for {} finished".format(file_path))
-                now = datetime.now()
+                now = datetime.utcnow()
                 finished_processors[file_path] = processor
                 self._last_runtime[file_path] = (now -
                                                  processor.start_time).total_seconds()
@@ -550,7 +550,7 @@ class DagFileProcessorManager(LoggingMixin):
             # If the file path is already being processed, or if a file was
             # processed recently, wait until the next batch
             file_paths_in_progress = self._processors.keys()
-            now = datetime.now()
+            now = datetime.utcnow()
             file_paths_recently_processed = []
             for file_path in self._file_paths:
                 last_finish_time = self.get_last_finish_time(file_path)

--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -66,7 +66,7 @@ def date_range(
     if end_date and num:
         raise Exception("Wait. Either specify end_date OR num")
     if not end_date and not num:
-        end_date = datetime.now()
+        end_date = datetime.utcnow()
 
     delta_iscron = False
     if isinstance(delta, six.string_types):

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -33,7 +33,7 @@ class DateTimeWithNumRunsForm(Form):
     # Date time and number of runs form for tree view, task duration
     # and landing times
     base_date = DateTimeField(
-        "Anchor date", widget=DateTimePickerWidget(), default=datetime.now())
+        "Anchor date", widget=DateTimePickerWidget(), default=datetime.utcnow())
     num_runs = SelectField("Number of runs", default=25, choices=(
         (5, "5"),
         (25, "25"),

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -159,7 +159,7 @@ def duration_f(v, c, m, p):
 def datetime_f(v, c, m, p):
     attr = getattr(m, p)
     dttm = attr.isoformat() if attr else ''
-    if datetime.now().isoformat()[:4] == dttm[:4]:
+    if datetime.utcnow().isoformat()[:4] == dttm[:4]:
         dttm = dttm[5:]
     return Markup("<nobr>{}</nobr>".format(dttm))
 
@@ -1069,7 +1069,7 @@ class Airflow(BaseView):
         task_id_to_dag = {
             task_id: dag
         }
-        end_date = ((dag.latest_execution_date or datetime.now())
+        end_date = ((dag.latest_execution_date or datetime.utcnow())
                     if future else execution_date)
 
         if 'start_date' in dag.default_args:
@@ -1188,7 +1188,7 @@ class Airflow(BaseView):
         if base_date:
             base_date = dateutil.parser.parse(base_date)
         else:
-            base_date = dag.latest_execution_date or datetime.now()
+            base_date = dag.latest_execution_date or datetime.utcnow()
 
         dates = dag.date_range(base_date, num=-abs(num_runs))
         min_date = dates[0] if dates else datetime(2000, 1, 1)
@@ -1242,7 +1242,7 @@ class Airflow(BaseView):
 
             def set_duration(tid):
                 if isinstance(tid, dict) and tid.get("state") == State.RUNNING:
-                    d = datetime.now() - dateutil.parser.parse(tid["start_date"])
+                    d = datetime.utcnow() - dateutil.parser.parse(tid["start_date"])
                     tid["duration"] = d.total_seconds()
                 return tid
 
@@ -1339,7 +1339,7 @@ class Airflow(BaseView):
         if dttm:
             dttm = dateutil.parser.parse(dttm)
         else:
-            dttm = dag.latest_execution_date or datetime.now().date()
+            dttm = dag.latest_execution_date or datetime.utcnow().date()
 
         DR = models.DagRun
         drs = (
@@ -1415,7 +1415,7 @@ class Airflow(BaseView):
         if base_date:
             base_date = dateutil.parser.parse(base_date)
         else:
-            base_date = dag.latest_execution_date or datetime.now()
+            base_date = dag.latest_execution_date or datetime.utcnow()
 
         dates = dag.date_range(base_date, num=-abs(num_runs))
         min_date = dates[0] if dates else datetime(2000, 1, 1)
@@ -1495,7 +1495,7 @@ class Airflow(BaseView):
         if base_date:
             base_date = dateutil.parser.parse(base_date)
         else:
-            base_date = dag.latest_execution_date or datetime.now()
+            base_date = dag.latest_execution_date or datetime.utcnow()
 
         dates = dag.date_range(base_date, num=-abs(num_runs))
         min_date = dates[0] if dates else datetime(2000, 1, 1)
@@ -1557,7 +1557,7 @@ class Airflow(BaseView):
         if base_date:
             base_date = dateutil.parser.parse(base_date)
         else:
-            base_date = dag.latest_execution_date or datetime.now()
+            base_date = dag.latest_execution_date or datetime.utcnow()
 
         dates = dag.date_range(base_date, num=-abs(num_runs))
         min_date = dates[0] if dates else datetime(2000, 1, 1)
@@ -1638,7 +1638,7 @@ class Airflow(BaseView):
             DagModel).filter(DagModel.dag_id == dag_id).first()
 
         if orm_dag:
-            orm_dag.last_expired = datetime.now()
+            orm_dag.last_expired = datetime.utcnow()
             session.merge(orm_dag)
         session.commit()
         session.close()
@@ -1675,7 +1675,7 @@ class Airflow(BaseView):
         if dttm:
             dttm = dateutil.parser.parse(dttm)
         else:
-            dttm = dag.latest_execution_date or datetime.now().date()
+            dttm = dag.latest_execution_date or datetime.utcnow().date()
 
         form = DateTimeForm(data={'execution_date': dttm})
 
@@ -1688,7 +1688,7 @@ class Airflow(BaseView):
         for ti in tis:
             tasks.append({
                 'startDate': wwwutils.epoch(ti.start_date),
-                'endDate': wwwutils.epoch(ti.end_date or datetime.now()),
+                'endDate': wwwutils.epoch(ti.end_date or datetime.utcnow()),
                 'isoStart': ti.start_date.isoformat()[:-4],
                 'isoEnd': ti.end_date.isoformat()[:-4],
                 'taskName': ti.task_id,
@@ -2055,7 +2055,7 @@ class ChartModelView(wwwutils.DataProfilingMixin, AirflowModelView):
             model.iteration_no += 1
         if not model.user_id and current_user and hasattr(current_user, 'id'):
             model.user_id = current_user.id
-        model.last_modified = datetime.now()
+        model.last_modified = datetime.utcnow()
 
 chart_mapping = (
     ('line', 'lineChart'),
@@ -2243,9 +2243,9 @@ class DagRunModelView(ModelViewOnly):
                 count += 1
                 dr.state = target_state
                 if target_state == State.RUNNING:
-                    dr.start_date = datetime.now()
+                    dr.start_date = datetime.utcnow()
                 else:
-                    dr.end_date = datetime.now()
+                    dr.end_date = datetime.utcnow()
             session.commit()
             models.DagStat.clean_dirty(dirty_ids, session=session)
             flash(

--- a/dags/test_dag.py
+++ b/dags/test_dag.py
@@ -16,7 +16,7 @@ from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from datetime import datetime
 
-now = datetime.now()
+now = datetime.utcnow()
 now_to_the_hour = now.replace(hour=now.time().hour-3 , minute=0, second=0, microsecond=0)
 START_DATE = now_to_the_hour 
 DAG_NAME = 'test_dag_v1'

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -78,7 +78,7 @@ pay special attention to ``start_date``, and may want to reactivate
 inactive DagRuns to get the new task to get onboarded properly.
 
 We recommend against using dynamic values as ``start_date``, especially
-``datetime.now()`` as it can be quite confusing. The task is triggered
+``datetime.utcnow()`` as it can be quite confusing. The task is triggered
 once the period closes, and in theory an ``@hourly`` DAG would never get to
 an hour after now as ``now()`` moves along.
 

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -16,6 +16,7 @@ flask-admin
 flask-cache
 flask-login==0.2.11
 flower
+freezegun
 future
 gunicorn
 hive-thrift-py

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,8 @@ qds = ['qds-sdk>=1.9.0']
 cloudant = ['cloudant>=0.5.9,<2.0'] # major update coming soon, clamp to 0.x
 
 all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant
-devel = ['lxml>=3.3.4', 'nose', 'nose-parameterized', 'mock', 'click', 'jira', 'moto']
+devel = ['lxml>=3.3.4', 'nose', 'nose-parameterized', 'mock', 'freezegun',
+         'click', 'jira', 'moto']
 devel_minreq = devel + mysql + doc + password + s3
 devel_hadoop = devel_minreq + hive + hdfs + webhdfs + kerberos
 devel_all = devel + all_dbs + doc + samba + s3 + slack + crypto + oracle + docker
@@ -204,7 +205,7 @@ def do_setup():
             'tabulate>=0.7.5, <0.8.0',
             'thrift>=0.9.2, <0.10',
             'zope.deprecation>=4.0, <5.0',
-	    'lxml==3.6.0',
+            'lxml==3.6.0',
         ],
         extras_require={
             'all': devel_all,

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -652,7 +652,7 @@ class SchedulerJobTest(unittest.TestCase):
 
         dr = scheduler.create_dag_run(dag)
         self.assertIsNotNone(dr)
-        dr.start_date = datetime.datetime.now() - datetime.timedelta(days=1)
+        dr.start_date = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         session.merge(dr)
         session.commit()
 
@@ -695,7 +695,7 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertIsNone(new_dr)
 
         # Should be scheduled as dagrun_timeout has passed
-        dr.start_date = datetime.datetime.now() - datetime.timedelta(days=1)
+        dr.start_date = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         session.merge(dr)
         session.commit()
         new_dr = scheduler.create_dag_run(dag)
@@ -812,12 +812,12 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertTrue(dag.start_date > DEFAULT_DATE)
 
         expected_run_duration = 5
-        start_time = datetime.datetime.now()
+        start_time = datetime.datetime.utcnow()
         scheduler = SchedulerJob(dag_id,
                                  run_duration=expected_run_duration,
                                  **self.default_scheduler_args)
         scheduler.run()
-        end_time = datetime.datetime.now()
+        end_time = datetime.datetime.utcnow()
 
         run_duration = (end_time - start_time).total_seconds()
         logging.info("Test ran in %.2fs, expected %.2fs",

--- a/tests/models.py
+++ b/tests/models.py
@@ -303,7 +303,7 @@ class TaskInstanceTest(unittest.TestCase):
                              pool='test_run_pooling_task_pool', owner='airflow',
                              start_date=datetime.datetime(2016, 2, 1, 0, 0, 0))
         ti = TI(
-            task=task, execution_date=datetime.datetime.now())
+            task=task, execution_date=datetime.datetime.utcnow())
         ti.run()
         self.assertEqual(ti.state, models.State.QUEUED)
 
@@ -324,7 +324,7 @@ class TaskInstanceTest(unittest.TestCase):
             owner='airflow',
             start_date=datetime.datetime(2016, 2, 1, 0, 0, 0))
         ti = TI(
-            task=task, execution_date=datetime.datetime.now())
+            task=task, execution_date=datetime.datetime.utcnow())
         ti.run(mark_success=True)
         self.assertEqual(ti.state, models.State.SUCCESS)
 
@@ -345,7 +345,7 @@ class TaskInstanceTest(unittest.TestCase):
             owner='airflow',
             start_date=datetime.datetime(2016, 2, 1, 0, 0, 0))
         ti = TI(
-            task=task, execution_date=datetime.datetime.now())
+            task=task, execution_date=datetime.datetime.utcnow())
         ti.run()
         self.assertTrue(ti.state == models.State.SKIPPED)
 
@@ -370,7 +370,7 @@ class TaskInstanceTest(unittest.TestCase):
                 pass
 
         ti = TI(
-            task=task, execution_date=datetime.datetime.now())
+            task=task, execution_date=datetime.datetime.utcnow())
 
         # first run -- up for retry
         run_with_error(ti)
@@ -411,7 +411,7 @@ class TaskInstanceTest(unittest.TestCase):
                 pass
 
         ti = TI(
-            task=task, execution_date=datetime.datetime.now())
+            task=task, execution_date=datetime.datetime.utcnow())
 
         # first run -- up for retry
         run_with_error(ti)
@@ -454,8 +454,8 @@ class TaskInstanceTest(unittest.TestCase):
             owner='airflow',
             start_date=datetime.datetime(2016, 2, 1, 0, 0, 0))
         ti = TI(
-            task=task, execution_date=datetime.datetime.now())
-        ti.end_date = datetime.datetime.now()
+            task=task, execution_date=datetime.datetime.utcnow())
+        ti.end_date = datetime.datetime.utcnow()
 
         ti.try_number = 1
         dt = ti.next_retry_datetime()
@@ -577,7 +577,7 @@ class TaskInstanceTest(unittest.TestCase):
             pool='test_xcom',
             owner='airflow',
             start_date=datetime.datetime(2016, 6, 2, 0, 0, 0))
-        exec_date = datetime.datetime.now()
+        exec_date = datetime.datetime.utcnow()
         ti = TI(
             task=task, execution_date=exec_date)
         ti.run(mark_success=True)
@@ -603,7 +603,7 @@ class TaskInstanceTest(unittest.TestCase):
             pool='test_xcom',
             owner='airflow',
             start_date=datetime.datetime(2016, 6, 2, 0, 0, 0))
-        exec_date = datetime.datetime.now()
+        exec_date = datetime.datetime.utcnow()
         ti = TI(
             task=task, execution_date=exec_date)
         ti.run(mark_success=True)

--- a/tests/operators/operators.py
+++ b/tests/operators/operators.py
@@ -174,7 +174,7 @@ class TransferTests(unittest.TestCase):
     def test_clear(self):
         self.dag.clear(
             start_date=DEFAULT_DATE,
-            end_date=datetime.datetime.now())
+            end_date=datetime.datetime.utcnow())
 
     def test_mysql_to_hive(self):
         # import airflow.operators

--- a/tests/operators/sensors.py
+++ b/tests/operators/sensors.py
@@ -53,12 +53,12 @@ class TimeoutTestSensor(BaseSensorOperator):
         return self.return_value
 
     def execute(self, context):
-        started_at = datetime.now()
+        started_at = datetime.utcnow()
         time_jump = self.params.get('time_jump')
         while not self.poke(context):
             if time_jump:
                 started_at -= time_jump
-            if (datetime.now() - started_at).total_seconds() > self.timeout:
+            if (datetime.utcnow() - started_at).total_seconds() > self.timeout:
                 if self.soft_fail:
                     raise AirflowSkipException('Snap. Time is OUT.')
                 else:


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-289

Per Apache guidelines you need to create a [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW/).

Testing Done:
- Passes existing tests with minor edits

Why the change?
- Currently we cannot run airflow on different systems having conflicting system timezones. Some of the issues with doing that are as follows: 
  - heartbeats appear out of sync to the scheduler (when workers are running on different timezones). With our architecture some of our workers will be running on a timezone different from utc.
  - if a dag_run is created on a different machine (with a different timezone), the manage_sla function might have unintended behavior as it checks for the time of execution by subtracting the start time of the dag_run from `datetime.now()` - though I am not entirely sure if this is possible - maybe if we have multiple scheduler instances running (on different timezones)?
  - To make airflow more system independent, given it is a distributed system meant for easy scalability.

Potential Consequences:
- Might have effects on how we view the data in the UI. 
- Might miss out other areas of the code which rely on system timezone, though its unlikely given the review system in place. Such an issue won't result in any regressions with current systems that are already running on utc.
