### PR TITLE
[AIRFLOW-417] Show useful error message for missing DAG in URL

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1154,6 +1154,13 @@ class Airflow(BaseView):
         dag_id = request.args.get('dag_id')
         blur = conf.getboolean('webserver', 'demo_mode')
         dag = dagbag.get_dag(dag_id)
+        if not dag:
+            flash(
+                "DAG [{}] doesn't seem to exist"
+                " at the moment".format(dag_id),
+                "error")
+            return redirect('/admin/')
+
         root = request.args.get('root')
         if root:
             dag = dag.sub_dag(

--- a/tests/core.py
+++ b/tests/core.py
@@ -1787,6 +1787,19 @@ class WebUiTests(unittest.TestCase):
         response = self.app.get(url)
         self.assertIn("run_this_last", response.data.decode('utf-8'))
 
+    def test_missing_dag_request(self):
+        response = self.app.get("/admin/airflow/graph?dag_id=missing_dag", follow_redirects=True)
+        # verify that user is redirected to the index page with an error message
+        assert "DAGs" in response.data.decode('utf-8')
+        assert "example_bash_operator" in response.data.decode('utf-8')
+        assert "alert-danger" in response.data.decode('utf-8')
+
+        response = self.app.get("/admin/airflow/graph?dag_id=example_bash_operator", follow_redirects=True)
+        # verify that the page for a valid DAG is rendered correctly
+        assert "example_bash_operator" in response.data.decode('utf-8')
+        assert "Graph View" in response.data.decode('utf-8')
+
+
     def tearDown(self):
         configuration.conf.set("webserver", "expose_config", "False")
         self.dag_bash.clear(start_date=DEFAULT_DATE, end_date=datetime.now())


### PR DESCRIPTION
Right now if a user runs tries to do certain things in the UI with dags
that don't exist they get confusing tracebacks rather than an error
rendered in html. Show a useful error message when a non-existent DAG
is requested.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-417

Testing Done:
- Tested by running the webserver and navigating to http://localhost:8080/admin/airflow/tree?dag_id=abcd. An error message is flashed and the user is redirected to the main admin page. The page displays correctly for DAGs that exist.
- Added test case to verify user redirected to the home page and shown an alert message

## Before
<img width="817" alt="non-existent-dag-before" src="https://cloud.githubusercontent.com/assets/907344/22615952/b4d4a0f2-ea56-11e6-8b36-9fed82163480.png">

## After

<img width="822" alt="non-existent-dag-after" src="https://cloud.githubusercontent.com/assets/907344/22615953/be1a1f3e-ea56-11e6-9634-26f2ce7664b7.png">

