### PR TITLE
[AIRFLOW-580] Prevent landscape warning for use of .format in logging

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -28,5 +28,6 @@ pylint:
     - super-on-old-class
     - wrong-import-order
     - wrong-import-position
+    - logging-format-interpolation
   options:
     docstring-min-length: 10


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-580

Testing Done:
- I've confirmed that this does prevent the warning messages as intended.
