### PR TITLE
[AIRFLOW-358][AIRFLOW-430] Add `connections` cli command

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -15,6 +15,7 @@
 
 from __future__ import print_function
 import logging
+import reprlib
 import os
 import subprocess
 import textwrap
@@ -26,6 +27,7 @@ from builtins import input
 from collections import namedtuple
 from dateutil.parser import parse as parsedate
 import json
+from tabulate import tabulate
 
 import daemon
 from daemon.pidfile import TimeoutPIDLockFile
@@ -43,7 +45,7 @@ from airflow.exceptions import AirflowException
 from airflow.executors import DEFAULT_EXECUTOR
 from airflow.models import (DagModel, DagBag, TaskInstance,
                             DagPickle, DagRun, Variable, DagStat,
-                            Pool)
+                            Pool, Connection)
 from airflow.ti_deps.dep_context import (DepContext, SCHEDULER_DEPS)
 from airflow.utils import db as db_utils
 from airflow.utils import logging as logging_utils
@@ -51,6 +53,7 @@ from airflow.utils.state import State
 from airflow.www.app import cached_app
 
 from sqlalchemy import func
+from sqlalchemy.orm import exc
 
 DAGS_FOLDER = os.path.expanduser(conf.get('core', 'DAGS_FOLDER'))
 
@@ -889,8 +892,112 @@ def upgradedb(args):  # noqa
             session.add(DagStat(dag_id=dag_id, state=state, count=count))
         session.commit()
 
+
 def version(args):  # noqa
     print(settings.HEADER + "  v" + airflow.__version__)
+
+
+def connections(args):
+    if args.list:
+        # Check that no other flags were passed to the command
+        invalid_args = list()
+        for arg in ['conn_id', 'conn_uri', 'conn_extra']:
+            if getattr(args, arg) is not None:
+                invalid_args.append(arg)
+        if invalid_args:
+            msg = ('\n\tThe following args are not compatible with the ' +
+                   '--list flag: {invalid!r}\n')
+            msg = msg.format(invalid=invalid_args)
+            print(msg)
+            return
+
+        session = settings.Session()
+        conns = session.query(Connection.conn_id, Connection.conn_type,
+                              Connection.host, Connection.port,
+                              Connection.is_encrypted,
+                              Connection.is_extra_encrypted,
+                              Connection.extra).all()
+        conns = [map(reprlib.repr, conn) for conn in conns] 
+        print(tabulate(conns, ['Conn Id', 'Conn Type', 'Host', 'Port',
+                               'Is Encrypted', 'Is Extra Encrypted', 'Extra'],
+                       tablefmt="fancy_grid"))
+        return
+
+    if args.delete:
+        # Check that only the `conn_id` arg was passed to the command
+        invalid_args = list()
+        for arg in ['conn_uri', 'conn_extra']:
+            if getattr(args, arg) is not None:
+                invalid_args.append(arg)
+        if invalid_args:
+            msg = ('\n\tThe following args are not compatible with the ' +
+                   '--delete flag: {invalid!r}\n')
+            msg = msg.format(invalid=invalid_args)
+            print(msg)
+            return
+
+        if args.conn_id is None:
+            print('\n\tTo delete a connection, you Must provide a value for ' +
+                  'the --conn_id flag.\n')
+            return
+
+        session = settings.Session()
+        try:
+            to_delete = (session
+                         .query(Connection)
+                         .filter(Connection.conn_id == args.conn_id)
+                         .one())
+        except exc.NoResultFound:
+            msg = '\n\tDid not find a connection with `conn_id`={conn_id}\n'
+            msg = msg.format(conn_id=args.conn_id)
+            print(msg)
+            return
+        except exc.MultipleResultsFound:
+            msg = ('\n\tFound more than one connection with ' +
+                   '`conn_id`={conn_id}\n')
+            msg = msg.format(conn_id=args.conn_id)
+            print(msg)
+            return
+        else:
+            deleted_conn_id = to_delete.conn_id
+            session.delete(to_delete)
+            session.commit()
+            msg = '\n\tSuccessfully deleted `conn_id`={conn_id}\n'
+            msg = msg.format(conn_id=deleted_conn_id)
+            print(msg)
+        return
+
+    if args.add:
+        # Check that the conn_id and conn_uri args were passed to the command:
+        missing_args = list()
+        for arg in ['conn_id', 'conn_uri']:
+            if getattr(args, arg) is None:
+                missing_args.append(arg)
+        if missing_args:
+            msg = ('\n\tThe following args are required to add a connection:' +
+                   ' {missing!r}\n'.format(missing=missing_args))
+            print(msg)
+            return
+
+        new_conn = Connection(conn_id=args.conn_id, uri=args.conn_uri)
+        if args.conn_extra is not None:
+            new_conn.set_extra(args.conn_extra)
+
+        session = settings.Session()
+        if not (session
+                .query(Connection)
+                .filter(Connection.conn_id == new_conn.conn_id).first()):
+            session.add(new_conn)
+            session.commit()
+            msg = '\n\tSuccessfully added `conn_id`={conn_id} : {uri}\n'
+            msg = msg.format(conn_id=new_conn.conn_id, uri=args.conn_uri)
+            print(msg)
+        else:
+            msg = '\n\tA connection with `conn_id`={conn_id} already exists\n'
+            msg = msg.format(conn_id=new_conn.conn_id)
+            print(msg)
+
+        return
 
 
 def flower(args):
