### PR TITLE
[AIRFLOW-619] Fix exception rendering Gantt chart while a TaskInstance is running

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1694,13 +1694,14 @@ class Airflow(BaseView):
 
         tasks = []
         for ti in tis:
+            end_date = ti.end_date if ti.end_date else datetime.now()
             tasks.append({
                 'startDate': wwwutils.epoch(ti.start_date),
-                'endDate': wwwutils.epoch(ti.end_date or datetime.now()),
+                'endDate': wwwutils.epoch(end_date),
                 'isoStart': ti.start_date.isoformat()[:-4],
-                'isoEnd': ti.end_date.isoformat()[:-4],
+                'isoEnd': end_date.isoformat()[:-4],
                 'taskName': ti.task_id,
-                'duration': "{}".format(ti.end_date - ti.start_date)[:-4],
+                'duration': "{}".format(end_date - ti.start_date)[:-4],
                 'status': ti.state,
                 'executionDate': ti.execution_date.isoformat(),
             })


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-619

In the Gantt view, if a TaskInstance has no end_date, replace the end_date with datetime.now() before returning the result to the render so we don't call methods on None.

Testing Done:
Load Gannt chart view of a DagRun which has running task instances, got exception before the fix.   After the fix the bar for the running task goes up to the current datetime and is correctly coded bright green.  Also verified that none of the other DAG views have a problem with running TaskInstances.

Before:


> Traceback (most recent call last):
  File "/home/dgies/airflow/venv/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/dgies/airflow/venv/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/dgies/airflow/venv/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/dgies/airflow/venv/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/dgies/airflow/venv/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/dgies/airflow/venv/lib/python2.7/site-packages/flask_admin/base.py", line 68, in inner
    return self._run_view(f, *args, **kwargs)
  File "/home/dgies/airflow/venv/lib/python2.7/site-packages/flask_admin/base.py", line 367, in _run_view
    return fn(self, *args, **kwargs)
  File "/home/dgies/airflow/venv/lib/python2.7/site-packages/flask_login.py", line 755, in decorated_view
    return func(*args, **kwargs)
  File "/home/dgies/airflow/venv/lib/python2.7/site-packages/airflow/www/utils.py", line 125, in wrapper
    return f(*args, **kwargs)
  File "/home/dgies/airflow/venv/lib/python2.7/site-packages/airflow/www/views.py", line 1701, in gantt
    'isoEnd': ti.end_date.isoformat()[:-4],
AttributeError: 'NoneType' object has no attribute 'isoformat'

After:
<img width="940" alt="screen shot 2016-11-09 at 9 45 30 am" src="https://cloud.githubusercontent.com/assets/4491601/20148409/4e9c04e4-a661-11e6-9db7-22b0be8ddbea.png">
