### PR TITLE
[AIRFLOW-308] Add link to refresh DAG within DAG view header

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -88,6 +88,12 @@
           Code
         </a>
       </li>
+      <li>
+        <a href="{{ url_for("airflow.refresh", dag_id=dag.dag_id) }}" title="Refresh">
+          <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
+          Refresh
+        </a>
+      </li>
     </ul>
   </div>
   <hr>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1500,7 +1500,7 @@ class Airflow(BaseView):
 
         dagbag.get_dag(dag_id)
         flash("DAG [{}] is now fresh as a daisy".format(dag_id))
-        return redirect('/')
+        return redirect(request.referrer)
 
     @expose('/refresh_all')
     @login_required


### PR DESCRIPTION
Adds a link in the DAG UI to address https://issues.apache.org/jira/browse/AIRFLOW-308 - see attached screenshot:
![screen shot 2016-07-01 at 10 59 51 am](https://cloud.githubusercontent.com/assets/354842/16530123/3ecd14a6-3f7b-11e6-80d3-4b405a60974e.png)

Testing Done:
- Clicked existing link on main DAG list and the one added above. Both work and now redirect to the originating screen.
