### PR TITLE
[AIRFLOW-403] Kill bash sub-processes on timeout

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -60,7 +60,7 @@ import six
 from airflow import settings, utils
 from airflow.executors import DEFAULT_EXECUTOR, LocalExecutor
 from airflow import configuration
-from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.exceptions import AirflowException, AirflowSkipException, AirflowTaskTimeout
 from airflow.dag.base_dag import BaseDag, BaseDagBag
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
 from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
@@ -1280,10 +1280,13 @@ class TaskInstance(Base):
                 # if it goes beyond
                 result = None
                 if task_copy.execution_timeout:
-                    with timeout(int(
-                            task_copy.execution_timeout.total_seconds())):
-                        result = task_copy.execute(context=context)
-
+                    try:
+                        with timeout(int(
+                                task_copy.execution_timeout.total_seconds())):
+                            result = task_copy.execute(context=context)
+                    except AirflowTaskTimeout:
+                        task_copy.on_kill()
+                        raise
                 else:
                     result = task_copy.execute(context=context)
 

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -14,6 +14,8 @@
 
 
 from builtins import bytes
+import os
+import signal
 import logging
 from subprocess import Popen, STDOUT, PIPE
 from tempfile import gettempdir, NamedTemporaryFile
@@ -80,7 +82,8 @@ class BashOperator(BaseOperator):
                 sp = Popen(
                     ['bash', fname],
                     stdout=PIPE, stderr=STDOUT,
-                    cwd=tmp_dir, env=self.env)
+                    cwd=tmp_dir, env=self.env,
+                    preexec_fn=os.setsid)
 
                 self.sp = sp
 
@@ -100,5 +103,6 @@ class BashOperator(BaseOperator):
             return line
 
     def on_kill(self):
-        logging.info('Sending SIGTERM signal to bash subprocess')
-        self.sp.terminate()
+        logging.info('Sending SIGTERM signal to bash process group')
+        os.killpg(os.getpgid(self.sp.pid), signal.SIGTERM)
+

--- a/tests/core.py
+++ b/tests/core.py
@@ -388,6 +388,28 @@ class CoreTest(unittest.TestCase):
             output_encoding='utf-8')
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
+    def test_bash_operator_kill(self):
+        import subprocess
+        import psutil
+        sleep_time = "100%d" % os.getpid()
+        t = BashOperator(
+            task_id='test_bash_operator_kill',
+            execution_timeout=timedelta(seconds=1),
+            bash_command="/bin/bash -c 'sleep %s'" % sleep_time,
+            dag=self.dag)
+        self.assertRaises(
+            exceptions.AirflowTaskTimeout,
+            t.run,
+            start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        sleep(2)
+        pid = -1
+        for proc in psutil.process_iter():
+            if proc.cmdline() == ['sleep', sleep_time]:
+                pid = proc.pid
+        if pid != -1:
+            os.kill(pid, signal.SIGTERM)
+            self.fail("BashOperator's subprocess still running after stopping on timeout!")
+
     def test_trigger_dagrun(self):
         def trigga(context, obj):
             if True:


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:

[AIRFLOW-403](https://issues.apache.org/jira/browse/AIRFLOW-403)

Fixed issues:
- bash operator's on_kill() method wasn't invoked on timeout
- on_kill() implementation was wrong

New behavior:
- Invoke on_kill() when timeout exception is thrown
- Kill entire process group so no underlying process left running

Added unit tests: tests.core.CoreTest.test_bash_operator_kill

Thanks.
