### PR TITLE
[WIP] Track and enforce git version

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -78,6 +78,7 @@ from airflow import hooks
 from airflow import executors
 from airflow import macros
 from airflow import contrib
+from airflow import version_control
 
 operators._integrate_plugins()
 hooks._integrate_plugins()

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -37,10 +37,9 @@ import time
 import psutil
 
 import airflow
-from airflow import jobs, settings
+from airflow import jobs, settings, executors
 from airflow import configuration as conf
 from airflow.exceptions import AirflowException
-from airflow.executors import DEFAULT_EXECUTOR
 from airflow.models import DagModel, DagBag, TaskInstance, DagPickle, DagRun, Variable
 from airflow.utils import db as db_utils
 from airflow.utils import logging as logging_utils
@@ -378,7 +377,7 @@ def run(args, dag=None):
                 print(e)
                 raise e
 
-        executor = DEFAULT_EXECUTOR
+        executor = airflow.executors.DEFAULT_EXECUTOR
         executor.start()
         print("Sending to executor.")
         executor.queue_task_instance(
@@ -892,6 +891,10 @@ def kerberos(args):  # noqa
         airflow.security.kerberos.run()
 
 
+def vc_collect_garbage(args):
+    print('vc_collect_garbage')
+
+
 Arg = namedtuple(
     'Arg', ['flags', 'help', 'action', 'default', 'nargs', 'type', 'choices', 'metavar'])
 Arg.__new__.__defaults__ = (None, None, None, None, None, None, None)
@@ -1245,6 +1248,10 @@ class CLIFactory(object):
             'args': ('dag_id_opt', 'subdir', 'run_duration', 'num_runs',
                      'do_pickle', 'pid', 'daemon', 'stdout', 'stderr',
                      'log_file'),
+        }, {
+            'func': vc_collect_garbage,
+            'help': "Run the custom version control function that collects garbage",
+            'args': tuple(),
         }, {
             'func': worker,
             'help': "Start a Celery worker node",

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -121,7 +121,6 @@ def get_dag(dag_id, subdir, dag_version):
     if dag_version:
         assert("DAGS_FOLDER" in subdir)
 
-        print(os.getpid(), 'calling vc.checkout_dags_folder')
         versioned_dags_folder_path = \
             airflow.version_control.checkout_dags_folder(dag_version)
         path_to_dag = subdir.replace("DAGS_FOLDER", versioned_dags_folder_path)
@@ -820,7 +819,6 @@ def worker(args):
         )
         vc_proc = multiprocessing.Process(
             target=airflow.version_control.on_worker_start,
-            args=(celery_proc.pid,)
         )
         vc_proc.start()
 

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -338,6 +338,7 @@ def run(args, dag=None):
     task = dag.get_task(task_id=args.task_id)
 
     ti = TaskInstance(task, args.execution_date)
+    ti.dag_version = args.dag_version
 
     if args.local:
         print("Logging into: " + filename)

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -116,11 +116,12 @@ def get_dag_from_args(args):
 
 def get_dag(dag_id, subdir, dag_version):
 
-    print('get_dag', dag_id, subdir, dag_version)
+    print(os.getpid(), 'get_dag', dag_id, subdir, dag_version)
 
     if dag_version:
         assert("DAGS_FOLDER" in subdir)
 
+        print(os.getpid(), 'calling vc.checkout_dags_folder')
         versioned_dags_folder_path = \
             airflow.version_control.checkout_dags_folder(dag_version)
         path_to_dag = subdir.replace("DAGS_FOLDER", versioned_dags_folder_path)
@@ -133,9 +134,14 @@ def get_dag(dag_id, subdir, dag_version):
     dagbag = DagBag(path_to_dag)
 
     if dag_id not in dagbag.dags:
+        # todo: check if it's checked out
+
         raise AirflowException(
-            'dag_id could not be found: {}. Either the dag did not exist or it failed to '
-            'parse.'.format(dag_id))
+            'dag_id could not be found: {}. Either the dag did not exist or it failed to parse subdir={} dag_version={} path_to_dag={} file_exists={}'.format(
+                dag_id, subdir, dag_version, path_to_dag,
+                os.path.isfile(path_to_dag)
+            )
+        )
     return dagbag.dags[dag_id]
 
 

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -796,13 +796,57 @@ def worker(args):
         stdout.close()
         stderr.close()
     else:
-        signal.signal(signal.SIGINT, sigint_handler)
-        signal.signal(signal.SIGTERM, sigint_handler)
+        serve_logs_proc = subprocess.Popen(['airflow', 'serve_logs'], env=env)
+        celery_proc = subprocess.Popen(
+            [
+                'celery',
+                'worker',
+                '-A', 'airflow.executors.celery_executor',
+                '-O', 'fair',
+                '-Q', str(args.queues),
+                '-c', str(args.concurrency)
+            ],
+            env=env,
+            # don't inherit stdin, so that Ctrl-C is not handled twice
+            stdin=subprocess.PIPE
+        )
 
-        sp = subprocess.Popen(['airflow', 'serve_logs'], env=env)
 
-        worker.run(**options)
-        sp.kill()
+        def kill_proc(dummy_signum, dummy_frame):
+            serve_logs_proc.terminate()
+
+            print('killing celery')
+            # 1. Send SIGTERM to celery, warm shutdown (celery will quit when all tasks finish)
+            celery_proc.terminate()
+
+            # 2. Send SIGTERM to each child of celery - give up on task.
+            # We go two levels deep in the process tree
+            #
+            # - celery master process
+            #   \- celery worker process
+            #      \- airflow run --local    <------- terminate
+            #         \- airflow run --raw
+            #   \- celery worker process
+            #      \- airflow run --local    <------- terminate
+            #         \- airflow run --raw
+            #   \- celery worker process
+            #   \- celery worker process
+            celery_workers = psutil.Process(celery_proc.pid).children()
+            for celery_worker in celery_workers:
+                for celery_child in psutil.Process(celery_worker.pid).children():
+                    print('sending SIGTERM to ', celery_worker.cmdline()[0])
+                    celery_child.send_signal(signal.SIGTERM)
+
+            # 3. Wait for warm shutdown to finish
+            celery_proc.wait()
+
+            sys.exit(0)
+
+        signal.signal(signal.SIGINT, kill_proc)
+        signal.signal(signal.SIGTERM, kill_proc)
+
+        while True:
+            pass
 
 
 def initdb(args):  # noqa
