### PR TITLE
[AIRFLOW-480] Allow for binary file download from Google Cloud Storage

### DIFF
--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -59,7 +59,8 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
 
         # Write the file to local file path, if requested.
         if filename:
-            with open(filename, 'w') as file_fd:
+            write_argument = 'wb' if isinstance(downloaded_file_bytes, bytes) else 'w'
+            with open(filename, write_argument) as file_fd:
                 file_fd.write(downloaded_file_bytes)
 
         return downloaded_file_bytes


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:

https://issues.apache.org/jira/browse/AIRFLOW-480
Per Apache guidelines you need to create a Jira issue.

Testing Done:

This bug fix allowed me to download a gzip file from GCS.
