### PR TITLE
[AIRFLOW-579] Mention BlaBlaCar as Airflow user

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Currently **officially** using Airflow:
 1. [Apigee](https://apigee.com) [[@btallman](https://github.com/btallman)]
 1. [Auth0](https://auth0.com) [[@sicarul](https://github.com/sicarul)]
 1. [Bellhops](https://github.com/bellhops)
+1. [BlaBlaCar](https://www.blablacar.com) [[@puckel](https://github.com/puckel) & [@wmorin](https://github.com/wmorin)]
 1. [Bloc](https://www.bloc.io) [[@dpaola2](https://github.com/dpaola2)]
 1. BlueApron [[@jasonjho](https://github.com/jasonjho) & [@matthewdavidhauser](https://github.com/matthewdavidhauser)]
 1. [Blue Yonder](http://www.blue-yonder.com) [[@blue-yonder](https://github.com/blue-yonder)]


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- List BlaBlaCar as Airflow user in the README.md file

You can see the associated JIRA ticket here [AIRFLOW-579](https://issues.apache.org/jira/browse/AIRFLOW-579).

Testing Done:
- Display the README.md in a markdown reader. It work well.
