### PR TITLE
[AIRFLOW-892] prevent AttributeError on HiveMetastoreHook calls

### DIFF
--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -299,6 +299,7 @@ class NamedHivePartitionSensor(BaseSensorOperator):
 
     def poke(self, context):
 
+        import airflow.hooks.hive_hooks
         if not hasattr(self, 'hook'):
             self.hook = airflow.hooks.hive_hooks.HiveMetastoreHook(
                 metastore_conn_id=self.metastore_conn_id)
@@ -368,6 +369,7 @@ class HivePartitionSensor(BaseSensorOperator):
         logging.info(
             'Poking for table {self.schema}.{self.table}, '
             'partition {self.partition}'.format(**locals()))
+        import airflow.hooks.hive_hooks
         if not hasattr(self, 'hook'):
             self.hook = airflow.hooks.hive_hooks.HiveMetastoreHook(
                 metastore_conn_id=self.metastore_conn_id)

--- a/tests/operators/sensors.py
+++ b/tests/operators/sensors.py
@@ -200,7 +200,6 @@ class HivePartitionSensorTests(unittest.TestCase):
         from thrift.transport.TTransport import TTransportException
         task = HivePartitionSensor(
             table='fake_table',
-            http_conn_id='metastore_default',
             poke_interval=5,
             task_id="fake_task_id")
         with self.assertRaises(TTransportException):
@@ -223,7 +222,6 @@ class NamedHivePartitionSensorTests(unittest.TestCase):
         from thrift.transport.TTransport import TTransportException
         task = NamedHivePartitionSensor(
             partition_names=['fake_schema.fake_table/ds=42'],
-            http_conn_id='metastore_default',
             poke_interval=5,
             task_id="fake_task_id")
         with self.assertRaises(TTransportException):

--- a/tests/operators/sensors.py
+++ b/tests/operators/sensors.py
@@ -22,7 +22,8 @@ import unittest
 from datetime import datetime, timedelta
 
 from airflow import DAG, configuration
-from airflow.operators.sensors import HttpSensor, BaseSensorOperator, HdfsSensor
+from airflow.operators.sensors import HttpSensor, BaseSensorOperator, HdfsSensor, HivePartitionSensor, \
+    NamedHivePartitionSensor
 from airflow.utils.decorators import apply_defaults
 from airflow.exceptions import (AirflowException,
                                 AirflowSensorTimeout,
@@ -180,4 +181,50 @@ class HdfsSensorTests(unittest.TestCase):
         # When
         # Then
         with self.assertRaises(AirflowSensorTimeout):
+            task.execute(None)
+
+
+class HivePartitionSensorTests(unittest.TestCase):
+
+    def setUp(self):
+        self.logger = logging.getLogger()
+        self.logger.setLevel(logging.DEBUG)
+
+    def test_poke_exception(self):
+        """
+        AttributeError exception occurs when airflow.hooks.hive_hooks is not imported,
+        thrift.transport.TTransport.TTransportException otherwise
+        This tests [AIRLFOW-]
+        """
+        self.logger.info("Test for proper HiveMetastoreHook behaviour in HivePartitionSensor")
+        from thrift.transport.TTransport import TTransportException
+        task = HivePartitionSensor(
+            table='fake_table',
+            http_conn_id='metastore_default',
+            poke_interval=5,
+            task_id="fake_task_id")
+        with self.assertRaises(TTransportException):
+            task.execute(None)
+
+
+class NamedHivePartitionSensorTests(unittest.TestCase):
+
+    def setUp(self):
+        self.logger = logging.getLogger()
+        self.logger.setLevel(logging.DEBUG)
+
+    def test_poke_exception(self):
+        """
+        AttributeError exception occurs when airflow.hooks.hive_hooks is not imported,
+        thrift.transport.TTransport.TTransportException otherwise
+        This tests [AIRLFOW-]
+        """
+        self.logger.info("Test for proper HiveMetastoreHook behaviour in HivePartitionSensor")
+        from thrift.transport.TTransport import TTransportException
+        task = NamedHivePartitionSensor(
+            partition_names=['fake_schema.fake_table/ds=42'],
+            http_conn_id='metastore_default',
+            poke_interval=5,
+            task_id="fake_task_id")
+        with self.assertRaises(TTransportException):
             task.execute(None)


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-892

Testing Done: 2 tests added in tests/operators/sensors.py