### PR TITLE
[AIRFLOW-565] Fixes DockerOperator on Python3.x

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -152,7 +152,7 @@ class DockerOperator(BaseOperator):
         if self.force_pull or len(self.cli.images(name=image)) == 0:
             logging.info('Pulling docker image ' + image)
             for l in self.cli.pull(image, stream=True):
-                output = json.loads(l)
+                output = json.loads(l.decode('utf-8'))
                 logging.info("{}".format(output['status']))
 
         cpu_shares = int(round(self.cpus * 1024))

--- a/tests/operators/docker_operator.py
+++ b/tests/operators/docker_operator.py
@@ -44,7 +44,7 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock.create_host_config.return_value = host_config
         client_mock.images.return_value = []
         client_mock.logs.return_value = ['container log']
-        client_mock.pull.return_value = ['{"status":"pull log"}']
+        client_mock.pull.return_value = [b'{"status":"pull log"}']
         client_mock.wait.return_value = 0
 
         client_class_mock.return_value = client_mock


### PR DESCRIPTION
The issue is that `self.cli.pull()` returns `bytes()`, and not a string. Then,
when we try to pass that to `json.loads()`, it raises an exception.

The fix is to convert the bytes to a string by decoding it as "utf-8". We're
hardcoding the encoding because, by the JSON schema, a JSON should encoded in
UTF-8, UTF-16 or UTF-32. Considering we're only pulling images from Docker
servers, we can be relatively safe that they'll behave correctly.

Fixes https://issues.apache.org/jira/browse/AIRFLOW-565
