### PR TITLE
[AIRFLOW-398] Option to use cgroups to limit task resource utilization

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -108,6 +108,7 @@ defaults = {
         'sql_alchemy_pool_recycle': 3600,
         'dagbag_import_timeout': 30,
         'non_pooled_task_slot_count': 128,
+        'task_runner': 'BashTaskRunner',
     },
     'operators': {
         'default_owner': 'airflow',
@@ -259,6 +260,8 @@ donot_pickle = False
 # How long before timing out a python file import while filling the DagBag
 dagbag_import_timeout = 30
 
+# The class to use for running task instances in a subprocess
+task_runner = BashTaskRunner
 
 [operators]
 # The default owner assigned to each new operator, unless

--- a/airflow/contrib/task_runner/__init__.py
+++ b/airflow/contrib/task_runner/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/airflow/contrib/task_runner/cgroup_task_runner.py
+++ b/airflow/contrib/task_runner/cgroup_task_runner.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import subprocess
+import logging
+import os
+import threading
+import uuid
+
+from butter import eventfd
+from cgroupspy import trees
+from cgroupspy.controllers import MemoryController
+
+from airflow.task_runner.base_task_runner import BaseTaskRunner
+
+
+class CgroupTaskRunner(BaseTaskRunner):
+    """
+    Runs the raw Airflow task in a cgroup that has containment for memory and
+    cpu. It uses the resource requirements defined in the task to construct
+    the settings for the cgroup.
+    """
+
+    def __init__(self, local_task_job):
+        super(CgroupTaskRunner, self).__init__(local_task_job)
+        self._process = None
+        self._finished_running = False
+        self._cpu_shares = None
+        self._mem_mb_limit = None
+
+    def _watch_for_oom(self, event_control_file, oom_control_file):
+        """
+        Monitors the OOM control file to write a logging message when an OOM
+        occurs.
+
+        :param event_control_file: Path to the event control file
+        :type event_control_file: unicode
+        :param oom_control_file: Path to the OOM control file
+        :type oom_control_file: unicode
+        """
+        efd = eventfd.eventfd()
+
+        with open(oom_control_file, "w") as ocfd:
+            with open(event_control_file, "w") as ecfd:
+                ecfd.write("%d %d" % (efd, ocfd.fileno()))
+
+            # The read is also successful when the cgroup is deleted at exit
+            os.read(efd, 8)
+            if not self._finished_running:
+                logging.error("Process killed due to OOM! Please check that "
+                              "this task consumes less than the configured "
+                              "limit of {} MB."
+                              .format(self._mem_mb_limit))
+
+    def _create_cgroup(self, path):
+        """
+        Create the specified cgroup.
+
+        :param path: The path of the cgroup to create.
+        E.g. cpu/mygroup/mysubgroup
+        :return: the Node associated with the created cgroup.
+        :rtype: cgroupspy.nodes.Node
+        """
+        node = trees.Tree().root
+        path_split = path.split(os.sep)
+        for path_element in path_split:
+            name_to_node = {x.name: x for x in node.children}
+            if path_element not in name_to_node:
+                self.logger.info("Creating cgroup {} in {}"
+                                 .format(path_element, node.path))
+                node = node.create_cgroup(path_element)
+            else:
+                self.logger.debug("Not creating cgroup {} in {} "
+                                  "since it already exists"
+                                 .format(path_element, node.path))
+                node = name_to_node[path_element]
+        return node
+
+    def _delete_cgroup(self, path):
+        """
+        Delete the specified cgroup.
+
+        :param path: The path of the cgroup to delete.
+        E.g. cpu/mygroup/mysubgroup
+        """
+        node = trees.Tree().root
+        path_split = path.split("/")
+        for path_element in path_split:
+            name_to_node = {x.name: x for x in node.children}
+            if path_element not in name_to_node:
+                self.logger.warn("Cgroup does not exist: {}"
+                                 .format(path))
+                return
+            else:
+                node = name_to_node[path_element]
+        # node is now the leaf node
+        parent = node.parent
+        self.logger.info("Deleting cgroup {}/{}".format(parent, node.name))
+        parent.delete_cgroup(node.name)
+
+    def start(self):
+        # Create a unique cgroup name
+        cgroup_name = "airflow/{}/{}".format(datetime.datetime.now().
+                                             strftime("%Y-%m-%d"),
+                                             str(uuid.uuid1()))
+
+        self.mem_cgroup_name = "memory/{}".format(cgroup_name)
+        self.cpu_cgroup_name = "cpu/{}".format(cgroup_name)
+
+        # Get the resource requirements from the task
+        task = self._task_instance.task
+        """:type: airflow.operators.BaseOperator"""
+        resources = task.resources
+        """:type: airflow.utils.operator_resources.Resources"""
+        cpus = resources.cpus.qty
+        self._cpu_shares = cpus * 1024
+        self._mem_mb_limit = resources.ram.qty
+
+        # Create the memory cgroup
+        mem_cgroup_node = self._create_cgroup(self.mem_cgroup_name)
+        self.logger.info("Setting {} with {} MB of memory"
+                         .format(self.mem_cgroup_name, self._mem_mb_limit))
+        assert(isinstance(mem_cgroup_node.controller,
+                          MemoryController))
+        mem_cgroup_node.controller.limit_in_bytes = self._mem_mb_limit * 1024 * 1024
+
+        # Create the CPU cgroup
+        cpu_cgroup_node = self._create_cgroup(self.cpu_cgroup_name)
+        self.logger.info("Setting {} with {} CPU shares"
+                         .format(self.cpu_cgroup_name, self._cpu_shares))
+        cpu_cgroup_node.controller.shares = self._cpu_shares
+
+        # Start the process w/ cgroups
+        self.logger.info("Starting task process with cgroups cpu,memory:{}"
+                         .format(cgroup_name))
+        cmd = ['cgexec',
+               '-g',
+               "cpu,memory:{}".format(cgroup_name)]
+        cmd.extend(self._command)
+        self.logger.info("Running: {}".format(cmd))
+        self._process = subprocess.Popen(cmd)
+
+        # Start a thread to watch for OOMs. This thread will exit when either
+        # an OOM occurs, or when the cgroup is deleted.
+        event_control_file = "/sys/fs/cgroup/{}/cgroup.event_control"\
+            .format(self.mem_cgroup_name)
+        oom_control_file = "/sys/fs/cgroup/{}/memory.oom_control"\
+            .format(self.mem_cgroup_name)
+        self.logger.debug("Using event control file {}"
+                          .format(event_control_file))
+        self.logger.debug("Using OOM control file {}"
+                          .format(oom_control_file))
+
+        # Watcher thread prints a helpful OOM error message
+        oom_watcher_thread = threading.Thread(
+            target=self._watch_for_oom,
+            args=(event_control_file, oom_control_file))
+        oom_watcher_thread.daemon = True
+        oom_watcher_thread.start()
+
+    def return_code(self):
+        return self._process.poll()
+
+    def terminate(self):
+        return self._process.terminate()
+
+    def on_finish(self):
+        # Let the OOM watcher thread know we're done to avoid false OOM alarms
+        self._finished_running = True
+        # Clean up the cgroups
+        self._delete_cgroup(self.mem_cgroup_name)
+        self._delete_cgroup(self.cpu_cgroup_name)
+

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -44,6 +44,7 @@ from airflow import configuration as conf
 from airflow.exceptions import AirflowException
 from airflow.models import DagRun
 from airflow.settings import Stats
+from airflow.task_runner import get_task_runner
 from airflow.utils.state import State
 from airflow.utils.db import provide_session, pessimistic_connection_handling
 from airflow.utils.dag_processing import (AbstractDagFileProcessor,
@@ -994,7 +995,7 @@ class SchedulerJob(BaseJob):
                                              task_concurrency_limit))
                     continue
 
