### PR TITLE
[AIRFLOW-861] make pickle_info endpoint be login_required

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -641,6 +641,7 @@ class Airflow(BaseView):
         return wwwutils.json_response(d)
 
     @expose('/pickle_info')
+    @login_required
     def pickle_info(self):
         d = {}
         dag_id = request.args.get('dag_id')


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-861


Testing Done:
- Unittests pass
