### PR TITLE
[AIRFLOW-842] do not query the DB with an empty IN clause

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3734,6 +3734,10 @@ class DagStat(Base):
         :param full_query: whether to check dag_runs for new drs not in dag_stats
         :type full_query: bool
         """
+        # avoid querying with an empty IN clause
+        if not dag_ids:
+            return
+
         dag_ids = set(dag_ids)
 
         qry = (
@@ -3744,6 +3748,10 @@ class DagStat(Base):
         dirty_ids = {dag.dag_id for dag in qry.all()}
         qry.delete(synchronize_session='fetch')
         session.commit()
+
+        # avoid querying with an empty IN clause
+        if not dirty_ids:
+            return
 
         qry = (
             session.query(DagRun.dag_id, DagRun.state, func.count('*'))

--- a/tests/core.py
+++ b/tests/core.py
@@ -978,12 +978,18 @@ class CoreTest(unittest.TestCase):
         session.query(models.DagStat).delete()
         session.commit()
 
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            models.DagStat.clean_dirty([], session=session)
+        self.assertEqual([], caught_warnings)
+
         run1 = self.dag_bash.create_dagrun(
             run_id="run1",
             execution_date=DEFAULT_DATE,
             state=State.RUNNING)
 
-        models.DagStat.clean_dirty([self.dag_bash.dag_id], session=session)
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            models.DagStat.clean_dirty([self.dag_bash.dag_id], session=session)
+        self.assertEqual([], caught_warnings)
 
         qry = session.query(models.DagStat).all()
 
@@ -998,7 +1004,9 @@ class CoreTest(unittest.TestCase):
             execution_date=DEFAULT_DATE+timedelta(days=1),
             state=State.RUNNING)
 
-        models.DagStat.clean_dirty([self.dag_bash.dag_id], session=session)
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            models.DagStat.clean_dirty([self.dag_bash.dag_id], session=session)
+        self.assertEqual([], caught_warnings)
 
         qry = session.query(models.DagStat).all()
 
@@ -1011,7 +1019,9 @@ class CoreTest(unittest.TestCase):
         session.query(models.DagRun).first().state = State.SUCCESS
         session.commit()
 
-        models.DagStat.clean_dirty([self.dag_bash.dag_id], session=session)
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            models.DagStat.clean_dirty([self.dag_bash.dag_id], session=session)
+        self.assertEqual([], caught_warnings)
 
         qry = session.query(models.DagStat).filter(models.DagStat.state == State.SUCCESS).all()
         self.assertEqual(1, len(qry))


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-842

Testing Done:
- Added checking for raised warnings in CoreTest.test_dag_stats.

