### PR TITLE
[AIRFLOW-893] Fix crashing webservers when a dagrun has no start date

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -108,7 +108,7 @@
                 <td class="text-nowrap">
                     {% if dag %}
                         {% set last_run = dag.get_last_dagrun(include_externally_triggered=True) %}
-                        {% if last_run %}
+                        {% if last_run and last_run.start_date %}
                             <a href="{{ url_for('airflow.graph', dag_id=last_run.dag_id, execution_date=last_run.execution_date ) }}">
                                 {{ last_run.execution_date.strftime("%Y-%m-%d %H:%M") }}
                             </a> <span id="statuses_info" class="glyphicon glyphicon-info-sign" aria-hidden="true" title="Start Date: {{last_run.start_date.strftime('%Y-%m-%d %H:%M')}}"></span>


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-893

This commit introduced a bug: [AIRFLOW-510] Filter Paused Dags, show Last Run & Trigger Dag
7c94d81c390881643f94d5e3d7d6fb351a445b72

Where webservers will crash if a dagrun does not have a start date set. This PR fixes the problem.

@artwr @bolkedebruin @btallman 
