### PR TITLE
[AIRFLOW-554]Add Jinja templating support for Spark-SQL Operator

### DIFF
--- a/airflow/contrib/hooks/spark_sql_hook.py
+++ b/airflow/contrib/hooks/spark_sql_hook.py
@@ -98,7 +98,7 @@ class SparkSqlHook(BaseHook):
         if self._num_executors:
             connection_cmd += ["--num-executors", str(self._num_executors)]
         if self._sql:
-            if self._sql.endswith('.sql'):
+            if self._sql.endswith('.sql') or self._sql.endswith(".hql"):
                 connection_cmd += ["-f", self._sql]
             else:
                 connection_cmd += ["-e", self._sql]

--- a/airflow/contrib/operators/spark_sql_operator.py
+++ b/airflow/contrib/operators/spark_sql_operator.py
@@ -43,6 +43,10 @@ class SparkSqlOperator(BaseOperator):
     :param yarn_queue: The YARN queue to submit to (Default: "default")
     :type yarn_queue: str
     """
+
+    template_fields = ["_sql"]
+    template_ext = [".sql", ".hql"]
+
     @apply_defaults
     def __init__(self,
                  sql,


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-554

This PR adds support for Jinja templated queries to be passed to the Spark SQL Operator.
