### PR TITLE
[AIRFLOW-450] example dag "example_http_operator" compatible issue with Python 3

### DIFF
--- a/airflow/example_dags/example_http_operator.py
+++ b/airflow/example_dags/example_http_operator.py
@@ -83,7 +83,7 @@ sensor = HttpSensor(
     http_conn_id='http_default',
     endpoint='',
     params={},
-    response_check=lambda response: True if "Google" in response.content else False,
+    response_check=lambda response: True if b"Google" in response.content else False,
     poke_interval=5,
     dag=dag)
 


### PR DESCRIPTION
fix below issue:
- _https://issues.apache.org/jira/browse/AIRFLOW-450_

Testing Done:
- airflow run example_http_operator http_sensor_check 2016-08-04
- tests passed
