### PR TITLE
Handle BigQuery 503 error

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -473,12 +473,12 @@ class BigQueryBaseCursor(object):
         job = jobs.get(projectId=self.project_id, jobId=job_id).execute()
 
         # Wait for query to finish.
-        job_status_flag = True
-        while (job_status_flag):
+        keep_polling_job = True
+        while (keep_polling_job):
             try:
                 job = jobs.get(projectId=self.project_id, jobId=job_id).execute()
                 if (job['status']['state'] == 'DONE'):
-                    job_status_flag = False
+                    keep_polling_job = False
                     # Check if job had errors.
                     if 'errorResult' in job['status']:
                         raise Exception(
@@ -492,9 +492,10 @@ class BigQueryBaseCursor(object):
 
             except HttpError, err:
                 if err.code in [500, 503]:
-                    logging.info('%s: Retryable error, waiting for job to complete: %s',err.code, job_id)
+                    logging.info('%s: Retryable error, waiting for job to complete: %s', err.code, job_id)
                     time.sleep(5)
-                else:raise Exception(
+                else:
+                    raise Exception(
                 'BigQuery job status check faild. Final error was: %s', err.code)
 
         return job_id

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -490,7 +490,7 @@ class BigQueryBaseCursor(object):
                     logging.info('Waiting for job to complete : %s, %s', self.project_id, job_id)
                     time.sleep(5)
 
-            except HTTPError, err:
+            except HttpError, err:
                 if err.code in [500, 503]:
                     logging.info('%s: Retryable error, waiting for job to complete: %s',err.code, job_id)
                     time.sleep(5)

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -470,7 +470,6 @@ class BigQueryBaseCursor(object):
             .insert(projectId=self.project_id, body=job_data) \
             .execute()
         job_id = query_reply['jobReference']['jobId']
-        job = jobs.get(projectId=self.project_id, jobId=job_id).execute()
 
         # Wait for query to finish.
         keep_polling_job = True


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:

https://issues.apache.org/jira/browse/AIRFLOW-667

We have encountered this issue few times in our production environment. I added this fix based on google's documentation.

https://cloud.google.com/bigquery/troubleshooting-errors

"This error returns when there is a temporary server failure such as a network connection problem or a server overload. In general, wait a few seconds and try again."

Testing Done:

Tests are done connecting to BQ tables using the PR code.
Subject - Handle BigQuery 503 error
added retry feature if BigQuery error is 500 or 503
set the retry time for 5 seconds