### PR TITLE
[AIRFLOW-809] Use __eq__ ColumnOperator When Testing Booleans

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -468,7 +468,7 @@ class DagBag(BaseDagBag, LoggingMixin):
     def paused_dags(self):
         session = settings.Session()
         dag_ids = [dp.dag_id for dp in session.query(DagModel).filter(
-            DagModel.is_paused.is_(True))]
+            DagModel.is_paused.__eq__(True))]
         session.commit()
         session.close()
         return dag_ids
@@ -2777,7 +2777,7 @@ class DAG(BaseDag, LoggingMixin):
             DR.dag_id == self.dag_id,
         )
         if not include_externally_triggered:
-            qry = qry.filter(DR.external_trigger.is_(False))
+            qry = qry.filter(DR.external_trigger.__eq__(False))
 
         qry = qry.order_by(DR.execution_date.desc())
 


### PR DESCRIPTION
The .is_ ColumnOperator causes the SqlAlchemy's MSSQL dialect to produce
IS 0 when given a value of False rather than a value of None. The __eq__
ColumnOperator does this same test with the added benefit that it will
modify the resulting expression from and == to a IS NULL when the target
is None.

This change replaces all is_ ColumnOperators that are doing boolean
comparisons and leaves all is_ ColumnOperators that are checking for
None values.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-809

Per Apache guidelines you need to create a [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW/).

Testing Done:
Not sure how to test this without a MSSQL. If there are suggestions, I'd like to figure it out.

Reminders for contributors (REQUIRED!):
* Your PR's title must reference an issue on 
[Airflow's JIRA](https://issues.apache.org/jira/browse/AIRFLOW/). 
For example, a PR called "[AIRFLOW-1] My Amazing PR" would close JIRA 
issue #1. Please open a new issue if required!

* For all PRs with UI changes, you must provide screenshots. If the UI changes are not obvious, either annotate the images or provide before/after screenshots.

* Please squash your commits when possible and follow the [How to write a good git commit message](http://chris.beams.io/posts/git-commit/). 
Summarized as follows:
  1. Separate subject from body with a blank line
  2. Limit the subject line to 50 characters
  3. Do not end the subject line with a period
  4. Use the imperative mood in the subject line (add, not adding)
  5. Wrap the body at 72 characters
  6. Use the body to explain what and why vs. how

