### PR TITLE
[AIRFLOW-892] prevent AttributeError on HiveMetastoreHook calls

### DIFF
--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -299,6 +299,7 @@ class NamedHivePartitionSensor(BaseSensorOperator):
 
     def poke(self, context):
 
+        from airflow.hooks.hive_hooks import HiveMetastoreHook
         if not hasattr(self, 'hook'):
             self.hook = airflow.hooks.hive_hooks.HiveMetastoreHook(
                 metastore_conn_id=self.metastore_conn_id)
@@ -368,6 +369,7 @@ class HivePartitionSensor(BaseSensorOperator):
         logging.info(
             'Poking for table {self.schema}.{self.table}, '
             'partition {self.partition}'.format(**locals()))
+        from airflow.hooks.hive_hooks import HiveMetastoreHook
         if not hasattr(self, 'hook'):
             self.hook = airflow.hooks.hive_hooks.HiveMetastoreHook(
                 metastore_conn_id=self.metastore_conn_id)


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-892

Testing Done:
- none, I have to figure out how to create a mock metastore and I'm only starting with this thing; here's what I used:
```python
from airflow.operators.sensors import HivePartitionSensor
foo=HivePartitionSensor(table='pageattributes',task_id='foo',metastore_conn_id='metastore_default')
foo.poke({})
```
this raises a AttributeError exception without the patch, and thrift.transport.TTransport.TTransportException: Could not connect to localhost:9083 with the patch

I guess catching the right exception would be enough?