### PR TITLE
[AIRFLOW-100][AIRFLOW-301] Add execution_date_fn to ExternalTaskSensor and fix unit test

### DIFF
--- a/airflow/migrations/versions/211e584da130_add_ti_state_index.py
+++ b/airflow/migrations/versions/211e584da130_add_ti_state_index.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """add TI state index
 
 Revision ID: 211e584da130

--- a/airflow/utils/tests.py
+++ b/airflow/utils/tests.py
@@ -16,7 +16,10 @@ import unittest
 
 def skipUnlessImported(module, obj):
     import importlib
-    m = importlib.import_module(module)
+    try:
+        m = importlib.import_module(module)
+    except ImportError:
+        m = None
     return unittest.skipUnless(
         obj in dir(m),
         "Skipping test because {} could not be imported from {}".format(

--- a/tests/models.py
+++ b/tests/models.py
@@ -557,7 +557,7 @@ class TaskInstanceTest(unittest.TestCase):
         ti.xcom_push(key=key, value=value)
         self.assertEqual(ti.xcom_pull(task_ids='test_xcom', key=key), value)
         ti.run()
-        exec_date = exec_date.replace(day=exec_date.day + 1)
+        exec_date += datetime.timedelta(days=1)
         ti = TI(
             task=task, execution_date=exec_date)
         ti.run()


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-100
- Adds an optional callable to `ExternalTaskSensor` that makes it easy to specify the queried `execution_date`
- https://issues.apache.org/jira/browse/AIRFLOW-301
- Fixes a unit test that always fails on the last day of the month

Testing Done:
- Added new unit tests
