### PR TITLE
[AIRFLOW-661] Add Celery broker_transport_options config

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -319,6 +319,10 @@ worker_log_server_port = 8793
 # information.
 broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
 
+# Celery broker transport options. Provide options in JSON format. Refer to
+# the Celery documentation for more information.
+# broker_transport_options =
+
 # Another key Celery setting
 celery_result_backend = db+mysql://airflow:airflow@localhost:3306/airflow
 

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -321,7 +321,7 @@ broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
 
 # Celery broker transport options. Provide options in JSON format. Refer to
 # the Celery documentation for more information.
-# broker_transport_options =
+broker_transport_options = {{}}
 
 # Another key Celery setting
 celery_result_backend = db+mysql://airflow:airflow@localhost:3306/airflow

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -16,6 +16,7 @@ from builtins import object
 import logging
 import subprocess
 import time
+import json
 
 from celery import Celery
 from celery import states as celery_states
@@ -39,6 +40,7 @@ class CeleryConfig(object):
     CELERYD_PREFETCH_MULTIPLIER = 1
     CELERY_ACKS_LATE = True
     BROKER_URL = configuration.get('celery', 'BROKER_URL')
+    BROKER_TRANSPORT_OPTIONS = json.loads(configuration.get('celery', 'BROKER_TRANSPORT_OPTIONS'))
     CELERY_RESULT_BACKEND = configuration.get('celery', 'CELERY_RESULT_BACKEND')
     CELERYD_CONCURRENCY = configuration.getint('celery', 'CELERYD_CONCURRENCY')
     CELERY_DEFAULT_QUEUE = DEFAULT_QUEUE


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-966

Testing Done:
- Manual testing: Celery worker receives broker_transport_options and connects to the correct Redis service.
- Unit tests: Travis builds are green. It does not look like there are any tests for the CeleryExecutor so I am not sure where to add new ones. 
