### PR TITLE
[AIRFLOW-976] Changing external state of task should not fail task

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -34,3 +34,7 @@ class AirflowTaskTimeout(AirflowException):
 
 class AirflowSkipException(AirflowException):
     pass
+
+class AirflowExternalStateChangeException(AirflowException):
+    pass
+

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -42,7 +42,7 @@ from tabulate import tabulate
 
 from airflow import executors, models, settings
 from airflow import configuration as conf
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowExternalStateChangeException
 from airflow.models import DagRun
 from airflow.settings import Stats
 from airflow.task_runner import get_task_runner
@@ -2051,7 +2051,6 @@ class LocalTaskJob(BaseJob):
 
         # terminating state is used so that a job don't try to
         # terminate multiple times
-        self.terminating = False
 
         # Keeps track of the fact that the task instance has been observed
         # as running at least once
@@ -2127,10 +2126,6 @@ class LocalTaskJob(BaseJob):
     def heartbeat_callback(self, session=None):
         """Self destruct task if state has been moved away from running externally"""
 
-        if self.terminating:
-            # task is already terminating, let it breathe
-            return
-
         self.task_instance.refresh_from_db()
         ti = self.task_instance
         if ti.state == State.RUNNING:
@@ -2153,5 +2148,4 @@ class LocalTaskJob(BaseJob):
             logging.warning(
                 "State of this instance has been externally set to "
                 "{}. Taking the poison pill. So long.".format(ti.state))
-            self.task_runner.terminate()
-            self.terminating = True
+            raise AirflowExternalStateChangeException("State was {} but expected RUNNING".format(ti.state))

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -61,7 +61,9 @@ import six
 from airflow import settings, utils
 from airflow.executors import DEFAULT_EXECUTOR, LocalExecutor
 from airflow import configuration
-from airflow.exceptions import AirflowException, AirflowSkipException, AirflowTaskTimeout
+from airflow.exceptions import (
+    AirflowException, AirflowSkipException, AirflowTaskTimeout,
+    AirflowExternalStateChangeException)
 from airflow.dag.base_dag import BaseDag, BaseDagBag
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
 from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
@@ -1443,7 +1445,9 @@ class TaskInstance(Base):
 
         # Let's go deeper
         try:
-            if task.retries and self.try_number % (task.retries + 1) != 0:
+            if type(error) == AirflowExternalStateChangeException:
+                logging.info('State of task was externally changed. Not doing anything.')
+            elif task.retries and self.try_number % (task.retries + 1) != 0:
                 self.state = State.UP_FOR_RETRY
                 logging.info('Marking task as UP_FOR_RETRY')
                 if task.email_on_retry and task.email:


### PR DESCRIPTION
Marking success raises an AirflowException right now, which causes the
task to be marked as failed. This changes the exception type and catches
it elsewhere in order to stop it from being handled as a failure.

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-976
Testing Done:
- Unittests in progress

