### PR TITLE
[AIRFLOW-691] Add SSH KeepAlive option to SSH_hook

### DIFF
--- a/airflow/contrib/hooks/ssh_hook.py
+++ b/airflow/contrib/hooks/ssh_hook.py
@@ -54,6 +54,8 @@ class SSHHook(BaseHook):
         conn = self.get_connection(conn_id)
         self.key_file = conn.extra_dejson.get('key_file', None)
         self.connect_timeout = conn.extra_dejson.get('connect_timeout', None)
+        self.tcp_keepalive = conn.extra_dejson.get('tcp_keepalive', False)
+        self.server_alive_interval = conn.extra_dejson.get('server_alive_interval', 60)
         self.no_host_key_check = conn.extra_dejson.get('no_host_key_check', False)
         self.tty = conn.extra_dejson.get('tty', False)
         self.sshpass = conn.extra_dejson.get('sshpass', False)
@@ -80,6 +82,10 @@ class SSHHook(BaseHook):
 
         if self.connect_timeout:
             connection_cmd += ["-o", "ConnectionTimeout={}".format(self.connect_timeout)]
+
+        if self.tcp_keepalive:
+            connection_cmd += ["-o", "TCPKeepAlive=yes"]
+            connection_cmd += ["-o", "ServerAliveInterval={}".format(self.server_alive_interval)]
 
         if self.no_host_key_check:
             connection_cmd += ["-o", "UserKnownHostsFile=/dev/null",


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-691

This patch adds the option to set tcp keepalive and to configure
the server alive interval for the ssh connection.