### PR TITLE
[AIRFLOW-548] Run continously by default and pickup dags immediately

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -319,10 +319,17 @@ job_heartbeat_sec = 5
 # how often the scheduler should run (in seconds).
 scheduler_heartbeat_sec = 5
 
-run_duration = 1800
+# after how much time should the scheduler terminate in seconds
+# -1 indicates to run continuously (see also num_runs)
+run_duration = -1
+
+# after how much time a new DAGs should be picked up from the filesystem
+min_file_process_interval = 0
+
 dag_dir_list_interval = 300
+
+# How often should stats be printed to the logs
 print_stats_interval = 30
-min_file_process_interval = 180
 
 child_process_log_directory = /tmp/airflow/scheduler/logs
 

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1324,7 +1324,7 @@ class SchedulerJob(BaseJob):
 
         # For the execute duration, parse and schedule DAGs
         while (datetime.now() - execute_start_time).total_seconds() < \
-                self.run_duration:
+                self.run_duration or self.run_duration < 0:
             self.logger.debug("Starting Loop...")
             loop_start_time = time.time()
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-548

Per Apache guidelines you need to create a [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW/).

Testing Done:
- Local testing

Reminders for contributors (REQUIRED!):
- Your PR's title must reference an issue on 
  [Airflow's JIRA](https://issues.apache.org/jira/browse/AIRFLOW/). 
  For example, a PR called "[AIRFLOW-1] My Amazing PR" would close JIRA 
  issue #1. Please open a new issue if required!
- Please squash your commits when possible and follow the [How to write a good git commit message](http://chris.beams.io/posts/git-commit/). 
  Summarized as follows:
  1. Separate subject from body with a blank line
  2. Limit the subject line to 50 characters
  3. Do not end the subject line with a period
  4. Use the imperative mood in the subject line (add, not adding)
  5. Wrap the body at 72 characters
  6. Use the body to explain what and why vs. how

A recent commit has changed the scheduler behavior that it now
always stops after a specified period of time. The operation scripts
(systemd etc) are not updated for this behavior and many users actually
prefer to run the scheduler continously.

Secondly the default behavior was changed to not pickup new DAGs
immediately, this has lead to confusion with users.

@plypaul @mistercrunch @aoen @r39132 @btallman 
