### PR TITLE
[AIRFLOW-990] Fixes DockerOperator logging with unicode values on Py27

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -175,14 +175,17 @@ class DockerOperator(BaseOperator):
 
             line = ''
             for line in self.cli.logs(container=self.container['Id'], stream=True):
-                logging.info("{}".format(line.strip()))
+                line = line.strip()
+                if hasattr(line, 'decode'):
+                    line = line.decode('utf-8')
+                logging.info(line)
 
             exit_code = self.cli.wait(self.container['Id'])
             if exit_code != 0:
                 raise AirflowException('docker container failed')
 
             if self.xcom_push:
-                return self.cli.logs(container=self.container['Id']) if self.xcom_all else str(line.strip())
+                return self.cli.logs(container=self.container['Id']) if self.xcom_all else str(line)
 
     def get_command(self):
         if self.command is not None and self.command.strip().find('[') == 0:


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-990

If a Docker container's logs has unicode values (e.g. "echo 😁"), the
DockerOperator will try to log it using `logging.info(line)`, which raises a
`UnicodeDecodeError`. To solve this, we need to decode the string as UTF-8
before sending it to `logging.info()`.