### PR TITLE
[AIRFLOW-919] Running tasks with no start date shouldn't break a DAGs UI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,5 @@
-Dear Airflow Maintainers,
-
 Please accept this PR that addresses the following issues:
-- *(replace with a link to AIRFLOW-X)*
-
-Per Apache guidelines you need to create a [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW/).
+- *(MANDATORY - replace with a link to JIRA - e.g. https://issues.apache.org/jira/browse/AIRFLOW-XXX)*
 
 Testing Done:
 - Unittests are required, if you do not include new unit tests please

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1220,7 +1220,8 @@ class Airflow(BaseView):
                 children_key = "_children"
 
             def set_duration(tid):
-                if isinstance(tid, dict) and tid.get("state") == State.RUNNING:
+                if (isinstance(tid, dict) and tid.get("state") == State.RUNNING and
+                        tid["start_date"] is not None):
                     d = datetime.now() - dateutil.parser.parse(tid["start_date"])
                     tid["duration"] = d.total_seconds()
                 return tid


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-919

I also made the airflow PR template a little bit less verbose (requires less edits when creating a PR).

Testing Done:
- Ran a webserver with this case and made sure that the DAG page loaded

@bolkedebruin @saguziel @artwr 