### PR TITLE
[AIRFLOW-571] added --forwarded_allow_ips as a command line argument to webserver

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -702,7 +702,7 @@ def webserver(args):
     try:
         forwarded_allow_ips = (args.forwarded_allow_ips or
                                conf.get('webserver', 'forwarded_allow_ips'))
-    except AirflowConfigException as _e:
+    except AirflowConfigException:
         forwarded_allow_ips = None
 
     if args.debug:

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -699,7 +699,7 @@ def webserver(args):
     if ssl_cert and not ssl_key:
         raise AirflowException(
             'An SSL key must also be provided for use with ' + ssl_cert)
-    forwarded_allow_ips = (args.forwarded_allow_ips or 
+    forwarded_allow_ips = (args.forwarded_allow_ips or
                            conf.get('webserver', 'forwarded_allow_ips'))
 
     if args.debug:

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1304,7 +1304,7 @@ class CLIFactory(object):
                  "stderr."),
         'forwarded_allow_ips': Arg(
             ("--forwarded_allow_ips", ),
-            default=conf.get('webserver', 'FORWARDED_ALLOW_IPS'),
+            default=None,
             help="Pass gunicorn front-end IPs allowed to handle set secure headers."),
         # resetdb
         'yes': Arg(

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -699,6 +699,7 @@ def webserver(args):
     if ssl_cert and not ssl_key:
         raise AirflowException(
             'An SSL key must also be provided for use with ' + ssl_cert)
+    forwarded_allow_ips = args.forwarded_allow_ips or conf.get('webserver', 'forwarded_allow_ips')
 
     if args.debug:
         print(
@@ -739,6 +740,9 @@ def webserver(args):
             run_args += ["-D"]
         if ssl_cert:
             run_args += ['--certfile', ssl_cert, '--keyfile', ssl_key]
+
+        if args.forwarded_allow_ips:
+            run_args += ['--forwarded-allow-ips', args.forwarded_allow_ips]
 
         run_args += ["airflow.www.app:cached_app()"]
 
@@ -1294,6 +1298,10 @@ class CLIFactory(object):
             default=conf.get('webserver', 'ERROR_LOGFILE'),
             help="The logfile to store the webserver error log. Use '-' to print to "
                  "stderr."),
+        'forwarded_allow_ips': Arg(
+            ("--forwarded_allow_ips", ),
+            default=conf.get('webserver', 'FORWARDED_ALLOW_IPS'),
+            help="Pass gunicorn front-end IPs allowed to handle set secure headers."),
         # resetdb
         'yes': Arg(
             ("-y", "--yes"),
@@ -1469,7 +1477,8 @@ class CLIFactory(object):
             'help': "Start a Airflow webserver instance",
             'args': ('port', 'workers', 'workerclass', 'worker_timeout', 'hostname',
                      'pid', 'daemon', 'stdout', 'stderr', 'access_logfile',
-                     'error_logfile', 'log_file', 'ssl_cert', 'ssl_key', 'debug'),
+                     'error_logfile', 'log_file', 'ssl_cert', 'ssl_key',
+                     'forwarded_allow_ips', 'debug'),
         }, {
             'func': resetdb,
             'help': "Burn down and rebuild the metadata database",

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -45,7 +45,7 @@ import airflow
 from airflow import api
 from airflow import jobs, settings
 from airflow import configuration as conf
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowConfigException
 from airflow.executors import DEFAULT_EXECUTOR
 from airflow.models import (DagModel, DagBag, TaskInstance,
                             DagPickle, DagRun, Variable, DagStat,
@@ -699,8 +699,11 @@ def webserver(args):
     if ssl_cert and not ssl_key:
         raise AirflowException(
             'An SSL key must also be provided for use with ' + ssl_cert)
-    forwarded_allow_ips = (args.forwarded_allow_ips or
-                           conf.get('webserver', 'forwarded_allow_ips'))
+    try:
+        forwarded_allow_ips = (args.forwarded_allow_ips or
+                               conf.get('webserver', 'forwarded_allow_ips'))
+    except AirflowConfigException as _e:
+        forwarded_allow_ips = None
 
     if args.debug:
         print(

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -699,7 +699,8 @@ def webserver(args):
     if ssl_cert and not ssl_key:
         raise AirflowException(
             'An SSL key must also be provided for use with ' + ssl_cert)
-    forwarded_allow_ips = args.forwarded_allow_ips or conf.get('webserver', 'forwarded_allow_ips')
+    forwarded_allow_ips = (args.forwarded_allow_ips or 
+                           conf.get('webserver', 'forwarded_allow_ips'))
 
     if args.debug:
         print(
@@ -741,8 +742,8 @@ def webserver(args):
         if ssl_cert:
             run_args += ['--certfile', ssl_cert, '--keyfile', ssl_key]
 
-        if args.forwarded_allow_ips:
-            run_args += ['--forwarded-allow-ips', args.forwarded_allow_ips]
+        if forwarded_allow_ips:
+            run_args += ['--forwarded-allow-ips', forwarded_allow_ips]
 
         run_args += ["airflow.www.app:cached_app()"]
 

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -214,6 +214,7 @@ web_server_ssl_key =
 # Pass gunicorn front-end IPs allowed to handle set secure headers.
 # Multiple IPs should be comma separated.  Set to * to disable checking.
 # Useful if you are running gunicorn behind a load balancer.
+# See http://docs.gunicorn.org/en/stable/settings.html#forwarded-allow-ips
 # forwarded_allow_ips = *
 
 # Number of seconds the gunicorn webserver waits before timing out on a worker
@@ -459,6 +460,7 @@ web_server_port = 8080
 dag_orientation = LR
 log_fetch_timeout_sec = 5
 hide_paused_dags_by_default = False
+forwarded_allow_ips = *
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -211,6 +211,11 @@ web_server_port = 8080
 web_server_ssl_cert =
 web_server_ssl_key =
 
+# Pass gunicorn front-end IPs allowed to handle set secure headers.
+# Multiple IPs should be comma separated.  Set to * to disable checking.
+# Useful if you are running gunicorn behind a load balancer.
+forwarded_allow_ips =
+
 # Number of seconds the gunicorn webserver waits before timing out on a worker
 web_server_worker_timeout = 120
 

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -214,7 +214,7 @@ web_server_ssl_key =
 # Pass gunicorn front-end IPs allowed to handle set secure headers.
 # Multiple IPs should be comma separated.  Set to * to disable checking.
 # Useful if you are running gunicorn behind a load balancer.
-forwarded_allow_ips =
+# forwarded_allow_ips = *
 
 # Number of seconds the gunicorn webserver waits before timing out on a worker
 web_server_worker_timeout = 120


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
- AIRFLOW-571

Testing Done:

No unittests added but I'm open to ideas on how to accomplish this.  This PR is adding a command line feature to pass `--forwarded-allow-ips STRING` along to gunicorn.  This fixes an issue when airflow webserver and gunicorn are run on one machine but a load balancer or reverse proxy is run on another, and https requests that are re-directed are changed to http requests.

Summary:

This allows the webserver to run on a separate machine from a load balancer and still handle set secure headers.  It adds the option '--forwarded_allow_ips' to 'airflow webserver' and passes to value to gunicorn if present.

More information:
http://docs.gunicorn.org/en/stable/settings.html#forwarded-allow-ips

I ran into a similar problem with airbnb/caravel: https://github.com/airbnb/caravel/issues/978
