### PR TITLE
[AIRFLOW-658] Improve schema_update_options in GCP

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -342,7 +342,7 @@ class BigQueryBaseCursor(object):
                  skip_leading_rows=0,
                  write_disposition='WRITE_EMPTY',
                  field_delimiter=',',
-                 schema_update_options=[]):
+                 schema_update_options=()):
         """
         Executes a BigQuery load command to load data from Google Cloud Storage
         to BigQuery. See here:

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -46,7 +46,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         bigquery_conn_id='bigquery_default',
         google_cloud_storage_conn_id='google_cloud_storage_default',
         delegate_to=None,
-        schema_update_options=[],
+        schema_update_options=(),
         *args,
         **kwargs):
         """


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-658

Testing Done:
- Ran changes against the existing BigQuery hook and operator tests and it passed.  Also did local tests that uploaded data from GCS to BigQuery using the `schema_update_options` field and also without using the field.  Everything worked so it should be good to go.