### PR TITLE
[AIRFLOW-740] Pin jinja2 to 2.8.1

### DIFF
--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -26,7 +26,7 @@ hive-thrift-py
 impyla
 ipython
 jaydebeapi
-jinja2
+jinja2<2.9.0
 ldap3
 lxml
 markdown

--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ def do_setup():
             'future>=0.15.0, <0.16',
             'gitpython>=2.0.2',
             'gunicorn>=19.3.0, <19.4.0',  # 19.4.? seemed to have issues
-            'jinja2>=2.7.3, <3.0',
+            'jinja2>=2.7.3, <2.9.0',
             'lxml>=3.6.0, <4.0',
             'markdown>=2.5.2, <3.0',
             'pandas>=0.17.1, <1.0.0',


### PR DESCRIPTION
Jinja2 2.9.1 seems to have a conflict with flask-admin.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-740

Testing Done:
- Unit tests should pass again

Will merge if tests pass. 

I filed an issue with jinja2: https://github.com/pallets/jinja/issues/642, recommendation was to pin < 2.9