### PR TITLE
[AIRFLOW-328][AIRFLOW-371] Remove redundant default configuration & fix unit test configuration

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -21,6 +21,7 @@ import copy
 import errno
 import logging
 import os
+import six
 import subprocess
 import warnings
 
@@ -88,102 +89,6 @@ def run_command(command):
     return output
 
 
-defaults = {
-    'core': {
-        'unit_test_mode': False,
-        'parallelism': 32,
-        'load_examples': True,
-        'plugins_folder': None,
-        'security': None,
-        'donot_pickle': False,
-        'remote_base_log_folder': '',
-        'remote_log_conn_id': '',
-        'encrypt_s3_logs': False,
-        's3_log_folder': '',  # deprecated!
-        'dag_concurrency': 16,
-        'max_active_runs_per_dag': 16,
-        'executor': 'SequentialExecutor',
-        'dags_are_paused_at_creation': True,
-        'sql_alchemy_pool_size': 5,
-        'sql_alchemy_pool_recycle': 3600,
-        'dagbag_import_timeout': 30,
-        'non_pooled_task_slot_count': 128,
-    },
-    'operators': {
-        'default_owner': 'airflow',
-        'default_cpus': 1,
-        'default_ram': 512,
-        'default_disk': 512,
-        'default_gpus': 0,
-    },
-    'webserver': {
-        'base_url': 'http://localhost:8080',
-        'web_server_host': '0.0.0.0',
-        'web_server_port': '8080',
-        'web_server_worker_timeout': 120,
-        'worker_refresh_batch_size': 1,
-        'worker_refresh_interval': 30,
-        'authenticate': False,
-        'filter_by_owner': False,
-        'owner_mode': 'user',
-        'demo_mode': False,
-        'secret_key': 'airflowified',
-        'expose_config': False,
-        'workers': 4,
-        'worker_class': 'sync',
-        'access_logfile': '',
-        'error_logfile': '',
-        'dag_orientation': 'LR',
-    },
-    'scheduler': {
-        'statsd_on': False,
-        'statsd_host': 'localhost',
-        'statsd_port': 8125,
-        'statsd_prefix': 'airflow',
-        'job_heartbeat_sec': 5,
-        'scheduler_heartbeat_sec': 60,
-        'authenticate': False,
-        'max_threads': 2,
-        'run_duration': 30 * 60,
-        'dag_dir_list_interval': 5 * 60,
-        'print_stats_interval': 30,
-        'min_file_process_interval': 180,
-        'child_process_log_directory': '/tmp/airflow/scheduler/logs'
-    },
-    'celery': {
-        'broker_url': 'sqla+mysql://airflow:airflow@localhost:3306/airflow',
-        'celery_app_name': 'airflow.executors.celery_executor',
-        'celery_result_backend': 'db+mysql://airflow:airflow@localhost:3306/airflow',
-        'celeryd_concurrency': 16,
-        'default_queue': 'default',
-        'flower_host': '0.0.0.0',
-        'flower_port': '5555',
-        'worker_log_server_port': '8793',
-    },
-    'email': {
-        'email_backend': 'airflow.utils.email.send_email_smtp',
-    },
-    'smtp': {
-        'smtp_starttls': True,
-        'smtp_ssl': False,
-        'smtp_user': '',
-        'smtp_password': '',
-    },
-    'kerberos': {
-        'ccache': '/tmp/airflow_krb5_ccache',
-        'principal': 'airflow',                 # gets augmented with fqdn
-        'reinit_frequency': '3600',
-        'kinit_path': 'kinit',
-        'keytab': 'airflow.keytab',
-    },
-    'github_enterprise': {
-        'api_rev': 'v3'
-    },
-    'admin': {
-        'hide_sensitive_variable_fields': True,
-    },
-}
-
 DEFAULT_CONFIG = """\
 [core]
 # The home folder for airflow, default is ~/airflow
@@ -206,8 +111,8 @@ remote_base_log_folder =
 remote_log_conn_id =
 # Use server-side encryption for logs stored in S3
 encrypt_s3_logs = False
-# deprecated option for remote log storage, use remote_base_log_folder instead!
-# s3_log_folder =
+# DEPRECATED option for remote log storage, use remote_base_log_folder instead!
+s3_log_folder =
 
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor
@@ -262,6 +167,9 @@ donot_pickle = False
 # How long before timing out a python file import while filling the DagBag
 dagbag_import_timeout = 30
 
+# What security module to use (for example kerberos):
+security =
+
 
 [operators]
 # The default owner assigned to each new operator, unless
@@ -311,7 +219,7 @@ access_logfile = -
 error_logfile = -
 
 # Expose the configuration file in the web server
-expose_config = true
+expose_config = False
 
 # Set to true to turn on authentication:
 # http://pythonhosted.org/airflow/installation.html#web-authentication
@@ -327,17 +235,22 @@ filter_by_owner = False
 # in order to user the ldapgroup mode.
 owner_mode = user
 
-# Default DAG orientation. Valid values are: LR (Left->Right), TB (Top->Bottom),
-# RL (Right->Left), BT (Bottom->Top).
+# Default DAG orientation. Valid values are:
+# LR (Left->Right), TB (Top->Bottom), RL (Right->Left), BT (Bottom->Top)
 dag_orientation = LR
+
+# Puts the webserver in demonstration mode; blurs the names of Operators for
+# privacy.
+demo_mode = False
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp
 
+
 [smtp]
 # If you want airflow to send emails on retries, failure, and you want to use
-# the airflow.utils.email.send_email_smtp function, you have to configure an smtp
-# server here
+# the airflow.utils.email.send_email_smtp function, you have to configure an
+# smtp server here
 smtp_host = localhost
 smtp_starttls = True
 smtp_ssl = False
@@ -345,6 +258,7 @@ smtp_user = airflow
 smtp_port = 25
 smtp_password = airflow
 smtp_mail_from = airflow@airflow.com
+
 
 [celery]
 # This section only applies if you are using the CeleryExecutor in
@@ -384,6 +298,7 @@ flower_port = 5555
 # Default queue that tasks get assigned to and that worker listen on.
 default_queue = default
 
+
 [scheduler]
 # Task instances listen for external kill signal (when you clear tasks
 # from the CLI or the UI), this defines the frequency at which they should
@@ -395,16 +310,26 @@ job_heartbeat_sec = 5
 # how often the scheduler should run (in seconds).
 scheduler_heartbeat_sec = 5
 
+run_duration = 1800
+dag_dir_list_interval = 300
+print_stats_interval = 30
+min_file_process_interval = 180
+
+child_process_log_directory = /tmp/airflow/scheduler/logs
+
 # Statsd (https://github.com/etsy/statsd) integration settings
-# statsd_on =  False
-# statsd_host =  localhost
-# statsd_port =  8125
-# statsd_prefix = airflow
+statsd_on = False
+statsd_host = localhost
+statsd_port = 8125
+statsd_prefix = airflow
 
 # The scheduler can run multiple threads in parallel to schedule dags.
 # This defines how many threads will run. However airflow will never
 # use more threads than the amount of cpu cores available.
 max_threads = 2
+
+authenticate = False
+
 
 [mesos]
 # Mesos master address which MesosExecutor will connect to.
@@ -442,6 +367,20 @@ authenticate = False
 # Mesos credentials, if authentication is enabled
 # default_principal = admin
 # default_secret = admin
+
+
+[kerberos]
+ccache = /tmp/airflow_krb5_ccache
+# gets augmented with fqdn
+principal = airflow
+reinit_frequency = 3600
+kinit_path = kinit
+keytab = airflow.keytab
+
+
+[github_enterprise]
+api_rev = v3
+
 
 [admin]
 # UI to hide sensitive variable fields when set to True
@@ -501,11 +440,11 @@ max_threads = 2
 """
 
 
