### PR TITLE
[AIRFLOW-489] Add API Framework

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -19,3 +19,8 @@ metastore_db
 .*csv
 CHANGELOG.txt
 .*zip
+# Apache Rat does not detect BSD-2 clause properly
+# it is compatible according to http://www.apache.org/legal/resolved.html#category-a
+kerberos_auth.py
+airflow_api_auth_backend_kerberos_auth_py.html
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ addons:
       - mysql-client-core-5.6
       - mysql-client-5.6
       - krb5-user
+      - krb5-kdc
+      - krb5-admin-server
+      - python-selinux
   postgresql: "9.2"
 python:
   - "2.7"
@@ -35,6 +38,8 @@ python:
 env:
   global:
     - TRAVIS_CACHE=$HOME/.travis_cache/
+    - KRB5_CONFIG=/etc/krb5.conf
+    - KRB5_KTNAME=/etc/airflow.keytab
     # Travis on google cloud engine has a global /etc/boto.cfg that
     # does not work with python 3
     - BOTO_CONFIG=/tmp/bogusvalue

--- a/NOTICE
+++ b/NOTICE
@@ -15,3 +15,4 @@ This product includes Underscore.js (http://underscorejs.org - MIT license), Cop
 This product includes FooTable (http://fooplugins.com/plugins/footable-jquery/ - MIT license), Copyright 2013 Steven Usher & Brad Vincent.
 This product includes dagre (https://github.com/cpettitt/dagre - MIT license), Copyright (c) 2012-2014 Chris Pettitt.
 This product includes d3js (https://d3js.org/ - https://github.com/mbostock/d3/blob/master/LICENSE), Copyright (c) 2010-2016, Michael Bostock.
+This product includes flask-kerberos (https://github.com/mkomitee/flask-kerberos - BSD License), Copyright (c) 2013, Michael Komitee

--- a/airflow/api/__init__.py
+++ b/airflow/api/__init__.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+import logging
+
+from airflow.exceptions import AirflowException
+from airflow import configuration as conf
+from importlib import import_module
+
+api_auth = None
+
+
+def load_auth():
+    auth_backend = 'airflow.api.auth.backend.default'
+    try:
+        auth_backend = conf.get("api", "auth_backend")
+    except conf.AirflowConfigException:
+        pass
+
+    try:
+        global api_auth
+        api_auth = import_module(auth_backend)
+    except ImportError as err:
+        logging.critical("Cannot import {} for API authentication due to: {}"
+                         .format(auth_backend, err))
+        raise AirflowException(err)

--- a/airflow/api/auth/__init__.py
+++ b/airflow/api/auth/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -10,14 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-org.name=TEST
-org.domain=LOCAL
-kdc.bind.address=localhost
-kdc.port=8888
-instance=DefaultKrbServer
-max.ticket.lifetime=86400000
-max.renewable.lifetime=604800000
-transport=TCP
-debug=true
-

--- a/airflow/api/auth/backend/__init__.py
+++ b/airflow/api/auth/backend/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -10,14 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-org.name=TEST
-org.domain=LOCAL
-kdc.bind.address=localhost
-kdc.port=8888
-instance=DefaultKrbServer
-max.ticket.lifetime=86400000
-max.renewable.lifetime=604800000
-transport=TCP
-debug=true
-

--- a/airflow/api/auth/backend/default.py
+++ b/airflow/api/auth/backend/default.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,13 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.name=TEST
-org.domain=LOCAL
-kdc.bind.address=localhost
-kdc.port=8888
-instance=DefaultKrbServer
-max.ticket.lifetime=86400000
-max.renewable.lifetime=604800000
-transport=TCP
-debug=true
+from functools import wraps
 
+client_auth = None
+
+
+def init_app(app):
+    pass
+
+
+def requires_authentication(function):
+    @wraps(function)
+    def decorated(*args, **kwargs):
+        return function(*args, **kwargs)
+
+    return decorated

--- a/airflow/api/auth/backend/kerberos_auth.py
+++ b/airflow/api/auth/backend/kerberos_auth.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2013, Michael Komitee
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from future.standard_library import install_aliases
+install_aliases()
+
+import kerberos
+import logging
+import os
+
+from airflow import configuration as conf
+
+from flask import Response
+from flask import _request_ctx_stack as stack
+from flask import make_response
+from flask import request
+from flask import g
+from functools import wraps
+
+from requests_kerberos import HTTPKerberosAuth
+from socket import getfqdn
+
+client_auth = HTTPKerberosAuth(service='airflow')
+
+_SERVICE_NAME = None
+
+
+def init_app(app):
+    global _SERVICE_NAME
+
+    hostname = app.config.get('SERVER_NAME')
+    if not hostname:
+        hostname = getfqdn()
+    logging.info("Kerberos: hostname {}".format(hostname))
+
+    service = 'airflow'
+
+    _SERVICE_NAME = "{}@{}".format(service, hostname)
+
+    if 'KRB5_KTNAME' not in os.environ:
+        os.environ['KRB5_KTNAME'] = conf.get('kerberos', 'keytab')
+
+    try:
+        logging.info("Kerberos init: {} {}".format(service, hostname))
+        principal = kerberos.getServerPrincipalDetails(service, hostname)
+    except kerberos.KrbError as err:
+        logging.warn("Kerberos: {}".format(err))
+    else:
+        logging.info("Kerberos API: server is {}".format(principal))
+
+
+def _unauthorized():
+    """
+    Indicate that authorization is required
+    :return:
+    """
+    return Response("Unauthorized", 401, {"WWW-Authenticate": "Negotiate"})
+
+
+def _forbidden():
+    return Response("Forbidden", 403)
+
+
+def _gssapi_authenticate(token):
+    state = None
+    ctx = stack.top
+    try:
+        rc, state = kerberos.authGSSServerInit(_SERVICE_NAME)
+        if rc != kerberos.AUTH_GSS_COMPLETE:
+            return None
+        rc = kerberos.authGSSServerStep(state, token)
+        if rc == kerberos.AUTH_GSS_COMPLETE:
+            ctx.kerberos_token = kerberos.authGSSServerResponse(state)
+            ctx.kerberos_user = kerberos.authGSSServerUserName(state)
+            return rc
+        elif rc == kerberos.AUTH_GSS_CONTINUE:
+            return kerberos.AUTH_GSS_CONTINUE
+        else:
+            return None
+    except kerberos.GSSError:
+        return None
+    finally:
+        if state:
+            kerberos.authGSSServerClean(state)
+
+
+def requires_authentication(function):
+    @wraps(function)
+    def decorated(*args, **kwargs):
+        header = request.headers.get("Authorization")
+        if header:
+            ctx = stack.top
+            token = ''.join(header.split()[1:])
+            rc = _gssapi_authenticate(token)
+            if rc == kerberos.AUTH_GSS_COMPLETE:
+                g.user = ctx.kerberos_user
+                response = function(*args, **kwargs)
+                response = make_response(response)
+                if ctx.kerberos_token is not None:
+                    response.headers['WWW-Authenticate'] = ' '.join(['negotiate',
+                                                                     ctx.kerberos_token])
+
+                return response
+            elif rc != kerberos.AUTH_GSS_CONTINUE:
+                return _forbidden()
+        return _unauthorized()
+    return decorated

--- a/airflow/api/client/__init__.py
+++ b/airflow/api/client/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -10,14 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-org.name=TEST
-org.domain=LOCAL
-kdc.bind.address=localhost
-kdc.port=8888
-instance=DefaultKrbServer
-max.ticket.lifetime=86400000
-max.renewable.lifetime=604800000
-transport=TCP
-debug=true
 

--- a/airflow/api/client/api_client.py
+++ b/airflow/api/client/api_client.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -10,14 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
-org.name=TEST
-org.domain=LOCAL
-kdc.bind.address=localhost
-kdc.port=8888
-instance=DefaultKrbServer
-max.ticket.lifetime=86400000
-max.renewable.lifetime=604800000
-transport=TCP
-debug=true
 
+class Client:
+    def __init__(self, api_base_url, auth):
+        self._api_base_url = api_base_url
+        self._auth = auth
+
+    def trigger_dag(self, dag_id, run_id=None, conf=None):
+        """
+        Creates a dag run for the specified dag
+        :param dag_id:
+        :param run_id:
+        :param conf:
+        :return:
+        """
+        raise NotImplementedError()

--- a/airflow/api/client/json_client.py
+++ b/airflow/api/client/json_client.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from future.moves.urllib.parse import urljoin
+
+from airflow.api.client import api_client
+
+import requests
+
+
+class Client(api_client.Client):
+    def trigger_dag(self, dag_id, run_id=None, conf=None):
+        endpoint = '/api/experimental/dags/{}/dag_runs'.format(dag_id)
+        url = urljoin(self._api_base_url, endpoint)
+
+        resp = requests.post(url,
+                             auth=self._auth,
+                             json={
+                                 "run_id": run_id,
+                                 "conf": conf,
+                             })
+
+        if not resp.ok:
+            raise IOError()
+
+        data = resp.json()
+
+        return data['message']

--- a/airflow/api/client/local_client.py
+++ b/airflow/api/client/local_client.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -10,14 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+from airflow.api.client import api_client
+from airflow.api.common.experimental import trigger_dag
 
-org.name=TEST
-org.domain=LOCAL
-kdc.bind.address=localhost
-kdc.port=8888
-instance=DefaultKrbServer
-max.ticket.lifetime=86400000
-max.renewable.lifetime=604800000
-transport=TCP
-debug=true
 
+class Client(api_client.Client):
+    def trigger_dag(self, dag_id, run_id=None, conf=None):
+        dr = trigger_dag.trigger_dag(dag_id=dag_id, run_id=run_id, conf=conf)
+        return "Created {}".format(dr)

--- a/airflow/api/common/__init__.py
+++ b/airflow/api/common/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -10,14 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-org.name=TEST
-org.domain=LOCAL
-kdc.bind.address=localhost
-kdc.port=8888
-instance=DefaultKrbServer
-max.ticket.lifetime=86400000
-max.renewable.lifetime=604800000
-transport=TCP
-debug=true
-

--- a/airflow/api/common/experimental/__init__.py
+++ b/airflow/api/common/experimental/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -10,14 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-org.name=TEST
-org.domain=LOCAL
-kdc.bind.address=localhost
-kdc.port=8888
-instance=DefaultKrbServer
-max.ticket.lifetime=86400000
-max.renewable.lifetime=604800000
-transport=TCP
-debug=true
-

--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+import json
+
+from airflow.exceptions import AirflowException
+from airflow.models import DagRun, DagBag
+from airflow.utils.state import State
+
+import logging
+
+
+def trigger_dag(dag_id, run_id=None, conf=None):
+    dagbag = DagBag()
+
+    if dag_id not in dagbag.dags:
+        raise AirflowException("Dag id {} not found".format(dag_id))
+
+    dag = dagbag.get_dag(dag_id)
+
+    execution_date = datetime.now()
+
+    if not run_id:
+        run_id = "manual__{0}".format(execution_date.isoformat())
+
+    dr = DagRun.find(dag_id=dag_id, run_id=run_id)
+    if dr:
+        raise AirflowException("Run id {} already exists for dag id {}".format(
+            run_id,
+            dag_id
+        ))
+
+    run_conf = None
+    if conf:
+        run_conf = json.loads(conf)
+
+    trigger = dag.create_dagrun(
+        run_id=run_id,
+        execution_date=execution_date,
+        state=State.RUNNING,
+        conf=run_conf,
+        external_trigger=True
+    )
+
+    return trigger

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -173,6 +173,16 @@ security =
 # values at runtime)
 unit_test_mode = False
 
+[cli]
+# In what way should the cli access the API. The LocalClient will use the
+# database directly, while the json_client will use the api running on the
+# webserver
+api_client = airflow.api.client.local_client
+endpoint_url = http://localhost:8080
+
+[api]
+# How to authenticate users of the API
+auth_backend = airflow.api.auth.backend.default
 
 [operators]
 # The default owner assigned to each new operator, unless
@@ -422,6 +432,13 @@ dag_concurrency = 16
 dags_are_paused_at_creation = False
 fernet_key = {FERNET_KEY}
 non_pooled_task_slot_count = 128
+
+[cli]
+api_client = airflow.api.client.local_client
+endpoint_url = http://localhost:8080
+
+[api]
+auth_backend = airflow.api.auth.backend.default
 
 [operators]
 default_owner = airflow

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -130,6 +130,7 @@ def configure_orm():
         engine_args['pool_size'] = conf.getint('core', 'SQL_ALCHEMY_POOL_SIZE')
         engine_args['pool_recycle'] = conf.getint('core',
                                                   'SQL_ALCHEMY_POOL_RECYCLE')
+        #engine_args['echo'] = True
 
     engine = create_engine(SQL_ALCHEMY_CONN, **engine_args)
     Session = scoped_session(

--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -11,27 +11,75 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+import logging
 
-from airflow.www.views import dagbag
+import airflow.api
 
-from flask import Blueprint, jsonify
+from airflow.api.common.experimental import trigger_dag as trigger
+from airflow.exceptions import AirflowException
+from airflow.www.app import csrf
+
+from flask import (
+    g, Markup, Blueprint, redirect, jsonify, abort, request, current_app, send_file
+)
+
+requires_authentication = airflow.api.api_auth.requires_authentication
 
 api_experimental = Blueprint('api_experimental', __name__)
 
+@csrf.exempt
+@api_experimental.route('/dags/<string:dag_id>/dag_runs', methods=['POST'])
+@requires_authentication
+def trigger_dag(dag_id):
+    """
+    Trigger a new dag run for a Dag
+    """
+    data = request.get_json(force=True)
+
+    run_id = None
+    if 'run_id' in data:
+        run_id = data['run_id']
+
+    conf = None
+    if 'conf' in data:
+        conf = data['conf']
+
+    try:
+        dr = trigger.trigger_dag(dag_id, run_id, conf)
+    except AirflowException as err:
+        logging.error(err)
+        response = jsonify(error="{}".format(err))
+        response.status_code = 404
+        return response
+
+    if getattr(g, 'user', None):
+        logging.info("User {} created {}".format(g.user, dr))
+
+    response = jsonify(message="Created {}".format(dr))
+    return response
+
+
+@api_experimental.route('/test', methods=['GET'])
+@requires_authentication
+def test():
+    return jsonify(status='OK')
+
 
 @api_experimental.route('/dags/<string:dag_id>/tasks/<string:task_id>', methods=['GET'])
+@requires_authentication
 def task_info(dag_id, task_id):
     """Returns a JSON with a task's public instance variables. """
+    from airflow.www.views import dagbag
+
     if dag_id not in dagbag.dags:
-        response = jsonify({'error': 'Dag {} not found'.format(dag_id)})
+        response = jsonify(error='Dag {} not found'.format(dag_id))
         response.status_code = 404
         return response
 
     dag = dagbag.dags[dag_id]
     if not dag.has_task(task_id):
-        response = (jsonify({'error': 'Task {} not found in dag {}'
-                    .format(task_id, dag_id)}))
+        response = (jsonify(error='Task {} not found in dag {}'
+                    .format(task_id, dag_id)))
         response.status_code = 404
         return response
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,43 @@
+Experimental Rest API
+=====================
+
+Airflow exposes an experimental Rest API. It is available through the webserver. Endpoints are
+available at /api/experimental/. Please note that we expect the endpoint definitions to change.
+
+Endpoints
+---------
+
+This is a place holder until the swagger definitions are active
+
+* /api/experimental/dags/<DAG_ID>/tasks/<TASK_ID> returns info for a task (GET).
+* /api/experimental/dags/<DAG_ID>/dag_runs creates a dag_run for a given dag id (POST).
+
+CLI
+-----
+
+For some functions the cli can use the API. To configure the CLI to use the API when available
+configure as follows:
+
+.. code-block:: bash
+
+    [cli]
+    api_client = airflow.api.client.json_client
+    endpoint_url = http://<WEBSERVER>:<PORT>
+
+
+Authentication
+--------------
+
+Only Kerberos authentication is currently supported for the API. To enable this set the following
+in the configuration:
+
+.. code-block:: bash
+
+    [api]
+    auth_backend = airflow.api.auth.backend.default
+
+    [kerberos]
+    keytab = <KEYTAB>
+
+The Kerberos service is configured as `airflow/fully.qualified.domainname@REALM`. Make sure this
+principal exists in the keytab file.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,6 +83,7 @@ Content
     scheduler
     plugins
     security
+    api
     integration
     faq
     code

--- a/scripts/ci/kadm5.acl
+++ b/scripts/ci/kadm5.acl
@@ -10,14 +10,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-org.name=TEST
-org.domain=LOCAL
-kdc.bind.address=localhost
-kdc.port=8888
-instance=DefaultKrbServer
-max.ticket.lifetime=86400000
-max.renewable.lifetime=604800000
-transport=TCP
-debug=true
-
+*/admin@TEST.LOCAL    *

--- a/scripts/ci/kdc.conf
+++ b/scripts/ci/kdc.conf
@@ -10,14 +10,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+[kdcdefaults]
+kdc_ports = 88
+kdc_tcp_ports = 88
 
-org.name=TEST
-org.domain=LOCAL
-kdc.bind.address=localhost
-kdc.port=8888
-instance=DefaultKrbServer
-max.ticket.lifetime=86400000
-max.renewable.lifetime=604800000
-transport=TCP
-debug=true
-
+[realms]
+TEST.LOCAL = {
+  #master_key_type = aes256-cts
+  acl_file = /var/kerberos/krb5kdc/kadm5.acl
+  dict_file = /usr/share/dict/words
+  admin_keytab = /var/kerberos/krb5kdc/kadm5.keytab
+  supported_enctypes = aes256-cts:normal aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
+}

--- a/scripts/ci/krb5.conf
+++ b/scripts/ci/krb5.conf
@@ -11,13 +11,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.name=TEST
-org.domain=LOCAL
-kdc.bind.address=localhost
-kdc.port=8888
-instance=DefaultKrbServer
-max.ticket.lifetime=86400000
-max.renewable.lifetime=604800000
-transport=TCP
-debug=true
+[logging]
+default = FILE:/var/log/krb5libs.log
+kdc = FILE:/var/log/krb5kdc.log
+admin_server = FILE:/var/log/kadmind.log
 
+[libdefaults]
+default_realm = TEST.LOCAL
+dns_lookup_realm = false
+dns_lookup_kdc = false
+ticket_lifetime = 24h
+renew_lifetime = 7d
+forwardable = true
+
+[realms]
+ TEST.LOCAL = {
+   kdc = localhost:88
+   kdc = localhost:88
+ }

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -49,6 +49,7 @@ python-daemon
 python-dateutil
 redis
 requests
+requests-kerberos
 setproctitle
 slackclient
 sphinx

--- a/scripts/ci/run_tests.sh
+++ b/scripts/ci/run_tests.sh
@@ -33,6 +33,9 @@ if [ "${TRAVIS}" ]; then
 
     ROOTDIR="$(dirname $(dirname $DIR))"
     export AIRFLOW__CORE__DAGS_FOLDER="$ROOTDIR/tests/dags"
+
+    # kdc init happens in setup_kdc.sh
+    kinit -kt ${KRB5_KTNAME} airflow
 fi
 
 echo Backend: $AIRFLOW__CORE__SQL_ALCHEMY_CONN

--- a/setup.py
+++ b/setup.py
@@ -149,9 +149,11 @@ slack = ['slackclient>=1.0.0']
 statsd = ['statsd>=3.0.1, <4.0']
 vertica = ['vertica-python>=0.5.1']
 ldap = ['ldap3>=0.9.9.1']
-kerberos = ['pykerberos>=1.1.8',
+kerberos = ['pykerberos>=1.1.13',
+            'requests_kerberos>=0.10.0',
             'thrift_sasl>=0.2.0',
-            'snakebite[kerberos]>=2.7.8']
+            'snakebite[kerberos]>=2.7.8',
+            'kerberos>=1.2.5']
 password = [
     'bcrypt>=2.0.0',
     'flask-bcrypt>=0.7.1',
@@ -197,6 +199,7 @@ def do_setup():
             'flask-admin==1.4.1',
             'flask-cache>=0.13.1, <0.14',
             'flask-login==0.2.11',
+            'flask-swagger==0.2.13',
             'flask-wtf==0.12',
             'funcsigs>=1.0.2, <1.1',
             'future>=0.15.0, <0.16',

--- a/tests/www/api/experimental/test_kerberos_endpoints.py
+++ b/tests/www/api/experimental/test_kerberos_endpoints.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import mock
+import os
+import socket
+import unittest
+
+from datetime import datetime
+
+from airflow import configuration
+from airflow.api.auth.backend.kerberos_auth import client_auth
+from airflow.www import app as application
+
+
+@unittest.skipIf('KRB5_KTNAME' not in os.environ,
+                 'Skipping Kerberos API tests due to missing KRB5_KTNAME')
+class ApiKerberosTests(unittest.TestCase):
+    def setUp(self):
+        configuration.load_test_config()
+        try:
+            configuration.conf.add_section("api")
+        except:
+            pass
+        configuration.conf.set("api",
+                               "auth_backend",
+                               "airflow.api.auth.backend.kerberos_auth")
+        try:
+            configuration.conf.add_section("kerberos")
+        except:
+            pass
+        configuration.conf.set("kerberos",
+                               "keytab",
+                               os.environ['KRB5_KTNAME'])
+
+        self.app = application.create_app(testing=True)
+
+    def test_trigger_dag(self):
+        with self.app.test_client() as c:
+            url_template = '/api/experimental/dags/{}/dag_runs'
+            response = c.post(
+                url_template.format('example_bash_operator'),
+                data=json.dumps(dict(run_id='my_run' + datetime.now().isoformat())),
+                content_type="application/json"
+            )
+            self.assertEqual(401, response.status_code)
+
+            response.url = 'http://{}'.format(socket.getfqdn())
+
+            class Request():
+                headers = {}
+
+            response.request = Request()
+            response.content = ''
+            response.raw = mock.MagicMock()
+            response.connection = mock.MagicMock()
+            response.connection.send = mock.MagicMock()
+
+            # disable mutual authentication for testing
+            client_auth.mutual_authentication = 3
+
+            # case can influence the results
+            client_auth.hostname_override = socket.getfqdn()
+
+            client_auth.handle_response(response)
+            self.assertIn('Authorization', response.request.headers)
+
+            response2 = c.post(
+                url_template.format('example_bash_operator'),
+                data=json.dumps(dict(run_id='my_run' + datetime.now().isoformat())),
+                content_type="application/json",
+                headers=response.request.headers
+            )
+            self.assertEqual(200, response2.status_code)
+
+    def test_unauthorized(self):
+        with self.app.test_client() as c:
+            url_template = '/api/experimental/dags/{}/dag_runs'
+            response = c.post(
+                url_template.format('example_bash_operator'),
+                data=json.dumps(dict(run_id='my_run' + datetime.now().isoformat())),
+                content_type="application/json"
+            )
+
+            self.assertEqual(401, response.status_code)

--- a/tox.ini
+++ b/tox.ini
@@ -32,14 +32,12 @@ setenv =
   COVERALLS_REPO_TOKEN=ic8IH7CrUrtweVbmY3VZQ7ncEGe1XJA5E
   cdh: HADOOP_DISTRO=cdh
   cdh: HADOOP_HOME=/tmp/hadoop-cdh
-  cdh: KRB5_CONFIG=/tmp/minikdc/work
-  cdh: HADOOP_OPTS=-D/tmp/minikdc/work/krb5.conf
+  cdh: HADOOP_OPTS=-D/tmp/krb5.conf
   cdh: MINICLUSTER_HOME=/tmp/minicluster-1.1-SNAPSHOT
   cdh: HIVE_HOME=/tmp/hive
   hdp: HADOOP_DISTRO=hdp
   hdp: HADOOP_HOME=/tmp/hadoop-hdp
-  hdp: KRB5_CONFIG=/tmp/minikdc/work
-  hdp: HADOOP_OPTS=-D/tmp/minikdc/work/krb5.conf
+  hdp: HADOOP_OPTS=-D/tmp/krb5.conf
   hdp: MINICLUSTER_HOME=/tmp/minicluster-1.1-SNAPSHOT
   hdp: HIVE_HOME=/tmp/hive
   airflow_backend_mysql: AIRFLOW__CORE__SQL_ALCHEMY_CONN=mysql://root@localhost/airflow
@@ -58,10 +56,12 @@ passenv =
     TRAVIS_PULL_REQUEST
     PATH
     BOTO_CONFIG
+    KRB5_CONFIG
+    KRB5_KTNAME
 commands =
   pip wheel -w {homedir}/.wheelhouse -f {homedir}/.wheelhouse -r scripts/ci/requirements.txt
   pip install --find-links={homedir}/.wheelhouse --no-index -r scripts/ci/requirements.txt
-  #{toxinidir}/scripts/ci/setup_kdc.sh
+  sudo {toxinidir}/scripts/ci/setup_kdc.sh
   {toxinidir}/scripts/ci/setup_env.sh
   {toxinidir}/scripts/ci/ldap.sh
   {toxinidir}/scripts/ci/load_fixtures.sh


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-489

Per Apache guidelines you need to create a [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW/).

Testing Done:
- to be added

Reminders for contributors (REQUIRED!):
- Your PR's title must reference an issue on 
  [Airflow's JIRA](https://issues.apache.org/jira/browse/AIRFLOW/). 
  For example, a PR called "[AIRFLOW-1] My Amazing PR" would close JIRA 
  issue #1. Please open a new issue if required!
- Please squash your commits when possible and follow the [How to write a good git commit message](http://chris.beams.io/posts/git-commit/). 
  Summarized as follows:
  1. Separate subject from body with a blank line
  2. Limit the subject line to 50 characters
  3. Do not end the subject line with a period
  4. Use the imperative mood in the subject line (add, not adding)
  5. Wrap the body at 72 characters
  6. Use the body to explain what and why vs. how
     This implements a framework for API calls to Airflow. Currently
     all access is done by cli or web ui. Especially in the context
     of the cli this raises security concerns which can be alleviated
     with a secured API call over the wire.

Secondly integration with other systems is a bit harder if you have
to call a cli. For public facing endpoints JSON is used.

As an example the trigger_dag functionality is now made into a
API call.

Backwards compat is retained by switching to a LocalClient.
- Docs and tests to be added
- Kerberos integration works
