### PR TITLE
Adding Clairvoyant as one of the Official Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Currently **officially** using Airflow:
 * [allegro.pl](http://allegro.tech/) [[@kretes](https://github.com/kretes)]
 * [Bellhops](https://github.com/bellhops)
 * BlueApron [[@jasonjho](https://github.com/jasonjho) & [@matthewdavidhauser](https://github.com/matthewdavidhauser)]
+* [Clairvoyant] (https://clairvoyantsoft.com) [@shekharv](https://github.com/shekharv)
 * [Clover Health] (https://www.cloverhealth.com) [[@gwax](https://github.com/gwax) & [@vansivallab](https://github.com/vansivallab)]
 * Chartboost [[@cgelman](https://github.com/cgelman) & [@dclubb](https://github.com/dclubb)]
 * [Cotap](https://github.com/cotap/) [[@maraca](https://github.com/maraca) & [@richardchew](https://github.com/richardchew)]


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that adds Clairvoyant LLC as one of the users 
