### PR TITLE
[AIRFLOW-783] Fix Py3 incompat in BaseTaskRunner

### DIFF
--- a/airflow/task_runner/base_task_runner.py
+++ b/airflow/task_runner/base_task_runner.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import codecs
 import getpass
 import os
 import json
@@ -119,7 +120,7 @@ class BaseTaskRunner(LoggingMixin):
         # Start daemon thread to read subprocess logging output
         log_reader = threading.Thread(
             target=self._read_task_logs,
-            args=(proc.stdout,),
+            args=(codecs.getreader('ascii')(proc.stdout),),
         )
         log_reader.daemon = True
         log_reader.start()


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-783

Testing Done:
- `run_unit_tests.sh` completes without `'str' does not support the buffer interface` error

