### PR TITLE
[AIRFLOW-989] Do not mark dag run successful if unfinished tasks

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4087,9 +4087,9 @@ class DagRun(Base):
                 logging.info('Marking run {} failed'.format(self))
                 self.state = State.FAILED
 
-            # if all roots succeeded, the run succeeded
-            elif all(r.state in (State.SUCCESS, State.SKIPPED)
-                     for r in roots):
+            # if all roots succeeded and no unfinished tasks, the run succeeded
+            elif not unfinished_tasks and all(r.state in (State.SUCCESS, State.SKIPPED)
+                                              for r in roots):
                 logging.info('Marking run {} successful'.format(self))
                 self.state = State.SUCCESS
 


### PR DESCRIPTION
Dag runs could be marked successful if all root tasks were successful,
even if some tasks did not run yet, ie. in case of clearing. Now
we consider unfinished_tasks, before marking successful.

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-989

Testing Done:
- Unit tests added

@r39132 @criccomini 