### PR TITLE
[AIRFLOW-404] Retry download if unpacking fails for hive

### DIFF
--- a/scripts/ci/setup_env.sh
+++ b/scripts/ci/setup_env.sh
@@ -123,6 +123,17 @@ echo "Downloading and unpacking hive"
 curl -z ${TRAVIS_CACHE}/hive/hive.tar.gz -o ${TRAVIS_CACHE}/hive/hive.tar.gz -L ${HIVE_URL}
 tar zxf ${TRAVIS_CACHE}/hive/hive.tar.gz --strip-components 1 -C ${HIVE_HOME}
 
+if [ $? != 0 ]; then
+    echo "Failed to extract hive from ${TRAVIS_CACHE}/hive/hive.tar.gz" >&2
+    echo "Trying again..." >&2
+    # dont use cache
+    curl -o ${TRAVIS_CACHE}/hive/hive.tar.gz -L ${HIVE_URL}
+    tar zxf ${TRAVIS_CACHE}/hive/hive.tar.gz --strip-components 1 -C ${HIVE_HOME}
+    if [ $? != 0 ]; then
+        echo "Failed twice in downloading and unpacking hive!" >&2
+        exit 1
+    fi
+fi
 
 echo "Downloading and unpacking minicluster"
 curl -z ${TRAVIS_CACHE}/minicluster/minicluster.zip -o ${TRAVIS_CACHE}/minicluster/minicluster.zip -L ${MINICLUSTER_URL}


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-404

Per Apache guidelines you need to create a [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW/).

Testing Done:
- Part of unit tests for travis

Travis cache can have a faulty files. This results in builds
that fail as they are dependent on certain components being
available, ie. hive. This addresses the issue for hive by
redownloading if unpacking fails.
