### PR TITLE
[AIRFLOW-692] Open XCom page to super-admins only

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2222,7 +2222,7 @@ class VariableView(wwwutils.DataProfilingMixin, AirflowModelView):
             form.val.data = '*' * 8
 
 
-class XComView(wwwutils.LoginMixin, AirflowModelView):
+class XComView(wwwutils.SuperUserMixin, AirflowModelView):
     verbose_name = "XCom"
     verbose_name_plural = "XComs"
     page_size = 20


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- *https://issues.apache.org/jira/browse/AIRFLOW-692*

Testing Done:
- Manually tested that XCom page is accessible only to super users

