### PR TITLE
[AIRFLOW-932] Do not mark tasks removed when backfilling

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1803,6 +1803,7 @@ class BackfillJob(BaseJob):
 
             # explictely mark running as we can fill gaps
             run.state = State.RUNNING
+            run.run_id = run_id
             run.verify_integrity(session=session)
 
             # check if we have orphaned tasks

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2696,6 +2696,8 @@ class DAG(BaseDag, LoggingMixin):
         self.orientation = orientation
         self.catchup = catchup
 
+        self.partial = False
+
         self._comps = {
             'dag_id',
             'task_ids',
@@ -3201,6 +3203,10 @@ class DAG(BaseDag, LoggingMixin):
                 tid for tid in t._upstream_task_ids if tid in dag.task_ids]
             t._downstream_task_ids = [
                 tid for tid in t._downstream_task_ids if tid in dag.task_ids]
+
+        if len(dag.tasks) < len(self.tasks):
+            dag.partial = True
+
         return dag
 
     def has_task(self, task_id):
@@ -3969,6 +3975,9 @@ class DagRun(Base):
                 else:
                     tis = tis.filter(TI.state.in_(state))
 
+        if self.dag and self.dag.partial:
+            tis = tis.filter(TI.task_id.in_(self.dag.task_ids))
+
         return tis.all()
 
     @provide_session
@@ -4029,6 +4038,7 @@ class DagRun(Base):
         """
 
         dag = self.get_dag()
+
         tis = self.get_task_instances(session=session)
 
         logging.info("Updating state for {} considering {} task(s)"
@@ -4113,7 +4123,7 @@ class DagRun(Base):
             try:
                 dag.get_task(ti.task_id)
             except AirflowException:
-                if self.state is not State.RUNNING:
+                if self.state is not State.RUNNING and not dag.partial:
                     ti.state = State.REMOVED
 
         # check for missing tasks


### PR DESCRIPTION
In a backfill one can specify a specific task to execute. We
create a subset of the orginal tasks in a subdag from the original dag.
The subdag has the same name as the original dag. This breaks
the integrity check of a dag_run as tasks are suddenly not in
scope any more.

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-921

Testing Done:
- New unit tests added

@aoen @saguziel @jlowin 

note to self: I need to carry this over to AIRFLOW-910