### PR TITLE
[AIRFLOW-640] Install and enable nose-ignore-docstring

### DIFF
--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -33,6 +33,7 @@ if [ -z "$nose_args" ]; then
 --cover-html \
 --cover-package=airflow \
 --cover-html-dir=airflow/www/static/coverage \
+--with-ignore-docstrings \
 -s \
 -v \
 --logging-level=DEBUG "

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -34,6 +34,7 @@ mock
 mysqlclient
 nose
 nose-exclude
+nose-ignore-docstring==0.2
 nose-parameterized
 pandas
 psutil>=4.2.0, <5.0.0

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,17 @@ qds = ['qds-sdk>=1.9.0']
 cloudant = ['cloudant>=0.5.9,<2.0'] # major update coming soon, clamp to 0.x
 
 all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant
-devel = ['lxml>=3.3.4', 'nose', 'nose-parameterized', 'mock', 'click', 'jira', 'moto', 'freezegun']
+devel = [
+    'click',
+    'freezegun'
+    'jira',
+    'lxml>=3.3.4',
+    'mock',
+    'moto',
+    'nose',
+    'nose-ignore-docstring==0.2',
+    'nose-parameterized',
+]
 devel_minreq = devel + mysql + doc + password + s3
 devel_hadoop = devel_minreq + hive + hdfs + webhdfs + kerberos
 devel_all = devel + all_dbs + doc + samba + s3 + slack + crypto + oracle + docker


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- [AIRFLOW-640](https://issues.apache.org/jira/browse/AIRFLOW-640)

Testing:

Check that Travis logs now includes the string `test_subdag_pools`