### PR TITLE
[AIRFLOW-916] Remove deprecated readfp function

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -545,7 +545,7 @@ class AirflowConfigParser(ConfigParser):
         # Python 2 requires StringIO buffer
         else:
             import StringIO
-            self.readfp(StringIO.StringIO(string))
+            self.read_file(StringIO.StringIO(string))
 
     def _validate(self):
         if (


### PR DESCRIPTION
ConfigParser.readfp() is deprecated in favor of read_file(), as described in warning messages shown in unit tests

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-916

