### PR TITLE
[AIRFLOW-379] Enhance Variables page functionality: import/export var

### DIFF
--- a/airflow/www/templates/airflow/variable_list.html
+++ b/airflow/www/templates/airflow/variable_list.html
@@ -1,0 +1,33 @@
+{#
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+#}
+{% extends 'admin/model/list.html' %}
+
+{% block model_menu_bar %}
+  {% if admin_view.verbose_name_plural %}
+    <h2>{{ admin_view.verbose_name_plural|title }}</h2>
+  {% endif %}
+  <form class="form-inline" action="{{ url_for("airflow.varimport") }}" method=post enctype=multipart/form-data style="margin-top: 50px;">
+    {% if csrf_token %}
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    {% endif %}
+    <input class="form-control" type="file" name="file">
+    <input class="btn btn-default" type="submit" value="Import Variables"/>
+  </form>
+  <hr/>
+  {{ super() }}
+{% endblock %}


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
-https://issues.apache.org/jira/browse/AIRFLOW-379

Testing Done:
- Manual testing of sequential imports and exports yielded no errors. Was unable to replicate uploading/downloading a file in the unittest environment.

Add export option under 'with selected' menu to export selected variables to json.
Add upload file option at top of page to import variables from json file.

The decision was made to avoid flask admin's default export functionality because it
does not handle the possibility of serialized jsons as variable values well.

The import variables field should be made to look nicer.

![image](https://cloud.githubusercontent.com/assets/6687910/17238097/9771b7cc-550d-11e6-9d4c-d61fc5a82964.png)