@@ -1254,7 +1298,7 @@ class CLIFactory(object):
             'args': tuple(),
         }, {
             'func': worker,
-            'help': "Start a Celery worker node",
+            'help': "Supervise or daemonize a Celery worker node",
             'args': ('do_pickle', 'queues', 'concurrency',
                      'pid', 'daemon', 'stdout', 'stderr', 'log_file'),
         }, {

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -109,10 +109,12 @@ base_log_folder = {AIRFLOW_HOME}/logs
 # location.
 remote_base_log_folder =
 remote_log_conn_id =
+
 # Use server-side encryption for logs stored in S3
 encrypt_s3_logs = False
-# DEPRECATED option for remote log storage, use remote_base_log_folder instead!
-s3_log_folder =
+
+# deprecated option for remote log storage, use remote_base_log_folder instead!
+# s3_log_folder =
 
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor
@@ -173,6 +175,9 @@ security =
 # Turn unit test mode on (overwrites many configuration options with test
 # values at runtime)
 unit_test_mode = False
+
+# Version control strategy
+version_control_strategy = noop
 
 
 [operators]

--- a/airflow/contrib/scripts/git.py
+++ b/airflow/contrib/scripts/git.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python
+from __future__ import print_function, absolute_import, division
+
+import logging
+
+from collections import defaultdict
+from errno import ENOENT
+from stat import S_IFDIR, S_IFLNK, S_IFREG
+from sys import argv, exit
+from time import time
+import subprocess
+import sys
+
+import fuse
+from fuse import FUSE, FuseOSError, Operations, LoggingMixIn
+
+if not hasattr(__builtins__, 'bytes'):
+    bytes = str
+
+now = time()
+
+# UTIL
+
+def stdout_of(cmd, cwd):
+    proc = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE
+    )
+    out, err = proc.communicate()
+    assert err is None
+
+    return out
+
+def commit_hashes_of(git_directory):
+    return stdout_of(
+        ['git', 'rev-list', '--all'],
+        cwd=git_directory
+    ).split('\n')
+
+def tree_of_commit(git_directory, commit_hash):
+    lines = stdout_of(
+        ['git', 'cat-file', '-p', commit_hash],
+        cwd=git_directory
+    ).split('\n')
+
+    _, tree_hash = lines[0].split(' ')
+    return tree_hash
+
+_directory_of_tree_cache = {}
+def directory_of_tree(git_directory, tree_hash):
+
+    key = (git_directory, tree_hash)
+    if key in _directory_of_tree_cache: return _directory_of_tree_cache[key]
+
+    lines = stdout_of(
+        ['git', 'cat-file', '-p', tree_hash],
+        cwd=git_directory
+    ).split('\n')
+
+    ret = []
+
+    for line in lines:
+        if not len(line): continue
+        a, filename = line.split('\t')
+        b, c, d = a.split(' ')
+
+        ret += [(b, c, d, filename)]
+
+    _directory_of_tree_cache[key] = ret
+    return _directory_of_tree_cache[key]
+
+def directory_of_commit(git_directory, commit_hash):
+    return directory_of_tree(git_directory, tree_of_commit(git_directory, commit_hash))
+
+
+_object_hash_of_cache = {}
+def object_hash_of(git_directory, tree_hash, path):
+
+    key = (git_directory, tree_hash, tuple(path))
+    if key in _object_hash_of_cache: return _object_hash_of_cache[key]
+
+    if len(path) == 0:
+        return tree_hash
+
+    match = None
+    for _, blob_or_tree, object_hash, filename in directory_of_tree(git_directory, tree_hash):
+        if filename == path[0]:
+            match = (blob_or_tree, object_hash, filename)
+
+    if match is None:
+        raise FuseOSError(ENOENT)
+
+    blob_or_tree, object_hash, filename = match
+
+    _object_hash_of_cache[key] = object_hash_of(git_directory, object_hash, path[1:])
+    return _object_hash_of_cache[key]
+
+
+_object_type_of_cache = {}
+def object_type_of(git_directory, object_hash):
+
+    key = (git_directory, object_hash)
+    if key in _object_type_of_cache: return _object_type_of_cache[key]
+
+    ret = stdout_of(
+        ['git', 'cat-file', '-t', object_hash],
+        cwd=git_directory
+    ).split('\n')[0]
+
+    _object_type_of_cache[key] = ret
+    return _object_type_of_cache[key]
+
+_blob_contents_cache = {}
+def get_blob_contents(git_directory, blob_hash):
+
+    key = (git_directory, blob_hash)
+    if key in _blob_contents_cache:
+        return _blob_contents_cache[key]
+
+    _blob_contents_cache[key] = stdout_of(
+        ['git', 'cat-file', '-p', blob_hash],
+        cwd=git_directory
+    )
+    return _blob_contents_cache[key]
+
+# GIT
+
+class Git(LoggingMixIn, Operations):
+    'Example memory filesystem. Supports only one level of files.'
+
+    def __init__(self, git_directory):
+        self.git_directory = git_directory
+        self.commit_hashes = commit_hashes_of(self.git_directory)
+
+        # todo: delete
+        self.files = {}
+        self.data = defaultdict(bytes)
+        self.fd = 0
+        now = time()
+        self.files['/'] = dict(st_mode=(S_IFDIR | 0o755), st_ctime=now,
+                               st_mtime=now, st_atime=now, st_nlink=2)
+
+
+    def chmod(self, path, mode):
+        raise FuseOSError(fuse.EROFS)
+
+    def chown(self, path, uid, gid):
+        raise FuseOSError(fuse.EROFS)
+
+    def create(self, path, mode):
+        raise FuseOSError(fuse.EROFS)
+
+    def getattr(self, path, fh=None):
+
+        assert path[0] == '/'
+
+        if path == '/' or path[1:] in self.commit_hashes:
+            return dict(st_mode=(S_IFDIR | 0o755), st_ctime=now,
+                                   st_mtime=now, st_atime=now, st_nlink=2)
+        else:
+            path_parts = path[1:].split('/')
+
+            if path_parts[0] not in self.commit_hashes:
+                raise FuseOSError(ENOENT)
+            else:
+
+                commit_sha, path_parts = path_parts[0], path_parts[1:]
+
+                object_hash = object_hash_of(
+                    self.git_directory,
+                    tree_of_commit(self.git_directory, commit_sha),
+                    path_parts
+                )
+
+                object_type = object_type_of(self.git_directory, object_hash)
+
+                assert object_type in ['blob', 'tree']
+
+                if object_type == 'tree':
+                    return dict(st_mode=(S_IFDIR | 0o755), st_ctime=now,
+                                st_mtime=now, st_atime=now, st_nlink=2)
+                else:
+                    return dict(st_mode=(S_IFREG | 0o755), st_ctime=now,
+                                st_mtime=now, st_atime=now, st_nlink=2, st_size=len(get_blob_contents(self.git_directory, object_hash)))
+
+
+
+    def getxattr(self, path, name, position=0):
+        raise FuseOSError(fuse.EROFS)
+
+    def listxattr(self, path):
+        raise FuseOSError(fuse.EROFS)
+
+    def mkdir(self, path, mode):
+        raise FuseOSError(fuse.EROFS)
+
+    def open(self, path, flags):
+        self.fd += 1
+        return self.fd
+
+    def read(self, path, size, offset, fh):
+
+        assert path[0] == '/'
+
+        path_parts = path[1:].split('/')
+
+        commit_hash, path_parts = path_parts[0], path_parts[1:]
+
+        object_hash = object_hash_of(
+            self.git_directory,
+            tree_of_commit(self.git_directory, commit_hash),
+            path_parts
+        )
+
+        return get_blob_contents(self.git_directory, object_hash)[offset:offset+size]
+
+    def readdir(self, path, fh):
+
+        if path == '/':
+            return self.commit_hashes
+        elif path[1:] in self.commit_hashes:
+            commit_hash = path[1:]
+
+            ret = ['.', '..']
+
+            for _, blob_or_tree, object_hash, filename in directory_of_commit(self.git_directory, commit_hash):
+                ret += [filename]
+
+            return ret
+
+        else:
+
+            ret = ['.', '..']
+
+            path_parts = path[1:].split('/')
+            commit_sha, path_parts = path_parts[0], path_parts[1:]
+
+            object_hash = object_hash_of(
+                self.git_directory,
+                tree_of_commit(self.git_directory, commit_sha),
+                path_parts
+            )
+
+            for _, blob_or_tree, object_hash, filename in directory_of_tree(self.git_directory, object_hash):
+                ret += [filename]
+
+            return ret
+
+    def readlink(self, path):
+        return self.data[path]
+
+    def removexattr(self, path, name):
+        print('removexattr??')
+        raise FuseOSError(fuse.EROFS)
+
+    def rename(self, old, new):
+        raise FuseOSError(fuse.EROFS)
+
+    def rmdir(self, path):
+        raise FuseOSError(fuse.EROFS)
+
+    def setxattr(self, path, name, value, options, position=0):
+        raise FuseOSError(fuse.EROFS)
+
+    def statfs(self, path):
+        return dict(f_bsize=512, f_blocks=4096, f_bavail=2048)
+
+    def symlink(self, target, source):
+        raise FuseOSError(fuse.EROFS)
+
+    def truncate(self, path, length, fh=None):
+        raise FuseOSError(fuse.EROFS)
+
+    def unlink(self, path):
+        raise FuseOSError(fuse.EROFS)
+
+    def utimens(self, path, times=None):
+        raise FuseOSError(fuse.EROFS)
+
+    def write(self, path, data, offset, fh):
+        raise FuseOSError(fuse.EROFS)
+
+
+if __name__ == '__main__':
+
+    if len(argv) != 3:
+        print('usage: %s <mountpoint> <path_to_git>' % argv[0])
+        exit(1)
+
+    logging.basicConfig(level=logging.DEBUG)
+    fuse = FUSE(Git(argv[2]), argv[1], foreground=True)

