### PR TITLE
[AIRFLOW-329] Update Dag Overview Page with Better Status Columns

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1094,6 +1094,8 @@ class SchedulerJob(BaseJob):
             self._process_task_instances(dag, tis_out)
             self.manage_slas(dag)
 
+        models.DagStat.clean_dirty([d.dag_id for d in dags])
+
     def _process_executor_events(self):
         """
         Respond to executor events.
@@ -1844,6 +1846,8 @@ class BackfillJob(BaseJob):
 
             # update dag run state
             run.update_state(session=session)
+            if run.dag.is_paused:
+                models.DagStat.clean_dirty([run.dag_id], session=session)
 
         executor.end()
 

--- a/airflow/migrations/versions/f2ca10b85618_add_dag_stats_table.py
+++ b/airflow/migrations/versions/f2ca10b85618_add_dag_stats_table.py
@@ -1,0 +1,42 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""add dag_stats table
+
+Revision ID: f2ca10b85618
+Revises: 64de9cddf6c9
+Create Date: 2016-07-20 15:08:28.247537
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'f2ca10b85618'
+down_revision = '64de9cddf6c9'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('dag_stats',
+                    sa.Column('dag_id', sa.String(length=250), nullable=False),
+                    sa.Column('state', sa.String(length=50), nullable=False),
+                    sa.Column('count', sa.Integer(), nullable=False, default=0),
+                    sa.Column('dirty', sa.Boolean(), nullable=False, default=False),
+                    sa.PrimaryKeyConstraint('dag_id', 'state'))
+
+
+def downgrade():
+    op.drop_table('dag_stats')

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -41,6 +41,21 @@ class State(object):
     UPSTREAM_FAILED = "upstream_failed"
     SKIPPED = "skipped"
 
+    task_states = (
+        SUCCESS,
+        RUNNING,
+        FAILED,
+        UPSTREAM_FAILED,
+        UP_FOR_RETRY,
+        QUEUED,
+    )
+
+    dag_states = (
+        SUCCESS,
+        RUNNING,
+        FAILED,
+    )
+
     state_color = {
         QUEUED: 'gray',
         RUNNING: 'lime',

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -37,8 +37,12 @@
                 <th>DAG</th>
                 <th>Schedule</th>
                 <th>Owner</th>
-                <th style="padding-left: 5px;">Recent Statuses
+                <th style="padding-left: 5px;">Recent Tasks
                   <span id="statuses_info" class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Status of tasks from all active DAG runs or, if not currently active, from most recent run."></span>
+                  <img id="loading" width="15" src="{{ url_for("static", filename="loading.gif") }}">
+                </th>
+                <th style="padding-left: 5px;">DAG Runs
+                  <span id="statuses_info" class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Status of all previous DAG runs."></span>
                   <img id="loading" width="15" src="{{ url_for("static", filename="loading.gif") }}">
                 </th>
                 <th class="text-center">Links</th>
@@ -93,12 +97,17 @@
                   {{ dag.owner if dag else orm_dags[dag_id].owners }}
                 </td>
 
-                <!-- Column 6: Recent Statuses -->
+                <!-- Column 6: Recent Tasks -->
                 <td style="padding:0px; width:200px; height:10px;">
-                    <svg height="10" width="10" id='dag-{{ dag.safe_dag_id }}' style="display: block;"></svg>
+                    <svg height="10" width="10" id='task-run-{{ dag.safe_dag_id }}' style="display: block;"></svg>
                 </td>
 
-                <!-- Column 7: Links -->
+                <!-- Column 7: Dag Runs -->
+                <td style="padding:0px; width:120px; height:10px;">
+                    <svg height="10" width="10" id='dag-run-{{ dag.safe_dag_id }}' style="display: block;"></svg>
+                </td>
+
+                <!-- Column 8: Links -->
                 <td class="text-center" style="display:flex; flex-direction:row; justify-content:space-around;">
                 {% if dag %}
 
@@ -198,7 +207,86 @@
       d3.json("{{ url_for('airflow.dag_stats') }}", function(error, json) {
         for(var dag_id in json) {
             states = json[dag_id];
-            g = d3.select('svg#dag-' + dag_id)
+            g = d3.select('svg#dag-run-' + dag_id)
+              .attr('height', diameter + (stroke_width_hover * 2))
+              .attr('width', '110px')
+              .selectAll("g")
+              .data(states)
+              .enter()
+              .append('g')
+              .attr('transform', function(d, i) {
+                x = (i * (diameter + circle_margin)) + (diameter/2 + circle_margin);
+                y = (diameter/2) + stroke_width_hover;
+                return 'translate(' + x + ',' + y + ')';
+              });
+
+            g.append('text')
+              .attr('fill', 'black')
+              .attr('text-anchor', 'middle')
+              .attr('vertical-align', 'middle')
+              .attr('font-size', 8)
+              .attr('y', 3)
+              .text(function(d){ return d.count > 0 ? d.count : ''; });
+
+            g.append('circle')
+              .attr('stroke-width', function(d) {
+                  if (d.count > 0)
+                    return stroke_width;
+                  else {
+                    return 1;
+                  }
+              })
+              .attr('stroke', function(d) {
+                  if (d.count > 0)
+                    return d.color;
+                  else {
+                    return 'gainsboro';
+                  }
+              })
+              .attr('fill-opacity', 0)
+              .attr('r', diameter/2)
+              .attr('title', function(d) {return d.state})
+              .attr('style', function(d) {
+                if (d.count > 0)
+                    return"cursor:pointer;"
+              })
+              .on('click', function(d, i) {
+                  if (d.count > 0)
+                    window.location = "/admin/dagrun/?flt1_dag_id_equals=" + d.dag_id + "&flt2_state_equals=" + d.state;
+              })
+              .on('mouseover', function(d, i) {
+                if (d.count > 0) {
+                    d3.select(this).transition().duration(400)
+                      .attr('fill-opacity', 0.3)
+                      .style("stroke-width", stroke_width_hover);
+                }
+              })
+              .on('mouseout', function(d, i) {
+                if (d.count > 0) {
+                    d3.select(this).transition().duration(400)
+                      .attr('fill-opacity', 0)
+                      .style("stroke-width", stroke_width);
+                }
+              })
+              .style("opacity", 0)
+              .transition()
+              .duration(500)
+              .delay(function(d, i){return i*50;})
+              .style("opacity", 1);
+            d3.select("#loading").remove();
+        }
+        $("#pause_header").tooltip();
+        $("#statuses_info").tooltip();
+
+        $("circle").tooltip({
+          html: true,
+          container: "body",
+        });
+      });
+      d3.json("{{ url_for('airflow.task_stats') }}", function(error, json) {
+        for(var dag_id in json) {
+            states = json[dag_id];
+            g = d3.select('svg#task-run-' + dag_id)
               .attr('height', diameter + (stroke_width_hover * 2))
               .attr('width', '180px')
               .selectAll("g")
@@ -273,6 +361,6 @@
           html: true,
           container: "body",
         });
-    });
+      });
   </script>
 {% endblock %}


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-329

Testing Done:
- Added a unit test to core tests, tests that dag_stats table is appropriately updated after dagrun creation and state change
  -Added sanity check for '/dag_stats' and '/task_stats' API endpoints

Renamed 'Recent Statuses' to 'Recent Tasks'. Created 'DAG Stats' column. Created a cache table dag_stats to hold data for 'DAG Stats' column with dirty bit for each row. Upon dagrun creation, state change, or deletion via web UI, appropriate rows will have dirty set to true and then dirty rows will be refreshed with up to date data. Upon execution of `airflow webserver` command, all rows in dag_stat will be dirtied and cleaned.

API endpoints in views.py have also been changed. '/dag_stats' has been renamed to '/task_stats', and endpoint reused for the 'DAG Stats' column.
