### PR TITLE
[AIRFLOW-78] airflow clear leaves dag_runs

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1057,6 +1057,10 @@ class SchedulerJob(BaseJob):
         """
         for dag in dags:
             dag = dagbag.get_dag(dag.dag_id)
+            if dag.reached_max_runs:
+                self.logger.info("Not processing DAG {} since its max runs has been reached"
+                                .format(dag.dag_id))
+                continue
             if dag.is_paused:
                 self.logger.info("Not processing DAG {} since it's paused"
                                  .format(dag.dag_id))

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2879,6 +2879,15 @@ class DAG(BaseDag, LoggingMixin):
                 l += task.subdag.subdags
         return l
 
+    @property
+    def reached_max_runs(self):
+        active_runs = DagRun.find(
+            dag_id=self.dag_id,
+            state=State.RUNNING,
+            external_trigger=False
+        )
+        return len(active_runs) >= self.max_active_runs
+
     def resolve_template_files(self):
         for t in self.tasks:
             t.resolve_template_files()


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-78

Testing Done:
- Expanded the jobs.test_scheduler_verify_max_active_runs test to test if scheduler respects max_active_dag_runs

Fix a bug in the scheduler where dag runs cleared via CLI would be picked up without checking max_active_dag_runs first, resulting in too many simultaneous dag runs.
