### PR TITLE
[AIRFLOW-653] Some endpoint urls have no test

### DIFF
--- a/tests/core.py
+++ b/tests/core.py
@@ -1356,6 +1356,18 @@ class WebUiTests(unittest.TestCase):
         response = self.app.get('/health')
         assert 'The server is healthy!' in response.data.decode('utf-8')
 
+    def test_headers(self):
+        response = self.app.get('/admin/airflow/headers')
+        assert '"headers":' in response.data.decode('utf-8')
+
+    def test_noaccess(self):
+        response = self.app.get('/admin/airflow/noaccess')
+        assert "You don't seem to have access." in response.data.decode('utf-8')
+
+    def test_pickle_info(self):
+        response = self.app.get('/admin/airflow/pickle_info')
+        assert '{' in response.data.decode('utf-8')
+
     def test_dag_views(self):
         response = self.app.get(
             '/admin/airflow/graph?dag_id=example_bash_operator')


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-653

Testing Done:
- All unit tests passed.

WebUiTests lack tests for some endpoints.
This commit adds tests for /admin/airflow/headers,
/admin/airflow/noaccess and /admin/airflow/pickle_info.