### PR TITLE
[AIRFLOW-347] Show empty DAG runs in tree view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1221,10 +1221,11 @@ class Airflow(BaseView):
         dag_runs = {
             dr.execution_date: alchemy_to_dict(dr) for dr in dag_runs}
 
+        dates = sorted(list(dag_runs.keys()))
+        max_date = max(dates) if dates else None
+
         tis = dag.get_task_instances(
                 session, start_date=min_date, end_date=base_date)
-        dates = sorted(list({ti.execution_date for ti in tis}))
-        max_date = max([ti.execution_date for ti in tis]) if dates else None
         task_instances = {}
         for ti in tis:
             tid = alchemy_to_dict(ti)


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-347

This issue was reported by @aoen and @criccomini 

Use DAG runs to construct the list of dates to display in the tree view. The old logic used execution dates from task instances to construct the list of dates, which meant that empty DAG runs would not show up in the UI.

Testing Done:
- Run the scheduler for the example_bash_operator DAG and clear out all task instances for a particular date (11/12 in the screenshot). Before the fix, the 11/12 DAG run doesn't show up in the tree view and after the fix, it does. Interacting with the modal dialog for the empty task instances doesn't throw any exceptions and works as expected.

Before
<img width="584" alt="tree_view_before" src="https://cloud.githubusercontent.com/assets/907344/20455019/bd7a7a7a-ae05-11e6-88de-eecbed9312d0.png">

After
<img width="667" alt="tree_view_after" src="https://cloud.githubusercontent.com/assets/907344/20455022/d0e808f2-ae05-11e6-89d0-f40dde653ebe.png">
