### PR TITLE
[AIRFLOW-661] Add Celery Task Result Expiry Conf

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -319,8 +319,13 @@ worker_log_server_port = 8793
 # information.
 broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
 
-# Another key Celery setting
+# The backend used by Celery for storing task results known as tombstones.
+# Refer to the Celery documentation for more information.
 celery_result_backend = db+mysql://airflow:airflow@localhost:3306/airflow
+# When using RabbitMQ as the celery result backend the default tombstone
+# lifetime is 24 hours. This setting allows you to control that. The value
+# is in minutes, so 3600 matches the default.
+celery_task_result_expires = 3600
 
 # Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start
 # it `airflow flower`. This defines the IP that Celery Flower runs on

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -39,7 +39,12 @@ class CeleryConfig(object):
     CELERYD_PREFETCH_MULTIPLIER = 1
     CELERY_ACKS_LATE = True
     BROKER_URL = configuration.get('celery', 'BROKER_URL')
-    CELERY_RESULT_BACKEND = configuration.get('celery', 'CELERY_RESULT_BACKEND')
+    CELERY_RESULT_BACKEND = configuration.get(
+        'celery',
+        'CELERY_RESULT_BACKEND')
+    CELERY_TASK_RESULT_EXPIRES = configuration.get(
+        'celery',
+        'CELERY_TASK_RESULT_EXPIRES')
     CELERYD_CONCURRENCY = configuration.getint('celery', 'CELERYD_CONCURRENCY')
     CELERY_DEFAULT_QUEUE = DEFAULT_QUEUE
     CELERY_DEFAULT_EXCHANGE = DEFAULT_QUEUE


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-661

Testing Done:
- Manual Testing: This configuration value is applied. Task tombstones in Celery expire as expected.
- Unit Tests: I believe all of the unit tests use the sequential executor, so I am uncertain how to write tests for the celery executor.

