### PR TITLE
[AIRFLOW-814] Use keyword args when initializing a Presto*CheckOperator

### DIFF
--- a/airflow/operators/presto_check_operator.py
+++ b/airflow/operators/presto_check_operator.py
@@ -80,7 +80,9 @@ class PrestoValueCheckOperator(ValueCheckOperator):
             self, sql, pass_value, tolerance=None,
             presto_conn_id='presto_default',
             *args, **kwargs):
-        super(PrestoValueCheckOperator, self).__init__(sql, pass_value, tolerance, *args, **kwargs)
+        super(PrestoValueCheckOperator, self).__init__(
+            sql=sql, pass_value=pass_value, tolerance=tolerance,
+            *args, **kwargs)
         self.presto_conn_id = presto_conn_id
 
     def get_db_hook(self):
@@ -110,7 +112,8 @@ class PrestoIntervalCheckOperator(IntervalCheckOperator):
             presto_conn_id='presto_default',
             *args, **kwargs):
         super(PrestoIntervalCheckOperator, self).__init__(
-            table, metrics_thresholds, date_filter_column, days_back,
+            table=table, metrics_thresholds=metrics_thresholds,
+            date_filter_column=date_filter_column, days_back=days_back,
             *args, **kwargs)
         self.presto_conn_id = presto_conn_id
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-814

This fixes problems like the following:

```python
>>> from airflow.operators import PrestoIntervalCheckOperator
>>> p = PrestoIntervalCheckOperator(task_id='id', table='table', metrics_thresholds=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.venv/lib/python3.5/site-packages/airflow/utils/decorators.py", line 86, in wrapper
    result = func(*args, **kwargs)
  File "/.venv/lib/python3.5/site-packages/airflow/operators/presto_check_operator.py", line 99, in __init__
    *args, **kwargs)
  File "/.venv/lib/python3.5/site-packages/airflow/utils/decorators.py", line 46, in wrapper
    "Use keyword arguments when initializing operators")
airflow.exceptions.AirflowException: Use keyword arguments when initializing operators
```

Given how minor the change is, and my uncertainty about whether new tests should really check every Operator for this problem, I've not added any. That said, I'm happy to do so if you feel it's warranted.