### PR TITLE
[AIRFLOW-899] Tasks in SCHEDULED state should be white in the UI instead of black

### DIFF
--- a/airflow/www/static/tree.css
+++ b/airflow/www/static/tree.css
@@ -38,7 +38,7 @@ rect.state {
     shape-rendering: crispEdges;
     cursor: pointer;
 }
-rect.null, rect.undefined {
+rect.null, rect.scheduled, rect.undefined {
     fill: white;
 }
 rect.success {


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-899

Tasks in SCHEDULED state should be white in the UI instead of black

Testing Done:
- Spun up a webserver

@artwr @bolkedebruin @criccomini 