### PR TITLE
[AIRFLOW-869] Refactor mark success functionality

### DIFF
--- a/airflow/api/common/experimental/mark_tasks.py
+++ b/airflow/api/common/experimental/mark_tasks.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+
+from airflow.jobs import BackfillJob
+from airflow.models import DagRun, TaskInstance
+from airflow.operators.subdag_operator import SubDagOperator
+from airflow.settings import Session
+from airflow.utils.state import State
+
+from sqlalchemy import or_
+
+
+def _create_dagruns(dag, execution_dates, state, run_id_template):
+    """
+    Infers from the dates which dag runs need to be created and does so.
+    :param dag: the dag to create dag runs for
+    :param execution_dates: list of execution dates to evaluate
+    :param state: the state to set the dag run to
+    :param run_id_template:the template for run id to be with the execution date
+    :return: newly created and existing dag runs for the execution dates supplied
+    """
+    # find out if we need to create any dag runs
+    drs = DagRun.find(dag_id=dag.dag_id, execution_date=execution_dates)
+    dates_to_create = list(set(execution_dates) - set([dr.execution_date for dr in drs]))
+
+    for date in dates_to_create:
+        dr = dag.create_dagrun(
+            run_id=run_id_template.format(date.isoformat()),
+            execution_date=date,
+            start_date=datetime.datetime.now(),
+            external_trigger=False,
+            state=state,
+        )
+        drs.append(dr)
+
+    return drs
+
+
+def set_state(task, execution_date, upstream=False, downstream=False,
+              future=False, past=False, state=State.SUCCESS, commit=False):
+    """
+    Set the state of a task instance and if needed its relatives. Can set state
+    for future tasks (calculated from execution_date) and retroactively
+    for past tasks. Will verify integrity of past dag runs in order to create
+    tasks that did not exist. It will not create dag runs that are missing
+    on the schedule (but it will as for subdag dag runs if needed).
+    :param task: the task from which to work. task.task.dag needs to be set
+    :param execution_date: the execution date from which to start looking
+    :param upstream: Mark all parents (upstream tasks)
+    :param downstream: Mark all siblings (downstream tasks) of task_id, including SubDags
+    :param future: Mark all future tasks on the interval of the dag up until
+        last execution date.
+    :param past: Retroactively mark all tasks starting from start_date of the DAG
+    :param state: State to which the tasks need to be set
+    :param commit: Commit tasks to be altered to the database
+    :return: list of tasks that have been created and updated
+    """
+    assert isinstance(execution_date, datetime.datetime)
+
+    # microseconds are supported by the database, but is not handled
+    # correctly by airflow on e.g. the filesystem and in other places
+    execution_date = execution_date.replace(microsecond=0)
+
+    assert task.dag is not None
+    dag = task.dag
+
+    latest_execution_date = dag.latest_execution_date
+    assert latest_execution_date is not None
+
+    # determine date range of dag runs and tasks to consider
+    end_date = latest_execution_date if future else execution_date
+
+    if 'start_date' in dag.default_args:
+        start_date = dag.default_args['start_date']
+    elif dag.start_date:
+        start_date = dag.start_date
+    else:
+        start_date = execution_date
+
+    start_date = execution_date if not past else start_date
+
+    if dag.schedule_interval == '@once':
+        dates = [start_date]
+    else:
+        dates = dag.date_range(start_date=start_date, end_date=end_date)
+
+    # find relatives (siblings = downstream, parents = upstream) if needed
+    task_ids = [task.task_id]
+    if downstream:
+        relatives = task.get_flat_relatives(upstream=False)
+        task_ids += [t.task_id for t in relatives]
+    if upstream:
+        relatives = task.get_flat_relatives(upstream=True)
+        task_ids += [t.task_id for t in relatives]
+
+    # verify the integrity of the dag runs in case a task was added or removed
+    # set the confirmed execution dates as they might be different
+    # from what was provided
+    confirmed_dates = []
+    drs = DagRun.find(dag_id=dag.dag_id, execution_date=dates)
+    for dr in drs:
+        dr.dag = dag
+        dr.verify_integrity()
+        confirmed_dates.append(dr.execution_date)
+
+    # go through subdagoperators and create dag runs. We will only work
+    # within the scope of the subdag. We wont propagate to the parent dag,
+    # but we will propagate from parent to subdag.
+    session = Session()
+    dags = [dag]
+    sub_dag_ids = []
+    while len(dags) > 0:
+        current_dag = dags.pop()
+        for task_id in task_ids:
+            if not current_dag.has_task(task_id):
+                continue
+
+            current_task = current_dag.get_task(task_id)
+            if isinstance(current_task, SubDagOperator):
+                # this works as a kind of integrity check
+                # it creates missing dag runs for subdagoperators,
+                # maybe this should be moved to dagrun.verify_integrity
+                drs = _create_dagruns(current_task.subdag,
+                                      execution_dates=confirmed_dates,
+                                      state=State.RUNNING,
+                                      run_id_template=BackfillJob.ID_FORMAT_PREFIX)
+
+                for dr in drs:
+                    dr.dag = current_task.subdag
+                    dr.verify_integrity()
+                    if commit:
+                        dr.state = state
+                        session.merge(dr)
+
+                dags.append(current_task.subdag)
+                sub_dag_ids.append(current_task.subdag.dag_id)
+
+    # now look for the task instances that are affected
+    TI = TaskInstance
+
+    # get all tasks of the main dag that will be affected by a state change
+    qry_dag = session.query(TI).filter(
+        TI.dag_id==dag.dag_id,
+        TI.execution_date.in_(confirmed_dates),
+        TI.task_id.in_(task_ids)).filter(
+        or_(TI.state.is_(None),
+            TI.state != state)
+    )
+
+    # get *all* tasks of the sub dags
+    if len(sub_dag_ids) > 0:
+        qry_sub_dag = session.query(TI).filter(
+            TI.dag_id.in_(sub_dag_ids),
+            TI.execution_date.in_(confirmed_dates)).filter(
+            or_(TI.state.is_(None),
+                TI.state != state)
+        )
+
+    if commit:
+        tis_altered = qry_dag.with_for_update().all()
+        if len(sub_dag_ids) > 0:
+            tis_altered += qry_sub_dag.with_for_update().all()
+        for ti in tis_altered:
+            ti.state = state
+        session.commit()
+    else:
+        tis_altered = qry_dag.all()
+        if len(sub_dag_ids) > 0:
+            tis_altered += qry_sub_dag.all()
+
+    session.close()
+
+    return tis_altered
+

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1632,6 +1632,8 @@ class BackfillJob(BaseJob):
     triggers a set of task instance runs, in the right order and lasts for
     as long as it takes for the set of task instance to be completed.
     """
+    ID_PREFIX = 'backfill_'
+    ID_FORMAT_PREFIX = ID_PREFIX + '{0}'
 
     __mapper_args__ = {
         'polymorphic_identity': 'BackfillJob'
@@ -1716,7 +1718,7 @@ class BackfillJob(BaseJob):
 
         active_dag_runs = []
         while next_run_date and next_run_date <= end_date:
-            run_id = 'backfill_' + next_run_date.isoformat()
+            run_id = BackfillJob.ID_FORMAT_PREFIX.format(next_run_date.isoformat())
 
             # check if we are scheduling on top of a already existing dag_run
             # we could find a "scheduled" run instead of a "backfill"

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -206,10 +206,6 @@
               type="button" class="btn" data-toggle="button">
               Downstream
             </button>
-            <button id="btn_success_recursive"
-              type="button" class="btn" data-toggle="button">
-              Recursive
-            </button>
           </span>
         </div>
         <div class="modal-footer">
@@ -340,7 +336,6 @@ function updateQueryStringParameter(uri, key, value) {
         "&downstream=" + $('#btn_success_downstream').hasClass('active') +
         "&future=" + $('#btn_success_future').hasClass('active') +
         "&past=" + $('#btn_success_past').hasClass('active') +
-        "&recursive=" + $('#btn_success_recursive').hasClass('active') +
         "&execution_date=" + execution_date +
         "&origin=" + encodeURIComponent(window.location);
 

--- a/tests/api/common/__init__.py
+++ b/tests/api/common/__init__.py
@@ -11,9 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import absolute_import
-
-from .client import *
-from .common import *
-

--- a/tests/api/common/mark_tasks.py
+++ b/tests/api/common/mark_tasks.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from airflow import models
+from airflow.api.common.experimental.mark_tasks import set_state, _create_dagruns
+from airflow.settings import Session
+from airflow.utils.dates import days_ago
+from airflow.utils.state import State
+
+
+DEV_NULL = "/dev/null"
+
+
+class TestMarkTasks(unittest.TestCase):
+    def setUp(self):
+        self.dagbag = models.DagBag(include_examples=True)
+        self.dag1 = self.dagbag.dags['test_example_bash_operator']
+        self.dag2 = self.dagbag.dags['example_subdag_operator']
+
+        self.execution_dates = [days_ago(2), days_ago(1)]
+
+        drs = _create_dagruns(self.dag1, self.execution_dates,
+                              state=State.RUNNING,
+                              run_id_template="scheduled__{}")
+        for dr in drs:
+            dr.dag = self.dag1
+            dr.verify_integrity()
+
+        drs = _create_dagruns(self.dag2,
+                              [self.dag2.default_args['start_date']],
+                              state=State.RUNNING,
+                              run_id_template="scheduled__{}")
+
+        for dr in drs:
+            dr.dag = self.dag2
+            dr.verify_integrity()
+
+        self.session = Session()
+
+    def snapshot_state(self, dag, execution_dates):
+        TI = models.TaskInstance
+        tis = self.session.query(TI).filter(
+            TI.dag_id==dag.dag_id,
+            TI.execution_date.in_(execution_dates)
+        ).all()
+
+        self.session.expunge_all()
+
+        return tis
+
+    def verify_state(self, dag, task_ids, execution_dates, state, old_tis):
+        TI = models.TaskInstance
+
+        tis = self.session.query(TI).filter(
+            TI.dag_id==dag.dag_id,
+            TI.execution_date.in_(execution_dates)
+        ).all()
+
+        self.assertTrue(len(tis) > 0)
+
+        for ti in tis:
+            if ti.task_id in task_ids and ti.execution_date in execution_dates:
+                self.assertEqual(ti.state, state)
+            else:
+                for old_ti in old_tis:
+                    if (old_ti.task_id == ti.task_id
+                            and old_ti.execution_date == ti.execution_date):
+                            self.assertEqual(ti.state, old_ti.state)
+
+    def test_mark_tasks_now(self):
+        # set one task to success but do not commit
+        snapshot = self.snapshot_state(self.dag1, self.execution_dates)
+        task = self.dag1.get_task("runme_1")
+        altered = set_state(task=task, execution_date=self.execution_dates[0],
+                            upstream=False, downstream=False, future=False,
+                            past=False, state=State.SUCCESS, commit=False)
+        self.assertEqual(len(altered), 1)
+        self.verify_state(self.dag1, [task.task_id], [self.execution_dates[0]],
+                          None, snapshot)
+
+        # set one and only one task to success
+        altered = set_state(task=task, execution_date=self.execution_dates[0],
+                            upstream=False, downstream=False, future=False,
+                            past=False, state=State.SUCCESS, commit=True)
+        self.assertEqual(len(altered), 1)
+        self.verify_state(self.dag1, [task.task_id], [self.execution_dates[0]],
+                          State.SUCCESS, snapshot)
+
+        # set no tasks
+        altered = set_state(task=task, execution_date=self.execution_dates[0],
+                            upstream=False, downstream=False, future=False,
+                            past=False, state=State.SUCCESS, commit=True)
+        self.assertEqual(len(altered), 0)
+        self.verify_state(self.dag1, [task.task_id], [self.execution_dates[0]],
+                          State.SUCCESS, snapshot)
+
+        # set task to other than success
+        altered = set_state(task=task, execution_date=self.execution_dates[0],
+                            upstream=False, downstream=False, future=False,
+                            past=False, state=State.FAILED, commit=True)
+        self.assertEqual(len(altered), 1)
+        self.verify_state(self.dag1, [task.task_id], [self.execution_dates[0]],
+                          State.FAILED, snapshot)
+
+        # dont alter other tasks
+        snapshot = self.snapshot_state(self.dag1, self.execution_dates)
+        task = self.dag1.get_task("runme_0")
+        altered = set_state(task=task, execution_date=self.execution_dates[0],
+                            upstream=False, downstream=False, future=False,
+                            past=False, state=State.SUCCESS, commit=True)
+        self.assertEqual(len(altered), 1)
+        self.verify_state(self.dag1, [task.task_id], [self.execution_dates[0]],
+                          State.SUCCESS, snapshot)
+
+    def test_mark_downstream(self):
+        # test downstream
+        snapshot = self.snapshot_state(self.dag1, self.execution_dates)
+        task = self.dag1.get_task("runme_1")
+        relatives = task.get_flat_relatives(upstream=False)
+        task_ids = [t.task_id for t in relatives]
+        task_ids.append(task.task_id)
+
+        altered = set_state(task=task, execution_date=self.execution_dates[0],
+                            upstream=False, downstream=True, future=False,
+                            past=False, state=State.SUCCESS, commit=True)
+        self.assertEqual(len(altered), 3)
+        self.verify_state(self.dag1, task_ids, [self.execution_dates[0]],
+                          State.SUCCESS, snapshot)
+
+    def test_mark_upstream(self):
+        # test upstream
+        snapshot = self.snapshot_state(self.dag1, self.execution_dates)
+        task = self.dag1.get_task("run_after_loop")
+        relatives = task.get_flat_relatives(upstream=True)
+        task_ids = [t.task_id for t in relatives]
+        task_ids.append(task.task_id)
+
+        altered = set_state(task=task, execution_date=self.execution_dates[0],
+                            upstream=True, downstream=False, future=False,
+                            past=False, state=State.SUCCESS, commit=True)
+        self.assertEqual(len(altered), 4)
+        self.verify_state(self.dag1, task_ids, [self.execution_dates[0]],
+                          State.SUCCESS, snapshot)
+
+    def test_mark_tasks_future(self):
+        # set one task to success towards end of scheduled dag runs
+        snapshot = self.snapshot_state(self.dag1, self.execution_dates)
+        task = self.dag1.get_task("runme_1")
+        altered = set_state(task=task, execution_date=self.execution_dates[0],
+                            upstream=False, downstream=False, future=True,
+                            past=False, state=State.SUCCESS, commit=True)
+        self.assertEqual(len(altered), 2)
+        self.verify_state(self.dag1, [task.task_id], self.execution_dates,
+                          State.SUCCESS, snapshot)
+
+    def test_mark_tasks_past(self):
+        # set one task to success towards end of scheduled dag runs
+        snapshot = self.snapshot_state(self.dag1, self.execution_dates)
+        task = self.dag1.get_task("runme_1")
+        altered = set_state(task=task, execution_date=self.execution_dates[1],
+                            upstream=False, downstream=False, future=False,
+                            past=True, state=State.SUCCESS, commit=True)
+        self.assertEqual(len(altered), 2)
+        self.verify_state(self.dag1, [task.task_id], self.execution_dates,
+                          State.SUCCESS, snapshot)
+
+    def test_mark_tasks_subdag(self):
+        # set one task to success towards end of scheduled dag runs
+        task = self.dag2.get_task("section-1")
+        relatives = task.get_flat_relatives(upstream=False)
+        task_ids = [t.task_id for t in relatives]
+        task_ids.append(task.task_id)
+
+        altered = set_state(task=task, execution_date=self.execution_dates[0],
+                            upstream=False, downstream=True, future=False,
+                            past=False, state=State.SUCCESS, commit=True)
+        self.assertEqual(len(altered), 14)
+
+        # cannot use snapshot here as that will require drilling down the
+        # the sub dag tree essentially recreating the same code as in the
+        # tested logic.
+        self.verify_state(self.dag2, task_ids, [self.execution_dates[0]],
+                          State.SUCCESS, [])
+
+    def tearDown(self):
+        self.dag1.clear()
+        self.dag2.clear()
+
+        # just to make sure we are fully cleaned up
+        self.session.query(models.DagRun).delete()
+        self.session.query(models.TaskInstance).delete()
+        self.session.commit()
+
+        self.session.close()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/dags/test_example_bash_operator.py
+++ b/tests/dags/test_example_bash_operator.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import airflow
+from builtins import range
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.models import DAG
+from datetime import timedelta
+
+
+args = {
+    'owner': 'airflow',
+    'start_date': airflow.utils.dates.days_ago(2)
+}
+
+dag = DAG(
+    dag_id='test_example_bash_operator', default_args=args,
+    schedule_interval='0 0 * * *',
+    dagrun_timeout=timedelta(minutes=60))
+
+cmd = 'ls -l'
+run_this_last = DummyOperator(task_id='run_this_last', dag=dag)
+
+run_this = BashOperator(
+    task_id='run_after_loop', bash_command='echo 1', dag=dag)
+run_this.set_downstream(run_this_last)
+
+for i in range(3):
+    i = str(i)
+    task = BashOperator(
+        task_id='runme_'+i,
+        bash_command='echo "{{ task_instance_key_str }}" && sleep 1',
+        dag=dag)
+    task.set_downstream(run_this)
+
+task = BashOperator(
+    task_id='also_run_this',
+    bash_command='echo "run_id={{ run_id }} | dag_run={{ dag_run }}"',
+    dag=dag)
+task.set_downstream(run_this_last)
+
+if __name__ == "__main__":
+    dag.cli()

--- a/tests/models.py
+++ b/tests/models.py
@@ -188,7 +188,7 @@ class DagBagTest(unittest.TestCase):
         class TestDagBag(models.DagBag):
             process_file_calls = 0
             def process_file(self, filepath, only_if_updated=True, safe_mode=True):
-                if 'example_bash_operator.py' in filepath:
+                if 'example_bash_operator.py' == os.path.basename(filepath):
                     TestDagBag.process_file_calls += 1
                 super(TestDagBag, self).process_file(filepath, only_if_updated, safe_mode)
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-869

Mark success was buggy and was directly creating and changing task instances, without considering dag runs. This patch removes direct database access from views.py and puts it in the API, making it ready for future use.  

* The recursive has been removed. It made no sense in my opinion. SubDags and their tasks are always considered. 
* It is dependent on existing dag runs. You cannot add a task instance somewhere in the middle of no-where.
* It will create dag runs for subdags to ensure consistency.

@aoen @r39132 @toddychen please provide feedback, the functionality itself should be working and testable in a local dev environment.