### PR TITLE
[AIRFLOW-536] Schedule all pending DAG runs in a single scheduler loop

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -104,10 +104,11 @@ class BaseExecutor(LoggingMixin):
         self.logger.debug("{} in queue".format(len(self.queued_tasks)))
         self.logger.debug("{} open slots".format(open_slots))
 
+        # sort by priority (descending) and execution date (ascending)
         sorted_queue = sorted(
             [(k, v) for k, v in self.queued_tasks.items()],
-            key=lambda x: x[1][1],
-            reverse=True)
+            key=lambda x: (-x[1][1], x[0][2]),
+            reverse=False)
         for i in range(min((open_slots, len(self.queued_tasks)))):
             key, (command, _, queue, ti) = sorted_queue.pop(0)
             # TODO(jlowin) without a way to know what Job ran which tasks,

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1133,9 +1133,13 @@ class SchedulerJob(BaseJob):
 
             self.logger.info("Processing {}".format(dag.dag_id))
 
-            dag_run = self.create_dag_run(dag)
-            if dag_run:
-                self.logger.info("Created {}".format(dag_run))
+            # create all valid DAG runs in a single scheduler invocation
+            while True:
+                dag_run = self.create_dag_run(dag)
+                if dag_run:
+                    self.logger.info("Created DAG run {}".format(dag_run))
+                else:
+                    break
             self._process_task_instances(dag, tis_out)
             self.manage_slas(dag)
 

--- a/scripts/perf/scheduler_ops_metrics.py
+++ b/scripts/perf/scheduler_ops_metrics.py
@@ -24,7 +24,7 @@ from airflow.utils.state import State
 
 SUBDIR = 'scripts/perf/dags'
 DAG_IDS = ['perf_dag_1', 'perf_dag_2']
-MAX_RUNTIME_SECS = 6
+MAX_RUNTIME_SECS = 600
 
 
 class SchedulerMetricsJob(SchedulerJob):
@@ -179,7 +179,8 @@ def main():
     clear_dag_runs()
     clear_dag_task_instances()
 
-    job = SchedulerMetricsJob(dag_ids=DAG_IDS, subdir=SUBDIR)
+    job = SchedulerMetricsJob(dag_ids=DAG_IDS, subdir=SUBDIR,
+        processor_poll_interval=1.0)
     job.run()
 
 

--- a/tests/test_utils/fake_datetime.py
+++ b/tests/test_utils/fake_datetime.py
@@ -21,4 +21,4 @@ class FakeDatetime(datetime):
     """
 
     def __new__(cls, *args, **kwargs):
-        return date.__new__(datetime, *args, **kwargs)
+        return datetime.__new__(datetime, *args, **kwargs)


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-536

This issue was reported by @aoen.

Currently only a single DAG run is scheduled when a DAG file is parsed 
by an iteration of the scheduler loop. Which means scheduling N pending
DAG runs will require N scheduler loop iterations (separated by 
file_process_interval waits). Modify the logic to schedule all pending DAG 
runs instead.

Testing Done:
- Added a unit test test_schedule_multiple_dag_runs that fakes the current 
date to a week after the start date of the test DAG. Running a single 
iteration of the scheduler loop should schedule 7 task instances associated 
with the DAG runs for each day.
- Modified unit tests test_scheduler_reschedule and test_dag_with_system_exit 
that implicitly assumed a single DAG run scheduled per scheduler loop, by 
explicitly faking the current date.
- Created a test DAG with a start date of 2016-11-24 and ran the scheduler on
2016-11-29. Verified on the tree view of the webserver that DAG runs from
2016-11-24 to 2016-11-28 got scheduled.