### PR TITLE
[AIRFLOW-682] Bump MAX_PERIODS to make mark_success work for large DAGs

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1095,7 +1095,7 @@ class Airflow(BaseView):
         future = request.args.get('future') == "true"
         past = request.args.get('past') == "true"
         recursive = request.args.get('recursive') == "true"
-        MAX_PERIODS = 1000
+        MAX_PERIODS = 5000
 
         # Flagging tasks as successful
         session = settings.Session()


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-682

@artwr @mistercrunch @plypaul 

It is not possible to mark success on some large DAGs due to the MAX_PERIODS being set to 1000. We should temporarily bump it up until work can be done to scale the mark success endpoint much higher.

Original PR is by @artwr 

Testing Done:
- Has been running in Airbnb prod for many months now

