### PR TITLE
[AIRFLOW-378] Add string casting to integer params of Spark-sql hook and fix param typo

### DIFF
--- a/airflow/contrib/hooks/spark_sql_hook.py
+++ b/airflow/contrib/hooks/spark_sql_hook.py
@@ -90,13 +90,13 @@ class SparkSqlHook(BaseHook):
             for conf_el in self._conf.split(","):
                 connection_cmd += ["--conf", conf_el]
         if self._executor_cores:
-            connection_cmd += ["--executor-cores", self._executor_cores]
+            connection_cmd += ["--executor-cores", str(self._executor_cores)]
         if self._executor_memory:
             connection_cmd += ["--executor-memory", self._executor_memory]
         if self._keytab:
             connection_cmd += ["--keytab", self._keytab]
         if self._num_executors:
-            connection_cmd += ["--num_executors", self._num_executors]
+            connection_cmd += ["--num-executors", str(self._num_executors)]
         if self._sql:
             if self._sql.endswith('.sql'):
                 connection_cmd += ["-f", self._sql]


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-378

This patch fixes minor bugs in parameter handling of the Spark-sql hook. The fix involves
casting integers to strings in order to allow correct passing of parameters to the spark-sql
binary. It also contains a minor typo fix for the num-executors parameter.
