### PR TITLE
[AIRFLOW-825][AIRFLOW915] Add Pipeline (dataflow) to Airflow.contrib

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -397,6 +397,18 @@ max_threads = 2
 authenticate = False
 
 
+[pipeline]
+# Settings for Data Pipelines (airflow.contrib.pipeline)
+
+# A prefix added to all pipeline XCom keys
+xcom_prefix = PIPELINE
+
+# Connection information for pipelines backed by Google Cloud Storage
+gcloud_storage_connection_id =
+gcloud_storage_bucket =
+gcloud_storage_prefix =
+
+
 [mesos]
 # Mesos master address which MesosExecutor will connect to.
 master = localhost:5050

--- a/airflow/contrib/example_dags/example_pipeline.py
+++ b/airflow/contrib/example_dags/example_pipeline.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import airflow
+from airflow import DAG
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.python_operator import PythonOperator
+from airflow.contrib.pipeline import Pipeline, add_pipelines
+import logging
+
+with DAG(dag_id='example_pipeline',
+         start_date=airflow.utils.dates.days_ago(1)) as dag:
+
+    # -----------------------------------------------------------------
+    # Upstream Task
+    # -----------------------------------------------------------------
+
+    # this task returns values that will be used by downstream tasks
+    upstream_task = PythonOperator(
+        task_id='upstream_task',
+        python_callable=(
+            lambda: {
+                'number': 2,
+                'numbers': [1, 2, 3],
+                'command': 'echo "Hello, World!"',}))
+
+    # -----------------------------------------------------------------
+    # Downstream Tasks
+    # -----------------------------------------------------------------
+
+    # this task renders upstream data into its template
+    downstream_bash = BashOperator(
+        task_id='downstream_bash',
+        bash_command="""
+            echo "here is the output of the pipelined command:"
+            {{ pipeline['command']}}
+            """)
+
+    # this task consumes upstream data in a function
+    def fn(all_data, some_data):
+        logging.info('here is all the data: {}'.format(all_data))
+        logging.info('here is just some of the some_data: {}'.format(some_data))
+
+    downstream_python = PythonOperator(
+        task_id='downstream_python', python_callable=fn)
+
+    # -----------------------------------------------------------------
+    # Pipelines
+    # -----------------------------------------------------------------
+
+    # This Pipeline is instantiated directly
+    Pipeline(
+        # the task that will create the data
+        upstream_task=upstream_task,
+        # select this key from the upstream data
+        upstream_key='command',
+        # the task that will consume the data
+        downstream_task=downstream_bash,
+        # the key the data will be available under
+        downstream_key='command')
+
+    # These Pipelines are created with a convenience function
+    # the pipelines are specified as:
+    #     {downstream_key: {task: upstream_task, key: upstream_key}}
+    add_pipelines(
+        downstream_task=downstream_python,
+        pipelines={
+            'all_data': {
+                'task': upstream_task
+            },
+            'some_data': {
+                'task': upstream_task,
+                'key': 'numbers'
+            }
+        },
+        pipeline_class=Pipeline)

