### PR TITLE
[AIRFLOW-317] Update logging.py to avoid exception when reading logs from s3.

### DIFF
--- a/airflow/utils/logging.py
+++ b/airflow/utils/logging.py
@@ -71,7 +71,7 @@ class S3Log(object):
             try:
                 s3_key = self.hook.get_key(remote_log_location)
                 if s3_key:
-                    return s3_key.get_contents_as_string().decode()
+                    return s3_key.get_contents_as_string()
             except:
                 pass
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:

https://issues.apache.org/jira/browse/AIRFLOW-317
There is unneeded decode() function after s3_key.get_contents_as_string(). The problem appears if log file contains non-ascii characters decode() function will raise Exception.
Without decode() it will work as always, but log decoding will be processed to browser.
