### PR TITLE
[AIRFLOW-538] Add support for JSON key dict in GCP base hook

### DIFF
--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -14,6 +14,7 @@
 #
 
 import logging
+import json
 
 import httplib2
 from oauth2client.client import GoogleCredentials
@@ -41,7 +42,7 @@ class GoogleCloudBaseHook(BaseHook):
 
     JSON key file: Specify 'Project Id', 'Key Path' and 'Scope'.
 
-    JSON key dict: Specify 'Project Id' and 'Scope'.
+    JSON key dict: Specify 'Project Id', 'Key Dict' and 'Scope'.
 
     Legacy P12 key files are not supported.
     """
@@ -79,7 +80,7 @@ class GoogleCloudBaseHook(BaseHook):
             if key_dict:
                 logging.info('Getting connection using a JSON key dict.')
                 credentials = ServiceAccountCredentials\
-                    .from_json_keyfile_dict(key_path, scopes)
+                    .from_json_keyfile_dict(json.loads(key_dict), scopes)
             else:
                 if key_path.endswith('.json'):
                     logging.info('Getting connection using a JSON key file.')

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -34,12 +34,14 @@ class GoogleCloudBaseHook(BaseHook):
     The class also contains some miscellaneous helper functions.
 
     All hook derived from this base hook use the 'Google Cloud Platform' connection
-    type. Two ways of authentication are supported:
+    type. Three ways of authentication are supported:
 
     Default credentials: Only specify 'Project Id'. Then you need to have executed
     ``gcloud auth`` on the Airflow worker machine.
 
     JSON key file: Specify 'Project Id', 'Key Path' and 'Scope'.
+
+    JSON key dict: Specify 'Project Id' and 'Scope'.
 
     Legacy P12 key files are not supported.
     """
