### PR TITLE
[AIRFLOW-446] Adds Zenly as an airflow user

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Currently **officially** using Airflow:
 1. Yahoo!
 1. [Zapier](https://www.zapier.com) [[@drknexus](https://github.com/drknexus) & [@statwonk](https://github.com/statwonk)]
 1. [Zendesk](https://www.github.com/zendesk)
+1. [Zenly](https://zen.ly) [[@cerisier](https://github.com/cerisier) & [@jbdalido](https://github.com/jbdalido)]
 
 ## Links
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- [AIRFLOW-446 - Add Zenly as an Airflow user](https://issues.apache.org/jira/browse/AIRFLOW-446)

Testing Done:
- Non Applicable

Signed-off-by: Corentin Kerisit c@42.am
