### PR TITLE
[AIRFLOW-604] Revert .first() to .one()

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3645,10 +3645,10 @@ class DagRun(Base):
             DR.dag_id == self.dag_id,
             DR.execution_date == self.execution_date,
             DR.run_id == self.run_id
-        ).first()
-        if dr:
-            self.id = dr.id
-            self.state = dr.state
+        ).one()
+
+        self.id = dr.id
+        self.state = dr.state
 
     @staticmethod
     @provide_session


### PR DESCRIPTION
Dear Airflow Maintainers,

.one() enforces the integrity of airflow as we expect
a tuple to be returned here. If not the database is
inconsistent and airflow should error out.

partially reverts: https://github.com/apache/incubator-airflow/pull/1730
