### PR TITLE
[AIRFLOW-825] Add Dataflow semantics to Airflow

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -3,6 +3,19 @@
 This file documents any backwards-incompatible changes in Airflow and
 assists people when migrating to a new version.
 
+## Airflow 1.9
+
+### New Features
+
+- Airflow now supports Dataflow semantics, allowing tasks to directly exchange information between named outputs and inputs. See `airflow.dataflow` for more information.
+
+### Breaking Changes
+
+- Previously, if an Operator returned a value, an XCom was automatically pushed containing that value. That behavior is no longer supported since returned values are now handled by Dataflow objects. A new argument, `return_xcom`, has been added to all Operators to re-enable this behavior. However, it defaults to `False`.
+
+### Deprecated Features
+- BashOperator's `xcom_push` argument has been deprecated in favor of `return_xcom`.
+
 ## Airflow 1.8
 
 ### Database
@@ -24,8 +37,8 @@ interfere.
 Please read through these options, defaults have changed since 1.7.1.
 
 #### child_process_log_directory
-In order the increase the robustness of the scheduler, DAGS our now processed in their own process. Therefore each 
-DAG has its own log file for the scheduler. These are placed in `child_process_log_directory` which defaults to 
+In order the increase the robustness of the scheduler, DAGS our now processed in their own process. Therefore each
+DAG has its own log file for the scheduler. These are placed in `child_process_log_directory` which defaults to
 `<AIRFLOW_HOME>/scheduler/latest`. You will need to make sure these log files are removed.
 
 > DAG logs or processor logs ignore and command line settings for log file locations.
@@ -35,7 +48,7 @@ Previously the command line option `num_runs` was used to let the scheduler term
 loops. This is now time bound and defaults to `-1`, which means run continuously. See also num_runs.
 
 #### num_runs
-Previously `num_runs` was used to let the scheduler terminate after a certain amount of loops. Now num_runs specifies 
+Previously `num_runs` was used to let the scheduler terminate after a certain amount of loops. Now num_runs specifies
 the number of times to try to schedule each DAG file within `run_duration` time. Defaults to `-1`, which means try
 indefinitely.
 
@@ -48,7 +61,7 @@ dags are not being picked up, have a look at this number and decrease it when ne
 
 #### catchup_by_default
 By default the scheduler will fill any missing interval DAG Runs between the last execution date and the current date.
-This setting changes that behavior to only execute the latest interval. This can also be specified per DAG as 
+This setting changes that behavior to only execute the latest interval. This can also be specified per DAG as
 `catchup = False / True`. Command line backfills will still work.
 
 ### Faulty Dags do not show an error in the Web UI
@@ -72,33 +85,33 @@ convenience variables to the config. In case your run a sceure Hadoop setup it m
 required to whitelist these variables by adding the following to your configuration:
 
 ```
-<property> 
+<property>
      <name>hive.security.authorization.sqlstd.confwhitelist.append</name>
      <value>airflow\.ctx\..*</value>
 </property>
 ```
 ### Google Cloud Operator and Hook alignment
 
-All Google Cloud Operators and Hooks are aligned and use the same client library. Now you have a single connection 
+All Google Cloud Operators and Hooks are aligned and use the same client library. Now you have a single connection
 type for all kinds of Google Cloud Operators.
 
 If you experience problems connecting with your operator make sure you set the connection type "Google Cloud Platform".
 
-Also the old P12 key file type is not supported anymore and only the new JSON key files are supported as a service 
+Also the old P12 key file type is not supported anymore and only the new JSON key files are supported as a service
 account.
 
 ### Deprecated Features
-These features are marked for deprecation. They may still work (and raise a `DeprecationWarning`), but are no longer 
+These features are marked for deprecation. They may still work (and raise a `DeprecationWarning`), but are no longer
 supported and will be removed entirely in Airflow 2.0
 
 - Hooks and operators must be imported from their respective submodules
 
