### PR TITLE
[AIRFLOW-778] Fix completey broken MetastorePartitionSensor

### DIFF
--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -152,7 +152,12 @@ class MetastorePartitionSensor(SqlSensor):
         self.schema = schema
         self.first_poke = True
         self.conn_id = mysql_conn_id
-        super(MetastorePartitionSensor, self).__init__(*args, **kwargs)
+        # TODO(aoen): We shouldn't be using SqlSensor here but MetastorePartitionSensor.
+        # The problem is the way apply_defaults works isn't compatible with inheritance.
+        # The inheritance model needs to be reworked in order to support overriding args/
+        # kwargs with arguments here, then 'conn_id' and 'sql' can be passed into the
+        # constructor below and apply_defaults will no longer throw an exception.
+        super(SqlSensor, self).__init__(*args, **kwargs)
 
     def poke(self, context):
         if self.first_poke:


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-778

MetastorePartitionSensor always throws an exception on initialization due to 72cc8b3006576153aa30d27643807b4ae5dfb593 . This PR reverts the breaking part of this commit.
Looks like the tests for this are only run if an explicit flag is set which is how this got past CI.

@bolkedebruin This should be merged onto the current beta. On a bit of a sidenote @bolkedebruin should we make the beta version a branch instead of a tarball so that other committers can merge fixes onto it and avoid bugging you?

@zodiac @bolkedebruin @artwr 