### PR TITLE
[AIRFLOW-886][AIRFLOW-887] Pass result to post_execute() hook

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -11,6 +11,15 @@ assists people when migrating to a new version.
 
 A new DaskExecutor allows Airflow tasks to be run in Dask Distributed clusters.
 
+### Deprecated Features
+These features are marked for deprecation. They may still work (and raise a `DeprecationWarning`), but are no longer
+supported and will be removed entirely in Airflow 2.0
+
+- `post_execute()` hooks now take two arguments, `context` and `result`
+  (AIRFLOW-886)
+
+  Previously, post_execute() only took one argument, `context`.
+
 ## Airflow 1.8
 
 ### Database

--- a/setup.py
+++ b/setup.py
@@ -209,7 +209,7 @@ def do_setup():
             'flask-swagger==0.2.13',
             'flask-wtf==0.12',
             'funcsigs==1.0.0',
-            'future>=0.15.0, <0.16',
+            'future>=0.15.0, <0.17',
             'gitpython>=2.0.2',
             'gunicorn>=19.3.0, <19.4.0',  # 19.4.? seemed to have issues
             'jinja2>=2.7.3, <2.9.0',


### PR DESCRIPTION
The post_execute() hook should receive
the Operator result in addition to the
execution context.

In addition, add support for python-future v0.16.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-886
- https://issues.apache.org/jira/browse/AIRFLOW-887

Testing Done:
- added unit tests