### PR TITLE
[AIRFLOW-512] Fix 'bellow' typo in docs & comments

### DIFF
--- a/airflow/contrib/auth/backends/kerberos_auth.py
+++ b/airflow/contrib/auth/backends/kerberos_auth.py
@@ -33,7 +33,7 @@ from airflow import configuration
 import logging
 
 login_manager = flask_login.LoginManager()
-login_manager.login_view = 'airflow.login'  # Calls login() bellow
+login_manager.login_view = 'airflow.login'  # Calls login() below
 login_manager.login_message = None
 
 

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -35,7 +35,7 @@ import traceback
 import re
 
 login_manager = flask_login.LoginManager()
-login_manager.login_view = 'airflow.login'  # Calls login() bellow
+login_manager.login_view = 'airflow.login'  # Calls login() below
 login_manager.login_message = None
 
 LOG = logging.getLogger(__name__)

--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -37,7 +37,7 @@ from airflow import configuration
 import logging
 
 login_manager = flask_login.LoginManager()
-login_manager.login_view = 'airflow.login'  # Calls login() bellow
+login_manager.login_view = 'airflow.login'  # Calls login() below
 login_manager.login_message = None
 
 LOG = logging.getLogger(__name__)

--- a/airflow/default_login.py
+++ b/airflow/default_login.py
@@ -30,7 +30,7 @@ from airflow import models
 DEFAULT_USERNAME = 'airflow'
 
 login_manager = flask_login.LoginManager()
-login_manager.login_view = 'airflow.login'  # Calls login() bellow
+login_manager.login_view = 'airflow.login'  # Calls login() below
 login_manager.login_message = None
 
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -135,7 +135,7 @@ There are many layers of ``airflow run`` commands, meaning it can call itself.
   command in the queue for it to run remote, on the worker. If using
   LocalExecutor, that translates into running it in a subprocess pool.
 - Local ``airflow run --local``: starts an ``airflow run --raw``
-  command (described bellow) as a subprocess and is in charge of
+  command (described below) as a subprocess and is in charge of
   emitting heartbeats, listening for external kill signals
   and ensures some cleanup takes place if the subprocess fails
 - Raw ``airflow run --raw`` runs the actual operator's execute method and

--- a/scripts/upstart/README
+++ b/scripts/upstart/README
@@ -10,7 +10,7 @@ upon system boot. If service process dies, upstart will automatically re-spawn i
 set in a *.conf file)
 
 You may have to adjust `start on` & `stop on` stanzas to make it work on other upstart systems. Some of the possible
-options are listed bellow
+options are listed below
 
 # This should work on most Linux distributions that support upstart
 start on started network-services


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-512

Testing Done:
- N/A, but ran core tests: `./run_unit_tests.sh tests.core:CoreTest -s`
