### PR TITLE
[AIRFLOW-597] Check if template content is not None

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2164,8 +2164,9 @@ class BaseOperator(object):
         # Getting the content of files for template_field / template_ext
         for attr in self.template_fields:
             content = getattr(self, attr)
-            if (content and isinstance(content, six.string_types) and
-                    any([content.endswith(ext) for ext in self.template_ext])):
+            if content is not None and \
+                    isinstance(content, six.string_types) and \
+                    any([content.endswith(ext) for ext in self.template_ext]):
                 env = self.dag.get_template_env()
                 try:
                     setattr(self, attr, env.loader.get_source(env, content)[0])

--- a/tests/core.py
+++ b/tests/core.py
@@ -587,6 +587,22 @@ class CoreTest(unittest.TestCase):
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
         assert val['success']
 
+    def test_template_non_bool(self):
+        """
+        Test templates can handle objects with no sense of truthiness
+        """
+        class NonBoolObject(object):
+            def __len__(self):
+                return NotImplemented
+            def __bool__(self):
+                return NotImplemented
+
+        t = OperatorSubclass(
+            task_id='test_bad_template_obj',
+            some_templated_field=NonBoolObject(),
+            dag=self.dag)
+        t.resolve_template_files()
+
     def test_import_examples(self):
         self.assertEqual(len(self.dagbag.dags), NUM_EXAMPLE_DAGS)
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-597

Per Apache guidelines you need to create a [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW/).

Testing Done:
- test case of a non-None template that can't be coerced to bool