--- a/airflow/contrib/pipeline/README.md
+++ b/airflow/contrib/pipeline/README.md
@@ -1,0 +1,77 @@
+# Airflow Pipelines
+
+Pipelines allow Airflow tasks to share data between (optionally named) outputs
+of upstream tasks and named inputs of downstream tasks.
+
+Pipelines automatically serialize/deserialize data and communicate between tasks. Users can specify:
+- The serialization method (how data objects are transformed to strings)
+    - For example, a dictionary might be serialized to JSON or a file might be uploaded to remote storage and serialized to a URI
+- The deserialization method (how data objects are reconstructed from serialized strings)
+    - For example, restoring a dictinoary from JSON or downloading a file from a remote URI
+
+The basic Pipeline class stores all data in Airflow XComs. XComs are only appropriate for very small and simple data. Other Pipelines include `FileSystemPipeline`, which stores data in the local filesystem (this can not be used with distributed Airflow environments) and `GCSPipeline`, which stores data in Google Cloud Storage.
+
+
+## Example
+
+```python
+
+with dag:
+
+    # ----
+    # create a task that generates data
+    upstream_task = PythonOperator(
+        task_id='upstream_task',
+        python_callable=lambda: {'output_1': 1, 'output_2': [2, 3]})
+
+    # ----
+    # create a task to work with that data
+    downstream_task = PythonOperator(
+        task_id='downstream_task',
+        python_callable=lambda x: x + 1)
+
+    # ----
+    # create a pipeline to automatically move data from the upstream task to the downstream task
+    Pipeline(
+        # identify the downstream task
+        downstream_task=downstream_task,
+
+        # the pipelined data will be available in the context under this key.
+        # since the task is a PythonOperator, it will also be passed as a kwarg.
+        downstream_key='x',
+
+        # specify the upstream task
+        upstream_task=upstream_task,
+
+        # the upstream task's result will be indexed by this optional key
+        upstream_key='output_1'
+    )
+
+    # ----
+    # or use the add_pipeline convenience function (this is equivalent to the above command)
+    add_pipeline(
+        downstream_task=downstream_task,
+        pipelines={
+            'x': {'task': upstream_task, 'key': output_1}
+        }
+    )
+
+```
+
+## Implementation
+
+Pipelines are built on top of Airflow's XCom system. Once a Pipeline is created,
+the following happens whenever tasks are run:
+
+After the upstream task runs:
+1. The `upstream_task` generates a `result`. If an `upstream_key` was provided to the `Pipeline`, the result is indexed by that key. This allows users to select one of potentially many named outputs for a specific pipeline.
+1. The pipeline's `serialize()` function is called on the result. This user-defined function takes the data and transforms it in to a string representation via some reversible transformation.
+1. The upstream task pushes an XCom containing the serialized result.
+
+Before the downstream task runs:
+1. The upstream task's XCom is pulled and the serialized data is retrieved
+1. The pipeline's `deserialize()` function is called to restore the original data from the serialized representation.
+1. The data is added to the `downstream_task`'s `context` as `context['pipeline'][downstream_key]`. This allows pipelines to be retrieved as named inputs. If the downstream task is a `PythonOperator`, the data is also passed as a keyword argument.
+
+After the downstream task runs:
+1. The pipeline's `clean_up()` method is called

--- a/airflow/contrib/pipeline/__init__.py
+++ b/airflow/contrib/pipeline/__init__.py
@@ -12,7 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from .operators import *
-from .pipeline import *
-from .sensors import *
+from .pipeline import Pipeline, add_pipelines

--- a/airflow/contrib/pipeline/filesystem_pipeline.py
+++ b/airflow/contrib/pipeline/filesystem_pipeline.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.contrib.pipeline import Pipeline
+import os
+
+
+class FileSystemPipeline(Pipeline):
+
+    def __init__(
+            self,
+            downstream_task,
+            downstream_key,
+            upstream_task,
+            upstream_key=None,
+            path_prefix='/tmp/airflow/',
+            extension='.air',
+            serialize=None,
+            deserialize=None):
+        """
+        FileSystemPipeline serializes data to the local filesystem. It can ONLY
+        be used if all Airflow processes have access to the same filesystem.
+
+        Files will be written to the provided path_prefix.
+        """
+        super(FileSystemPipeline, self).__init__(
+            downstream_task=downstream_task,
+            downstream_key=downstream_key,
+            upstream_task=upstream_task,
+            upstream_key=upstream_key,
+            serialize=serialize,
+            deserialize=deserialize)
+        self.path_prefix = path_prefix
+        self.extension = extension
+
+    def _serialize(self, data, context):
+        fpath = os.path.join(
+            self.path_prefix,
+            self.generate_unique_id(context, extension=self.extension))
+        os.makedirs(os.path.dirname(fpath), exist_ok=True)
+        with open(fpath, mode='w') as f:
+            f.write(self.serialize(data, context))
+        return fpath
+
+    def _deserialize(self, fpath, context):
+        self._fpath = fpath
+        with open(fpath, mode='r') as f:
+            data = self.deserialize(f.read(), context)
+        return data
+
+    def clean_up(self, context):
+        if hasattr(self, '_fpath') and self._fpath.startswith(self.path_prefix):
+            os.remove(self._fpath)
+            del self._fpath

