### PR TITLE
[AIRFLOW-938] Use test for True in task_stats queries

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -506,7 +506,7 @@ class Airflow(BaseView):
             session.query(DagRun.dag_id, sqla.func.max(DagRun.execution_date).label('execution_date'))
             .join(Dag, Dag.dag_id == DagRun.dag_id)
             .filter(DagRun.state != State.RUNNING)
-            .filter(Dag.is_active == 1)
+            .filter(Dag.is_active == True)
             .group_by(DagRun.dag_id)
             .subquery('last_dag_run')
         )
@@ -514,7 +514,7 @@ class Airflow(BaseView):
             session.query(DagRun.dag_id, DagRun.execution_date)
             .join(Dag, Dag.dag_id == DagRun.dag_id)
             .filter(DagRun.state == State.RUNNING)
-            .filter(Dag.is_active == 1)
+            .filter(Dag.is_active == True)
             .subquery('running_dag_run')
         )
 


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-938

Testing Done:
- Existing tests

@bolkedebruin @aoen 

I've seen the other PR but I'll try to see if this method works because I believe `__eq__(True)` is just `== True`, and it is how it is down here http://docs.sqlalchemy.org/en/latest/core/sqlelement.html#sqlalchemy.sql.expression.and_ (underscore is part of link)