### PR TITLE
AIRFLOW-906 Update Code icon from lightning bolt to file

### DIFF
--- a/airflow/www/static/bootstrap-theme.css
+++ b/airflow/www/static/bootstrap-theme.css
@@ -3068,7 +3068,7 @@ tbody.collapse.in {
 .glyphicon-log-in:before {
   content: "\e161";
 }
-.glyphicon-flash:before {
+.glyphicon-file:before {
   content: "\e162";
 }
 .glyphicon-log-out:before {

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -90,7 +90,7 @@
       </li>
       <li>
         <a href="{{ url_for("airflow.code", dag_id=dag.dag_id, root=root) }}">
-          <span class="glyphicon glyphicon-flash" aria-hidden="true"></span>
+          <span class="glyphicon glyphicon-file" aria-hidden="true"></span>
           Code
         </a>
       </li>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -167,7 +167,7 @@
 
                 <!-- Code -->
                 <a href="{{ url_for("airflow.code", dag_id=dag.dag_id) }}" title="Code View">
-                    <span class="glyphicon glyphicon-flash" aria-hidden="true"></span>
+                    <span class="glyphicon glyphicon-file" aria-hidden="true"></span>
                 </a>
 
                 <!-- Logs -->

--- a/airflow/www/templates/airflow/list_dags.html
+++ b/airflow/www/templates/airflow/list_dags.html
@@ -167,7 +167,7 @@
                 <i class="icon-align-left"></i>
               </a>
               <a href="{{ url_for("airflow.code", dag_id=row.dag_id) }}" title="Code View">
-                <span class="glyphicon glyphicon-flash" aria-hidden="true"></span>
+                <span class="glyphicon glyphicon-file" aria-hidden="true"></span>
               </a>
               <a href="{{ url_for("airflow.refresh", dag_id=row.dag_id) }}" title="Refresh">
                 <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>


### PR DESCRIPTION
Lightning bolts are not a visual metaphor for code or files. Since Glyphicon doesn't have a code icon (<>, for instance), we should use its file icon.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
AIRFLOW-906

Testing Done:
None.

Before/After screenshots in AIRFLOW-906 (https://issues.apache.org/jira/browse/AIRFLOW-906)