### PR TITLE
[AIRFLOW-956] Get docs working on readthedocs.org

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+python:
+    pip_install: true
+    extra_requirements:
+        - doc
+        - docker
+        - gcp_api
+        - emr 


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-956

Testing Done:
- Built on readthedocs at http://incubator-airflow.readthedocs.io/en/airflow-956-configparser/ off my fork and spot checked pages, notably the contrib/3rd party stuff. Using changes in this branch plus addition of configparser as dependency (see https://github.com/apache/incubator-airflow/pull/2130)

Unfortunately, older releases will be broken still unless we patch them. But at least moving forward, we should have versioned docs.

We also have a number of warnings in the doc building right now (non-existing attributes mentioned, indents/spacing, etc) that I'll see if I can cleanup in a separate pull. QuboleOperator also has an odd error that I need to look into, but it doesn't seem to show up in current/local docs either so I left it for now.

After merging, http://airflow.readthedocs.io/en/latest/ should build properly (existing RTD project by @mistercrunch). Whoever has maintainer access to it, I'd suggest:

* Disable 'stable' version until we have a stable version. When we do have a stable version, I think that'd be the more appropriate default version (rather than 'latest').
* Remember to set versions as active once we have older versions that build.
* Set email notifications for build failures to...probably not dev list, maybe a committers list if that exists?
* There are some domain settings as well if we want to update https://airflow.incubator.apache.org/
* Also http://docs.readthedocs.io/en/latest/webhooks.html#github would be good to enable (on github repo side)