### PR TITLE
[AIRFLOW-877] GoogleCloudStorageDownloadOperator remove '.sql' template extension

### DIFF
--- a/airflow/contrib/operators/gcs_download_operator.py
+++ b/airflow/contrib/operators/gcs_download_operator.py
@@ -25,7 +25,6 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
     Downloads a file from Google Cloud Storage.
     """
     template_fields = ('bucket','object','filename','store_to_xcom_key',)
-    template_ext = ('.sql',)
     ui_color = '#f0eee4'
 
     @apply_defaults


### PR DESCRIPTION
Remove '.sql' from template_ext: Otherwise causes template not found if try to download .sql file

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-877

@criccomini 