### PR TITLE
[AIRFLOW-337] Add __repr__ to VariableAccessor and VariableJsonAccessor

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1466,17 +1466,25 @@ class TaskInstance(Base):
             {var.variable_name}.
             """
             def __init__(self):
-                pass
+                self.var = None
 
             def __getattr__(self, item):
-                return Variable.get(item)
+                self.var = Variable.get(item)
+                return self.var
+
+            def __repr__(self):
+                return str(self.var)
 
         class VariableJsonAccessor:
             def __init__(self):
-                pass
+                self.var = None
 
             def __getattr__(self, item):
-                return Variable.get(item, deserialize_json=True)
+                self.var =  Variable.get(item, deserialize_json=True)
+                return self.var
+
+            def __repr__(self):
+                return str(self.var)
 
         return {
             'dag': task.dag,


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-337

Testing Done:
- The example_python_operator should cover this, but does not get run yet due to another bug. This will be fixed separately.

The VariableJsonAccessor and VariableAccessor were missing the **repr**
function that leads to a VariableError when printing out the context
being passed to for example a PythonOperator.