-                command = TI.generate_command(
+                command = " ".join(TI.generate_command(
                     task_instance.dag_id,
                     task_instance.task_id,
                     task_instance.execution_date,
@@ -1005,7 +1006,7 @@ class SchedulerJob(BaseJob):
                     ignore_depends_on_past=False,
                     pool=task_instance.pool,
                     file_path=simple_dag_bag.get_dag(task_instance.dag_id).full_filepath,
-                    pickle_id=simple_dag_bag.get_dag(task_instance.dag_id).pickle_id)
+                    pickle_id=simple_dag_bag.get_dag(task_instance.dag_id).pickle_id))
 
                 priority = task_instance.priority_weight
                 queue = task_instance.queue
@@ -1827,24 +1828,20 @@ class LocalTaskJob(BaseJob):
         super(LocalTaskJob, self).__init__(*args, **kwargs)
 
     def _execute(self):
-        command = self.task_instance.command(
-            raw=True,
-            ignore_dependencies=self.ignore_dependencies,
-            ignore_depends_on_past=self.ignore_depends_on_past,
-            force=self.force,
-            pickle_id=self.pickle_id,
-            mark_success=self.mark_success,
-            job_id=self.id,
-            pool=self.pool,
-        )
-        self.process = subprocess.Popen(['bash', '-c', command])
+
+        self.task_runner = get_task_runner(self)
         return_code = None
