### PR TITLE
[AIRFLOW-668] Fix TypeError of run_command on python3

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -76,7 +76,7 @@ def run_command(command):
     Runs command and returns stdout
     """
     process = subprocess.Popen(
-        command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
     output, stderr = process.communicate()
 
     if process.returncode != 0:


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- *(https://issues.apache.org/jira/browse/AIRFLOW-668)*

Run airflow with python 3 and using the flag _cmd on airflow.cfg causes the error:
"airflow/configuration.py", line 447, in _validate "sqlite" in self.get('core', 'sql_alchemy_conn')): TypeError: 'str' does not support the buffer interface"
The fix is enabling universal_newlines and allowing python 3 to treat output as string instead of a byte.