### PR TITLE
[AIRFLOW-705] [AIRFLOW-706] Decode run_command output; use shlex.split for commands

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -24,6 +24,8 @@ import os
 import six
 import subprocess
 import warnings
+import shlex
+import sys
 
 from future import standard_library
 standard_library.install_aliases()
@@ -76,8 +78,9 @@ def run_command(command):
     Runs command and returns stdout
     """
     process = subprocess.Popen(
-        command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    output, stderr = process.communicate()
+        shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, stderr = [stream.decode(sys.getdefaultencoding(), 'ignore')
+                      for stream in process.communicate()]
 
     if process.returncode != 0:
         raise AirflowConfigException(

--- a/tests/core.py
+++ b/tests/core.py
@@ -58,7 +58,7 @@ from airflow.utils.dates import infer_time_unit, round_time, scale_time_units
 from airflow.utils.logging import LoggingMixin
 from lxml import html
 from airflow.exceptions import AirflowException
-from airflow.configuration import AirflowConfigException
+from airflow.configuration import AirflowConfigException, run_command
 
 import six
 
@@ -1041,6 +1041,20 @@ class CoreTest(unittest.TestCase):
         session.query(models.DagStat).delete()
         session.commit()
         session.close()
+
+    def test_run_command(self):
+        if six.PY3:
+            write = r'sys.stdout.buffer.write("\u1000foo".encode("utf8"))'
+        else:
+            write = r'sys.stdout.write(u"\u1000foo".encode("utf8"))'
+
+        cmd = 'import sys; {0}; sys.stdout.flush()'.format(write)
+
+        self.assertEqual(run_command("python -c '{0}'".format(cmd)),
+                         u'\u1000foo' if six.PY3 else 'foo')
+
+        self.assertEqual(run_command('echo "foo bar"'), u'foo bar\n')
+        self.assertRaises(AirflowConfigException, run_command, 'bash -c "exit 1"')
 
 
 class CliTests(unittest.TestCase):


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-705
- https://issues.apache.org/jira/browse/AIRFLOW-706

Testing Done:
- Changed `sql_alchemy_conn` to `sql_alchemy_conn_cmd` in test configuration to exercise `run_command` in tests