### PR TITLE
[Airflow-409] Polite Logging Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.bkp
 *.egg-info
 *.pyc
+*.swp
 .DS_Store
 .ipynb*
 .coverage

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -72,15 +72,30 @@ def sigquit_handler(sig, frame):
     print("\n".join(code))
 
 
-def setup_logging(filename):
-    root = logging.getLogger()
+def setup_file_logging(filename, fmt=settings.SIMPLE_LOG_FORMAT):
     handler = logging.FileHandler(filename)
-    formatter = logging.Formatter(settings.SIMPLE_LOG_FORMAT)
+    formatter = logging.Formatter(fmt)
     handler.setFormatter(formatter)
-    root.addHandler(handler)
-    root.setLevel(settings.LOGGING_LEVEL)
+    handler.setLevel(settings.LOGGING_LEVEL)
 
-    return handler.stream
+    root = logging.getLogger()
+    root.addHandler(handler)
+
+    return handler
+
+
+def setup_stream_logging(
+    fmt=settings.SIMPLE_LOG_FORMAT, level=settings.LOGGING_LEVEL
+):
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter(fmt)
+    handler.setFormatter(formatter)
+    handler.setLevel(level)
+
+    root = logging.getLogger()
+    root.addHandler(handler)
+
+    return handler
 
 
 def setup_locations(process, pid=None, stdout=None, stderr=None, log=None):
@@ -116,10 +131,7 @@ def get_dag(args):
 
 
 def backfill(args, dag=None):
-    logging.basicConfig(
-        level=settings.LOGGING_LEVEL,
-        format=settings.SIMPLE_LOG_FORMAT)
-
+    setup_stream_logging()
     dag = dag or get_dag(args)
 
     if not args.start_date and not args.end_date:
@@ -292,11 +304,7 @@ def run(args, dag=None):
     iso = args.execution_date.isoformat()
     filename = "{directory}/{iso}".format(**locals())
 
-    logging.root.handlers = []
-    logging.basicConfig(
-        filename=filename,
-        level=settings.LOGGING_LEVEL,
-        format=settings.LOG_FORMAT)
+    handler = setup_file_logging(filename, settings.LOG_FORMAT)
 
     if not args.pickle and not dag:
         dag = get_dag(args)
@@ -368,8 +376,8 @@ def run(args, dag=None):
     # don't continue logging to the task's log file. The flush is important
     # because we subsequently read from the log to insert into S3 or Google
     # cloud storage.
-    logging.root.handlers[0].flush()
-    logging.root.handlers = []
+    handler.flush()
+    logging.root.removeHandler(handler)
 
     # store logs remotely
     remote_base = conf.get('core', 'REMOTE_BASE_LOG_FOLDER')
@@ -484,9 +492,7 @@ def render(args):
 
 
 def clear(args):
-    logging.basicConfig(
-        level=settings.LOGGING_LEVEL,
-        format=settings.SIMPLE_LOG_FORMAT)
+    setup_stream_logging()
     dag = get_dag(args)
 
     if args.task_regex:
@@ -692,13 +698,13 @@ def scheduler(args):
 
     if args.daemon:
         pid, stdout, stderr, log_file = setup_locations("scheduler", args.pid, args.stdout, args.stderr, args.log_file)
-        handle = setup_logging(log_file)
+        handler = setup_file_logging(log_file)
         stdout = open(stdout, 'w+')
         stderr = open(stderr, 'w+')
 
         ctx = daemon.DaemonContext(
             pidfile=TimeoutPIDLockFile(pid, -1),
-            files_preserve=[handle],
+            files_preserve=[handler.stream],
             stdout=stdout,
             stderr=stderr,
         )
@@ -751,13 +757,13 @@ def worker(args):
 
     if args.daemon:
         pid, stdout, stderr, log_file = setup_locations("worker", args.pid, args.stdout, args.stderr, args.log_file)
