### PR TITLE
[AIRFLOW-623] Sometimes ldap attributes is not always list

### DIFF
--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -75,7 +75,12 @@ def group_contains_user(conn, search_base, group_filter, user_name_attr, usernam
         LOG.warn("Unable to find group for %s %s", search_base, search_filter)
     else:
         for resp in conn.response:
-            if 'attributes' in resp and resp['attributes'].get(user_name_attr)[0] == username:
+            if (
+                'attributes' in resp and (
+                    resp['attributes'].get(user_name_attr)[0] == username or
+                    resp['attributes'].get(user_name_attr) == username
+                )
+            ):
                 return True
     return False
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-623

Sometimes the search attributes that come back are not a list always, but a string, so we need to check for an exact match as well as if it's a list