### PR TITLE
[AIRFLOW-813] Fix unterminated scheduler unit tests

### DIFF
--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -267,7 +267,8 @@ class SchedulerJobTest(unittest.TestCase):
         Utility function that runs a single scheduler loop without actually
         changing/scheduling any dags. This is useful to simulate the other side effects of
         running a scheduler loop, e.g. to see what parse errors there are in the
-        dags_folder.
+        dags_folder. The run_duration is limited to 20 seconds as the scheduler
+        will run forever as num_runs is ignored when there is no dag file.
 
         :param dags_folder: the directory to traverse
         :type directory: str
@@ -275,7 +276,8 @@ class SchedulerJobTest(unittest.TestCase):
         scheduler = SchedulerJob(
             dag_id='this_dag_doesnt_exist',  # We don't want to actually run anything
             num_runs=1,
-            subdir=os.path.join(dags_folder))
+            subdir=os.path.join(dags_folder),
+            run_duration=20)
         scheduler.heartrate = 0
         scheduler.run()
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-813

Set scheduler run duration to 20 seconds to fix unterminated new unit
tests introduced in PR #2018. The bug is due to that num_runs is ignored
when no valid dag file is present.

Testing Done:
Trevis run passed at the forked repo: 
![screen shot 2017-01-27 at 11 34 08 am](https://cloud.githubusercontent.com/assets/24922485/22384743/88e5af40-e484-11e6-8eb0-489db5973d40.png)