-  `airflow.operators.PigOperator` is no longer supported; `from airflow.operators.pig_operator import PigOperator` is. 
+  `airflow.operators.PigOperator` is no longer supported; `from airflow.operators.pig_operator import PigOperator` is.
   (AIRFLOW-31, AIRFLOW-200)
 
 - Operators no longer accept arbitrary arguments
 
-  Previously, `Operator.__init__()` accepted any arguments (either positional `*args` or keyword `**kwargs`) without 
+  Previously, `Operator.__init__()` accepted any arguments (either positional `*args` or keyword `**kwargs`) without
   complaint. Now, invalid arguments will be rejected. (https://github.com/apache/incubator-airflow/pull/1285)
 
 ## Airflow 1.7.1.2

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -74,6 +74,7 @@ class AirflowMacroPlugin(object):
 
 from airflow import operators
 from airflow import hooks
+from airflow import dataflow
 from airflow import executors
 from airflow import macros
 from airflow import contrib

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -200,6 +200,14 @@ default_ram = 512
 default_disk = 512
 default_gpus = 0
 
+[dataflow]
+# A prefix added to all Dataflow keys
+key_prefix = DATAFLOW
+
+# Connection information for Dataflows backed by Google Cloud Storage
+gcloud_storage_connection_id =
+gcloud_storage_bucket =
+gcloud_storage_prefix =
 
 [webserver]
 # The base url of your website as airflow cannot guess what domain or

--- a/airflow/contrib/dataflow/__init__.py
+++ b/airflow/contrib/dataflow/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/airflow/contrib/dataflow/file_dataflow.py
+++ b/airflow/contrib/dataflow/file_dataflow.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.dataflow import Dataflow
+import os
+import json
+try:
+    # Python 2
+    import cPickle as pickle
+except:
+    # Python 3
+    import pickle
+
+class FileDataflow(Dataflow):
+    def __init__(
+            self,
+            upstream_task,
+            index=None,
+            path='/tmp/airflow/dataflow',
+            serializer='pickle'):
+        """
+        This Dataflow uses the local filesystem to store data. It can only be
+        used in environments where all Airflow processes have read and write
+        access to the filesystem.
+
+        path: files will be written in subdirectories of this path
+        serializer: data will be serialized by this method
+        """
+        serializers = ('pickle', 'json')
+        if serializer not in serializers:
+            raise ValueError(
+                'Unsupported serializer: "{}". Provide one of: {}'.format(
+                    serializer, serializers))
+        self.serializer = serializer
+        self.path = path
+
+        super(FileDataflow, self).__init__(
+            upstream_task=upstream_task,
+            index=index)
+
+    def serialize(self, data, context):
+        fpath = os.path.join(self.path, self.key(context))
+        os.makedirs(os.path.dirname(fpath), exist_ok=True)
+
+        if self.serializer == 'pickle':
+            with open(fpath, mode='wb') as f:
+                pickle.dump(data, f)
+        elif self.serializer == 'json':
+            with open(fpath, mode='w') as f:
+                json.dump(data, f)
+
+        return fpath
+
+    def deserialize(self, data, context):
+        if self.serializer == 'pickle':
+            with open(data, mode='rb') as f:
+                data = pickle.load(f)
+        elif self.serializer == 'json':
+            with open(data, mode='r') as f:
+                data = json.load(f)
+        return data

--- a/airflow/contrib/dataflow/gcs_dataflow.py
+++ b/airflow/contrib/dataflow/gcs_dataflow.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.dataflow import Dataflow
+from airflow import configuration as conf
+from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
+import os
+from tempfile import NamedTemporaryFile
+
+try:
+    import cPickle as pickle
+except:
+    import pickle
+
+
+class GCSFileDataflow(Dataflow):
+    def __init__(
+            self,
+            upstream_task,
+            index=None,
+            bucket=None,
+            path_prefix=None,
+            gcs_connection_id=None):
+        """
+
+        GCSFileDataflow expects the upstream task to return a path to a file on
+        the local filesystem. The contents of that file are uploaded to GCS.
+        Prior to running the downstream task, the file contents are downloaded
+        to a temporary file. The temporary file's path is passed to the
+        downstream task. The temporary file is deleted after the downstream
+        task runs.
+
+        :param upstream_task: The Operator that produces the Dataflow result
+        :type upstream_task: Operator
+        :param index: If provided, the source operator's result is indexed
+            by this value prior to being passed to the dataflow. For example,
+            if the source operator returns a dictionary, the index could be
+            used to select a specific key rather than the entire result.
+        :type index: object
+        :param bucket: The GCS bucket that will be used for storage. If None,
+            the dataflow.gcloud_storage_bucket configuration parameter is
+            checked.
+        :type bucket: string
+        :param path_prefix: The path prefix is prepended to the dataflow key
+            to specify the storage URI. If None is provided, the
+            dataflow.gcloud_storage_prefix configuration value is checked.
+        :type path_prefix: string
+        :param gcs_connection_id: The connection ID that should be used
+            to connect to GCS. If None is provided, the
+            dataflow.gcloud_storage_connection_id configuration value is
+            checked.
+        :type gcs_connection_id: string
+        """
+
+        bucket = bucket or conf.get('dataflow', 'gcloud_storage_bucket')
+        if not bucket:
+            raise ValueError('No GCS bucket provided and no default set.')
+        self.bucket = bucket
+
+        path_prefix = path_prefix or conf.get(
+            'dataflow', 'gcloud_storage_prefix')
+        if not path_prefix:
+            raise ValueError('No GCS path prefix provided and no default set.')
+        self.path_prefix = path_prefix
+
+        gcs_connection_id = gcs_connection_id or conf.get(
+            'dataflow', 'gcloud_storage_connection_id')
+
+        self.gcs_hook = GoogleCloudStorageHook(
+            google_cloud_storage_conn_id=gcs_connection_id)
+
+        super(GCSFileDataflow, self).__init__(
+            upstream_task=upstream_task,
+            index=index)
+
+    def serialize(self, filename, context):
+        gcs_path = os.path.join(self.path_prefix.strip('/'), self.key(context))
+        self.gcs_hook.upload(
+            self.bucket,
+            gcs_path,
+            filename)
+        return gcs_path
+
+    def deserialize(self, gcs_path, context):
+        self._tmp_file = NamedTemporaryFile(delete=False)
+        self.gcs_hook.download(
+            self.bucket,
+            gcs_path,
+            filename=self._tmp_file.name)
+        return self._tmp_file.name
+
+    def clean_up(self, context):
+        os.remove(self._tmp_file.name)
+        del self._tmp_file
+
+
+class GCSDataflow(GCSFileDataflow):
+    def __init__(
+            self,
+            upstream_task,
+            index=None,
+            bucket=None,
+            path_prefix=None,
+            gcs_connection_id=None,
+            serialize=pickle.dump,
+            deserialize=pickle.load):
+        """
+
+        GCSDataflow uses Google Cloud Storage to store data. It expects the
+        upstream task to return an object that is serialized and stored in GCS.
+        The object is downloaded and deserialized before being provided to the
+        downstream task.
+
+        Note the difference to GCSFileDataflow, which works by transferring
+        file paths rather than objects.
+
+        :param upstream_task: The Operator that produces the Dataflow result
+        :type upstream_task: Operator
+        :param index: If provided, the source operator's result is indexed
+            by this value prior to being passed to the dataflow. For example,
+            if the source operator returns a dictionary, the index could be
+            used to select a specific key rather than the entire result.
+        :type index: object
+        :param bucket: The GCS bucket that will be used for storage. If None,
+            the dataflow.gcloud_storage_bucket configuration parameter is
+            checked.
+        :type bucket: string
+        :param path_prefix: The path prefix is prepended to the dataflow key
+            to specify the storage URI. If None is provided, the
+            dataflow.gcloud_storage_prefix configuration value is checked.
+        :type path_prefix: string
+        :param gcs_connection_id: The connection ID that should be used
+            to connect to GCS. If None is provided, the
+            dataflow.gcloud_storage_connection_id configuration value is
+            checked.
+        :type gcs_connection_id: string
+        :param serialize: A function serialize(data, filepath) that writes data
+            to a filepath on the local filesystem.
+        :type serialize: callable
+        :param deserialize: A function deserialize(filepath) that loads data
+            from a filepath on the local filesystem. deserialize() should
+            usually be the inverse of serialize(), such that:
+                ( data == deserialize(serialize(data, path)) ) is True
+        :type deserialize: callable
+        """
+        self._serialize = serialize
+        self._deserialize = deserialize
+        super(GCSDataflow, self).__init__(
+            upstream_task=upstream_task,
+            index=index,
+            bucket=bucket,
+            path_prefix=path_prefix,
+            gcs_connection_id=gcs_connection_id)
+
+    def serialize(self, data, context):
+
+        with NamedTemporaryFile() as tmp:
+            self._serialize(data, tmp)
+            tmp.seek(0)
+            return super(GCSDataflow, self).serialize(tmp.name, context)
+
+    def deserialize(self, data, context):
+        fpath = super(GCSDataflow, self).deserialize(data, context)
+
+        with open(fpath, 'rb') as f:
+            return self._deserialize(f)

--- a/airflow/dataflow.py
+++ b/airflow/dataflow.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow import configuration
+from airflow.models import XCom
+import os
+
+DATAFLOW_KEY = configuration.get('DATAFLOW', 'key_prefix')
+NONE_STRING = '__ALL__'
+
+class Dataflow:
+
+    def __init__(self, upstream_task, index=None):
+        """
+        Dataflow objects are used to pass data from an upstream task to a
+        downstream task. Airflow operators are not necessarily run in the
+        same environment and may not have access to the same resources, so
+        Dataflows are responsible for serializing data to ensure it can be
+        accessed by any task that needs it.
+
+        A Dataflow object represents the result of a task and is defined by
+        a `upstream_task` and an optional `index`. If the task returns
+        an indexable result like a tuple or dictionary, the index is used to
+        select an appropriate piece rather than the entire result.
+
+        Dataflow objects are added to downstream tasks with a key. For example:
+        ```python
+            downstream_task.add_dataflows(result=Dataflow(upstream_task))
+        ```
+        This means that the result of the `upstream_task` will be available to
+        the `downstream_task` under the key `result`. It can be accessed in the
+        `downstream_task`'s context as `context['dataflows']['result']` or, if
+        the `downstream_task` is a PythonOperator, it will be passed to the
+        python callable as a keyword argument.
+
+        ## Mechanics
+
+        Dataflows have three important methods: `serialize()`, `deserialize()`,
+        and `clean_up()`.
+
+        `serialize()` is called after the upstream task runs. It is passed the
+        upstream result and expected to return a representation of that data
+        that can be pickled and stored in the Airflow database. For very small
+        data, it is ok to pass the data  directly. However, for performance and
+        practical reasons, it is preferable to use the serialize method to store
+        data in distributed storage and return a pointer to that data, like a
+        URI.
+
+        `deserialize()` is called before the downstream task runs. It is passed
+        the serialized data and expected to return the data it represents.
+
+        `clean_up()` is called after the downstream task runs and can be used
+        to delete temporary files or perform any maintainence steps.
+
+        ## Arguments
+
+        :param upstream_task: The Operator that produces the Dataflow result
+        :type upstream_task: Operator
+        :param index: If provided, the source operator's result is indexed
+            by this value prior to being passed to the dataflow. For example,
+            if the source operator returns a dictionary, the index could be
+            used to select a specific key rather than the entire result.
+        :type index: object
+        """
+        self.upstream_task = upstream_task
+        self.source_task_id = upstream_task.task_id
+        self.index = index
+
+    def serialize(self, data, context):
+        """
+        Convert data to a serialized representation. The representation is
+        stored and later passed to the deserialize method.
+
+        The serialized data will be stored as a pickled Python object and does
+        not necessarily have to be a string; however, for performance reasons,
+        large data objects should not be stored directly.
+
+        This method should be overridden by Dataflow subclasses.
+        """
+        return data
+
+    def deserialize(self, serialized_data, context):
+        """
+        Deserialize data from a representation.
+
+        This method should be overridden by Dataflow subclasses.
+        """
+        return serialized_data
+
+    def clean_up(self, context):
+        """
+        Method called after the task runs in case any clean up is needed.
+        """
+        pass
+
+    def key(self, context, extension=None):
+        """
+        Returns a url-safe unique name that can be used to reference a specific
+        Dataflow item.
+        """
+        dag_id = context['dag'].dag_id
+        task_id = self.source_task_id
+        execution_date = str(context['execution_date'])
+
+        key = os.path.join(dag_id, task_id, execution_date)
+        if self.index is not None:
+            index = str(self.index).replace('/', '_')
+            key = os.path.join(key, str(self.index))
+        key = os.path.join(key, 'dataflow')
+        if extension is not None:
+            key += extension
+        return key
+
+    def _set_data(self, data, context):
+
+        if self.index is not None:
+            data = data[self.index]
+
+        # if this XCom already exists, don't do unnecessary work
+        if XCom.get_many(
+                execution_date=context['execution_date'],
+                key='{}:{}'.format(DATAFLOW_KEY, self.key(context)),
+                task_ids=self.source_task_id,
+                dag_ids=context['dag'].dag_id,
+                count=True):
+            return
+
+        serialized_data = self.serialize(data, context)
+
+        XCom.set(
+            key='{}:{}'.format(DATAFLOW_KEY, self.key(context)),
+            value=serialized_data,
+            task_id=self.source_task_id,
+            dag_id=context['dag'].dag_id,
+            execution_date=context['execution_date'])
+
+    def _get_data(self, context):
+
+        serialized_data = XCom.get_one(
+            key='{}:{}'.format(DATAFLOW_KEY, self.key(context)),
+            task_id=self.source_task_id,
+            dag_id=context['dag'].dag_id,
+            execution_date=context['execution_date'])
+
+        return self.deserialize(serialized_data, context)

--- a/airflow/example_dags/example_dataflow.py
+++ b/airflow/example_dags/example_dataflow.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.python_operator import PythonOperator
+from airflow import DAG
+from airflow.dataflow import Dataflow
+from datetime import datetime, timedelta
+import logging
+
+three_days_ago = datetime.combine(datetime.today() - timedelta(3),
+                                  datetime.min.time())
+args = {
+    'owner': 'airflow',
+    'start_date': three_days_ago,
+}
+
+def dataflow_fn(all_data, some_data, **context):
+    logging.info('here is all the data: {}'.format(all_data))
+    logging.info('here is just some of the some_data: {}'.format(some_data))
+    logging.info('and here is the raw data in the context: {}'.format(
+        context['dataflows']))
+
+dataflow_cmd = """
+    echo "these are the dataflows:"
+    echo {{ dataflows }}
+
+    echo "and here is the output of the dataflow command:"
+    {{ dataflows['command']}}
+    """
+
+with DAG(dag_id='example_dataflow', default_args=args) as dag:
+
+    data_generator = PythonOperator(
+        task_id='data_generator',
+        python_callable=lambda: ('string', [1, 2, 3], {'a': 'b'}))
+
+    dict_generator = PythonOperator(
+        task_id='dict_generator',
+        python_callable=lambda: {'cmd': 'echo "HELLO, WORLD!"'})
+
+    # Dataflows are defined as a dictionary of (key: Dataflow) pairs. The key
+    # is how the data is accessed in the downstream task. The Dataflow object
+    # tells Airflow how to serialize/deserialize the data and is passed the
+    # source task and an optional index for that task's return.
+    py_dataflow = PythonOperator(
+        task_id='python_dataflow',
+        python_callable=dataflow_fn,
+        provide_context=True,
+        dataflows=dict(
+            all_data=Dataflow(data_generator),
+            some_data=Dataflow(data_generator, index=1)))
+
+    # Dataflows can also be provided after Operators are created
+    bash_dataflow = BashOperator(
+        task_id='bash_dataflow_task',
+        bash_command=dataflow_cmd)
+
+    bash_dataflow.add_dataflows(
+        command=Dataflow(dict_generator, index='cmd'))

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -56,10 +56,17 @@ class BashOperator(BaseOperator):
             output_encoding='utf-8',
             *args, **kwargs):
 
