### PR TITLE
[AIRFLOW-340] Remove unused dependency on Babel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,6 @@ def do_setup():
         scripts=['airflow/bin/airflow'],
         install_requires=[
             'alembic>=0.8.3, <0.9',
-            'babel>=1.3, <2.0',
             'croniter>=0.3.8, <0.4',
             'dill>=0.2.2, <0.3',
             'flask>=0.10.1, <0.11',


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-340

This PR removes the unused dependency on Babel.