@@ -1240,6 +1347,31 @@ class CLIFactory(object):
         'task_params': Arg(
             ("-tp", "--task_params"),
             help="Sends a JSON params dict to the task"),
+        # connections
+        'list_connections': Arg(
+            ('-l', '--list'),
+            help='List all connections',
+            action='store_true'),
+        'add_connection': Arg(
+            ('-a', '--add'),
+            help='Add a connection',
+            action='store_true'),
+        'delete_connection': Arg(
+            ('-d', '--delete'),
+            help='Delete a connection',
+            action='store_true'),
+        'conn_id': Arg(
+            ('--conn_id',),
+            help='Connection id, required to add/delete a connection',
+            type=str),
+        'conn_uri': Arg(
+            ('--conn_uri',),
+            help='Connection URI, required to add a connection',
+            type=str),
+        'conn_extra': Arg(
+            ('--conn_extra',),
+            help='Connection `Extra` field, optional when adding a connection',
+            type=str),
     }
     subparsers = (
         {
@@ -1348,7 +1480,7 @@ class CLIFactory(object):
             'func': upgradedb,
             'help': "Upgrade the metadata database to latest version",
             'args': tuple(),
-        }, {
+        },{
             'func': scheduler,
             'help': "Start a scheduler instance",
             'args': ('dag_id_opt', 'subdir', 'run_duration', 'num_runs',
@@ -1368,6 +1500,11 @@ class CLIFactory(object):
             'func': version,
             'help': "Show the version",
             'args': tuple(),
+        }, {
+            'func': connections,
+            'help': "List/Add/Delete connections",
+            'args': ('list_connections', 'add_connection', 'delete_connection',
+                     'conn_id', 'conn_uri', 'conn_extra'),
         },
     )
     subparsers_dict = {sp['func'].__name__: sp for sp in subparsers}

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -513,6 +513,30 @@ class Connection(Base):
     is_extra_encrypted = Column(Boolean, unique=False, default=False)
     _extra = Column('extra', String(5000))
 
+    _types = [
+        ('fs', 'File (path)'),
+        ('ftp', 'FTP',),
+        ('google_cloud_platform', 'Google Cloud Platform'),
+        ('hdfs', 'HDFS',),
+        ('http', 'HTTP',),
+        ('hive_cli', 'Hive Client Wrapper',),
+        ('hive_metastore', 'Hive Metastore Thrift',),
+        ('hiveserver2', 'Hive Server 2 Thrift',),
+        ('jdbc', 'Jdbc Connection',),
+        ('mysql', 'MySQL',),
+        ('postgres', 'Postgres',),
+        ('oracle', 'Oracle',),
+        ('vertica', 'Vertica',),
+        ('presto', 'Presto',),
+        ('s3', 'S3',),
+        ('samba', 'Samba',),
+        ('sqlite', 'Sqlite',),
+        ('ssh', 'SSH',),
+        ('cloudant', 'IBM Cloudant',),
+        ('mssql', 'Microsoft SQL Server'),
+        ('mesos_framework-id', 'Mesos Framework ID'),
+    ]
+
     def __init__(
             self, conn_id=None, conn_type=None,
             host=None, login=None, password=None,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2422,29 +2422,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
 
     }
     form_choices = {
-        'conn_type': [
-            ('fs', 'File (path)'),
-            ('ftp', 'FTP',),
-            ('google_cloud_platform', 'Google Cloud Platform'),
-            ('hdfs', 'HDFS',),
-            ('http', 'HTTP',),
-            ('hive_cli', 'Hive Client Wrapper',),
-            ('hive_metastore', 'Hive Metastore Thrift',),
-            ('hiveserver2', 'Hive Server 2 Thrift',),
-            ('jdbc', 'Jdbc Connection',),
-            ('mysql', 'MySQL',),
-            ('postgres', 'Postgres',),
-            ('oracle', 'Oracle',),
-            ('vertica', 'Vertica',),
-            ('presto', 'Presto',),
-            ('s3', 'S3',),
-            ('samba', 'Samba',),
-            ('sqlite', 'Sqlite',),
-            ('ssh', 'SSH',),
-            ('cloudant', 'IBM Cloudant',),
-            ('mssql', 'Microsoft SQL Server'),
-            ('mesos_framework-id', 'Mesos Framework ID'),
-        ]
+        'conn_type': models.Connection._types
     }
 
     def on_model_change(self, form, model, is_created):


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- [AIRFLOW-358](https://issues.apache.org/jira/browse/AIRFLOW-358)
- [AIRFLOW-430](https://issues.apache.org/jira/browse/AIRFLOW-430)

Testing Done:
- core.CliTests.test_cli_connections_list
- core.CliTests.test_cli_connections_add_delete
- Travis CI tests pass on my branch
- Also tested functionality in a Docker airflow deploy.
