### PR TITLE
[AIRFLOW-831] Restore import to fix broken tests

### DIFF
--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -26,7 +26,7 @@ import six
 import sys
 from tempfile import mkdtemp
 
-from airflow import AirflowException, settings
+from airflow import AirflowException, settings, models
 from airflow.bin import cli
 from airflow.jobs import BackfillJob, SchedulerJob
 from airflow.models import DAG, DagModel, DagBag, DagRun, Pool, TaskInstance as TI


### PR DESCRIPTION
The global `models` object is used in the code and was inadvertently
removed. This PR restores it

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-831

Should resolve a testing conflict that was unintentionally introduced by timing differences between #2013 and #2018