### PR TITLE
[AIRFLOW-686] Match auth backend config section

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -534,7 +534,7 @@ class AirflowConfigParser(ConfigParser):
         elif (
             self.getboolean("webserver", "authenticate") and
             self.get("webserver", "owner_mode").lower() == 'ldapgroup' and
-            self.get("core", "auth_backend") != (
+            self.get("webserver", "auth_backend") != (
                 'airflow.contrib.auth.backends.ldap_auth')
         ):
             raise AirflowConfigException(


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- *https://issues.apache.org/jira/browse/AIRFLOW-686*

This commit makes that refers the same configuration when using
ldapgroup owner mode with ldap auth.