### PR TITLE
[AIRFLOW-494] Add per-operator success/failure metrics

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1268,6 +1268,8 @@ class TaskInstance(Base):
                     self.xcom_push(key=XCOM_RETURN_KEY, value=result)
 
                 task_copy.post_execute(context=context)
+                Stats.incr('operator_successes_{}'.format(
+                    self.task.__class__.__name__), 1, 1)
             self.state = State.SUCCESS
         except AirflowSkipException:
             self.state = State.SKIPPED
@@ -1307,6 +1309,7 @@ class TaskInstance(Base):
         session = settings.Session()
         self.end_date = datetime.now()
         self.set_duration()
+        Stats.incr('operator_failures_{}'.format(task.__class__.__name__), 1, 1)
         if not test_mode:
             session.add(Log(State.FAILED, self))
 


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-494

It would be good to have metrics for success/failure rates of each operator, that way when we e.g. do a new release we will have some signal if there is a regression in an operator. It will also be useful if e.g. a user wants to upgrade their infrastructure and make sure that all of the operators still work as expected.

Testing Done:
- Local staging and make sure that several operators successes/failures were accurately reflected

@zodiac @mistercrunch @artwr @plypaul 
