### PR TITLE
Change import so hive_metastore is not a required module for operator tests

### DIFF
--- a/tests/operators/__init__.py
+++ b/tests/operators/__init__.py
@@ -17,4 +17,3 @@ from .subdag_operator import *
 from .operators import *
 from .sensors import *
 from .hive_operator import *
-from .s3_to_hive_operator import *


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-873

Testing Done:
- Ran existing tests in tests/operators/. They were successful
