### PR TITLE
[AIRFLOW-307] Code cleanup. There is no __neq__ python magic method.

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1903,7 +1903,7 @@ class BaseOperator(object):
             all(self.__dict__.get(c, None) == other.__dict__.get(c, None)
                 for c in self._comps))
 
-    def __neq__(self, other):
+    def __ne__(self, other):
         return not self == other
 
     def __lt__(self, other):
@@ -2559,7 +2559,7 @@ class DAG(LoggingMixin):
             all(self.__dict__.get(c, None) == other.__dict__.get(c, None)
                 for c in self._comps))
 
-    def __neq__(self, other):
+    def __ne__(self, other):
         return not self == other
 
     def __lt__(self, other):


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-307

Mistype fixed.
