### PR TITLE
[AIRFLOW-830][AIRFLOW-829][AIRFLOW-88] Reduce Travis log verbosity

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -72,7 +72,7 @@ for root, dirs, files in os.walk(plugins_folder, followlinks=True):
             if file_ext != '.py':
                 continue
 
-            logging.info('Importing plugin module ' + filepath)
+            logging.debug('Importing plugin module ' + filepath)
             # normalize root path as namespace
             namespace = '_'.join([re.sub(norm_pattern, '__', root), mod_name])
 
@@ -92,7 +92,7 @@ for root, dirs, files in os.walk(plugins_folder, followlinks=True):
 
 
 def make_module(name, objects):
-    logging.info('Creating module ' + name)
+    logging.debug('Creating module ' + name)
     name = name.lower()
     module = imp.new_module(name)
     module._name = name.split('.')[-1]

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -28,17 +28,6 @@ export AIRFLOW_USE_NEW_IMPORTS=1
 # any argument received is overriding the default nose execution arguments:
 
 nose_args=$@
-if [ -z "$nose_args" ]; then
-  nose_args="--with-coverage \
---cover-erase \
---cover-html \
---cover-package=airflow \
---cover-html-dir=airflow/www/static/coverage \
---with-ignore-docstrings \
--s \
--v \
---logging-level=DEBUG "
-fi
 
 #--with-doctest
 
@@ -50,7 +39,18 @@ yes | airflow resetdb
 airflow initdb
 
 if [ "${TRAVIS}" ]; then
-  # For impersonation tests running on SQLite on Travis, make the database world readable so other 
+    if [ -z "$nose_args" ]; then
+      nose_args="--with-coverage \
+    --cover-erase \
+    --cover-html \
+    --cover-package=airflow \
+    --cover-html-dir=airflow/www/static/coverage \
+    --with-ignore-docstrings \
+    -v \
+    --logging-level=DEBUG "
+    fi
+
+  # For impersonation tests running on SQLite on Travis, make the database world readable so other
   # users can update it
   AIRFLOW_DB="/home/travis/airflow/airflow.db"
   if [ -f "${AIRFLOW_DB}" ]; then
@@ -60,6 +60,18 @@ if [ "${TRAVIS}" ]; then
   # For impersonation tests on Travis, make airflow accessible to other users via the global PATH
   # (which contains /usr/local/bin)
   sudo ln -s "${VIRTUAL_ENV}/bin/airflow" /usr/local/bin/
+else
+    if [ -z "$nose_args" ]; then
+      nose_args="--with-coverage \
+    --cover-erase \
+    --cover-html \
+    --cover-package=airflow \
+    --cover-html-dir=airflow/www/static/coverage \
+    --with-ignore-docstrings \
+    -s \
+    -v \
+    --logging-level=DEBUG "
+    fi
 fi
 
 echo "Starting the unit tests with the following nose arguments: "$nose_args


### PR DESCRIPTION
Remove the -s flag for Travis unit tests to suppress output of successful tests. Reduce the plugin manager's verbosity from INFO to DEBUG.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-829
- https://issues.apache.org/jira/browse/AIRFLOW-830
- (and potentially) https://issues.apache.org/jira/browse/AIRFLOW-88


