### PR TITLE
[AIRFLOW-636] log and document DagBag skipping modules

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -247,6 +247,9 @@ class DagBag(BaseDagBag, LoggingMixin):
                 with open(filepath, 'rb') as f:
                     content = f.read()
                     if not all([s in content for s in (b'DAG', b'airflow')]):
+                        logging.warning(
+                            "{} does not appear to contain a DAG "
+                            "import statement - skipping".format(filepath))
                         return found_dags
 
             self.logger.debug("Importing {}".format(filepath))

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -159,7 +159,7 @@ def duration_f(v, c, m, p):
 
 def datetime_f(v, c, m, p):
     attr = getattr(m, p)
-    dttm = attr.isoformat() if attr else ''
+    dttm = attr.isoformat()[:16] if attr else ''
     if datetime.now().isoformat()[:4] == dttm[:4]:
         dttm = dttm[5:]
     return Markup("<nobr>{}</nobr>".format(dttm))


### PR DESCRIPTION
Warn for every skipped file + related entry in the documentation.

Also squeezing in a FAQ entry for "Why is ``execution_date`` off?"