### PR TITLE
[AIRFLOW-900] Double trigger should not kill original task instance

### DIFF
--- a/tests/core.py
+++ b/tests/core.py
@@ -896,64 +896,6 @@ class CoreTest(unittest.TestCase):
                 trigger_rule="non_existant",
                 dag=self.dag)
 
-    def test_run_task_twice(self):
-        """If two copies of a TI run, the new one should die, and old should live"""
-        dagbag = models.DagBag(
-            dag_folder=TEST_DAG_FOLDER,
-            include_examples=False,
-        )
-        TI = models.TaskInstance
-        dag = dagbag.dags.get('sleep_forever_dag')
-        task = dag.task_dict.get('sleeps_forever')
-    
-        ti = TI(task=task, execution_date=DEFAULT_DATE)
-        job1 = jobs.LocalTaskJob(
-            task_instance=ti, ignore_ti_state=True, executor=SequentialExecutor())
-        job2 = jobs.LocalTaskJob(
-            task_instance=ti, ignore_ti_state=True, executor=SequentialExecutor())
-
-        p1 = multiprocessing.Process(target=job1.run)
-        p2 = multiprocessing.Process(target=job2.run)
-        try:
-            p1.start()
-            start_time = timetime()
-            sleep(5.0) # must wait for session to be created on p1
-            settings.engine.dispose()
-            session = settings.Session()
-            ti.refresh_from_db(session=session)
-            self.assertEqual(State.RUNNING, ti.state)
-            p1pid = ti.pid
-            settings.engine.dispose()
-            p2.start()
-            p2.join(5) # wait 5 seconds until termination
-            self.assertFalse(p2.is_alive())
-            self.assertTrue(p1.is_alive())
-
-            settings.engine.dispose()
-            session = settings.Session()
-            ti.refresh_from_db(session=session)
-            self.assertEqual(State.RUNNING, ti.state)
-            self.assertEqual(p1pid, ti.pid)
-
-            # check changing hostname kills task
-            ti.refresh_from_db(session=session, lock_for_update=True)
-            ti.hostname = 'nonexistenthostname'
-            session.merge(ti)
-            session.commit()
-
-            p1.join(5)
-            self.assertFalse(p1.is_alive())
-        finally:
-            try:
-                p1.terminate()
-            except AttributeError:
-                pass # process already terminated
-            try:
-                p2.terminate()
-            except AttributeError:
-                pass # process already terminated
-            session.close()
-
     def test_terminate_task(self):
         """If a task instance's db state get deleted, it should fail"""
         TI = models.TaskInstance

--- a/tests/dags/test_double_trigger.py
+++ b/tests/dags/test_double_trigger.py
@@ -11,19 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Used for unit tests"""
-import airflow
-from airflow.operators.bash_operator import BashOperator
+from datetime import datetime
+
 from airflow.models import DAG
+from airflow.operators.dummy_operator import DummyOperator
 
-dag = DAG(
-    dag_id='sleep_forever_dag',
-    schedule_interval=None,
-)
+DEFAULT_DATE = datetime(2016, 1, 1)
 
-task = BashOperator(
-    task_id='sleeps_forever',
-    dag=dag,
-    bash_command="sleep 10000000000",
-    start_date=airflow.utils.dates.days_ago(2),
-    owner='airflow')
+args = {
+    'owner': 'airflow',
+    'start_date': DEFAULT_DATE,
+}
+
+dag = DAG(dag_id='test_localtaskjob_double_trigger', default_args=args)
+task = DummyOperator(
+    task_id='test_localtaskjob_double_trigger_task',
+    dag=dag)


### PR DESCRIPTION
This update the tests of an earlier AIRFLOW-900.

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-900

Testing Done:
- Unittests updated

Will merge when unit tests pass.
