### PR TITLE
[AIRFLOW-933] Replace eval with literal_eval to prevent RCE

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -15,6 +15,7 @@
 
 from past.builtins import basestring, unicode
 
+import ast
 import os
 import pkg_resources
 import socket
@@ -44,7 +45,6 @@ from flask._compat import PY2
 import jinja2
 import markdown
 import nvd3
-import ast
 
 from wtforms import (
     Form, SelectField, TextAreaField, PasswordField, StringField, validators)
@@ -231,8 +231,8 @@ def data_profiling_required(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
         if (
-                    current_app.config['LOGIN_DISABLED'] or
-                    (not current_user.is_anonymous() and current_user.data_profiling())
+            current_app.config['LOGIN_DISABLED'] or
+            (not current_user.is_anonymous() and current_user.data_profiling())
         ):
             return f(*args, **kwargs)
         else:
@@ -312,7 +312,7 @@ class Airflow(BaseView):
 
         # Processing templated fields
         try:
-            args = eval(chart.default_params)
+            args = ast.literal_eval(chart.default_params)
             if type(args) is not type(dict()):
                 raise AirflowException('Not a dict')
         except:


### PR DESCRIPTION
Replace eval with a literal eval to help prevent arbitrary code
execution on the webserver host.

Please accept this PR that addresses the following issues:
- [AIRFLOW-933](https://issues.apache.org/jira/browse/AIRFLOW-933)

Testing in progress.

