### PR TITLE
[AIRFLOW-542] Add tooltip to DAGs links icons

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -113,48 +113,48 @@
 
                 <!-- Tree -->
                 <a href="{{ url_for('airflow.tree', dag_id=dag.dag_id, num_runs=25) }}" title="Tree View">
-                    <span class="glyphicon glyphicon-tree-deciduous" aria-hidden="true"></span>
+                    <span class="glyphicon glyphicon-tree-deciduous" aria-hidden="true" title="Tree View"></span>
                 </a>
 
                 <!-- Graph -->
                 <a href="{{ url_for('airflow.graph', dag_id=dag.dag_id) }}" title="Graph View">
-                    <span class="glyphicon glyphicon-certificate" aria-hidden="true"></span>
+                    <span class="glyphicon glyphicon-certificate" aria-hidden="true" title="Graph View"></span>
                 </a>
 
                 <!-- Duration -->
                 <a href="{{ url_for('airflow.duration', dag_id=dag.dag_id) }}" title="Tasks Duration">
-                    <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
+                    <span class="glyphicon glyphicon-stats" aria-hidden="true" title="Tasks Duration"></span>
                 </a>
 
                 <!-- Retries -->
                 <a href="{{ url_for('airflow.tries', dag_id=dag.dag_id) }}" title="Task Tries">
-                    <span class="glyphicon glyphicon-duplicate" aria-hidden="true"></span>
+                    <span class="glyphicon glyphicon-duplicate" aria-hidden="true" title="Task Tries"></span>
                 </a>
 
                 <!-- Landing Times -->
                 <a href="{{ url_for("airflow.landing_times", dag_id=dag.dag_id) }}" title="Landing Times">
-                    <span class="glyphicon glyphicon-plane" aria-hidden="true"></span>
+                    <span class="glyphicon glyphicon-plane" aria-hidden="true" title="Landing Times"></span>
                 </a>
 
                 <!-- Gantt -->
                 <a href="{{ url_for("airflow.gantt", dag_id=dag.dag_id) }}" title="Gantt View">
-                    <span class="glyphicon glyphicon-align-left" aria-hidden="true"></span>
+                    <span class="glyphicon glyphicon-align-left" aria-hidden="true" title="Gantt View"></span>
                 </a>
 
                 <!-- Code -->
                 <a href="{{ url_for("airflow.code", dag_id=dag.dag_id) }}" title="Code View">
-                    <span class="glyphicon glyphicon-flash" aria-hidden="true"></span>
+                    <span class="glyphicon glyphicon-flash" aria-hidden="true" title="Code View"></span>
                 </a>
 
                 <!-- Logs -->
                 <a href="/admin/log/?sort=1&amp;desc=1&amp;flt1_dag_id_equals={{ dag.dag_id }}" title="Logs">
-                    <span class="glyphicon glyphicon-align-justify" aria-hidden="true"></span>
+                    <span class="glyphicon glyphicon-align-justify" aria-hidden="true" title="Logs"></span>
                 </a>
                 {% endif %}
 
                 <!-- Refresh -->
                 <a href="{{ url_for("airflow.refresh", dag_id=dag_id) }}" title="Refresh">
-                  <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
+                  <span class="glyphicon glyphicon-refresh" aria-hidden="true" title="Refresh"></span>
                 </a>
 
                 </td>


### PR DESCRIPTION
Dear Airflow Maintainers,

Currently there are nine icons on DAGs links actions. This add a tooltip describing icon action for clarity.

![link-tooltip](https://cloud.githubusercontent.com/assets/165865/19017107/5c058d8c-8805-11e6-8f0a-78fa9aa851b6.png)

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-542

Testing Done:
Run local webserver
