### PR TITLE
[AIRFLOW-660] Add id autoincrement column to task_fail table

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1611,6 +1611,7 @@ class TaskFail(Base):
 
     __tablename__ = "task_fail"
 
+    id = Column(Integer, primary_key=True, autoincrement=True)
     task_id = Column(String(ID_LEN), primary_key=True)
     dag_id = Column(String(ID_LEN), primary_key=True)
     execution_date = Column(DateTime, primary_key=True)


### PR DESCRIPTION
This fixes constraint issue when task fails more than once - with current primary key it's impossible
to insert another record about second failure.