### PR TITLE
[AIRFLOW-717] Add Cloud Storage updated sensor

### DIFF
--- a/airflow/contrib/sensors/gcs_sensor.py
+++ b/airflow/contrib/sensors/gcs_sensor.py
@@ -30,13 +30,13 @@ class GoogleCloudStorageObjectSensor(BaseSensorOperator):
     def __init__(
             self,
             bucket,
-            object,
+            object,  # pylint:disable=redefined-builtin
             google_cloud_conn_id='google_cloud_storage_default',
             delegate_to=None,
             *args,
             **kwargs):
         """
-        Create a new GoogleCloudStorageDownloadOperator.
+        Create a new GoogleCloudStorageObjectSensor.
 
         :param bucket: The Google cloud storage bucket where the object is.
         :type bucket: string
@@ -62,3 +62,65 @@ class GoogleCloudStorageObjectSensor(BaseSensorOperator):
             google_cloud_storage_conn_id=self.google_cloud_conn_id,
             delegate_to=self.delegate_to)
         return hook.exists(self.bucket, self.object)
+
+
+def ts_function(context):
+    """
+    Default callback for the GoogleCloudStorageObjectUpdatedSensor. The default
+    behaviour is check for the object being updated after execution_date +
+    schedule_interval.
+    """
+    return context['execution_date'] + context['dag'].schedule_interval
+
+
+class GoogleCloudStorageObjectUpdatedSensor(BaseSensorOperator):
+    """
+    Checks if an object is updated in Google Cloud Storage.
+    """
+    template_fields = ('bucket', 'object')
+    template_ext = ('.sql',)
+    ui_color = '#f0eee4'
+
+    @apply_defaults
+    def __init__(
+            self,
+            bucket,
+            object,  # pylint:disable=redefined-builtin
+            ts_func=ts_function,
+            google_cloud_conn_id='google_cloud_storage_default',
+            delegate_to=None,
+            *args,
+            **kwargs):
+        """
+        Create a new GoogleCloudStorageObjectUpdatedSensor.
+
+        :param bucket: The Google cloud storage bucket where the object is.
+        :type bucket: string
+        :param object: The name of the object to download in the Google cloud
+            storage bucket.
+        :type object: string
+        :param ts_func: Callback for defining the update condition. The default callback
+            returns execution_date + schedule_interval. The callback takes the context
+            as parameter.
+        :type ts_func: function
+        :param google_cloud_storage_conn_id: The connection ID to use when
+            connecting to Google cloud storage.
+        :type google_cloud_storage_conn_id: string
+        :param delegate_to: The account to impersonate, if any.
+            For this to work, the service account making the request must have domain-wide
+            delegation enabled.
+        :type delegate_to: string
+        """
+        super(GoogleCloudStorageObjectUpdatedSensor, self).__init__(*args, **kwargs)
+        self.bucket = bucket
+        self.object = object
+        self.ts_func = ts_func
+        self.google_cloud_conn_id = google_cloud_conn_id
+        self.delegate_to = delegate_to
+
+    def poke(self, context):
+        logging.info('Sensor checks existence of : %s, %s', self.bucket, self.object)
+        hook = GoogleCloudStorageHook(
+            google_cloud_storage_conn_id=self.google_cloud_conn_id,
+            delegate_to=self.delegate_to)
+        return hook.is_updated_after(self.bucket, self.object, self.ts_func(context))


### PR DESCRIPTION
Add a Cloud Storage sensor that triggers when a object is created
or updated after a specific date. Allow setting a callback that
defines the update requirements. The default is execution_date
+ trigger_interval.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-717

Testing Done:
Added integration tests to:
https://github.com/alexvanboxel/airflow-gcp-examples
