### PR TITLE
[AIRFLOW-585] Fix race condition in backfill execution loop

### DIFF
--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -123,7 +123,10 @@ class TriggerRuleDep(BaseTIDep):
         upstream = len(task.upstream_task_ids)
         tr = task.trigger_rule
         upstream_done = done >= upstream
-
+        upstream_tasks_state = {
+            "successes": successes, "skipped": skipped, "failed": failed,
+            "upstream_failed": upstream_failed, "done": done
+        }
         # TODO(aoen): Ideally each individual trigger rules would be it's own class, but
         # this isn't very feasible at the moment since the database queries need to be
         # bundled together for efficiency.
@@ -147,33 +150,44 @@ class TriggerRuleDep(BaseTIDep):
         if tr == TR.ONE_SUCCESS:
             if successes <= 0:
                 yield self._failing_status(
-                    reason="Task's trigger rule '{0}' requires one upstream task "
-                           "success, but none were found.".format(tr))
+                    reason="Task's trigger rule '{0}' requires one upstream "
+                    "task success, but none were found. "
+                    "upstream_tasks_state={1}, upstream_task_ids={2}"
+                    .format(tr, upstream_tasks_state, task.upstream_task_ids))
         elif tr == TR.ONE_FAILED:
             if not failed and not upstream_failed:
                 yield self._failing_status(
-                    reason="Task's trigger rule '{0}' requires one upstream task failure "
-                           ", but none were found.".format(tr))
+                    reason="Task's trigger rule '{0}' requires one upstream "
+                    "task failure, but none were found. "
+                    "upstream_tasks_state={1}, upstream_task_ids={2}"
+                    .format(tr, upstream_tasks_state, task.upstream_task_ids))
         elif tr == TR.ALL_SUCCESS:
             num_failures = upstream - successes
             if num_failures > 0:
                 yield self._failing_status(
-                    reason="Task's trigger rule '{0}' requires all upstream tasks to "
-                           "have succeeded, but found {1} non-success(es)."
-                           .format(tr, num_failures))
+                    reason="Task's trigger rule '{0}' requires all upstream "
+                    "tasks to have succeeded, but found {1} non-success(es). "
+                    "upstream_tasks_state={2}, upstream_task_ids={3}"
+                    .format(tr, num_failures, upstream_tasks_state,
+                            task.upstream_task_ids))
         elif tr == TR.ALL_FAILED:
             num_successes = upstream - failed - upstream_failed
             if num_successes > 0:
                 yield self._failing_status(
-                    reason="Task's trigger rule '{0}' requires all upstream tasks to "
-                           "have failed, but found {1} non-faliure(s)."
-                           .format(tr, num_successes))
+                    reason="Task's trigger rule '{0}' requires all upstream "
+                    "tasks to have failed, but found {1} non-failure(s). "
+                    "upstream_tasks_state={2}, upstream_task_ids={3}"
+                    .format(tr, num_successes, upstream_tasks_state,
+                            task.upstream_task_ids))
         elif tr == TR.ALL_DONE:
             if not upstream_done:
                 yield self._failing_status(
-                    reason="Task's trigger rule '{0}' requires all upstream tasks to "
-                           "have completed, but found '{1}' task(s) that weren't done."
-                           .format(tr, upstream - done))
+                    reason="Task's trigger rule '{0}' requires all upstream "
+                    "tasks to have completed, but found {1} task(s) that "
+                    "weren't done. upstream_tasks_state={2}, "
+                    "upstream_task_ids={3}"
+                    .format(tr, upstream-done, upstream_tasks_state,
+                            task.upstream_task_ids))
         else:
             yield self._failing_status(
                 reason="No strategy to evaluate trigger rule '{0}'.".format(tr))


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-585

Atomically read all task instance states for a DAG run at the beginning of every iteration of the inner loop. This avoids race conditions that create spurious deadlocks. This is a fix for the random build failures that have been happening on Travis for some time now.

Here's an example of how such a deadlock can happen - let's say we have a DAG with tasks A and B, with B dependent on A (A -> B) and A has been picked up by a worker (but not completed), which means B is not ready to run. The backfill / local executor process is actively running .
1. Let tasks_to_run be read as [B, A] in BackfillJob._execute
2. In the while loop, B is inspected first, and it's correctly identified as not runnable (since A hasn't succeeded yet). B is added to not_ready. Now, not_ready = [B]
3. The backfill / local executor process gets interrupted and control is given to the worker process, which then runs task A and marks it as complete in the DB (in the TaskInstance run method).
4. Control is given back to the backfill / local executor process that goes on to inspect task A. It calls ti.refresh_from_db, and finds A is complete, so it pops it off the tasks_to_run list. Now, tasks_to_run = [B]
5. The following code segment in the loop incorrectly marks the DAG run as deadlocked and the backfill job is marked failed

Since we are now reading the state for all task instances for a DAG run atomically, we get rid of the race condition.

Also put in additional logging to track down similar issues more easily in the wild.

Testing Done:
- All existing unit tests pass. No spurious deadlock failures on Travis yet.
- Ran a few example backfills from the CLI

I am unsure how to add an isolated unit test for this specific race condition since there are so many interacting parts. Thoughts?
