### PR TITLE
[AIRFLOW-674] Ability to add descriptions for DAGs

### DIFF
--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -50,7 +50,11 @@ default_args = {
     # 'trigger_rule': u'all_success'
 }
 
-dag = DAG('tutorial', default_args=default_args, schedule_interval=timedelta(days=1))
+dag = DAG(
+    'tutorial',
+    default_args=default_args,
+    description='A simple tutorial DAG',
+    schedule_interval=timedelta(days=1))
 
 # t1, t2 and t3 are examples of tasks created by instantiating operators
 t1 = BashOperator(

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2483,6 +2483,8 @@ class DAG(BaseDag, LoggingMixin):
 
     :param dag_id: The id of the DAG
     :type dag_id: string
+    :param description: The description for the DAG to e.g. be shown on the webserver
+    :type description: string
     :param schedule_interval: Defines how often that DAG runs, this
         timedelta object gets added to your latest task instance's
         execution_date to figure out the next schedule
@@ -2536,6 +2538,7 @@ class DAG(BaseDag, LoggingMixin):
 
     def __init__(
             self, dag_id,
+            description='',
             schedule_interval=timedelta(days=1),
             start_date=None, end_date=None,
             full_filepath=None,
@@ -2567,6 +2570,7 @@ class DAG(BaseDag, LoggingMixin):
         self._concurrency = concurrency
         self._pickle_id = None
 
+        self._description = description
         self.task_dict = dict()
         self.start_date = start_date
         self.end_date = end_date
@@ -2724,6 +2728,10 @@ class DAG(BaseDag, LoggingMixin):
     @concurrency.setter
     def concurrency(self, value):
         self._concurrency = value
+
+    @property
+    def description(self):
+        return self._description
 
     @property
     def pickle_id(self):

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -33,7 +33,7 @@
         <span style='color:#AAA;'>SUBDAG: </span> <span> {{ dag.dag_id }}</span>
       {% else %}
         <input id="pause_resume" dag_id="{{ dag.dag_id }}" type="checkbox" {{ "checked" if not dag.is_paused else "" }} data-toggle="toggle" data-size="mini">
-        <span style='color:#AAA;'>DAG: </span> <span> {{ dag.dag_id }}</span>
+        <span style='color:#AAA;'>DAG: </span> <span> {{ dag.dag_id }}</span> <small class="text-muted"> {{ dag.description }} </small>
       {% endif %}
       {% if root %}
         <span style='color:#AAA;'>ROOT: </span> <span> {{ root }}</span>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -73,7 +73,7 @@
                 <!-- Column 3: Name -->
                 <td>
                     {% if dag_id in webserver_dags %}
-                    <a href="{{ url_for('airflow.tree', dag_id=dag.dag_id) }}">
+                    <a href="{{ url_for('airflow.tree', dag_id=dag.dag_id) }}" title="{{ dag.description }}">
                         {{ dag_id }}
                     </a>
                     {% else %}


### PR DESCRIPTION
Dear Airflow Maintainers,

@mistercrunch @artwr @plypaul 

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-674

Descriptions are rendered in two places right now, as a tooltip on the DAGs page for each DAG, and after the DAG name in the various individual DAG views (see screenshots below).

Testing Done:
- Spun up local webserver, tried empty description, normal description, very long description.

Screenshots:
![image](https://cloud.githubusercontent.com/assets/1592778/20906424/dbf2885e-bafc-11e6-8eeb-78302e87d25a.png)
![image](https://cloud.githubusercontent.com/assets/1592778/20906420/d651ccfc-bafc-11e6-9893-ef677be50bf0.png)
