### PR TITLE
[AIRFLOW-609]: Add application_name connection parameter to postgres hook

### DIFF
--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -38,7 +38,7 @@ class PostgresHook(DbApiHook):
             port=conn.port)
         # check for ssl parameters in conn.extra
         for arg_name, arg_val in conn.extra_dejson.items():
-            if arg_name in ['sslmode', 'sslcert', 'sslkey', 'sslrootcert', 'sslcrl']:
+            if arg_name in ['sslmode', 'sslcert', 'sslkey', 'sslrootcert', 'sslcrl', 'application_name']:
                 conn_args[arg_name] = arg_val
         psycopg2_conn = psycopg2.connect(**conn_args)
         if psycopg2_conn.server_version < 70400:


### PR DESCRIPTION
Please accept this PR that addresses the following issues:

https://issues.apache.org/jira/browse/AIRFLOW-609

Testing Done:
- Tested through a DAG, because the test would otherwise require a live running postgres instance.

```
def test_dummy(**kwargs):
    hook = PostgresHook(postgres_conn_id='postgres_default')
    conn = hook.get_conn()
    time.sleep(20)
```
and then 

`SELECT * from pg_stat_activity;`

from within postgres.

This works for DAGS and operators using the hook. If running airflow on the same pg instance, you'll get internally generated connections through sqlalchemy which will not use the same connection parameters and also won't have the application_name set.

(internal connections can be set too using: 
postgresql://airflow:airflow@localhost:5432/airflow?application_name=airflow_internal
)
