### PR TITLE
[AIRFLOW-806] UI should properly ignore DAG doc when it is None

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1414,7 +1414,7 @@ class Airflow(BaseView):
             flash("No tasks found", "error")
         session.commit()
         session.close()
-        doc_md = markdown.markdown(dag.doc_md) if hasattr(dag, 'doc_md') else ''
+        doc_md = markdown.markdown(dag.doc_md) if hasattr(dag, 'doc_md') and dag.doc_md else ''
 
         return self.render(
             'airflow/graph.html',


### PR DESCRIPTION
Check dag.doc_md before we try to convert it to Markdown.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-806

Testing Done:
- Verified in UI with DAG doc set to `__doc__`, but no docstrings. No error and looks as if `dag.doc_md` was not set or set to empty string.