-class ConfigParserWithDefaults(ConfigParser):
+class AirflowConfigParser(ConfigParser):
 
     # These configuration elements can be fetched as the stdout of commands
-    # following the "{section}__{name}__cmd" pattern, the idea behind this is to not
-    # store password on boxes in text files.
+    # following the "{section}__{name}__cmd" pattern, the idea behind this
+    # is to not store password on boxes in text files.
     as_command_stdout = {
         ('core', 'sql_alchemy_conn'),
         ('core', 'fernet_key'),
@@ -513,33 +452,51 @@ class ConfigParserWithDefaults(ConfigParser):
         ('celery', 'celery_result_backend')
     }
 
-    def __init__(self, defaults, *args, **kwargs):
-        self.defaults = defaults
+    def __init__(self, *args, **kwargs):
         ConfigParser.__init__(self, *args, **kwargs)
+        self.read_string(parameterized_config(DEFAULT_CONFIG))
         self.is_validated = False
+
+    def read_string(self, string, source='<string>'):
+        """
+        Read configuration from a string.
+
+        A backwards-compatible version of the ConfigParser.read_string()
+        method that was introduced in Python 3.
+        """
+        # Python 3 added read_string() method
+        if six.PY3:
+            ConfigParser.read_string(self, string, source=source)
+        # Python 2 requires StringIO buffer
+        else:
+            import StringIO
+            self.readfp(StringIO.StringIO(string))
 
     def _validate(self):
         if (
                 self.get("core", "executor") != 'SequentialExecutor' and
                 "sqlite" in self.get('core', 'sql_alchemy_conn')):
