### PR TITLE
[AIRFLOW-811] [BugFix] bash_operator does not return full output

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -133,7 +133,7 @@ class BashOperator(BaseOperator):
                                 logging.info("stdout: {0}".format(output))
 
                             if self.xcom_push:
-                                return output.decode(self.output_encoding)
+                                return output
                         else:
                             logging.warning("stdout file: {0} is empty".format(stdout_file.name))
                 else:


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-811

Testing Done:
- added new multiline check unit test case

added small features in bash_operator with this PR
- regex filtered output
- output as info logging switch
- memory file mapped optimized output handling