-        while return_code is None:
-            self.heartbeat()
-            return_code = self.process.poll()
+        try:
+            self.task_runner.start()
+            while return_code is None:
+                self.heartbeat()
+                return_code = self.task_runner.return_code()
+        finally:
+            self.task_runner.on_finish()
 
     def on_kill(self):
-        self.process.terminate()
+        self.task_runner.terminate()
+        self.task_runner.on_finish()
 
     @provide_session
     def heartbeat_callback(self, session=None):

--- a/airflow/task_runner/__init__.py
+++ b/airflow/task_runner/__init__.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from airflow import configuration
+from airflow.task_runner.bash_task_runner import BashTaskRunner
+from airflow.exceptions import AirflowException
+
+_TASK_RUNNER = configuration.get('core', 'TASK_RUNNER')
+
+
+def get_task_runner(local_task_job):
+    """
+    Get the task runner that can be used to run the given job.
+
+    :param local_task_job: The LocalTaskJob associated with the TaskInstance
+    that needs to be executed.
+    :type local_task_job: airflow.jobs.LocalTaskJob
+    :return: The task runner to use to run the task.
+    :rtype: airflow.task_runner.base_task_runner.BaseTaskRunner
+    """
+    if _TASK_RUNNER == "BashTaskRunner":
+        return BashTaskRunner(local_task_job)
+    elif _TASK_RUNNER == "CgroupTaskRunner":
+        from airflow.contrib.task_runner.cgroup_task_runner import CgroupTaskRunner
+        return CgroupTaskRunner(local_task_job)
+    else:
+        raise AirflowException("Unknown task runner type {}".format(_TASK_RUNNER))

--- a/airflow/task_runner/base_task_runner.py
+++ b/airflow/task_runner/base_task_runner.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.utils.logging import LoggingMixin
+
+
+class BaseTaskRunner(LoggingMixin):
+    """
+    Runs Airflow task instances by invoking the `airflow run` command with raw
+    mode enabled in a subprocess.
+    """
+
+    def __init__(self, local_task_job):
+        """
+        :param local_task_job: The local task job associated with running the
+        associated task instance.
+        :type local_task_job: airflow.jobs.LocalTaskJob
+        """
+        self._task_instance = local_task_job.task_instance
+        self._command = self._task_instance.command_as_list(
+            raw=True,
+            ignore_dependencies=local_task_job.ignore_dependencies,
+            ignore_depends_on_past=local_task_job.ignore_depends_on_past,
+            force=local_task_job.force,
+            pickle_id=local_task_job.pickle_id,
+            mark_success=local_task_job.mark_success,
+            job_id=local_task_job.id,
+            pool=local_task_job.pool,
+        )
+
+    def start(self):
+        """
+        Start running the task instance in a subprocess.
+        """
+        raise NotImplementedError()
+
+    def return_code(self):
+        """
+        :return: The return code associated with running the task instance or
+        None if the task is not yet done.
+        :rtype int:
+        """
+        raise NotImplementedError()
+
+    def terminate(self):
+        """
+        Kill the running task instance.
+        """
+        raise NotImplementedError()
+
+    def on_finish(self):
+        """
+        A callback that should be called when this is done running.
+        """
+        raise NotImplementedError()

--- a/airflow/task_runner/bash_task_runner.py
+++ b/airflow/task_runner/bash_task_runner.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+
+from airflow.task_runner.base_task_runner import BaseTaskRunner
+
+
+class BashTaskRunner(BaseTaskRunner):
+    """
+    Runs the raw Airflow task by invoking through the Bash shell.
+    """
+    def __init__(self, local_task_job):
+        super(BashTaskRunner, self).__init__(local_task_job)
+        self._process = None
+
+    def start(self):
+        self._process = subprocess.Popen(['bash', '-c', " ".join(self._command)])
+
+    def return_code(self):
+        return self._process.poll()
+
+    def terminate(self):
+        self._process.terminate()
+
+    def on_finish(self):
+        pass


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-398

Currently, this is getting added to `contrib`.

Testing Done:
- Tested locally, but unit tests not included due to issues with setting cgroups inside Travis. Looking into this further...
- Sample run where a high-memory task is killed due to OOM