--- a/airflow/contrib/pipeline/gcs_pipeline.py
+++ b/airflow/contrib/pipeline/gcs_pipeline.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.configuration import conf
+from airflow.contrib.pipeline import Pipeline
+from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
+import json
+import os
+from tempfile import NamedTemporaryFile
+
+
+def json_deserialize_from_filename(filename, context):
+    with open(filename, 'r') as f:
+        return json.load(f)
+
+
+class GCSPipeline(Pipeline):
+
+    def __init__(
+            self,
+            bucket,
+            blob_prefix,
+            gcs_connection_id,
+            downstream_task,
+            downstream_key,
+            upstream_task,
+            upstream_key=None,
+            extension='.air',
+            serialize=None,
+            deserialize=None):
+        """
+        GCSPipeline serializes data to Google Cloud Storage.
+
+        Files will be written to gs://{bucket}/{blob_prefix}/{unique_key}
+
+        serialize() receives data and is expected to return a representation
+        that can be written to GCS.
+
+        deserialize() receives a temporary filename that contains the GCS data.
+        """
+
+        if deserialize is None:
+            deserialize = json_deserialize_from_filename
+
+        super(GCSPipeline, self).__init__(
+            downstream_key=downstream_key,
+            upstream_task=upstream_task,
+            downstream_task=downstream_task,
+            upstream_key=upstream_key,
+            serialize=serialize,
+            deserialize=deserialize)
+
+        self.extension = extension
+
+        bucket = bucket or conf.get('pipeline', 'gcloud_storage_bucket')
+        if not bucket:
+            raise ValueError('No GCS bucket provided and no default set.')
+        self.bucket = bucket
+
+        blob_prefix = blob_prefix or conf.get(
+            'pipeline', 'gcloud_storage_prefix')
+        if not blob_prefix:
+            raise ValueError('No GCS blob prefix provided and no default set.')
+        self.blob_prefix = blob_prefix
+
+        self.gcs_connection_id = gcs_connection_id or conf.get(
+            'pipeline', 'gcloud_storage_connection_id')
+
+        self.gcs_hook = GoogleCloudStorageHook(
+            google_cloud_storage_conn_id=gcs_connection_id)
+
+    def _serialize(self, data, context):
+        gcs_path = os.path.join(
+            self.blob_prefix.strip('/'),
+            self.generate_unique_id(context, extension=self.extension))
+        with NamedTemporaryFile() as tmp:
+            serialized_data = self.serialize(data, context)
+            if not isinstance(serialized_data, bytes):
+                serialized_data = serialized_data.encode()
+            tmp.write(serialized_data)
+            tmp.seek(0)
+            self.gcs_hook.upload(self.bucket, gcs_path, tmp.name)
+        return gcs_path
+
+    def _deserialize(self, gcs_path, context):
+        with NamedTemporaryFile() as tmp:
+            self.gcs_hook.download(self.bucket, gcs_path, tmp.name)
+            tmp.seek(0)
+            data = self.deserialize(tmp.name, context)
+        return data

