### PR TITLE
[WiP] Checking that xcom exists before deleting it

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3536,11 +3536,14 @@ class XCom(Base):
         session.expunge_all()
 
         # remove any duplicate XComs
-        session.query(cls).filter(
+        x = session.query(cls).filter(
             cls.key == key,
             cls.execution_date == execution_date,
             cls.task_id == task_id,
-            cls.dag_id == dag_id).delete()
+            cls.dag_id == dag_id).first()
+
+        if x:
+            session.delete(x)
 
         # insert new XCom
         session.add(XCom(


### PR DESCRIPTION
We had contention on the xcom table where the table has grown to a reasonable size and the DELETEs with full table scan were pilling up.

The combination of not issuing a delete if the XCom doesn't exist (lower level lock) and a btree composite index (upcoming commit) in this PR on `(dag_id, task_id, execution_date)` should ensure that this won't hurt again.
