### PR TITLE
[AIRFLOW-449] Add Whistle Labs as an Airflow user

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Currently **officially** using Airflow:
 1. [Thumbtack](https://www.thumbtack.com/) [[@natekupp](https://github.com/natekupp)]
 1. [WePay](http://www.wepay.com) [[@criccomini](https://github.com/criccomini) & [@mtagle](https://github.com/mtagle)]
 1. [WeTransfer](https://github.com/WeTransfer) [[@jochem](https://github.com/jochem)]
+1. [Whistle Labs](http://www.whistle.com) [[@ananya77041](https://github.com/ananya77041)]
 1. Wooga
 1. Xoom [[@gepser](https://github.com/gepser) & [@omarvides](https://github.com/omarvides)]
 1. Yahoo!


### PR DESCRIPTION
Adding Whistle Labs as a user of Airflow.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-449

Testing Done:
- N/A