--- a/airflow/executors/__init__.py
+++ b/airflow/executors/__init__.py
@@ -47,4 +47,5 @@ else:
     else:
         raise AirflowException("Executor {0} not supported.".format(_EXECUTOR))
 
+
 logging.info("Using executor " + _EXECUTOR)

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -60,6 +60,7 @@ class BaseExecutor(LoggingMixin):
             ignore_depends_on_past=False,
             pool=None):
         pool = pool or task_instance.pool
+
         command = task_instance.command(
             local=True,
             mark_success=mark_success,
@@ -67,7 +68,8 @@ class BaseExecutor(LoggingMixin):
             ignore_dependencies=ignore_dependencies,
             ignore_depends_on_past=ignore_depends_on_past,
             pool=pool,
-            pickle_id=pickle_id)
+            pickle_id=pickle_id,
+            dag_version=task_instance.dag_version)
         self.queue_command(
             task_instance,
             command,

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1013,8 +1013,6 @@ class SchedulerJob(BaseJob):
 
                 DAGS_FOLDER = os.path.expanduser(conf.get('core', 'DAGS_FOLDER'))
 
-                print('TI.generate_command', '*'*50)
-
                 command = TI.generate_command(
                     task_instance.dag_id,
                     task_instance.task_id,
@@ -1029,6 +1027,8 @@ class SchedulerJob(BaseJob):
                     pickle_id=simple_dag_bag.get_dag(task_instance.dag_id).pickle_id,
                     dag_version=task_instance.dag_version
                 )
+
+                print('TI.generate_command', command, '*'*50)
 
                 priority = task_instance.priority_weight
                 queue = task_instance.queue
@@ -1931,7 +1931,6 @@ class LocalTaskJob(BaseJob):
         super(LocalTaskJob, self).__init__(*args, **kwargs)
 
     def _execute(self):
-        print('running raw')
         command = self.task_instance.command(
             raw=True,
             ignore_dependencies=self.ignore_dependencies,

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1028,8 +1028,6 @@ class SchedulerJob(BaseJob):
                     dag_version=task_instance.dag_version
                 )
 
-                print('TI.generate_command', command, '*'*50)
-
                 priority = task_instance.priority_weight
                 queue = task_instance.queue
                 self.logger.info("Sending to executor {} with priority {} and queue {}"
@@ -1377,16 +1375,18 @@ class SchedulerJob(BaseJob):
                 # If a task instance is up for retry but the corresponding DAG run
                 # isn't running, mark the task instance as FAILED so we don't try
                 # to re-run it.
-                self._change_state_for_tis_without_dagrun(simple_dag_bag,
-                                                          [State.UP_FOR_RETRY],
-                                                          State.FAILED)
+                self._change_state_for_tis_without_dagrun(
+                    simple_dag_bag,
+                    [State.UP_FOR_RETRY],
+                    State.FAILED)
                 # If a task instance is scheduled or queued, but the corresponding
                 # DAG run isn't running, set the state to NONE so we don't try to
                 # re-run it.
-                self._change_state_for_tis_without_dagrun(simple_dag_bag,
-                                                          [State.QUEUED,
-                                                           State.SCHEDULED],
-                                                          State.NONE)
+                self._change_state_for_tis_without_dagrun(
+                    simple_dag_bag,
+                    [State.QUEUED,
+                    State.SCHEDULED],
+                    State.NONE)
 
                 self._execute_task_instances(simple_dag_bag,
                                              (State.SCHEDULED,

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1338,7 +1338,7 @@ class SchedulerJob(BaseJob):
         # For the execute duration, parse and schedule DAGs
         while (datetime.now() - execute_start_time).total_seconds() < \
                 self.run_duration:
-            self.logger.debug("Starting Loop...")
+            self.logger.info("Starting Loop...")
             loop_start_time = time.time()
 
             # Traverse the DAG directory for Python files containing DAGs
@@ -1391,6 +1391,8 @@ class SchedulerJob(BaseJob):
                 self._execute_task_instances(simple_dag_bag,
                                              (State.SCHEDULED,
                                               State.UP_FOR_RETRY))
+            else:
+                self.logger.info('no dags')
 
             # Call hearbeats
             self.logger.info("Heartbeating the executor")

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1078,10 +1078,6 @@ class SchedulerJob(BaseJob):
         """
         for dag in dags:
             dag = dagbag.get_dag(dag.dag_id)
-            if dag.reached_max_runs:
-                self.logger.info("Not processing DAG {} since its max runs has been reached"
-                                .format(dag.dag_id))
-                continue
             if dag.is_paused:
                 self.logger.info("Not processing DAG {} since it's paused"
                                  .format(dag.dag_id))

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -66,7 +66,7 @@ class BaseJob(Base, LoggingMixin):
     """
     Abstract class to be derived for jobs. Jobs are processing items with state
     and duration that aren't task instances. For instance a BackfillJob is
-    a collection of task instance runs, but should have it's own state, start
+    a collection of task instance runs, but should have its own state, start
     and end time.
     """
 
@@ -487,7 +487,9 @@ class SchedulerJob(BaseJob):
         self.subdir = subdir
 
         self.num_runs = num_runs
-        self.run_duration = run_duration
+        self.run_duration = run_duration or conf.getint(
+            'scheduler', 'run_duration'
+        )
         self._processor_poll_interval = processor_poll_interval
 
         self.do_pickle = do_pickle
@@ -503,26 +505,25 @@ class SchedulerJob(BaseJob):
             self.using_sqlite = True
 
         # How often to scan the DAGs directory for new files. Default to 5 minutes.
-        self.dag_dir_list_interval = conf.getint('scheduler',
-                                                 'dag_dir_list_interval')
-        # How often to print out DAG file processing stats to the log. Default to
+        self.dag_dir_list_interval = conf.getint('scheduler', 'dag_dir_list_interval')
+
+        # How often to print out DAG file processing stats to the log. Defaults to
         # 30 seconds.
-        self.print_stats_interval = conf.getint('scheduler',
-                                                'print_stats_interval')
+        self.print_stats_interval = conf.getint('scheduler', 'print_stats_interval')
+
         # Parse and schedule each file no faster than this interval. Default
         # to 3 minutes.
         self.file_process_interval = file_process_interval
+
         # Directory where log files for the processes that scheduled the DAGs reside
-        self.child_process_log_directory = conf.get('scheduler',
-                                                    'child_process_log_directory')
-        if run_duration is None:
-            self.run_duration = conf.getint('scheduler',
-                                            'run_duration')
+        self.child_process_log_directory = conf.get(
+            'scheduler', 'child_process_log_directory'
+        )
 
     @provide_session
     def manage_slas(self, dag, session=None):
         """
-        Finding all tasks that have SLAs defined, and sending alert emails
+        Find all tasks that have SLAs defined, and sending alert emails
         where needed. New SLA misses are also recorded in the database.
 
         Where assuming that the scheduler runs often, so we only check for
@@ -802,7 +803,7 @@ class SchedulerJob(BaseJob):
             # todo: run.dag is transient but needs to be set
             run.dag = dag
             # todo: preferably the integrity check happens at dag collection time
-            run.verify_integrity(session=session)
+            run.ensure_integrity(session=session)
             run.update_state(session=session)
             if run.state == State.RUNNING:
                 make_transient(run)
@@ -818,6 +819,7 @@ class SchedulerJob(BaseJob):
             # every task (in ti.is_runnable). This is also called in
             # update_state above which has already checked these tasks
             for ti in tis:
+
                 task = dag.get_task(ti.task_id)
 
                 # fixme: ti.task is transient but needs to be set
@@ -1009,6 +1011,10 @@ class SchedulerJob(BaseJob):
                                              task_concurrency_limit))
                     continue
 
+                DAGS_FOLDER = os.path.expanduser(conf.get('core', 'DAGS_FOLDER'))
+
+                print('TI.generate_command', '*'*50)
+
                 command = TI.generate_command(
                     task_instance.dag_id,
                     task_instance.task_id,
@@ -1019,8 +1025,10 @@ class SchedulerJob(BaseJob):
                     ignore_dependencies=False,
                     ignore_depends_on_past=False,
                     pool=task_instance.pool,
-                    file_path=simple_dag_bag.get_dag(task_instance.dag_id).full_filepath,
-                    pickle_id=simple_dag_bag.get_dag(task_instance.dag_id).pickle_id)
+                    file_path=simple_dag_bag.get_dag(task_instance.dag_id).full_filepath.replace(DAGS_FOLDER, 'DAGS_FOLDER'),
+                    pickle_id=simple_dag_bag.get_dag(task_instance.dag_id).pickle_id,
+                    dag_version=task_instance.dag_version
+                )
 
                 priority = task_instance.priority_weight
                 queue = task_instance.queue
@@ -1214,22 +1222,29 @@ class SchedulerJob(BaseJob):
         # DAGs in parallel. By processing them in separate processes,
         # we can get parallelism and isolation from potentially harmful
         # user code.
-        self.logger.info("Processing files using up to {} processes at a time "
-                         .format(self.max_threads))
-        self.logger.info("Running execute loop for {} seconds"
-                         .format(self.run_duration))
-        self.logger.info("Processing each file at most {} times"
-                         .format(self.num_runs))
-        self.logger.info("Process each file at most once every {} seconds"
-                         .format(self.file_process_interval))
-        self.logger.info("Checking for new files in {} every {} seconds"
-                         .format(self.subdir, self.dag_dir_list_interval))
+        self.logger.info(
+            "Processing files using up to %s processes at a time", self.max_threads
+        )
+        self.logger.info(
+            "Running execute loop for %s seconds", self.run_duration
+        )
+        self.logger.info(
+            "Processing each file at most %s times", self.num_runs
+        )
+        self.logger.info(
+            "Process each file at most once every %s seconds", self.file_process_interval
+        )
+        self.logger.info(
+            "Checking for new files in %s every %s seconds",
+            self.subdir, self.dag_dir_list_interval
+        )
 
         # Build up a list of Python files that could contain DAGs
         self.logger.info("Searching for files in {}".format(self.subdir))
         known_file_paths = list_py_file_paths(self.subdir)
-        self.logger.info("There are {} files in {}"
-                         .format(len(known_file_paths), self.subdir))
+        self.logger.info("There are %s files in %s",
+            len(known_file_paths), self.subdir
+        )
 
         def processor_factory(file_path, log_file_path):
             return DagFileProcessor(file_path,
@@ -1270,8 +1285,9 @@ class SchedulerJob(BaseJob):
                 try:
                     psutil.wait_procs(child_processes, timeout)
                 except psutil.TimeoutExpired:
-                    self.logger.debug("Ran out of time while waiting for "
-                                      "processes to exit")
+                    self.logger.debug(
+                        "Ran out of time while waiting for processes to exit"
+                    )
 
                 # Then SIGKILL
                 child_processes = [x for x in this_process.children(recursive=True)
@@ -1431,6 +1447,7 @@ class SchedulerJob(BaseJob):
         self.executor.end()
 
         settings.Session.remove()
+
 
     @provide_session
     def process_file(self, file_path, pickle_dags=False, session=None):
@@ -1892,6 +1909,7 @@ class LocalTaskJob(BaseJob):
             mark_success=False,
             pickle_id=None,
             pool=None,
+            dag_version=None,
             *args, **kwargs):
         self.task_instance = task_instance
         self.ignore_dependencies = ignore_dependencies
@@ -1900,6 +1918,7 @@ class LocalTaskJob(BaseJob):
         self.pool = pool
         self.pickle_id = pickle_id
         self.mark_success = mark_success
+        self.dag_version = dag_version
 
         # terminating state is used so that a job don't try to
         # terminate multiple times
@@ -1912,6 +1931,7 @@ class LocalTaskJob(BaseJob):
         super(LocalTaskJob, self).__init__(*args, **kwargs)
 
     def _execute(self):
+        print('running raw')
         command = self.task_instance.command(
             raw=True,
             ignore_dependencies=self.ignore_dependencies,

--- a/airflow/migrations/versions/785ece547642_add_task_instance_dag_version_column.py
+++ b/airflow/migrations/versions/785ece547642_add_task_instance_dag_version_column.py
@@ -1,0 +1,37 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Add task_instance.dag_version column
+
+Revision ID: 785ece547642
+Revises: 211e584da130
+Create Date: 2016-07-14 15:38:39.571101
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '785ece547642'
+down_revision = '211e584da130'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('task_instance', sa.Column('dag_version', sa.String(1000)))
+
+
+def downgrade():
+    op.drop_column('task_instance', 'dag_version')

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -56,8 +56,8 @@ from croniter import croniter
 import six
 
 import airflow
-from airflow import settings, utils
-from airflow.executors import DEFAULT_EXECUTOR, LocalExecutor
+from airflow import settings, utils, executors
+from airflow.executors import LocalExecutor
 from airflow import configuration
 from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.dag.base_dag import BaseDag, BaseDagBag
@@ -156,7 +156,7 @@ class DagBag(BaseDagBag, LoggingMixin):
     def __init__(
             self,
             dag_folder=None,
-            executor=DEFAULT_EXECUTOR,
+            executor=airflow.executors.DEFAULT_EXECUTOR,
             include_examples=configuration.getboolean('core', 'LOAD_EXAMPLES')):
 
         print(os.getpid(), 'dagbag created', '*'*100)
@@ -3241,7 +3241,7 @@ class DAG(BaseDag, LoggingMixin):
         if not executor and local:
             executor = LocalExecutor()
         elif not executor:
-            executor = DEFAULT_EXECUTOR
+            executor = airflow.executors.DEFAULT_EXECUTOR
         job = BackfillJob(
             self,
             start_date=start_date,

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -427,7 +427,6 @@ class DagBag(BaseDagBag, LoggingMixin):
                             ))
                     except Exception as e:
                         logging.warning(e)
-                        import traceback
                         traceback.print_exc()
         Stats.gauge(
             'collect_dags', (datetime.now() - start_dttm).total_seconds(), 1)

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -159,6 +159,8 @@ class DagBag(BaseDagBag, LoggingMixin):
             executor=DEFAULT_EXECUTOR,
             include_examples=configuration.getboolean('core', 'LOAD_EXAMPLES')):
 
+        print(os.getpid(), 'dagbag created', '*'*100)
+
         dag_folder = dag_folder or DAGS_FOLDER
         self.logger.info("Filling up the DagBag from {}".format(dag_folder))
         self.dag_folder = dag_folder

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -55,6 +55,7 @@ from sqlalchemy.orm import relationship, synonym
 from croniter import croniter
 import six
 
+import airflow
 from airflow import settings, utils
 from airflow.executors import DEFAULT_EXECUTOR, LocalExecutor
 from airflow import configuration
@@ -140,7 +141,7 @@ class DagBag(BaseDagBag, LoggingMixin):
     settings are now dagbag level so that one system can run multiple,
     independent settings sets.
 
-    :param dag_folder: the folder to scan to find DAGs
+    :param dag_folder: the folder or file to scan to find DAGs
     :type dag_folder: unicode
     :param executor: the executor to use when executing task instances
         in this DagBag
@@ -293,8 +294,15 @@ class DagBag(BaseDagBag, LoggingMixin):
         for m in mods:
             for dag in list(m.__dict__.values()):
                 if isinstance(dag, DAG):
+
                     if not dag.full_filepath:
                         dag.full_filepath = filepath
+
+                    dag.version_control_hash = \
+                        airflow.version_control.get_version_control_hash_of(
+                            filepath
+                        )
+
                     dag.is_subdag = False
                     dag.module_name = m.__name__
                     self.bag_dag(dag, parent_dag=dag, root_dag=dag)
@@ -400,8 +408,7 @@ class DagBag(BaseDagBag, LoggingMixin):
                             os.path.split(filepath)[-1])
                         if file_ext != '.py' and not zipfile.is_zipfile(filepath):
                             continue
