### PR TITLE
[AIRFLOW-139] Let psycopg2 handle autocommit for PostgresHook

### DIFF
--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -26,7 +26,7 @@ class PostgresHook(DbApiHook):
     '''
     conn_name_attr = 'postgres_conn_id'
     default_conn_name = 'postgres_default'
-    supports_autocommit = False
+    supports_autocommit = True
 
     def get_conn(self):
         conn = self.get_connection(self.postgres_conn_id)
@@ -41,8 +41,6 @@ class PostgresHook(DbApiHook):
             if arg_name in ['sslmode', 'sslcert', 'sslkey', 'sslrootcert', 'sslcrl', 'application_name']:
                 conn_args[arg_name] = arg_val
         psycopg2_conn = psycopg2.connect(**conn_args)
-        if psycopg2_conn.server_version < 70400:
-            self.supports_autocommit = True
         return psycopg2_conn
 
     @staticmethod

--- a/tests/operators/operators.py
+++ b/tests/operators/operators.py
@@ -165,7 +165,10 @@ class PostgresTest(unittest.TestCase):
 
         sql = "VACUUM ANALYZE;"
         t = operators.postgres_operator.PostgresOperator(
-            task_id='postgres_operator_test_vacuum', sql=sql, dag=self.dag)
+            task_id='postgres_operator_test_vacuum',
+            sql=sql,
+            dag=self.dag,
+            autocommit=True)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
 

--- a/tests/operators/operators.py
+++ b/tests/operators/operators.py
@@ -160,6 +160,17 @@ class PostgresTest(unittest.TestCase):
             dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
+    def test_vacuum(self):
+        """
+        Verifies the VACUUM operation runs well with the PostgresOperator
+        """
+        import airflow.operators.postgres_operator
+
+        sql = "VACUUM ANALYZE;"
+        t = operators.postgres_operator.PostgresOperator(
+            task_id='postgres_operator_test_vacuum', sql=sql, dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
 @skipUnlessImported('airflow.operators.hive_operator', 'HiveOperator')
 @skipUnlessImported('airflow.operators.postgres_operator', 'PostgresOperator')
 class TransferTests(unittest.TestCase):

--- a/tests/operators/operators.py
+++ b/tests/operators/operators.py
@@ -15,17 +15,13 @@
 from __future__ import print_function
 
 import datetime
-import os
-import unittest
-import six
 
-from airflow import DAG, configuration, operators, utils
+from airflow import DAG, configuration, operators
 from airflow.utils.tests import skipUnlessImported
+
 configuration.load_test_config()
 
-import os
 import unittest
-
 
 DEFAULT_DATE = datetime.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
@@ -95,6 +91,7 @@ class MySqlTest(unittest.TestCase):
             sql="SELECT count(1) FROM INFORMATION_SCHEMA.TABLES",
             dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
 
 @skipUnlessImported('airflow.operators.postgres_operator', 'PostgresOperator')
 class PostgresTest(unittest.TestCase):
@@ -170,6 +167,7 @@ class PostgresTest(unittest.TestCase):
         t = operators.postgres_operator.PostgresOperator(
             task_id='postgres_operator_test_vacuum', sql=sql, dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
 
 @skipUnlessImported('airflow.operators.hive_operator', 'HiveOperator')
 @skipUnlessImported('airflow.operators.postgres_operator', 'PostgresOperator')


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-139

Re-posting from the JIRA comment:

This indeed causes problems with (for example) Redshift. 
I agree special cases should be discouraged though the current implementation definitely feels like a special case handling. 
There was no issue attached to the original commit (https://github.com/apache/incubator-airflow/commit/28da05d860147b5e0df37d998f437af6a5d4d178) but I'm supposing it came due to https://www.postgresql.org/docs/7.4/static/release-7-4.html.
The documentation states:
"The server-side autocommit setting was removed and reimplemented in client applications and languages. Server-side autocommit was causing too many problems with languages and applications that wanted to control their own autocommit behavior, so autocommit was removed from the server and added to individual client APIs as appropriate."
As far as I can see, psycopg2 supports setting autocommit and I'd be very surprised if it didn't handle it well.
I tested it locally and I can confirm it works well with 9.5.4 with the following code:

```
>>> import psycopg2
>>> conn_string = "host='127.0.0.1' dbname='db' user='user' password='pwd'"
>>> conn = psycopg2.connect(conn_string)
>>> conn.autocommit = True
>>> cursor = conn.cursor()
>>> cursor.execute('SELECT VERSION();')
>>> cursor.fetchall()
[('PostgreSQL 9.5.4 on x86_64-pc-linux-gnu, compiled by gcc (Debian 4.9.2-10) 4.9.2, 64-bit',)]
```

In all honesty, I'm not sure what was the purpose of the original fix and I think those lines should be removed.

With regards to tests, I can't find where tests for hooks exist at the moment and what kind of things we might want to test. Also, are there any best practices on how we test against databases if at all? I think the added code should have had unit-tests, not really sure what we might want to test by removing the code, that `Postgres.Hook.autocommit = True`?
