### PR TITLE
[AIRFLOW-55] Add support for HDFS remote logging

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -494,6 +494,9 @@ def run(args, dag=None):
         # GCS
         elif remote_base.startswith('gs:/'):
             logging_utils.GCSLog().write(log, remote_log_location)
+        # HDFS
+        elif remote_base.startswith('hdfs:/'):
+            logging_utils.HDFSLog().write(log, remote_log_location)
         # Other
         elif remote_base and remote_base != 'None':
             logging.error(

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -36,8 +36,8 @@ dags_folder = {AIRFLOW_HOME}/dags
 base_log_folder = {AIRFLOW_HOME}/logs
 
 # Airflow can store logs remotely in AWS S3 or Google Cloud Storage. Users
-# must supply a remote location URL (starting with either 's3://...' or
-# 'gs://...') and an Airflow connection id that provides access to the storage
+# must supply a remote location URL (starting with either 's3://', 'gs://', or
+# 'hdfs://') and an Airflow connection id that provides access to the storage
 # location.
 remote_base_log_folder =
 remote_log_conn_id =

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -90,6 +90,7 @@ def run_command(command):
 
     return output
 
+
 _templates_dir = os.path.join(os.path.dirname(__file__), 'config_templates')
 with open(os.path.join(_templates_dir, 'default_airflow.cfg')) as f:
     DEFAULT_CONFIG = f.read()

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -753,12 +753,20 @@ class Airflow(BaseView):
                 # S3
                 if remote_log_path.startswith('s3:/'):
                     remote_log += log_utils.S3Log().read(
-                        remote_log_path, return_error=surface_log_retrieval_errors)
+                        remote_log_path,
+                        return_error=surface_log_retrieval_errors)
                     remote_log_loaded = True
                 # GCS
                 elif remote_log_path.startswith('gs:/'):
                     remote_log += log_utils.GCSLog().read(
-                        remote_log_path, return_error=surface_log_retrieval_errors)
+                        remote_log_path,
+                        return_error=surface_log_retrieval_errors)
+                    remote_log_loaded = True
+                # HDFS
+                elif remote_log_path.startswith('hdfs:/'):
+                    remote_log += log_utils.HDFSLog().read(
+                        remote_log_path,
+                        return_error=surface_log_retrieval_errors)
                     remote_log_loaded = True
                 # unsupported
                 else:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,45 +17,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import logging
 import unittest
 
-import airflow.utils.logging
 from airflow import configuration
 from airflow.exceptions import AirflowException
 from airflow.utils.operator_resources import Resources
 
-
-class LogUtilsTest(unittest.TestCase):
-
-    def test_gcs_url_parse(self):
-        """
-        Test GCS url parsing
-        """
-        logging.info(
-            'About to create a GCSLog object without a connection. This will '
-            'log an error but testing will proceed.')
-        glog = airflow.utils.logging.GCSLog()
-
-        self.assertEqual(
-            glog.parse_gcs_url('gs://bucket/path/to/blob'),
-            ('bucket', 'path/to/blob'))
-
-        # invalid URI
-        self.assertRaises(
-            AirflowException,
-            glog.parse_gcs_url,
-            'gs:/bucket/path/to/blob')
-
-        # trailing slash
-        self.assertEqual(
-            glog.parse_gcs_url('gs://bucket/path/to/blob/'),
-            ('bucket', 'path/to/blob'))
-
-        # bucket only
-        self.assertEqual(
-            glog.parse_gcs_url('gs://bucket/'),
-            ('bucket', ''))
 
 class OperatorResourcesTest(unittest.TestCase):
 

--- a/tests/utils/logging.py
+++ b/tests/utils/logging.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import logging
+import unittest
+
+from airflow.utils.logging import GCSLog, HDFSLog
+from airflow.exceptions import AirflowException
+
+
+class GCSLogTest(unittest.TestCase):
+
+    def test_gcs_url_parse(self):
+        """
+        Test GCS url parsing
+        """
+        logging.info(
+            'About to create a GCSLog object without a connection. This will '
+            'log an error, but testing will proceed.')
+        glog = GCSLog()
+
+        self.assertEqual(
+            glog.parse_gcs_url('gs://bucket/path/to/blob'),
+            ('bucket', 'path/to/blob'))
+
+        # invalid URI
+        self.assertRaises(
+            AirflowException,
+            glog.parse_gcs_url,
+            'gs:/bucket/path/to/blob')
+
+        # trailing slash
+        self.assertEqual(
+            glog.parse_gcs_url('gs://bucket/path/to/blob/'),
+            ('bucket', 'path/to/blob'))
+
+        # bucket only
+        self.assertEqual(
+            glog.parse_gcs_url('gs://bucket/'),
+            ('bucket', ''))
+
+
+class HDFSLogTest(unittest.TestCase):
+
+    def test_hdfs_escape_filename(self):
+        """
+        Test HDFS escape filename
+        """
+        logging.info(
+            'About to create an HDFSLog object without a connection. This '
+            'will log an error, but testing will proceed.')
+        hdfs_log = HDFSLog()
+
+        path = hdfs_log.escape_filename(
+            '/logs/airflow/my_dag/task_1/2017-01-01T00:00:00')
+        self.assertEqual(
+            '/logs/airflow/my_dag/task_1/2017-01-01T00-00-00', path)
+
+    def test_hdfs_remove_scheme(self):
+        """
+        Test HDFS escape filename
+        """
+        logging.info(
+            'About to create an HDFSLog object without a connection. This '
+            'will log an error, but testing will proceed.')
+        hdfs_log = HDFSLog()
+
+        # with scheme
+        path = hdfs_log.remove_scheme(
+            'hdfs:///logs/airflow/my_dag/task_1/2017-01-01T00:00:00')
+        self.assertEqual(
+            '/logs/airflow/my_dag/task_1/2017-01-01T00:00:00', path)
+
+        # no scheme
+        path = hdfs_log.remove_scheme(
+            '/logs/airflow/my_dag/task_1/2017-01-01T00:00:00')
+        self.assertEqual(
+            '/logs/airflow/my_dag/task_1/2017-01-01T00:00:00', path)


### PR DESCRIPTION
Implemented using WebHDFS hook because HDFS hook (using snakebite)
does not support a copyFromLocal.

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-55

Testing Done:
- Added unit tests to test the path parsing.
- Was able to view logs in the UI that were pulled from HDFS.