### PR TITLE
[AIRFLOW-709] Use Same Engine for Migrations and Reflection

### DIFF
--- a/airflow/migrations/versions/1507a7289a2f_create_is_encrypted.py
+++ b/airflow/migrations/versions/1507a7289a2f_create_is_encrypted.py
@@ -44,7 +44,8 @@ def upgrade():
     # first check if the user already has this done. This should only be
     # true for users who are upgrading from a previous version of Airflow
     # that predates Alembic integration
-    inspector = Inspector.from_engine(settings.engine)
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
 
     # this will only be true if 'connection' already exists in the db,
     # but not if alembic created it in a previous migration

--- a/airflow/migrations/versions/1507a7289a2f_create_is_encrypted.py
+++ b/airflow/migrations/versions/1507a7289a2f_create_is_encrypted.py
@@ -29,8 +29,6 @@ depends_on = None
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.engine.reflection import Inspector
-from airflow import settings
-
 
 connectionhelper = sa.Table(
     'connection',

--- a/airflow/migrations/versions/e3a246e0dc1_current_schema.py
+++ b/airflow/migrations/versions/e3a246e0dc1_current_schema.py
@@ -35,8 +35,10 @@ from airflow import settings
 
 
 def upgrade():
-    inspector = Inspector.from_engine(settings.engine)
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
     tables = inspector.get_table_names()
+
     if 'connection' not in tables:
         op.create_table(
             'connection',

--- a/airflow/migrations/versions/e3a246e0dc1_current_schema.py
+++ b/airflow/migrations/versions/e3a246e0dc1_current_schema.py
@@ -31,9 +31,6 @@ import sqlalchemy as sa
 from sqlalchemy import func
 from sqlalchemy.engine.reflection import Inspector
 
-from airflow import settings
-
-
 def upgrade():
     conn = op.get_bind()
     inspector = Inspector.from_engine(conn)


### PR DESCRIPTION
Solves query blocking in MS-SQL server when running initdb and allows for a MS-SQL metadata
database.

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-709

Testing Done:

There is no way to test against MS-SQL in TravisCI. However, this does not break the build for any of the databases that are tested. 
