### PR TITLE
[AIRFLOW-333] Fix non-module plugin components

### DIFF
--- a/airflow/executors/__init__.py
+++ b/airflow/executors/__init__.py
@@ -39,9 +39,9 @@ elif _EXECUTOR == 'MesosExecutor':
     DEFAULT_EXECUTOR = MesosExecutor()
 else:
     # Loading plugins
-    from airflow.plugins_manager import executors as _executors
-    for _executor in _executors:
-        globals()[_executor.__name__] = _executor
+    from airflow.plugins_manager import executors_modules
+    for executors_module in executors_modules:
+        globals()[executors_module.__name__] = executors_module
     if _EXECUTOR in globals():
         DEFAULT_EXECUTOR = globals()[_EXECUTOR]()
     else:

--- a/airflow/hooks/__init__.py
+++ b/airflow/hooks/__init__.py
@@ -64,21 +64,24 @@ if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
 
 def _integrate_plugins():
     """Integrate plugins to the context"""
-    from airflow.plugins_manager import hooks as _hooks
-    for _hook_module in _hooks:
-        sys.modules[_hook_module.__name__] = _hook_module
-        globals()[_hook_module._name] = _hook_module
+    from airflow.plugins_manager import hooks_modules
+    for hooks_module in hooks_modules:
+        sys.modules[hooks_module.__name__] = hooks_module
+        globals()[hooks_module._name] = hooks_module
 
         ##########################################################
         # TODO FIXME Remove in Airflow 2.0
 
         if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
             from zope.deprecation import deprecated as _deprecated
-            for _hook in _hook_module._objects:
-                globals()[_hook.__name__] = _deprecated(
-                    _hook,
+            for _hook in hooks_module._objects:
+                hook_name = _hook.__name__
+                globals()[hook_name] = _hook
+                _deprecated(
+                    hook_name,
                     "Importing plugin hook '{i}' directly from "
                     "'airflow.hooks' has been deprecated. Please "
                     "import from 'airflow.hooks.[plugin_module]' "
                     "instead. Support for direct imports will be dropped "
-                    "entirely in Airflow 2.0.".format(i=_hook))
+                    "entirely in Airflow 2.0.".format(i=hook_name))
+

--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -65,10 +65,10 @@ def ds_format(ds, input_format, output_format):
 def _integrate_plugins():
     """Integrate plugins to the context"""
     import sys
-    from airflow.plugins_manager import macros as _macros
-    for _macro_module in _macros:
-        sys.modules[_macro_module.__name__] = _macro_module
-        globals()[_macro_module._name] = _macro_module
+    from airflow.plugins_manager import macros_modules
+    for macros_module in macros_modules:
+        sys.modules[macros_module.__name__] = macros_module
+        globals()[macros_module._name] = macros_module
 
         ##########################################################
         # TODO FIXME Remove in Airflow 2.0
@@ -76,11 +76,13 @@ def _integrate_plugins():
         import os as _os
         if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
             from zope.deprecation import deprecated as _deprecated
-            for _macro in _macro_module._objects:
-                globals()[_macro.__name__] = _deprecated(
-                    _macro,
+            for _macro in macros_module._objects:
+                macro_name = _macro.__name__
+                globals()[macro_name] = _macro
+                _deprecated(
+                    macro_name,
                     "Importing plugin macro '{i}' directly from "
                     "'airflow.macros' has been deprecated. Please "
                     "import from 'airflow.macros.[plugin_module]' "
                     "instead. Support for direct imports will be dropped "
-                    "entirely in Airflow 2.0.".format(i=_macro))
+                    "entirely in Airflow 2.0.".format(i=macro_name))

--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -100,21 +100,23 @@ if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
 
 def _integrate_plugins():
     """Integrate plugins to the context"""
-    from airflow.plugins_manager import operators as _operators
-    for _operator_module in _operators:
-        sys.modules[_operator_module.__name__] = _operator_module
-        globals()[_operator_module._name] = _operator_module
+    from airflow.plugins_manager import operators_modules
+    for operators_module in operators_modules:
+        sys.modules[operators_module.__name__] = operators_module
+        globals()[operators_module._name] = operators_module
 
         ##########################################################
         # TODO FIXME Remove in Airflow 2.0
 
         if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
             from zope.deprecation import deprecated as _deprecated
-            for _operator in _operator_module._objects:
-                globals()[_operator.__name__] = _deprecated(
-                    _operator,
+            for _operator in operators_module._objects:
+                operator_name = _operator.__name__
+                globals()[operator_name] = _operator
+                _deprecated(
+                    operator_name,
                     "Importing plugin operator '{i}' directly from "
                     "'airflow.operators' has been deprecated. Please "
                     "import from 'airflow.operators.[plugin_module]' "
                     "instead. Support for direct imports will be dropped "
-                    "entirely in Airflow 2.0.".format(i=_operator))
+                    "entirely in Airflow 2.0.".format(i=operator_name))

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -24,8 +24,6 @@ import logging
 import os
 import re
 import sys
-from itertools import chain
-merge = chain.from_iterable
 
 from airflow import configuration
 
@@ -100,18 +98,25 @@ def make_module(name, objects):
     module.__dict__.update((o.__name__, o) for o in objects)
     return module
 
-operators, hooks, executors, macros, admin_views = [], [], [], [], []
-flask_blueprints, menu_links = [], []
+# Plugin components to integrate as modules
+operators_modules = []
+hooks_modules = []
+executors_modules = []
+macros_modules = []
+
+# Plugin components to integrate directly
+admin_views = []
+flask_blueprints = []
+menu_links = []
 
 for p in plugins:
-    operators.append(make_module('airflow.operators.' + p.name, p.operators))
-    hooks.append(make_module('airflow.hooks.' + p.name, p.hooks))
-    executors.append(make_module('airflow.executors.' + p.name, p.executors))
-    macros.append(make_module('airflow.macros.' + p.name, p.macros))
-    admin_views.append(
-        make_module('airflow.www.admin_views' + p.name, p.admin_views))
-    flask_blueprints.append(
-        make_module(
-            'airflow.www.flask_blueprints' + p.name, p.flask_blueprints))
-    menu_links.append(
-        make_module('airflow.www.menu_links' + p.name, p.menu_links))
+    operators_modules.append(
+        make_module('airflow.operators.' + p.name, p.operators))
+    hooks_modules.append(make_module('airflow.hooks.' + p.name, p.hooks))
+    executors_modules.append(
+        make_module('airflow.executors.' + p.name, p.executors))
+    macros_modules.append(make_module('airflow.macros.' + p.name, p.macros))
+
+    admin_views.extend(p.admin_views)
+    flask_blueprints.extend(p.flask_blueprints)
+    menu_links.extend(p.menu_links)


### PR DESCRIPTION
- Distinguish between module and non-module plugin components
- Fix handling of non-module plugin components
  - admin views, flask blueprints, and menu links need to not be
    wrapped in modules

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-333

Per Apache guidelines you need to create a [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW/).

Testing Done:
- Placed sample plugin from documentation in airflow/plugins folder and started airflow
- Could not figure out how to hook in before a particular test runs to interrupt plugin import without interfering with everything else.
