### PR TITLE
Docs tweak: change seasons to months in project description

### DIFF
--- a/docs/project.rst
+++ b/docs/project.rst
@@ -4,12 +4,11 @@ Project
 History
 -------
 
-Airflow was started in the fall of 2014 by Maxime Beauchemin at Airbnb.
+Airflow was started in October 2014 by Maxime Beauchemin at Airbnb.
 It was open source from the very first commit and officially brought under
-the Airbnb Github and announced in the spring of 2015.
+the Airbnb Github and announced in June 2015.
 
-The project joined the Apache Software Foundation's incubation program in the
-winter of 2016.
+The project joined the Apache Software Foundation's incubation program in March 2016.
 
 
 Committers


### PR DESCRIPTION
(I was hoping I didn't need to open a Jira issue for this very minor documentation tweak -- but let me know if I should.)

Things like "winter 2016" are ambiguous even in the northern hemisphere, and mean something totally different in the southern hemisphere (July/August/September). Changing the season-based dates to months. References:

* http://incubator.apache.org/projects/airflow.html
* http://nerds.airbnb.com/airflow/
* https://github.com/apache/incubator-airflow/graphs/contributors