### PR TITLE
AIRFLOW-296: template_ext is being treated as a string rather than a tuple in qubole operator

### DIFF
--- a/airflow/contrib/operators/qubole_operator.py
+++ b/airflow/contrib/operators/qubole_operator.py
@@ -95,7 +95,7 @@ class QuboleOperator(BaseOperator):
 
     template_fields = ('query', 'script_location', 'sub_command', 'script', 'files', 'archives', 'program', 'cmdline',
                        'sql', 'where_clause', 'extract_query', 'boundary_query', 'macros', 'tags', 'name', 'parameters')
-    template_ext = ('.txt')
+    template_ext = ('.txt',)
     ui_color = '#3064A1'
     ui_fgcolor = '#fff'
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- _https://issues.apache.org/jira/browse/AIRFLOW-296_
