### PR TITLE
[AIRFLOW-430] Support connection management via CLI

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -642,6 +642,34 @@ class Connection(Base):
 
         return obj
 
+    @staticmethod
+    @provide_session
+    def create(conn_id=None, conn_type=None, host=None, login=None, password=None,
+               schema=None, port=None, extra=None, uri=None, session=None):
+        con = Connection(
+            conn_id=conn_id, conn_type=conn_type, host=host, login=login,
+            password=password, schema=schema, port=port, extra=extra, uri=uri)
+        session.add(con)
+        session.commit()
+
+    @staticmethod
+    @provide_session
+    def find(session=None, **filters):
+        query = session.query(Connection)
+        for attr, value in filters.items():
+            if attr and hasattr(Connection, attr) and value is not None:
+                query = query.filter(getattr(Connection, attr) == value)
+        return query.all()
+
+    @staticmethod
+    @provide_session
+    def delete(connection, session=None):
+        if not isinstance(connection, Connection):
+            raise AirflowException(
+                "{} is not an instance of a Connection".format(connection))
+        session.delete(connection)
+        session.commit()
+
 
 class DagPickle(Base):
     """

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -313,6 +313,8 @@ Connections
 
 The connection information to external systems is stored in the Airflow
 metadata database and managed in the UI (``Menu -> Admin -> Connections``)
+It can also be viewed/added/deleted from the CLI via 'airflow connections'.
+
 A ``conn_id`` is defined there and hostname / login / password / schema
 information attached to it. Airflow pipelines can simply refer to the
 centrally managed ``conn_id`` without having to hard code any of this

--- a/tests/core.py
+++ b/tests/core.py
@@ -1001,6 +1001,28 @@ class CliTests(unittest.TestCase):
         os.remove('variables1.json')
         os.remove('variables2.json')
 
+    def test_connections(self):
+        # test list connections
+        cli.connections(self.parser.parse_args(['connections']))
+        cli.connections(self.parser.parse_args(['connections', '-l']))
+        # test create connections
+        cli.connections(self.parser.parse_args([
+            'connections', '-c', '-ci', 'postgres_local', '-ct', 'postgres',
+            '-ch', 'localhost', '-cp', '10000']))
+        cli.connections(self.parser.parse_args([
+            'connections', '-c', '-ci', 'bq_local', '-ct', 'bigquery', '-ch', 'localhost',
+            '-cp', '3340', '-cl', 'root', '-cw', 'pass', '-cs', 'foo', '-ce', '{"foo":"bar"}']))
+        cli.connections(self.parser.parse_args([
+            'connections', '-c', '-cu', 'postgres://user:password@localhost:5432/master']))
+        #test delete connections
+        answer = 'yes'
+        cli.connections(self.parser.parse_args([
+            'connections', '-d', '-np', '-ci', 'bg_local', '-ct', 'bigquery',
+            '-ch', 'localhost', '-cp', '3340', '-cl', 'root', '-cs', 'foo']))
+        cli.connections(self.parser.parse_args(['connections', '-d', '-np', '-ci', 'bg_local']))
+        cli.connections(self.parser.parse_args(['connections', '-d', '-np']))
+
+
 class WebUiTests(unittest.TestCase):
     def setUp(self):
         configuration.load_test_config()


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-430

This PR addresses the issue by adding CLI support for:
- adding a new connection
- deleting connection(s)
- listing existing connections

Originally intend to wait after REST API is introduced, but given that will take some time to streamline, I think it would benefit the community to support this via cli for now.
