### PR TITLE
[WIP] [AIRFLOW-276] Prepend [ready] on worker ready, add script to reload old workers

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -460,6 +460,7 @@ def webserver(args):
             '-b ' + args.hostname + ':' + str(args.port),
             '-n ' + 'airflow-webserver',
             '-p ' + str(pid),
+            '-c', 'airflow.www.gunicorn_config',
         ]
 
         if args.access_logfile:

--- a/airflow/www/gunicorn_config.py
+++ b/airflow/www/gunicorn_config.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import setproctitle
+
+def post_worker_init(worker):
+    setproctitle.setproctitle('[ready] ' + setproctitle.getproctitle())

--- a/scripts/refresh_dags.sh
+++ b/scripts/refresh_dags.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+NUM_WORKER_PROCS_EXPECTED=2
+WORKER_STARTUP_WAIT=5 # if some workers are starting up, how long to wait before to checking again
+WORKER_REFRESH_WAIT=30 # if all workers are ready, how long to wait before refreshing a worker
+
+NUM_MASTER_PROCS_FOUND=$(ps aux | grep "gunicorn: master" | grep -v "grep" | wc -l | sed -e 's/^[[:space:]]*//')
+
+if [ "$NUM_MASTER_PROCS_FOUND" -ne "1" ]
+then
+    echo "Expected 1 gunicorn master process, found $NUM_MASTER_PROCS_FOUND"
+    exit 1
+fi
+
+MASTER_PID=$(ps aux | grep "gunicorn: master" | grep -v "grep" | awk '{print $2}')
+echo $MASTER_PID
+
+
+# State transition diagram, where each state is [$NUM_READY_WORKER_PROCS_FOUND / $NUM_WORKER_PROCS_FOUND].
+# We expect most time to be spent in [n / n]. The horizontal transition at ? happens when the new worker
+# parses all the dags.
+#
+#    V ------------------------------------------------------------------------------------------------------|
+# [n / n] ----$WORKER_REFRESH_WAIT----> [n / n + 1]  ----$WORKER_STARTUP_WAIT----?----> [n + 1 / n + 1] ---- |
+#                                            ^-----------------------------------|
+#
+while true
+do
+    NUM_WORKER_PROCS_FOUND=$(ps aux | grep "gunicorn: worker" | grep -v grep | wc -l | sed -e 's/^[[:space:]]*//')
+    NUM_READY_WORKER_PROCS_FOUND=$(ps aux | grep "\[ready\] gunicorn: worker" | grep -v grep | wc -l | sed -e 's/^[[:space:]]*//')
+
+    echo "found [$NUM_READY_WORKER_PROCS_FOUND / $NUM_WORKER_PROCS_FOUND] workers"
+
+    if [ $NUM_WORKER_PROCS_FOUND -gt $NUM_READY_WORKER_PROCS_FOUND ]
+    then
+        echo "some workers are starting up, waiting..."
+        sleep $WORKER_STARTUP_WAIT
+        continue
+    fi
+
+    if [ $NUM_WORKER_PROCS_FOUND -gt $NUM_WORKER_PROCS_EXPECTED ]
+    then
+        echo "killing a worker"
+        kill -TTOU $MASTER_PID
+        sleep 1
+        continue
+    fi
+
+    if [ $NUM_WORKER_PROCS_FOUND -eq $NUM_WORKER_PROCS_EXPECTED ]
+    then
+        sleep $WORKER_REFRESH_WAIT
+        echo "doing a refresh"
+        kill -TTIN $MASTER_PID
+        continue
+    fi
+
+done

--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,7 @@ def do_setup():
             'python-dateutil>=2.3, <3',
             'python-nvd3==0.14.2',
             'requests>=2.5.1, <3',
-            'setproctitle>=1.1.8, <2',
+            'setproctitle>=1.1.10, <2',
             'sqlalchemy>=0.9.8',
             'thrift>=0.9.2, <0.10',
             'zope.deprecation>=4.0, <5.0',


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- [https://issues.apache.org/jira/browse/AIRFLOW-276](https://issues.apache.org/jira/browse/AIRFLOW-276)
#### Testing Done:
- Add new dags to dags folder while `reload_dag.sh` is running and verify that they show up eventually
