### PR TITLE
[AIRFLOW-850] Add a PythonSensor

### DIFF
--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -679,3 +679,57 @@ class HttpSensor(BaseSensorOperator):
             raise ae
 
         return True
+
+class PythonSensor(BaseSensorOperator):
+    """
+    Waits for a Python callable to return True
+
+    :param python_callable: A reference to an object that is callable
+    :type python_callable: python callable
+    :param op_kwargs: a dictionary of keyword arguments that will get unpacked
+        in your function
+    :type op_kwargs: dict
+    :param op_args: a list of positional arguments that will get unpacked when
+        calling your callable
+    :type op_args: list
+    :param provide_context: if set to true, Airflow will pass a set of
+        keyword arguments that can be used in your function. This set of
+        kwargs correspond exactly to what you can use in your jinja
+        templates. For this to work, you need to define `**kwargs` in your
+        function header.
+    :type provide_context: bool
+    :param templates_dict: a dictionary where the values are templates that
+        will get templated by the Airflow engine sometime between
+        ``__init__`` and ``execute`` takes place and are made available
+        in your callable's context after the template has been applied
+    :type templates_dict: dict of str
+    """
+
+    template_fields = ('templates_dict',)
+    template_ext = tuple()
+
+    def __init__(
+            self,
+            python_callable,
+            op_args=None,
+            op_kwargs=None,
+            provide_context=False,
+            templates_dict=None,
+            *args, **kwargs):
+        super(PythonSensor, self).__init__(*args, **kwargs)
+        self.python_callable = python_callable
+        self.op_args = op_args or []
+        self.op_kwargs = op_kwargs or {}
+        self.provide_context = provide_context
+        self.templates_dict = templates_dict
+
+
+    def poke(self, context):
+        if self.provide_context:
+            context.update(self.op_kwargs)
+            context['templates_dict'] = self.templates_dict
+            self.op_kwargs = context
+
+        logging.info("Poking callable: " + str(self.python_callable))
+        return_value = self.python_callable(*self.op_args, **self.op_kwargs)
+        return bool(return_value)


### PR DESCRIPTION
A general purpose PythonSensor which allows an arbitrary Python
callable to delay Task execution until the callable returns True

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-850

Testing Done:
Added tests for python callables which return True, False, or raise an exception


