### PR TITLE
[AIRFLOW-812] Fix scheduler run bug when dag file is absent

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -634,6 +634,8 @@ class DagFileProcessorManager(LoggingMixin):
         """
         :return: whether all file paths have been processed max_runs times
         """
+        if not self._file_paths:  # No dag file is present.
+            return False
         for file_path in self._file_paths:
             if self._run_count[file_path] != self._max_runs:
                 return False


### PR DESCRIPTION

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-812

When scheduler run_numbers and run_duration are set to -1 (unlimited),
we expect the scheduler to run continuously. However, when dag folder is
empty, the scheduler terminates immediately. This is due to a bug in
utils/dag_processing when checking max_runs_reached. Instead the
existence of dag file should be checked first. If no dag file is
present, false will be returned.

Testing Done:
Travis runs on my fork went fine. 