### PR TITLE
[AIRFLOW-149] Task Dependency Engine + Blocked Task Instance Explainer

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -44,6 +44,7 @@ from airflow.executors import DEFAULT_EXECUTOR
 from airflow.models import (DagModel, DagBag, TaskInstance,
                             DagPickle, DagRun, Variable, DagStat,
                             Pool)
+from airflow.ti_deps.dep_context import (DepContext, SCHEDULER_DEPS)
 from airflow.utils import db as db_utils
 from airflow.utils import logging as logging_utils
 from airflow.utils.state import State
@@ -154,8 +155,8 @@ def backfill(args, dag=None):
             local=args.local,
             donot_pickle=(args.donot_pickle or
                           conf.getboolean('core', 'donot_pickle')),
-            ignore_dependencies=args.ignore_dependencies,
             ignore_first_depends_on_past=args.ignore_first_depends_on_past,
+            ignore_task_deps=args.ignore_dependencies,
             pool=args.pool)
 
 
@@ -356,18 +357,20 @@ def run(args, dag=None):
         run_job = jobs.LocalTaskJob(
             task_instance=ti,
             mark_success=args.mark_success,
-            force=args.force,
             pickle_id=args.pickle,
-            ignore_dependencies=args.ignore_dependencies,
+            ignore_all_deps=args.ignore_all_dependencies,
             ignore_depends_on_past=args.ignore_depends_on_past,
+            ignore_task_deps=args.ignore_dependencies,
+            ignore_ti_state=args.force,
             pool=args.pool)
         run_job.run()
     elif args.raw:
         ti.run(
             mark_success=args.mark_success,
-            force=args.force,
-            ignore_dependencies=args.ignore_dependencies,
+            ignore_all_deps=args.ignore_all_dependencies,
             ignore_depends_on_past=args.ignore_depends_on_past,
+            ignore_task_deps=args.ignore_dependencies,
+            ignore_ti_state=args.force,
             job_id=args.job_id,
             pool=args.pool,
         )
@@ -396,9 +399,10 @@ def run(args, dag=None):
             ti,
             mark_success=args.mark_success,
             pickle_id=pickle_id,
-            ignore_dependencies=args.ignore_dependencies,
+            ignore_all_deps=args.ignore_all_dependencies,
             ignore_depends_on_past=args.ignore_depends_on_past,
-            force=args.force,
+            ignore_task_deps=args.ignore_dependencies,
+            ignore_ti_state=args.force,
             pool=args.pool)
         executor.heartbeat()
         executor.end()
@@ -442,6 +446,31 @@ def run(args, dag=None):
         elif remote_base and remote_base != 'None':
             logging.error(
                 'Unsupported remote log location: {}'.format(remote_base))
+
+
+def task_failed_deps(args):
+    """
+    Returns the unmet dependencies for a task instance from the perspective of the
+    scheduler (i.e. why a task instance doesn't get scheduled and then queued by the
+    scheduler, and then run by an executor).
+
+    >>> airflow task_failed_deps tutorial sleep 2015-01-01
+    Task instance dependencies not met:
+    Dagrun Running: Task instance's dagrun did not exist: Unknown reason
+    Trigger Rule: Task's trigger rule 'all_success' requires all upstream tasks to have succeeded, but found 1 non-success(es).
+    """
+    dag = get_dag(args)
+    task = dag.get_task(task_id=args.task_id)
+    ti = TaskInstance(task, args.execution_date)
+
+    dep_context = DepContext(deps=SCHEDULER_DEPS)
+    failed_deps = list(ti.get_failed_dep_statuses(dep_context=dep_context))
+    if failed_deps:
+        print("Task instance dependencies not met:")
+        for dep in failed_deps:
+            print("{}: {}".format(dep.dep_name, dep.reason))
+    else:
+        print("Task instance dependencies are all met.")
 
 
 def task_state(args):
@@ -505,7 +534,7 @@ def test(args, dag=None):
     if args.dry_run:
         ti.dry_run()
     else:
-        ti.run(force=True, ignore_dependencies=True, test_mode=True)
+        ti.run(ignore_task_deps=True, ignore_ti_state=True, test_mode=True)
 
 
 def render(args):
@@ -1063,13 +1092,32 @@ class CLIFactory(object):
             ("-kt", "--keytab"), "keytab",
             nargs='?', default=conf.get('kerberos', 'keytab')),
         # run
+        # TODO(aoen): "force" is a poor choice of name here since it implies it overrides
+        # all dependencies (not just past success), e.g. the ignore_depends_on_past
+        # dependency. This flag should be deprecated and renamed to 'ignore_ti_state' and
+        # the "ignore_all_dependencies" command should be called the"force" command
+        # instead.
         'force': Arg(
             ("-f", "--force"),
-            "Force a run regardless of previous success", "store_true"),
+            "Ignore previous task instance state, rerun regardless if task already "
+            "succeeded/failed",
+            "store_true"),
         'raw': Arg(("-r", "--raw"), argparse.SUPPRESS, "store_true"),
