### PR TITLE
[AIRFLOW-946] call commands with virtualenv if available

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -78,6 +78,7 @@ from airflow.utils.dates import cron_presets, date_range as utils_date_range
 from airflow.utils.db import provide_session
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.email import send_email
+from airflow.utils.file import use_virtualenv
 from airflow.utils.helpers import (
     as_tuple, is_container, is_in, validate_key, pprinttable)
 from airflow.utils.operator_resources import Resources
@@ -1016,7 +1017,8 @@ class TaskInstance(Base, LoggingMixin):
         :return: shell command that can be used to run the task instance
         """
         iso = execution_date.isoformat()
-        cmd = ["airflow", "run", str(dag_id), str(task_id), str(iso)]
+        cmd = [use_virtualenv("airflow"), "run", str(dag_id), str(task_id),
+               str(iso)]
         cmd.extend(["--mark_success"]) if mark_success else None
         cmd.extend(["--pickle", str(pickle_id)]) if pickle_id else None
         cmd.extend(["--job_id", str(job_id)]) if job_id else None

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -18,6 +18,7 @@ from __future__ import unicode_literals
 import errno
 import os
 import shutil
+import sys
 from tempfile import mkdtemp
 
 from contextlib import contextmanager
@@ -41,7 +42,6 @@ def mkdirs(path, mode):
     """
     Creates the directory specified by path, creating intermediate directories
     as necessary. If directory already exists, this is a no-op.
-
     :param path: The directory to create
     :type path: str
     :param mode: The mode to give to the directory e.g. 0o755, ignores umask
@@ -55,3 +55,16 @@ def mkdirs(path, mode):
             raise
     finally:
         os.umask(o_umask)
+
+
+def use_virtualenv(command):
+    """
+    If we're in a virtualenv, ensure we call the given command using the
+    its virtualenv wrapped script. Otherwise, just return command.
+
+    Example: gunicorn -> /path/to/venv/bin/gunicorn
+    """
+    if hasattr(sys, 'real_prefix'):
+        return os.path.join(os.path.dirname(sys.executable), command)
+
+    return command

--- a/tests/utils/file.py
+++ b/tests/utils/file.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from mock import patch
+
+from airflow.utils.file import use_virtualenv
+
+
+class VirtualEnvTest(unittest.TestCase):
+
+    @patch('airflow.utils.file.sys', executable='/usr/bin/python')
+    def test_not_using_virtualenv(self, mock_sys):
+        if hasattr(mock_sys, 'real_prefix'):
+            del mock_sys.real_prefix
+        self.assertEqual('gunicorn', use_virtualenv('gunicorn'))
+
+    @patch('airflow.utils.file.sys', real_prefix='/usr',
+           executable='/path/to/venv/bin/python')
+    def test_using_virtualenv(self, mock_sys):
+        self.assertEqual('/path/to/venv/bin/gunicorn',
+                         use_virtualenv('gunicorn'))


### PR DESCRIPTION
The webserver, worker, and flower commands all call another command
(via subprocess or os.execvp). If airflow is being called from within a
virtualenv, then we should also call these commands (gunicorn, airflow,
and flower) within the virtualenv as well. Same applies to the airflow command used to execute a task instance.

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-946

Testing Done:
- Added unit test for new helper method
- Successfully ran webserver/worker/flower and a task instance using `/path/to/venv/bin/command` without entering virtualenv.

