### PR TITLE
[AIRFLOW-566] Add timeout while fetching logs

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -252,6 +252,10 @@ dag_orientation = LR
 # privacy.
 demo_mode = False
 
+# The amount of time (in secs) webserver will wait for initial handshake
+# while fetching logs from other worker machine
+handshake_timeout = 5
+
 [email]
 email_backend = airflow.utils.email.send_email_smtp
 
@@ -421,6 +425,7 @@ base_url = http://localhost:8080
 web_server_host = 0.0.0.0
 web_server_port = 8080
 dag_orientation = LR
+handshake_timeout = 5
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -254,7 +254,7 @@ demo_mode = False
 
 # The amount of time (in secs) webserver will wait for initial handshake
 # while fetching logs from other worker machine
-handshake_timeout = 5
+log_fetch_timeout_sec = 5
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp
@@ -425,7 +425,7 @@ base_url = http://localhost:8080
 web_server_host = 0.0.0.0
 web_server_port = 8080
 dag_orientation = LR
-handshake_timeout = 5
+log_fetch_timeout_sec = 5
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -758,7 +758,7 @@ class Airflow(BaseView):
                 log += "*** Fetching here: {url}\n".format(**locals())
                 try:
                     import requests
-                    response = requests.get(url)
+                    response = requests.get(url, timeout=5)
                     response.raise_for_status()
                     log += '\n' + response.text
                     log_loaded = True

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -759,10 +759,10 @@ class Airflow(BaseView):
                 log += "*** Fetching here: {url}\n".format(**locals())
                 try:
                     import requests
-                    timeout = None # No timeout
+                    timeout = None  # No timeout
                     try:
-                        timeout = conf.getint('webserver', 'handshake_timeout')
-                    except AirflowConfigException, ValueError:
+                        timeout = conf.getint('webserver', 'log_fetch_timeout_sec')
+                    except (AirflowConfigException, ValueError):
                         pass
 
                     response = requests.get(url, timeout=timeout)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -75,6 +75,7 @@ from airflow.utils.helpers import alchemy_to_dict
 from airflow.utils import logging as log_utils
 from airflow.www import utils as wwwutils
 from airflow.www.forms import DateTimeForm, DateTimeWithNumRunsForm
+from airflow.configuration import AirflowConfigException
 
 QUERY_LIMIT = 100000
 CHART_LIMIT = 200000
@@ -758,7 +759,13 @@ class Airflow(BaseView):
                 log += "*** Fetching here: {url}\n".format(**locals())
                 try:
                     import requests
-                    response = requests.get(url, timeout=5)
+                    timeout = None # No timeout
+                    try:
+                        timeout = conf.getint('webserver', 'handshake_timeout')
+                    except AirflowConfigException, ValueError:
+                        pass
+
+                    response = requests.get(url, timeout=timeout)
                     response.raise_for_status()
                     log += '\n' + response.text
                     log_loaded = True


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- _https://issues.apache.org/jira/browse/AIRFLOW-566_

Testing Done:
- Manuall tested

`Add request timeout while fetching logs from different machine, so it
does not take forever incase the other machine is down and move on to
next step, which is fetching logs from clouds.`
