### PR TITLE
[AIRFLOW-500] For github enterprise auth use unique id for teams instead of slug

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -240,7 +240,7 @@ your GHE installation will be able to login to Airflow.
     client_id = oauth_key_from_github_enterprise
     client_secret = oauth_secret_from_github_enterprise
     oauth_callback_route = /example/ghe_oauth/callback
-    allowed_teams = example_team_1, example_team_2
+    allowed_teams = 1, 345, 23
 
 Setting up GHE Authentication
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- _[AIRFLOW-500](https://issues.apache.org/jira/browse/AIRFLOW-500)_

Testing Done:
- ran unit tests in master vs my branch. no new errors
- tested login on our internal GHE deployment