```
[2016-08-04 21:28:22,868] {models.py:162} INFO - Filling up the DagBag from /home/paul_yang/airflow/dags/test_dag.py
[2016-08-04 21:28:23,014] {cgroup_task_runner.py:52} INFO - Creating cgroup 5f2bdc08-5a8a-11e6-99a5-22000b8c08f9 in /memory/airflow/2016-08-04
[2016-08-04 21:28:23,014] {cgroup_task_runner.py:102} INFO - Setting memory/airflow/2016-08-04/5f2bdc08-5a8a-11e6-99a5-22000b8c08f9 with 512 MB of memory
[2016-08-04 21:28:23,020] {cgroup_task_runner.py:52} INFO - Creating cgroup 5f2bdc08-5a8a-11e6-99a5-22000b8c08f9 in /cpu/airflow/2016-08-04
[2016-08-04 21:28:23,021] {cgroup_task_runner.py:109} INFO - Setting cpu/airflow/2016-08-04/5f2bdc08-5a8a-11e6-99a5-22000b8c08f9 with 1024 CPU shares
[2016-08-04 21:28:23,021] {cgroup_task_runner.py:113} INFO - Starting task process with cgroups cpu,memory:airflow/2016-08-04/5f2bdc08-5a8a-11e6-99a5-22000b8c08f9
[2016-08-04 21:28:23,021] {cgroup_task_runner.py:119} INFO - Running: ['cgexec', '-g', 'cpu,memory:airflow/2016-08-04/5f2bdc08-5a8a-11e6-99a5-22000b8c08f9', u'airflow', u'run', 'test_dag', 'oom', '2016-01-01T00:00:00', u'--job_id', '248', u'--force', u'--raw', u'-sd', u'DAGS_FOLDER/test_dag.py']
[2016-08-04 21:28:23,753] {models.py:162} INFO - Filling up the DagBag from /home/paul_yang/airflow/dags/test_dag.py
[2016-08-04 21:28:23,801] {models.py:1320} INFO -
--------------------------------------------------------------------------------
Starting attempt 1 of 2
--------------------------------------------------------------------------------

[2016-08-04 21:28:23,828] {models.py:1343} INFO - Executing <Task(BashOperator): oom> on 2016-01-01 00:00:00
[2016-08-04 21:28:23,846] {bash_operator.py:69} INFO - tmp dir root location:
/tmp
[2016-08-04 21:28:23,847] {bash_operator.py:78} INFO - Temporary script location :/tmp/airflowtmpZhB3HD//tmp/airflowtmpZhB3HD/oomo1Vb1L
[2016-08-04 21:28:23,847] {bash_operator.py:79} INFO - Running command: python /home/paul_yang/python/mem.py
[2016-08-04 21:28:23,850] {bash_operator.py:87} INFO - Output:
[2016-08-04 21:28:24,100] {bash_operator.py:91} INFO - /tmp/airflowtmpZhB3HD/oomo1Vb1L: line 1: 108392 Killed                  python /home/paul_yang/python/mem.py
[2016-08-04 21:28:24,101] {bash_operator.py:94} INFO - Command exited with return code 137
[2016-08-04 21:28:24,101] {models.py:1410} ERROR - Bash command failed
Traceback (most recent call last):
  File "/mnt/home/paul_yang/forked/airflow/airflow/models.py", line 1369, in run
    result = task_copy.execute(context=context)
  File "/mnt/home/paul_yang/forked/airflow/airflow/operators/bash_operator.py", line 97, in execute
    raise AirflowException("Bash command failed")
AirflowException: Bash command failed
[2016-08-04 21:28:24,102] {models.py:1422} INFO - Marking task as UP_FOR_RETRY
[2016-08-04 21:28:24,121] {models.py:1451} ERROR - Bash command failed
[2016-08-04 21:28:28,032] {cgroup_task_runner.py:80} INFO - Deleting cgroup <Node /memory/airflow/2016-08-04>/5f2bdc08-5a8a-11e6-99a5-22000b8c08f9
[2016-08-04 21:28:28,038] {cgroup_task_runner.py:80} INFO - Deleting cgroup <Node /cpu/airflow/2016-08-04>/5f2bdc08-5a8a-11e6-99a5-22000b8c08f9
```

To prevent Airflow tasks from using too much memory and causing machines
to go OOM, this introduces an optional mechanism to use cgroups to
limit task resource utilization.
