### PR TITLE
[AIRFLOW-759] Use previous dag_run to verify depend_on_past

### DIFF
--- a/airflow/ti_deps/deps/prev_dagrun_dep.py
+++ b/airflow/ti_deps/deps/prev_dagrun_dep.py
@@ -41,13 +41,11 @@ class PrevDagrunDep(BaseTIDep):
         # Don't depend on the previous task instance if we are the first task
         dag = ti.task.dag
         if dag.catchup:
-            if ti.execution_date == ti.task.start_date:
+            if dag.previous_schedule(ti.execution_date) < ti.task.start_date:
                 yield self._passing_status(
                     reason="This task instance was the first task instance for its task.")
                 raise StopIteration
-
         else:
-
             dr = ti.get_dagrun()
             last_dagrun = dr.get_previous_dagrun() if dr else None
 


### PR DESCRIPTION
The start_date and the schedule interval can be misaligned. This
is automatically corrected in the scheduler. The dependency checker
however did not do this.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-759

Testing Done:
- Integration tests


@msumit @btallman @aoen @plypaul 