### PR TITLE
[AIRFLOW-633] Show TI attributes in TI view

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -753,6 +753,7 @@ class TaskInstance(Base):
         self.unixname = getpass.getuser()
         if state:
             self.state = state
+        self.hostname = ''
         self.init_on_load()
 
     @reconstructor
@@ -954,6 +955,7 @@ class TaskInstance(Base):
             self.start_date = ti.start_date
             self.end_date = ti.end_date
             self.try_number = ti.try_number
+            self.hostname = ti.hostname
         else:
             self.state = None
 

--- a/airflow/www/templates/airflow/task.html
+++ b/airflow/www/templates/airflow/task.html
@@ -44,13 +44,26 @@
             <h5>Attribute: {{ attr }}</h5>
             {{ value|safe }}
         {% endfor %}
-        <h5>Attributes</h5>
+        <h5>Task Instance Attributes</h5>
         <table class="table table-striped table-bordered">
             <tr>
                 <th>Attribute</th>
                 <th>Value</th>
             </tr>
-            {% for attr, value in attributes %}
+            {% for attr, value in ti_attrs %}
+                <tr>
+                    <td>{{ attr }}</td>
+                    <td class='code'>{{ value }}</td>
+                </tr>
+            {% endfor %}
+        </table>
+        <h5>Task Attributes</h5>
+        <table class="table table-striped table-bordered">
+            <tr>
+                <th>Attribute</th>
+                <th>Value</th>
+            </tr>
+            {% for attr, value in task_attrs %}
                 <tr>
                     <td>{{ attr }}</td>
                     <td class='code'>{{ value }}</td>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -831,13 +831,20 @@ class Airflow(BaseView):
         ti = TI(task=task, execution_date=dttm)
         ti.refresh_from_db()
 
-        attributes = []
+        ti_attrs = []
+        for attr_name in dir(ti):
+            if not attr_name.startswith('_'):
+                attr = getattr(ti, attr_name)
+                if type(attr) != type(self.task):
+                    ti_attrs.append((attr_name, str(attr)))
+
+        task_attrs = []
         for attr_name in dir(task):
             if not attr_name.startswith('_'):
                 attr = getattr(task, attr_name)
                 if type(attr) != type(self.task) and \
                                 attr_name not in attr_renderer:
-                    attributes.append((attr_name, str(attr)))
+                    task_attrs.append((attr_name, str(attr)))
 
         # Color coding the special attributes that are code
         special_attrs_rendered = {}
@@ -867,7 +874,8 @@ class Airflow(BaseView):
         title = "Task Instance Details"
         return self.render(
             'airflow/task.html',
-            attributes=attributes,
+            task_attrs=task_attrs,
+            ti_attrs=ti_attrs,
             failed_dep_reasons=failed_dep_reasons or no_failed_deps_result,
             task_id=task_id,
             execution_date=execution_date,


### PR DESCRIPTION
@mistercrunch @artwr 

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-633

Show task instance properties in addition to task properties in the task instance view. The primary reason for this is so that we can see things like the host a task ran on without opening the log file (which is huge in the case of long-running/persistent jobs, especially e.g due to the constant airflow heartbeat). Pagination of the log would help too but this change is still necessary and a quicker win.

I think ideally we want to only show an explicit subset of fields, but for now making behavior consistent with how task (not task instance) attributes are displayed. Going to merge to open source once this is merged.

Testing Done:
- Airbnb production webserver

<img width="1200" alt="screen shot 2016-11-15 at 11 34 30 am" src="https://cloud.githubusercontent.com/assets/1592778/20324808/dae2861a-ab36-11e6-8bfa-3942ed529856.png">