+        # TODO Remove xcom_push in Airflow 2.0
+        if xcom_push:
+            kwargs['return_xcom'] = True
+            warnings.warn(
+                'xcom_push is deprecated and will be removed soon. '
+                'Use return_xcom instead.',
+                DeprecationWarning)
+
         super(BashOperator, self).__init__(*args, **kwargs)
         self.bash_command = bash_command
         self.env = env
-        self.xcom_push_flag = xcom_push
         self.output_encoding = output_encoding
 
     def execute(self, context):
@@ -99,8 +106,7 @@ class BashOperator(BaseOperator):
                 if sp.returncode:
                     raise AirflowException("Bash command failed")
 
-        if self.xcom_push_flag:
-            return line
+        return line
 
     def on_kill(self):
         logging.info('Sending SIGTERM signal to bash process group')

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -72,6 +72,9 @@ class PythonOperator(BaseOperator):
             self.template_ext = templates_exts
 
     def execute(self, context):
+        if self.dataflows:
+            self.op_kwargs.update(context['dataflows'])
+
         if self.provide_context:
             context.update(self.op_kwargs)
             context['templates_dict'] = self.templates_dict

--- a/tests/contrib/dataflow/__init__.py
+++ b/tests/contrib/dataflow/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/contrib/dataflow/file_dataflow.py
+++ b/tests/contrib/dataflow/file_dataflow.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+from datetime import datetime
+from airflow import configuration
+configuration.load_test_config()
+
+from airflow import DAG
+from airflow.models import BaseOperator
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.contrib.dataflow.file_dataflow import FileDataflow
+
+TEST_DAG_ID = 'test_dataflow_dag'
+DEFAULT_DATE = datetime(2017, 1, 1)
+
+class FileDataflowTest(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+        self.args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE,
+            'end_date': DEFAULT_DATE}
+        self.dag = DAG(TEST_DAG_ID, default_args=self.args)
+
+        self.data = {'a': 'abc', 'b': [1, 2, 3]}
+
+        with self.dag:
+            self.data_generator = PythonOperator(
+                task_id='data_generator',
+                python_callable=lambda: self.data)
+
+    def test_file_dataflows(self):
+
+        with self.dag:
+            # Checks that dataflows are available in the Operator context
+            def check_dataflows(pickle, json):
+                if pickle != self.data['a']:
+                    raise Exception('failure: pickle')
+                if json != self.data:
+                    raise Exception('failure: json')
+
+            op = PythonOperator(
+                task_id='test_run_file_dataflows',
+                python_callable=check_dataflows,
+                dataflows=dict(
+                    pickle=FileDataflow(self.data_generator, index='a'),
+                    json=FileDataflow(self.data_generator, serializer='json')))
+
+        # run generator
+        self.data_generator.run()
+
+        # run downstream tasks
+        op.run()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/dataflow.py
+++ b/tests/dataflow.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+from datetime import datetime
+from airflow import configuration
+configuration.load_test_config()
+
+from airflow import DAG
+from airflow.models import BaseOperator
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.dataflow import Dataflow
+
+TEST_DAG_ID = 'test_dataflow_dag'
+DEFAULT_DATE = datetime(2017, 1, 1)
+
+class DataflowTest(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+        self.args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE,
+            'end_date': DEFAULT_DATE}
+        self.dag = DAG(TEST_DAG_ID, default_args=self.args)
+
+        self.tuple_data = ('abc', [1, 2, 3])
+        self.dict_data = {'a': 'abc', 'b': [1, 2, 3]}
+        self.bash_data = 'Hello, World!'
+
+        with self.dag:
+            self.tuple_data_generator = PythonOperator(
+                task_id='tuple_data_generator',
+                python_callable=lambda: self.tuple_data)
+
+            self.dict_data_generator = PythonOperator(
+                task_id='dict_data_generator',
+                python_callable=lambda: self.dict_data)
+
+            self.bash_data_generator = BashOperator(
+                task_id='bash_data_generator',
+                bash_command=r'echo "{}"'.format(self.bash_data))
+
+        self.dataflow_1 = Dataflow(self.tuple_data_generator, index=1)
+        self.dataflow_2 = Dataflow(self.dict_data_generator, index='a')
+        self.dataflow_3 = Dataflow(self.bash_data_generator)
+
+    def check_dataflows(self, x, y, z):
+        if x != self.tuple_data[1]:
+            raise Exception('failure: tuple_data')
+        if y != self.dict_data['a']:
+            raise Exception('failure: dict_data')
+        if z != self.bash_data:
+            raise Exception('failure: bash_data')
+
+    def test_create_dataflows(self):
+        """
+        Test that dataflow objects can be created and properly create
+        task relationships
+        """
+
+        with self.dag:
+            op1 = DummyOperator(
+                task_id='op1',
+                dataflows=dict(x=self.dataflow_1, y=self.dataflow_2))
+
+            self.assertTrue(('x', self.dataflow_1) in op1.dataflows.items())
+            self.assertTrue(('y', self.dataflow_2) in op1.dataflows.items())
+            self.assertTrue(
+                self.tuple_data_generator.task_id in op1.upstream_task_ids)
+            self.assertTrue(
+                op1.task_id in self.tuple_data_generator.downstream_task_ids)
+
+            op2 = DummyOperator(task_id='op2')
+            op2.add_dataflows(
+                x=self.dataflow_1,
+                y=self.dataflow_2,
+                z=self.dataflow_3)
+            self.assertTrue(('z', self.dataflow_3) in op2.dataflows.items())
+
+    def test_run_dataflows(self):
+
+        with self.dag:
+            # Checks that dataflows are available in the Operator context
+            def check_dataflows_context(**context):
+                self.check_dataflows(
+                    x=context['dataflows']['x'],
+                    y=context['dataflows']['y'],
+                    z=context['dataflows']['z'])
+            op_context = PythonOperator(
+                task_id='test_run_dataflows_context',
+                python_callable=check_dataflows_context,
+                provide_context=True,
+                dataflows=dict(
+                    x=self.dataflow_1,
+                    y=self.dataflow_2,
+                    z=self.dataflow_3))
+
+            # Checks that dataflows are passed directly to the Operator as
+            # keyword args
+            def check_dataflows_kwargs(x, y, z):
+                self.check_dataflows(x=x, y=y, z=z)
+            op_kwargs = PythonOperator(
+                task_id='test_run_dataflows_kwargs',
+                python_callable=check_dataflows_kwargs,
+                dataflows=dict(
+                    x=self.dataflow_1,
+                    y=self.dataflow_2,
+                    z=self.dataflow_3))
+
+            # Checks that dataflows are available in bash context
+            op_bash_context = BashOperator(
+                task_id='test_run_dataflows_bash',
+                bash_command="""
+                    if [ $({{ dataflows['z'] }}) == 'Hello, World!']; then
+                        echo 'success!'
+                    else
+                        exit 1
+                    fi
+                    """,
+                dataflows=dict(
+                    x=self.dataflow_1,
+                    y=self.dataflow_2,
+                    z=self.dataflow_3))
+
+        # run generators
+        self.tuple_data_generator.run()
+        self.dict_data_generator.run()
+        self.bash_data_generator.run()
+
+        # run downstream tasks
+        op_context.run()
+        op_kwargs.run()
+        op_bash_context.run()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-825 

