### PR TITLE
[AIRFLOW-463] Link Airflow icon to landing page

### DIFF
--- a/airflow/www/templates/admin/master.html
+++ b/airflow/www/templates/admin/master.html
@@ -54,13 +54,12 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" rel="home" href="#">
-          <img
-          style="float: left; width:35px; margin-top: -7px;"
-                src="{{ url_for("static", filename="pin_100.png") }}"
-                title="{{ current_user.username }}">
-          <span>Airflow</span>
-        </a>
+          <a class="navbar-brand" rel="home" href="{{ url_for('admin.index') }}" style="cursor: pointer;">
+              <img style="float: left; width:35px; margin-top: -7px;"
+                   src="{{ url_for("static", filename="pin_100.png") }}"
+                   title="{{ current_user.username }}">
+              <span>Airflow</span>
+          </a>
       </div>
       <!-- navbar content -->
       <div class="collapse navbar-collapse" id="admin-navbar-collapse">


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- _https://issues.apache.org/jira/browse/AIRFLOW-463_

As of now the Airflow image icon on top left doesn't leads users to anywhere. It should take users to initial landing page, which is generally happened on most of the other sites.
