### PR TITLE
[AIRFLOW-407] Add different colors for some sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Airflow
 
+
 [![PyPI version](https://badge.fury.io/py/airflow.svg)](https://badge.fury.io/py/airflow)
 [![Build Status](https://travis-ci.org/apache/incubator-airflow.svg)](https://travis-ci.org/apache/incubator-airflow)
 [![Coverage Status](https://img.shields.io/codecov/c/github/apache/incubator-airflow/master.svg)](https://codecov.io/github/apache/incubator-airflow?branch=master)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Airflow
 
-
 [![PyPI version](https://badge.fury.io/py/airflow.svg)](https://badge.fury.io/py/airflow)
 [![Build Status](https://travis-ci.org/apache/incubator-airflow.svg)](https://travis-ci.org/apache/incubator-airflow)
 [![Coverage Status](https://img.shields.io/codecov/c/github/apache/incubator-airflow/master.svg)](https://codecov.io/github/apache/incubator-airflow?branch=master)

--- a/airflow/contrib/operators/fs_operator.py
+++ b/airflow/contrib/operators/fs_operator.py
@@ -33,6 +33,7 @@ class FileSensor(BaseSensorOperator):
     :type fs_conn_id: string
     """
     template_fields = ('filepath',)
+    ui_color = '#91818a'
 
     @apply_defaults
     def __init__(

--- a/airflow/contrib/sensors/emr_base_sensor.py
+++ b/airflow/contrib/sensors/emr_base_sensor.py
@@ -25,6 +25,7 @@ class EmrBaseSensor(BaseSensorOperator):
     Subclasses should implement get_emr_response() and state_from_response() methods.
     Subclasses should also implment NON_TERMINAL_STATES and FAILED_STATE constants.
     """
+    ui_color = '#66c3ff'
 
     @apply_defaults
     def __init__(

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -259,7 +259,7 @@ class NamedHivePartitionSensor(BaseSensorOperator):
     """
 
     template_fields = ('partition_names', )
-    ui_color = '#2b2d42'
+    ui_color = '#8d99ae'
 
     @apply_defaults
     def __init__(

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -92,6 +92,7 @@ class SqlSensor(BaseSensorOperator):
     """
     template_fields = ('sql',)
     template_ext = ('.hql', '.sql',)
+    ui_color = '#7c7287'
 
     @apply_defaults
     def __init__(self, conn_id, sql, *args, **kwargs):
@@ -135,6 +136,7 @@ class MetastorePartitionSensor(SqlSensor):
     :type mysql_conn_id: str
     """
     template_fields = ('partition_name', 'table', 'schema')
+    ui_color = '#8da7be'
 
     @apply_defaults
     def __init__(
@@ -190,6 +192,7 @@ class ExternalTaskSensor(BaseSensorOperator):
         or execution_date_fn can be passed to ExternalTaskSensor, but not both.
     :type execution_date_fn: callable
     """
+    ui_color = '#19647e'
 
     @apply_defaults
     def __init__(
@@ -256,6 +259,7 @@ class NamedHivePartitionSensor(BaseSensorOperator):
     """
 
     template_fields = ('partition_names', )
+    ui_color = '#2b2d42'
 
     @apply_defaults
     def __init__(
@@ -329,6 +333,7 @@ class HivePartitionSensor(BaseSensorOperator):
     :type metastore_conn_id: str
     """
     template_fields = ('schema', 'table', 'partition',)
+    ui_color = '#2b2d42'
 
     @apply_defaults
     def __init__(
@@ -365,6 +370,7 @@ class HdfsSensor(BaseSensorOperator):
     Waits for a file or folder to land in HDFS
     """
     template_fields = ('filepath',)
+    ui_color = '#4d9de0'
 
     @apply_defaults
     def __init__(


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- [https://issues.apache.org/jira/browse/AIRFLOW-407](https://issues.apache.org/jira/browse/AIRFLOW-407)

These colors were added (leftmost is the default sensor color):

![image](https://cloud.githubusercontent.com/assets/130362/17538403/e57502e4-5e59-11e6-9a65-80134d1e77af.png)
#### Testing
- [x] Create a DAG with all these operators and take a screenshot
