### PR TITLE
[AIRFLOW-771] Make S3 logs append instead of clobber

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -494,10 +494,7 @@ def run(args, dag=None):
             logging_utils.S3Log().write(log, remote_log_location)
         # GCS
         elif remote_base.startswith('gs:/'):
-            logging_utils.GCSLog().write(
-                log,
-                remote_log_location,
-                append=True)
+            logging_utils.GCSLog().write(log, remote_log_location)
         # Other
         elif remote_base and remote_base != 'None':
             logging.error(

--- a/airflow/utils/logging.py
+++ b/airflow/utils/logging.py
@@ -81,7 +81,7 @@ class S3Log(object):
         logging.error(err)
         return err if return_error else ''
 
-    def write(self, log, remote_log_location, append=False):
+    def write(self, log, remote_log_location, append=True):
         """
         Writes the log to the remote_log_location. Fails silently if no hook
         was created.
@@ -159,7 +159,7 @@ class GCSLog(object):
         logging.error(err)
         return err if return_error else ''
 
-    def write(self, log, remote_log_location, append=False):
+    def write(self, log, remote_log_location, append=True):
         """
         Writes the log to the remote_log_location. Fails silently if no hook
         was created.


### PR DESCRIPTION
S3 logs are clobbered at the moment by new task instance runs which is bad e.g. in the case of retries. Appending is already the case for GCS logs.

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-771

@artwr @bolkedebruin @plypaul