**Testing Done:**
- Unit tests for Dataflow object
- Contrib unit tests for FileDataflow (contrib)
- local testing for GCSDataflow (contrib)

**Example use:**
The upstream task, `data_generator`, returns a tuple of three objects.
The downstream task, `python_dataflow`, defines a two dataflows from the upstream task. The first is called `all_data` and receives the whole output of the data generator; the second is called `some_data` and only receives the 1st element. These two arguments are passed as keyword functions to the python callable, as well as the Operator context (for use in non-PythonOperators).

Dataflows use XComs by default but are easily extended to use alternative storage. I have included a filesystem-backed Dataflow and a Google Cloud Storage-backed Dataflow in the contrib folder; the filesystem one includes unit tests.

```python
    data_generator = PythonOperator(
        task_id='data_generator',
        python_callable=lambda: ('string', [1, 2, 3], {'a': 'b'}))

    def dataflow_fn(all_data, some_data, **context):
        logging.info('here is all the data: {}'.format(all_data))
        logging.info('here is just some of the some_data: {}'.format(some_data))
        logging.info('and here is the raw data in the context: {}'.format(
            context['dataflows']))

    python_dataflow = PythonOperator(
        task_id='python_dataflow',
        python_callable=dataflow_fn,
        provide_context=True,
        dataflows=dict(
            all_data=Dataflow(data_generator),
            some_data=Dataflow(data_generator, index=1)))

```

