### PR TITLE
FIX: spelling / keyword

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -15,7 +15,7 @@ Here are some of the common causes:
   as where the worker runs.
 
 - Is your ``start_date`` set properly? The Airflow scheduler triggers the
-  task soon after the ``start_date + scheduler_interval`` is passed.
+  task soon after the ``start_date + schedule_interval`` is passed.
 
 - Is your ``start_date`` beyond where you can see it in the UI? If you
   set your it to some time say 3 months ago, you won't be able to see


### PR DESCRIPTION
Fixing a spelling / keyword issue in the FAQ docs.

---

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- _(replace with a link to AIRFLOW-X)_

Per Apache guidelines you need to create a [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW/).

Testing Done:
- Unittests are required, if you do not include new unit tests please
  specify why you think this is not required. We like to improve our
  coverage so a non existing test is even a better reason to include one.

Reminders for contributors (REQUIRED!):
- Your PR's title must reference an issue on 
  [Airflow's JIRA](https://issues.apache.org/jira/browse/AIRFLOW/). 
  For example, a PR called "[AIRFLOW-1] My Amazing PR" would close JIRA 
  issue #1. Please open a new issue if required!
- Please squash your commits when possible and follow the [How to write a good git commit message](http://chris.beams.io/posts/git-commit/). 
  Summarized as follows:
  1. Separate subject from body with a blank line
  2. Limit the subject line to 50 characters
  3. Do not end the subject line with a period
  4. Use the imperative mood in the subject line (add, not adding)
  5. Wrap the body at 72 characters
  6. Use the body to explain what and why vs. how
     `scheduler_interval` => `schedule_interval`
