### PR TITLE
[AIRFLOW-367] fix imports for github enterprise authentication

### DIFF
--- a/airflow/contrib/auth/backends/github_enterprise_auth.py
+++ b/airflow/contrib/auth/backends/github_enterprise_auth.py
@@ -19,7 +19,8 @@ import flask_login
 # pylint: disable=unused-import
 from flask_login import (current_user,
                          logout_user,
-                         login_required)
+                         login_required,
+                         login_user)
 # pylint: enable=unused-import
 
 from flask import url_for, redirect, request


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- _https://issues.apache.org/jira/browse/AIRFLOW-367_

issue summary: 
login is broken in GHE for new users:

``````
[2016-07-26 22:11:43,077] {github_enterprise_auth.py:199} ERROR -
Traceback (most recent call last):
  File "/opt/virtualenvs/airflow/lib/python3.5/site-packages/airflow/contrib/auth/backends/github_enterprise_auth.py", line 188, in oauth_callback
    'Null response from GHE, denying access.'
airflow.contrib.auth.backends.github_enterprise_auth.AuthenticationError: Null response from GHE, denying access.
[2016-07-26 22:12:12,313] {app.py:1423} ERROR - Exception on / [GET]
Traceback (most recent call last):
  File "/opt/virtualenvs/airflow/lib/python3.5/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/opt/virtualenvs/airflow/lib/python3.5/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/opt/virtualenvs/airflow/lib/python3.5/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/opt/virtualenvs/airflow/lib/python3.5/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/opt/virtualenvs/airflow/lib/python3.5/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/virtualenvs/airflow/lib/python3.5/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/opt/virtualenvs/airflow/lib/python3.5/site-packages/airflow/contrib/auth/backends/github_enterprise_auth.py", line 215, in oauth_callback
    login_user(GHEUser(user))
NameError: name 'login_user' is not defined```
``````
