### PR TITLE
[AIRFLOW-933] use ast.literal_eval rather than eval.

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -44,6 +44,7 @@ from flask._compat import PY2
 import jinja2
 import markdown
 import nvd3
+import ast
 
 from wtforms import (
     Form, SelectField, TextAreaField, PasswordField, StringField, validators)
@@ -168,7 +169,7 @@ def nobr_f(v, c, m, p):
 
 def label_link(v, c, m, p):
     try:
-        default_params = eval(m.default_params)
+        default_params = ast.literal_eval(m.default_params)
     except:
         default_params = {}
     url = url_for(


### PR DESCRIPTION
This PR addresses the following issues:

(https://issues.apache.org/jira/browse/AIRFLOW-933)
Testing

This PR is trying to solve a secure issue. The test was done by setting up a local web server and reproduce the issue described in JIRA link above.

@bolkedebruin

Note: updated commit message.
