### PR TITLE
[AIRFLOW-700] Update to configuration commenting for web auth

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -240,7 +240,7 @@ error_logfile = -
 expose_config = False
 
 # Set to true to turn on authentication:
-# http://pythonhosted.org/airflow/installation.html#web-authentication
+# http://pythonhosted.org/airflow/security.html#web-authentication
 authenticate = False
 
 # Filter the list of dags by owner name (requires authentication to be enabled)


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
[https://issues.apache.org/jira/browse/AIRFLOW-700](https://issues.apache.org/jira/browse/AIRFLOW-700)

Updating the default config file to point to the new documentation as the web authentication section was moved to the "security" section of the docs in commit 6c49c5f

Testing Done:
- No tests as only documentation update