### PR TITLE
[AIRFLOW-822] Close db session before throwing an exception

### DIFF
--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -48,11 +48,11 @@ class BaseHook(object):
             .filter(Connection.conn_id == conn_id)
             .all()
         )
+        session.expunge_all()
+        session.close()
         if not db:
             raise AirflowException(
                 "The conn_id `{0}` isn't defined".format(conn_id))
-        session.expunge_all()
-        session.close()
         return db
 
     @classmethod


### PR DESCRIPTION
Dear Airflow Maintainers,

I've did a minor change to resolve session leakage. The basehook contains functionality to retrieve connection details from the database. If a connections host doesn't exists it will throw an exception. This exception will be thrown before the connection to the database is closed. Therefore the session to the db might stay open and linger.

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-822

Cheers