-        handle = setup_logging(log_file)
+        handler = setup_file_logging(log_file)
         stdout = open(stdout, 'w+')
         stderr = open(stderr, 'w+')
 
         ctx = daemon.DaemonContext(
             pidfile=TimeoutPIDLockFile(pid, -1),
-            files_preserve=[handle],
+            files_preserve=[handler.stream],
             stdout=stdout,
             stderr=stderr,
         )
@@ -789,8 +795,7 @@ def resetdb(args):
     if args.yes or input(
             "This will drop existing tables if they exist. "
             "Proceed? (y/n)").upper() == "Y":
-        logging.basicConfig(level=settings.LOGGING_LEVEL,
-                            format=settings.SIMPLE_LOG_FORMAT)
+        setup_stream_logging()
         db_utils.resetdb()
     else:
         print("Bail.")

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -111,11 +111,14 @@ def policy(task_instance):
     """
     pass
 
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(LOGGING_LEVEL)
+
 
 def configure_logging(log_format=LOG_FORMAT):
-    logging.root.handlers = []
-    logging.basicConfig(
-        format=log_format, stream=sys.stdout, level=LOGGING_LEVEL)
+    handler.setFormatter(logging.Formatter(log_format))
+    logging.getLogger().addHandler(handler)
+
 
 engine = None
 Session = None

--- a/airflow/utils/logging.py
+++ b/airflow/utils/logging.py
@@ -23,6 +23,7 @@ import logging
 
 from airflow import configuration
 from airflow.exceptions import AirflowException
+from airflow.settings import LOGGING_LEVEL
 
 
 class LoggingMixin(object):
@@ -35,7 +36,10 @@ class LoggingMixin(object):
         try:
             return self._logger
         except AttributeError:
-            self._logger = logging.root.getChild(self.__class__.__module__ + '.' + self.__class__.__name__)
+            self._logger = logging.root.getChild(
+                self.__class__.__module__ + '.' + self.__class__.__name__
+            )
+            self._logger.setLevel(LOGGING_LEVEL)
             return self._logger
 
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -15,17 +15,17 @@
 from __future__ import print_function
 
 import doctest
-import json
 import os
-import re
 import unittest
+import logging
 import multiprocessing
 import mock
 import tempfile
 from datetime import datetime, time, timedelta
 from email.mime.multipart import MIMEMultipart
 from email.mime.application import MIMEApplication
-import signal
+from io import StringIO
+from tempfile import NamedTemporaryFile
 from time import sleep
 import warnings
 
@@ -834,6 +834,30 @@ class CoreTest(unittest.TestCase):
         assert sum([f.duration for f in f_fails]) >= 3
 
 
+class CliLoggingTests(unittest.TestCase):
+    def tearDown(self):
+        if self.handler:
+            logging.getLogger().removeHandler(self.handler)
+
+    def test_setup_stream_logging(self):
+        # Make sure our handler is getting messages.
+        self.handler = cli.setup_stream_logging()
+        stream = StringIO()
+        self.handler.stream = stream  # Override stderr default stream.
+        logger = logging.getLogger()
+        logger.info("test message")
+        self.assertIn("test message", stream.getvalue())
+
+    def test_setup_file_logging(self):
+        with NamedTemporaryFile('w+t') as tempfile:
+            self.handler = cli.setup_file_logging(tempfile.name)
+            logger = logging.getLogger()
+            logger.info("test message")
+            tempfile.seek(0)
+            log_message = tempfile.read()
+            self.assertIn("test message", log_message)
+
+
 class CliTests(unittest.TestCase):
     def setUp(self):
         configuration.load_test_config()
@@ -843,6 +867,25 @@ class CliTests(unittest.TestCase):
         self.dagbag = models.DagBag(
             dag_folder=DEV_NULL, include_examples=True)
         # Persist DAGs
+
+    def _add_null_handler(self):
+        """Adds a null handler to the root logger.  We check this is still
+        around on tests that modify the logger."""
+        self.null_handler = logging.NullHandler()
+        logging.getLogger().addHandler(self.null_handler)
+
+    def _assert_null_handler(self):
+        """Ensures the NullHandler from `_add_null_handler` is still around."""
+        self.assertIn(self.null_handler, logging.getLogger().handlers)
+
+    def _assert_stream_handler(self):
+        """Ensures a stream handler (from `setup_stream_logging`) has been
+        added."""
+        for handler in logging.getLogger().handlers:
+            if isinstance(handler, logging.StreamHandler):
+                return
+
+        self.fail('no StreamHandler found')
 
     def test_cli_list_dags(self):
         args = self.parser.parse_args(['list_dags', '--report'])
@@ -902,6 +945,8 @@ class CliTests(unittest.TestCase):
         assert self.dagbag.dags['example_bash_operator'].is_paused in [False, 0]
 
     def test_subdag_clear(self):
+        self._add_null_handler()
+
         args = self.parser.parse_args([
             'clear', 'example_subdag_operator', '--no_confirm'])
         cli.clear(args)
@@ -909,7 +954,12 @@ class CliTests(unittest.TestCase):
             'clear', 'example_subdag_operator', '--no_confirm', '--exclude_subdags'])
         cli.clear(args)
 
+        self._assert_null_handler()
+        self._assert_stream_handler()
+
     def test_backfill(self):
+        self._add_null_handler()
+
         cli.backfill(self.parser.parse_args([
             'backfill', 'example_bash_operator',
             '-s', DEFAULT_DATE.isoformat()]))
@@ -925,6 +975,9 @@ class CliTests(unittest.TestCase):
         cli.backfill(self.parser.parse_args([
             'backfill', 'example_bash_operator', '-l',
             '-s', DEFAULT_DATE.isoformat()]))
+
+        self._assert_null_handler()
+        self._assert_stream_handler()
 
     def test_process_subdir_path_with_placeholder(self):
         assert cli.process_subdir('DAGS_FOLDER/abc') == os.path.join(configuration.get_dags_folder(), 'abc')

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,47 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Checks that existing loggers are preserved after importing airflow (settings).
+"""
+
+import logging
+import unittest
+
+from airflow import settings
+
+
+class ConfigureLoggingTestCase(unittest.TestCase):
+    def setUp(self):
+        self.logger = logging.getLogger()
+        self.handler = logging.NullHandler()
+
+        self.existing_handlers = self.logger.handlers
+        self.logger.handlers = []
+
+    def tearDown(self):
+        self.logger.handlers = self.existing_handlers
+
+    def test(self):
+        self.logger.setLevel(logging.DEBUG)
+        self.logger.addHandler(self.handler)
+
+        self.assertEqual(self.logger.handlers, [self.handler])
+
+        settings.configure_logging()
+
+        # Make sure our log settings are preserved.
+        self.assertEqual(self.logger.level, logging.DEBUG)
+        self.assertIn(self.handler, self.logger.handlers)
+
+        # Make sure default StreamHandler got added.
+        self.assertIn(settings.handler, self.logger.handlers)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,6 +22,7 @@ import unittest
 
 import airflow.utils.logging
 from airflow import configuration
+from airflow import settings
 from airflow.exceptions import AirflowException
 from airflow.utils.operator_resources import Resources
 
@@ -56,6 +57,17 @@ class LogUtilsTest(unittest.TestCase):
         self.assertEqual(
             glog.parse_gcs_url('gs://bucket/'),
             ('bucket', ''))
+
+
+class LoggingMixinTest(unittest.TestCase):
+    def test(self):
+        class MyLoggingClass(airflow.utils.logging.LoggingMixin):
+            pass
+
+        log_class = MyLoggingClass()
+        self.assertEqual(log_class.logger.name, 'tests.utils.MyLoggingClass')
+        self.assertEqual(log_class.logger.level, settings.LOGGING_LEVEL)
+
 
 class OperatorResourcesTest(unittest.TestCase):
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-409

This PR avoids the pattern of:

```
logging.getLogger().handlers = []  # Blow away existing root handlers.
logging.basicConfig(...)  # Install a simple stream handler to standard error/out.
```

And instead calls `addHandler` as appropriate.  This also avoids changing the root logger's log level and only modifies handler log levels.

Testing Done:
- Added unit tests.
- Tested out CLI commands to verify logging still functioned.
