### PR TITLE
    [AIRFLOW-910] Use parallel task execution for backfills

### DIFF
--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -162,6 +162,54 @@ class BackfillJobTest(unittest.TestCase):
                 ignore_first_depends_on_past=True)
             job.run()
 
+    def test_backfill_ordered_concurrent_execute(self):
+        dag = DAG(
+            dag_id='test_backfill_ordered_concurrent_execute',
+            start_date=DEFAULT_DATE,
+            schedule_interval="@daily")
+
+        with dag:
+            op1 = DummyOperator(task_id='leave1')
+            op2 = DummyOperator(task_id='leave2')
+            op3 = DummyOperator(task_id='upstream_level_1')
+            op4 = DummyOperator(task_id='upstream_level_2')
+            op5 = DummyOperator(task_id='upstream_level_3')
+            # order randomly
+            op2.set_downstream(op3)
+            op1.set_downstream(op3)
+            op4.set_downstream(op5)
+            op3.set_downstream(op4)
+
+        dag.clear()
+
+        executor = TestExecutor(do_update=True)
+        job = BackfillJob(dag=dag,
+                          executor=executor,
+                          start_date=DEFAULT_DATE,
+                          end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+                          )
+        job.run()
+
+        # test executor history keeps a list
+        history = executor.history
+
+        # check if right order. Every loop has a 'pause' (0) to change state
+        # from RUNNING to SUCCESS.
+        # 6,0,3,0,3,0,3,0 = 8 loops
+        self.assertEqual(8, len(history))
+
+        loop_count = 0
+
+        while len(history) > 0:
+            queued_tasks = history.pop(0)
+            if loop_count == 0:
+                # first loop should contain 6 tasks (3 days x 2 tasks)
+                self.assertEqual(6, len(queued_tasks))
+            if loop_count == 2 or loop_count == 4 or loop_count == 6:
+                # 3 days x 1 task
+                self.assertEqual(3, len(queued_tasks))
+            loop_count += 1
+
     def test_backfill_pooled_tasks(self):
         """
         Test that queued tasks are executed by BackfillJob

--- a/tests/operators/subdag_operator.py
+++ b/tests/operators/subdag_operator.py
@@ -102,8 +102,8 @@ class SubDagOperatorTests(unittest.TestCase):
         subdag = dagbag.get_dag('test_subdag_deadlock.subdag')
         subdag.clear()
 
-        # first make sure subdag is deadlocked
-        self.assertRaisesRegexp(AirflowException, 'deadlocked', subdag.run, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        # first make sure subdag has failed
+        self.assertRaises(AirflowException, subdag.run, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
         # now make sure dag picks up the subdag error
         self.assertRaises(AirflowException, dag.run, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)


### PR DESCRIPTION
    The refactor to use dag runs in backfills caused a regression
    in task execution performance as dag runs were executed
    sequentially. Next to that, the backfills were non deterministic
    due to the random execution of tasks, causing root tasks
    being added to the non ready list too soon.

    This updates the backfill logic as follows:
    * Parallelize execution of tasks
    * Use a leave first execution model; Breadth-first algorithm by Jerermiah
    * Replace state updates from the executor by task based only

Please accept this PR that addresses the following issues:
- *(MANDATORY - replace with a link to JIRA - e.g. https://issues.apache.org/jira/browse/AIRFLOW-XXX)*

Testing Done:
- Unittests are required, if you do not include new unit tests please
specify why you think this is not required. We like to improve our
coverage so a non existing test is even a better reason to include one.

Reminders for contributors (REQUIRED!):
* Your PR's title must reference an issue on 
[Airflow's JIRA](https://issues.apache.org/jira/browse/AIRFLOW/). 
For example, a PR called "[AIRFLOW-1] My Amazing PR" would close JIRA 
issue #1. Please open a new issue if required!

* For all PRs with UI changes, you must provide screenshots. If the UI changes are not obvious, either annotate the images or provide before/after screenshots.

* Please squash your commits when possible and follow the [How to write a good git commit message](http://chris.beams.io/posts/git-commit/). 
Summarized as follows:
  1. Separate subject from body with a blank line
  2. Limit the subject line to 50 characters
  3. Do not end the subject line with a period
  4. Use the imperative mood in the subject line (add, not adding)
  5. Wrap the body at 72 characters
  6. Use the body to explain what and why vs. how

