### PR TITLE
[AIRFLOW-843] Store exceptions on task_instance

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1429,6 +1429,7 @@ class TaskInstance(Base):
         logging.exception(error)
         task = self.task
         session = settings.Session()
+        self.exception = error
         self.end_date = datetime.now()
         self.set_duration()
         Stats.incr('operator_failures_{}'.format(task.__class__.__name__), 1, 1)

--- a/tests/core.py
+++ b/tests/core.py
@@ -438,6 +438,26 @@ class CoreTest(unittest.TestCase):
             os.kill(pid, signal.SIGTERM)
             self.fail("BashOperator's subprocess still running after stopping on timeout!")
 
+    def test_on_failure_callback(self):
+        # Annoying workaround for nonlocal not existing in python 2
+        data = {'called': False}
+
+        def check_failure(context, test_case=self):
+            data['called'] = True
+            error = getattr(context['task_instance'], 'exception', None)
+            test_case.assertIsInstance(error, AirflowException)
+
+        t = BashOperator(
+            task_id='check_on_failure_callback',
+            bash_command="exit 1",
+            dag=self.dag,
+            on_failure_callback=check_failure)
+        self.assertRaises(
+            exceptions.AirflowException,
+            t.run,
+            start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        self.assertTrue(data['called'])
+
     def test_trigger_dagrun(self):
         def trigga(context, obj):
             if True:


### PR DESCRIPTION
Store exceptions encountered executing a task on the task instance
object, making it available for on_failure_callback handlers.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-843

Testing Done:
- Added unit test to check that running a bash operator that returns a non-zero exit code stores the appropriate exception on the task instance
