### PR TITLE
[AIRFLOW-669] JobScheduler skips the first dag run

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -677,12 +677,16 @@ class SchedulerJob(BaseJob):
         session.commit()
 
     @provide_session
-    def create_dag_run(self, dag, session=None):
+    def create_dag_run(self, dag, session=None, now=None):
         """
         This method checks whether a new DagRun needs to be created
         for a DAG based on scheduling interval
         Returns DagRun if one is scheduled. Otherwise returns None.
         """
+        # This allows us to simulate this running at a moment in time under test
+        if now is None:
+            now = datetime.now()
+
         if dag.schedule_interval:
             active_runs = DagRun.find(
                 dag_id=dag.dag_id,
@@ -697,9 +701,9 @@ class SchedulerJob(BaseJob):
             for dr in active_runs:
                 if (
                         dr.start_date and dag.dagrun_timeout and
-                        dr.start_date < datetime.now() - dag.dagrun_timeout):
+                        dr.start_date < now - dag.dagrun_timeout):
                     dr.state = State.FAILED
-                    dr.end_date = datetime.now()
+                    dr.end_date = now
                     timedout_runs += 1
             session.commit()
             if len(active_runs) - timedout_runs >= dag.max_active_runs:
@@ -768,11 +772,11 @@ class SchedulerJob(BaseJob):
             if next_run_date and min_task_end_date and next_run_date > min_task_end_date:
                 return
 
-            if next_run_date and period_end and period_end <= datetime.now():
+            if next_run_date and period_end and next_run_date <= now:
                 next_run = dag.create_dagrun(
                     run_id='scheduled__' + next_run_date.isoformat(),
                     execution_date=next_run_date,
-                    start_date=datetime.now(),
+                    start_date=now,
                     state=State.RUNNING,
                     external_trigger=False
                 )

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -442,6 +442,35 @@ class SchedulerJobTest(unittest.TestCase):
         dr = scheduler.create_dag_run(dag)
         self.assertIsNone(dr)
 
+    def test_scheduler_dagrun_does_not_skip_first(self):
+        """
+        Test that the dagrun skips the first iteration
+        """
+        ts1 = datetime.datetime(2016, 11, 1, 12, 1)
+        ts2 = datetime.datetime(2016, 11, 1, 13, 1)
+        start_date = datetime.datetime(2016, 11, 1, 12)
+
+        # Execute the dag every hour
+        dag = DAG(
+            'test_scheduler_dagrun_skips_first',
+            start_date=start_date,
+            schedule_interval="00 * * * *"
+        )
+
+        scheduler = SchedulerJob()
+        dag.clear()
+
+        # The first dag run should start at start date
+        dr = scheduler.create_dag_run(dag, now=ts1)
+        self.assertIsNotNone(dr)
+        self.assertEqual(dr.execution_date, datetime.datetime(2016, 11, 1, 12))
+
+        # The second dag run should start at start date + 1 hour
+        dr = scheduler.create_dag_run(dag, now=ts2)
+        self.assertIsNotNone(dr)
+        self.assertEqual(dr.execution_date, datetime.datetime(2016, 11, 1, 13))
+
+
     def test_scheduler_process_task_instances(self):
         """
         Test if _process_task_instances puts the right task instances into the


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-669

Per Apache guidelines you need to create a [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW/).

Testing Done:
- Unittest
