### PR TITLE
[AIRFLOW-415] Make dag_id not found error clearer

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -110,7 +110,8 @@ def get_dag(args):
     dagbag = DagBag(process_subdir(args.subdir))
     if args.dag_id not in dagbag.dags:
         raise AirflowException(
-            'dag_id could not be found: {}'.format(args.dag_id))
+            'dag_id could not be found: {}. Either the dag did not exist or it failed to '
+            'parse.'.format(args.dag_id))
     return dagbag.dags[args.dag_id]
 
 


### PR DESCRIPTION
When a dag fails to parse and a user tries to run it e.g. via the command line airflow will give an error "dag_id not found" which is not clear since it sounds like the dag is completely missing rather than it just failing to parse. The message should be made clearer to address this possibility.

The longer term fix is to not display exceptions with tracebacks to users like this but catch and give an error message.

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-415

@artwr @mistercrunch
