### PR TITLE
[AIRFLOW-518] Require DataProfilingMixin for the Variables CRUD access

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2102,7 +2102,7 @@ class KnowEventTypeView(wwwutils.DataProfilingMixin, AirflowModelView):
 # admin.add_view(mv)
 
 
-class VariableView(wwwutils.LoginMixin, AirflowModelView):
+class VariableView(wwwutils.DataProfilingMixin, AirflowModelView):
     verbose_name = "Variable"
     verbose_name_plural = "Variables"
     list_template = 'airflow/variable_list.html'


### PR DESCRIPTION
Many of us use the "Variable" model CRUD (create/update/delete) as a k/v
store to power frameworks that read these values to dynamically generate
pipelines.

With the basic "LoginMixin" role (lowest level of access to Airflow)
having access to the Variable CRUD, people could easily alter a Variable
to run arbitrary code on the platform, depending on how variables are
use in that environment.

It's a safer bet to elevate CRUD on Variable to DataProfilingMixin, and
make sure that the lowest level of access cannot interfere with these
Variables.
