### PR TITLE
add mytaxi to the list of companies using airflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Currently **officially** using Airflow:
 1. [Markovian](https://markovian.com/) [[@al-xv](https://github.com/al-xv), [@skogsbaeck](https://github.com/skogsbaeck), [@waltherg](https://github.com/waltherg)]
 1. [Mercadoni](https://www.mercadoni.com.co) [[@demorenoc](https://github.com/demorenoc)]
 1. [MFG Labs](https://github.com/MfgLabs)
+1. [mytaxi](https://mytaxi.com) [[@mytaxi](https://github.com/mytaxi)]
 1. [Nerdwallet](https://www.nerdwallet.com)
 1. [OfferUp](https://offerupnow.com)
 1. [OneFineStay](https://www.onefinestay.com) [[@slangwald](https://github.com/slangwald)]


### PR DESCRIPTION
Edited the readme with github handle for mytaxi. We are using airflow with our etl since mid of 2016.
