### PR TITLE
[AIRFLOW-435] Multiprocessing Scheduler is very slow

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -314,22 +314,29 @@ default_queue = default
 # listen (in seconds).
 job_heartbeat_sec = 5
 
-# The scheduler constantly tries to trigger new tasks (look at the
-# scheduler section in the docs for more information). This defines
-# how often the scheduler should run (in seconds).
+# When the scheduler is running, it periodically updates a timestamp in the DB
+# to indicate that it's running. This controls how often this timestamp is
+# updated.
 scheduler_heartbeat_sec = 5
 
 # after how much time should the scheduler terminate in seconds
 # -1 indicates to run continuously (see also num_runs)
 run_duration = -1
 
-# after how much time a new DAGs should be picked up from the filesystem
-min_file_process_interval = 0
+# On startup, the DAG directory is scanned for DAG definition files. After the
+# the initial scan, subsequent scans are performed with an interval of this
+# many seconds.
+dag_dir_list_interval = 180
 
-dag_dir_list_interval = 300
-
-# How often should stats be printed to the logs
+# To aid debugging, a text table containing a list of DAG definition file names
+# and the corresponding processing time is periodically printed to the log.
+# This controls how often this table should be printed.
 print_stats_interval = 30
+
+# The scheduler should schedule the DAGs in a DAG definition file no more than
+# once every (this many) seconds. 0 means that it should try to schedule a DAG
+# definition file as often as possible.
+min_file_process_interval = 0
 
 child_process_log_directory = /tmp/airflow/scheduler/logs
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-435

One of the scheduler default values may make it look like it's not scheduling as fast as it should, so changing the default so that it processes DAG definition files as fast as possible.

Testing Done:
- Unittests are required, if you do not include new unit tests please
  specify why you think this is not required. We like to improve our
  coverage so a non existing test is even a better reason to include one.

Reminders for contributors (REQUIRED!):
- Your PR's title must reference an issue on 
  [Airflow's JIRA](https://issues.apache.org/jira/browse/AIRFLOW/). 
  For example, a PR called "[AIRFLOW-1] My Amazing PR" would close JIRA 
  issue #1. Please open a new issue if required!
- Please squash your commits when possible and follow the [How to write a good git commit message](http://chris.beams.io/posts/git-commit/). 
  Summarized as follows:
  1. Separate subject from body with a blank line
  2. Limit the subject line to 50 characters
  3. Do not end the subject line with a period
  4. Use the imperative mood in the subject line (add, not adding)
  5. Wrap the body at 72 characters
  6. Use the body to explain what and why vs. how
