### PR TITLE
[AIRFLOW-702] Fix LDAP Regex Bug

### DIFF
--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -100,7 +100,7 @@ def groups_user(conn, search_base, user_filter, user_name_att, username):
 
     user_groups = conn.response[0]["attributes"]["memberOf"]
 
-    regex = re.compile("cn=([^,]*).*")
+    regex = re.compile("cn=([^,]*).*", re.IGNORECASE)
     groups_list = []
     try:
         groups_list = [regex.search(i).group(1) for i in user_groups]


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-702

Testing Done:
- For ensuring that existing behaviour is upheld, this is covered by the existing unit tests.
- I don't believe there's a good way to add a new unit test for the new behaviour as it relies on different behaviour from the ldap server it is connecting to. I have however used this to connect to Windows Active Directory successfully.
