### PR TITLE
[AIRFLOW-888] Don't automatically push XComs

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -7,18 +7,19 @@ assists people when migrating to a new version.
 
 ### New Features
 
-#### Dask Executor
-
-A new DaskExecutor allows Airflow tasks to be run in Dask Distributed clusters.
+- [AIRFLOW-862] A new DaskExecutor allows Airflow tasks to be run in Dask Distributed clusters
 
 ### Deprecated Features
 These features are marked for deprecation. They may still work (and raise a `DeprecationWarning`), but are no longer
-supported and will be removed entirely in Airflow 2.0
+supported and will be removed entirely in a future version of Airflow.
 
-- `post_execute()` hooks now take two arguments, `context` and `result`
-  (AIRFLOW-886)
+- [AIRFLOW-886] `post_execute()` hooks now take two arguments, `context` and `result`. Previously, post_execute() only took one argument, `context`.
 
-  Previously, post_execute() only took one argument, `context`.
+### Breaking Changes
+These changes are not backwards-compatible with previous versions of Airflow.
+
+- [AIRFLOW-888] Operators no longer automatically push XComs. This behavior can be reenabled globally
+  by setting `auto_xcom_push = True` in the `operators` setting of Airflow.cfg or on a per-Operator basis by passing `auto_xcom_push=True` when creating the Operator.
 
 ## Airflow 1.8
 
@@ -47,8 +48,8 @@ interfere.
 Please read through these options, defaults have changed since 1.7.1.
 
 #### child_process_log_directory
-In order the increase the robustness of the scheduler, DAGS our now processed in their own process. Therefore each 
-DAG has its own log file for the scheduler. These are placed in `child_process_log_directory` which defaults to 
+In order the increase the robustness of the scheduler, DAGS our now processed in their own process. Therefore each
+DAG has its own log file for the scheduler. These are placed in `child_process_log_directory` which defaults to
 `<AIRFLOW_HOME>/scheduler/latest`. You will need to make sure these log files are removed.
 
 > DAG logs or processor logs ignore and command line settings for log file locations.
@@ -58,7 +59,7 @@ Previously the command line option `num_runs` was used to let the scheduler term
 loops. This is now time bound and defaults to `-1`, which means run continuously. See also num_runs.
 
 #### num_runs
-Previously `num_runs` was used to let the scheduler terminate after a certain amount of loops. Now num_runs specifies 
+Previously `num_runs` was used to let the scheduler terminate after a certain amount of loops. Now num_runs specifies
 the number of times to try to schedule each DAG file within `run_duration` time. Defaults to `-1`, which means try
 indefinitely. This is only available on the command line.
 
@@ -71,7 +72,7 @@ dags are not being picked up, have a look at this number and decrease it when ne
 
 #### catchup_by_default
 By default the scheduler will fill any missing interval DAG Runs between the last execution date and the current date.
-This setting changes that behavior to only execute the latest interval. This can also be specified per DAG as 
+This setting changes that behavior to only execute the latest interval. This can also be specified per DAG as
 `catchup = False / True`. Command line backfills will still work.
 
 ### Faulty Dags do not show an error in the Web UI
@@ -95,33 +96,33 @@ convenience variables to the config. In case your run a sceure Hadoop setup it m
 required to whitelist these variables by adding the following to your configuration:
 
 ```
-<property> 
+<property>
      <name>hive.security.authorization.sqlstd.confwhitelist.append</name>
      <value>airflow\.ctx\..*</value>
 </property>
 ```
 ### Google Cloud Operator and Hook alignment
 
-All Google Cloud Operators and Hooks are aligned and use the same client library. Now you have a single connection 
+All Google Cloud Operators and Hooks are aligned and use the same client library. Now you have a single connection
 type for all kinds of Google Cloud Operators.
 
 If you experience problems connecting with your operator make sure you set the connection type "Google Cloud Platform".
 
-Also the old P12 key file type is not supported anymore and only the new JSON key files are supported as a service 
+Also the old P12 key file type is not supported anymore and only the new JSON key files are supported as a service
 account.
 
 ### Deprecated Features
-These features are marked for deprecation. They may still work (and raise a `DeprecationWarning`), but are no longer 
+These features are marked for deprecation. They may still work (and raise a `DeprecationWarning`), but are no longer
 supported and will be removed entirely in Airflow 2.0
 
 - Hooks and operators must be imported from their respective submodules
 
-  `airflow.operators.PigOperator` is no longer supported; `from airflow.operators.pig_operator import PigOperator` is. 
+  `airflow.operators.PigOperator` is no longer supported; `from airflow.operators.pig_operator import PigOperator` is.
   (AIRFLOW-31, AIRFLOW-200)
 
 - Operators no longer accept arbitrary arguments
 
-  Previously, `Operator.__init__()` accepted any arguments (either positional `*args` or keyword `**kwargs`) without 
+  Previously, `Operator.__init__()` accepted any arguments (either positional `*args` or keyword `**kwargs`) without
   complaint. Now, invalid arguments will be rejected. (https://github.com/apache/incubator-airflow/pull/1285)
 
 ### Known Issues

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -180,6 +180,7 @@ security =
 # values at runtime)
 unit_test_mode = False
 
+
 [cli]
 # In what way should the cli access the API. The LocalClient will use the
 # database directly, while the json_client will use the api running on the
@@ -187,9 +188,11 @@ unit_test_mode = False
 api_client = airflow.api.client.local_client
 endpoint_url = http://localhost:8080
 
+
 [api]
 # How to authenticate users of the API
 auth_backend = airflow.api.auth.backend.default
+
 
 [operators]
 # The default owner assigned to each new operator, unless
@@ -199,6 +202,11 @@ default_cpus = 1
 default_ram = 512
 default_disk = 512
 default_gpus = 0
+
+# Operators should automatically push XComs containing their results. This sets
+# the default value for a parameter with the same name than can be passed to
+# individual Operators.
+auto_xcom_push = False
 
 
 [webserver]
@@ -279,6 +287,7 @@ log_fetch_timeout_sec = 5
 # By default, the webserver shows paused DAGs. Flip this to hide paused
 # DAGs by default
 hide_paused_dags_by_default = False
+
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp

--- a/airflow/example_dags/example_xcom.py
+++ b/airflow/example_dags/example_xcom.py
@@ -36,6 +36,7 @@ def push(**kwargs):
     kwargs['ti'].xcom_push(key='value from pusher 1', value=value_1)
 
 
+# this requires changing the default configuration
 def push_by_returning(**kwargs):
     # pushes an XCom without a specific target, just by returning it
     return value_2
@@ -61,7 +62,10 @@ push1 = PythonOperator(
     task_id='push', dag=dag, python_callable=push)
 
 push2 = PythonOperator(
-    task_id='push_by_returning', dag=dag, python_callable=push_by_returning)
+    task_id='push_by_returning',
+    dag=dag,
+    python_callable=push_by_returning,
+    auto_xcom_push=True)
 
 pull = PythonOperator(
     task_id='puller', dag=dag, python_callable=puller)


### PR DESCRIPTION
XComs are no longer automatically pushed by Operators that return values, but
the behavior can be enabled in airflow.cfg or on a per-operator basis.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-888

Testing Done:
- Added unit test