### PR TITLE
[AIRFLOW-834] change raise StopIteration into return

### DIFF
--- a/airflow/ti_deps/deps/base_ti_dep.py
+++ b/airflow/ti_deps/deps/base_ti_dep.py
@@ -84,12 +84,12 @@ class BaseTIDep(object):
         if self.IGNOREABLE and dep_context.ignore_all_deps:
             yield self._passing_status(
                 reason="Context specified all dependencies should be ignored.")
-            raise StopIteration
+            return
 
         if self.IS_TASK_DEP and dep_context.ignore_task_deps:
             yield self._passing_status(
                 reason="Context specified all task dependencies should be ignored.")
-            raise StopIteration
+            return
 
         for dep_status in self._get_dep_statuses(ti, session, dep_context):
             yield dep_status

--- a/airflow/ti_deps/deps/not_in_retry_period_dep.py
+++ b/airflow/ti_deps/deps/not_in_retry_period_dep.py
@@ -29,12 +29,12 @@ class NotInRetryPeriodDep(BaseTIDep):
             yield self._passing_status(
                 reason="The context specified that being in a retry period was "
                        "permitted.")
-            raise StopIteration
+            return
 
         if ti.state != State.UP_FOR_RETRY:
             yield self._passing_status(
                 reason="The task instance was not marked for retrying.")
-            raise StopIteration
+            return
 
         # Calculate the date first so that it is always smaller than the timestamp used by
         # ready_for_retry

--- a/airflow/ti_deps/deps/prev_dagrun_dep.py
+++ b/airflow/ti_deps/deps/prev_dagrun_dep.py
@@ -31,12 +31,12 @@ class PrevDagrunDep(BaseTIDep):
             yield self._passing_status(
                 reason="The context specified that the state of past DAGs could be "
                        "ignored.")
-            raise StopIteration
+            return
 
         if not ti.task.depends_on_past:
             yield self._passing_status(
                 reason="The task did not have depends_on_past set.")
-            raise StopIteration
+            return
 
         # Don't depend on the previous task instance if we are the first task
         dag = ti.task.dag
@@ -44,7 +44,7 @@ class PrevDagrunDep(BaseTIDep):
             if dag.previous_schedule(ti.execution_date) < ti.task.start_date:
                 yield self._passing_status(
                     reason="This task instance was the first task instance for its task.")
-                raise StopIteration
+                return
         else:
             dr = ti.get_dagrun()
             last_dagrun = dr.get_previous_dagrun() if dr else None
@@ -52,14 +52,14 @@ class PrevDagrunDep(BaseTIDep):
             if not last_dagrun:
                 yield self._passing_status(
                     reason="This task instance was the first task instance for its task.")
-                raise StopIteration
+                return
 
         previous_ti = ti.previous_ti
         if not previous_ti:
             yield self._failing_status(
                 reason="depends_on_past is true for this task's DAG, but the previous "
                        "task instance has not run yet.")
-            raise StopIteration
+            return
 
         if previous_ti.state not in {State.SKIPPED, State.SUCCESS}:
             yield self._failing_status(

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -37,11 +37,11 @@ class TriggerRuleDep(BaseTIDep):
         if not ti.task.upstream_list:
             yield self._passing_status(
                 reason="The task instance did not have any upstream tasks.")
-            raise StopIteration
+            return
 
         if ti.task.trigger_rule == TR.DUMMY:
             yield self._passing_status(reason="The task had a dummy trigger rule set.")
-            raise StopIteration
+            return
 
         # TODO(unknown): this query becomes quite expensive with dags that have many
         # tasks. It should be refactored to let the task report to the dag run and get the

--- a/airflow/ti_deps/deps/valid_state_dep.py
+++ b/airflow/ti_deps/deps/valid_state_dep.py
@@ -47,11 +47,11 @@ class ValidStateDep(BaseTIDep):
         if dep_context.ignore_ti_state:
             yield self._passing_status(
                 reason="Context specified that state should be ignored.")
-            raise StopIteration
+            return
 
         if ti.state in self._valid_states:
             yield self._passing_status(reason="Task state {} was valid.".format(ti.state))
-            raise StopIteration
+            return
 
         yield self._failing_status(
             reason="Task is in the '{0}' state which is not a valid state for "


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-834

This silences PendingDeprecationWarnings in Python 3.5.

See https://www.python.org/dev/peps/pep-0479/#id34 for an example why
it isn't a good idea to raise StopIteration instead of just returning.