### PR TITLE
[AIRFLOW-703] Stop Xcom being cleared too early

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1200,7 +1200,6 @@ class TaskInstance(Base):
             session.commit()
             return
 
-        self.clear_xcom_data()
         hr = "\n" + ("-" * 80) + "\n"  # Line break
 
         # For reporting purposes, we report based on 1-indexed,
@@ -1284,6 +1283,9 @@ class TaskInstance(Base):
                     task_copy.on_kill()
                     raise AirflowException("Task received SIGTERM signal")
                 signal.signal(signal.SIGTERM, signal_handler)
+
+                # Don't clear Xcom until the task is certain to execute
+                self.clear_xcom_data()
 
                 self.render_templates()
                 task_copy.pre_execute(context=context)

--- a/tests/models.py
+++ b/tests/models.py
@@ -588,6 +588,13 @@ class TaskInstanceTest(unittest.TestCase):
         # prior success)
         self.assertEqual(ti.xcom_pull(task_ids='test_xcom', key=key), value)
 
+        # Test AIRFLOW-703: Xcom shouldn't be cleared if other TI is running
+        ti.run(ignore_all_deps=True, mark_success=True)
+        self.assertEqual(ti.xcom_pull(task_ids='test_xcom', key=key), value)
+        # Xcom IS finally cleared once task has executed
+        ti.run(ignore_all_deps=True)
+        self.assertEqual(ti.xcom_pull(task_ids='test_xcom', key=key), None)
+
     def test_xcom_pull_different_execution_date(self):
         """
         tests xcom fetch behavior with different execution dates, using

--- a/tests/models.py
+++ b/tests/models.py
@@ -588,7 +588,8 @@ class TaskInstanceTest(unittest.TestCase):
         # prior success)
         self.assertEqual(ti.xcom_pull(task_ids='test_xcom', key=key), value)
 
-        # Test AIRFLOW-703: Xcom shouldn't be cleared if other TI is running
+        # Test AIRFLOW-703: Xcom shouldn't be cleared if the task doesn't
+        # execute, even if dependencies are ignored
         ti.run(ignore_all_deps=True, mark_success=True)
         self.assertEqual(ti.xcom_pull(task_ids='test_xcom', key=key), value)
         # Xcom IS finally cleared once task has executed


### PR DESCRIPTION
Only clear Xcom when the task is CERTAIN to start executing
Fixes AIRFLOW-703

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-703

Per Apache guidelines you need to create a [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW/).

Testing Done:
Expanded on a test case which was checking only a subset of this bug
 
- Unittests are required, if you do not include new unit tests please
specify why you think this is not required. We like to improve our
coverage so a non existing test is even a better reason to include one.

Reminders for contributors (REQUIRED!):
* Your PR's title must reference an issue on 
[Airflow's JIRA](https://issues.apache.org/jira/browse/AIRFLOW/). 
For example, a PR called "[AIRFLOW-1] My Amazing PR" would close JIRA 
issue #1. Please open a new issue if required!

* For all PRs with UI changes, you must provide screenshots. If the UI changes are not obvious, either annotate the images or provide before/after screenshots.

* Please squash your commits when possible and follow the [How to write a good git commit message](http://chris.beams.io/posts/git-commit/). 
Summarized as follows:
  1. Separate subject from body with a blank line
  2. Limit the subject line to 50 characters
  3. Do not end the subject line with a period
  4. Use the imperative mood in the subject line (add, not adding)
  5. Wrap the body at 72 characters
  6. Use the body to explain what and why vs. how

