### PR TITLE
[AIRFLOW-447] Store source URIs in Python 3 compatible list

### DIFF
--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -121,7 +121,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                                delegate_to=self.delegate_to)
 
         schema_fields = self.schema_fields if self.schema_fields else json.loads(gcs_hook.download(self.bucket, self.schema_object))
-        source_uris = map(lambda schema_object: 'gs://{}/{}'.format(self.bucket, schema_object), self.source_objects)
+        source_uris = ['gs://{}/{}'.format(self.bucket, schema_object) for schema_object in self.source_objects]
         conn = bq_hook.get_conn()
         cursor = conn.cursor()
         cursor.run_load(


### PR DESCRIPTION
In Python 2 map would generate a list, in Python 3 this is no longer true.
Downstream a job with source_uris set to a Python 3 map object cannot be json-serialized
when attempting to store the job in the database.

This fix keeps the source_uris in a json-serializable list in both Python 2 and 3.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
    - https://issues.apache.org/jira/browse/AIRFLOW-447

Testing Done:
    - Successfully ran BigQuery-related operators on Python 3.5.
