### PR TITLE
[AIRFLOW-536] Schedule all pending DAG runs in a single scheduler loop

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1106,9 +1106,13 @@ class SchedulerJob(BaseJob):
 
             self.logger.info("Processing {}".format(dag.dag_id))
 
-            dag_run = self.create_dag_run(dag)
-            if dag_run:
-                self.logger.info("Created {}".format(dag_run))
+            # create all valid DAG runs in a single scheduler invocation
+            while True:
+                dag_run = self.create_dag_run(dag)
+                if dag_run:
+                    self.logger.info("Created DAG run {}".format(dag_run))
+                else:
+                    break
             self._process_task_instances(dag, tis_out)
             self.manage_slas(dag)
 

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -37,6 +37,7 @@ from airflow.utils.timeout import timeout
 from airflow.utils.dag_processing import SimpleDagBag
 from mock import patch
 from tests.executor.test_executor import TestExecutor
+from tests.test_utils.fake_datetime import FakeDatetime
 
 from airflow import configuration
 configuration.load_test_config()
@@ -851,6 +852,7 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertIsNotNone(dr)
         self.assertEquals(dr.execution_date, datetime.datetime(2016, 1, 1, 10, 10))
 
+    @mock.patch('airflow.jobs.datetime', FakeDatetime)
     def test_scheduler_reschedule(self):
         """
         Checks if tasks that are not taken up by the executor
@@ -894,10 +896,14 @@ class SchedulerJobTest(unittest.TestCase):
             scheduler.heartrate = 0
             scheduler.run()
 
+        FakeDatetime.now = classmethod(
+            lambda cls: DEFAULT_DATE+datetime.timedelta(days=1))
         do_schedule()
         self.assertEquals(1, len(executor.queued_tasks))
         executor.queued_tasks.clear()
 
+        FakeDatetime.now = classmethod(
+            lambda cls: DEFAULT_DATE+datetime.timedelta(days=2))
         do_schedule()
         self.assertEquals(2, len(executor.queued_tasks))
 
@@ -1021,11 +1027,15 @@ class SchedulerJobTest(unittest.TestCase):
                      expected_run_duration)
         assert run_duration - expected_run_duration < 5.0
 
+    @mock.patch('airflow.jobs.datetime', FakeDatetime)
     def test_dag_with_system_exit(self):
         """
-        Test to check that a DAG with a system.exit() doesn't break the scheduler.
+        Test to check that a DAG with a system.exit() doesn't break the
+        scheduler.
         """
 
+        FakeDatetime.now = classmethod(
+            lambda cls: datetime.datetime(2000, 1, 2))
         dag_id = 'exit_test_dag'
         dag_ids = [dag_id]
         dag_directory = os.path.join(models.DAGS_FOLDER,
@@ -1047,6 +1057,7 @@ class SchedulerJobTest(unittest.TestCase):
         session = settings.Session()
         self.assertEqual(
             len(session.query(TI).filter(TI.dag_id == dag_id).all()), 1)
+
 
     def test_dag_get_active_runs(self):
         """
@@ -1101,3 +1112,29 @@ class SchedulerJobTest(unittest.TestCase):
             running_date = 'Except'
 
         self.assertEqual(execution_date, running_date, 'Running Date must match Execution Date')
+
+    @mock.patch('airflow.jobs.datetime', FakeDatetime)
+    def test_schedule_multiple_dag_runs(self):
+        """
+        Test to check that multiple valid DAG runs are scheduled in a single
+        scheduler loop.
+        """
+        # The start date for test_start_date_scheduling is 2100-1-1. If we mock
+        # datetime.now() as 2100-1-8, DAG runs for 2100-1-1 to 2100-1-7 should
+        # get scheduled in a single scheduler loop
+        FakeDatetime.now = classmethod(
+            lambda cls: datetime.datetime(2100, 1, 8))
+        dag_id = 'test_start_date_scheduling'
+        dag_ids = [dag_id]
+        dag_directory = os.path.join(models.DAGS_FOLDER,
+                                     "..",
+                                     "dags")
+
+        scheduler = SchedulerJob(dag_ids=dag_ids,
+                                 subdir= dag_directory,
+                                 num_runs=1,
+                                 **self.default_scheduler_args)
+        scheduler.run()
+        session = settings.Session()
+        self.assertEqual(
+            len(session.query(TI).filter(TI.dag_id == dag_id).all()), 7)

--- a/tests/test_utils/fake_datetime.py
+++ b/tests/test_utils/fake_datetime.py
@@ -21,4 +21,4 @@ class FakeDatetime(datetime):
     """
 
     def __new__(cls, *args, **kwargs):
-        return date.__new__(datetime, *args, **kwargs)
+        return datetime.__new__(datetime, *args, **kwargs)


### PR DESCRIPTION
This is an update to #1906 , so that it applies to current master. Please note however I have my concerns that this patch will bias the scheduler towards one DAG as it fills the queue with tasks from one DAG and then goes to the next DAG. Starving DAGs that come after the first for resources. As such it should be updated.

@aoen @vijaysbhat 



===
commit abfd398378e929a81d4855452262c11ba3a87aaf
Author: Vijay Bhat <vijaysbhat@gmail.com>
Date:   Sat Nov 19 04:27:15 2016 -0800

    [AIRFLOW-536] Schedule all pending DAG runs in a single scheduler loop

    Currently only a single DAG run is scheduled when
    a DAG file is parsed by an iteration of the
    scheduler loop. Which means scheduling N pending
    DAG runs will require N scheduler loops (separated
    by file_process_interval waits). Modify the logic
    to schedule all pending DAG runs instead.


