### PR TITLE
[AIRFLOW-504][AIRFLOW-507] Update to Travis' trusty environment and fix mysql issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-sudo: false
+sudo: true
+dist: trusty
 language: python
 jdk: oraclejdk7
 services:
@@ -23,6 +24,10 @@ addons:
       - slapd
       - ldap-utils
       - openssh-server
+      - mysql-server-5.6
+      - mysql-client-core-5.6
+      - mysql-client-5.6
+      - krb5-user
   postgresql: "9.2"
 python:
   - "2.7"
@@ -30,6 +35,9 @@ python:
 env:
   global:
     - TRAVIS_CACHE=$HOME/.travis_cache/
+    # Travis on google cloud engine has a global /etc/boto.cfg that
+    # does not work with python 3
+    - BOTO_CONFIG=/tmp/bogusvalue
   matrix:
     - TOX_ENV=py27-cdh-airflow_backend_mysql
     - TOX_ENV=py27-cdh-airflow_backend_sqlite

--- a/airflow/migrations/versions/4addfa1236f1_add_fractional_seconds_to_mysql_tables.py
+++ b/airflow/migrations/versions/4addfa1236f1_add_fractional_seconds_to_mysql_tables.py
@@ -1,0 +1,111 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Add fractional seconds to mysql tables
+
+Revision ID: 4addfa1236f1
+Revises: f2ca10b85618
+Create Date: 2016-09-11 13:39:18.592072
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4addfa1236f1'
+down_revision = 'f2ca10b85618'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+from alembic import context
+
+
+def upgrade():
+    if context.config.get_main_option('sqlalchemy.url').startswith('mysql'):
+        op.alter_column(table_name='dag', column_name='last_scheduler_run', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='dag', column_name='last_pickled', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='dag', column_name='last_expired', type_=mysql.DATETIME(fsp=6))
+
+        op.alter_column(table_name='dag_pickle', column_name='created_dttm', type_=mysql.DATETIME(fsp=6))
+
+        op.alter_column(table_name='dag_run', column_name='execution_date', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='dag_run', column_name='start_date', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='dag_run', column_name='end_date', type_=mysql.DATETIME(fsp=6))
+
+        op.alter_column(table_name='import_error', column_name='timestamp', type_=mysql.DATETIME(fsp=6))
+
+        op.alter_column(table_name='job', column_name='start_date', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='job', column_name='end_date', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='job', column_name='latest_heartbeat', type_=mysql.DATETIME(fsp=6))
+
+        op.alter_column(table_name='known_event', column_name='start_date', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='known_event', column_name='end_date', type_=mysql.DATETIME(fsp=6))
+
+        op.alter_column(table_name='log', column_name='dttm', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='log', column_name='execution_date', type_=mysql.DATETIME(fsp=6))
+
+        op.alter_column(table_name='sla_miss', column_name='execution_date', type_=mysql.DATETIME(fsp=6), nullable=False)
+        op.alter_column(table_name='sla_miss', column_name='timestamp', type_=mysql.DATETIME(fsp=6))
+
+        op.alter_column(table_name='task_fail', column_name='execution_date', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='task_fail', column_name='start_date', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='task_fail', column_name='end_date', type_=mysql.DATETIME(fsp=6))
+
+        op.alter_column(table_name='task_instance', column_name='execution_date', type_=mysql.DATETIME(fsp=6), nullable=False)
+        op.alter_column(table_name='task_instance', column_name='start_date', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='task_instance', column_name='end_date', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='task_instance', column_name='queued_dttm', type_=mysql.DATETIME(fsp=6))
+
+        op.alter_column(table_name='xcom', column_name='timestamp', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='xcom', column_name='execution_date', type_=mysql.DATETIME(fsp=6))
+
+
+def downgrade():
+    if context.config.get_main_option('sqlalchemy.url').startswith('mysql'):
+        op.alter_column(table_name='dag', column_name='last_scheduler_run', type_=mysql.DATETIME())
+        op.alter_column(table_name='dag', column_name='last_pickled', type_=mysql.DATETIME())
+        op.alter_column(table_name='dag', column_name='last_expired', type_=mysql.DATETIME())
+
+        op.alter_column(table_name='dag_pickle', column_name='created_dttm', type_=mysql.DATETIME())
+
+        op.alter_column(table_name='dag_run', column_name='execution_date', type_=mysql.DATETIME())
+        op.alter_column(table_name='dag_run', column_name='start_date', type_=mysql.DATETIME())
+        op.alter_column(table_name='dag_run', column_name='end_date', type_=mysql.DATETIME())
+
+        op.alter_column(table_name='import_error', column_name='timestamp', type_=mysql.DATETIME())
+
+        op.alter_column(table_name='job', column_name='start_date', type_=mysql.DATETIME())
+        op.alter_column(table_name='job', column_name='end_date', type_=mysql.DATETIME())
+        op.alter_column(table_name='job', column_name='latest_heartbeat', type_=mysql.DATETIME())
+
+        op.alter_column(table_name='known_event', column_name='start_date', type_=mysql.DATETIME())
+        op.alter_column(table_name='known_event', column_name='end_date', type_=mysql.DATETIME())
+
+        op.alter_column(table_name='log', column_name='dttm', type_=mysql.DATETIME())
+        op.alter_column(table_name='log', column_name='execution_date', type_=mysql.DATETIME())
+
+        op.alter_column(table_name='sla_miss', column_name='execution_date', type_=mysql.DATETIME(), nullable=False)
+        op.alter_column(table_name='sla_miss', column_name='timestamp', type_=mysql.DATETIME())
+
+        op.alter_column(table_name='task_fail', column_name='execution_date', type_=mysql.DATETIME())
+        op.alter_column(table_name='task_fail', column_name='start_date', type_=mysql.DATETIME())
+        op.alter_column(table_name='task_fail', column_name='end_date', type_=mysql.DATETIME())
+
+        op.alter_column(table_name='task_instance', column_name='execution_date', type_=mysql.DATETIME(), nullable=False)
+        op.alter_column(table_name='task_instance', column_name='start_date', type_=mysql.DATETIME())
+        op.alter_column(table_name='task_instance', column_name='end_date', type_=mysql.DATETIME())
+        op.alter_column(table_name='task_instance', column_name='queued_dttm', type_=mysql.DATETIME())
+
+        op.alter_column(table_name='xcom', column_name='timestamp', type_=mysql.DATETIME())
+        op.alter_column(table_name='xcom', column_name='execution_date', type_=mysql.DATETIME())

