### PR TITLE
[AIRFLOW-191] Fix connection leak with PostgreSQL backend

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -156,6 +156,9 @@ class BaseJob(Base, LoggingMixin):
         '''
         session = settings.Session()
         job = session.query(BaseJob).filter_by(id=self.id).one()
+        make_transient(job)
+        session.commit()
+        session.close()
 
         if job.state == State.SHUTDOWN:
             self.kill()
@@ -168,6 +171,7 @@ class BaseJob(Base, LoggingMixin):
 
         job.latest_heartbeat = datetime.now()
 
+        session = settings.Session()
         session.merge(job)
         session.commit()
 


### PR DESCRIPTION
This issue happens because job falls asleep during heartbeat without
closing a session, which holds a connection. This turns database
connection into IDLE state, but doesn't releases it for other clients,
so when connection poll get exhausted, they get blocked for ~heartbeat
timeframe causing global performance degradation.
