### PR TITLE
[AIRFLOW-845] Sensor execute method should return the value of the po…

### DIFF
--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -81,6 +81,7 @@ class BaseSensorOperator(BaseOperator):
                     raise AirflowSensorTimeout('Snap. Time is OUT.')
             sleep(self.poke_interval)
         logging.info("Success criteria met. Exiting.")
+        return self.poke(context)
 
 
 class SqlSensor(BaseSensorOperator):

--- a/tests/operators/sensors.py
+++ b/tests/operators/sensors.py
@@ -22,6 +22,7 @@ import unittest
 from datetime import datetime, timedelta
 
 from airflow import DAG, configuration
+from airflow.models import TaskInstance as TI
 from airflow.operators.sensors import HttpSensor, BaseSensorOperator, HdfsSensor
 from airflow.utils.decorators import apply_defaults
 from airflow.exceptions import (AirflowException,
@@ -31,7 +32,6 @@ configuration.load_test_config()
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 TEST_DAG_ID = 'unit_test_dag'
-
 
 class TimeoutTestSensor(BaseSensorOperator):
     """
@@ -181,3 +181,47 @@ class HdfsSensorTests(unittest.TestCase):
         # Then
         with self.assertRaises(AirflowSensorTimeout):
             task.execute(None)
+
+class ReturnSensor(BaseSensorOperator):
+    """
+    Sensor that returns some value through xcom
+    """
+
+    @apply_defaults
+    def __init__(
+            self,
+            *args,
+            **kwargs):
+        super(ReturnSensor, self).__init__(*args, **kwargs)
+
+    def poke(self, context):
+        value = ['file1', 'file2', 'file3']
+        return value
+
+
+class ReturnSensorTests(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+        args = {
+            'owner': 'airflow',
+            'mysql_conn_id': 'airflow_db',
+            'start_date': DEFAULT_DATE
+        }
+        dag = DAG(TEST_DAG_ID, default_args=args)
+        self.dag = dag
+
+    def test_return_sensor(self):
+        """
+        Test that the sensor returns an xcom through return value
+        """
+        value = ['file1', 'file2', 'file3']
+
+        t = ReturnSensor(
+            task_id='test_return_sensor',
+            dag=self.dag)
+        ti = TI(
+            task=t, execution_date=DEFAULT_DATE)
+        ti.run(ignore_all_deps=True)
+
+        self.assertEqual(ti.xcom_pull(task_ids='test_return_sensor'), value)


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- *https://issues.apache.org/jira/browse/AIRFLOW-845*

Makes it possible to have a sensor's `return` value retrieved via `xcom_pull`, which is handy for e.g. passing on a list of files to drive further parts of the DAG.

Testing Done:
- Tested in production.