-            raise AirflowConfigException("error: cannot use sqlite with the {}".
-                format(self.get('core', 'executor')))
+            raise AirflowConfigException(
+                "error: cannot use sqlite with the {}".format(
+                    self.get('core', 'executor')))
 
         elif (
             self.getboolean("webserver", "authenticate") and
             self.get("webserver", "owner_mode") not in ['user', 'ldapgroup']
         ):
-            raise AirflowConfigException("error: owner_mode option should be either "
-                                         "'user' or 'ldapgroup' "
-                                         "when filtering by owner is set")
+            raise AirflowConfigException(
+                "error: owner_mode option should be either "
+                "'user' or 'ldapgroup' when filtering by owner is set")
 
         elif (
             self.getboolean("webserver", "authenticate") and
             self.get("webserver", "owner_mode").lower() == 'ldapgroup' and
-            self.get("core", "auth_backend") != 'airflow.contrib.auth.backends.ldap_auth'
+            self.get("core", "auth_backend") != (
+                'airflow.contrib.auth.backends.ldap_auth')
         ):
-            raise AirflowConfigException("error: attempt at using ldapgroup "
-                                         "filtering without using the Ldap backend")
+            raise AirflowConfigException(
+                "error: attempt at using ldapgroup "
+                "filtering without using the Ldap backend")
 
         self.is_validated = True
 
@@ -551,17 +508,19 @@ class ConfigParserWithDefaults(ConfigParser):
 
     def _get_cmd_option(self, section, key):
         fallback_key = key + '_cmd'
-        if (
-                (section, key) in ConfigParserWithDefaults.as_command_stdout and
-                self.has_option(section, fallback_key)):
-            command = self.get(section, fallback_key)
-            return run_command(command)
+        # if this is a valid command key...
+        if (section, key) in AirflowConfigParser.as_command_stdout:
+            # if the original key is present, return it no matter what
+            if self.has_option(section, key):
+                return ConfigParser.get(self, section, key)
+            # otherwise, execute the fallback key
+            elif self.has_option(section, fallback_key):
+                command = self.get(section, fallback_key)
+                return run_command(command)
 
     def get(self, section, key, **kwargs):
         section = str(section).lower()
         key = str(key).lower()
-
-        d = self.defaults
 
         # first check environment variables
         option = self._get_env_var_option(section, key)
@@ -578,13 +537,9 @@ class ConfigParserWithDefaults(ConfigParser):
         if option:
             return option
 
