### PR TITLE
[AIRFLOW-817] Check for None value of execution_date in endpoint

### DIFF
--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -50,7 +50,7 @@ def trigger_dag(dag_id):
         conf = data['conf']
 
     execution_date = None
-    if 'execution_date' in data:
+    if 'execution_date' in data and data['execution_date'] is not None:
         execution_date = data['execution_date']
 
         # Convert string datetime into actual datetime


### PR DESCRIPTION
execution_date can be present in json while resolving to None.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-817

@lukem-ow