### PR TITLE
[AIRFLOW-860] [AIRFLOW-935] fixes plugin executor import cycle and executor selection

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -45,7 +45,7 @@ from airflow import api
 from airflow import jobs, settings
 from airflow import configuration as conf
 from airflow.exceptions import AirflowException
-from airflow.executors import DEFAULT_EXECUTOR
+from airflow.executors import GetDefaultExecutor
 from airflow.models import (DagModel, DagBag, TaskInstance,
                             DagPickle, DagRun, Variable, DagStat,
                             Pool, Connection)
@@ -439,7 +439,7 @@ def run(args, dag=None):
                 print(e)
                 raise e
 
-        executor = DEFAULT_EXECUTOR
+        executor = GetDefaultExecutor()
         executor.start()
         print("Sending to executor.")
         executor.queue_task_instance(

--- a/airflow/executors/__init__.py
+++ b/airflow/executors/__init__.py
@@ -22,6 +22,7 @@ from airflow.executors.sequential_executor import SequentialExecutor
 
 from airflow.exceptions import AirflowException
 
+DEFAULT_EXECUTOR = None
 
 def _integrate_plugins():
     """Integrate plugins to the context."""
@@ -30,27 +31,51 @@ def _integrate_plugins():
         sys.modules[executors_module.__name__] = executors_module
         globals()[executors_module._name] = executors_module
 
-_EXECUTOR = configuration.get('core', 'EXECUTOR')
+def GetDefaultExecutor():
+    """Creates a new instance of the configured executor if none exists and returns it"""
+    global DEFAULT_EXECUTOR
 
-if _EXECUTOR == 'LocalExecutor':
-    DEFAULT_EXECUTOR = LocalExecutor()
-elif _EXECUTOR == 'SequentialExecutor':
-    DEFAULT_EXECUTOR = SequentialExecutor()
-elif _EXECUTOR == 'CeleryExecutor':
-    from airflow.executors.celery_executor import CeleryExecutor
-    DEFAULT_EXECUTOR = CeleryExecutor()
-elif _EXECUTOR == 'DaskExecutor':
-    from airflow.executors.dask_executor import DaskExecutor
-    DEFAULT_EXECUTOR = DaskExecutor()
-elif _EXECUTOR == 'MesosExecutor':
-    from airflow.contrib.executors.mesos_executor import MesosExecutor
-    DEFAULT_EXECUTOR = MesosExecutor()
-else:
-    # Loading plugins
-    _integrate_plugins()
-    if _EXECUTOR in globals():
-        DEFAULT_EXECUTOR = globals()[_EXECUTOR]()
+    if DEFAULT_EXECUTOR is not None:
+        return DEFAULT_EXECUTOR
+
+    executor_name = configuration.get('core', 'EXECUTOR')
+
+    DEFAULT_EXECUTOR = _get_executor(executor_name)
+
+    logging.info("Using executor " + executor_name)
+
+    return DEFAULT_EXECUTOR
+
+
+def _get_executor(executor_name):
+    """
+    Creates a new instance of the named executor. In case the executor name is not know in airflow, 
+    look for it in the plugins
+    """
+    if executor_name == 'LocalExecutor':
+        return LocalExecutor()
+    elif executor_name == 'SequentialExecutor':
+        return SequentialExecutor()
+    elif executor_name == 'CeleryExecutor':
+        from airflow.executors.celery_executor import CeleryExecutor
+        return CeleryExecutor()
+    elif executor_name == 'DaskExecutor':
+        from airflow.executors.dask_executor import DaskExecutor
+        return DaskExecutor()
+    elif executor_name == 'MesosExecutor':
+        from airflow.contrib.executors.mesos_executor import MesosExecutor
+        return MesosExecutor()
     else:
-        raise AirflowException("Executor {0} not supported.".format(_EXECUTOR))
+        # Loading plugins
+        _integrate_plugins()
+        executor_path = executor_name.split('.')
+        if len(executor_path) != 2:
+            raise AirflowException(
+                "Executor {0} not supported: please specify in format plugin_module.executor".format(executor_name))
 
-logging.info("Using executor " + _EXECUTOR)
+        if executor_path[0] in globals():
+            return globals()[executor_path[0]].__dict__[executor_path[1]]()
+        else:
+            raise AirflowException("Executor {0} not supported.".format(executor_name))
+
+

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -95,7 +95,7 @@ class BaseJob(Base, LoggingMixin):
 
     def __init__(
             self,
-            executor=executors.DEFAULT_EXECUTOR,
+            executor=executors.GetDefaultExecutor(),
             heartrate=conf.getfloat('scheduler', 'JOB_HEARTBEAT_SEC'),
             *args, **kwargs):
         self.hostname = socket.getfqdn()

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -59,7 +59,7 @@ from croniter import croniter
 import six
 
 from airflow import settings, utils
-from airflow.executors import DEFAULT_EXECUTOR, LocalExecutor
+from airflow.executors import GetDefaultExecutor, LocalExecutor
 from airflow import configuration
 from airflow.exceptions import AirflowException, AirflowSkipException, AirflowTaskTimeout
 from airflow.dag.base_dag import BaseDag, BaseDagBag
@@ -165,9 +165,12 @@ class DagBag(BaseDagBag, LoggingMixin):
     def __init__(
             self,
             dag_folder=None,
-            executor=DEFAULT_EXECUTOR,
+            executor=None,
             include_examples=configuration.getboolean('core', 'LOAD_EXAMPLES')):
 
+        # do not use default arg in signature, to fix import cycle on plugin load
+        if executor is None:
+            executor = GetDefaultExecutor()
         dag_folder = dag_folder or settings.DAGS_FOLDER
         self.logger.info("Filling up the DagBag from {}".format(dag_folder))
         self.dag_folder = dag_folder
@@ -3364,7 +3367,7 @@ class DAG(BaseDag, LoggingMixin):
         if not executor and local:
             executor = LocalExecutor()
         elif not executor:
-            executor = DEFAULT_EXECUTOR
+            executor = GetDefaultExecutor()
         job = BackfillJob(
             self,
             start_date=start_date,

--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -16,7 +16,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, Pool
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.db import provide_session
-from airflow.executors import DEFAULT_EXECUTOR
+from airflow.executors import GetDefaultExecutor
 
 
 class SubDagOperator(BaseOperator):
@@ -30,7 +30,7 @@ class SubDagOperator(BaseOperator):
     def __init__(
             self,
             subdag,
-            executor=DEFAULT_EXECUTOR,
+            executor=GetDefaultExecutor(),
             *args, **kwargs):
         """
         Yo dawg. This runs a sub dag. By convention, a sub dag's dag_id

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -936,8 +936,9 @@ class Airflow(BaseView):
         ignore_ti_state = request.args.get('ignore_ti_state') == "true"
 
         try:
-            from airflow.executors import DEFAULT_EXECUTOR as executor
+            from airflow.executors import GetDefaultExecutor
             from airflow.executors import CeleryExecutor
+            executor = GetDefaultExecutor()
             if not isinstance(executor, CeleryExecutor):
                 flash("Only works with the CeleryExecutor, sorry", "error")
                 return redirect(origin)

--- a/tests/plugins_manager.py
+++ b/tests/plugins_manager.py
@@ -45,6 +45,14 @@ class PluginsTest(unittest.TestCase):
         from airflow.executors.test_plugin import PluginExecutor
         self.assertTrue(issubclass(PluginExecutor, BaseExecutor))
 
+        from airflow.executors import GetDefaultExecutor
+        self.assertTrue(issubclass(type(GetDefaultExecutor()), BaseExecutor))
+
+        # test plugin executor import based on a name string, (like defined in airflow.cfg)
+        # this is not identical to the first assertion!
+        from airflow.executors import _get_executor
+        self.assertTrue(issubclass(type(_get_executor('test_plugin.PluginExecutor')), BaseExecutor))
+
     def test_macros(self):
         from airflow.macros.test_plugin import plugin_macro
         self.assertTrue(callable(plugin_macro))


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
 - [AIRFLOW-860](https://issues.apache.org/jira/browse/AIRFLOW-860)
 - [AIRFLOW-935](https://issues.apache.org/jira/browse/AIRFLOW-935)


## ISSUE 1 ([AIRFLOW-860](https://issues.apache.org/jira/browse/AIRFLOW-860)):
When a plugin is made with a custom Operator and executor, an import cycle occurs when the executor is chosen in airflow.cfg because the executors/__init__.py starts loading plugins too early when a non standard executor is chosen.

### To reproduce:
Make a plugin with both a custom operator (derived from BaseOperator) and a custom executor. Then use the custom executor in airflow.cfg to trigger the import loop. It will fail to resolve BaseOperator, since the plugin contains "import airflow.models" and models.py will trigger a plugin load again because it imports executors.DEFAULT_EXECUTOR. 
executors/__init__.py loads the plugins when an unknown executor is specified in airflow.cfg.
Spitting the plugin executor and operator into separate modules or even plugins does not resolve the problem

### fix:
changed DEFAULT_EXECUTOR use to a function call which returns the default executor. This lazy approach fixes the import cycle.


## ISSUE 2 [AIRFLOW-935](https://issues.apache.org/jira/browse/AIRFLOW-935):

revision eb5982d4aac135051666d2977bbf6adfc8b9e2a7 (included in 1.8) breaks plugin executors altogether. It makes a new module for every plugin, so import statements need to be adapted, but the executor selection is left unchanged, so it ends up passing the plugin module as the executor (instead of the actual executor class).

### fix:
fixed executor selection to work with the new plugin modules system. in Airflow.cfg a executor can now be specified as {pugin_name}.{executor_name}


## Testing Done:
The current tests do not cover these issues at all. Tested with custom plugins in v1-8-stable and master.
