### PR TITLE
[AIRFLOW-665] Fix email attachments

### DIFF
--- a/airflow/utils/email.py
+++ b/airflow/utils/email.py
@@ -75,11 +75,12 @@ def send_email_smtp(to, subject, html_content, files=None, dryrun=False, cc=None
     for fname in files or []:
         basename = os.path.basename(fname)
         with open(fname, "rb") as f:
-            msg.attach(MIMEApplication(
+            part = MIMEApplication(
                 f.read(),
-                Content_Disposition='attachment; filename="%s"' % basename,
                 Name=basename
-            ))
+            )
+            part['Content-Disposition'] = 'attachment; filename="%s"' % basename
+            msg.attach(part)
 
     send_MIME_email(SMTP_MAIL_FROM, recipients, msg, dryrun)
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -1958,6 +1958,8 @@ class EmailSmtpTest(unittest.TestCase):
         assert msg['Subject'] == 'subject'
         assert msg['From'] == configuration.get('smtp', 'SMTP_MAIL_FROM')
         assert len(msg.get_payload()) == 2
+        assert msg.get_payload()[-1].get(u'Content-Disposition') == \
+               u'attachment; filename="' + os.path.basename(attachment.name) + '"'
         mimeapp = MIMEApplication('attachment')
         assert msg.get_payload()[-1].get_payload() == mimeapp.get_payload()
 
@@ -1975,6 +1977,8 @@ class EmailSmtpTest(unittest.TestCase):
         assert msg['Subject'] == 'subject'
         assert msg['From'] == configuration.get('smtp', 'SMTP_MAIL_FROM')
         assert len(msg.get_payload()) == 2
+        assert msg.get_payload()[-1].get(u'Content-Disposition') == \
+               u'attachment; filename="' + os.path.basename(attachment.name) + '"'
         mimeapp = MIMEApplication('attachment')
         assert msg.get_payload()[-1].get_payload() == mimeapp.get_payload()
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
[AIRFLOW-665](https://issues.apache.org/jira/browse/AIRFLOW-665)

Content-Disposition must be set separately on
the MIMEApplication.  Passing it to the constructor
just puts it in the Content-Type header.

Thanks to appants[at]gmail.com

Testing Done:
```
from airflow.utils.email import send_email
with open('dummy.txt', 'w') as f:
    f.write('dummy attachment')
send_email('user@server.com', 'test subject', 'hello', files=['dummy.txt'])
```