-                        if not any(
-                                [re.findall(p, filepath) for p in patterns]):
+                        if not any([re.findall(p, filepath) for p in patterns]):
                             ts = datetime.now()
                             found_dags = self.process_file(
                                 filepath, only_if_updated=only_if_updated)
@@ -418,6 +425,8 @@ class DagBag(BaseDagBag, LoggingMixin):
                             ))
                     except Exception as e:
                         logging.warning(e)
+                        import traceback
+                        traceback.print_exc()
         Stats.gauge(
             'collect_dags', (datetime.now() - start_dttm).total_seconds(), 1)
         Stats.gauge(
@@ -701,6 +710,7 @@ class TaskInstance(Base):
     priority_weight = Column(Integer)
     operator = Column(String(1000))
     queued_dttm = Column(DateTime)
+    dag_version = Column(String(1000))
 
     __table_args__ = (
         Index('ti_dag_state', dag_id, state),
@@ -734,7 +744,8 @@ class TaskInstance(Base):
             pickle_id=None,
             raw=False,
             job_id=None,
-            pool=None):
+            pool=None,
+            dag_version=None):
         """
         Returns a command that can be executed anywhere where airflow is
         installed. This command is part of the message sent to executors by
@@ -763,7 +774,9 @@ class TaskInstance(Base):
             file_path=path,
             raw=raw,
             job_id=job_id,
-            pool=pool)
+            pool=pool,
+            dag_version=dag_version
+        )
 
     @staticmethod
     def generate_command(dag_id,
@@ -778,7 +791,8 @@ class TaskInstance(Base):
                          file_path=None,
                          raw=False,
                          job_id=None,
-                         pool=None
+                         pool=None,
+                         dag_version=None
                          ):
         """
         Generates the shell command required to execute this task instance.
