### PR TITLE
[AIRFLOW-954] Fix configparser ImportError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -202,6 +202,7 @@ def do_setup():
         scripts=['airflow/bin/airflow'],
         install_requires=[
             'alembic>=0.8.3, <0.9',
+            'configparser>=3.5.0, <3.6.0',
             'croniter>=0.3.8, <0.4',
             'dill>=0.2.2, <0.3',
             'flask>=0.11, <0.12',
@@ -211,7 +212,7 @@ def do_setup():
             'flask-swagger==0.2.13',
             'flask-wtf==0.12',
             'funcsigs==1.0.0',
-            'future>=0.15.0, <0.17',
+            'future>=0.16.0, <0.17',
             'gitpython>=2.0.2',
             'gunicorn>=19.3.0, <19.4.0',  # 19.4.? seemed to have issues
             'jinja2>=2.7.3, <2.9.0',


### PR DESCRIPTION
Fixes support for Python 2.7 since
https://github.com/apache/incubator-airflow/pull/2091 was merged

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-954

Testing Done:
- Tested running `airflow initdb` locally with a clean virtualenv, and a separate virtualenv that was installed with the current HEAD of master