### PR TITLE
[AIRFLOW-663] Improve time units for task duration and landing times charts

### DIFF
--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -179,3 +179,36 @@ def round_time(dt, delta, start_date=datetime.min):
     # in the special case when start_date > dt the search for upper will
     # immediately stop for upper == 1 which results in lower = upper // 2 = 0
     # and this function returns start_date.
+
+
+def infer_time_unit(time_seconds_arr):
+    """
+    Determine the most appropriate time unit for an array of time durations
+    specified in seconds.
+
+    e.g. 5400 seconds => 'minutes', 36000 seconds => 'hours'
+    """
+    if len(time_seconds_arr) == 0:
+        return 'hours'
+    max_time_seconds = max(time_seconds_arr)
+    if max_time_seconds <= 60*2:
+        return 'seconds'
+    elif max_time_seconds <= 60*60*2:
+        return 'minutes'
+    elif max_time_seconds <= 24*60*60*2:
+        return 'hours'
+    else:
+        return 'days'
+
+
+def scale_time_units(time_seconds_arr, unit):
+    """
+    Convert an array of time durations in seconds to the specified time unit.
+    """
+    if unit == 'minutes':
+        return list(map(lambda x: x*1.0/60, time_seconds_arr))
+    elif unit == 'hours':
+        return list(map(lambda x: x*1.0/(60*60), time_seconds_arr))
+    elif unit == 'days':
+        return list(map(lambda x: x*1.0/(24*60*60), time_seconds_arr))
+    return time_seconds_arr

--- a/tests/core.py
+++ b/tests/core.py
@@ -21,6 +21,7 @@ import re
 import unittest
 import multiprocessing
 import mock
+from numpy.testing import assert_array_almost_equal
 import tempfile
 from datetime import datetime, time, timedelta
 from email.mime.multipart import MIMEMultipart
@@ -54,7 +55,7 @@ from airflow.bin import cli
 from airflow.www import app as application
 from airflow.settings import Session
 from airflow.utils.state import State
-from airflow.utils.dates import round_time
+from airflow.utils.dates import infer_time_unit, round_time, scale_time_units
 from airflow.utils.logging import LoggingMixin
 from lxml import html
 from airflow.exceptions import AirflowException
@@ -809,6 +810,33 @@ class CoreTest(unittest.TestCase):
         rt6 = round_time(datetime(2015, 9, 13, 0, 0), timedelta(1), datetime(
             2015, 9, 14, 0, 0))
         assert rt6 == datetime(2015, 9, 14, 0, 0)
+
+    def test_infer_time_unit(self):
+
+        assert infer_time_unit([130, 5400, 10]) == 'minutes'
+
+        assert infer_time_unit([110, 50, 10, 100]) == 'seconds'
+
+        assert infer_time_unit([100000, 50000, 10000, 20000]) == 'hours'
+
+        assert infer_time_unit([200000, 100000]) == 'days'
+
+    def test_scale_time_units(self):
+
+        # use assert_almost_equal from numpy.testing since we are comparing
+        # floating point arrays
+        arr1 = scale_time_units([130, 5400, 10], 'minutes')
+        assert_array_almost_equal(arr1, [2.167, 90.0, 0.167], decimal=3)
+
+        arr2 = scale_time_units([110, 50, 10, 100], 'seconds')
+        assert_array_almost_equal(arr2, [110.0, 50.0, 10.0, 100.0], decimal=3)
+
+        arr3 = scale_time_units([100000, 50000, 10000, 20000], 'hours')
+        assert_array_almost_equal(arr3, [27.778, 13.889, 2.778, 5.556],
+                                  decimal=3)
+
+        arr4 = scale_time_units([200000, 100000], 'days')
+        assert_array_almost_equal(arr4, [2.315, 1.157], decimal=3)
 
     def test_duplicate_dependencies(self):
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-663

The task duration and landing time charts display time interval values in hours.
This is not the appropriate unit for tasks that execute on smaller time scales
(~minutes, ~seconds), and the chart is unreadable in those cases. Convert the
time values to the appropriate units and update the y axis label to show the unit.

Testing Done:
- Tested the task duration and landing time UI for DAGs with a variety of time scales for task execution.

**Task Duration**
Before
<img width="818" alt="task_duration_before" src="https://cloud.githubusercontent.com/assets/907344/20783930/ea547ac4-b74b-11e6-90ff-3ef2c51439ab.png">

After
<img width="817" alt="task_duration_after" src="https://cloud.githubusercontent.com/assets/907344/20783911/c1fc76d0-b74b-11e6-8e7f-b1ab5e974b40.png">

**Landing Time**
Before
<img width="811" alt="landing_time_before" src="https://cloud.githubusercontent.com/assets/907344/20783924/d9b5fa08-b74b-11e6-8fd2-677746700107.png">

After
<img width="804" alt="landing_time_after" src="https://cloud.githubusercontent.com/assets/907344/20784125/217b9392-b74d-11e6-9c62-fafb19c1fdf3.png">

