### PR TITLE
fix cli to work with celery4 and python3

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -823,6 +823,7 @@ def worker(args):
     options = {
         'optimization': 'fair',
         'O': 'fair',
+        'loglevel': 'INFO',
         'queues': args.queues,
         'concurrency': args.concurrency,
     }


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- *(replace with a link to AIRFLOW-X)*

Per Apache guidelines you need to create a [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW/).

Testing Done:
- Unittests are required, if you do not include new unit tests please
specify why you think this is not required. We like to improve our
coverage so a non existing test is even a better reason to include one.

Reminders for contributors (REQUIRED!):
* Your PR's title must reference an issue on 
[Airflow's JIRA](https://issues.apache.org/jira/browse/AIRFLOW/). 
For example, a PR called "[AIRFLOW-1] My Amazing PR" would close JIRA 
issue #1. Please open a new issue if required!

* For all PRs with UI changes, you must provide screenshots. If the UI changes are not obvious, either annotate the images or provide before/after screenshots.

* Please squash your commits when possible and follow the [How to write a good git commit message](http://chris.beams.io/posts/git-commit/). 
Summarized as follows:
  1. Separate subject from body with a blank line
  2. Limit the subject line to 50 characters
  3. Do not end the subject line with a period
  4. Use the imperative mood in the subject line (add, not adding)
  5. Wrap the body at 72 characters
  6. Use the body to explain what and why vs. how


loglevel  is required

[2016-12-01 16:35:07,414: CRITICAL/MainProcess] Unrecoverable error: TypeError('unorderable types: NoneType() <= int()',)
Traceback (most recent call last):
  File "/Users/roberto/.virtualenvs/stairflow/lib/python3.5/site-packages/celery/worker/worker.py", line 203, in start
    self.blueprint.start(self)
  File "/Users/roberto/.virtualenvs/stairflow/lib/python3.5/site-packages/celery/bootsteps.py", line 115, in start
    self.on_start()
  File "/Users/roberto/.virtualenvs/stairflow/lib/python3.5/site-packages/celery/apps/worker.py", line 143, in on_start
    self.emit_banner()
  File "/Users/roberto/.virtualenvs/stairflow/lib/python3.5/site-packages/celery/apps/worker.py", line 159, in emit_banner
    string(self.colored.reset(self.extra_info() or '')),
  File "/Users/roberto/.virtualenvs/stairflow/lib/python3.5/site-packages/celery/apps/worker.py", line 188, in extra_info
    if self.loglevel <= logging.INFO:
TypeError: unorderable types: NoneType() <= int()