### PR TITLE
[AIRFLOW-381] Manual UI Dag Run creation: require dag_id field

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -48,7 +48,7 @@ import markdown
 import nvd3
 
 from wtforms import (
-    Form, SelectField, TextAreaField, PasswordField, StringField)
+    Form, SelectField, TextAreaField, PasswordField, StringField, validators)
 
 from pygments import highlight, lexers
 from pygments.formatters import HtmlFormatter
@@ -2007,6 +2007,9 @@ class DagRunModelView(ModelViewOnly):
             ('failed', 'failed'),
         ],
     }
+    form_args = dict(
+        dag_id=dict(validators=[validators.DataRequired()])
+    )
     column_list = (
         'state', 'dag_id', 'execution_date', 'run_id', 'external_trigger')
     column_filters = column_list


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-381

Testing Done:
- Manual inspection of dag run creation view