+        'ignore_all_dependencies': Arg(
+            ("-A", "--ignore_all_dependencies"),
+            "Ignores all non-critical dependencies, including ignore_ti_state and "
+            "ignore_task_deps"
+            "store_true"),
+        # TODO(aoen): ignore_dependencies is a poor choice of name here because it is too
+        # vague (e.g. a task being in the appropriate state to be run is also a dependency
+        # but is not ignored by this flag), the name 'ignore_task_dependencies' is
+        # slightly better (as it ignores all dependencies that are specific to the task),
+        # so deprecate the old command name and use this instead.
         'ignore_dependencies': Arg(
             ("-i", "--ignore_dependencies"),
-            "Ignore upstream and depends_on_past dependencies", "store_true"),
+            "Ignore task-specific dependencies, e.g. upstream, depends_on_past, and "
+            "retry delay dependencies",
+            "store_true"),
         'ignore_depends_on_past': Arg(
             ("-I", "--ignore_depends_on_past"),
             "Ignore depends_on_past dependencies (but respect "
@@ -1229,7 +1277,7 @@ class CLIFactory(object):
             'args': (
                 'dag_id', 'task_id', 'execution_date', 'subdir',
                 'mark_success', 'force', 'pool',
-                'local', 'raw', 'ignore_dependencies',
+                'local', 'raw', 'ignore_all_dependencies', 'ignore_dependencies',
                 'ignore_depends_on_past', 'ship_dag', 'pickle', 'job_id'),
         }, {
             'func': initdb,
@@ -1243,6 +1291,14 @@ class CLIFactory(object):
             'func': dag_state,
             'help': "Get the status of a dag run",
             'args': ('dag_id', 'execution_date', 'subdir'),
+        }, {
+            'func': task_failed_deps,
+            'help': (
+                "Returns the unmet dependencies for a task instance from the perspective "
+                "of the scheduler. In other words, why a task instance doesn't get "
+                "scheduled and then queued by the scheduler, and then run by an "
+                "executor)."),
+            'args': ('dag_id', 'task_id', 'execution_date', 'subdir'),
         }, {
             'func': task_state,
             'help': "Get the status of a task instance",

--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -52,7 +52,7 @@ t1.doc_md = """\
 #### Task Documentation
 You can document your task using the attributes `doc_md` (markdown),
 `doc` (plain text), `doc_rst`, `doc_json`, `doc_yaml` which gets
-rendered in the UI's Task Details page.
+rendered in the UI's Task Instance Details page.
 ![img](http://montcs.bloomu.edu/~bobmon/Semesters/2012-01/491/import%20soul.png)
 """
 

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -55,17 +55,19 @@ class BaseExecutor(LoggingMixin):
             task_instance,
             mark_success=False,
             pickle_id=None,
-            force=False,
-            ignore_dependencies=False,
+            ignore_all_deps=False,
             ignore_depends_on_past=False,
+            ignore_task_deps=False,
+            ignore_ti_state=False,
             pool=None):
         pool = pool or task_instance.pool
         command = task_instance.command(
             local=True,
             mark_success=mark_success,
-            force=force,
-            ignore_dependencies=ignore_dependencies,
+            ignore_all_deps=ignore_all_deps,
             ignore_depends_on_past=ignore_depends_on_past,
+            ignore_task_deps=ignore_task_deps,
+            ignore_ti_state=ignore_ti_state,
             pool=pool,
             pickle_id=pickle_id)
         self.queue_command(

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -44,6 +44,7 @@ from airflow import configuration as conf
 from airflow.exceptions import AirflowException
 from airflow.models import DagRun
 from airflow.settings import Stats
+from airflow.ti_deps.dep_context import RUN_DEPS, DepContext
 from airflow.utils.state import State
 from airflow.utils.db import provide_session, pessimistic_connection_handling
 from airflow.utils.dag_processing import (AbstractDagFileProcessor,
@@ -592,8 +593,6 @@ class SchedulerJob(BaseJob):
                     session.delete(ti)
                     session.commit()
 
-            blocking_tis = ([ti for ti in blocking_tis
-                            if ti.are_dependencies_met(session=session)])
             task_list = "\n".join([
                 sla.task_id + ' on ' + sla.execution_date.isoformat()
                 for sla in slas])
@@ -781,7 +780,6 @@ class SchedulerJob(BaseJob):
         active DAG runs and adding task instances that should run to the
         queue.
         """
-        DagModel = models.DagModel
         session = settings.Session()
 
         # update the state of the previously active dag runs
@@ -789,7 +787,7 @@ class SchedulerJob(BaseJob):
         active_dag_runs = []
         for run in dag_runs:
             self.logger.info("Examining DAG run {}".format(run))
-            # do not consider runs that are executed in the future
+            # don't consider runs that are executed in the future
             if run.execution_date > datetime.now():
                 self.logging.error("Execution date is in future: {}"
                                    .format(run.execution_date))
@@ -827,7 +825,9 @@ class SchedulerJob(BaseJob):
                 if task.adhoc:
                     continue
 
-                if ti.is_runnable(flag_upstream_failed=True):
+                if ti.are_dependencies_met(
+                        dep_context=DepContext(flag_upstream_failed=True),
+                        session=session):
                     self.logger.debug('Queuing task: {}'.format(ti))
                     queue.append(ti.key)
 
@@ -1015,9 +1015,10 @@ class SchedulerJob(BaseJob):
                     task_instance.execution_date,
                     local=True,
                     mark_success=False,
-                    force=False,
-                    ignore_dependencies=False,
+                    ignore_all_deps=False,
                     ignore_depends_on_past=False,
+                    ignore_task_deps=False,
+                    ignore_ti_state=False,
                     pool=task_instance.pool,
                     file_path=simple_dag_bag.get_dag(task_instance.dag_id).full_filepath,
                     pickle_id=simple_dag_bag.get_dag(task_instance.dag_id).pickle_id)
@@ -1564,11 +1565,14 @@ class BackfillJob(BaseJob):
 
     def __init__(
             self,
-            dag, start_date=None, end_date=None, mark_success=False,
+            dag,
+            start_date=None,
+            end_date=None,
+            mark_success=False,
             include_adhoc=False,
             donot_pickle=False,
-            ignore_dependencies=False,
             ignore_first_depends_on_past=False,
+            ignore_task_deps=False,
             pool=None,
             *args, **kwargs):
         self.dag = dag
@@ -1578,8 +1582,8 @@ class BackfillJob(BaseJob):
         self.mark_success = mark_success
         self.include_adhoc = include_adhoc
         self.donot_pickle = donot_pickle
-        self.ignore_dependencies = ignore_dependencies
         self.ignore_first_depends_on_past = ignore_first_depends_on_past
+        self.ignore_task_deps = ignore_task_deps
         self.pool = pool
         super(BackfillJob, self).__init__(*args, **kwargs)
 
@@ -1705,11 +1709,16 @@ class BackfillJob(BaseJob):
                         session.commit()
                         continue
 
+                    backfill_context = DepContext(
+                        deps=RUN_DEPS,
+                        ignore_depends_on_past=ignore_depends_on_past,
+                        ignore_task_deps=self.ignore_task_deps,
+                        flag_upstream_failed=True)
                     # Is the task runnable? -- then run it
-                    if ti.is_queueable(
-                            include_queued=True,
-                            ignore_depends_on_past=ignore_depends_on_past,
-                            flag_upstream_failed=True):
+                    if ti.are_dependencies_met(
+                            dep_context=backfill_context,
+                            session=session,
+                            verbose=True):
                         self.logger.debug('Sending {} to executor'.format(ti))
                         if ti.state == State.NONE:
                             ti.state = State.SCHEDULED
@@ -1719,7 +1728,7 @@ class BackfillJob(BaseJob):
                             ti,
                             mark_success=self.mark_success,
                             pickle_id=pickle_id,
-                            ignore_dependencies=self.ignore_dependencies,
+                            ignore_task_deps=self.ignore_task_deps,
                             ignore_depends_on_past=ignore_depends_on_past,
                             pool=self.pool)
                         started.add(key)
@@ -1864,8 +1873,14 @@ class BackfillJob(BaseJob):
                 '---------------------------------------------------\n'
                 'BackfillJob is deadlocked.')
             deadlocked_depends_on_past = any(
-                t.are_dependencies_met() != t.are_dependencies_met(
-                    ignore_depends_on_past=True)
+                t.are_dependencies_met(
+                    dep_context=DepContext(ignore_depends_on_past=False),
+                    session=session,
+                    verbose=True) !=
+                t.are_dependencies_met(
+                    dep_context=DepContext(ignore_depends_on_past=True),
+                    session=session,
+                    verbose=True)
                 for t in deadlocked)
             if deadlocked_depends_on_past:
                 err += (
@@ -1890,17 +1905,19 @@ class LocalTaskJob(BaseJob):
     def __init__(
             self,
             task_instance,
-            ignore_dependencies=False,
+            ignore_all_deps=False,
             ignore_depends_on_past=False,
-            force=False,
+            ignore_task_deps=False,
+            ignore_ti_state=False,
             mark_success=False,
             pickle_id=None,
             pool=None,
             *args, **kwargs):
         self.task_instance = task_instance
-        self.ignore_dependencies = ignore_dependencies
+        self.ignore_all_deps = ignore_all_deps
         self.ignore_depends_on_past = ignore_depends_on_past
-        self.force = force
+        self.ignore_task_deps = ignore_task_deps
+        self.ignore_ti_state = ignore_ti_state
         self.pool = pool
         self.pickle_id = pickle_id
         self.mark_success = mark_success
@@ -1918,9 +1935,10 @@ class LocalTaskJob(BaseJob):
     def _execute(self):
         command = self.task_instance.command(
             raw=True,
-            ignore_dependencies=self.ignore_dependencies,
+            ignore_all_deps=self.ignore_all_deps,
             ignore_depends_on_past=self.ignore_depends_on_past,
-            force=self.force,
+            ignore_task_deps=self.ignore_task_deps,
+            ignore_ti_state=self.ignore_ti_state,
             pickle_id=self.pickle_id,
             mark_success=self.mark_success,
             job_id=self.id,

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -49,10 +49,10 @@ from urllib.parse import urlparse
 from sqlalchemy import (
     Column, Integer, String, DateTime, Text, Boolean, ForeignKey, PickleType,
     Index, Float)
-from sqlalchemy import case, func, or_, and_
+from sqlalchemy import func, or_, and_
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.dialects.mysql import LONGTEXT
-from sqlalchemy.orm import relationship, synonym
+from sqlalchemy.orm import reconstructor, relationship, synonym
 
 from croniter import croniter
 import six
@@ -62,6 +62,10 @@ from airflow.executors import DEFAULT_EXECUTOR, LocalExecutor
 from airflow import configuration
 from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.dag.base_dag import BaseDag, BaseDagBag
+from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
+from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
+from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
+from airflow.ti_deps.dep_context import DepContext, QUEUE_DEPS, RUN_DEPS
 from airflow.utils.dates import cron_presets, date_range as utils_date_range
 from airflow.utils.db import provide_session
 from airflow.utils.decorators import apply_defaults
@@ -722,18 +726,23 @@ class TaskInstance(Base):
         self.pool = task.pool
         self.priority_weight = task.priority_weight_total
         self.try_number = 0
-        self.test_mode = False  # can be changed when calling 'run'
-        self.force = False  # can be changed when calling 'run'
         self.unixname = getpass.getuser()
         if state:
             self.state = state
+        self.init_on_load()
+
+    @reconstructor
+    def init_on_load(self):
+        """ Initialize the attributes that aren't stored in the DB. """
+        self.test_mode = False  # can be changed when calling 'run'
 
     def command(
             self,
             mark_success=False,
-            ignore_dependencies=False,
+            ignore_all_deps=False,
             ignore_depends_on_past=False,
-            force=False,
+            ignore_task_deps=False,
+            ignore_ti_state=False,
             local=False,
             pickle_id=None,
             raw=False,
@@ -759,9 +768,10 @@ class TaskInstance(Base):
             self.task_id,
             self.execution_date,
             mark_success=mark_success,
-            ignore_dependencies=ignore_dependencies,
+            ignore_all_deps=ignore_all_deps,
             ignore_depends_on_past=ignore_depends_on_past,
-            force=force,
+            ignore_task_deps=ignore_task_deps,
+            ignore_ti_state=ignore_ti_state,
             local=local,
             pickle_id=pickle_id,
             file_path=path,
@@ -774,9 +784,10 @@ class TaskInstance(Base):
                          task_id,
                          execution_date,
                          mark_success=False,
-                         ignore_dependencies=False,
+                         ignore_all_deps=False,
                          ignore_depends_on_past=False,
-                         force=False,
+                         ignore_task_deps=False,
+                         ignore_ti_state=False,
                          local=False,
                          pickle_id=None,
                          file_path=None,
@@ -795,14 +806,17 @@ class TaskInstance(Base):
         :type execution_date: datetime
         :param mark_success: Whether to mark the task as successful
         :type mark_success: bool
-        :param ignore_dependencies: Whether to ignore the dependencies and run
-        anyway
-        :type ignore_dependencies: bool
-        :param ignore_depends_on_past: Whether to ignore the depends on past
-        setting and run anyway
-        :type ignore_depends_on_past: bool
-        :param force: Whether to force running - see TaskInstance.run()
-        :type force: bool
+        :param ignore_all_deps: Ignore all ignoreable dependencies.
+            Overrides the other ignore_* parameters.
+        :type ignore_all_deps: boolean
+        :param ignore_depends_on_past: Ignore depends_on_past parameter of DAGs
+            (e.g. for Backfills)
+        :type ignore_depends_on_past: boolean
+        :param ignore_task_deps: Ignore task-specific dependencies such as depends_on_past
+            and trigger rule
+        :type ignore_task_deps: boolean
+        :param ignore_ti_state: Ignore the task instance's previous failure/success
+        :type ignore_ti_state: boolean
         :param local: Whether to run the task locally
         :type local: bool
         :param pickle_id: If the DAG was serialized to the DB, the ID
@@ -820,9 +834,10 @@ class TaskInstance(Base):
         cmd += "--mark_success " if mark_success else ""
         cmd += "--pickle {pickle_id} " if pickle_id else ""
         cmd += "--job_id {job_id} " if job_id else ""
-        cmd += "-i " if ignore_dependencies else ""
+        cmd += "-A " if ignore_all_deps else ""
+        cmd += "-i " if ignore_task_deps else ""
         cmd += "-I " if ignore_depends_on_past else ""
-        cmd += "--force " if force else ""
+        cmd += "--force " if ignore_ti_state else ""
         cmd += "--local " if local else ""
         cmd += "--pool {pool} " if pool else ""
         cmd += "--raw " if raw else ""
@@ -944,56 +959,7 @@ class TaskInstance(Base):
         session.merge(self)
         session.commit()
 
-    def is_queueable(
-            self,
-            include_queued=False,
-            ignore_depends_on_past=False,
-            flag_upstream_failed=False):
-        """
-        Returns a boolean on whether the task instance has met all dependencies
-        and is ready to run. It considers the task's state, the state
-        of its dependencies, depends_on_past and makes sure the execution
-        isn't in the future. It doesn't take into
-        account whether the pool has a slot for it to run.
-
-        :param include_queued: If True, tasks that have already been queued
-            are included. Defaults to False.
-        :type include_queued: boolean
-        :param ignore_depends_on_past: if True, ignores depends_on_past
-            dependencies. Defaults to False.
-        :type ignore_depends_on_past: boolean
-        :param flag_upstream_failed: This is a hack to generate
-            the upstream_failed state creation while checking to see
-            whether the task instance is runnable. It was the shortest
-            path to add the feature
-        :type flag_upstream_failed: boolean
-        """
-        # is the execution date in the future?
-        if self.execution_date > datetime.now():
-            return False
-        # is the task still in the retry waiting period?
-        elif self.is_premature():
-            return False
-        # does the task have an end_date prior to the execution date?
-        elif self.task.end_date and self.execution_date > self.task.end_date:
-            return False
-        # has the task been skipped?
-        elif self.state == State.SKIPPED:
-            return False
-        # has the task already been queued (and are we excluding queued tasks)?
-        elif self.state == State.QUEUED and not include_queued:
-            return False
-        # is the task runnable and have its dependencies been met?
-        elif (
-                self.state in State.runnable() and
-                self.are_dependencies_met(
-                    ignore_depends_on_past=ignore_depends_on_past,
-                    flag_upstream_failed=flag_upstream_failed)):
-            return True
-        # anything else
-        else:
-            return False
-
+    @property
     def is_premature(self):
         """
         Returns whether a task is in UP_FOR_RETRY state and its retry interval
@@ -1001,28 +967,6 @@ class TaskInstance(Base):
         """
         # is the task still in the retry waiting period?
         return self.state == State.UP_FOR_RETRY and not self.ready_for_retry()
-
-    def is_runnable(
-            self,
-            include_queued=False,
-            ignore_depends_on_past=False,
-            flag_upstream_failed=False):
-        """
-        Returns whether a task is ready to run AND there's room in the
-        queue.
-
-        :param include_queued: If True, tasks that are already QUEUED are
-            considered "runnable". Defaults to False.
-        :type include_queued: boolean
-        :param ignore_depends_on_past: if True, ignores depends_on_past
-            dependencies. Defaults to False.
-        :type ignore_depends_on_past: boolean
-        """
-        queueable = self.is_queueable(
-            include_queued=include_queued,
-            ignore_depends_on_past=ignore_depends_on_past,
-            flag_upstream_failed=flag_upstream_failed)
-        return queueable and not self.pool_full()  # pylint: disable=E1120
 
     @provide_session
     def are_dependents_done(self, session=None):
@@ -1048,155 +992,67 @@ class TaskInstance(Base):
         count = ti[0][0]
         return count == len(task.downstream_task_ids)
 
+    @property
     @provide_session
-    def evaluate_trigger_rule(self, successes, skipped, failed,
-                              upstream_failed, done,
-                              flag_upstream_failed, session=None):
-        """
-        Returns a boolean on whether the current task can be scheduled
-        for execution based on its trigger_rule.
-
-        :param flag_upstream_failed: This is a hack to generate
-            the upstream_failed state creation while checking to see
-            whether the task instance is runnable. It was the shortest
-            path to add the feature
-        :type flag_upstream_failed: boolean
-        :param successes: Number of successful upstream tasks
-        :type successes: boolean
-        :param skipped: Number of skipped upstream tasks
-        :type skipped: boolean
-        :param failed: Number of failed upstream tasks
-        :type failed: boolean
-        :param upstream_failed: Number of upstream_failed upstream tasks
-        :type upstream_failed: boolean
-        :param done: Number of completed upstream tasks
-        :type done: boolean
-        """
-        TR = TriggerRule
-
-        task = self.task
-        upstream = len(task.upstream_task_ids)
-        tr = task.trigger_rule
-        upstream_done = done >= upstream
-
-        # handling instant state assignment based on trigger rules
-        if flag_upstream_failed:
-            if tr == TR.ALL_SUCCESS:
-                if upstream_failed or failed:
-                    self.set_state(State.UPSTREAM_FAILED, session)
-                elif skipped:
-                    self.set_state(State.SKIPPED, session)
-            elif tr == TR.ALL_FAILED:
-                if successes or skipped:
-                    self.set_state(State.SKIPPED, session)
-            elif tr == TR.ONE_SUCCESS:
-                if upstream_done and not successes:
-                    self.set_state(State.SKIPPED, session)
-            elif tr == TR.ONE_FAILED:
-                if upstream_done and not (failed or upstream_failed):
-                    self.set_state(State.SKIPPED, session)
-
-        return (
-            (tr == TR.ONE_SUCCESS and successes > 0) or
-            (tr == TR.ONE_FAILED and (failed or upstream_failed)) or
-            (tr == TR.ALL_SUCCESS and successes >= upstream) or
-            (tr == TR.ALL_FAILED and failed + upstream_failed >= upstream) or
-            (tr == TR.ALL_DONE and upstream_done)
-        )
+    def previous_ti(self, session=None):
+        """ The task instance for the task that ran before this task instance """
+        return session.query(TaskInstance).filter(
+            TaskInstance.dag_id == self.dag_id,
+            TaskInstance.task_id == self.task.task_id,
+            TaskInstance.execution_date ==
+            self.task.dag.previous_schedule(self.execution_date),
+        ).first()
 
     @provide_session
     def are_dependencies_met(
             self,
+            dep_context=None,
             session=None,
-            flag_upstream_failed=False,
-            ignore_depends_on_past=False,
             verbose=False):
         """
-        Returns a boolean on whether the upstream tasks are in a SUCCESS state
-        and considers depends_on_past and the previous run's state.
+        Returns whether or not all the conditions are met for this task instance to be run
+        given the context for the dependencies (e.g. a task instance being force run from
+        the UI will ignore some dependencies).
 
-        :param flag_upstream_failed: This is a hack to generate
-            the upstream_failed state creation while checking to see
-            whether the task instance is runnable. It was the shortest
-            path to add the feature
-        :type flag_upstream_failed: boolean
-        :param ignore_depends_on_past: if True, ignores depends_on_past
-            dependencies. Defaults to False.
-        :type ignore_depends_on_past: boolean
-        :param verbose: verbose provides more logging in the case where the
-            task instance is evaluated as a check right before being executed.
-            In the case of the scheduler evaluating the dependencies, this
-            logging would be way too verbose.
+        :param dep_context: The execution context that determines the dependencies that
+            should be evaluated.
+        :type dep_context: DepContext
+        :param session: database session
+        :type session: Session
+        :param verbose: whether or not to print details on failed dependencies
         :type verbose: boolean
         """
-        TI = TaskInstance
-        TR = TriggerRule
+        dep_context = dep_context or DepContext()
+        for dep_status in self.get_failed_dep_statuses(
+                dep_context=dep_context,
+                session=session):
+            if verbose:
+                logging.warning(
+                    "Dependencies not met for %s, dependency '%s' FAILED: %s",
+                    self, dep_status.dep_name, dep_status.reason)
+            return False
+        if verbose:
+            logging.info("Dependencies all met for %s", self)
+        return True
 
-        task = self.task
-
-        # Checking that the depends_on_past is fulfilled
-        if (task.depends_on_past and not ignore_depends_on_past and
-                not self.execution_date == task.start_date):
-            previous_ti = session.query(TI).filter(
-                TI.dag_id == self.dag_id,
-                TI.task_id == task.task_id,
-                TI.execution_date == self.task.dag.previous_schedule(
-                    self.execution_date),
-                TI.state.in_({State.SUCCESS, State.SKIPPED}),
-            ).first()
-            if not previous_ti:
-                if verbose:
-                    logging.warning("depends_on_past not satisfied")
-                return False
-
-            # Applying wait_for_downstream
-            previous_ti.task = self.task
-            if task.wait_for_downstream and not \
-                    previous_ti.are_dependents_done(session=session):
-                if verbose:
-                    logging.warning("wait_for_downstream not satisfied")
-                return False
-
-        # Checking that all upstream dependencies have succeeded
-        if not task.upstream_list or task.trigger_rule == TR.DUMMY:
-            return True
-
-        # todo: this query becomes quite expensive with dags that have
-        # many tasks. It should be refactored to let the task report
-        # to the dag run and get the aggregates from there
-        qry = (
-            session
-            .query(
-                func.coalesce(func.sum(
-                    case([(TI.state == State.SUCCESS, 1)], else_=0)), 0),
-                func.coalesce(func.sum(
-                    case([(TI.state == State.SKIPPED, 1)], else_=0)), 0),
-                func.coalesce(func.sum(
-                    case([(TI.state == State.FAILED, 1)], else_=0)), 0),
-                func.coalesce(func.sum(
-                    case([(TI.state == State.UPSTREAM_FAILED, 1)], else_=0)), 0),
-                func.count(TI.task_id),
-            )
-            .filter(
-                TI.dag_id == self.dag_id,
-                TI.task_id.in_(task.upstream_task_ids),
-                TI.execution_date == self.execution_date,
-                TI.state.in_([
-                    State.SUCCESS, State.FAILED,
-                    State.UPSTREAM_FAILED, State.SKIPPED]),
-            )
-        )
-
-        successes, skipped, failed, upstream_failed, done = qry.first()
-
-        satisfied = self.evaluate_trigger_rule(
-            session=session, successes=successes, skipped=skipped,
-            failed=failed, upstream_failed=upstream_failed, done=done,
-            flag_upstream_failed=flag_upstream_failed)
-
-        if verbose and not satisfied:
-            logging.warning("Trigger rule `{}` not satisfied".format(task.trigger_rule))
-        return satisfied
+    @provide_session
+    def get_failed_dep_statuses(
+            self,
+            dep_context=None,
+            session=None):
+        dep_context = dep_context or DepContext()
+        for dep in dep_context.deps | self.task.deps:
+            for dep_status in dep.get_dep_statuses(
+                    self,
+                    session,
+                    dep_context):
+                if dep_status.passed:
+                    logging.debug("%s dependency '%s' PASSED: %s",
+                                  self,
+                                  dep_status.dep_name,
+                                  dep_status.reason)
+                else:
+                    yield dep_status
 
     def __repr__(self):
         return (
@@ -1265,9 +1121,10 @@ class TaskInstance(Base):
     def run(
             self,
             verbose=True,
-            ignore_dependencies=False,
+            ignore_all_deps=False,
             ignore_depends_on_past=False,
-            force=False,
+            ignore_task_deps=False,
+            ignore_ti_state=False,
             mark_success=False,
             test_mode=False,
             job_id=None,
@@ -1278,13 +1135,14 @@ class TaskInstance(Base):
 
         :param verbose: whether to turn on more verbose loggin
         :type verbose: boolean
-        :param ignore_dependencies: Doesn't check for deps, just runs
-        :type ignore_dependencies: boolean
-        :param ignore_depends_on_past: Ignore depends_on_past but respect
-            other dependencies
+        :param ignore_all_deps: Ignore all of the non-critical dependencies, just runs
+        :type ignore_all_deps: boolean
+        :param ignore_depends_on_past: Ignore depends_on_past DAG attribute
         :type ignore_depends_on_past: boolean
-        :param force: Forces a run regarless of previous success
-        :type force: boolean
+        :param ignore_task_deps: Don't check the dependencies of this TI's task
+        :type ignore_task_deps: boolean
+        :param ignore_ti_state: Disregards previous task instance state
+        :type ignore_ti_state: boolean
         :param mark_success: Don't run the task, mark its state as success
         :type mark_success: boolean
         :param test_mode: Doesn't record success or failure in the DB
@@ -1295,146 +1153,143 @@ class TaskInstance(Base):
         task = self.task
         self.pool = pool or task.pool
         self.test_mode = test_mode
-        self.force = force
         self.refresh_from_db(session=session, lock_for_update=True)
         self.job_id = job_id
-        iso = datetime.now().isoformat()
         self.hostname = socket.getfqdn()
         self.operator = task.__class__.__name__
 
-        if self.state == State.RUNNING:
-            logging.warning("Another instance is running, skipping.")
-        elif self.state == State.REMOVED:
-            self.clear_xcom_data()
-            logging.debug("Task {} was removed from the dag".format(self))
-        elif not force and self.state == State.SUCCESS:
-            logging.info(
-                "Task {self} previously succeeded"
-                " on {self.end_date}".format(**locals())
-            )
+        if not ignore_all_deps and not ignore_ti_state and self.state == State.SUCCESS:
             Stats.incr('previously_succeeded', 1, 1)
-        elif (
-                not ignore_dependencies and
-                not self.are_dependencies_met(
-                    session=session,
-                    ignore_depends_on_past=ignore_depends_on_past,
-                    verbose=True)):
-            logging.warning("Dependencies not met yet")
-        elif (
-                # TODO: move this to the scheduler
-                self.state == State.UP_FOR_RETRY and
-                not self.ready_for_retry()):
-            next_run = self.next_retry_datetime().isoformat()
-            logging.info(
-                "Not ready for retry yet. " +
-                "Next run after {0}".format(next_run)
-            )
-        elif force or self.state in State.runnable():
-            self.clear_xcom_data()
-            HR = "\n" + ("-" * 80) + "\n"  # Line break
 
-            # For reporting purposes, we report based on 1-indexed,
-            # not 0-indexed lists (i.e. Attempt 1 instead of
-            # Attempt 0 for the first attempt).
-            msg = "Starting attempt {attempt} of {total}".format(
-                attempt=self.try_number % (task.retries + 1) + 1,
-                total=task.retries + 1)
-            self.start_date = datetime.now()
+        queue_dep_context = DepContext(
+            deps=QUEUE_DEPS,
+            ignore_all_deps=ignore_all_deps,
+            ignore_ti_state=ignore_ti_state,
+            ignore_depends_on_past=ignore_depends_on_past,
+            ignore_task_deps=ignore_task_deps)
+        if not self.are_dependencies_met(
+                dep_context=queue_dep_context,
+                session=session,
+                verbose=True):
+            return
 
-            if not mark_success and self.state != State.QUEUED and (
-                    self.pool or self.task.dag.concurrency_reached):
-                # If a pool is set for this task, marking the task instance
-                # as QUEUED
+        self.clear_xcom_data()
+        hr = "\n" + ("-" * 80) + "\n"  # Line break
+
+        # For reporting purposes, we report based on 1-indexed,
+        # not 0-indexed lists (i.e. Attempt 1 instead of
+        # Attempt 0 for the first attempt).
+        msg = "Starting attempt {attempt} of {total}".format(
+            attempt=self.try_number % (task.retries + 1) + 1,
+            total=task.retries + 1)
+        self.start_date = datetime.now()
+
+        dep_context = DepContext(
+            deps=RUN_DEPS - QUEUE_DEPS,
+            ignore_all_deps=ignore_all_deps,
+            ignore_depends_on_past=ignore_depends_on_past,
+            ignore_task_deps=ignore_task_deps,
+            ignore_ti_state=ignore_ti_state)
+        runnable = self.are_dependencies_met(
+            dep_context=dep_context,
+            session=session,
+            verbose=True)
+
+        if not runnable and not mark_success:
+            if self.state != State.QUEUED:
+                # If a task's dependencies are met but it can't be run yet then queue it
+                # instead
                 self.state = State.QUEUED
                 msg = "Queuing attempt {attempt} of {total}".format(
                     attempt=self.try_number % (task.retries + 1) + 1,
                     total=task.retries + 1)
-                logging.info(HR + msg + HR)
+                logging.info(hr + msg + hr)
 
                 self.queued_dttm = datetime.now()
                 session.merge(self)
                 session.commit()
                 logging.info("Queuing into pool {}".format(self.pool))
-                return
+            return
 
-            # print status message
-            logging.info(HR + msg + HR)
-            self.try_number += 1
+        # print status message
+        logging.info(hr + msg + hr)
+        self.try_number += 1
 
-            if not test_mode:
-                session.add(Log(State.RUNNING, self))
-            self.state = State.RUNNING
-            self.end_date = None
-            if not test_mode:
-                session.merge(self)
-            session.commit()
+        if not test_mode:
+            session.add(Log(State.RUNNING, self))
+        self.state = State.RUNNING
+        self.end_date = None
+        if not test_mode:
+            session.merge(self)
+        session.commit()
 
-            # Closing all pooled connections to prevent
-            # "max number of connections reached"
-            settings.engine.dispose()
-            if verbose:
-                if mark_success:
-                    msg = "Marking success for "
-                else:
-                    msg = "Executing "
-                msg += "{self.task} on {self.execution_date}"
+        # Closing all pooled connections to prevent
+        # "max number of connections reached"
+        settings.engine.dispose()
+        if verbose:
+            if mark_success:
+                msg = "Marking success for "
+            else:
+                msg = "Executing "
+            msg += "{self.task} on {self.execution_date}"
 
-            context = {}
-            try:
-                logging.info(msg.format(self=self))
-                if not mark_success:
-                    context = self.get_template_context()
+        context = {}
+        try:
+            logging.info(msg.format(self=self))
+            if not mark_success:
+                context = self.get_template_context()
 
-                    task_copy = copy.copy(task)
-                    self.task = task_copy
+                task_copy = copy.copy(task)
+                self.task = task_copy
 
-                    def signal_handler(signum, frame):
-                        """Setting kill signal handler"""
-                        logging.error("Killing subprocess")
-                        task_copy.on_kill()
-                        raise AirflowException("Task received SIGTERM signal")
-                    signal.signal(signal.SIGTERM, signal_handler)
+                def signal_handler(signum, frame):
+                    '''Setting kill signal handler'''
+                    logging.error("Killing subprocess")
+                    task_copy.on_kill()
+                    raise AirflowException("Task received SIGTERM signal")
+                signal.signal(signal.SIGTERM, signal_handler)
 
-                    self.render_templates()
-                    task_copy.pre_execute(context=context)
+                self.render_templates()
+                task_copy.pre_execute(context=context)
 
-                    # If a timeout is specified for the task, make it fail
-                    # if it goes beyond
-                    result = None
-                    if task_copy.execution_timeout:
-                        with timeout(int(task_copy.execution_timeout.total_seconds())):
-                            result = task_copy.execute(context=context)
-
-                    else:
+                # If a timeout is specified for the task, make it fail
+                # if it goes beyond
+                result = None
+                if task_copy.execution_timeout:
+                    with timeout(int(
+                            task_copy.execution_timeout.total_seconds())):
                         result = task_copy.execute(context=context)
 
-                    # If the task returns a result, push an XCom containing it
-                    if result is not None:
-                        self.xcom_push(key=XCOM_RETURN_KEY, value=result)
+                else:
+                    result = task_copy.execute(context=context)
 
-                    task_copy.post_execute(context=context)
-                self.state = State.SUCCESS
-            except AirflowSkipException:
-                self.state = State.SKIPPED
-            except (Exception, KeyboardInterrupt) as e:
-                self.handle_failure(e, test_mode, context)
-                raise
+                # If the task returns a result, push an XCom containing it
+                if result is not None:
+                    self.xcom_push(key=XCOM_RETURN_KEY, value=result)
 
-            # Recording SUCCESS
-            self.end_date = datetime.now()
-            self.set_duration()
-            if not test_mode:
-                session.add(Log(self.state, self))
-                session.merge(self)
-            session.commit()
+                task_copy.post_execute(context=context)
+            self.state = State.SUCCESS
+        except AirflowSkipException:
+            self.state = State.SKIPPED
+        except (Exception, KeyboardInterrupt) as e:
+            self.handle_failure(e, test_mode, context)
+            raise
 
-            # Success callback
-            try:
-                if task.on_success_callback:
-                    task.on_success_callback(context)
-            except Exception as e3:
-                logging.error("Failed when executing success callback")
-                logging.exception(e3)
+        # Recording SUCCESS
+        self.end_date = datetime.now()
+        self.set_duration()
+        if not test_mode:
+            session.add(Log(self.state, self))
+            session.merge(self)
+        session.commit()
+
+        # Success callback
+        try:
+            if task.on_success_callback:
+                task.on_success_callback(context)
+        except Exception as e3:
+            logging.error("Failed when executing success callback")
+            logging.exception(e3)
 
         session.commit()
 
@@ -1863,7 +1718,7 @@ class BaseOperator(object):
         this represents the ``timedelta`` after the period is closed. For
         example if you set an SLA of 1 hour, the scheduler would send dan email
         soon after 1:00AM on the ``2016-01-02`` if the ``2016-01-01`` instance
-        has not succeede yet.
+        has not succeeded yet.
         The scheduler pays special attention for jobs with an SLA and
         sends alert
         emails for sla misses. SLA misses are also recorded in the database
@@ -2147,6 +2002,19 @@ class BaseOperator(object):
             return 'adhoc_' + self.owner
 
     @property
+    def deps(self):
+        """
+        Returns the list of dependencies for the operator. These differ from execution
+        context dependencies in that they are specific to tasks and can be
+        extended/overriden by subclasses.
+        """
+        return {
+            NotInRetryPeriodDep(),
+            PrevDagrunDep(),
+            TriggerRuleDep(),
+        }
+
+    @property
     def schedule_interval(self):
         """
         The schedule interval of the DAG always wins over individual tasks so
@@ -2378,9 +2246,8 @@ class BaseOperator(object):
             self,
             start_date=None,
             end_date=None,
-            ignore_dependencies=False,
             ignore_first_depends_on_past=False,
-            force=False,
+            ignore_ti_state=False,
             mark_success=False):
         """
         Run a set of task instances for a date range.
@@ -2391,10 +2258,9 @@ class BaseOperator(object):
         for dt in self.dag.date_range(start_date, end_date=end_date):
             TaskInstance(self, dt).run(
                 mark_success=mark_success,
-                ignore_dependencies=ignore_dependencies,
                 ignore_depends_on_past=(
                     dt == start_date and ignore_first_depends_on_past),
-                force=force,)
+                ignore_ti_state=ignore_ti_state)
 
     def dry_run(self):
         logging.info('Dry run')
@@ -2991,8 +2857,7 @@ class DAG(BaseDag, LoggingMixin):
 
     @provide_session
     def set_dag_runs_state(
-            self, start_date, end_date, state=State.RUNNING, session=None):
-        dates = utils_date_range(start_date, end_date)
+            self, state=State.RUNNING, session=None):
         drs = session.query(DagModel).filter_by(dag_id=self.dag_id).all()
         dirty_ids = []
         for dr in drs:
@@ -3057,7 +2922,7 @@ class DAG(BaseDag, LoggingMixin):
         if do_it:
             clear_task_instances(tis, session)
             if reset_dag_runs:
-                self.set_dag_runs_state(start_date, end_date, session=session)
+                self.set_dag_runs_state(session=session)
         else:
             count = 0
             print("Bail. Nothing was cleared.")
@@ -3219,7 +3084,7 @@ class DAG(BaseDag, LoggingMixin):
             local=False,
             executor=None,
             donot_pickle=configuration.getboolean('core', 'donot_pickle'),
-            ignore_dependencies=False,
+            ignore_task_deps=False,
             ignore_first_depends_on_past=False,
             pool=None):
         """
@@ -3238,7 +3103,7 @@ class DAG(BaseDag, LoggingMixin):
             include_adhoc=include_adhoc,
             executor=executor,
             donot_pickle=donot_pickle,
-            ignore_dependencies=ignore_dependencies,
+            ignore_task_deps=ignore_task_deps,
             ignore_first_depends_on_past=ignore_first_depends_on_past,
             pool=pool)
         job.run()

--- a/airflow/ti_deps/__init__.py
+++ b/airflow/ti_deps/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/airflow/ti_deps/dep_context.py
+++ b/airflow/ti_deps/dep_context.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from airflow.ti_deps.deps.dag_ti_slots_available_dep import DagTISlotsAvailableDep
+from airflow.ti_deps.deps.dag_unpaused_dep import DagUnpausedDep
+from airflow.ti_deps.deps.dagrun_exists_dep import DagrunRunningDep
+from airflow.ti_deps.deps.exec_date_after_start_date_dep import ExecDateAfterStartDateDep
+from airflow.ti_deps.deps.not_running_dep import NotRunningDep
+from airflow.ti_deps.deps.not_skipped_dep import NotSkippedDep
+from airflow.ti_deps.deps.pool_has_space_dep import PoolHasSpaceDep
+from airflow.ti_deps.deps.runnable_exec_date_dep import RunnableExecDateDep
+from airflow.ti_deps.deps.valid_state_dep import ValidStateDep
+from airflow.utils.state import State
+
+
+class DepContext(object):
+    """
+    A base class for contexts that specifies which dependencies should be evaluated in
+    the context for a task instance to satisfy the requirements of the context. Also
+    stores state related to the context that can be used by dependendency classes.
+
+    For example there could be a SomeRunContext that subclasses this class which has
+    dependencies for:
+    - Making sure there are slots available on the infrastructure to run the task instance
+    - A task-instance's task-specific dependencies are met (e.g. the previous task
+      instance completed successfully)
+    - ...
+
+    :param deps: The context-specific dependencies that need to be evaluated for a
+        task instance to run in this execution context.
+    :type deps: set(BaseTIDep)
+    :param flag_upstream_failed: This is a hack to generate the upstream_failed state
+        creation while checking to see whether the task instance is runnable. It was the
+        shortest path to add the feature. This is bad since this class should be pure (no
+        side effects).
+    :type flag_upstream_failed: boolean
+    :param ignore_all_deps: Whether or not the context should ignore all ignoreable
+        dependencies. Overrides the other ignore_* parameters
+    :type ignore_all_deps: boolean
+    :param ignore_depends_on_past: Ignore depends_on_past parameter of DAGs (e.g. for
+        Backfills)
+    :type ignore_depends_on_past: boolean
+    :param ignore_task_deps: Ignore task-specific dependencies such as depends_on_past and
+        trigger rule
+    :type ignore_task_deps: boolean
+    :param ignore_ti_state: Ignore the task instance's previous failure/success
+    :type ignore_ti_state: boolean
+    """
+    def __init__(
+            self,
+            deps=None,
+            flag_upstream_failed=False,
+            ignore_all_deps=False,
+            ignore_depends_on_past=False,
+            ignore_task_deps=False,
+            ignore_ti_state=False):
+        self.deps = deps or set()
+        self.flag_upstream_failed = flag_upstream_failed
+        self.ignore_all_deps = ignore_all_deps
+        self.ignore_depends_on_past = ignore_depends_on_past
+        self.ignore_task_deps = ignore_task_deps
+        self.ignore_ti_state = ignore_ti_state
+
+# In order to be able to get queued a task must have one of these states
+QUEUEABLE_STATES = {
+    State.FAILED,
+    State.NONE,
+    State.QUEUED,
+    State.SCHEDULED,
+    State.SKIPPED,
+    State.UPSTREAM_FAILED,
+    State.UP_FOR_RETRY,
+}
+
+# The minimum execution context for task instances to be executed.
+MIN_EXEC_DEPS = {
+    NotRunningDep(),
+    NotSkippedDep(),
+    RunnableExecDateDep(),
+}
+
+# Context to get the dependencies that need to be met in order for a task instance to
+# be backfilled.
+QUEUE_DEPS = MIN_EXEC_DEPS | {
+    ValidStateDep(QUEUEABLE_STATES)
+}
+
+# Dependencies that need to be met for a given task instance to be able to get run by an
+# executor. This class just extends QueueContext by adding dependencies for resources.
+RUN_DEPS = QUEUE_DEPS | {
+    DagTISlotsAvailableDep(),
+    PoolHasSpaceDep(),
+}
+
+# TODO(aoen): SCHEDULER_DEPS is not coupled to actual execution in any way and
+# could easily be modified or removed from the scheduler causing this dependency to become
+# outdated and incorrect. This coupling should be created (e.g. via a dag_deps analog of
+# ti_deps that will be used in the scheduler code) to ensure that the logic here is
+# equivalent to the logic in the scheduler.
+
+# Dependencies that need to be met for a given task instance to get scheduled by the
+# scheduler, then queued by the scheduler, then run by an executor.
+SCHEDULER_DEPS = RUN_DEPS | {
+    DagrunRunningDep(),
+    DagUnpausedDep(),
+    ExecDateAfterStartDateDep(),
+}

--- a/airflow/ti_deps/deps/__init__.py
+++ b/airflow/ti_deps/deps/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/airflow/ti_deps/deps/base_ti_dep.py
+++ b/airflow/ti_deps/deps/base_ti_dep.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import namedtuple
+
+from airflow.utils.db import provide_session
+
+
+class BaseTIDep(object):
+    """
+    Abstract base class for dependencies that must be satisfied in order for task
+    instances to run. For example, a task that can only run if a certain number of its
+    upstream tasks succeed. This is an abstract class and must be subclassed to be used.
+    """
+
+    # If this dependency can be ignored by a context in which it is added to. Needed
+    # because some dependencies should never be ignoreable in their contexts.
+    IGNOREABLE = False
+
+    # Whether this dependency is not a global task instance dependency but specific
+    # to some tasks (e.g. depends_on_past is not specified by all tasks).
+    IS_TASK_DEP = False
+
+    def __init__(self):
+        pass
+
+    def __eq__(self, other):
+        return type(self) == type(other)
+
+    def __hash__(self):
+        return hash(type(self))
+
+    def __repr__(self):
+        return "<TIDep({self.name})>".format(self=self)
+
+    @property
+    def name(self):
+        """
+        The human-readable name for the dependency. Use the classname as the default name
+        if this method is not overridden in the subclass.
+        """
+        return getattr(self, 'NAME', self.__class__.__name__)
+
+    def _get_dep_statuses(self, ti, session, dep_context):
+        """
+        Abstract method that returns an iterable of TIDepStatus objects that describe
+        whether the given task instance has this dependency met.
+
+        For example a subclass could return an iterable of TIDepStatus objects, each one
+        representing if each of the passed in task's upstream tasks succeeded or not.
+
+        :param ti: the task instance to get the dependency status for
+        :type ti: TaskInstance
+        :param session: database session
+        :type session: Session
+        :param dep_context: the context for which this dependency should be evaluated for
+        :type dep_context: DepContext
+        """
+        raise NotImplementedError
+
+    @provide_session
+    def get_dep_statuses(self, ti, session, dep_context):
+        """
+        Wrapper around the private _get_dep_statuses method that contains some global
+        checks for all dependencies.
+
+        :param ti: the task instance to get the dependency status for
+        :type ti: TaskInstance
+        :param session: database session
+        :type session: Session
+        :param dep_context: the context for which this dependency should be evaluated for
+        :type dep_context: DepContext
+        """
+        if self.IGNOREABLE and dep_context.ignore_all_deps:
+            yield self._passing_status(
+                reason="Context specified all dependencies should be ignored.")
+            raise StopIteration
+
+        if self.IS_TASK_DEP and dep_context.ignore_task_deps:
+            yield self._passing_status(
+                reason="Context specified all task dependencies should be ignored.")
+            raise StopIteration
+
+        for dep_status in self._get_dep_statuses(ti, session, dep_context):
+            yield dep_status
+
+    @provide_session
+    def is_met(self, ti, session, dep_context):
+        """
+        Returns whether or not this dependency is met for a given task instance. A
+        dependency is considered met if all of the dependency statuses it reports are
+        passing.
+
+        :param ti: the task instance to see if this dependency is met for
+        :type ti: TaskInstance
+        :param session: database session
+        :type session: Session
+        :param dep_context: The context this dependency is being checked under that stores
+            state that can be used by this dependency.
+        :type dep_context: BaseDepContext
+        """
+        return all(status.passed for status in
+                   self.get_dep_statuses(ti, session, dep_context))
+
+    @provide_session
+    def get_failure_reasons(self, ti, session, dep_context):
+        """
+        Returns an iterable of strings that explain why this dependency wasn't met.
+
+        :param ti: the task instance to see if this dependency is met for
+        :type ti: TaskInstance
+        :param session: database session
+        :type session: Session
+        :param dep_context: The context this dependency is being checked under that stores
+            state that can be used by this dependency.
+        :type dep_context: BaseDepContext
+        """
+        for dep_status in self.get_dep_statuses(ti, session, dep_context):
+            if not dep_status.passed:
+                yield dep_status.reason
+
+    def _failing_status(self, reason=''):
+        return TIDepStatus(self.name, False, reason)
+
+    def _passing_status(self, reason=''):
+        return TIDepStatus(self.name, True, reason)
+
+
+# Dependency status for a specific task instance indicating whether or not the task
+# instance passed the dependency.
+TIDepStatus = namedtuple('TIDepStatus', ['dep_name', 'passed', 'reason'])

--- a/airflow/ti_deps/deps/dag_ti_slots_available_dep.py
+++ b/airflow/ti_deps/deps/dag_ti_slots_available_dep.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils.db import provide_session
+
+
+class DagTISlotsAvailableDep(BaseTIDep):
+    NAME = "Task Instance Slots Available"
+    IGNOREABLE = True
+
+    @provide_session
+    def _get_dep_statuses(self, ti, session, dep_context):
+        if ti.task.dag.concurrency_reached:
+            yield self._failing_status(
+                reason="The maximum number of running tasks ({0}) for this task's DAG "
+                       "'{1}' has been reached.".format(ti.dag_id,
+                                                        ti.task.dag.concurrency))

--- a/airflow/ti_deps/deps/dag_unpaused_dep.py
+++ b/airflow/ti_deps/deps/dag_unpaused_dep.py
@@ -11,4 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils.db import provide_session
 
+
+class DagUnpausedDep(BaseTIDep):
+    NAME = "Dag Not Paused"
+    IGNOREABLE = True
+
+    @provide_session
+    def _get_dep_statuses(self, ti, session, dep_context):
+        if ti.task.dag.is_paused:
+            yield self._failing_status(
+                reason="Task's DAG '{0}' is paused.".format(ti.dag_id))

--- a/airflow/ti_deps/deps/dagrun_exists_dep.py
+++ b/airflow/ti_deps/deps/dagrun_exists_dep.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils.db import provide_session
+from airflow.utils.state import State
+
+
+class DagrunRunningDep(BaseTIDep):
+    NAME = "Dagrun Running"
+    IGNOREABLE = True
+
+    @provide_session
+    def _get_dep_statuses(self, ti, session, dep_context):
+        dag = ti.task.dag
+        dagrun = ti.get_dagrun(session)
+        if not dagrun:
+            # The import is needed here to avoid a circular dependency
+            from airflow.models import DagRun
+            running_dagruns = DagRun.find(
+                dag_id=dag.dag_id,
+                state=State.RUNNING,
+                external_trigger=False,
+                session=session
+            )
+
+            if len(running_dagruns) >= dag.max_active_runs:
+                reason = ("The maximum number of active dag runs ({0}) for this task "
+                          "instance's DAG '{1}' has been reached.".format(
+                              dag.max_active_runs,
+                              ti.dag_id))
+            else:
+                reason = "Unknown reason"
+            yield self._failing_status(
+                reason="Task instance's dagrun did not exist: {0}.".format(reason))
+        else:
+            if dagrun.state != State.RUNNING:
+                yield self._failing_status(
+                    reason="Task instance's dagrun was not in the 'running' state but in "
+                           "the state '{}'.".format(dagrun.state))

--- a/airflow/ti_deps/deps/exec_date_after_start_date_dep.py
+++ b/airflow/ti_deps/deps/exec_date_after_start_date_dep.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils.db import provide_session
+
+
+class ExecDateAfterStartDateDep(BaseTIDep):
+    NAME = "Execution Date"
+    IGNOREABLE = True
+
+    @provide_session
+    def _get_dep_statuses(self, ti, session, dep_context):
+        if ti.task.start_date and ti.execution_date < ti.task.start_date:
+            yield self._failing_status(
+                reason="The execution date is {0} but this is before the task's start "
+                "date {1}.".format(
+                    ti.execution_date.isoformat(),
+                    ti.task.start_date.isoformat()))
+
+        if (ti.task.dag and ti.task.dag.start_date and
+                ti.execution_date < ti.task.dag.start_date):
+            yield self._failing_status(
+                reason="The execution date is {0} but this is before the task's "
+                "DAG's start date {1}.".format(
+                    ti.execution_date.isoformat(),
+                    ti.task.dag.start_date.isoformat()))

--- a/airflow/ti_deps/deps/not_in_retry_period_dep.py
+++ b/airflow/ti_deps/deps/not_in_retry_period_dep.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import datetime
+
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils.db import provide_session
+from airflow.utils.state import State
+
+
+class NotInRetryPeriodDep(BaseTIDep):
+    NAME = "Not In Retry Period"
+    IGNOREABLE = True
+    IS_TASK_DEP = True
+
+    @provide_session
+    def _get_dep_statuses(self, ti, session, dep_context):
+        if ti.state != State.UP_FOR_RETRY:
+            yield self._passing_status(
+                reason="The task instance was not marked for retrying.")
+            raise StopIteration
+
+        # Calculate the date first so that it is always smaller than the timestamp used by
+        # ready_for_retry
+        cur_date = datetime.now()
+        next_task_retry_date = ti.next_retry_datetime()
+        if ti.is_premature:
+            yield self._failing_status(
+                reason="Task is not ready for retry yet but will be retried "
+                       "automatically. Current date is {0} and task will be retried "
+                       "at {1}.".format(cur_date.isoformat(),
+                                        next_task_retry_date.isoformat()))

--- a/airflow/ti_deps/deps/not_running_dep.py
+++ b/airflow/ti_deps/deps/not_running_dep.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils.db import provide_session
+from airflow.utils.state import State
+
+
+class NotRunningDep(BaseTIDep):
+    NAME = "Task Instance Not Already Running"
+
+    # Task instances must not already be running, as running two copies of the same
+    # task instance at the same time (AKA double-trigger) should be avoided at all
+    # costs, even if the context specifies that all dependencies should be ignored.
+    IGNOREABLE = False
+
+    @provide_session
+    def _get_dep_statuses(self, ti, session, dep_context):
+        if ti.state == State.RUNNING:
+            yield self._failing_status(
+                reason="Task is already running, it started on {0}.".format(
+                    ti.start_date))

--- a/airflow/ti_deps/deps/not_skipped_dep.py
+++ b/airflow/ti_deps/deps/not_skipped_dep.py
@@ -11,4 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils.db import provide_session
+from airflow.utils.state import State
 
+
+class NotSkippedDep(BaseTIDep):
+    NAME = "Task Instance Not Skipped"
+    IGNOREABLE = True
+
+    @provide_session
+    def _get_dep_statuses(self, ti, session, dep_context):
+        if ti.state == State.SKIPPED:
+            yield self._failing_status(reason="The task instance has been skipped.")

--- a/airflow/ti_deps/deps/pool_has_space_dep.py
+++ b/airflow/ti_deps/deps/pool_has_space_dep.py
@@ -11,4 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils.db import provide_session
 
+
+class PoolHasSpaceDep(BaseTIDep):
+    NAME = "DAG's Pool Has Space"
+    IGNOREABLE = True
+
+    @provide_session
+    def _get_dep_statuses(self, ti, session, dep_context):
+        if ti.pool_full():
+            yield self._failing_status(
+                reason="Task's pool '{0}' is full.".format(ti.pool))

--- a/airflow/ti_deps/deps/prev_dagrun_dep.py
+++ b/airflow/ti_deps/deps/prev_dagrun_dep.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils.db import provide_session
+from airflow.utils.state import State
+
+
+class PrevDagrunDep(BaseTIDep):
+    """
+    Is the past dagrun in a state that allows this task instance to run, e.g. did this
+    task instance's task in the previous dagrun complete if we are depending on past.
+    """
+    NAME = "Previous Dagrun State"
+    IGNOREABLE = True
+    IS_TASK_DEP = True
+
+    @provide_session
+    def _get_dep_statuses(self, ti, session, dep_context):
+        if dep_context.ignore_depends_on_past:
+            yield self._passing_status(
+                reason="The context specified that the state of past DAGs could be "
+                       "ignored.")
+            raise StopIteration
+
+        if not ti.task.depends_on_past:
+            yield self._passing_status(
+                reason="The task did not have depends_on_past set.")
+            raise StopIteration
+
+        # Don't depend on the previous task instance if we are the first task
+        if ti.execution_date == ti.task.start_date:
+            yield self._passing_status(
+                reason="This task instance was the first task instance for it's task.")
+            raise StopIteration
+
+        previous_ti = ti.previous_ti
+        if not previous_ti:
+            yield self._failing_status(
+                reason="depends_on_past is true for this task's DAG, but the previous "
+                       "task instance has not run yet.")
+            raise StopIteration
+
+        if previous_ti.state not in {State.SKIPPED, State.SUCCESS}:
+            yield self._failing_status(
+                reason="depends_on_past is true for this task, but the previous task "
+                       "instance {0} is in the state '{1}' which is not a successful "
+                       "state.".format(previous_ti, previous_ti.state))
+
+        previous_ti.task = ti.task
+        if (ti.task.wait_for_downstream and
+                not previous_ti.are_dependents_done(session=session)):
+            yield self._failing_status(
+                reason="The tasks downstream of the previous task instance {0} haven't "
+                       "completed.".format(previous_ti))

--- a/airflow/ti_deps/deps/runnable_exec_date_dep.py
+++ b/airflow/ti_deps/deps/runnable_exec_date_dep.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import datetime
+
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils.db import provide_session
+
+
+class RunnableExecDateDep(BaseTIDep):
+    NAME = "Execution Date"
+    IGNOREABLE = True
+
+    @provide_session
+    def _get_dep_statuses(self, ti, session, dep_context):
+        cur_date = datetime.now()
+
+        if ti.execution_date > cur_date:
+            yield self._failing_status(
+                reason="Execution date {0} is in the future (the current "
+                       "date is {1}).".format(ti.execution_date.isoformat(),
+                                              cur_date.isoformat()))
+
+        if ti.task.end_date and ti.execution_date > ti.task.end_date:
+            yield self._failing_status(
+                reason="The execution date is {0} but this is after the task's end date "
+                "{1}.".format(
+                    ti.execution_date.isoformat(),
+                    ti.task.end_date.isoformat()))
+
+        if (ti.task.dag and
+                ti.task.dag.end_date and
+                ti.execution_date > ti.task.dag.end_date):
+            yield self._failing_status(
+                reason="The execution date is {0} but this is after the task's DAG's "
+                "end date {1}.".format(
+                    ti.execution_date.isoformat(),
+                    ti.task.dag.end_date.isoformat()))

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from sqlalchemy import case, func
+
+import airflow
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils.db import provide_session
+from airflow.utils.state import State
+
+
+class TriggerRuleDep(BaseTIDep):
+    """
+    Determines if a task's upstream tasks are in a state that allows a given task instance
+    to run.
+    """
+    NAME = "Trigger Rule"
+    IGNOREABLE = True
+    IS_TASK_DEP = True
+
+    @provide_session
+    def _get_dep_statuses(self, ti, session, dep_context):
+        TI = airflow.models.TaskInstance
+        TR = airflow.models.TriggerRule
+
+        # Checking that all upstream dependencies have succeeded
+        if not ti.task.upstream_list:
+            yield self._passing_status(
+                reason="The task instance did not have any upstream tasks.")
+            raise StopIteration
+
+        if ti.task.trigger_rule == TR.DUMMY:
+            yield self._passing_status(reason="The task had a dummy trigger rule set.")
+            raise StopIteration
+
+        # TODO(unknown): this query becomes quite expensive with dags that have many
+        # tasks. It should be refactored to let the task report to the dag run and get the
+        # aggregates from there.
+        qry = (
+            session
+            .query(
+                func.coalesce(func.sum(
+                    case([(TI.state == State.SUCCESS, 1)], else_=0)), 0),
+                func.coalesce(func.sum(
+                    case([(TI.state == State.SKIPPED, 1)], else_=0)), 0),
+                func.coalesce(func.sum(
+                    case([(TI.state == State.FAILED, 1)], else_=0)), 0),
+                func.coalesce(func.sum(
+                    case([(TI.state == State.UPSTREAM_FAILED, 1)], else_=0)), 0),
+                func.count(TI.task_id),
+            )
+            .filter(
+                TI.dag_id == ti.dag_id,
+                TI.task_id.in_(ti.task.upstream_task_ids),
+                TI.execution_date == ti.execution_date,
+                TI.state.in_([
+                    State.SUCCESS, State.FAILED,
+                    State.UPSTREAM_FAILED, State.SKIPPED]),
+            )
+        )
+
+        successes, skipped, failed, upstream_failed, done = qry.first()
+        for dep_status in self._evaluate_trigger_rule(
+                ti=ti,
+                successes=successes,
+                skipped=skipped,
+                failed=failed,
+                upstream_failed=upstream_failed,
+                done=done,
+                flag_upstream_failed=dep_context.flag_upstream_failed,
+                session=session):
+            yield dep_status
+
+    @provide_session
+    def _evaluate_trigger_rule(
+            self,
+            ti,
+            successes,
+            skipped,
+            failed,
+            upstream_failed,
+            done,
+            flag_upstream_failed,
+            session):
+        """
+        Yields a dependency status that indicate whether the given task instance's trigger
+        rule was met.
+
+        :param ti: the task instance to evaluate the trigger rule of
+        :type ti: TaskInstance
+        :param successes: Number of successful upstream tasks
+        :type successes: boolean
+        :param skipped: Number of skipped upstream tasks
+        :type skipped: boolean
+        :param failed: Number of failed upstream tasks
+        :type failed: boolean
+        :param upstream_failed: Number of upstream_failed upstream tasks
+        :type upstream_failed: boolean
+        :param done: Number of completed upstream tasks
+        :type done: boolean
+        :param flag_upstream_failed: This is a hack to generate
+            the upstream_failed state creation while checking to see
+            whether the task instance is runnable. It was the shortest
+            path to add the feature
+        :type flag_upstream_failed: boolean
+        :param session: database session
+        :type session: Session
+        """
+
+        TR = airflow.models.TriggerRule
+
+        task = ti.task
+        upstream = len(task.upstream_task_ids)
+        tr = task.trigger_rule
+        upstream_done = done >= upstream
+
+        # TODO(aoen): Ideally each individual trigger rules would be it's own class, but
+        # this isn't very feasible at the moment since the database queries need to be
+        # bundled together for efficiency.
+        # handling instant state assignment based on trigger rules
+        if flag_upstream_failed:
+            if tr == TR.ALL_SUCCESS:
+                if upstream_failed or failed:
+                    ti.set_state(State.UPSTREAM_FAILED, session)
+                elif skipped:
+                    ti.set_state(State.SKIPPED, session)
+            elif tr == TR.ALL_FAILED:
+                if successes or skipped:
+                    ti.set_state(State.SKIPPED, session)
+            elif tr == TR.ONE_SUCCESS:
+                if upstream_done and not successes:
+                    ti.set_state(State.SKIPPED, session)
+            elif tr == TR.ONE_FAILED:
+                if upstream_done and not (failed or upstream_failed):
+                    ti.set_state(State.SKIPPED, session)
+
+        if tr == TR.ONE_SUCCESS:
+            if successes <= 0:
+                yield self._failing_status(
+                    reason="Task's trigger rule '{0}' requires one upstream task "
+                           "success, but none were found.".format(tr))
+        elif tr == TR.ONE_FAILED:
+            if not failed and not upstream_failed:
+                yield self._failing_status(
+                    reason="Task's trigger rule '{0}' requires one upstream task failure "
+                           ", but none were found.".format(tr))
+        elif tr == TR.ALL_SUCCESS:
+            num_failures = upstream - successes
+            if num_failures > 0:
+                yield self._failing_status(
+                    reason="Task's trigger rule '{0}' requires all upstream tasks to "
+                           "have succeeded, but found {1} non-success(es)."
+                           .format(tr, num_failures))
+        elif tr == TR.ALL_FAILED:
+            num_successes = upstream - failed - upstream_failed
+            if num_successes > 0:
+                yield self._failing_status(
+                    reason="Task's trigger rule '{0}' requires all upstream tasks to "
+                           "have failed, but found {1} non-faliure(s)."
+                           .format(tr, num_successes))
+        elif tr == TR.ALL_DONE:
+            if not upstream_done:
+                yield self._failing_status(
+                    reason="Task's trigger rule '{0}' requires all upstream tasks to "
+                           "have completed, but found '{1}' task(s) that weren't done."
+                           .format(tr, upstream - done))
+        else:
+            yield self._failing_status(
+                reason="No strategy to evaluate trigger rule '{0}'.".format(tr))

--- a/airflow/ti_deps/deps/valid_state_dep.py
+++ b/airflow/ti_deps/deps/valid_state_dep.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from airflow.exceptions import AirflowException
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils.db import provide_session
+
+
+class ValidStateDep(BaseTIDep):
+    NAME = "Task Instance State"
+    IGNOREABLE = True
+
+    """
+    Ensures that the task instance's state is in a given set of valid states.
+
+    :param valid_states: A list of valid states that a task instance can have to meet
+        this dependency.
+    :type valid_states: set(str)
+    :return: whether or not the task instance's state is valid
+    """
+    def __init__(self, valid_states):
+        super(ValidStateDep, self).__init__()
+
+        if not valid_states:
+            raise AirflowException(
+                'ValidStatesDep received an empty set of valid states.')
+        self._valid_states = valid_states
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self._valid_states == other._valid_states
+
+    def __hash__(self):
+        return hash((type(self), tuple(self._valid_states)))
+
+    @provide_session
+    def _get_dep_statuses(self, ti, session, dep_context):
+        if dep_context.ignore_ti_state:
+            yield self._passing_status(
+                reason="Context specified that state should be ignored.")
+            raise StopIteration
+
+        if ti.state in self._valid_states:
+            yield self._passing_status(reason="Task state {} was valid.".format(ti.state))
+            raise StopIteration
+
+        yield self._failing_status(
+            reason="Task is in the '{0}' state which is not a valid state for "
+                   "execution. The task must be cleared in order to be run.".format(
+                       ti.state))

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -85,18 +85,6 @@ class State(object):
             return 'black'
 
     @classmethod
-    def runnable(cls):
-        return [
-            cls.NONE,
-            cls.FAILED,
-            cls.UP_FOR_RETRY,
-            cls.UPSTREAM_FAILED,
-            cls.SKIPPED,
-            cls.QUEUED,
-            cls.SCHEDULED
-        ]
-
-    @classmethod
     def finished(cls):
         """
         A list of states indicating that a task started and completed a

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -125,7 +125,7 @@
               <hr/>
           </div>
           <button id="btn_task" type="button" class="btn btn-primary">
-            Task Details
+            Task Instance Details
           </button>
           <button id="btn_rendered" type="button" class="btn btn-primary">
             Rendered
@@ -142,14 +142,21 @@
             Run
           </button>
           <span class="btn-group">
-            <button id="btn_force"
+            <button id="btn_ignore_all_deps"
               type="button" class="btn" data-toggle="button"
-              title="Ignore previous success, re-run regardless"
-              >Force</button>
-            <button id="btn_deps"
+              title="Ignores all non-critical dependencies, including task state and task_deps"
+              >Ignore All Deps</button>
+          </span>
+          <span class="btn-group">
+            <button id="btn_ignore_ti_state"
               type="button" class="btn" data-toggle="button"
-              tittle="Disregard the status of upstream dependencies and depends_on_past"
-              >Ignore Dependencies</button>
+              title="Ignore previous success/failure"
+              >Ignore Task State</button>
+          </span>
+          <button id="btn_ignore_task_deps"
+            type="button" class="btn" data-toggle="button"
+            title="Disregard the task-specific dependencies, e.g. status of upstream task instances and depends_on_past"
+            >Ignore Task Deps</button>
           </span>
           <hr/>
           <button id="btn_clear" type="button" class="btn btn-primary"
@@ -300,8 +307,9 @@ function updateQueryStringParameter(uri, key, value) {
       url = "{{ url_for('airflow.run') }}" +
         "?task_id=" + encodeURIComponent(task_id) +
         "&dag_id=" + encodeURIComponent(dag_id) +
-        "&force=" + $('#btn_force').hasClass('active') +
-        "&deps=" + $('#btn_deps').hasClass('active') +
+        "&ignore_all_deps=" + $('#btn_ignore_all_deps').hasClass('active') +
+        "&ignore_task_deps=" + $('#btn_ignore_task_deps').hasClass('active') +
+        "&ignore_ti_state=" + $('#btn_ignore_ti_state').hasClass('active') +
         "&execution_date=" + execution_date +
         "&origin=" + encodeURIComponent(window.location);
       window.location = url;

--- a/airflow/www/templates/airflow/task.html
+++ b/airflow/www/templates/airflow/task.html
@@ -22,6 +22,24 @@
     {{ super() }}
     <h4>{{ title }}</h4>
     <div>
+        <h5>Dependencies Blocking Task From Getting Scheduled</h5>
+        <table class="table table-striped table-bordered">
+            <tr>
+                <th>Dependency</th>
+                <th>Reason</th>
+            </tr>
+            {% for dependency, reason in failed_dep_reasons %}
+                <tr>
+                    <td>{{ dependency }}</td>
+                    {% autoescape false %}
+                    <td class='code'>{{ reason }}</td>
+                    {% endautoescape %}
+                </tr>
+            {% endfor %}
+        </table>
+        {{ html_code|safe }}
+    </div>
+    <div>
         {% for attr, value in special_attrs_rendered.items() %}
             <h5>Attribute: {{ attr }}</h5>
             {{ value|safe }}

--- a/airflow/www/templates/airflow/task_instance.html
+++ b/airflow/www/templates/airflow/task_instance.html
@@ -39,7 +39,7 @@
   <ul class="nav nav-pills">
     <li><a href="{{ url_for("airflow.task", dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date) }}">
         <span class="glyphicon glyphicon-certificate" aria-hidden="true"></span>
-      Task Details</a></li>
+      Task Instance Details</a></li>
     <li><a href="{{ url_for("airflow.rendered", dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date) }}">
         <span class="glyphicon glyphicon-certificate" aria-hidden="true"></span>
       Rendered Template</a></li>

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -29,7 +29,7 @@ Here are some of the common causes:
   needs to have succeeded (except if it is the first run for that task).
   Also, if ``wait_for_downstream=True``, make sure you understand
   what it means.
-  You can view how these properties are set from the ``Task Details``
+  You can view how these properties are set from the ``Task Instance Details``
   page for your task.
 
 - Are the DagRuns you need created and active? A DagRun represents a specific

--- a/tests/contrib/operators/fs_operator.py
+++ b/tests/contrib/operators/fs_operator.py
@@ -58,7 +58,7 @@ class FileSensorTest(unittest.TestCase):
             _hook=self.hook,
             dag=self.dag,
         )
-        task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+        task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/contrib/operators/ssh_execute_operator.py
+++ b/tests/contrib/operators/ssh_execute_operator.py
@@ -59,7 +59,7 @@ class SSHExecuteOperatorTest(unittest.TestCase):
             ssh_hook=self.hook,
             dag=self.dag,
         )
