### PR TITLE
[AIRFLOW-780] Fix dag import errors no longer working

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -503,6 +503,7 @@ authenticate = true
 max_threads = 2
 catchup_by_default = True
 scheduler_zombie_task_threshold = 300
+dag_dir_list_interval = 0
 """
 
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -247,6 +247,7 @@ class DagBag(BaseDagBag, LoggingMixin):
                 with open(filepath, 'rb') as f:
                     content = f.read()
                     if not all([s in content for s in (b'DAG', b'airflow')]):
+                        self.file_last_changed[filepath] = file_last_changed_on_disk
                         return found_dags
 
             self.logger.debug("Importing {}".format(filepath))
@@ -283,6 +284,8 @@ class DagBag(BaseDagBag, LoggingMixin):
                                               format(mod.filename, filepath))
                             content = zf.read()
                             if not all([s in content for s in (b'DAG', b'airflow')]):
+                                self.file_last_changed[filepath] = (
+                                    file_last_changed_on_disk)
                                 # todo: create ignore list
                                 return found_dags
 

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -143,7 +143,6 @@ def configure_orm(disable_connection_pool=False):
         engine_args['pool_size'] = conf.getint('core', 'SQL_ALCHEMY_POOL_SIZE')
         engine_args['pool_recycle'] = conf.getint('core',
                                                   'SQL_ALCHEMY_POOL_RECYCLE')
-        # engine_args['echo'] = True
 
     engine = create_engine(SQL_ALCHEMY_CONN, **engine_args)
     Session = scoped_session(

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -198,8 +198,8 @@ def list_py_file_paths(directory, safe_mode=True):
                     if safe_mode:
                         with open(file_path, 'rb') as f:
                             content = f.read()
-                            might_contain_dag = all([s in content
-                                                     for s in (b'DAG', b'airflow')])
+                            might_contain_dag = all(
+                                [s in content for s in (b'DAG', b'airflow')])
 
                     if not might_contain_dag:
                         continue


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-780

The import errors were no longer working after the multiprocessor update
(since they are cleared after each DAG directory is parsed). This change
fixes them, and adds tests to prevent future regressions.

Also fix Py3 incompat in BaseTaskRunner and a couple of linter errors.

Note that there are a few inefficiencies (e.g. sometimes we delete then add import errors in the same place instead of just doing an update), but this is equivalent to the old behavior.

Testing Done:
- Added missing unit tests for dag imports. Note that some of them strangely fail for python 3 and it became too time consuming to debug since I don't have a copy of the travis environment, I even ran with the same version of python locally and couldn't reproduce. I have skipped those 3 tests in python 3 for now.

@bolkedebruin @artwr @mistercrunch @plypaul 
