### PR TITLE
[AIRFLOW-984] enable subclassing of SubDagOperator

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2968,11 +2968,11 @@ class DAG(BaseDag, LoggingMixin):
         """
         # Check SubDag for class but don't check class directly, see
         # https://github.com/airbnb/airflow/issues/1168
+        from airflow.operators import SubDagOperator as SDO1
+        from airflow.operators.subdag_operator import SubDagOperator as SDO2
         l = []
         for task in self.tasks:
-            if (
-                    task.__class__.__name__ == 'SubDagOperator' and
-                    hasattr(task, 'subdag')):
+            if isinstance(task, (SDO1, SDO2)):
                 l.append(task.subdag)
                 l += task.subdag.subdags
         return l

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2968,11 +2968,10 @@ class DAG(BaseDag, LoggingMixin):
         """
         # Check SubDag for class but don't check class directly, see
         # https://github.com/airbnb/airflow/issues/1168
-        from airflow.operators import SubDagOperator as SDO1
-        from airflow.operators.subdag_operator import SubDagOperator as SDO2
+        from airflow.operators.subdag_operator import SubDagOperator
         l = []
         for task in self.tasks:
-            if isinstance(task, (SDO1, SDO2)):
+            if isinstance(task, SubDagOperator):
                 l.append(task.subdag)
                 l += task.subdag.subdags
         return l

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2971,7 +2971,9 @@ class DAG(BaseDag, LoggingMixin):
         from airflow.operators.subdag_operator import SubDagOperator
         l = []
         for task in self.tasks:
-            if isinstance(task, SubDagOperator):
+            if (isinstance(task, SubDagOperator) or
+                #TODO remove in Airflow 2.0
+                type(task).__name__ == 'SubDagOperator'):
                 l.append(task.subdag)
                 l += task.subdag.subdags
         return l


### PR DESCRIPTION
Please accept this PR that addresses the following issues:

- https://issues.apache.org/jira/browse/AIRFLOW-984

This essentially (though not technically) reverts https://github.com/apache/incubator-airflow/pull/1196. The issue referenced in that PR no longer exists, so I couldn't get the full context for why that change was made. However, this PR still addresses what I understand to be the original problem, while also letting users create subclasses of `SubDagOperator` that work as expected.