### PR TITLE
[AIRFLOW-297] support exponential backoff option for retry delay

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1144,13 +1144,26 @@ class TaskInstance(Base):
             "{ti.execution_date} [{ti.state}]>"
         ).format(ti=self)
 
+    def next_retry_datetime(self):
+        """
+        Get datetime of the next retry if the task instance fails. For exponential
+        backoff, retry_delay is used as base and will be converted to seconds.
+        """
+        delay = self.task.retry_delay
+        if self.task.retry_exponential_backoff:
+            delay_backoff_in_seconds = delay.total_seconds() ** self.try_number
+            delay = timedelta(seconds=delay_backoff_in_seconds)
+            if self.task.max_retry_delay:
+                delay = min(self.task.max_retry_delay, delay)
+        return self.end_date + delay
+
+
     def ready_for_retry(self):
         """
         Checks on whether the task instance is in the right state and timeframe
         to be retried.
         """
-        return self.state == State.UP_FOR_RETRY and \
-            self.end_date + self.task.retry_delay < datetime.now()
+        return self.state == State.UP_FOR_RETRY and self.next_retry_datetime() < datetime.now()
 
     @provide_session
     def pool_full(self, session):
@@ -1238,7 +1251,7 @@ class TaskInstance(Base):
             # todo: move this to the scheduler
                 self.state == State.UP_FOR_RETRY and
                 not self.ready_for_retry()):
-            next_run = (self.end_date + task.retry_delay).isoformat()
+            next_run = self.next_retry_datetime().isoformat()
             logging.info(
                 "Not ready for retry yet. " +
                 "Next run after {0}".format(next_run)
@@ -1691,6 +1704,12 @@ class BaseOperator(object):
     :type retries: int
     :param retry_delay: delay between retries
     :type retry_delay: timedelta
+    :param retry_exponential_backoff: allow progressive longer waits between
+        retries by using exponential backoff algorithm on retry delay (delay
+        will be converted into seconds)
+    :type retry_exponential_backoff: bool
+    :param max_retry_delay: maximum delay interval between retries
+    :type max_retry_delay: timedelta
     :param start_date: The ``start_date`` for the task, determines
         the ``execution_date`` for the first task instance. The best practice
         is to have the start_date rounded
@@ -1788,6 +1807,8 @@ class BaseOperator(object):
             email_on_failure=True,
             retries=0,
             retry_delay=timedelta(seconds=300),
+            retry_exponential_backoff=False,
+            max_retry_delay=None,
             start_date=None,
             end_date=None,
             schedule_interval=None,  # not hooked as of now
@@ -1863,6 +1884,8 @@ class BaseOperator(object):
         else:
             logging.debug("retry_delay isn't timedelta object, assuming secs")
             self.retry_delay = timedelta(seconds=retry_delay)
+        self.retry_exponential_backoff = retry_exponential_backoff
+        self.max_retry_delay = max_retry_delay
         self.params = params or {}  # Available in templates!
         self.adhoc = adhoc
         self.priority_weight = priority_weight
@@ -1883,6 +1906,8 @@ class BaseOperator(object):
             'email',
             'email_on_retry',
             'retry_delay',
+            'retry_exponential_backoff',
+            'max_retry_delay',
             'start_date',
             'schedule_interval',
             'depends_on_past',

--- a/tests/models.py
+++ b/tests/models.py
@@ -419,6 +419,38 @@ class TaskInstanceTest(unittest.TestCase):
         self.assertEqual(ti.state, State.FAILED)
         self.assertEqual(ti.try_number, 4)
 
+    def test_next_retry_datetime(self):
+        delay = datetime.timedelta(seconds=3)
+        delay_squared = datetime.timedelta(seconds=9)
+        max_delay = datetime.timedelta(seconds=10)
+
+        dag = models.DAG(dag_id='fail_dag')
+        task = BashOperator(
+            task_id='task_with_exp_backoff_and_max_delay',
+            bash_command='exit 1',
+            retries=3,
+            retry_delay=delay,
+            retry_exponential_backoff=True,
+            max_retry_delay=max_delay,
+            dag=dag,
+            owner='airflow',
+            start_date=datetime.datetime(2016, 2, 1, 0, 0, 0))
+        ti = TI(
+            task=task, execution_date=datetime.datetime.now())
+        ti.end_date = datetime.datetime.now()
+
+        ti.try_number = 1
+        dt = ti.next_retry_datetime()
+        self.assertEqual(dt, ti.end_date+delay)
+
+        ti.try_number = 2
+        dt = ti.next_retry_datetime()
+        self.assertEqual(dt, ti.end_date+delay_squared)
+
+        ti.try_number = 3
+        dt = ti.next_retry_datetime()
+        self.assertEqual(dt, ti.end_date+max_delay)
+
     def test_depends_on_past(self):
         dagbag = models.DagBag()
         dag = dagbag.get_dag('test_depends_on_past')


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
-[AIRFLOW-297](https://issues.apache.org/jira/browse/AIRFLOW-297)

Testing Done:
- Generated DAGs and ran tests locally
- Testing for this may extend total unit tests time a bit (given delay is exponential). If there are better ways for testing this, please let me know and I can add it as needed.

Reminders for contributors (REQUIRED!):
- Your PR's title must reference an issue on 
  [Airflow's JIRA](https://issues.apache.org/jira/browse/AIRFLOW/). 
  For example, a PR called "[AIRFLOW-1] My Amazing PR" would close JIRA 
  issue #1. Please open a new issue if required!
- Please squash your commits when possible and follow the [How to write a good git commit message](http://chris.beams.io/posts/git-commit/). 
  Summarized as follows:
  1. Separate subject from body with a blank line
  2. Limit the subject line to 50 characters
  3. Do not end the subject line with a period
  4. Use the imperative mood in the subject line (add, not adding)
  5. Wrap the body at 72 characters
  6. Use the body to explain what and why vs. how
