### PR TITLE
AIRFLOW-156: Add date option to trigger_dag

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -167,7 +167,7 @@ def trigger_dag(args):
         logging.error("Cannot find dag {}".format(args.dag_id))
         sys.exit(1)
 
-    execution_date = datetime.now()
+    execution_date = args.execution_date if args.execution_date else datetime.now()
     run_id = args.run_id or "manual__{0}".format(execution_date.isoformat())
 
     dr = DagRun.find(dag_id=args.dag_id, run_id=run_id)
@@ -1050,6 +1050,9 @@ class CLIFactory(object):
         'conf': Arg(
             ('-c', '--conf'),
             "JSON string that gets pickled into the DagRun's conf attribute"),
+        'date': Arg(
+            ("-d", "--execution_date"), "Override execution_date YYYY-MM-DD",
+            type=parsedate),
         # pool
         'pool_set': Arg(
             ("-s", "--set"),
@@ -1272,7 +1275,7 @@ class CLIFactory(object):
         }, {
             'func': trigger_dag,
             'help': "Trigger a DAG run",
-            'args': ('dag_id', 'subdir', 'run_id', 'conf'),
+            'args': ('dag_id', 'subdir', 'run_id', 'conf', 'date'),
         }, {
             'func': pool,
             'help': "CRUD operations on pools",

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -167,7 +167,7 @@ def trigger_dag(args):
         logging.error("Cannot find dag {}".format(args.dag_id))
         sys.exit(1)
 
-    execution_date = args.execution_date if args.execution_date else datetime.now()
+    execution_date = parsedate(args.execution_date) if args.execution_date else datetime.now()
     run_id = args.run_id or "manual__{0}".format(execution_date.isoformat())
 
     dr = DagRun.find(dag_id=args.dag_id, run_id=run_id)
@@ -1050,9 +1050,10 @@ class CLIFactory(object):
         'conf': Arg(
             ('-c', '--conf'),
             "JSON string that gets pickled into the DagRun's conf attribute"),
-        'date': Arg(
-            ("-d", "--execution_date"), "Override execution_date YYYY-MM-DD",
-            type=parsedate),
+        'execution_date': Arg(
+            ('-e', '--execution_date'),
+            'Execution date of DAG run (defaults to the current time)'
+        ),
         # pool
         'pool_set': Arg(
             ("-s", "--set"),
@@ -1275,7 +1276,7 @@ class CLIFactory(object):
         }, {
             'func': trigger_dag,
             'help': "Trigger a DAG run",
-            'args': ('dag_id', 'subdir', 'run_id', 'conf', 'date'),
+            'args': ('dag_id', 'subdir', 'run_id', 'conf', 'execution_date'),
         }, {
             'func': pool,
             'help': "CRUD operations on pools",

--- a/airflow/example_dags/example_trigger_date_dag.py
+++ b/airflow/example_dags/example_trigger_date_dag.py
@@ -17,7 +17,7 @@ This example illustrates the following features :
 """
 
 from airflow import DAG
-from airflow.operators import TriggerDagRunOperator
+from airflow.operators.dagrun_operator import TriggerDagRunOperator
 from datetime import datetime
 
 import pprint
@@ -42,14 +42,14 @@ dag = DAG(dag_id='example_trigger_date_dag',
 trigger = TriggerDagRunOperator(task_id='test_trigger_date_dagrun',
                                 trigger_dag_id="example_trigger_target_dag",
                                 python_callable=conditionally_trigger,
-                                execution_date="2015-01-01",
+                                execution_date=datetime(2015, 1, 1),
                                 params={'condition_param': True,
                                         'message': 'Hello World'},
                                 dag=dag)
 
 no_trigger = TriggerDagRunOperator(task_id='test_no_trigger_date_dagrun',
-                                trigger_dag_id="example_trigger_target_dag",
-                                python_callable=conditionally_trigger,
-                                params={'condition_param': True,
-                                        'message': 'Hello World'},
-                                dag=dag)
+                                   trigger_dag_id="example_trigger_target_dag",
+                                   python_callable=conditionally_trigger,
+                                   params={'condition_param': True,
+                                           'message': 'Hello World'},
+                                   dag=dag)

--- a/airflow/example_dags/example_trigger_date_dag.py
+++ b/airflow/example_dags/example_trigger_date_dag.py
@@ -1,0 +1,55 @@
+
+"""This example illustrates the use of the TriggerDagRunOperator. There are 2
+entities at work in this scenario:
+1. The Controller DAG - the DAG that conditionally executes the trigger
+2. The Target DAG - DAG being triggered (in example_trigger_target_dag.py)
+
+This example illustrates the following features :
+1. A TriggerDagRunOperator that takes:
+  a. A python callable that decides whether or not to trigger the Target DAG
+  b. An optional params dict passed to the python callable to help in
+     evaluating whether or not to trigger the Target DAG
+  c. The id (name) of the Target DAG
+  d. The python callable can add contextual info to the DagRun created by
+     way of adding a Pickleable payload (e.g. dictionary of primitives). This
+     state is then made available to the TargetDag
+2. A Target DAG : c.f. example_trigger_target_dag.py
+"""
+
+from airflow import DAG
+from airflow.operators import TriggerDagRunOperator
+from datetime import datetime
+
+import pprint
+
+pp = pprint.PrettyPrinter(indent=4)
+
+
+def conditionally_trigger(context, dag_run_obj):
+    """This function decides whether or not to Trigger the remote DAG"""
+    # Demonstrates use of the custom execution date in the conditional trigger
+    if dag_run_obj.execution_date < datetime(2016, 1, 1):
+        dag_run_obj.payload = {'message': context['params']['message']}
+        return dag_run_obj
+    return None
+
+# Define the DAG
+dag = DAG(dag_id='example_trigger_date_dag',
+          default_args={"owner": "airflow",
+                        "start_date": datetime.now()},
+          schedule_interval='@once')
+
+trigger = TriggerDagRunOperator(task_id='test_trigger_date_dagrun',
+                                trigger_dag_id="example_trigger_target_dag",
+                                python_callable=conditionally_trigger,
+                                execution_date="2015-01-01",
+                                params={'condition_param': True,
+                                        'message': 'Hello World'},
+                                dag=dag)
+
+no_trigger = TriggerDagRunOperator(task_id='test_no_trigger_date_dagrun',
+                                trigger_dag_id="example_trigger_target_dag",
+                                python_callable=conditionally_trigger,
+                                params={'condition_param': True,
+                                        'message': 'Hello World'},
+                                dag=dag)

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -350,7 +350,7 @@ class DagBag(BaseDagBag, LoggingMixin):
                     Stats.incr('zombies_killed')
         session.commit()
 
-    def bag_dag(self, dag, parent_dag, root_dag):
+    def bag_dag(self, dag, parent_dag=None, root_dag=None):
         """
         Adds the DAG into the bag, recurses into sub dags.
         """

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -24,9 +24,10 @@ from airflow import configuration as conf
 
 
 class DagRunOrder(object):
-    def __init__(self, run_id=None, payload=None):
+    def __init__(self, run_id=None, payload=None, execution_date=None):
         self.run_id = run_id
         self.payload = payload
+        self.execution_date = execution_date
 
 
 class TriggerDagRunOperator(BaseOperator):
@@ -45,6 +46,9 @@ class TriggerDagRunOperator(BaseOperator):
         to your tasks while executing that DAG run. Your function header
         should look like ``def foo(context, dag_run_obj):``
     :type python_callable: python callable
+    :param execution_date: the date to run the dag for in 'YYYY-MM-DD' format.
+        Defaults to ``datetime.now()``
+    :type execution_date: str
     """
     template_fields = tuple()
     template_ext = tuple()
@@ -55,13 +59,20 @@ class TriggerDagRunOperator(BaseOperator):
             self,
             trigger_dag_id,
             python_callable,
+            execution_date = None,
             *args, **kwargs):
         super(TriggerDagRunOperator, self).__init__(*args, **kwargs)
         self.python_callable = python_callable
         self.trigger_dag_id = trigger_dag_id
+        if execution_date:
+            print("Setting execution date to: " + execution_date)
+            self.execution_date = datetime.strptime(execution_date, '%Y-%m-%d')
+        else:
+            self.execution_date = None
 
     def execute(self, context):
-        dro = DagRunOrder(run_id='trig__' + datetime.now().isoformat())
+        date = self.execution_date if self.execution_date else datetime.now()
+        dro = DagRunOrder(run_id='trig__' + date.isoformat(), execution_date=date)
         dro = self.python_callable(context, dro)
         if dro:
             session = settings.Session()
@@ -71,6 +82,7 @@ class TriggerDagRunOperator(BaseOperator):
                 run_id=dro.run_id,
                 state=State.RUNNING,
                 conf=dro.payload,
+                execution_date=date,
                 external_trigger=True)
             logging.info("Creating DagRun {}".format(dr))
             session.add(dr)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.models import DagBag
