### PR TITLE
[AIRFLOW-783] Fix py3 incompatibility in BaseTaskRunner

### DIFF
--- a/airflow/task_runner/base_task_runner.py
+++ b/airflow/task_runner/base_task_runner.py
@@ -89,7 +89,7 @@ class BaseTaskRunner(LoggingMixin):
 
     def _read_task_logs(self, stream):
         while True:
-            line = stream.readline()
+            line = stream.readline().decode('utf-8')
             if len(line) == 0:
                 break
             self.logger.info('Subtask: {}'.format(line.rstrip('\n')))


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-783

Supersedes https://github.com/apache/incubator-airflow/pull/2008

@zeapo @aoen @wrs