### PR TITLE
[AIRFLOW-739] Set pickle_info log to debug

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3063,7 +3063,7 @@ class DAG(BaseDag, LoggingMixin):
             d['pickle_len'] = len(pickled)
             d['pickling_duration'] = "{}".format(datetime.now() - dttm)
         except Exception as e:
-            logging.exception(e)
+            logging.debug(e)
             d['is_picklable'] = False
             d['stacktrace'] = traceback.format_exc()
         return d


### PR DESCRIPTION
pickle_info tries to pickle. If it catches an exception
it is assumed that the DAG is not pickable and continues.
Therefore, it should log to debug instead and not provide
a full stacktrace.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-739

Testing Done:
- Unit tests should be more quiet

