### PR TITLE
[AIRFLOW-757] Set child_process_log_directory default more sensible

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -349,7 +349,7 @@ dag_dir_list_interval = 300
 # How often should stats be printed to the logs
 print_stats_interval = 30
 
-child_process_log_directory = /tmp/airflow/scheduler/logs
+child_process_log_directory = {AIRFLOW_HOME}/logs/scheduler
 
 # Local task jobs periodically heartbeat to the DB. If the job has
 # not heartbeat in this many seconds, the scheduler will mark the


### PR DESCRIPTION
The default of child_process_log_directory was pointing to
/tmp/airflow/logs/scheduler. This could take people by surprise as
it is a non standard location and deviates from Airflow's other
log folders.

@criccomini @aoen @artwr 
