### PR TITLE
[- AIRFLOW-229][AIRFLOW-372] take start_date from default_args when not in dag

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -435,6 +435,10 @@ class SchedulerJob(BaseJob):
             else:
                 next_run_date = dag.following_schedule(last_scheduled_run)
 
+            # if start_date is not defined for the dag, take if from default_args
+            if not dag.start_date and 'start_date' in dag.default_args:
+                dag.start_date = dag.default_args['start_date']
+
             # don't ever schedule prior to the dag's start_date
             if dag.start_date:
                 next_run_date = (dag.start_date if not next_run_date


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-229
- AIRFLOW-372

Testing Done:
No unit-testing required since only a single if clause was added

Summarized as follows:
if start_date is not defined for the dag, take if from default_args