@@ -813,6 +827,7 @@ class TaskInstance(Base):
         """
         iso = execution_date.isoformat()
         cmd = "airflow run {dag_id} {task_id} {iso} "
+        cmd += "--dag-version={dag_version} " if dag_version else " "
         cmd += "--mark_success " if mark_success else ""
         cmd += "--pickle {pickle_id} " if pickle_id else ""
         cmd += "--job_id {job_id} " if job_id else ""
@@ -911,6 +926,7 @@ class TaskInstance(Base):
             self.start_date = ti.start_date
             self.end_date = ti.end_date
             self.try_number = ti.try_number
+            self.dag_version = ti.dag_version
         else:
             self.state = None
 
@@ -1394,7 +1410,9 @@ class TaskInstance(Base):
                     self.render_templates()
                     task_copy.pre_execute(context=context)
 
-                    # If a timeout is specified for the task, make it fail
+                    print('eggsecuting!', type(task_copy))
+
+                    # If a timout is specified for the task, make it fail
                     # if it goes beyond
                     result = None
                     if task_copy.execution_timeout:
@@ -3287,7 +3305,7 @@ class DAG(BaseDag, LoggingMixin):
 
         # create the associated task instances
         # state is None at the moment of creation
-        run.verify_integrity(session=session)
+        run.ensure_integrity(session=session)
 
         run.refresh_from_db()
         return run
@@ -3847,10 +3865,10 @@ class DagRun(Base):
         return self.state
 
     @provide_session
-    def verify_integrity(self, session=None):
+    def ensure_integrity(self, session=None):
         """
         Verifies the DagRun by checking for removed tasks or tasks that are not in the
