### PR TITLE
Add Zapier

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Currently **officially** using Airflow:
 1. [WePay](http://www.wepay.com) [[@criccomini](https://github.com/criccomini) & [@mtagle](https://github.com/mtagle)]
 1. Yahoo!
 1. [Zendesk](https://www.github.com/zendesk)
+1. [Zapier](https://www.zapier.com) [[@drknexus](https://github.com/drknexus) & [@statwonk](https://github.com/statwonk)]
 
 ## Links
 


### PR DESCRIPTION
Dear Airflow Maintainers,

The standard submission form seems irrelevant as this is just an incremental update of the list of companies using Airflow.  I've added [Zapier][https://www.zapier.com].  If you are no longer accepting updates to this list I can create an issue and update the Readme to eliminate the call to action.

Best,

Russell
