### PR TITLE
[AIRFLOW-514] hive hook loads data from pandas DataFrame into hive and infers types

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -269,6 +269,68 @@ class HiveCliHook(BaseHook):
                 else:
                     logging.info("SUCCESS")
 
+    def load_df(
+            self,
+            df,
+            table,
+            create=True,
+            recreate=False,
+            field_dict=None,
+            delimiter=',',
+            encoding='utf8',
+            pandas_kwargs={}, **kwargs):
+        """
+        Loads a pandas DataFrame into hive.
+
+        Hive data types will be inferred if not passed but column names will
+        not be sanitized.
+
+        :param table: target Hive table, use dot notation to target a
+            specific database
+        :type table: str
+        :param create: whether to create the table if it doesn't exist
+        :type create: bool
+        :param recreate: whether to drop and recreate the table at every
+            execution
+        :type recreate: bool
+        :param field_dict: mapping from column name to hive data type
+        :type field_dict: dict
+        :param encoding: string encoding to use when writing DataFrame to file
+        :type encoding: str
+        :param pandas_kwargs: passed to DataFrame.to_csv
+        :type pandas_kwargs: dict
+        :param kwargs: passed to self.load_file
+        """
+
+        def _infer_field_types_from_df(df):
+            DTYPE_KIND_HIVE_TYPE = {
+                'b': 'BOOLEAN',  # boolean
+                'i': 'BIGINT',   # signed integer
+                'u': 'BIGINT',   # unsigned integer
+                'f': 'DOUBLE',   # floating-point
+                'c': 'STRING',   # complex floating-point
+                'O': 'STRING',   # object
+                'S': 'STRING',   # (byte-)string
+                'U': 'STRING',   # Unicode
+                'V': 'STRING'    # void
+            }
+
+            return dict((col, DTYPE_KIND_HIVE_TYPE[dtype.kind]) for col, dtype in df.dtypes.iteritems())
+
+        with TemporaryDirectory(prefix='airflow_hiveop_') as tmp_dir:
+            with NamedTemporaryFile(dir=tmp_dir) as f:
+
+                if field_dict is None and (create or recreate):
+                    field_dict = _infer_field_types_from_df(df)
+
+                df.to_csv(f, sep=delimiter, **pandas_kwargs)
+
+                return self.load_file(filepath=f.name,
+                                      table=table,
+                                      delimiter=delimiter,
+                                      field_dict=field_dict,
+                                      **kwargs)
+
     def load_file(
             self,
             filepath,
@@ -307,6 +369,8 @@ class HiveCliHook(BaseHook):
         if recreate:
             hql += "DROP TABLE IF EXISTS {table};\n"
         if create or recreate:
+            if field_dict is None:
+                raise ValueError("Must provide a field dict when creating a table")
             fields = ",\n    ".join(
                 [k + ' ' + v for k, v in field_dict.items()])
             hql += "CREATE TABLE IF NOT EXISTS {table} (\n{fields})\n"


### PR DESCRIPTION
Dear Airflow Maintainers,

**What:** An additional method of the HiveCliHook that uploads a pandas DataFrame 
to hive
**Why:** A common workflow for us is to pull a hive table into memory via the 
HiveHook, modify, and then save (elsewhere).  

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-514

Testing Done:
- None currently but I will add unittests if you agree this is functionality we want to add to airflow
