### PR TITLE
[AIRFLOW-137] Fix max_active_runs on clearing tasks

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -793,8 +793,12 @@ class SchedulerJob(BaseJob):
             self.logger.info("Examining DAG run {}".format(run))
             # don't consider runs that are executed in the future
             if run.execution_date > datetime.now():
-                self.logging.error("Execution date is in future: {}"
-                                   .format(run.execution_date))
+                self.logger.error("Execution date is in future: {}"
+                                  .format(run.execution_date))
+                continue
+
+            if len(active_dag_runs) >= dag.max_active_runs:
+                self.logger.info("Active dag runs > max_active_run.")
                 continue
 
             # skip backfill dagruns for now as long as they are not really scheduled


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:

https://issues.apache.org/jira/browse/AIRFLOW-137

(extra: also fixed issue with 'self.logging' in an error condition, that apparently wasn't called. It will lead to a scheduler crash, because self.logging is not an attribute. self.logger is.)

Testing Done:
- Tested through UI and running the scheduler (LocalExecutor mode). Results:
  * max_active_runs is respected. Because the "find" on dagrun uses an order-by, it is safe to use the max_active_runs check as done in the code, because that forces the dagruns to be processed in order.
  * Tested for max_active_runs=1 and 3. Both are processed correctly.
  * Tested with 5 intermediately cleared dags. The scheduler first reprocesses those cleared dags, then continues to add more dagruns at the very end.

- Unittest added.

