### PR TITLE
[AIRFLOW-370] Create AirflowConfigException in exceptions.py

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -32,15 +32,14 @@ from builtins import str
 from collections import OrderedDict
 from configparser import ConfigParser
 
+from .exceptions import AirflowConfigException
+
 # show Airflow's deprecation warnings
 warnings.filterwarnings(
     action='default', category=DeprecationWarning, module='airflow')
 warnings.filterwarnings(
     action='default', category=PendingDeprecationWarning, module='airflow')
 
-
-class AirflowConfigException(Exception):
-    pass
 
 try:
     from cryptography.fernet import Fernet

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -20,6 +20,10 @@ class AirflowException(Exception):
     pass
 
 
+class AirflowConfigException(AirflowException):
+    pass
+    
+
 class AirflowSensorTimeout(AirflowException):
     pass
 


### PR DESCRIPTION
All exceptions should be created in `exceptions.py`.

https://issues.apache.org/jira/browse/AIRFLOW-370
