### PR TITLE
[AIRFLOW-931] attempt to re-run QUEUED tasks to avoid LocalExecutor race condition

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1043,7 +1043,7 @@ class SchedulerJob(BaseJob):
 
                 if dag_id not in dag_id_to_running_task_count:
                     dag_id_to_running_task_count[dag_id] = \
-                        DagRun.get_running_tasks(
+                        DagRun.get_running_or_queued_tasks(
                             session,
                             dag_id,
                             simple_dag_bag.get_dag(dag_id).task_ids)
@@ -1434,7 +1434,7 @@ class SchedulerJob(BaseJob):
                                                           State.NONE)
 
                 self._execute_task_instances(simple_dag_bag,
-                                             (State.SCHEDULED,))
+                                             (State.QUEUED, State.SCHEDULED,))
 
             # Call hearbeats
             self.logger.info("Heartbeating the executor")

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4077,22 +4077,22 @@ class DagRun(Base):
         session.commit()
 
     @staticmethod
-    def get_running_tasks(session, dag_id, task_ids):
+    def get_running_or_queued_tasks(session, dag_id, task_ids):
         """
-        Returns the number of tasks running in the given DAG.
+        Returns the number of tasks running or queued in the given DAG.
 
         :param session: ORM session
         :param dag_id: ID of the DAG to get the task concurrency of
         :type dag_id: unicode
         :param task_ids: A list of valid task IDs for the given DAG
         :type task_ids: list[unicode]
-        :return: The number of running tasks
+        :return: The number of running or queued tasks
         :rtype: int
         """
         qry = session.query(func.count(TaskInstance.task_id)).filter(
             TaskInstance.dag_id == dag_id,
             TaskInstance.task_id.in_(task_ids),
-            TaskInstance.state == State.RUNNING,
+            TaskInstance.state == State.RUNNING or TaskInstance.state == State.QUEUED,
         )
         return qry.scalar()
 

--- a/tests/dags/test_queued_with_concurrency.py
+++ b/tests/dags/test_queued_with_concurrency.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+Addresses issue [AIRFLOW-931]
+DAG designed to test what happens when a DAG with concurrency > 1
+kicks off with multiple non-dependent tasks
+Note this will have to run with LocalExecutor to actually run into the
+race condition
+"""
+from datetime import datetime
+
+from airflow.models import DAG
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.subdag_operator import SubDagOperator
+from airflow.utils.trigger_rule import TriggerRule
+import time
+
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+default_args = dict(
+    start_date=DEFAULT_DATE,
+    owner='airflow')
+
+concurrency_dag = DAG(dag_id='test_queued_with_concurrency_dag', concurrency=2, default_args=default_args)
+
+
+def pausing_callable():
+    time.sleep(5)
+
+task1 = PythonOperator(
+    task_id='test_concurrency_1',
+    python_callable=pausing_callable,
+    dag=concurrency_dag)
+
+task2 = PythonOperator(
+    task_id='test_concurrency_2',
+    python_callable=pausing_callable,
+    dag=concurrency_dag)
+
+task3 = PythonOperator(
+    task_id='test_concurrency_3',
+    python_callable=pausing_callable,
+    dag=concurrency_dag)
+
+task4 = PythonOperator(
+    task_id='test_concurrency_4',
+    python_callable=pausing_callable,
+    dag=concurrency_dag)

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -358,6 +358,22 @@ class SchedulerJobTest(unittest.TestCase):
             },
             dagrun_state=State.FAILED)
 
+    def test_queued_with_concurrency(self):
+        """
+        [AIRFLOW-931] DagRuns with multiple non-dependent tasks and concurrency > 1 should succeed
+        Note this test doesn't actually prove the fix works as the tests run on SequentialExecutor
+        which doesn't have the same race condition problem that LocalExecutor does.
+        """
+        self.evaluate_dagrun(
+            dag_id='test_queued_with_concurrency_dag',
+            expected_task_states={
+                'test_concurrency_1': State.SUCCESS,
+                'test_concurrency_2': State.SUCCESS,
+                'test_concurrency_3': State.SUCCESS,
+                'test_concurrency_4': State.SUCCESS,
+            },
+            dagrun_state=State.SUCCESS)
+
     def test_dagrun_root_fail_unfinished(self):
         """
         DagRuns with one unfinished and one failed root task -> RUNNING


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
-  https://issues.apache.org/jira/browse/AIRFLOW-931

Testing Done:
- I added a test, but the problem is only found when using LocalExecutor. The test passes with SequentialExecutor (trivially, as the race condition doesn't happen there). I tried manually setting things up to run the unit tests with LocalExecutor but couldn't get it working.  However when installing from master and running the `test_queued_with_concurrency_dag` I added it would always get stuck with two of the tasks as enqueued but never running.  My branch stops that from happening.

It's also worth noting that https://github.com/apache/incubator-airflow/commit/ef6dd1b29b794c5e0fd4f2bc8422a386395950f5 breaks things on python 2.7.10. I had to manually revert that in order to test all of this. 



