### PR TITLE
[AIRFLOW-618] Cast DateTimes to avoid sqlite errors in Travis (and in general)

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3650,9 +3650,11 @@ class DagRun(Base):
         """
         DR = DagRun
 
+        exec_date = func.cast(self.execution_date, DateTime)
+
         dr = session.query(DR).filter(
             DR.dag_id == self.dag_id,
-            DR.execution_date == self.execution_date,
+            func.cast(DR.execution_date, DateTime) == exec_date,
             DR.run_id == self.run_id
         ).one()
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AIRFLOW-618

For some reason, sqllite does not always match datetimes correctly.
This causes unit test failures, in particular the trigger_dagrun test.
Casting the datetime explicitly appears to solve the issue.