@@ -63,29 +65,36 @@ class GoogleCloudBaseHook(BaseHook):
         service hook connection.
         """
         key_path = self._get_field('key_path', False)
+        key_dict = self._get_field('key_dict', False)
         scope = self._get_field('scope', False)
 
         kwargs = {}
         if self.delegate_to:
             kwargs['sub'] = self.delegate_to
 
-        if not key_path:
-            logging.info('Getting connection using `gcloud auth` user, since no key file '
-                         'is defined for hook.')
-            credentials = GoogleCredentials.get_application_default()
-        else:
+        if key_dict or key_path:
             if not scope:
-                raise AirflowException('Scope should be defined when using a key file.')
+                raise AirflowException('Scope should be defined when using a JSON key.')
             scopes = [s.strip() for s in scope.split(',')]
-            if key_path.endswith('.json'):
-                logging.info('Getting connection using a JSON key file.')
+            if key_dict:
+                logging.info('Getting connection using a JSON key dict.')
                 credentials = ServiceAccountCredentials\
-                    .from_json_keyfile_name(key_path, scopes)
-            elif key_path.endswith('.p12'):
-                raise AirflowException('Legacy P12 key file are not supported, '
-                                       'use a JSON key file.')
+                    .from_json_keyfile_dict(key_path, scopes)
             else:
-                raise AirflowException('Unrecognised extension for key file.')
+                if key_path.endswith('.json'):
+                    logging.info('Getting connection using a JSON key file.')
+                    credentials = ServiceAccountCredentials\
+                        .from_json_keyfile_name(key_path, scopes)
+                elif key_path.endswith('.p12'):
+                    raise AirflowException('Legacy P12 key file are not supported, '
+                                           'use a JSON key file.')
+                else:
+                    raise AirflowException('Unrecognised extension for key file.')
+
+        else:
+            logging.info('Getting connection using `gcloud auth` user, since no key file '
+                         'or dict is defined for hook.')
+            credentials = GoogleCredentials.get_application_default()
 
         http = httplib2.Http()
         return credentials.authorize(http)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2397,6 +2397,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
         'extra__jdbc__drv_clsname',
         'extra__google_cloud_platform__project',
         'extra__google_cloud_platform__key_path',
+        'extra__google_cloud_platform__key_dict',
         'extra__google_cloud_platform__scope',
     )
     verbose_name = "Connection"
@@ -2418,6 +2419,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
         'extra__jdbc__drv_clsname': StringField('Driver Class'),
         'extra__google_cloud_platform__project': StringField('Project Id'),
         'extra__google_cloud_platform__key_path': StringField('Keyfile Path'),
+        'extra__google_cloud_platform__key_dict': StringField('JSON-encoded Key Dictionary'),
         'extra__google_cloud_platform__scope': StringField('Scopes (comma seperated)'),
 
     }

--- a/tests/contrib/hooks/gcp_api_base_hook.py
+++ b/tests/contrib/hooks/gcp_api_base_hook.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+import json
 from mock import ANY, Mock, patch
 import tempfile
 import unittest
@@ -45,7 +46,7 @@ class TestGcpBaseHookOptions(unittest.TestCase):
         gcp_hook = hook.GoogleCloudBaseHook('gcp_default')
         gcp_hook.extras = {
             'extra__google_cloud_platform__project': 'foo_project',
-            'extra__google_cloud_platform__key_dict': dict(foo='bar'),
+            'extra__google_cloud_platform__key_dict': json.dumps(dict(foo='bar')),
             'extra__google_cloud_platform__scope': 's1,s2',
         }
         gcp_hook.delegate_to = None

--- a/tests/contrib/hooks/gcp_api_base_hook.py
+++ b/tests/contrib/hooks/gcp_api_base_hook.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from mock import ANY, Mock, patch
+import tempfile
+import unittest
+
+from oauth2client.service_account import ServiceAccountCredentials
+
+from airflow.contrib.hooks import gcp_api_base_hook as hook
+
+
+class TestGcpBaseHookOptions(unittest.TestCase):
+    @patch(hook.__name__ + '.GoogleCloudBaseHook.__init__',
+           Mock(return_value=None))
+    @patch.object(ServiceAccountCredentials, 'from_json_keyfile_name')
+    def test_base_hook_with_json_file(self, from_file):
+        tmpfile = tempfile.NamedTemporaryFile(suffix='.json')
+        gcp_hook = hook.GoogleCloudBaseHook('gcp_default')
+        gcp_hook.extras = {
+            'extra__google_cloud_platform__project': 'foo_project',
+            'extra__google_cloud_platform__key_path': tmpfile.name,
+            'extra__google_cloud_platform__scope': 's1,s2',
+        }
+        gcp_hook.delegate_to = None
+        gcp_hook._authorize()
+        from_file.assert_called_once_with(ANY, ANY)
+
+    @patch(hook.__name__ + '.GoogleCloudBaseHook.__init__',
+           Mock(return_value=None))
+    @patch.object(ServiceAccountCredentials, 'from_json_keyfile_dict')
+    def test_base_hook_with_json_dict(self, from_dict):
+        gcp_hook = hook.GoogleCloudBaseHook('gcp_default')
+        gcp_hook.extras = {
+            'extra__google_cloud_platform__project': 'foo_project',
+            'extra__google_cloud_platform__key_dict': dict(foo='bar'),
+            'extra__google_cloud_platform__scope': 's1,s2',
+        }
+        gcp_hook.delegate_to = None
+        gcp_hook._authorize()
+        from_dict.assert_called_once_with(ANY, ANY)
+
+    @patch(hook.__name__ + '.GoogleCloudBaseHook.__init__',
+           Mock(return_value=None))
+    def test_base_hook_get_project(self):
+        gcp_hook = hook.GoogleCloudBaseHook('gcp_default')
+        gcp_hook.extras = {
+            'extra__google_cloud_platform__project': 'foo_project',
+        }
+        self.assertEquals('foo_project', gcp_hook.project_id)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
-https://issues.apache.org/jira/browse/AIRFLOW-538

Some system deployments use JSON dictionaries rather than a keyfile to store GCP credentials.  This PR adds support for those, as well as unit tests for the overall hook.

@alexvanboxel  FYI as a major contributor to this code
