### PR TITLE
[AIRFLOW-568] Fix double task_stats count if a DagRun is active

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -511,6 +511,7 @@ class Airflow(BaseView):
 
         LastDagRun = (
             session.query(DagRun.dag_id, sqla.func.max(DagRun.execution_date).label('execution_date'))
+            .filter(DagRun.state != State.RUNNING)
             .group_by(DagRun.dag_id)
             .subquery('last_dag_run')
         )


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-568

Testing Done:
- Manually tested by loading the status page before, during, and after an active DagRun
