### PR TITLE
[AIRFLOW-443] Make module names unique when importing

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -42,6 +42,8 @@ import sys
 import textwrap
 import traceback
 import warnings
+import hashlib
+
 from urllib.parse import urlparse
 
 from sqlalchemy import (
@@ -245,7 +247,9 @@ class DagBag(BaseDagBag, LoggingMixin):
 
             self.logger.debug("Importing {}".format(filepath))
             org_mod_name, _ = os.path.splitext(os.path.split(filepath)[-1])
-            mod_name = 'unusual_prefix_' + org_mod_name
+            mod_name = ('unusual_prefix_'
+                        + hashlib.sha1(filepath.encode('utf-8')).hexdigest()
+                        + '_' + org_mod_name)
 
             if mod_name in sys.modules:
                 del sys.modules[mod_name]


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-443

Per Apache guidelines you need to create a [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW/).

Testing Done:
- Tba.

Module names are normalized to "unusual_prefix_<filename>" in case
of non-ZIP imports. If there are two modules with the same filename
in a different directory they can overwrite each other. This is
exhibited by the looking at the code from the web interface.

This is fixed by including the filepath in the normalization.