-        task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+        task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     def test_with_env(self):
         task = SSHExecuteOperator(
@@ -69,7 +69,7 @@ class SSHExecuteOperatorTest(unittest.TestCase):
             env={"AIRFLOW_test": "test"},
             dag=self.dag,
         )
-        task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+        task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
 
 if __name__ == '__main__':

--- a/tests/dags/test_issue_1225.py
+++ b/tests/dags/test_issue_1225.py
@@ -39,7 +39,7 @@ def delayed_fail():
     """
     Delayed failure to make sure that processes are running before the error
     is raised.
-    
+
     TODO handle more directly (without sleeping)
     """
     time.sleep(5)
@@ -129,17 +129,3 @@ dag7_subdag1 = SubDagOperator(
     subdag=subdag7)
 subdag7_task1.set_downstream(subdag7_task2)
 subdag7_task2.set_downstream(subdag7_task3)
-
-# DAG tests that queued tasks are run
-dag8 = DAG(
-    dag_id='test_scheduled_queued_tasks',
-    start_date=DEFAULT_DATE,
-    end_date=DEFAULT_DATE,
-    default_args=default_args)
-dag8_task1 = PythonOperator(
-    # use delayed_fail because otherwise LocalExecutor will have a chance to
-    # complete the task
-    python_callable=delayed_fail,
-    task_id='test_queued_task',
-    dag=dag8,
-    pool='test_queued_pool')

