### PR TITLE
[AIRFLOW-813] Fix unterminated unit tests in SchedulerJobTest

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -354,6 +354,8 @@ class DagFileProcessorManager(LoggingMixin):
         self._last_finish_time = {}
         # Map from file path to the number of runs
         self._run_count = defaultdict(int)
+        # Scheduler heartbeat key.
+        self._heart_beat_key = 'heart-beat'
 
     @property
     def file_paths(self):
@@ -628,17 +630,20 @@ class DagFileProcessorManager(LoggingMixin):
 
         self.symlink_latest_log_directory()
 
+        # Update scheduler heartbeat count.
+        self._run_count[self._heart_beat_key] += 1
+
         return simple_dags
 
     def max_runs_reached(self):
         """
         :return: whether all file paths have been processed max_runs times
         """
-        if not self._file_paths:  # No dag file is present.
-            return False
         for file_path in self._file_paths:
             if self._run_count[file_path] != self._max_runs:
                 return False
+        if self._run_count[self._heart_beat_key] < self._max_runs:
+            return False
         return True
 
     def terminate(self):

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -267,8 +267,7 @@ class SchedulerJobTest(unittest.TestCase):
         Utility function that runs a single scheduler loop without actually
         changing/scheduling any dags. This is useful to simulate the other side effects of
         running a scheduler loop, e.g. to see what parse errors there are in the
-        dags_folder. The run_duration is limited to 20 seconds as the scheduler
-        will run forever as num_runs is ignored when there is no dag file.
+        dags_folder.
 
         :param dags_folder: the directory to traverse
         :type directory: str
@@ -276,8 +275,7 @@ class SchedulerJobTest(unittest.TestCase):
         scheduler = SchedulerJob(
             dag_id='this_dag_doesnt_exist',  # We don't want to actually run anything
             num_runs=1,
-            subdir=os.path.join(dags_folder),
-            run_duration=20)
+            subdir=os.path.join(dags_folder))
         scheduler.heartrate = 0
         scheduler.run()
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-813

Following up the discussion in #2028, a new counter is added to
track the number of scheduler heartbeats (or runs). max_runs_check
now checks both number of runs of dag files and scheduler. In
the case no dag file is found, scheduler will terminate after num-runs
heartbeats have passed.

@aoen @bolkedebruin PTAL, thanks. 

Testing Done:
tests.job:SchedulerJobTest passed.