### PR TITLE
[AIRFLOW-654] Add SSL Config Option for CeleryExecutor w/ RabbitMQ

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -15,6 +15,7 @@
 from builtins import object
 import logging
 import subprocess
+import ssl
 import time
 
 from celery import Celery
@@ -43,6 +44,10 @@ class CeleryConfig(object):
     CELERYD_CONCURRENCY = configuration.getint('celery', 'CELERYD_CONCURRENCY')
     CELERY_DEFAULT_QUEUE = DEFAULT_QUEUE
     CELERY_DEFAULT_EXCHANGE = DEFAULT_QUEUE
+    BROKER_USE_SSL = {'keyfile': configuration.get('celery', 'CELERY_SSL_KEY'),
+                      'certfile': configuration.get('celery', 'CELERY_SSL_CERT'),
+                      'ca_certs': configuration.get('celery', 'CELERY_SSL_CACERT'),
+                      'cert_reqs': ssl.CERT_REQUIRED}
 
 app = Celery(
     configuration.get('celery', 'CELERY_APP_NAME'),

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -44,10 +44,18 @@ class CeleryConfig(object):
     CELERYD_CONCURRENCY = configuration.getint('celery', 'CELERYD_CONCURRENCY')
     CELERY_DEFAULT_QUEUE = DEFAULT_QUEUE
     CELERY_DEFAULT_EXCHANGE = DEFAULT_QUEUE
-    BROKER_USE_SSL = {'keyfile': configuration.get('celery', 'CELERY_SSL_KEY'),
-                      'certfile': configuration.get('celery', 'CELERY_SSL_CERT'),
-                      'ca_certs': configuration.get('celery', 'CELERY_SSL_CACERT'),
-                      'cert_reqs': ssl.CERT_REQUIRED}
+    if configuration.get('celery', 'CELERY_SSL_ACTIVE'):
+        try:
+            BROKER_USE_SSL = {'keyfile': configuration.get('celery', 'CELERY_SSL_KEY'),
+                              'certfile': configuration.get('celery', 'CELERY_SSL_CERT'),
+                              'ca_certs': configuration.get('celery', 'CELERY_SSL_CACERT'),
+                              'cert_reqs': ssl.CERT_REQUIRED}
+        except ValueError:
+            raise AirflowException('ValueError: CELERY_SSL_ACTIVE is True, please ensure CELERY_SSL_KEY, '
+                                   'CELERY_SSL_CERT and CELERY_SSL_CACERT are set')
+        except Exception as e:
+            raise AirflowException('Exception: There was an unknown Celery SSL Error.  Please ensure you want to use '
+                                   'SSL and/or have all necessary certs and key.')
 
 app = Celery(
     configuration.get('celery', 'CELERY_APP_NAME'),

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -310,3 +310,14 @@ standard port 443, you'll need to configure that too. Be aware that super user p
     # Optionally, set the server to listen on the standard SSL port.
     web_server_port = 443
     base_url = http://<hostname or IP>:443
+
+Enable CeleryExecutor with SSL. Ensure you properly generate client and server
+certs and keys.
+
+.. code-block:: bash
+
+    [celery]
+    CELERY_SSL_ACTIVE = True
+    CELERY_SSL_KEY = <path to key>
+    CELERY_SSL_CERT = <path to cert>
+    CELERY_SSL_CACERT = <path to cacert>


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- *(https://issues.apache.org/jira/browse/AIRFLOW-654)*


Testing Done:
- Tested in the following system with wireshark: Ubuntu 16.04, Airflow 1.7.1.3, celery[auth] 4.0
- No unit test because not helpful without a remote broker to test handshake
- System implementations can vary, but follows celery+rabbitmq conventions


- Add BROKER_USE_SSL config to give option to send AMQP messages over SSL
- Should be easier to maintain and use than pub/private keys for SSH tunnels, especially in automation system
- Can be set using usual airflow options (e.g. airflow.cfg, env vars, etc.) for the following vars: CELERY_SSL_KEY, CELERY_SSL_CERT, CELERY_SSL_CACERT.  Namespace chosen to be similar and differentiable to the upcoming webserver SSL patch vars, to keep in mind formal networking terms, and to be consistent with RabbitMQ terms