### PR TITLE
[AIRFLOW-394] Add an option to the Task Duration graph to show cumula…

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1063,7 +1063,8 @@ class SchedulerJob(BaseJob):
                 continue
 
             if not dag:
-                self.logger.error("DAG ID {} was not found in the DagBag")
+                self.logger.error("DAG ID {} was not found in the DagBag"
+                                  .format(dag.dag_id))
                 continue
 
             self.logger.info("Processing {}".format(dag.dag_id))

--- a/airflow/migrations/versions/64de9cddf6c9_add_task_fails_journal_table.py
+++ b/airflow/migrations/versions/64de9cddf6c9_add_task_fails_journal_table.py
@@ -1,0 +1,46 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""add task fails journal table
+
+Revision ID: 64de9cddf6c9
+Revises: 211e584da130
+Create Date: 2016-08-03 14:02:59.203021
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '64de9cddf6c9'
+down_revision = '211e584da130'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'task_fail',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('task_id', sa.String(length=250), nullable=False),
+        sa.Column('dag_id', sa.String(length=250), nullable=False),
+        sa.Column('execution_date', sa.DateTime(), nullable=False),
+        sa.Column('start_date', sa.DateTime(), nullable=True),
+        sa.Column('end_date', sa.DateTime(), nullable=True),
+        sa.Column('duration', sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+def downgrade():
+    op.drop_table('task_fail')

--- a/airflow/www/templates/airflow/duration_chart.html
+++ b/airflow/www/templates/airflow/duration_chart.html
@@ -27,6 +27,10 @@
 
 {% block body %}
 {{ super() }}
+<div>
+  <label for="isCumulative">Cumulative Duration</label>
+  <input id="isCumulative" type="checkbox" value="1">
+</div>
 <div style="float: left" class="form-inline">
     <form method="get" style="float:left;">
         Base date: {{ form.base_date(class_="form-control") }}
@@ -38,15 +42,30 @@
         <input name="_csrf_token" type="hidden" value="{{ csrf_token() }}">
     </form>
 </div>
-<div style="clear: both;">{{ chart |safe }}</div>
+<div id="dur_chart" style="clear: both;">{{ chart |safe }}</div>
+<div id="cum_dur_chart" style="clear: both;">{{ cum_chart | safe}}</div>
 <hr/>
 {% endblock %}
 
 {% block tail %}
-    {{ super() }}
-    <div class="container"></div>
-
-      <script src="{{ admin_static.url(
-        filename='vendor/bootstrap-daterangepicker/daterangepicker.js') }}">
-      </script>
+  <script>
+    function handleCheck() {
+      if ($('#isCumulative').is(':checked')) {
+        $('#dur_chart').hide();
+        $('#cum_dur_chart').show();
+      } else {
+        $('#dur_chart').show();
+        $('#cum_dur_chart').hide();
+      };
+    };
+    $( document ).on('chartload', function() {
+      handleCheck();
+    });
+    $('#isCumulative').click(function() {
+      handleCheck();
+    });
+  </script>
+  <script src="{{ admin_static.url(
+    filename='vendor/bootstrap-daterangepicker/daterangepicker.js') }}"></script>
+  {{ super() }}
 {% endblock %}


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-394

Testing Done:
- Added a unit test to CoreTests to check if task failures are correctly logged to TaskFail table

The current task duration chart only reports the task duration times for successful task attempts. If a task is retried multiple times, we don't get a sense of the cumulative duration for that task. With this feature, exposed as a checkbox UI option on the existing Task Duration chart, we can now display the total (a.k.a cumulative) task time for a task instance.
