### PR TITLE
[AIRFLOW-828] Add maximum XCom size

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -200,6 +200,10 @@ default_ram = 512
 default_disk = 512
 default_gpus = 0
 
+[xcom]
+
+# the maximum size of a pickled XCom object, in bytes
+max_size = 20000
 
 [webserver]
 # The base url of your website as airflow cannot guess what domain or

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -22,7 +22,7 @@ class AirflowException(Exception):
 
 class AirflowConfigException(AirflowException):
     pass
-    
+
 
 class AirflowSensorTimeout(AirflowException):
     pass
@@ -33,4 +33,8 @@ class AirflowTaskTimeout(AirflowException):
 
 
 class AirflowSkipException(AirflowException):
+    pass
+
+
+class XComException(AirflowException):
     pass

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -61,7 +61,8 @@ import six
 from airflow import settings, utils
 from airflow.executors import DEFAULT_EXECUTOR, LocalExecutor
 from airflow import configuration
-from airflow.exceptions import AirflowException, AirflowSkipException, AirflowTaskTimeout
+from airflow.exceptions import (
+    AirflowException, AirflowSkipException, AirflowTaskTimeout, XComException)
 from airflow.dag.base_dag import BaseDag, BaseDagBag
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
 from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
@@ -3599,6 +3600,15 @@ class XCom(Base):
         Store an XCom value.
         """
         session.expunge_all()
+
+        # check XCom size
+        max_xcom_size = configuration.getint('XCOM', 'MAX_SIZE')
+        xcom_size = sys.getsizeof(pickle.dumps(value))
+        if xcom_size > max_xcom_size:
+            raise XComException(
+                "The XCom's pickled size ({} bytes) is larger than the "
+                "maximum allowed size ({} bytes).".format(
+                    xcom_size, max_xcom_size))
 
         # remove any duplicate XComs
         session.query(cls).filter(


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-828

Adds a configurable maximum size for XComs that is checked before pushing any XCom. An error is
raised if the maximum size is exceeded.

Testing Done:
- Added unit tests

