### PR TITLE
[AIRFLOW-439] Add Scaleway as an Airflow user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Currently **officially** using Airflow:
 1. [Nerdwallet](https://www.nerdwallet.com)
 1. [Postmates](http://www.postmates.com) [[@syeoryn](https://github.com/syeoryn)]
 1. [Qubole](https://qubole.com) [[@msumit](https://github.com/msumit)]
+1. [Scaleway](https://scaleway.com) [[@kdeldycke](https://github.com/kdeldycke)]
 1. [Sense360](https://github.com/Sense360) [[@kamilmroczek](https://github.com/KamilMroczek)]
 1. [Sidecar](https://hello.getsidecar.com/) [[@getsidecar](https://github.com/getsidecar)]
 1. [SimilarWeb](https://www.similarweb.com/) [[@similarweb](https://github.com/similarweb)]


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- [AIRFLOW-439 Add Scaleway as an Airflow user](https://issues.apache.org/jira/browse/AIRFLOW-439).

Testing:
- Done: Not Applicable.

Changes made:
- Add Scaleway to `README.rst`. Line 111.
