### PR TITLE
[AIRFLOW-365] Set dag.fileloc explicitly and use for Code view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -18,7 +18,6 @@ from past.builtins import basestring, unicode
 import os
 import pkg_resources
 import socket
-import importlib
 from functools import wraps
 from datetime import datetime, timedelta
 import dateutil.parser
@@ -579,8 +578,8 @@ class Airflow(BaseView):
         dag = dagbag.get_dag(dag_id)
         title = dag_id
         try:
-            m = importlib.import_module(dag.module_name)
-            code = inspect.getsource(m)
+            with open(dag.fileloc, 'r') as f:
+                code = f.read()
             html_code = highlight(
                 code, lexers.PythonLexer(), HtmlFormatter(linenos=True))
         except IOError as e:

--- a/tests/models.py
+++ b/tests/models.py
@@ -200,6 +200,24 @@ class DagBagTest(unittest.TestCase):
         assert dagbag.get_dag(dag_id) != None
         assert dagbag.process_file_calls == 1
 
+    def test_get_dag_fileloc(self):
+        """
+        Test that fileloc is correctly set when we load example DAGs,
+        specifically SubDAGs.
+        """
+        dagbag = models.DagBag(include_examples=True)
+
+        expected = {
+            'example_bash_operator': 'example_bash_operator.py',
+            'example_subdag_operator': 'example_subdag_operator.py',
+            'example_subdag_operator.section-1': 'subdags/subdag.py'
+        }
+
+        for dag_id, path in expected.items():
+            dag = dagbag.get_dag(dag_id)
+            self.assertTrue(
+                dag.fileloc.endswith('airflow/example_dags/' + path))
+
 
 class TaskInstanceTest(unittest.TestCase):
 


### PR DESCRIPTION
Code view for subdag has not been working. I do not think we are able
cleanly figure out where the code for the factory method lives when we
process the dags, so we need to save the location when the subdag is
created.

Previously for a subdag, its `fileloc` attribute would be set to the
location of the parent dag. I think it is appropriate to instead set
it to the actual child dag location instead. We do not lose any
information this way (we still have the link to the parent dag that
has its location) and now we can always read this attribute for the
code view. This should not affect the use of this field for refreshing
dags, because we always refresh the parent for a subdag.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-365

Testing Done:
- Unittests pass. Added a test to ensure `fileloc` is set properly for dags and sub dags
- Played around with refresh button when changing parent/child dags, works the same as expected
- Code view for parent dag is the same as expected
- Code view for sub dag now shows the proper file, as shown in the screenshot below
- Did the same UI checks for some non-example dags I have

![sub dag code](https://cloud.githubusercontent.com/assets/1597448/22491139/329dc460-e7d6-11e6-8883-470e6b22ceed.png)




