### PR TITLE
[AIRFLOW-779] Handle non-existent db entry better

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -2024,7 +2024,7 @@ class LocalTaskJob(BaseJob):
             if self.task_runner.process:
                 ti.pid = self.task_runner.process.pid
             ti.hostname = socket.getfqdn()
-            ti.state = State.RUNNING
+            #ti.state = State.RUNNING
             session.merge(ti)
             session.commit()
             session.close()

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -2085,7 +2085,11 @@ class LocalTaskJob(BaseJob):
 
         self.task_instance.refresh_from_db()
         ti = self.task_instance
-        if ti.state == State.RUNNING:
+        if ti is None:
+            logging.warning("Task instance does not exist in DB. Terminating")
+            self.task_runner.terminate()
+            self.terminating = True
+        elif ti.state == State.RUNNING:
             self.was_running = True
             fqdn = socket.getfqdn()
             if not (fqdn == ti.hostname and

--- a/tests/core.py
+++ b/tests/core.py
@@ -661,6 +661,7 @@ class CoreTest(unittest.TestCase):
         TI = models.TaskInstance
         ti = TI(
             task=self.runme_0, execution_date=DEFAULT_DATE)
+        ti.state = State.RUNNING
         job = jobs.LocalTaskJob(task_instance=ti, ignore_ti_state=True)
         job.run()
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-779


Testing Done:
- Killed a task while it was running using the task instances UI, verified behavior is the same as before, and logging worked


@aoen @bolkedebruin
@zodiac 