--- a/airflow/contrib/pipeline/pipeline.py
+++ b/airflow/contrib/pipeline/pipeline.py
@@ -1,0 +1,273 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow import configuration
+from airflow.models import XCom
+from airflow.operators.python_operator import PythonOperator
+from collections import namedtuple
+import logging
+import os
+import json
+import types
+
+PIPELINE_PREFIX = configuration.get('PIPELINE', 'xcom_prefix')
+CONTEXT_KEY = 'pipeline'
+
+PipelineIndex = namedtuple('PipelineIndex', ['operator', 'index'])
+
+
+def json_serialize(data, context):
+    return json.dumps(data)
+
+
+def json_deserialize(data, context):
+    return json.loads(data)
+
+
+class Pipeline(object):
+
+    def __init__(
+            self,
+            downstream_task,
+            downstream_key,
+            upstream_task,
+            upstream_key=None,
+            serialize=None,
+            deserialize=None):
+        """
+        Pipeline objects are used to pass data from an upstream task to a
+        downstream task. Airflow operators are not necessarily run in the
+        same environment and may not have access to the same resources, so
+        Pipelines are responsible for serializing data to ensure it can be
+        accessed by any task that needs it.
+
+        A Pipeline object stores the result of an upstream task with an
+        optional `upstream_key`. If the task returns an indexable result
+        like a tuple or dictionary, the key is used to select an appropriate
+        part rather than the entire result.
+
+        The downstream task is passed the result with a specified `key`. The
+        result can be accessed in the downstream task's context as
+        `context['pipeline'][downstream_key]` or, if the downstream task is a
+        PythonOperator, it will also be passed to the python callable as a
+        keyword argument.
+
+        ## Arguments
+
+        :param downstream_task: The Operator that receives the Pipeline result
+        :type downstream_task: Operator
+        :param downstream_key: The key under which the pipelined result will be     stored
+        :type downstream_key: str
+        :param upstream_task: The Operator that produces the Pipeline result
+        :type upstream_task: Operator
+        :param upstream_key: If provided, the upstream operator's result is
+            indexed by this value prior to being serialized. For example,
+            if the source operator returns a dictionary, this could be
+            used to select a specific key rather than the entire result.
+        :type upstream_key: object
+        :param serialize: A function of `(data, context)` used
+            to produce a serialized representation of the data. It is expected
+            to return a string that can be used to deserialize the data.
+        :type serialize: callable
+        :param deserialize: A function of
+            `(serialized_data, context)` used to deserialize data from the
+            stored representation. It should return the deserialized data.
+        :type deserialize: callable
+        """
+        if downstream_task.task_id not in upstream_task.downstream_task_ids:
+            upstream_task.set_downstream(downstream_task)
+        self.upstream_task = upstream_task
+        self.downstream_task = downstream_task
+        self.upstream_key = upstream_key
+        self.downstream_key = downstream_key
+        if serialize is None:
+            serialize = json_serialize
+        if deserialize is None:
+            deserialize = json_deserialize
+        self.serialize = serialize
+        self.deserialize = deserialize
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+        self._set_task_hooks()
+
+    def _serialize(self, data, context):
+        """
+        Convert data to a serialized representation. The representation is
+        stored and later passed to the deserialize method.
+
+        This method calls self.serialize, if set.
+
+        """
+        data = self.serialize(data, context)
+        return data
+
+    def _deserialize(self, data, context):
+        """
+        Deserialize data from a representation.
+
+        This method calls self.deserialize, if set.
+        """
+        if self.deserialize is not None:
+            data = self.deserialize(data, context)
+        return data
+
+    def clean_up(self, context):
+        """
+        Method called after the task runs in case any clean up is needed.
+        """
+        pass
+
+    def generate_unique_id(self, context, extension=None):
+        """
+        Returns a url-safe unique name that can be used to reference a specific
+        Pipeline result.
+        """
+        pipeline = self.__class__.__name__
+        dag_id = context['dag'].dag_id
+        task_id = self.upstream_task.task_id
+        execution_date = str(context['execution_date'])
+
+        key = os.path.join(pipeline, dag_id, task_id, execution_date)
+        if self.upstream_key is not None:
+            key = os.path.join(key, str(self.upstream_key).lstrip('/'))
+        if extension is not None:
+            key += extension
+        return key
+
+    def _upstream_post_execute(self, task, context, result):
+        """
+        Serializes Pipeline data and pushes an XCom containing the result.
+        """
+        if self.upstream_key is not None:
+            result = result[self.upstream_key]
+
+        # if this XCom already exists, don't do unnecessary work
+        if XCom.get_many(
+                execution_date=context['execution_date'],
+                key='{}:{}'.format(
+                    PIPELINE_PREFIX, self.generate_unique_id(context)),
+                task_ids=self.upstream_task.task_id,
+                dag_ids=context['dag'].dag_id):
+            return
+
+        serialized_data = self._serialize(result, context)
+        if not isinstance(serialized_data, str):
+            raise TypeError(
+                'Pipeline data must be a serialized as a string '
+                '(received {})'.format(type(serialized_data)))
+
+        XCom.set(
+            key='{}:{}'.format(
+                PIPELINE_PREFIX, self.generate_unique_id(context)),
+            value=serialized_data,
+            task_id=self.upstream_task.task_id,
+            dag_id=context['dag'].dag_id,
+            execution_date=context['execution_date'])
+
+    def _downstream_pre_execute(self, task, context):
+        """
+        Retrieves pipeline data from an XCom and deserializes it
+        """
+        serialized_data = XCom.get_one(
+            key='{}:{}'.format(
+                PIPELINE_PREFIX, self.generate_unique_id(context)),
+            task_id=self.upstream_task.task_id,
+            dag_id=context['dag'].dag_id,
+            execution_date=context['execution_date'])
+
+        data = self._deserialize(serialized_data, context)
+        context.setdefault(CONTEXT_KEY, {})[self.downstream_key] = data
+
+        if isinstance(task, PythonOperator):
+            task.op_kwargs.update({self.downstream_key: data})
+
+    def _downstream_post_execute(self, task, context, result):
+        """
+        Cleans up pipeline data
+        """
+        self.clean_up(context)
+
+    def _set_task_hooks(self):
+        """
+        Modifies tasks to run Pipelines
+
+        Tasks are given a new attribute called "_pipelines", a set of all
+        Pipelines referencing that task. If the attribute is being created, the
+        Task's pre_execute and post_execute hooks are also modified to call the
+        appropriate Pipeline methods. Otherwise, the Pipeline just adds itself
+        to the set.
+        """
+        for p_task in (self.upstream_task, self.downstream_task):
+            if hasattr(p_task, '_pipelines'):
+                p_task._pipelines.add(self)
+            else:
+                original_pre_execute = p_task.pre_execute
+                original_post_execute = p_task.post_execute
+
+                def pre_execute(task, context):
+                    # call original method
+                    original_pre_execute(context)
+
+                    # call pipelines
+                    for pipeline in task._pipelines:
+                        if task is pipeline.downstream_task:
+                            pipeline._downstream_pre_execute(task, context)
+
+                def post_execute(task, context, result):
+                    # call original method
+                    original_post_execute(context, result)
+
+                    # call pipelines
+                    for pipeline in task._pipelines:
+                        if task is pipeline.upstream_task:
+                            pipeline._upstream_post_execute(
+                                task, context, result)
+                        elif task is pipeline.downstream_task:
+                            pipeline._downstream_post_execute(
+                                task, context, result)
+
+                p_task.pre_execute = types.MethodType(pre_execute, p_task)
+                p_task.post_execute = types.MethodType(post_execute, p_task)
+
+                p_task._pipelines = set([self])
+
+
+def add_pipelines(
+        downstream_task, pipelines, pipeline_class=Pipeline, **pipeline_kwargs):
+    r"""
+    :param downstream_task: the downstream task
+    :type downstream_task: BaseOperator
+    :param pipelines: a dictionary of
+        {downstream_key: {'task': upstream_task, 'key': upstream_key}}
+        pairs. If the 'key' key is omitted, it is assumed to be None
+    :type pipelines: dict
+    :param pipeline_class: a Pipeline class or function returning a Pipeline
+        class
+    :type pipeline_class: Pipeline or callable returning a Pipeline
+    """
+
+    if not isinstance(pipelines, dict):
+        raise TypeError(
+            'pipelines should be a dictionary of '
+            r"{downstream_key: {'task': upstream_task, 'key': upstream_key}} "
+            "pairs (the 'key' key may be omitted).")
+    for downstream_key, upstream_dict in pipelines.items():
+        upstream_task = upstream_dict['task']
+        upstream_key = upstream_dict.get('key', None)
+        pipeline_class(
+            downstream_key=downstream_key,
+            upstream_task=upstream_task,
+            downstream_task=downstream_task,
+            upstream_key=upstream_key,
+            **pipeline_kwargs)

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1356,8 +1356,9 @@ class TaskInstance(Base):
                 # Don't clear Xcom until the task is certain to execute
                 self.clear_xcom_data()
 
