### PR TITLE
[AIRFLOW-982] Clarify ALL/ONE_SUCCESS behavior change

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -47,8 +47,8 @@ interfere.
 Please read through these options, defaults have changed since 1.7.1.
 
 #### child_process_log_directory
-In order the increase the robustness of the scheduler, DAGS our now processed in their own process. Therefore each 
-DAG has its own log file for the scheduler. These are placed in `child_process_log_directory` which defaults to 
+In order the increase the robustness of the scheduler, DAGS our now processed in their own process. Therefore each
+DAG has its own log file for the scheduler. These are placed in `child_process_log_directory` which defaults to
 `<AIRFLOW_HOME>/scheduler/latest`. You will need to make sure these log files are removed.
 
 > DAG logs or processor logs ignore and command line settings for log file locations.
@@ -58,7 +58,7 @@ Previously the command line option `num_runs` was used to let the scheduler term
 loops. This is now time bound and defaults to `-1`, which means run continuously. See also num_runs.
 
 #### num_runs
-Previously `num_runs` was used to let the scheduler terminate after a certain amount of loops. Now num_runs specifies 
+Previously `num_runs` was used to let the scheduler terminate after a certain amount of loops. Now num_runs specifies
 the number of times to try to schedule each DAG file within `run_duration` time. Defaults to `-1`, which means try
 indefinitely. This is only available on the command line.
 
@@ -71,7 +71,7 @@ dags are not being picked up, have a look at this number and decrease it when ne
 
 #### catchup_by_default
 By default the scheduler will fill any missing interval DAG Runs between the last execution date and the current date.
-This setting changes that behavior to only execute the latest interval. This can also be specified per DAG as 
+This setting changes that behavior to only execute the latest interval. This can also be specified per DAG as
 `catchup = False / True`. Command line backfills will still work.
 
 ### Faulty Dags do not show an error in the Web UI
@@ -95,33 +95,37 @@ convenience variables to the config. In case your run a sceure Hadoop setup it m
 required to whitelist these variables by adding the following to your configuration:
 
 ```
-<property> 
+<property>
      <name>hive.security.authorization.sqlstd.confwhitelist.append</name>
      <value>airflow\.ctx\..*</value>
 </property>
 ```
 ### Google Cloud Operator and Hook alignment
 
-All Google Cloud Operators and Hooks are aligned and use the same client library. Now you have a single connection 
+All Google Cloud Operators and Hooks are aligned and use the same client library. Now you have a single connection
 type for all kinds of Google Cloud Operators.
 
 If you experience problems connecting with your operator make sure you set the connection type "Google Cloud Platform".
 
-Also the old P12 key file type is not supported anymore and only the new JSON key files are supported as a service 
+Also the old P12 key file type is not supported anymore and only the new JSON key files are supported as a service
 account.
 
+### all_success and one_success trigger rules now include SKIPPED state
+This is to prevent DAGs from finishing prematurely when upstream tasks were skipped. A task that joins multiple parent
+nodes (branching) should now use the all_success rule instead of one_success.
+
 ### Deprecated Features
-These features are marked for deprecation. They may still work (and raise a `DeprecationWarning`), but are no longer 
+These features are marked for deprecation. They may still work (and raise a `DeprecationWarning`), but are no longer
 supported and will be removed entirely in Airflow 2.0
 
 - Hooks and operators must be imported from their respective submodules
 
-  `airflow.operators.PigOperator` is no longer supported; `from airflow.operators.pig_operator import PigOperator` is. 
+  `airflow.operators.PigOperator` is no longer supported; `from airflow.operators.pig_operator import PigOperator` is.
   (AIRFLOW-31, AIRFLOW-200)
 
 - Operators no longer accept arbitrary arguments
 
-  Previously, `Operator.__init__()` accepted any arguments (either positional `*args` or keyword `**kwargs`) without 
+  Previously, `Operator.__init__()` accepted any arguments (either positional `*args` or keyword `**kwargs`) without
   complaint. Now, invalid arguments will be rejected. (https://github.com/apache/incubator-airflow/pull/1285)
 
 ### Known Issues

--- a/airflow/contrib/example_dags/example_qubole_operator.py
+++ b/airflow/contrib/example_dags/example_qubole_operator.py
@@ -81,7 +81,6 @@ branching.set_upstream(t3)
 
 join = DummyOperator(
     task_id='join',
-    trigger_rule='one_success',
     dag=dag
 )
 

--- a/airflow/example_dags/example_branch_operator.py
+++ b/airflow/example_dags/example_branch_operator.py
@@ -42,7 +42,6 @@ branching.set_upstream(run_this_first)
 
 join = DummyOperator(
     task_id='join',
-    trigger_rule='one_success',
     dag=dag
 )
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -582,11 +582,11 @@ upstream tasks have succeeded". All other rules described here are based
 on direct parent tasks and are values that can be passed to any operator
 while creating tasks:
 
-* ``all_success``: (default) all parents have succeeded
+* ``all_success``: (default) all parents have succeeded or skipped
 * ``all_failed``: all parents are in a ``failed`` or ``upstream_failed`` state
 * ``all_done``: all parents are done with their execution
 * ``one_failed``: fires as soon as at least one parent has failed, it does not wait for all parents to be done
-* ``one_success``: fires as soon as at least one parent succeeds, it does not wait for all parents to be done
+* ``one_success``: fires as soon as at least one parent succeeds or skips, it does not wait for all parents to be done
 * ``dummy``: dependencies are just for show, trigger at will
 
 Note that these can be used in conjunction with ``depends_on_past`` (boolean)


### PR DESCRIPTION
Examples and docs should reflect change that included "Skipped" state
when evaluating the ALL_SUCCESS and ONE_SUCCESS trigger rules.

Sorry, should've done this as part of https://github.com/apache/incubator-airflow/pull/2125. Filed [AIRFLOW-983](https://issues.apache.org/jira/browse/AIRFLOW-983) to get this cleaned up, as it is a bit confusing.

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-982

Testing Done:
- Ran updated branch example
