### PR TITLE
[AIRFLOW-979] Add GovTech GDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Currently **officially** using Airflow:
 1. [FreshBooks](https://github.com/freshbooks) [[@DinoCow](https://github.com/DinoCow)]
 1. [Gentner Lab](http://github.com/gentnerlab) [[@neuromusic](https://github.com/neuromusic)]
 1. [Glassdoor](https://github.com/Glassdoor) [[@syvineckruyk](https://github.com/syvineckruyk)]
+1. [GovTech GDS](https://gds-gov.tech) [[@chrissng](https://github.com/chrissng) & [@datagovsg](https://github.com/datagovsg)]
 1. [Gusto](https://gusto.com) [[@frankhsu](https://github.com/frankhsu)]
 1. [Handshake](https://joinhandshake.com/) [[@mhickman](https://github.com/mhickman)]
 1. [Handy](http://www.handy.com/careers/73115?gh_jid=73115&gh_src=o5qcxn) [[@marcintustin](https://github.com/marcintustin) / [@mtustin-handy](https://github.com/mtustin-handy)]


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-979 Add GovTech GDS (https://issues.apache.org/jira/browse/AIRFLOW-979)

Testing Done:
- Not Applicable

Changes made:
- Add GovTech GDS. Line 109.