-        # ...then the defaults
-        if section in d and key in d[section]:
-            return expand_env_var(d[section][key])
-
         else:
-            logging.warn("section/key [{section}/{key}] not found "
-                         "in config".format(**locals()))
+            logging.warning("section/key [{section}/{key}] not found "
+                            "in config".format(**locals()))
 
             raise AirflowConfigException(
                 "section/key [{section}/{key}] not found "
@@ -594,9 +549,9 @@ class ConfigParserWithDefaults(ConfigParser):
         val = str(self.get(section, key)).lower().strip()
         if '#' in val:
             val = val.split('#')[0].strip()
-        if val == "true":
+        if val.lower() == 'true':
             return True
-        elif val == "false":
+        elif val.lower() == 'false':
             return False
         else:
             raise AirflowConfigException("Not a boolean.")
@@ -651,7 +606,7 @@ class ConfigParserWithDefaults(ConfigParser):
                     {key.lower(): opt})
 
         # add bash commands
-        for (section, key) in ConfigParserWithDefaults.as_command_stdout:
+        for (section, key) in AirflowConfigParser.as_command_stdout:
             opt = self._get_cmd_option(section, key)
             if opt:
                 if not display_sensitive:
@@ -659,16 +614,6 @@ class ConfigParserWithDefaults(ConfigParser):
                 if display_source:
                     opt = (opt, 'bash cmd')
                 cfg.setdefault(section, OrderedDict()).update({key: opt})
-
-        # add defaults
-        for section in sorted(self.defaults):
-            for key in sorted(self.defaults[section].keys()):
-                if key not in cfg.setdefault(section, OrderedDict()):
-                    opt = str(self.defaults[section][key])
-                    if display_source:
-                        cfg[section][key] = (opt, 'default')
-                    else:
-                        cfg[section][key] = opt
 
         return cfg
 
@@ -732,8 +677,8 @@ if not os.path.isfile(TEST_CONFIG_FILE):
 
 if not os.path.isfile(AIRFLOW_CONFIG):
     # These configuration options are used to generate a default configuration
-    # when it is missing. The right way to change your configuration is to alter
-    # your configuration file, not this code.
+    # when it is missing. The right way to change your configuration is to
+    # alter your configuration file, not this code.
     logging.info("Creating new airflow config file in: " + AIRFLOW_CONFIG)
     with open(AIRFLOW_CONFIG, 'w') as f:
         f.write(parameterized_config(DEFAULT_CONFIG))
@@ -742,10 +687,10 @@ logging.info("Reading the config from " + AIRFLOW_CONFIG)
 
 
 def test_mode():
-    conf = ConfigParserWithDefaults(defaults)
+    conf = AirflowConfigParser()
     conf.read(TEST_CONFIG)
 
-conf = ConfigParserWithDefaults(defaults)
+conf = AirflowConfigParser()
 conf.read(AIRFLOW_CONFIG)
 
 
@@ -784,7 +729,6 @@ def set(section, option, value):  # noqa
 
 ########################
 # convenience method to access config entries
-
 
 def get_dags_folder():
     return os.path.expanduser(get('core', 'DAGS_FOLDER'))

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,6 +4,8 @@ Configuration
 Setting up the sandbox in the :doc:`start` section was easy;
 building a production-grade environment requires a bit more work!
 
+.. _setting-options:
+
 Setting Configuration Options
 '''''''''''''''''''''''''''''
 
@@ -228,3 +230,20 @@ integrated with upstart
 .. code-block:: bash
 
     initctl airflow-webserver status
+
+Test Mode
+'''''''''
+Airflow has a fixed set of "test mode" configuration options. You can load these
+at any time by calling ``airflow.configuration.load_test_config()`` (note this
+operation is not reversible!). However, some options (like the DAG_FOLDER) are
+loaded before you have a chance to call load_test_config(). In order to eagerly load
+the test configuration, set test_mode in airflow.cfg:
+
+.. code-block:: bash
+
+  [tests]
+  unit_test_mode = True
+
+Due to Airflow's automatic environment variable expansion (see :ref:`setting-options`),
+you can also set the env var ``AIRFLOW__CORE__UNIT_TEST_MODE`` to temporarily overwrite
+airflow.cfg.

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -16,7 +16,7 @@
 
 # environment
 export AIRFLOW_HOME=${AIRFLOW_HOME:=~/airflow}