**Summary (from JIRA):**

Following discussion on the dev list, this adds first-class Dataflow semantics
to Airflow.

A Dataflow object represents the result of an upstream task. If the upstream
task has multiple outputs contained in a tuple, dict, or other indexable form,
an index may be provided so the Dataflow only uses the appropriate output.

Dataflows are passed to downstream tasks with a key. This has two effects:
    1. It sets up a dependency between the upstream and downstream tasks to
       ensure that the downstream task does not run before the upstream result
       is available.
    2. It ensures that the [indexed] upstream result is available in the
       downstream task's context as ``context['dataflows'][key]``. In addition,
       the result will be passed directly to PythonOperators as a keyword
       argument.

Dataflows use the XCom mechanism to exchange data. Data is passed through the
following series of steps:
    1. After the upstream task runs, data is passed to the Dataflow object's
       _set_data() method.
    2. The Dataflow's serialize() method is called on the data. This method
       takes the data object and returns a representation that can be used to
       reconstruct it later.
    3. _set_data() stores the serialized result as an XCom.
    4. Before the downstream task runs, it calls the Dataflow _get_data()
       method.
    5. _get_data() retrieves the upstream XCom.
    6. The Dataflow's deserialize() method is called. This method takes the
       serialiezd representation and returns the data object.
    7. The data object is passed to the downstream task.

The basic Dataflow object has identity serialize and deserialize methods,
meaning data is stored directly in the Airflow database. Therefore, for
performance and practical reasons, basic Dataflows should not be used with large
or complex results.

Dataflows can easily be extended to use remote storage. In this case, the
serialize method should write the data in to storage and return a URI, which
will be stored as an XCom. The URI will be passed to deserialize() so that the
data can be downloaded and reconstructed.