### PR TITLE
[AIRFLOW-91] Add SSL config option for the webserver

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -197,6 +197,11 @@ web_server_host = 0.0.0.0
 # The port on which to run the web server
 web_server_port = 8080
 
+# Paths to the SSL certificate and key for the web server. When both are
+# provided SSL will be enabled. This does not change the web server port.
+web_server_ssl_cert =
+web_server_ssl_key =
+
 # Number of seconds the gunicorn webserver waits before timing out on a worker
 web_server_worker_timeout = 120
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -288,3 +288,25 @@ backend. In order to setup an application:
 5. Fill in the required information (the 'Authorized redirect URIs' must be fully qualifed e.g. http://airflow.example.com/oauth2callback)
 6. Click 'Create'
 7. Copy 'Client ID', 'Client Secret', and your redirect URI to your airflow.cfg according to the above example
+
+SSL
+---
+
+SSL can be enabled by providing a certificate and key. Once enabled, be sure to use
+"https://" in your browser.
+
+.. code-block:: bash
+
+    [webserver]
+    web_server_ssl_cert = <path to cert>
+    web_server_ssl_key = <path to key>
+
+Enabling SSL will not automatically change the web server port. If you want to use the
+standard port 443, you'll need to configure that too. Be aware that super user privileges
+(or cap_net_bind_service on Linux) are required to listen on port 443.
+
+.. code-block:: bash
+
+    # Optionally, set the server to listen on the standard SSL port.
+    web_server_port = 443
+    base_url = http://<hostname or IP>:443


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-91

Testing Done:
- Manual testing with and without SSL and -d. Let me know if there is an easy way to test this.

The CLI options are:

$ airflow webserver --ssl_cert <path> --ssl_key <path>

and the airflow.cfg options are:

web_server_ssl_cert = <path>
web_server_ssl_key = <path>