-export AIRFLOW_CONFIG=$AIRFLOW_HOME/unittests.cfg
+export AIRFLOW__CORE__UNIT_TEST_MODE=True
 
 # configuration test
 export AIRFLOW__TESTSECTION__TESTKEY=testvalue

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -38,15 +38,9 @@ class ConfTest(unittest.TestCase):
         # test env vars
         self.assertEqual(cfg_dict['testsection']['testkey'], '< hidden >')
 
-        # test defaults
-        conf.remove_option('core', 'load_examples')
-        cfg_dict = conf.as_dict()
-        self.assertEqual(cfg_dict['core']['load_examples'], 'True')
-
         # test display_source
         cfg_dict = conf.as_dict(display_source=True)
         self.assertEqual(cfg_dict['core']['unit_test_mode'][1], 'airflow.cfg')
-        self.assertEqual(cfg_dict['core']['load_examples'][1], 'default')
         self.assertEqual(
             cfg_dict['testsection']['testkey'], ('< hidden >', 'env var'))
 

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -19,11 +19,10 @@ import unittest
 from airflow import configuration
 from airflow.configuration import conf
 
-configuration.test_mode()
-
 class ConfTest(unittest.TestCase):
+
     def setup(self):
-        configuration.test_mode()
+        configuration.load_test_config()
 
     def test_env_var_config(self):
         opt = conf.get('testsection', 'testkey')
@@ -40,7 +39,8 @@ class ConfTest(unittest.TestCase):
 
         # test display_source
         cfg_dict = conf.as_dict(display_source=True)
-        self.assertEqual(cfg_dict['core']['unit_test_mode'][1], 'airflow.cfg')
+        self.assertEqual(
+            cfg_dict['core']['load_examples'][1], 'airflow config')
         self.assertEqual(
             cfg_dict['testsection']['testkey'], ('< hidden >', 'env var'))
 

--- a/tests/contrib/hooks/aws_hook.py
+++ b/tests/contrib/hooks/aws_hook.py
@@ -29,7 +29,7 @@ except ImportError:
 class TestAwsHook(unittest.TestCase):
     @mock_emr
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
 
     @unittest.skipIf(mock_emr is None, 'mock_emr package not present')
     @mock_emr

--- a/tests/contrib/hooks/emr_hook.py
+++ b/tests/contrib/hooks/emr_hook.py
@@ -29,7 +29,7 @@ except ImportError:
 class TestEmrHook(unittest.TestCase):
     @mock_emr
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
 
     @unittest.skipIf(mock_emr is None, 'mock_emr package not present')
     @mock_emr

