### PR TITLE
[AIRFLOW-428] Clean shutdown celery on SIGTERM

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -769,13 +769,58 @@ def worker(args):
         stdout.close()
         stderr.close()
     else:
-        signal.signal(signal.SIGINT, sigint_handler)
-        signal.signal(signal.SIGTERM, sigint_handler)
+        serve_logs_proc = subprocess.Popen(['airflow', 'serve_logs'], env=env)
+        celery_proc = subprocess.Popen(
+            [
+                'celery',
+                'worker',
+                '-A', 'airflow.executors.celery_executor',
+                '-O', 'fair',
+                '-Q', str(args.queues),
+                '-c', str(args.concurrency)
+            ],
+            env=env,
+            # don't inherit stdin, so that Ctrl-C is not handled twice
+            stdin=subprocess.PIPE
+        )
 
-        sp = subprocess.Popen(['airflow', 'serve_logs'], env=env)
 
-        worker.run(**options)
-        sp.kill()
+        def kill_proc(dummy_signum, dummy_frame):
+            serve_logs_proc.terminate()
+
+            # 1. Celery responsd to SIGTERM with warm shutdown quit when all
+            #    tasks finish
+            logging.debug('Sending SIGTERM to Celery')
+            celery_proc.terminate()
+
+            # 2. Send SIGTERM to each child of celery - give up on task.
+            # We go two levels deep in the process tree
+            #
+            # - celery master process
+            #   \- celery worker process
+            #      \- airflow run --local    <------- terminate
+            #         \- airflow run --raw
+            #   \- celery worker process
+            #      \- airflow run --local    <------- terminate
+            #         \- airflow run --raw
+            #   \- celery worker process
+            #   \- celery worker process
+            celery_workers = psutil.Process(celery_proc.pid).children()
+            for celery_worker in celery_workers:
+                for celery_child in psutil.Process(celery_worker.pid).children():
+                    print('sending SIGTERM to ', celery_worker.cmdline()[0])
+                    celery_child.send_signal(signal.SIGTERM)
+
+            # 3. Wait for warm shutdown to finish
+            celery_proc.wait()
+
+            sys.exit(0)
+
+        signal.signal(signal.SIGINT, kill_proc)
+        signal.signal(signal.SIGTERM, kill_proc)
+
+        while True:
+            pass
 
 
 def initdb(args):  # noqa
@@ -1215,7 +1260,7 @@ class CLIFactory(object):
                      'log_file'),
         }, {
             'func': worker,
-            'help': "Start a Celery worker node",
+            'help': "Supervise or daemonize a Celery worker node",
             'args': ('do_pickle', 'queues', 'concurrency',
                      'pid', 'daemon', 'stdout', 'stderr', 'log_file'),
         }, {

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -808,7 +808,7 @@ def worker(args):
             celery_workers = psutil.Process(celery_proc.pid).children()
             for celery_worker in celery_workers:
                 for celery_child in psutil.Process(celery_worker.pid).children():
-                    print('sending SIGTERM to ', celery_worker.cmdline()[0])
+                    logging.debug('sending SIGTERM to ', celery_worker.cmdline()[0])
                     celery_child.send_signal(signal.SIGTERM)
 
             # 3. Wait for warm shutdown to finish

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1930,7 +1930,7 @@ class LocalTaskJob(BaseJob):
         self.process = subprocess.Popen(['bash', '-c', command])
 
         def kill_proc(dummy_signum, dummy_frame):
-            print('LocalTaskJob received sigterm')
+            logging.debug('LocalTaskJob received sigterm')
             self.process.terminate()
             time.sleep(10)
             self.process.kill()

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1878,6 +1878,11 @@ class BackfillJob(BaseJob):
 
 
 class LocalTaskJob(BaseJob):
+    """
+    Spawns and supervises an ``airflow run --raw`` command as a subprocess.
+    Emits heartbeats, listens for external kill signals and ensures some
+    cleanup tasks take place if the subprocess fails.
+    """
 
     __mapper_args__ = {
         'polymorphic_identity': 'LocalTaskJob'
@@ -1923,6 +1928,15 @@ class LocalTaskJob(BaseJob):
             pool=self.pool,
         )
         self.process = subprocess.Popen(['bash', '-c', command])
+
+        def kill_proc(dummy_signum, dummy_frame):
+            print('LocalTaskJob received sigterm')
+            self.process.terminate()
+            time.sleep(10)
+            self.process.kill()
+
+        signal.signal(signal.SIGTERM, kill_proc)
+
         return_code = None
         while return_code is None:
             self.heartbeat()
@@ -1943,8 +1957,10 @@ class LocalTaskJob(BaseJob):
         TI = models.TaskInstance
         ti = self.task_instance
         state = session.query(TI.state).filter(
-            TI.dag_id==ti.dag_id, TI.task_id==ti.task_id,
-            TI.execution_date==ti.execution_date).scalar()
+            TI.dag_id == ti.dag_id, TI.task_id == ti.task_id,
+            TI.execution_date == ti.execution_date
+        ).scalar()
+
         if state == State.RUNNING:
             self.was_running = True
         elif self.was_running and hasattr(self, 'process'):


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- [AIRFLOW-428](https://issues.apache.org/jira/browse/AIRFLOW-428)
#### Changes
- LocalTaskJob (aka `airflow run --local`) now handles SIGTERM and SIGINT properly by propagating them to its children (which is an `airflow run` command).
- `airflow worker` now runs celery as a subprocess instead of directly
- `airflow worker` now handles SIGINT and SIGTERM; there was code previously to catch them but it was never called because celery installs its own signal handlers
- `airflow worker` handles SIGINT/SIGTERM by sending SIGTERM to `airflow run` commands
#### Testing Done
- [ ] Run airflow worker, wait for it to receive tasks, then send sigterm to it
- [ ] Run airflow worker, wait for it to receive tasks, then send sigint to it
