### PR TITLE
[AIRFLOW-386] limit scope to user email only for github oauth

### DIFF
--- a/airflow/contrib/auth/backends/github_enterprise_auth.py
+++ b/airflow/contrib/auth/backends/github_enterprise_auth.py
@@ -101,7 +101,7 @@ class GHEAuthBackend(object):
             consumer_key=get_config_param('client_id'),
             consumer_secret=get_config_param('client_secret'),
             # need read:org to get team member list
-            request_token_params={'scope': 'user,read:org'},
+            request_token_params={'scope': 'user:email,read:org'},
             base_url=self.ghe_host,
             request_token_url=None,
             access_token_method='POST',


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- [AIRFLOW-386](https://issues.apache.org/jira/browse/AIRFLOW-386)

Testing Done:
- tested login on my dev instance
