### PR TITLE
[AIRFLOW-510] Filter Paused Dags, Add Last Run Column and Trigger Dag Icon

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -255,6 +255,10 @@ demo_mode = False
 # while fetching logs from other worker machine
 log_fetch_timeout_sec = 5
 
+# By default, the webserver shows paused DAGs. Flip this to hide paused
+# DAGs by default
+hide_paused_dags_by_default = False
+
 [email]
 email_backend = airflow.utils.email.send_email_smtp
 
@@ -432,6 +436,7 @@ web_server_host = 0.0.0.0
 web_server_port = 8080
 dag_orientation = LR
 log_fetch_timeout_sec = 5
+hide_paused_dags_by_default = False
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2682,17 +2682,22 @@ class DAG(BaseDag, LoggingMixin):
         return dttm
 
     @provide_session
-    def get_last_dagrun(self, session=None):
+    def get_last_dagrun(self, session=None, include_externally_triggered=False):
         """
         Returns the last dag run for this dag, None if there was none.
         Last dag run can be any type of run eg. scheduled or backfilled.
         Overriden DagRuns are ignored
         """
         DR = DagRun
-        last = session.query(DR).filter(
+        qry = session.query(DR).filter(
             DR.dag_id == self.dag_id,
-            DR.external_trigger == False
-        ).order_by(DR.execution_date.desc()).first()
+        )
+        if not include_externally_triggered:
+            qry = qry.filter(DR.external_trigger.is_(False))
+
+        qry = qry.order_by(DR.execution_date.desc())
+
+        last = qry.first()
 
         return last
 

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -41,6 +41,8 @@
                   <span id="statuses_info" class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Status of tasks from all active DAG runs or, if not currently active, from most recent run."></span>
                   <img id="loading" width="15" src="{{ url_for("static", filename="loading.gif") }}">
                 </th>
+                <th style="padding-left: 5px;">Last Run <span id="statuses_info" class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Execution Date/Time of Highest Dag Run."></span>
+                </th>
                 <th style="padding-left: 5px;">DAG Runs
                   <span id="statuses_info" class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Status of all previous DAG runs."></span>
                   <img id="loading" width="15" src="{{ url_for("static", filename="loading.gif") }}">
@@ -102,59 +104,81 @@
                     <svg height="10" width="10" id='task-run-{{ dag.safe_dag_id }}' style="display: block;"></svg>
                 </td>
 
-                <!-- Column 7: Dag Runs -->
+                <!-- Column 7: Last Run -->
+                <td class="text-nowrap">
+                    {% if dag %}
+                        {% set last_run = dag.get_last_dagrun(include_externally_triggered=True) %}
+                        {% if last_run %}
+                            <a href="{{ url_for('airflow.graph', dag_id=last_run.dag_id, execution_date=last_run.execution_date ) }}">
+                                {{ last_run.execution_date.strftime("%Y-%m-%d %H:%M") }}
+                            </a> <span id="statuses_info" class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Start Date: {{last_run.start_date.strftime('%Y-%m-%d %H:%M')}}"></span>
+                        {% else %}
+                            <!--No DAG Runs-->
+                        {% endif %}
+                    {% else %}
+                        <!--No DAG Runs-->
+                    {% endif %}
+                </td>
+
+                <!-- Column 8: Dag Runs -->
                 <td style="padding:0px; width:120px; height:10px;">
                     <svg height="10" width="10" id='dag-run-{{ dag.safe_dag_id }}' style="display: block;"></svg>
                 </td>
 
-                <!-- Column 8: Links -->
+                <!-- Column 9: Links -->
                 <td class="text-center" style="display:flex; flex-direction:row; justify-content:space-around;">
                 {% if dag %}
 
-                <!-- Graph -->
-                <a href="{{ url_for('airflow.graph', dag_id=dag.dag_id) }}" title="Graph View">
-                    <span class="glyphicon glyphicon-certificate" aria-hidden="true" title="Graph View"></span>
+                <!-- Trigger Dag -->
+                <a href="{{ url_for('airflow.trigger', dag_id=dag.dag_id) }}"
+                   onclick="return confirmTriggerDag('{{ dag.safe_dag_id }}')" title="Trigger Dag">
+                    <span class="glyphicon glyphicon-play-circle" aria-hidden="true"></span>
                 </a>
 
                 <!-- Tree -->
                 <a href="{{ url_for('airflow.tree', dag_id=dag.dag_id, num_runs=25) }}" title="Tree View">
