### PR TITLE
[AIRFLOW-461] Support autodetected schemas in BigQuery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -198,6 +198,7 @@ def do_setup():
             'python-nvd3==0.14.2',
             'requests>=2.5.1, <3',
             'setproctitle>=1.1.8, <2',
+            'six>=1, <2',
             'sqlalchemy>=0.9.8',
             'tabulate>=0.7.5, <0.8.0',
             'thrift>=0.9.2, <0.10',


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-461

Testing Done:
Tested locally; we don't have a facility for public GCS tests yet.

Adds support for the new autodetect parameter when loading BigQuery tables. This will attempt to generate schemas-on-read when working with CSV and JSON files, so no explicit schema has to be passed.

cc @criccomini @alexvanboxel this has only one small change that is _potentially_ not backwards compatible -- the order of `source_uris` and `schema_fields` is reversed in the `run_load()` method of `BigQueryHook`, because source_uris is required but schema_fields now has a default (None). This will impact you if you're calling the hook's `run_load()` directly with positional arguments, but it won't affect anyone using Operators because all arguments are passed by keyword.
