### PR TITLE
[AIRFLOW-813] Check unlimited-runs first in max_runs_reached()

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1365,7 +1365,7 @@ class CLIFactory(object):
             help="Set number of seconds to execute before exiting"),
         'num_runs': Arg(
             ("-n", "--num_runs"),
-            default=None, type=int,
+            default=-1, type=int,
             help="Set the number of runs to execute before exiting"),
         # worker
         'do_pickle': Arg(

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -639,6 +639,8 @@ class DagFileProcessorManager(LoggingMixin):
         """
         :return: whether all file paths have been processed max_runs times
         """
+        if self._max_runs == -1:  # Unlimited runs.
+            return False
         for file_path in self._file_paths:
             if self._run_count[file_path] != self._max_runs:
                 return False


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-813

This is a follow up CL for #2030, given that a special value (-1)
is used to represent unlimited runs, that special value should 
be checked first while evaluating max_runs_reached.

Note that the cli default arg value for num_runs should be changed
from None to -1 to match the SchedulerJob constructor default.
```
    # __init__ for SchedulerJob
    # https://github.com/apache/incubator-airflow/blob/master/airflow/jobs.py#L461
    def __init__(
            self,
            dag_id=None,
            dag_ids=None,
            subdir=models.DAGS_FOLDER,
            num_runs=-1,
            file_process_interval=conf.getint('scheduler',
                                              'min_file_process_interval'),
            processor_poll_interval=1.0,
            run_duration=None,
            do_pickle=False,
            *args, **kwargs):
```


Testing Done:
![screen shot 2017-01-28 at 7 33 25 am](https://cloud.githubusercontent.com/assets/24922485/22397685/147b443c-e52c-11e6-9ab6-ad94fdbb06d9.png)