-                self.render_templates()
                 task_copy.pre_execute(context=context)
+
+                self.render_templates(jinja_context=context)
 
                 # If a timeout is specified for the task, make it fail
                 # if it goes beyond
@@ -1579,9 +1580,10 @@ class TaskInstance(Base):
             }
         }
 
-    def render_templates(self):
+    def render_templates(self, jinja_context=None):
         task = self.task
-        jinja_context = self.get_template_context()
+        if jinja_context is None:
+            jinja_context = self.get_template_context()
         if hasattr(self, 'task') and hasattr(self.task, 'dag'):
             if self.task.dag.user_defined_macros:
                 jinja_context.update(

--- a/tests/contrib/pipeline/__init__.py
+++ b/tests/contrib/pipeline/__init__.py
@@ -13,6 +13,4 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from .operators import *
-from .pipeline import *
-from .sensors import *
+from . import pipeline

--- a/tests/contrib/pipeline/pipeline.py
+++ b/tests/contrib/pipeline/pipeline.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+from datetime import datetime
+import functools
+import json
+from airflow import configuration
+configuration.load_test_config()
+
+from airflow import DAG
+from airflow.models import BaseOperator, XCom
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.contrib.pipeline import add_pipelines
+from airflow.contrib.pipeline.filesystem_pipeline import FileSystemPipeline
+
+TEST_DAG_ID = 'test_pipeline_dag'
+DEFAULT_DATE = datetime(2017, 1, 1)
+
+
+class PipelineTest(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+        self.dag = lambda: DAG(
+            TEST_DAG_ID,
+            default_args=dict(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE))
+
+        self.dict_data = {'a': 'abc', 'b': [1, 2, 3]}
+
+    def test_create_pipelines(self):
+        """
+        Test that pipeline objects can be created and properly create
+        task relationships
+        """
+
+        with self.dag():
+
+            upstream = PythonOperator(
+                task_id='upstream', python_callable=lambda: self.dict_data)
+
+            op1 = DummyOperator(task_id='op1')
+            add_pipelines(
+                downstream_task=op1,
+                pipelines=dict(x=dict(task=upstream, key='a')))
+
+            self.assertTrue(upstream.task_id in op1.upstream_task_ids)
+            self.assertTrue(op1.task_id in upstream.downstream_task_ids)
+
+    def test_serialize_object_error(self):
+        """
+        Tests that attempting to serialize an object raises an error
+        """
+
+        with self.dag():
+            upstream = PythonOperator(
+                task_id='upstream', python_callable=lambda: self.dict_data)
+
+            op1 = DummyOperator(task_id='op1')
+
+            # this _add_pipelines doesn't serialize as string and
+            # should raise an error when the upstream task is run
+            add_pipelines(
+                downstream_task=op1,
+                pipelines=dict(x=dict(task=upstream)),
+                serialize=lambda data, context: data)
+
+            upstream.clear()
+            with self.assertRaises(TypeError):
+                upstream.run()
+
+    def test_run_pipelines(self):
+
+        with self.dag():
+
+            upstream = PythonOperator(
+                task_id='upstream', python_callable=lambda: self.dict_data)
+
+            # checks pipeline data was received correctly
+            def check_pipelines(x, y):
+                if x != self.dict_data:
+                    raise ValueError('x data did not match')
+
+                if y != self.dict_data['a']:
+                    raise ValueError('y data did not match')
+
+            # Checks that pipelines are available in the Operator context
+            def check_pipelines_context(**context):
+                check_pipelines(
+                    context['pipeline']['x'],
+                    context['pipeline']['y'],)
+
+            # Checks that pipelines are passed directly to the Operator as
+            # keyword args
+            check_kwargs = PythonOperator(
+                task_id='test_run_pipelines_kwargs',
+                python_callable=check_pipelines)
+            add_pipelines(
+                downstream_task=check_kwargs,
+                pipelines=dict(
+                    x=dict(task=upstream),
+                    y=dict(task=upstream, key='a'),))
+
+            # Checks that pipelines are available in Operator context
+            check_context = PythonOperator(
+                task_id='test_run_pipelines_context',
+                python_callable=check_pipelines_context,
+                provide_context=True)
+            add_pipelines(
+                downstream_task=check_context,
+                pipelines=dict(
+                    x=dict(task=upstream),
+                    y=dict(task=upstream, key='a'),))
+
+            # Checks that pipelines are available in bash context
+            op_bash_context = BashOperator(
+                task_id='test_run_pipelines_bash',
+                bash_command="""
+                    if [ "{{ pipeline['x'] }}" = "abc" ]; then
+                        echo 'success!'
+                    else
+                        exit 1
+                    fi
+                    """)
+            add_pipelines(
+                downstream_task=op_bash_context,
+                pipelines=dict(x=dict(task=upstream, key='a')))
+
+        # run generator
+        upstream.clear()
+        upstream.run()
+
+        # run downstream tasks
+        check_context.run()
+        check_kwargs.run()
+        op_bash_context.run()
+
+    def test_filesystem_pipeline(self):
+
+        def check_pipelines(x, y):
+            if x != self.dict_data:
+                raise ValueError('x data did not match')
+
+            if y != self.dict_data['a']:
+                raise ValueError('y data did not match')
+
+        with self.dag():
+            upstream = PythonOperator(
+                task_id='upstream', python_callable=lambda: self.dict_data)
+
+            op = PythonOperator(
+                task_id='test_filesystem_pipeline',
+                python_callable=check_pipelines)
+            add_pipelines(
+                pipeline_class=FileSystemPipeline,
+                downstream_task=op,
+                pipelines=dict(
+                    x=dict(task=upstream), y=dict(task=upstream, key='a')))
+
+        upstream.clear()
+        upstream.run()
+
+        xcoms = XCom.get_many(execution_date=DEFAULT_DATE, task_ids='upstream')
+
+        for xcom in xcoms:
+            if not xcom.key.startswith('PIPELINE'):
+                continue
+
+            self.assertTrue(
+                xcom.value.startswith(
+                    '/tmp/airflow/FileSystemPipeline/test_pipeline_dag/upstream'
+                ))
+
+            with open(xcom.value, 'r') as f:
+                xcom_data = f.read()
+            if xcom.key.endswith('a'):
+                self.assertTrue(json.loads(xcom_data) == self.dict_data['a'])
+            else:
+                self.assertTrue(json.loads(xcom_data) == self.dict_data)
+
+        op.run()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-825 (automate passing data between operators)
- https://issues.apache.org/jira/browse/AIRFLOW-915 (allow task to modify context in pre_execute())

Testing Done:
- New unit tests for `Pipeline` and `FileSystemPipeline`

#### Overview

Pipelines (formerly "dataflow") are a "high level" interface that allow data generated by one Operator to be easily accessed by another. 

It has always been possible to do this manually (and indeed, most users do) by writing and alternatively reading data from parameterized locations in local or remote storage or through the XCom system. Pipelines automate that cumbersome work by introducing a customizable API for "piping" data through storage automatically.

(Note: this supersedes #2046 and is intended to address concerns with that implementation, chiefly the need to modify Airflow core. This version [and the fact that it is in contrib] should alleviate those worries.)

#### Implementation

Pipelines are implemented entirely through `pre_execute()` and `post_execute()` hooks as well as the `XCom` protocol. The files live in `contrib` so they are clearly "outside" Airflow proper, though it is my hope that they will prove useful to many people. 

Different Pipeline classes use different storage: the default (`Pipeline`) uses XComs. Once #2048 is merged, this will only work for small data. I have also included a `FileSystemPipeline` that writes data to the local filesystem (and should only be used on single-machine Airflow installs) and `GCSPipeline` that writes to Google Cloud Storage.

Users can extend Pipelines easily to use their preferred storage locations; the implementations of `GCSPipeline` and `FileSystemPipeline` show how lightweight extensions can be.

All Pipeline classes accept `serialize` and `deserialize` parameters -- these are functions that tell the Pipeline how to convert data to its remote representation. The default is JSON.


#### Sample use:

```python

with dag:

    # ----
    # create a task that generates data
    upstream_task = PythonOperator(
        task_id='upstream_task',
        python_callable=lambda: {'output_1': 1, 'output_2': [2, 3]})

    # ----
    # create a task to work with that data
    downstream_task = PythonOperator(
        task_id='downstream_task',
        python_callable=lambda x: x + 1)

    # ----
    # create a pipeline to automatically move data from the upstream task to the downstream task
    Pipeline(
        # identify the downstream task
        downstream_task=downstream_task,

        # the pipelined data will be available in the context under this key.
        # since the task is a PythonOperator, it will also be passed as a kwarg.
        downstream_key='x',

        # specify the upstream task
        upstream_task=upstream_task,

        # the upstream task's result will be indexed by this optional key
        upstream_key='output_1'
    )

    # ----
    # or use the add_pipeline convenience function (this is equivalent to the above command)
    add_pipeline(
        downstream_task=downstream_task,
        pipelines={
            'x': {'task': upstream_task, 'key': output_1}
        }
    )

```

Using `FileSystemPipeline` or `GCSPipeline` is identical, just dropping the class in appropriately (or passing the `pipeline_class` argument to `add_pipeline()`.