### PR TITLE
[AIRFLOW-472] Add liligo as an Airflow user

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Currently **officially** using Airflow:
 1. [Kiwi.com](https://kiwi.com/) [[@underyx](https://github.com/underyx)]
 1. [Kogan.com](https://github.com/kogan) [[@geeknam](https://github.com/geeknam)]
 1. [LendUp](https://www.lendup.com/) [[@lendup](https://github.com/lendup)]
+1. [liligo](http://liligo.com/) [[@tromika](https://github.com/tromika)]
 1. [LingoChamp](http://www.liulishuo.com/) [[@haitaoyao](https://github.com/haitaoyao)]
 1. [Lucid](http://luc.id) [[@jbrownlucid](https://github.com/jbrownlucid) & [@kkourtchikov](https://github.com/kkourtchikov)]
 1. [Lyft](https://www.lyft.com/)[[@SaurabhBajaj](https://github.com/SaurabhBajaj)]


### PR DESCRIPTION
Dear Airflow Maintainers,

Could you pls add liligo to the Airflow users list in the Readme?

Thanks in advance!

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-472
