### PR TITLE
[AIRFLOW-293] Task execution independent of heartrate

### DIFF
--- a/airflow/utils/timeout.py
+++ b/airflow/utils/timeout.py
@@ -34,7 +34,6 @@ class timeout(object):
         self.error_message = error_message
 
     def handle_timeout(self, signum, frame):
-        logging.error("Process timed out")
         raise AirflowTaskTimeout(self.error_message)
 
     def __enter__(self):

--- a/tests/core.py
+++ b/tests/core.py
@@ -56,6 +56,7 @@ from airflow.utils.logging import LoggingMixin
 from lxml import html
 from airflow.exceptions import AirflowException
 from airflow.configuration import AirflowConfigException
+from airflow.utils.timeout import timeout
 
 import six
 
@@ -554,6 +555,20 @@ class CoreTest(unittest.TestCase):
             task=self.runme_0, execution_date=DEFAULT_DATE)
         job = jobs.LocalTaskJob(task_instance=ti, force=True)
         job.run()
+
+    def test_local_task_job_with_long_heartrate(self):
+        """
+        Even though the heartrate is long, the job should still complete
+        quickly.
+        """
+        TI = models.TaskInstance
+        ti = TI(
+            task=self.runme_0, execution_date=DEFAULT_DATE)
+        job = jobs.LocalTaskJob(task_instance=ti,
+                                force=True,
+                                heartrate=9999)
+        with timeout(30):
+            job.run()
 
     def test_scheduler_job(self):
         job = jobs.SchedulerJob(dag_id='example_bash_operator', test_mode=True)


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-293

This PR updates the run workflow so that it can exit early if the task finishes sooner than the job heart rate.

@mistercrunch @aoen 
