### PR TITLE
[AIRFLOW-652] Endpoint /sandbox is unnecessary

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -624,23 +624,6 @@ class Airflow(BaseView):
             nukular=ascii_.nukular,
             info=traceback.format_exc()), 500
 
-    @expose('/sandbox')
-    @login_required
-    def sandbox(self):
-        title = "Sandbox Suggested Configuration"
-        cfg_loc = conf.AIRFLOW_CONFIG + '.sandbox'
-        f = open(cfg_loc, 'r')
-        config = f.read()
-        f.close()
-        code_html = Markup(highlight(
-            config,
-            lexers.IniLexer(),  # Lexer call
-            HtmlFormatter(noclasses=True))
-        )
-        return self.render(
-            'airflow/code.html',
-            code_html=code_html, title=title, subtitle=cfg_loc)
-
     @expose('/noaccess')
     def noaccess(self):
         return self.render('airflow/noaccess.html')


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-652

Testing Done:
- All unit tests passed

views.py exposes an endpoint /sandbox, but it's
unused. This commit removes that for code cleanup.