### PR TITLE
[AIRFLOW-612] move resources/articles links in the to wiki

### DIFF
--- a/docs/project.rst
+++ b/docs/project.rst
@@ -33,24 +33,15 @@ Contributor page:
 Resources & links
 -----------------
 
+* `Airflow's official documentation <http://airflow.apache.org/>`_
 * Mailing list (send emails to
-  ``dev-subscribe@airflow.incubator.apache.org`` and
+  ``dev-subscribe@airflow.incubator.apache.org`` and/or
   ``commits-subscribe@airflow.incubator.apache.org``
   to subscribe to each)
-* `Issues <https://issues.apache.org/jira/browse/AIRFLOW>`_
-* `Airbnb Blog Post about Airflow <http://nerds.airbnb.com/airflow/>`_
-* `Airflow Common Pitfalls <https://cwiki.apache.org/confluence/display/AIRFLOW/Common+Pitfalls>`_
-* `Hadoop Summit Airflow Video <https://www.youtube.com/watch?v=oYp49mBwH60>`_
-* `Airflow at Agari Blog Post <http://agari.com/blog/airflow-agari>`_
-* `Talk: Best practices with Airflow (nov 2015) <https://youtu.be/dgaoqOZlvEA>`_
-* `Airflow Lesson 1: TriggerDagRunOperator <https://www.linkedin.com/pulse/airflow-lesson-1-triggerdagrunoperator-siddharth-anand?published=t>`_
-* `Docker Airflow (externally maintained) <https://github.com/puckel/docker-airflow>`_
-* `Airflow: Tips, Tricks, and Pitfalls @ Handy <https://medium.com/handy-tech/airflow-tips-tricks-and-pitfalls-9ba53fba14eb#.o2snqeoz7>`_
-* `Airflow Chef recipe (community contributed) <https://github.com/bahchis/airflow-cookbook>`_ ,
-  `another here <https://supermarket.chef.io/cookbooks/airflow>`_
-* Airflow Puppet Module (community contributed) `puppet-airflow <https://github.com/similarweb/puppet-airflow>`_,
-  `airflow <https://forge.puppetlabs.com/similarweb/airflow>`_
+* `Issues on Apache's Jira <https://issues.apache.org/jira/browse/AIRFLOW>`_
 * `Gitter (chat) Channel <https://gitter.im/airbnb/airflow>`_
+* `More resources and links to Airflow related content on the Wiki <https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Links>`_
+
 
 
 Roadmap


### PR DESCRIPTION
Only the most important and static links stay in the docs, articles and external resources move to the Wiki (and the docs link to the wiki...)