### PR TITLE
[AIRFLOW-321] Fix a wrong code example about tests/dags

### DIFF
--- a/tests/dags/README.md
+++ b/tests/dags/README.md
@@ -6,5 +6,5 @@ To access a DAG in this folder, use the following code inside a unit test. Note 
 
 ```python
 dagbag = DagBag()
-dag = dagbag.get(dag_id)
+dag = dagbag.get_dag(dag_id)
 ```


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-321

Testing Done:
- All 187 unit tests passed.

tests/dags/README.md has a code example such as
"dag = dagbag.get(dag_id)", but DagBag doesn't have a method called get.
That should be fixed as get_dag.