-        database yet. It will set state to removed or add the task if required.
+        database yet. Set state to removed or add the task if required.
         """
         dag = self.get_dag()
         tis = self.get_task_instances(session=session)
@@ -3872,6 +3890,9 @@ class DagRun(Base):
 
             if task.task_id not in task_ids:
                 ti = TaskInstance(task, self.execution_date)
+                # Sometimes this is not set, eg in tests
+                if hasattr(dag, 'version_control_hash'):
+                    ti.dag_version = dag.version_control_hash
                 session.add(ti)
 
         session.commit()

--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import airflow
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, Pool
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.db import provide_session
-from airflow.executors import DEFAULT_EXECUTOR
 
 
 class SubDagOperator(BaseOperator):
@@ -30,7 +30,7 @@ class SubDagOperator(BaseOperator):
     def __init__(
             self,
             subdag,
-            executor=DEFAULT_EXECUTOR,
+            executor=airflow.executors.DEFAULT_EXECUTOR,
             *args, **kwargs):
         """
         Yo dawg. This runs a sub dag. By convention, a sub dag's dag_id

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -518,6 +518,8 @@ class DagFileProcessorManager(LoggingMixin):
         running_processors = {}
         """:type : dict[unicode, AbstractDagFileProcessor]"""
 
+        print('processors', self._processors, 'finished_processors', finished_processors, 'file_path_queue', self._file_path_queue)
+
         for file_path, processor in self._processors.items():
             if processor.done:
                 self.logger.info("Processor for {} finished".format(file_path))
@@ -567,6 +569,10 @@ class DagFileProcessorManager(LoggingMixin):
                                         set(file_paths_in_progress) -
                                         set(file_paths_recently_processed) -
                                         set(files_paths_at_run_limit))