--- a/tests/dags/test_scheduler_dags.py
+++ b/tests/dags/test_scheduler_dags.py
@@ -22,7 +22,7 @@ DEFAULT_DATE = datetime(2100, 1, 1)
 # Previously backfill would queue the task but never run it
 dag1 = DAG(
     dag_id='test_start_date_scheduling',
-    start_date=DEFAULT_DATE)
+    start_date=datetime(2100, 1, 1))
 dag1_task1 = DummyOperator(
     task_id='dummy',
     dag=dag1,

--- a/tests/models.py
+++ b/tests/models.py
@@ -22,7 +22,7 @@ import os
 import unittest
 import time
 
-from airflow import models, AirflowException
+from airflow import models, settings, AirflowException
 from airflow.exceptions import AirflowSkipException
 from airflow.models import DAG, TaskInstance as TI
 from airflow.models import State as ST
@@ -30,6 +30,7 @@ from airflow.models import DagModel
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
+from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.utils.state import State
 from mock import patch
 from nose_parameterized import parameterized
@@ -288,11 +289,15 @@ class TaskInstanceTest(unittest.TestCase):
         dag >> op5
         self.assertIs(op5.dag, dag)
 
-    def test_run_pooling_task(self):
+    @patch.object(TI, 'pool_full')
+    def test_run_pooling_task(self, mock_pool_full):
         """
         test that running task with mark_success param update task state as
         SUCCESS without running task.
         """
+        # Mock the pool out with a full pool because the pool doesn't actually exist
+        mock_pool_full.return_value = True
+
         dag = models.DAG(dag_id='test_run_pooling_task')
         task = DummyOperator(task_id='test_run_pooling_task_op', dag=dag,
                              pool='test_run_pooling_task_pool', owner='airflow',
@@ -302,11 +307,15 @@ class TaskInstanceTest(unittest.TestCase):
         ti.run()
         self.assertEqual(ti.state, models.State.QUEUED)
 
-    def test_run_pooling_task_with_mark_success(self):
+    @patch.object(TI, 'pool_full')
+    def test_run_pooling_task_with_mark_success(self, mock_pool_full):
         """
         test that running task with mark_success param update task state as SUCCESS
         without running task.
         """
+        # Mock the pool out with a full pool because the pool doesn't actually exist
+        mock_pool_full.return_value = True
+
         dag = models.DAG(dag_id='test_run_pooling_task_with_mark_success')
         task = DummyOperator(
             task_id='test_run_pooling_task_with_mark_success_op',
@@ -339,7 +348,6 @@ class TaskInstanceTest(unittest.TestCase):
             task=task, execution_date=datetime.datetime.now())
         ti.run()
         self.assertTrue(ti.state == models.State.SKIPPED)
-
 
     def test_retry_delay(self):
         """
@@ -378,10 +386,14 @@ class TaskInstanceTest(unittest.TestCase):
         run_with_error(ti)
         self.assertEqual(ti.state, State.FAILED)
 
-    def test_retry_handling(self):
+    @patch.object(TI, 'pool_full')
+    def test_retry_handling(self, mock_pool_full):
         """
         Test that task retries are handled properly
         """
+        # Mock the pool with a pool with slots open since the pool doesn't actually exist
+        mock_pool_full.return_value = False
+
         dag = models.DAG(dag_id='test_retry_handling')
         task = BashOperator(
             task_id='test_retry_handling_op',
@@ -410,6 +422,10 @@ class TaskInstanceTest(unittest.TestCase):
         run_with_error(ti)
         self.assertEqual(ti.state, State.FAILED)
         self.assertEqual(ti.try_number, 2)
+
+        # Clear the TI state since you can't run a task with a FAILED state without
+        # clearing it first
+        ti.set_state(None, settings.Session())
 
         # third run -- up for retry
         run_with_error(ti)
@@ -534,10 +550,15 @@ class TaskInstanceTest(unittest.TestCase):
         run_date = task.start_date + datetime.timedelta(days=5)
 
         ti = TI(downstream, run_date)
-        completed = ti.evaluate_trigger_rule(
-            successes=successes, skipped=skipped, failed=failed,
-            upstream_failed=upstream_failed, done=done,
+        dep_results = TriggerRuleDep()._evaluate_trigger_rule(
+            ti=ti,
+            successes=successes,
+            skipped=skipped,
+            failed=failed,
+            upstream_failed=upstream_failed,
+            done=done,
             flag_upstream_failed=flag_upstream_failed)
+        completed = all([dep.passed for dep in dep_results])
 
         self.assertEqual(completed, expect_completed)
         self.assertEqual(ti.state, expect_state)

--- a/tests/operators/hive_operator.py
+++ b/tests/operators/hive_operator.py
@@ -94,7 +94,7 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
             import airflow.operators.hive_operator
             t = operators.hive_operator.HiveOperator(
                 task_id='basic_hql', hql=self.hql, dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         def test_hive_queues(self):
             import airflow.operators.hive_operator
@@ -103,7 +103,7 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
                 mapred_queue='default', mapred_queue_priority='HIGH',
                 mapred_job_name='airflow.test_hive_queues',
                 dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
 
         def test_hive_dryrun(self):
@@ -117,7 +117,7 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
             t = operators.hive_operator.HiveOperator(
                 task_id='beeline_hql', hive_cli_conn_id='beeline_default',
                 hql=self.hql, dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         def test_presto(self):
             sql = """
@@ -126,7 +126,7 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
             import airflow.operators.presto_check_operator
             t = operators.presto_check_operator.PrestoCheckOperator(
                 task_id='presto_check', sql=sql, dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         def test_presto_to_mysql(self):
             import airflow.operators.presto_to_mysql
@@ -140,14 +140,14 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
                 mysql_table='test_static_babynames',
                 mysql_preoperator='TRUNCATE TABLE test_static_babynames;',
                 dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         def test_hdfs_sensor(self):
             t = operators.sensors.HdfsSensor(
                 task_id='hdfs_sensor_check',
                 filepath='hdfs://user/hive/warehouse/airflow.db/static_babynames',
                 dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         def test_webhdfs_sensor(self):
             t = operators.sensors.WebHdfsSensor(
@@ -155,7 +155,7 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
                 filepath='hdfs://user/hive/warehouse/airflow.db/static_babynames',
                 timeout=120,
                 dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         def test_sql_sensor(self):
             t = operators.sensors.SqlSensor(
@@ -163,7 +163,7 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
                 conn_id='presto_default',
                 sql="SELECT 'x' FROM airflow.static_babynames LIMIT 1;",
                 dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         def test_hive_stats(self):
             import airflow.operators.hive_stats_operator
@@ -172,14 +172,14 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
                 table="airflow.static_babynames_partitioned",
                 partition={'ds': DEFAULT_DATE_DS},
                 dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         def test_named_hive_partition_sensor(self):
             t = operators.sensors.NamedHivePartitionSensor(
                 task_id='hive_partition_check',
                 partition_names=["airflow.static_babynames_partitioned/ds={{ds}}"],
                 dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         def test_named_hive_partition_sensor_succeeds_on_multiple_partitions(self):
             t = operators.sensors.NamedHivePartitionSensor(
@@ -189,7 +189,7 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
                     "airflow.static_babynames_partitioned/ds={{ds}}"
                 ],
                 dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         @nose.tools.raises(airflow.exceptions.AirflowSensorTimeout)
         def test_named_hive_partition_sensor_times_out_on_nonexistent_partition(self):
@@ -202,14 +202,14 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
                 poke_interval=0.1,
                 timeout=1,
                 dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         def test_hive_partition_sensor(self):
             t = operators.sensors.HivePartitionSensor(
                 task_id='hive_partition_check',
                 table='airflow.static_babynames_partitioned',
                 dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         def test_hive_metastore_sql_sensor(self):
             t = operators.sensors.MetastorePartitionSensor(
@@ -217,7 +217,7 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
                 table='airflow.static_babynames_partitioned',
                 partition_name='ds={}'.format(DEFAULT_DATE_DS),
                 dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         def test_hive2samba(self):
             import airflow.operators.hive_to_samba_operator
@@ -227,7 +227,7 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
                 hql="SELECT * FROM airflow.static_babynames LIMIT 10000",
                 destination_filepath='test_airflow.csv',
                 dag=self.dag)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         def test_hive_to_mysql(self):
             import airflow.operators.hive_to_mysql
@@ -247,4 +247,4 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
                 ],
                 dag=self.dag)
             t.clear(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)

--- a/tests/operators/operators.py
+++ b/tests/operators/operators.py
@@ -57,7 +57,7 @@ class MySqlTest(unittest.TestCase):
             sql=sql,
             mysql_conn_id='airflow_db',
             dag=self.dag)
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     def mysql_operator_test_multi(self):
         sql = [
@@ -69,7 +69,7 @@ class MySqlTest(unittest.TestCase):
             task_id='mysql_operator_test_multi',
             mysql_conn_id='airflow_db',
             sql=sql, dag=self.dag)
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     def test_mysql_to_mysql(self):
         sql = "SELECT * FROM INFORMATION_SCHEMA.TABLES LIMIT 100;"
@@ -86,7 +86,7 @@ class MySqlTest(unittest.TestCase):
             destination_table="test_mysql_to_mysql",
             sql=sql,
             dag=self.dag)
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     def test_sql_sensor(self):
         t = operators.sensors.SqlSensor(
@@ -94,7 +94,7 @@ class MySqlTest(unittest.TestCase):
             conn_id='mysql_default',
             sql="SELECT count(1) FROM INFORMATION_SCHEMA.TABLES",
             dag=self.dag)
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
 @skipUnlessImported('airflow.operators.postgres_operator', 'PostgresOperator')
 class PostgresTest(unittest.TestCase):
@@ -113,7 +113,7 @@ class PostgresTest(unittest.TestCase):
         import airflow.operators.postgres_operator
         t = operators.postgres_operator.PostgresOperator(
             task_id='basic_postgres', sql=sql, dag=self.dag)
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
         autocommitTask = operators.postgres_operator.PostgresOperator(
             task_id='basic_postgres_with_autocommit',
@@ -123,7 +123,7 @@ class PostgresTest(unittest.TestCase):
         autocommitTask.run(
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE,
-            force=True)
+            ignore_ti_state=True)
 
     def postgres_operator_test_multi(self):
         sql = [
@@ -133,7 +133,7 @@ class PostgresTest(unittest.TestCase):
         import airflow.operators.postgres_operator
         t = operators.postgres_operator.PostgresOperator(
             task_id='postgres_operator_test_multi', sql=sql, dag=self.dag)
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     def test_postgres_to_postgres(self):
         sql = "SELECT * FROM INFORMATION_SCHEMA.TABLES LIMIT 100;"
@@ -150,7 +150,7 @@ class PostgresTest(unittest.TestCase):
             destination_table="test_postgres_to_postgres",
             sql=sql,
             dag=self.dag)
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     def test_sql_sensor(self):
         t = operators.sensors.SqlSensor(
@@ -158,7 +158,7 @@ class PostgresTest(unittest.TestCase):
             conn_id='postgres_default',
             sql="SELECT count(1) FROM INFORMATION_SCHEMA.TABLES",
             dag=self.dag)
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
 @skipUnlessImported('airflow.operators.hive_operator', 'HiveOperator')
 @skipUnlessImported('airflow.operators.postgres_operator', 'PostgresOperator')
@@ -189,7 +189,7 @@ class TransferTests(unittest.TestCase):
             recreate=True,
             delimiter=",",
             dag=self.dag)
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     def test_mysql_to_hive_partition(self):
         from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
@@ -205,4 +205,4 @@ class TransferTests(unittest.TestCase):
             create=True,
             delimiter=",",
             dag=self.dag)
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)

--- a/tests/operators/sensors.py
+++ b/tests/operators/sensors.py
@@ -89,7 +89,7 @@ class SensorTimeoutTest(unittest.TestCase):
         self.assertRaises(
             AirflowSensorTimeout,
             t.run,
-            start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, force=True)
+            start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
 
 class HttpSensorTests(unittest.TestCase):

--- a/tests/test_utils/README.md
+++ b/tests/test_utils/README.md
@@ -1,0 +1,1 @@
+Utilities for use in tests.

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tests/test_utils/fake_datetime.py
+++ b/tests/test_utils/fake_datetime.py
@@ -12,3 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
+
+
+class FakeDatetime(datetime):
+    """
+    A fake replacement for datetime that can be mocked for testing.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        return date.__new__(datetime, *args, **kwargs)

--- a/tests/ti_deps/__init__.py
+++ b/tests/ti_deps/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tests/ti_deps/contexts/__init__.py
+++ b/tests/ti_deps/contexts/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tests/ti_deps/deps/__init__.py
+++ b/tests/ti_deps/deps/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tests/ti_deps/deps/dag_ti_slots_available_dep.py
+++ b/tests/ti_deps/deps/dag_ti_slots_available_dep.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from airflow.ti_deps.deps.dag_ti_slots_available_dep import DagTISlotsAvailableDep
+from fake_models import FakeDag, FakeTask, FakeTI
+
+
+class DagTISlotsAvailableDepTest(unittest.TestCase):
+
+    def test_concurrency_reached(self):
+        """
+        Test concurrency reached should fail dep
+        """
+        dag = FakeDag(concurrency=1, concurrency_reached=True)
+        task = FakeTask(dag=dag)
+        ti = FakeTI(task=task, dag_id="fake_dag")
+
+        self.assertFalse(DagTISlotsAvailableDep().is_met(ti=ti, dep_context=None))
+
+    def test_all_conditions_met(self):
+        """
+        Test all conditions met should pass dep
+        """
+        dag = FakeDag(concurrency=1, concurrency_reached=False)
+        task = FakeTask(dag=dag)
+        ti = FakeTI(task=task, dag_id="fake_dag")
+
+        self.assertTrue(DagTISlotsAvailableDep().is_met(ti=ti, dep_context=None))

--- a/tests/ti_deps/deps/dag_unpaused_dep.py
+++ b/tests/ti_deps/deps/dag_unpaused_dep.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from airflow.ti_deps.deps.dag_unpaused_dep import DagUnpausedDep
+from fake_models import FakeDag, FakeTask, FakeTI
+
+
+class DagUnpausedDepTest(unittest.TestCase):
+
+    def test_concurrency_reached(self):
+        """
+        Test paused DAG should fail dependency
+        """
+        dag = FakeDag(is_paused=True)
+        task = FakeTask(dag=dag)
+        ti = FakeTI(task=task, dag_id="fake_dag")
+
+        self.assertFalse(DagUnpausedDep().is_met(ti=ti, dep_context=None))
+
+    def test_all_conditions_met(self):
+        """
+        Test all conditions met should pass dep
+        """
+        dag = FakeDag(is_paused=False)
+        task = FakeTask(dag=dag)
+        ti = FakeTI(task=task, dag_id="fake_dag")
+
+        self.assertTrue(DagUnpausedDep().is_met(ti=ti, dep_context=None))

--- a/tests/ti_deps/deps/dagrun_exists_dep.py
+++ b/tests/ti_deps/deps/dagrun_exists_dep.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from airflow.ti_deps.deps.dagrun_exists_dep import DagrunRunningDep
+from fake_models import FakeDag, FakeTask, FakeTI
+
+
+class DagrunRunningDepTest(unittest.TestCase):
+
+    def test_dagrun_doesnt_exist(self):
+        """
+        Task instances without dagruns should fail this dep
+        """
+        dag = FakeDag(running_dagruns=[], max_active_runs=1)
+        task = FakeTask(dag=dag)
+        ti = FakeTI(dagrun=None, task=task, dag_id="fake_dag")
+
+        self.assertFalse(DagrunRunningDep().is_met(ti=ti, dep_context=None))
+
+    def test_dagrun_exists(self):
+        """
+        Task instances with a dagrun should pass this dep
+        """
+        dag = FakeDag(running_dagruns=[], max_active_runs=1)
+        task = FakeTask(dag=dag)
+        ti = FakeTI(dagrun="Fake Dagrun", task=task, dag_id="fake_dag")
+
+        self.assertTrue(DagrunRunningDep().is_met(ti=ti, dep_context=None))

--- a/tests/ti_deps/deps/fake_models.py
+++ b/tests/ti_deps/deps/fake_models.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A collection of fake models used for unit testing
+
+
+class FakeTI(object):
+
+    def __init__(self, **kwds):
+        self.__dict__.update(kwds)
+
+    def pool_full(self):
+        # Allow users of this fake to set pool_filled in the contructor to make this
+        # return True
+        try:
+            return self.pool_filled
+        except AttributeError:
+            # If pool_filled was not set default to false
+            return False
+
+    def get_dagrun(self, _):
+        return self.dagrun
+
+    def are_dependents_done(self, session):
+        return self.dependents_done
+
+
+class FakeTask(object):
+
+    def __init__(self, **kwds):
+        self.__dict__.update(kwds)
+
+
+class FakeDag(object):
+
+    def __init__(self, **kwds):
+        self.__dict__.update(kwds)
+
+    def get_running_dagruns(self, _):
+        return self.running_dagruns
+
+
+class FakeContext(object):
+
+    def __init__(self, **kwds):
+        self.__dict__.update(kwds)

--- a/tests/ti_deps/deps/not_in_retry_period_dep.py
+++ b/tests/ti_deps/deps/not_in_retry_period_dep.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from datetime import datetime, timedelta
+
+from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
+from airflow.utils.state import State
+from fake_models import FakeDag, FakeTask, FakeTI
+
+
+class NotInRetryPeriodDepTest(unittest.TestCase):
+
+    def test_still_in_retry_period(self):
+        """
+        Task instances that are in their retry period should fail this dep
+        """
+        dag = FakeDag()
+        task = FakeTask(dag=dag, retry_delay=timedelta(minutes=1))
+        ti = FakeTI(
+            task=task,
+            state=State.UP_FOR_RETRY,
+            end_date=datetime(2016, 1, 1),
+            is_premature=True)
+
+        self.assertFalse(NotInRetryPeriodDep().is_met(ti=ti, dep_context=None))
+
+    def test_retry_period_finished(self):
+        """
+        Task instance's that have had their retry period elapse should pass this dep
+        """
+        dag = FakeDag()
+        task = FakeTask(dag=dag, retry_delay=timedelta(minutes=1))
+        ti = FakeTI(
+            task=task,
+            state=State.UP_FOR_RETRY,
+            end_date=datetime(2016, 1, 1),
+            is_premature=False)
+
+        self.assertTrue(NotInRetryPeriodDep().is_met(ti=ti, dep_context=None))
+
+    def test_not_in_retry_period(self):
+        """
+        Task instance's that are not up for retry can not be in their retry period
+        """
+        dag = FakeDag()
+        task = FakeTask(dag=dag)
+        ti = FakeTI(task=task, state=State.SUCCESS)
+
+        self.assertTrue(NotInRetryPeriodDep().is_met(ti=ti, dep_context=None))

--- a/tests/ti_deps/deps/not_running_dep.py
+++ b/tests/ti_deps/deps/not_running_dep.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from datetime import datetime
+
+from airflow.ti_deps.deps.not_running_dep import NotRunningDep
+from airflow.utils.state import State
+from fake_models import FakeTI
+
+
+class NotRunningDepTest(unittest.TestCase):
+
+    def test_ti_running(self):
+        """
+        Running task instances should fail this dep
+        """
+        ti = FakeTI(state=State.RUNNING, start_date=datetime(2016, 1, 1))
+
+        self.assertFalse(NotRunningDep().is_met(ti=ti, dep_context=None))
+
+    def test_ti_not_running(self):
+        """
+        Non-running task instances should pass this dep
+        """
+        ti = FakeTI(state=State.NONE, start_date=datetime(2016, 1, 1))
+
+        self.assertTrue(NotRunningDep().is_met(ti=ti, dep_context=None))

--- a/tests/ti_deps/deps/not_skipped_dep.py
+++ b/tests/ti_deps/deps/not_skipped_dep.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from airflow.ti_deps.deps.not_skipped_dep import NotSkippedDep
+from airflow.utils.state import State
+from fake_models import FakeTI
+
+
+class NotSkippedDepTest(unittest.TestCase):
+
+    def test_skipped(self):
+        """
+        Skipped task instances should fail this dep
+        """
+        ti = FakeTI(state=State.SKIPPED)
+
+        self.assertFalse(NotSkippedDep().is_met(ti=ti, dep_context=None))
+
+    def test_not_skipped(self):
+        """
+        Non-skipped task instances should pass this dep
+        """
+        ti = FakeTI(state=State.RUNNING)
+
+        self.assertTrue(NotSkippedDep().is_met(ti=ti, dep_context=None))

--- a/tests/ti_deps/deps/pool_has_space_dep.py
+++ b/tests/ti_deps/deps/pool_has_space_dep.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from airflow.ti_deps.deps.pool_has_space_dep import PoolHasSpaceDep
+from fake_models import FakeTI
+
+
+class PoolHasSpaceDepTest(unittest.TestCase):
+
+    def test_pool_full(self):
+        """
+        Full pools should fail this dep
+        """
+        ti = FakeTI(pool="fake_pool", pool_filled=True)
+
+        self.assertFalse(PoolHasSpaceDep().is_met(ti=ti, dep_context=None))
+
+    def test_not_skipped(self):
+        """
+        Pools with room should pass this dep
+        """
+        ti = FakeTI(pool="fake_pool", pool_filled=False)
+
+        self.assertTrue(PoolHasSpaceDep().is_met(ti=ti, dep_context=None))

--- a/tests/ti_deps/deps/prev_dagrun_dep.py
+++ b/tests/ti_deps/deps/prev_dagrun_dep.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from datetime import datetime
+
+from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
+from airflow.utils.state import State
+from fake_models import FakeContext, FakeTask, FakeTI
+
+
+class PrevDagrunDepTest(unittest.TestCase):
+
+    def test_not_depends_on_past(self):
+        """
+        If depends on past isn't set in the task then the previous dagrun should be
+        ignored, even though there is no previous_ti which would normally fail the dep
+        """
+        task = FakeTask(
+            depends_on_past=False,
+            start_date=datetime(2016, 1, 1),
+            wait_for_downstream=False)
+        prev_ti = FakeTI(
+            task=task,
+            execution_date=datetime(2016, 1, 2),
+            state=State.SUCCESS,
+            dependents_done=True)
+        ti = FakeTI(
+            task=task,
+            previous_ti=prev_ti,
+            execution_date=datetime(2016, 1, 3))
+        dep_context = FakeContext(ignore_depends_on_past=False)
+
+        self.assertTrue(PrevDagrunDep().is_met(ti=ti, dep_context=dep_context))
+
+    def test_context_ignore_depends_on_past(self):
+        """
+        If the context overrides depends_on_past then the dep should be met, even though
+        there is no previous_ti which would normally fail the dep
+        """
+        task = FakeTask(
+            depends_on_past=True,
+            start_date=datetime(2016, 1, 1),
+            wait_for_downstream=False)
+        prev_ti = FakeTI(
+            task=task,
+            execution_date=datetime(2016, 1, 2),
+            state=State.SUCCESS,
+            dependents_done=True)
+        ti = FakeTI(
+            task=task,
+            previous_ti=prev_ti,
+            execution_date=datetime(2016, 1, 3))
+        dep_context = FakeContext(ignore_depends_on_past=True)
+
+        self.assertTrue(PrevDagrunDep().is_met(ti=ti, dep_context=dep_context))
+
+    def test_first_task_run(self):
+        """
+        The first task run for a TI should pass since it has no previous dagrun.
+        """
+        task = FakeTask(
+            depends_on_past=True,
+            start_date=datetime(2016, 1, 1),
+            wait_for_downstream=False)
+        prev_ti = None
+        ti = FakeTI(
+            task=task,
+            previous_ti=prev_ti,
+            execution_date=datetime(2016, 1, 1))
+        dep_context = FakeContext(ignore_depends_on_past=False)
+
+        self.assertTrue(PrevDagrunDep().is_met(ti=ti, dep_context=dep_context))
+
+    def test_prev_ti_bad_state(self):
+        """
+        If the previous TI did not complete execution this dep should fail.
+        """
+        task = FakeTask(
+            depends_on_past=True,
+            start_date=datetime(2016, 1, 1),
+            wait_for_downstream=False)
+        prev_ti = FakeTI(
+            state=State.NONE,
+            dependents_done=True)
+        ti = FakeTI(
+            task=task,
+            previous_ti=prev_ti,
+            execution_date=datetime(2016, 1, 2))
+        dep_context = FakeContext(ignore_depends_on_past=False)
+
+        self.assertFalse(PrevDagrunDep().is_met(ti=ti, dep_context=dep_context))
+
+    def test_failed_wait_for_downstream(self):
+        """
+        If the previous TI specified to wait for the downstream tasks of the previous
+        dagrun then it should fail this dep if the downstream TIs of the previous TI are
+        not done.
+        """
+        task = FakeTask(
+            depends_on_past=True,
+            start_date=datetime(2016, 1, 1),
+            wait_for_downstream=True)
+        prev_ti = FakeTI(
+            state=State.SUCCESS,
+            dependents_done=False)
+        ti = FakeTI(
+            task=task,
+            previous_ti=prev_ti,
+            execution_date=datetime(2016, 1, 2))
+        dep_context = FakeContext(ignore_depends_on_past=False)
+
+        self.assertFalse(PrevDagrunDep().is_met(ti=ti, dep_context=dep_context))
+
+    def test_all_met(self):
+        """
+        Test to make sure all of the conditions for the dep are met
+        """
+        task = FakeTask(
+            depends_on_past=True,
+            start_date=datetime(2016, 1, 1),
+            wait_for_downstream=True)
+        prev_ti = FakeTI(
+            state=State.SUCCESS,
+            dependents_done=True)
+        ti = FakeTI(
+            task=task,
+            previous_ti=prev_ti,
+            execution_date=datetime(2016, 1, 2))
+        dep_context = FakeContext(ignore_depends_on_past=False)
+
+        self.assertTrue(PrevDagrunDep().is_met(ti=ti, dep_context=dep_context))

--- a/tests/ti_deps/deps/runnable_exec_date_dep.py
+++ b/tests/ti_deps/deps/runnable_exec_date_dep.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from datetime import datetime
+from mock import patch
+
+from airflow.ti_deps.deps.runnable_exec_date_dep import RunnableExecDateDep
+from fake_models import FakeDag, FakeTask, FakeTI
+from tests.test_utils.fake_datetime import FakeDatetime
+
+
+class RunnableExecDateDepTest(unittest.TestCase):
+
+    @patch('airflow.ti_deps.deps.runnable_exec_date_dep.datetime', FakeDatetime)
+    def test_exec_date_after_end_date(self):
+        """
+        If the dag's execution date is in the future this dep should fail
+        """
+        FakeDatetime.now = classmethod(lambda cls: datetime(2016, 1, 1))
+        dag = FakeDag(end_date=datetime(2016, 1, 3))
+        task = FakeTask(dag=dag, end_date=datetime(2016, 1, 3))
+        ti = FakeTI(task=task, execution_date=datetime(2016, 1, 2))
+
+        self.assertFalse(RunnableExecDateDep().is_met(ti=ti, dep_context=None))
+
+    def test_exec_date_before_task_end_date(self):
+        """
+        If the task instance execution date is before the DAG's end date this dep should
+        fail
+        """
+        FakeDatetime.now = classmethod(lambda cls: datetime(2016, 1, 3))
+        dag = FakeDag(end_date=datetime(2016, 1, 1))
+        task = FakeTask(dag=dag, end_date=datetime(2016, 1, 2))
+        ti = FakeTI(task=task, execution_date=datetime(2016, 1, 1))
+
+        self.assertFalse(RunnableExecDateDep().is_met(ti=ti, dep_context=None))
+
+    def test_exec_date_after_task_end_date(self):
+        """
+        If the task instance execution date is after the DAG's end date this dep should
+        fail
+        """
+        FakeDatetime.now = classmethod(lambda cls: datetime(2016, 1, 3))
+        dag = FakeDag(end_date=datetime(2016, 1, 3))
+        task = FakeTask(dag=dag, end_date=datetime(2016, 1, 1))
+        ti = FakeTI(task=task, execution_date=datetime(2016, 1, 2))
+
+        self.assertFalse(RunnableExecDateDep().is_met(ti=ti, dep_context=None))
+
+    def test_exec_date_before_dag_end_date(self):
+        """
+        If the task instance execution date is before the dag's end date this dep should
+        fail
+        """
+        dag = FakeDag(start_date=datetime(2016, 1, 2))
+        task = FakeTask(dag=dag, start_date=datetime(2016, 1, 1))
+        ti = FakeTI(task=task, execution_date=datetime(2016, 1, 1))
+
+        self.assertFalse(RunnableExecDateDep().is_met(ti=ti, dep_context=None))
+
+    def test_exec_date_after_dag_end_date(self):
+        """
+        If the task instance execution date is after the dag's end date this dep should
+        fail
+        """
+        dag = FakeDag(end_date=datetime(2016, 1, 1))
+        task = FakeTask(dag=dag, end_date=datetime(2016, 1, 3))
+        ti = FakeTI(task=task, execution_date=datetime(2016, 1, 2))
+
+        self.assertFalse(RunnableExecDateDep().is_met(ti=ti, dep_context=None))
+
+    def test_all_deps_met(self):
+        """
+        Test to make sure all of the conditions for the dep are met
+        """
+        dag = FakeDag(end_date=datetime(2016, 1, 2))
+        task = FakeTask(dag=dag, end_date=datetime(2016, 1, 2))
+        ti = FakeTI(task=task, execution_date=datetime(2016, 1, 1))
+
+        self.assertTrue(RunnableExecDateDep().is_met(ti=ti, dep_context=None))

--- a/tests/ti_deps/deps/trigger_rule_dep.py
+++ b/tests/ti_deps/deps/trigger_rule_dep.py
@@ -1,0 +1,295 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from airflow.utils.trigger_rule import TriggerRule
+from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
+from airflow.utils.state import State
+from fake_models import FakeTask, FakeTI
+
+
+class TriggerRuleDepTest(unittest.TestCase):
+
+    def test_no_upstream_tasks(self):
+        """
+        If the TI has no upstream TIs then there is nothing to check and the dep is passed
+        """
+        task = FakeTask(
+            trigger_rule=TriggerRule.ALL_DONE,
+            upstream_list=[])
+        ti = FakeTI(
+            task=task,
+            state=State.UP_FOR_RETRY)
+
+        self.assertTrue(TriggerRuleDep().is_met(ti=ti, dep_context=None))
+
+    def test_dummy_tr(self):
+        """
+        The dummy trigger rule should always pass this dep
+        """
+        task = FakeTask(
+            trigger_rule=TriggerRule.DUMMY,
+            upstream_list=[])
+        ti = FakeTI(
+            task=task,
+            state=State.UP_FOR_RETRY)
+
+        self.assertTrue(TriggerRuleDep().is_met(ti=ti, dep_context=None))
+
+    def test_one_success_tr_success(self):
+        """
+        One-success trigger rule success
+        """
+        task = FakeTask(
+            trigger_rule=TriggerRule.ONE_SUCCESS,
+            upstream_task_ids=[])
+        ti = FakeTI(task=task)
+
+        dep_statuses = tuple(TriggerRuleDep()._evaluate_trigger_rule(
+            ti=ti,
+            successes=1,
+            skipped=2,
+            failed=2,
+            upstream_failed=2,
+            done=2,
+            flag_upstream_failed=False,
+            session="Fake Session"))
+
+        self.assertEqual(len(dep_statuses), 0)
+
+    def test_one_success_tr_failure(self):
+        """
+        One-success trigger rule failure
+        """
+        task = FakeTask(
+            trigger_rule=TriggerRule.ONE_SUCCESS,
+            upstream_task_ids=[])
+        ti = FakeTI(task=task)
+
+        dep_statuses = tuple(TriggerRuleDep()._evaluate_trigger_rule(
+            ti=ti,
+            successes=0,
+            skipped=2,
+            failed=2,
+            upstream_failed=2,
+            done=2,
+            flag_upstream_failed=False,
+            session="Fake Session"))
+
+        self.assertEqual(len(dep_statuses), 1)
+        self.assertFalse(dep_statuses[0].passed)
+
+    def test_one_failure_tr_failure(self):
+        """
+        One-failure trigger rule failure
+        """
+        task = FakeTask(
+            trigger_rule=TriggerRule.ONE_FAILED,
+            upstream_task_ids=[])
+        ti = FakeTI(task=task)
+
+        dep_statuses = tuple(TriggerRuleDep()._evaluate_trigger_rule(
+            ti=ti,
+            successes=2,
+            skipped=0,
+            failed=0,
+            upstream_failed=0,
+            done=2,
+            flag_upstream_failed=False,
+            session="Fake Session"))
+
+    def test_one_failure_tr_success(self):
+        """
+        One-failure trigger rule success
+        """
+        task = FakeTask(
+            trigger_rule=TriggerRule.ONE_FAILED,
+            upstream_task_ids=[])
+        ti = FakeTI(task=task)
+
+        dep_statuses = tuple(TriggerRuleDep()._evaluate_trigger_rule(
+            ti=ti,
+            successes=0,
+            skipped=2,
+            failed=2,
+            upstream_failed=0,
+            done=2,
+            flag_upstream_failed=False,
+            session="Fake Session"))
+
+        self.assertEqual(len(dep_statuses), 0)
+
+        dep_statuses = tuple(TriggerRuleDep()._evaluate_trigger_rule(
+            ti=ti,
+            successes=0,
+            skipped=2,
+            failed=0,
+            upstream_failed=2,
+            done=2,
+            flag_upstream_failed=False,
+            session="Fake Session"))
+
+        self.assertEqual(len(dep_statuses), 0)
+
+    def test_all_success_tr_success(self):
+        """
+        All-success trigger rule success
+        """
+        task = FakeTask(
+            trigger_rule=TriggerRule.ALL_SUCCESS,
+            upstream_task_ids=["FakeTaskID"])
+        ti = FakeTI(task=task)
+
+        dep_statuses = tuple(TriggerRuleDep()._evaluate_trigger_rule(
+            ti=ti,
+            successes=1,
+            skipped=0,
+            failed=0,
+            upstream_failed=0,
+            done=1,
+            flag_upstream_failed=False,
+            session="Fake Session"))
+
+        self.assertEqual(len(dep_statuses), 0)
+
+    def test_all_success_tr_failure(self):
+        """
+        All-success trigger rule failure
+        """
+        task = FakeTask(
+            trigger_rule=TriggerRule.ALL_SUCCESS,
+            upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
+        ti = FakeTI(task=task)
+
+        dep_statuses = tuple(TriggerRuleDep()._evaluate_trigger_rule(
+            ti=ti,
+            successes=1,
+            skipped=0,
+            failed=1,
+            upstream_failed=0,
+            done=2,
+            flag_upstream_failed=False,
+            session="Fake Session"))
+
+        self.assertEqual(len(dep_statuses), 1)
+        self.assertFalse(dep_statuses[0].passed)
+
+    def test_all_failed_tr_success(self):
+        """
+        All-failed trigger rule success
+        """
+        task = FakeTask(
+            trigger_rule=TriggerRule.ALL_FAILED,
+            upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
+        ti = FakeTI(task=task)
+
+        dep_statuses = tuple(TriggerRuleDep()._evaluate_trigger_rule(
+            ti=ti,
+            successes=0,
+            skipped=0,
+            failed=2,
+            upstream_failed=0,
+            done=2,
+            flag_upstream_failed=False,
+            session="Fake Session"))
+
+        self.assertEqual(len(dep_statuses), 0)
+
+    def test_all_failed_tr_failure(self):
+        """
+        All-failed trigger rule failure
+        """
+        task = FakeTask(
+            trigger_rule=TriggerRule.ALL_FAILED,
+            upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
+        ti = FakeTI(task=task)
+
+        dep_statuses = tuple(TriggerRuleDep()._evaluate_trigger_rule(
+            ti=ti,
+            successes=2,
+            skipped=0,
+            failed=0,
+            upstream_failed=0,
+            done=2,
+            flag_upstream_failed=False,
+            session="Fake Session"))
+
+        self.assertEqual(len(dep_statuses), 1)
+        self.assertFalse(dep_statuses[0].passed)
+
+    def test_all_done_tr_success(self):
+        """
+        All-done trigger rule success
+        """
+        task = FakeTask(
+            trigger_rule=TriggerRule.ALL_DONE,
+            upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
+        ti = FakeTI(task=task)
+
+        dep_statuses = tuple(TriggerRuleDep()._evaluate_trigger_rule(
+            ti=ti,
+            successes=2,
+            skipped=0,
+            failed=0,
+            upstream_failed=0,
+            done=2,
+            flag_upstream_failed=False,
+            session="Fake Session"))
+
+        self.assertEqual(len(dep_statuses), 0)
+
+    def test_all_done_tr_failure(self):
+        """
+        All-done trigger rule failure
+        """
+        task = FakeTask(
+            trigger_rule=TriggerRule.ALL_DONE,
+            upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
+        ti = FakeTI(task=task)
+
+        dep_statuses = tuple(TriggerRuleDep()._evaluate_trigger_rule(
+            ti=ti,
+            successes=1,
+            skipped=0,
+            failed=0,
+            upstream_failed=0,
+            done=1,
+            flag_upstream_failed=False,
+            session="Fake Session"))
+
+        self.assertEqual(len(dep_statuses), 1)
+        self.assertFalse(dep_statuses[0].passed)
+
+    def test_unknown_tr(self):
+        """
+        Unknown trigger rules should cause this dep to fail
+        """
+        task = FakeTask(
+            trigger_rule="Unknown Trigger Rule",
+            upstream_task_ids=[])
+        ti = FakeTI(task=task)
+
+        dep_statuses = tuple(TriggerRuleDep()._evaluate_trigger_rule(
+            ti=ti,
+            successes=1,
+            skipped=0,
+            failed=0,
+            upstream_failed=0,
+            done=1,
+            flag_upstream_failed=False,
+            session="Fake Session"))
+
+        self.assertEqual(len(dep_statuses), 1)
+        self.assertFalse(dep_statuses[0].passed)

--- a/tests/ti_deps/deps/valid_state_dep.py
+++ b/tests/ti_deps/deps/valid_state_dep.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from datetime import datetime
+
+from airflow import AirflowException
+from airflow.ti_deps.deps.valid_state_dep import ValidStateDep
+from airflow.utils.state import State
+from fake_models import FakeTI
+
+
+class ValidStateDepTest(unittest.TestCase):
+
+    def test_valid_state(self):
+        """
+        Valid state should pass this dep
+        """
+        ti = FakeTI(state=State.QUEUED, end_date=datetime(2016, 1, 1))
+
+        self.assertTrue(ValidStateDep({State.QUEUED}).is_met(ti=ti, dep_context=None))
+
+    def test_invalid_state(self):
+        """
+        Invalid state should fail this dep
+        """
+        ti = FakeTI(state=State.SUCCESS, end_date=datetime(2016, 1, 1))
+
+        self.assertFalse(ValidStateDep({State.FAILURE}).is_met(ti=ti, dep_context=None))
+
+    def test_no_valid_states(self):
+        """
+        If there are no valid states the dependency should throw
+        """
+        ti = FakeTI(state=State.SUCCESS, end_date=datetime(2016, 1, 1))
+
+        with self.assertRaises(AirflowException):
+            ValidStateDep({}).is_met(ti=ti, dep_context=None)


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-149

Here is the original PR with Max's LGTM: https://github.com/aoen/incubator-airflow/pull/1
Since then I have made some fixes but this PR is essentially the same. It could definitely use more
eyes as there are likely still issues.

**Goals**
- Simplify, consolidate, and make consistent the logic of whether or not a task should be run
- Provide a view/better logging that gives insight into why a task instance is not currently running
  (no more viewing the scheduler logs to find out why a task instance isn't running for the majority
  of cases):
  ![image](https://cloud.githubusercontent.com/assets/1592778/17637621/aa669f5e-6099-11e6-81c2-d988d2073aac.png)

**Notable Functional Changes**
- Webserver view + task_failing_deps CLI command to explain why a given task instance isn't being
  run by the scheduler
- Running a backfill in the command line and running a task in the UI will now display detailed
  error messages based on which dependencies were not met for a task instead of appearing to succeed
  but actually failing silently
- Maximum task concurrency and pools are now respected by backfills
- Backfill now has the equivalent of the old force flag to run even for successful tasks
  This will break one use case:
  Using pools to restrict some resource on airflow executors themselves (rather than an externa
  l resource like a DB), e.g. some task uses 60% of cpu on a worker so we restrict that task's pool
  size to 1 to prevent two of the tasks from running on the same host. When backfilling a task of
  this type, now the backfill will wait on the pool to have slots open up before running the task
  even though we don't need to do this if backfilling on a different host outside of the pool. I
  think breaking this use case is OK since the use case is a hack due to not having a proper
  resource isolation solution (e.g. mesos should be used in this case instead).
- To make things less confusing for users, there is now a "ignore all dependencies" option for
  running tasks, "ignore dependencies" has been renamed to "ignore task dependencies", and "force"
  has been renamed to "ignore task instance state". The new "Ignore all dependencies" flag will
  ignore the following:
  - task instance's pool being full
  - execution date for a task instance being in the future
  - a task instance being in the retry waiting period
  - the task instance's task ending prior to the task instance's execution date
  - task instance is already queued
  - task instance has already completed
  - task instance is in the shutdown state
  - WILL NOT IGNORE task instance is already running
- SLA miss emails will now include all tasks that did not finish for a particular DAG run, even if
  the tasks didn't run because depends_on_past was not met for a task
- Tasks with pools won't get queued automatically the first time they reach a worker; if
  they are ready to run they will be run immediately
- Running a task via the UI or via the command line (backfill/run commands) will now log why a task
  could not get run if one if it's dependencies isn't met. For tasks kicked off via the web UI this
  means that tasks don't silently fail to get queued despite a successful message in the UI.
- Queuing a task into a pool that doesn't exist will now get stopped in the scheduler instead of a
  worker

**TODO**
- Fix test that is failing for mysql/postgres (not sure that it is related)

**Follow Up Items**
- Update the docs to reference the new explainer views/CLI command

**Testing Done**
- New unit tests
- Running in airbnb production for 2 days (will have been more by the time this is merged)
- Make sure blocked deps are all shown in UI, including dagrun doesn't exist dep
- Logs look good
- Make sure ui throws error when ti_deps aren't met when you try to schedule a task
- No delay/load issues
- Test celery worker starting a task via the UI with various flags (on Bronze), and make sure the
  task actually completed by checking start_date changed
- Run a task that has already succeeded in the UI and make sure it's state gets changed
  (including in the UI)
- Make sure can backfill overtop of failed tasks
- Make sure tasks still get queued when e.g. concurrency is reached or pool is reached (can test one
  don't have to test both)
- Make sure backfill flags still work (because they aren't passed to tasks anymore right?)
  -a, --include_adhoc Include dags with the adhoc parameter.
  -i, --ignore_dependencies
  Skip upstream tasks, run only the tasks matching the
  regexp. Only works in conjunction with task_regex
  -I, --ignore_first_depends_on_past
- Test airflow backfill and run commands with some flags
- Tasks that should have been deadlocked are still deadlocked after this change.
- Made sure that the right failing dependencies were shown on the task instance page.
- Tested new CLI command by running it
- Ui still works with all the various force flag combos (ignore_task_deps especially)
- Backfill before a task's start date should work
- Make sure that for the TI pop up dialog in tree view all buttons that are links work
- Make sure logs aren't too crazy (logging a lot more e.g. in scheduler)

**Future Work**
- Add ignore_ti_state flag to airflow backfill command to be consistent with UI/airflow run command.
- Show one more dagrun in the tree view (even when that dagrun's execution date hasn't occurred yet) so that users can see why task instances in the next dagrun are blocked. I wanted to include this in the first release but it's non-trivial to do (one way to solve this is to generate DAG runs before their execution date occurs). You can still view a non-existent task instance by passing the right query parameters to the task instance page, or by querying via the new command-line command.
- Break down failed dependency explanations better (e.g. if the trigger rules requiring all upstream task successes fails, indicate the specific upstream tasks that failed)
- Make failing dependencies for task instances more visible to users (e.g. asynchronously display failing dependencies when mousing over a task instance in the tree view).
- Parallelize task instance dependency checking.
- Don't pass around the ignore_x_deps type flags (e.g. ignore_all_deps), instead create a set of DependencyContext object at the first place the flags are initialized and pass this context down
- Can add some more tips to fix a failing dependency in the new view that shows failed task instance dependencies (e.g. for "depends_on_past" when the last task state is failing we can give the tip to get this task to succeed, or even provide a button to clear it right from that view)
- Additional task instance dependencies, e.g. DAG does not parse, there are no schedulers running (a task can't get scheduled until a scheduler is running), or the airflow scheduler queue is backed up, or no executors being available to run the task instance
- Keep history of changes to blocked dependencies that are accessible via the UI (this is useful to know why a task's execution was delayed)

@jlowin @mistercrunch @artwr 
cc: @shenghuy @PeterAttardo
