### PR TITLE
[AIRFLOW-734] Fix SMTP auth regression when not using user/pass

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -280,9 +280,10 @@ email_backend = airflow.utils.email.send_email_smtp
 smtp_host = localhost
 smtp_starttls = True
 smtp_ssl = False
-smtp_user = airflow
+# Uncomment and set the user/pass settings if you want to use SMTP AUTH
+# smtp_user = airflow
+# smtp_password = airflow
 smtp_port = 25
-smtp_password = airflow
 smtp_mail_from = airflow@airflow.com
 
 

--- a/airflow/utils/email.py
+++ b/airflow/utils/email.py
@@ -31,6 +31,7 @@ from email.mime.application import MIMEApplication
 from email.utils import formatdate
 
 from airflow import configuration
+from airflow.exceptions import AirflowConfigException
 
 
 def send_email(to, subject, html_content, files=None, dryrun=False, cc=None, bcc=None, mime_subtype='mixed'):
@@ -87,10 +88,16 @@ def send_email_smtp(to, subject, html_content, files=None, dryrun=False, cc=None
 def send_MIME_email(e_from, e_to, mime_msg, dryrun=False):
     SMTP_HOST = configuration.get('smtp', 'SMTP_HOST')
     SMTP_PORT = configuration.getint('smtp', 'SMTP_PORT')
-    SMTP_USER = configuration.get('smtp', 'SMTP_USER')
-    SMTP_PASSWORD = configuration.get('smtp', 'SMTP_PASSWORD')
     SMTP_STARTTLS = configuration.getboolean('smtp', 'SMTP_STARTTLS')
     SMTP_SSL = configuration.getboolean('smtp', 'SMTP_SSL')
+    SMTP_USER = None
+    SMTP_PASSWORD = None
+
+    try:
+        SMTP_USER = configuration.get('smtp', 'SMTP_USER')
+        SMTP_PASSWORD = configuration.get('smtp', 'SMTP_PASSWORD')
+    except AirflowConfigException:
+        logging.debug("No user/password found for SMTP, so logging in with no authentication.")
 
     if not dryrun:
         s = smtplib.SMTP_SSL(SMTP_HOST, SMTP_PORT) if SMTP_SSL else smtplib.SMTP(SMTP_HOST, SMTP_PORT)

--- a/tests/core.py
+++ b/tests/core.py
@@ -2108,6 +2108,21 @@ class EmailSmtpTest(unittest.TestCase):
 
     @mock.patch('smtplib.SMTP_SSL')
     @mock.patch('smtplib.SMTP')
+    def test_send_mime_noauth(self, mock_smtp, mock_smtp_ssl):
+        configuration.conf.remove_option('smtp', 'SMTP_USER')
+        configuration.conf.remove_option('smtp', 'SMTP_PASSWORD')
+        mock_smtp.return_value = mock.Mock()
+        mock_smtp_ssl.return_value = mock.Mock()
+        utils.email.send_MIME_email('from', 'to', MIMEMultipart(), dryrun=False)
+        assert not mock_smtp_ssl.called
+        mock_smtp.assert_called_with(
+            configuration.get('smtp', 'SMTP_HOST'),
+            configuration.getint('smtp', 'SMTP_PORT'),
+        )
+        assert not mock_smtp.login.called
+
+    @mock.patch('smtplib.SMTP_SSL')
+    @mock.patch('smtplib.SMTP')
     def test_send_mime_dryrun(self, mock_smtp, mock_smtp_ssl):
         utils.email.send_MIME_email('from', 'to', MIMEMultipart(), dryrun=True)
         assert not mock_smtp.called


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-734
