### PR TITLE
[AIRFLOW-952] Allow deleting extra field in connection UI

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -630,6 +630,9 @@ class Connection(Base):
             except NameError:
                 self._extra = value
                 self.is_extra_encrypted = False
+        else:
+            self._extra = value
+            self.is_extra_encrypted = False
 
     @declared_attr
     def extra(cls):

--- a/tests/core.py
+++ b/tests/core.py
@@ -2211,6 +2211,14 @@ class ConnectionTest(unittest.TestCase):
         assert conns[0].schema == 'airflow'
         assert conns[0].login == 'root'
 
+    def test_empty_extra_field(self):
+        conn = BaseHook.get_connection(conn_id='test_uri')
+
+        conn.set_extra('{"k1": "v1"}')
+        self.assertEqual(conn.get_extra(), '{"k1": "v1"}')
+
+        conn.set_extra(None)
+        self.assertIsNone(conn.get_extra())
 
 class WebHDFSHookTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
The current implementation of the Connection model disallows
saving of an empty extra field. The UI doesn't throw any error
when an empty field is entered, it silently ignores the update.

This PR adds an extra code path for None values passed
to the extra field, and also a test case to verify desired
behavior for empty and non-empty values for the extra
field.

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-952

Testing Done:
- ConnectionTest.test_empty_extra_field tests the model behavior when non-empty and empty values are passed for the extra field.
- Also tested that I can save both non-empty and empty extra fields through the web UI.