--- a/tests/contrib/operators/emr_add_steps_operator.py
+++ b/tests/contrib/operators/emr_add_steps_operator.py
@@ -28,7 +28,7 @@ ADD_STEPS_SUCCESS_RETURN = {
 
 class TestEmrAddStepsOperator(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
 
         # Mock out the emr_client (moto has incorrect response)
         mock_emr_client = MagicMock()

--- a/tests/contrib/operators/emr_create_job_flow_operator.py
+++ b/tests/contrib/operators/emr_create_job_flow_operator.py
@@ -28,7 +28,7 @@ RUN_JOB_FLOW_SUCCESS_RETURN = {
 
 class TestEmrCreateJobFlowOperator(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
 
         # Mock out the emr_client (moto has incorrect response)
         mock_emr_client = MagicMock()

--- a/tests/contrib/operators/emr_terminate_job_flow_operator.py
+++ b/tests/contrib/operators/emr_terminate_job_flow_operator.py
@@ -27,7 +27,7 @@ TERMINATE_SUCCESS_RETURN = {
 
 class TestEmrTerminateJobFlowOperator(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
 
         # Mock out the emr_client (moto has incorrect response)
         mock_emr_client = MagicMock()

--- a/tests/contrib/operators/fs_operator.py
+++ b/tests/contrib/operators/fs_operator.py
@@ -23,7 +23,7 @@ from airflow.contrib.operators.fs_operator import FileSensor
 
 TEST_DAG_ID = 'unit_tests'
 DEFAULT_DATE = datetime(2015, 1, 1)
-configuration.test_mode()
+configuration.load_test_config()
 
 
 def reset(dag_id=TEST_DAG_ID):
@@ -37,7 +37,7 @@ reset()
 
 class FileSensorTest(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         from airflow.contrib.hooks.fs_hook import FSHook
         hook = FSHook()
         args = {

--- a/tests/contrib/operators/hipchat_operator.py
+++ b/tests/contrib/operators/hipchat_operator.py
@@ -31,7 +31,7 @@ except ImportError:
 
 class HipChatOperatorTest(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
 
     @unittest.skipIf(mock is None, 'mock package not present')
     @mock.patch('requests.request')

--- a/tests/contrib/operators/ssh_execute_operator.py
+++ b/tests/contrib/operators/ssh_execute_operator.py
@@ -23,7 +23,7 @@ from airflow.contrib.operators.ssh_execute_operator import SSHExecuteOperator
 
 TEST_DAG_ID = 'unit_tests'
 DEFAULT_DATE = datetime(2015, 1, 1)
-configuration.test_mode()
+configuration.load_test_config()
 
 
 def reset(dag_id=TEST_DAG_ID):
@@ -38,7 +38,7 @@ reset()
 
 class SSHExecuteOperatorTest(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         from airflow.contrib.hooks.ssh_hook import SSHHook
         hook = SSHHook()
         hook.no_host_key_check = True

--- a/tests/contrib/sensors/emr_base_sensor.py
+++ b/tests/contrib/sensors/emr_base_sensor.py
@@ -21,7 +21,7 @@ from airflow.contrib.sensors.emr_base_sensor import EmrBaseSensor
 
 class TestEmrBaseSensor(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
 
     def test_subclasses_that_implment_required_methods_and_constants_succeed_when_response_is_good(self):
         class EmrBaseSensorSubclass(EmrBaseSensor):

--- a/tests/contrib/sensors/emr_job_flow_sensor.py
+++ b/tests/contrib/sensors/emr_job_flow_sensor.py
@@ -87,7 +87,7 @@ DESCRIBE_CLUSTER_TERMINATED_RETURN = {
 
 class TestEmrJobFlowSensor(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
 
         # Mock out the emr_client (moto has incorrect response)
         self.mock_emr_client = MagicMock()

--- a/tests/contrib/sensors/emr_step_sensor.py
+++ b/tests/contrib/sensors/emr_step_sensor.py
@@ -82,7 +82,7 @@ DESCRIBE_JOB_STEP_COMPLETED_RETURN = {
 
 class TestEmrStepSensor(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
 
         # Mock out the emr_client (moto has incorrect response)
         self.mock_emr_client = MagicMock()

--- a/tests/core.py
+++ b/tests/core.py
@@ -35,7 +35,7 @@ from airflow import configuration
 from airflow.executors import SequentialExecutor, LocalExecutor
 from airflow.models import Variable
 
-configuration.test_mode()
+configuration.load_test_config()
 from airflow import jobs, models, DAG, utils, macros, settings, exceptions
 from airflow.models import BaseOperator
 from airflow.operators.bash_operator import BashOperator
@@ -116,7 +116,7 @@ class CoreTest(unittest.TestCase):
                               "num_runs": 1}
 
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         self.dagbag = models.DagBag(
             dag_folder=DEV_NULL, include_examples=True)
         self.args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
@@ -836,7 +836,7 @@ class CoreTest(unittest.TestCase):
 
 class CliTests(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         app = application.create_app()
         app.config['TESTING'] = True
         self.parser = cli.CLIFactory.get_parser()
@@ -1003,7 +1003,7 @@ class CliTests(unittest.TestCase):
 
 class WebUiTests(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         configuration.conf.set("webserver", "authenticate", "False")
         app = application.create_app()
         app.config['TESTING'] = True
@@ -1226,7 +1226,7 @@ class WebPasswordAuthTest(unittest.TestCase):
         self.assertEqual(response.status_code, 302)
 
     def tearDown(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         session = Session()
         session.query(models.User).delete()
         session.commit()
@@ -1310,7 +1310,7 @@ class WebLdapAuthTest(unittest.TestCase):
         assert 'Connections' in response.data.decode('utf-8')
 
     def tearDown(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         session = Session()
         session.query(models.User).delete()
         session.commit()
@@ -1346,7 +1346,7 @@ class LdapGroupTest(unittest.TestCase):
             assert set(auth.ldap_groups) == set(users[user])
 
     def tearDown(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         configuration.conf.set("webserver", "authenticate", "False")
 
 
@@ -1365,7 +1365,7 @@ class FakeSession(object):
 
 class HttpOpSensorTest(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE_ISO}
         dag = DAG(TEST_DAG_ID, default_args=args)
         self.dag = dag
@@ -1419,7 +1419,7 @@ class FakeWebHDFSHook(object):
 
 class ConnectionTest(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         utils.db.initdb()
         os.environ['AIRFLOW_CONN_TEST_URI'] = (
             'postgres://username:password@ec2.compute.com:5432/the_database')
@@ -1475,7 +1475,7 @@ class ConnectionTest(unittest.TestCase):
 
 class WebHDFSHookTest(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
 
     def test_simple_init(self):
         from airflow.hooks.webhdfs_hook import WebHDFSHook
@@ -1498,7 +1498,7 @@ except ImportError:
                  "Skipping test because S3Hook is not installed")
 class S3HookTest(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         self.s3_test_url = "s3://test/this/is/not/a-real-key.txt"
 
     def test_parse_s3_url(self):
@@ -1523,7 +1523,7 @@ conn.sendall(b'hello')
 
 class SSHHookTest(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         from airflow.contrib.hooks.ssh_hook import SSHHook
         self.hook = SSHHook()
         self.hook.no_host_key_check = True

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -37,7 +37,7 @@ from airflow.utils.timeout import timeout
 from tests.executor.test_executor import TestExecutor
 
 from airflow import configuration
-configuration.test_mode()
+configuration.load_test_config()
 
 try:
     from unittest import mock

--- a/tests/operators/hive_operator.py
+++ b/tests/operators/hive_operator.py
@@ -20,7 +20,7 @@ import unittest
 import six
 
 from airflow import DAG, configuration, operators, utils
-configuration.test_mode()
+configuration.load_test_config()
 
 import os
 import unittest
@@ -39,7 +39,7 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
 
     class HiveServer2Test(unittest.TestCase):
         def setUp(self):
-            configuration.test_mode()
+            configuration.load_test_config()
 
         def test_select_conn(self):
             from airflow.hooks.hive_hooks import HiveServer2Hook
@@ -71,7 +71,7 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
     class HivePrestoTest(unittest.TestCase):
 
         def setUp(self):
-            configuration.test_mode()
+            configuration.load_test_config()
             args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
             dag = DAG('test_dag_id', default_args=args)
             self.dag = dag

--- a/tests/operators/operators.py
+++ b/tests/operators/operators.py
@@ -21,7 +21,7 @@ import six
 
 from airflow import DAG, configuration, operators, utils
 from airflow.utils.tests import skipUnlessImported
-configuration.test_mode()
+configuration.load_test_config()
 
 import os
 import unittest
@@ -36,7 +36,7 @@ TEST_DAG_ID = 'unit_test_dag'
 @skipUnlessImported('airflow.operators.mysql_operator', 'MySqlOperator')
 class MySqlTest(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'mysql_conn_id': 'airflow_db',
@@ -99,7 +99,7 @@ class MySqlTest(unittest.TestCase):
 @skipUnlessImported('airflow.operators.postgres_operator', 'PostgresOperator')
 class PostgresTest(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         dag = DAG(TEST_DAG_ID, default_args=args)
         self.dag = dag
@@ -166,7 +166,7 @@ class TransferTests(unittest.TestCase):
     cluster = None
 
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         dag = DAG(TEST_DAG_ID, default_args=args)
         self.dag = dag

--- a/tests/operators/sensors.py
+++ b/tests/operators/sensors.py
@@ -26,7 +26,7 @@ from airflow.utils.decorators import apply_defaults
 from airflow.exceptions import (AirflowException,
                                 AirflowSensorTimeout,
                                 AirflowSkipException)
-configuration.test_mode()
+configuration.load_test_config()
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 TEST_DAG_ID = 'unit_test_dag'
@@ -69,7 +69,7 @@ class TimeoutTestSensor(BaseSensorOperator):
 
 class SensorTimeoutTest(unittest.TestCase):
     def setUp(self):
-        configuration.test_mode()
+        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -57,7 +57,6 @@ class LogUtilsTest(unittest.TestCase):
             glog.parse_gcs_url('gs://bucket/'),
             ('bucket', ''))
 
-
 class OperatorResourcesTest(unittest.TestCase):
     def test_all_resources_specified(self):
         resources = Resources(cpus=1, ram=2, disk=3, gpus=4)
@@ -70,21 +69,21 @@ class OperatorResourcesTest(unittest.TestCase):
         resources = Resources(cpus=0, disk=1)
         self.assertEqual(resources.cpus.qty, 0)
         self.assertEqual(resources.ram.qty,
-                         configuration.defaults['operators']['default_ram'])
+                         configuration.getint('operators', 'default_ram'))
         self.assertEqual(resources.disk.qty, 1)
         self.assertEqual(resources.gpus.qty,
-                         configuration.defaults['operators']['default_gpus'])
+                         configuration.getint('operators', 'default_gpus'))
 
     def test_no_resources_specified(self):
         resources = Resources()
         self.assertEqual(resources.cpus.qty,
-                         configuration.defaults['operators']['default_cpus'])
+                         configuration.getint('operators', 'default_cpus'))
         self.assertEqual(resources.ram.qty,
-                         configuration.defaults['operators']['default_ram'])
+                         configuration.getint('operators', 'default_ram'))
         self.assertEqual(resources.disk.qty,
-                         configuration.defaults['operators']['default_disk'])
+                         configuration.getint('operators', 'default_disk'))
         self.assertEqual(resources.gpus.qty,
-                         configuration.defaults['operators']['default_gpus'])
+                         configuration.getint('operators', 'default_gpus'))
 
     def test_negative_resource_qty(self):
         with self.assertRaises(AirflowException):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -58,6 +58,10 @@ class LogUtilsTest(unittest.TestCase):
             ('bucket', ''))
 
 class OperatorResourcesTest(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+
     def test_all_resources_specified(self):
         resources = Resources(cpus=1, ram=2, disk=3, gpus=4)
         self.assertEqual(resources.cpus.qty, 1)


### PR DESCRIPTION
AIRFLOW-328
https://issues.apache.org/jira/browse/AIRFLOW-328
Previously, Airflow had both a default template for airflow.cfg AND a
dictionary of default values. Frequently, these get out of sync (an
option in one has a different value than in the other, or isn’t present
in the other). This commit removes the default dict and uses the
airflow.cfg template to provide defaults. The ConfigParser first reads
the template, loading all the options it contains, and then reads the
user’s actual airflow.cfg to overwrite the default values with any new
ones.

AIRFLOW-371
https://issues.apache.org/jira/browse/AIRFLOW-371
Calling test_mode() didn't actually change Airflow's configuration! This actually wasn't an issue in unit tests because the unit test run script was hardcoded to point at the unittest.cfg file, but it needed to be fixed.