--- a/scripts/ci/load_data.sh
+++ b/scripts/ci/load_data.sh
@@ -24,5 +24,5 @@ DATABASE=airflow_ci
 
 mysqladmin -u root create ${DATABASE}
 mysql -u root < ${DATA_DIR}/mysql_schema.sql
-mysqlimport -u root --fields-optionally-enclosed-by="\"" --fields-terminated-by=, --ignore-lines=1 ${DATABASE} ${DATA_FILE}
+mysqlimport --local -u root --fields-optionally-enclosed-by="\"" --fields-terminated-by=, --ignore-lines=1 ${DATABASE} ${DATA_FILE}
 

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,7 @@ passenv =
     TRAVIS_CACHE
     TRAVIS_PULL_REQUEST
     PATH
+    BOTO_CONFIG
 commands =
   pip wheel -w {homedir}/.wheelhouse -f {homedir}/.wheelhouse -r scripts/ci/requirements.txt
   pip install --find-links={homedir}/.wheelhouse --no-index -r scripts/ci/requirements.txt


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-504
- AIRFLOW-507

Testing Done:
- Unit tests pass on travis'

To update to Travis and use Mysql 5.6 in the CI environment the 
following was required.

Both utcnow() and now() return fractional seconds. These
are sometimes used in primary_keys (eg. in task_instance).
If MySQL is not configured to store these fractional seconds
a primary key might fail (eg. at session.merge) resulting in
a duplicate entry being added or worse.

Postgres does store fractional seconds if left unconfigured,
sqlite needs to be examined.

@aoen @mistercrunch @zodiac @jlowin
