### PR TITLE
[AIRFLOW-986] HiveCliHook ignores 'proxy_user' value in a connection's extra parameter

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -107,7 +107,7 @@ class HiveCliHook(BaseHook):
                     template = utils.replace_hostname_pattern(
                         utils.get_components(template))
 
-                proxy_user = ""  # noqa
+                proxy_user = conn.extra_dejson.get('proxy_user', "")  # noqa
                 if conn.extra_dejson.get('proxy_user') == "login" and conn.login:
                     proxy_user = "hive.server2.proxy.user={0}".format(conn.login)
                 elif conn.extra_dejson.get('proxy_user') == "owner" and self.run_as:

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -112,6 +112,8 @@ class HiveCliHook(BaseHook):
                     proxy_user = "hive.server2.proxy.user={0}".format(conn.login)
                 elif conn.extra_dejson.get('proxy_user') == "owner" and self.run_as:
                     proxy_user = "hive.server2.proxy.user={0}".format(self.run_as)
+                elif proxy_user != "":
+                    proxy_user = "hive.server2.proxy.user={0}".format(proxy_user)
 
                 jdbc_url += ";principal={template};{proxy_user}"
             elif self.auth:

--- a/tests/operators/hive_operator.py
+++ b/tests/operators/hive_operator.py
@@ -148,6 +148,33 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
             self.assertEqual(sql, args[0])
             self.assertEqual(self.nondefault_schema, kwargs['schema'])
 
+    class HiveCliTest(unittest.TestCase):
+
+        def setUp(self):
+            configuration.load_test_config()
+            self.nondefault_schema = "nondefault"
+
+        def test_get_proxy_user_value(self):
+            from airflow.hooks.hive_hooks import HiveCliHook
+            import mock
+            import os
+
+            # Configure
+            os.environ["AIRFLOW__CORE__SECURITY"] = "kerberos"
+
+            hook = HiveCliHook()
+            returner = mock.MagicMock()
+            returner.extra_dejson = {'proxy_user': 'a_user_proxy'}
+            hook.use_beeline = True
+            hook.conn = returner
+
+            # Run
+            result = hook._prepare_cli_cmd()
+
+            # Verify
+            self.assertIn('hive.server2.proxy.user=a_user_proxy', result[2])
+
+
     class HivePrestoTest(unittest.TestCase):
 
         def setUp(self):


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
-https://issues.apache.org/jira/browse/AIRFLOW-986

Testing Done:
- Manual testing: HiveCliHook now appends the value of 'proxy_user' in connection's extra parameters to JDBC url correctly.
- Unittest: I did not find a unit test for HiveCliHook in tests folder, not sure whether I may add one.