+
+            print('files_paths_to_queue', files_paths_to_queue)
+            print(self._file_paths, file_paths_in_progress, file_paths_recently_processed, files_paths_at_run_limit)
+            print(self._process_file_interval)
 
             for file_path, processor in self._processors.items():
                 self.logger.debug("File path {} is still being processed (started: {})"

--- a/airflow/version_control/__init__.py
+++ b/airflow/version_control/__init__.py
@@ -38,5 +38,5 @@ def get_version_control_hash_of(filepath):
     return dagFolderVersionManager.get_version_control_hash_of(filepath)
 
 
-def on_worker_start():
-	return dagFolderVersionManager.on_worker_start()
+def on_worker_start(celery_pid):
+	return dagFolderVersionManager.on_worker_start(celery_pid)

--- a/airflow/version_control/__init__.py
+++ b/airflow/version_control/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+# hardcoded symlink to git
+
+from git import GitDagFolderVersionManager
+from noop import NoopDagFolderVersionManager
+from airflow import configuration as conf
+
+VERSION_CONTROL_STRATEGY = conf.get('core', "version_control_strategy")
+DAGS_FOLDER = conf.get('core', "dags_folder")
+
+if VERSION_CONTROL_STRATEGY == "git":
+	dagFolderVersionManager = GitDagFolderVersionManager(DAGS_FOLDER)
+elif VERSION_CONTROL_STRATEGY == "noop":
+	dagFolderVersionManager = NoopDagFolderVersionManager(DAGS_FOLDER)
+else:
+	raise ValueError('unrecognized version control strategy')
+
+def checkout_dags_folder(git_sha_hash):
+	return dagFolderVersionManager.checkout_dags_folder(git_sha_hash)
+
+def get_version_control_hash_of(filepath):
+	return dagFolderVersionManager.get_version_control_hash_of(filepath)

--- a/airflow/version_control/__init__.py
+++ b/airflow/version_control/__init__.py
@@ -36,3 +36,7 @@ def checkout_dags_folder(git_sha_hash):
 
 def get_version_control_hash_of(filepath):
     return dagFolderVersionManager.get_version_control_hash_of(filepath)
+
+
+def on_worker_start():
+	return dagFolderVersionManager.on_worker_start()

--- a/airflow/version_control/__init__.py
+++ b/airflow/version_control/__init__.py
@@ -1,6 +1,19 @@
 #!/usr/bin/env python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # hardcoded symlink to git
+
 
 from git import GitDagFolderVersionManager
 from noop import NoopDagFolderVersionManager
@@ -10,14 +23,16 @@ VERSION_CONTROL_STRATEGY = conf.get('core', "version_control_strategy")
 DAGS_FOLDER = conf.get('core', "dags_folder")
 
 if VERSION_CONTROL_STRATEGY == "git":
-	dagFolderVersionManager = GitDagFolderVersionManager(DAGS_FOLDER)
+    dagFolderVersionManager = GitDagFolderVersionManager(DAGS_FOLDER)
 elif VERSION_CONTROL_STRATEGY == "noop":
-	dagFolderVersionManager = NoopDagFolderVersionManager(DAGS_FOLDER)
+    dagFolderVersionManager = NoopDagFolderVersionManager(DAGS_FOLDER)
 else:
-	raise ValueError('unrecognized version control strategy')
+    raise ValueError('unrecognized version control strategy')
+
 
 def checkout_dags_folder(git_sha_hash):
-	return dagFolderVersionManager.checkout_dags_folder(git_sha_hash)
+    return dagFolderVersionManager.checkout_dags_folder(git_sha_hash)
+
 
 def get_version_control_hash_of(filepath):
-	return dagFolderVersionManager.get_version_control_hash_of(filepath)
+    return dagFolderVersionManager.get_version_control_hash_of(filepath)

--- a/airflow/version_control/__init__.py
+++ b/airflow/version_control/__init__.py
@@ -38,5 +38,5 @@ def get_version_control_hash_of(filepath):
     return dagFolderVersionManager.get_version_control_hash_of(filepath)
 
 
-def on_worker_start(celery_pid):
-	return dagFolderVersionManager.on_worker_start(celery_pid)
+def on_worker_start():
+	return dagFolderVersionManager.on_worker_start()

--- a/airflow/version_control/dag_folder_version_manager.py
+++ b/airflow/version_control/dag_folder_version_manager.py
@@ -42,3 +42,9 @@ class DagFolderVersionManager():
         Return the version control version of @filepath.
         """
         raise NotImplementedError()
+
+    def on_worker_start(self):
+        """
+        Called when worker starts
+        """
+        pass

--- a/airflow/version_control/dag_folder_version_manager.py
+++ b/airflow/version_control/dag_folder_version_manager.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+class DagFolderVersionManager():
+    """
+    Class that represents a version control strategy and is capable of returning views
+    into @master_dags_folder at a given version as well as checking for the current
+    version of @master_dags_folder. Under normal operation, only one instance of this
+    class should be created, and the value of the core.DAGS_FOLDER configuration
+    parameter should be used to create that instance. To implement different version
+    control strategies (hg, svn, etc) inherit this class and implement
+    `checkout_dags_folder` as well as `get_version_control_hash_of`.
+    """
+
+    def __init__(self, master_dags_folder):
+        """
+        @master_dags_folder can be set for dependency injection in tests
+        """
+        self.master_dags_folder = master_dags_folder
+
+    def checkout_dags_folder(self, dag_version):
+        """
+        Return a path to a folder representing `self.master_dags_folder` as of
+        @dag_version
+        """
+        raise NotImplementedError()
+
+    def get_version_control_hash_of(self, filepath):
+        """
+        Return the version control version of @filepath.
+        """
+        raise NotImplementedError()

--- a/airflow/version_control/dag_folder_version_manager.py
+++ b/airflow/version_control/dag_folder_version_manager.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 class DagFolderVersionManager():
     """

--- a/airflow/version_control/git.py
+++ b/airflow/version_control/git.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+import errno
+import os
+import subprocess
+
+from airflow import configuration as conf
+from airflow.version_control.dag_folder_version_manager import DagFolderVersionManager
+
+
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if e.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
+
+class GitDagFolderVersionManager(DagFolderVersionManager):
+
+
+    def __init__(self, master_dags_folder_path):
+        self.master_dags_folder_path = master_dags_folder_path
+        self.dags_folder_container = "/tmp/airflow_versioned_dag_folders"
+
+    def checkout_dags_folder(self, git_sha_hash):
+        mkdir_p(self.dags_folder_container)
+
+        master_dags_folder_path = os.path.expanduser(self.master_dags_folder_path)
+
+        dags_folder_path = self.dags_folder_container + "/" + git_sha_hash
+
+        # todo(xuanji): maybe check the return code
+        proc = subprocess.Popen(
+            ['git', 'clone', '-q', master_dags_folder_path, dags_folder_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        out, err = proc.communicate()
+        if err:
+            if 'already exists and is not an empty directory' in err:
+                pass
+            else:
+                print(err)
+                raise ValueError('oops')
+
+        proc = subprocess.Popen(
+            ['git', 'checkout', git_sha_hash],
+            cwd=dags_folder_path,
+            stdout=subprocess.PIPE
+        )
+
+        return dags_folder_path
+
+
+    def get_version_control_hash_of(self, filepath):
+        # TODO(xuanji): check for dirty (https://github.com/oohlaf/oh-my-zsh/blob/master/lib/git.zsh#L11)
+
+        proc = subprocess.Popen(
+            ['git', 'rev-parse', 'HEAD'],
+            cwd=os.path.dirname(filepath),
+            stdout=subprocess.PIPE
+        )
+        out, err = proc.communicate()
+        assert err is None
+
+        return out.replace('\n', '')

--- a/airflow/version_control/git.py
+++ b/airflow/version_control/git.py
@@ -71,4 +71,4 @@ class GitDagFolderVersionManager(DagFolderVersionManager):
     def on_worker_start(self):
         while True:
             print('collecting garbage...')
-            time.sleep(10)
+            time.sleep(1)

--- a/airflow/version_control/git.py
+++ b/airflow/version_control/git.py
@@ -3,6 +3,7 @@
 import errno
 import os
 import subprocess
+import time
 
 from airflow.version_control.dag_folder_version_manager import DagFolderVersionManager
 
@@ -66,3 +67,8 @@ class GitDagFolderVersionManager(DagFolderVersionManager):
         assert err is None
 
         return out.replace('\n', '')
+
+    def on_worker_start(self):
+        while True:
+            print('collecting garbage...')
+            time.sleep(10)

--- a/airflow/version_control/git.py
+++ b/airflow/version_control/git.py
@@ -4,7 +4,6 @@ import errno
 import os
 import subprocess
 
-from airflow import configuration as conf
 from airflow.version_control.dag_folder_version_manager import DagFolderVersionManager
 
 
@@ -16,6 +15,7 @@ def mkdir_p(path):
             pass
         else:
             raise
+
 
 class GitDagFolderVersionManager(DagFolderVersionManager):
 
@@ -37,7 +37,7 @@ class GitDagFolderVersionManager(DagFolderVersionManager):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )
-        out, err = proc.communicate()
+        _, err = proc.communicate()
         if err:
             if 'already exists and is not an empty directory' in err:
                 pass
@@ -53,9 +53,9 @@ class GitDagFolderVersionManager(DagFolderVersionManager):
 
         return dags_folder_path
 
-
     def get_version_control_hash_of(self, filepath):
-        # TODO(xuanji): check for dirty (https://github.com/oohlaf/oh-my-zsh/blob/master/lib/git.zsh#L11)
+        # TODO(xuanji): check for dirty
+        # (https://github.com/oohlaf/oh-my-zsh/blob/master/lib/git.zsh#L11)
 
         proc = subprocess.Popen(
             ['git', 'rev-parse', 'HEAD'],

--- a/airflow/version_control/noop.py
+++ b/airflow/version_control/noop.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from airflow.version_control.dag_folder_version_manager import DagFolderVersionManager
+
+
+class NoopDagFolderVersionManager(DagFolderVersionManager):
+
+    def __init__(self, master_dags_folder):
+        self.master_dags_folder = master_dags_folder
+
+    def get_version_control_hash_of(self, _):
+        return None
+
+    def checkout_dags_folder(self, _):
+        return self.master_dags_folder

--- a/airflow/version_control/noop.py
+++ b/airflow/version_control/noop.py
@@ -13,3 +13,6 @@ class NoopDagFolderVersionManager(DagFolderVersionManager):
 
     def checkout_dags_folder(self, _):
         return self.master_dags_folder
+
+    def on_worker_start(self):
+        return

--- a/airflow/www/templates/airflow/dag_details.html
+++ b/airflow/www/templates/airflow/dag_details.html
@@ -1,13 +1,13 @@
-{# 
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -63,6 +63,14 @@
       <tr>
         <th>filepath</td>
         <td>{{ dag.filepath }}</td>
+      </tr>
+      <tr>
+        <th>full_filepath</td>
+        <td>{{ dag.full_filepath }}</td>
+      </tr>
+      <tr>
+        <th>version_control_hash</td>
+        <td>{{ dag.version_control_hash }}</td>
       </tr>
       <tr>
         <th>owner</td>

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -1,13 +1,13 @@
-{# 
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -248,8 +248,12 @@ function update(source) {
       .style("stroke-width", function(d) {return (d.run_id != undefined)? "2": "1"})
       .style("stroke-opacity", function(d) {return d.external_trigger ? "0": "1"})
       .attr("title", function(d){
-        s =  "Task_id: " + d.task_id + "<br>";
+        s = "";
+        s +=  "Task_id: " + d.task_id + "<br>";
         s += "Run: " + d.execution_date + "<br>";
+        if (d.dag_version && d.dag_version.slice) {
+          s += "Dag version: " + d.dag_version.slice(0, 5) + "<br>";
+        }
         if(d.run_id != undefined){
           s += "run_id: <nobr>" + d.run_id + "</nobr><br>";
         }

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -874,9 +874,10 @@ class Airflow(BaseView):
         deps = request.args.get('deps') == "true"
 
         try:
-            from airflow.executors import DEFAULT_EXECUTOR as executor
-            from airflow.executors import CeleryExecutor
-            if not isinstance(executor, CeleryExecutor):
+            if not isinstance(
+                    airflow.executors.DEFAULT_EXECUTOR,
+                    airflow.executors.CeleryExecutor
+            ):
                 flash("Only works with the CeleryExecutor, sorry", "error")
                 return redirect(origin)
         except ImportError:

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -23,10 +23,8 @@ import os
 import time
 import unittest
 
-from airflow import AirflowException, settings
-from airflow import models
+from airflow import AirflowException, executors, models, settings
 from airflow.bin import cli
-from airflow.executors import DEFAULT_EXECUTOR
 from airflow.jobs import BackfillJob, SchedulerJob
 from airflow.models import DAG, DagModel, DagBag, DagRun, Pool, TaskInstance as TI
 from airflow.operators.dummy_operator import DummyOperator
@@ -362,7 +360,7 @@ class SchedulerJobTest(unittest.TestCase):
         scheduler2 = SchedulerJob(
             dag_id,
             num_runs=5,
-            executor=DEFAULT_EXECUTOR.__class__(),
+            executor=airlfow.executors.DEFAULT_EXECUTOR.__class__(),
             **self.default_scheduler_args)
         scheduler2.run()
 

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -809,8 +809,7 @@ class SchedulerJobTest(unittest.TestCase):
 
     def test_scheduler_reschedule(self):
         """
-        Checks if tasks that are not taken up by the executor
-        get rescheduled
+        Checks if tasks that are not taken up by the executor get rescheduled
         """
         executor = TestExecutor()
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- _(to be replaced with a link to AIRFLOW-X)_
#### Testing Done:
- TBD
#### Changes
- Assuming that `DAG_FOLDER` is a git repository, on dag parsing, the created dag objects will have the git revision (sha) of `DAG_FOLDER` as a property
- Task instances now have the git sha of their parent DAG as a property. 
  - This is first set when the scheduler creates them. 
  - It is stored in the database.
- An executor and worker that executes a task instance now check a copy of the `DAG_FOLDER` out at the revision of the task instance
#### TODO:
- Check that changing the version changes values used in derived files as well (eg .hql)
- Limit resources consumed by git checkout folders
- Unit tests
- Test on real cluster, deploy changes to the dag folder while server and workers are running
