### PR TITLE
[AIRFLOW-586] test_dag_v1 fails from 0 to 3 a.m.

### DIFF
--- a/dags/test_dag.py
+++ b/dags/test_dag.py
@@ -14,10 +14,10 @@
 
 from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
-from datetime import datetime
+from datetime import datetime, timedelta
 
 now = datetime.now()
-now_to_the_hour = now.replace(hour=now.time().hour-3 , minute=0, second=0, microsecond=0)
+now_to_the_hour = (now - timedelta(0, 0, 0, 0, 0, 3)).replace(minute=0, second=0, microsecond=0)
 START_DATE = now_to_the_hour 
 DAG_NAME = 'test_dag_v1'
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-586

Testing Done:
- ran core unit tests locally and confirmed all tests passed

dags/test_dag.py tries to set START_DATE to 3 hours before using
datetime.replace, but it doesn't support minus value as argument.
So we have to use timedelta instead of simple numeric subtraction.
