### PR TITLE
[AIRFLOW-523] Add AltX as Airflow user

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Currently **officially** using Airflow:
 1. [Airbnb](http://airbnb.io/) [[@mistercrunch](https://github.com/mistercrunch), [@artwr](https://github.com/artwr)]
 1. [Agari](https://github.com/agaridata) [[@r39132](https://github.com/r39132)]
 1. [allegro.pl](http://allegro.tech/) [[@kretes](https://github.com/kretes)]
+1. [AltX](https://www.getaltx.com/about) [[@pedromduarte](https://github.com/pedromduarte)]
 1. [Apigee](https://apigee.com) [[@btallman](https://github.com/btallman)]
 1. [Bellhops](https://github.com/bellhops)
 1. BlueApron [[@jasonjho](https://github.com/jasonjho) & [@matthewdavidhauser](https://github.com/matthewdavidhauser)]


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- [AIRFLOW-523](https://issues.apache.org/jira/browse/AIRFLOW-523)

Testing Done:
- Tests passing in Travis CI