+
+
+def mock_dag_bag(*args):
+    """Given instances of the ``DAG`` class, returns a ``DagBag`` instance
+    (for use with ``mock.patch``) that contains the DAGs."""
+    for dag in args:
+        if not hasattr(dag, 'is_subdag'):
+            dag.is_subdag = False  # Normally set in ``DagBag.bag_dag``.
+
+    dag_bag = DagBag()
+
+    for dag in args:
+        dag_bag.bag_dag(dag)
+
+    return dag_bag

--- a/tests/operators/dag_run_operator.py
+++ b/tests/operators/dag_run_operator.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+from io import StringIO
+from logging import getLogger, StreamHandler
+from mock import patch
+from unittest import TestCase
+
+from airflow import DAG
+from airflow.models import DagRun, TaskInstance
+from airflow.operators.dagrun_operator import TriggerDagRunOperator
+
+from tests.helpers import mock_dag_bag
+
+
+DEFAULT_DATE = datetime(2015, 1, 1)
+EXECUTION_DATE_OVERRIDE = datetime(2015, 2, 1, 14, 20, 5)
+TEST_DAG_ID = 'unit_test_dag'
+TRIGGER_DAG_ID = 'unit_test_trigger_dag'
+
+
+class TriggerDagRunOperatorTestCase(TestCase):
+    def setUp(self):
+        args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE,
+        }
+        self.dag = DAG(TEST_DAG_ID, default_args=args)
+        self.trigger_dag = DAG(TRIGGER_DAG_ID, default_args=args)
+        self.dag_bag = mock_dag_bag(self.trigger_dag)
+
+        # Set up logging intercept.
+        self.root_logger = getLogger()
+        self.log_stream = StringIO()
+        self.root_logger.addHandler(StreamHandler(stream=self.log_stream))
+
+        self.callback_called = False
+
+    def test_callable_ignore_status(self):
+        # Make sure python_callable is correctly called and ignore output
+        # (None) is respected.
+        def my_callable(context, dro):
+            self.assertEqual(dro.run_id, 'trig__2015-01-01T00:00:00')
+            self.assertEqual(dro.execution_date, DEFAULT_DATE)
+            self.callback_called = True
+
+        task = TriggerDagRunOperator(
+            task_id='test_trigger_dag_run_ignore_status',
+            trigger_dag_id=self.trigger_dag.dag_id,
+            python_callable=my_callable,
+            dag=self.dag,
+            # No execution_date set -> should be passed from TaskInstance in
+            # context.
+        )
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.run()
+
+        self.assertTrue(self.callback_called)
+        self.assertIn('Criteria not met, moving on',
+                      self.log_stream.getvalue())
+
+    @patch('airflow.operators.dagrun_operator.DagBag')
+    def test_callable_run_status(self, mock_DagBag):
+        mock_DagBag.return_value = self.dag_bag
+
+        def my_callable(context, dro):
+            self.assertEqual(dro.run_id, 'trig__2015-02-01T14:20:05')
+            self.assertEqual(dro.execution_date, EXECUTION_DATE_OVERRIDE)
+            self.callback_called = True
+            return dro
+
+        task = TriggerDagRunOperator(
+            task_id='test_trigger_dag_run_run_status',
+            trigger_dag_id=self.trigger_dag.dag_id,
+            python_callable=my_callable,
+            dag=self.dag,
+            execution_date=EXECUTION_DATE_OVERRIDE,
+        )
+
+        # Run task.
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.run()
+
+        self.assertTrue(self.callback_called)
+        self.assertIn('Creating DagRun', self.log_stream.getvalue())
+
+    @patch('airflow.operators.dagrun_operator.DagBag')
+    def test_callable_can_modify_dro(self, mock_DagBag):
+        mock_DagBag.return_value = self.dag_bag
+        RUN_ID = 'test_trigger_dag_run_hotswap'
+
+        def my_callable(context, dro):
+            self.assertEqual(dro.execution_date, DEFAULT_DATE)
+            dro.run_id = RUN_ID
+            dro.execution_date = EXECUTION_DATE_OVERRIDE
+            self.callback_called = True
+            return dro
+
+        task = TriggerDagRunOperator(
+            task_id='test_trigger_dag_run_modify_dro',
+            trigger_dag_id=self.trigger_dag.dag_id,
+            python_callable=my_callable,
+            dag=self.dag,
+        )
+
+        # Run task.
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.run()
+
+        self.assertTrue(self.callback_called)
+        self.assertIn('Creating DagRun', self.log_stream.getvalue())
+
+        # Make sure we kicked off a DAG run with the right params.
+        dr = DagRun.find(dag_id=self.trigger_dag.dag_id,
+                         run_id=RUN_ID,
+                         execution_date=EXECUTION_DATE_OVERRIDE)
+        self.assertIsNotNone(dr)


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- [AIRFLOW-156](https://issues.apache.org/jira/browse/AIRFLOW-156)

This finishes the work started by @jeffreypicard in #1531. 

Testing Done:
- Add unit tests for `TriggerDagRunOperator` (none existed) that cover basic usage and passing in `execution_date`.
- Manually CLI command with and without execution_date and verified the output looked correct.
