### PR TITLE
[AIRFLOW-659] Automatic Refresh on DAG Graph View

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -261,6 +261,11 @@ dag_orientation = LR
 # privacy.
 demo_mode = False
 
+# Rate at which to automatically refresh the task states in the graph view in
+# milliseconds. If not set or set to 0, the graph will require refreshing
+# manually. Otherwise the manual refresh button will not be displayed.
+graph_refresh_rate = 0
+
 # The amount of time (in secs) webserver will wait for initial handshake
 # while fetching logs from other worker machine
 log_fetch_timeout_sec = 5

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -1,13 +1,13 @@
-{# 
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -76,9 +76,11 @@
         <span id="error_msg">Oops.</span>
 </div>
 <hr style="margin-bottom: 0px;"/>
+{% if refresh_rate|int == 0 %}
 <button class="btn btn-default pull-right" id="refresh_button">
     <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
 </button>
+{% endif %}
 <div id="svg_container">
 
     <svg width="{{ width }}" height="{{ height }}">
@@ -345,25 +347,29 @@
       $('#datatable_section').hide(1000);
     }
 
-    d3.select("#refresh_button").on("click",
-        function() {
-            $("#loading").css("display", "block");
-            $("div#svg_container").css("opacity", "0.2");
-            $.get(
-                "/admin/airflow/object/task_instances",
-                {dag_id : "{{ dag.dag_id }}", execution_date : "{{ execution_date }}"})
-            .done(
-                function(task_instances) {
-                    update_nodes_states(JSON.parse(task_instances));
-                    $("#loading").hide();
-                    $("div#svg_container").css("opacity", "1");
-                    $('#error').hide();
-                }
-            ).fail(function(jqxhr, textStatus, err) {
-                error(textStatus + ': ' + err);
-            });
-        }
-    );
+    function refreshGraph() {
+        $("#loading").css("display", "block");
+        $("div#svg_container").css("opacity", "0.2");
+        $.get(
+            "/admin/airflow/object/task_instances",
+            {dag_id : "{{ dag.dag_id }}", execution_date : "{{ execution_date }}"})
+        .done(
+            function(task_instances) {
+                update_nodes_states(JSON.parse(task_instances));
+                $("#loading").hide();
+                $("div#svg_container").css("opacity", "1");
+                $('#error').hide();
+            }
+        ).fail(function(jqxhr, textStatus, err) {
+            error(textStatus + ': ' + err);
+        });
+    }
+
+    {% if refresh_rate|int > 0 %}
+    window.setInterval(refreshGraph, {{ refresh_rate }})
+    {% else %}
+    d3.select("#refresh_button").on("click", refreshGraph);
+    {% endif %}
 
     </script>
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1416,6 +1416,10 @@ class Airflow(BaseView):
         session.close()
         doc_md = markdown.markdown(dag.doc_md) if hasattr(dag, 'doc_md') else ''
 
+        refresh_rate = int(conf.get('webserver', 'graph_refresh_rate'))
+        if not refresh_rate:
+            refresh_rate = 0
+
         return self.render(
             'airflow/graph.html',
             dag=dag,
@@ -1435,7 +1439,8 @@ class Airflow(BaseView):
             task_instances=json.dumps(task_instances, indent=2),
             tasks=json.dumps(tasks, indent=2),
             nodes=json.dumps(nodes, indent=2),
-            edges=json.dumps(edges, indent=2),)
+            edges=json.dumps(edges, indent=2),
+            refresh_rate=refresh_rate)
 
     @expose('/duration')
     @login_required


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-659

Testing Done:
- Manual Testing: with the new config value set to 0, the site behaves as before. With a value greater than 0, the graph refreshes itself automatically as expected.
- Unit Tests: UI change only. I don't believe it is possible to write unit-tests for this.

Screenshots:
With graph_refresh_rate = 0:
![image](https://cloud.githubusercontent.com/assets/19971132/20751703/1a3f9518-b6f5-11e6-9140-98baa527b7ec.png)

With graph_refresh_rate = 10000 (this value is in milliseconds):
![image](https://cloud.githubusercontent.com/assets/19971132/20751738/522515f2-b6f5-11e6-9aeb-d048fc7e3ff6.png)

Note that the refresh button does not appear when the config is setup to allow the graph to refresh automatically.