-                    <span class="glyphicon glyphicon-tree-deciduous" aria-hidden="true" title="Tree View"></span>
+                    <span class="glyphicon glyphicon-tree-deciduous" aria-hidden="true"></span>
+                </a>
+
+                <!-- Graph -->
+                <a href="{{ url_for('airflow.graph', dag_id=dag.dag_id) }}" title="Graph View">
+                    <span class="glyphicon glyphicon-certificate" aria-hidden="true"></span>
                 </a>
 
                 <!-- Duration -->
                 <a href="{{ url_for('airflow.duration', dag_id=dag.dag_id) }}" title="Tasks Duration">
-                    <span class="glyphicon glyphicon-stats" aria-hidden="true" title="Tasks Duration"></span>
+                    <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
                 </a>
 
                 <!-- Retries -->
                 <a href="{{ url_for('airflow.tries', dag_id=dag.dag_id) }}" title="Task Tries">
-                    <span class="glyphicon glyphicon-duplicate" aria-hidden="true" title="Task Tries"></span>
+                    <span class="glyphicon glyphicon-duplicate" aria-hidden="true"></span>
                 </a>
 
                 <!-- Landing Times -->
                 <a href="{{ url_for("airflow.landing_times", dag_id=dag.dag_id) }}" title="Landing Times">
-                    <span class="glyphicon glyphicon-plane" aria-hidden="true" title="Landing Times"></span>
+                    <span class="glyphicon glyphicon-plane" aria-hidden="true"></span>
                 </a>
 
                 <!-- Gantt -->
                 <a href="{{ url_for("airflow.gantt", dag_id=dag.dag_id) }}" title="Gantt View">
-                    <span class="glyphicon glyphicon-align-left" aria-hidden="true" title="Gantt View"></span>
+                    <span class="glyphicon glyphicon-align-left" aria-hidden="true"></span>
                 </a>
 
                 <!-- Code -->
                 <a href="{{ url_for("airflow.code", dag_id=dag.dag_id) }}" title="Code View">
-                    <span class="glyphicon glyphicon-flash" aria-hidden="true" title="Code View"></span>
+                    <span class="glyphicon glyphicon-flash" aria-hidden="true"></span>
                 </a>
 
                 <!-- Logs -->
                 <a href="/admin/log/?sort=1&amp;desc=1&amp;flt1_dag_id_equals={{ dag.dag_id }}" title="Logs">
-                    <span class="glyphicon glyphicon-align-justify" aria-hidden="true" title="Logs"></span>
+                    <span class="glyphicon glyphicon-align-justify" aria-hidden="true"></span>
                 </a>
                 {% endif %}
 
                 <!-- Refresh -->
                 <a href="{{ url_for("airflow.refresh", dag_id=dag_id) }}" title="Refresh">
-                  <span class="glyphicon glyphicon-refresh" aria-hidden="true" title="Refresh"></span>
+                  <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
                 </a>
 
                 </td>
@@ -162,6 +186,11 @@
         {% endfor %}
         </tbody>
     </table>
+    {% if not hide_paused %}
+    <a href="/admin/?showPaused=False">Hide Paused DAGs</a>
+    {% else %}
+    <a href="/admin/?showPaused=True">Show Paused DAGs</a>
+    {% endif %}
   </div>
 {% endblock %}
 
@@ -171,6 +200,10 @@
   <script src="{{ url_for('static', filename='jquery.dataTables.min.js') }}"></script>
   <script src="{{ url_for('static', filename='bootstrap-toggle.min.js') }}"></script>
   <script>
+
+      function confirmTriggerDag(dag_id){
+          return confirm("Are you sure you want to run '"+dag_id+"' now?");
+      }
       all_dags = $("[id^=toggle]");
       $.each(all_dags, function(i,v) {
         $(v).change (function() {


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- _https://issues.apache.org/jira/browse/AIRFLOW-510_

Per Apache guidelines you need to create a [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW/).

Modify the HomeView to filter out paused dags if wanted and display the last
run date time on each dag, as well as allow externally triggering the dag from an icon

![homeview 1](https://cloud.githubusercontent.com/assets/173950/19336243/a9137ece-90be-11e6-9acb-ca74a93a28a7.png)
![homeview 2](https://cloud.githubusercontent.com/assets/173950/19336242/a90e4b0c-90be-11e6-963d-d75c872a93f9.png)
