### PR TITLE
[AIRFLOW-840] Make ticket renewer python3 compatible

### DIFF
--- a/scripts/ci/krb5.conf
+++ b/scripts/ci/krb5.conf
@@ -27,5 +27,4 @@ forwardable = true
 [realms]
  TEST.LOCAL = {
    kdc = localhost:88
-   kdc = localhost:88
  }

--- a/scripts/ci/setup_kdc.sh
+++ b/scripts/ci/setup_kdc.sh
@@ -24,18 +24,17 @@ PASS="airflow"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cp ${DIR}/kdc.conf /etc/krb5kdc/kdc.conf
-
 ln -sf /dev/urandom /dev/random
 
+cp ${DIR}/kdc.conf /etc/krb5kdc/kdc.conf
 cp ${DIR}/kadm5.acl /etc/krb5kdc/kadm5.acl
-
 cp ${DIR}/krb5.conf /etc/krb5.conf
 
-# create admin
+# create kerberos database
 echo -e "${PASS}\n${PASS}" | kdb5_util create -s
-
+# create admin
 echo -e "${PASS}\n${PASS}" | kadmin.local -q "addprinc ${ADMIN}/admin"
+# create airflow
 echo -e "${PASS}\n${PASS}" | kadmin.local -q "addprinc -randkey airflow"
 echo -e "${PASS}\n${PASS}" | kadmin.local -q "addprinc -randkey airflow/${FQDN}"
 kadmin.local -q "ktadd -k ${KRB5_KTNAME} airflow"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -23,4 +23,5 @@ from .jobs import *
 from .impersonation import *
 from .models import *
 from .operators import *
+from .security import *
 from .utils import *

--- a/tests/security/__init__.py
+++ b/tests/security/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -10,16 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-[kdcdefaults]
-kdc_ports = 88
-kdc_tcp_ports = 88
 
-[realms]
-TEST.LOCAL = {
-  #master_key_type = aes256-cts
-  acl_file = /etc/krb5kdc/kadm5.acl
-  dict_file = /usr/share/dict/words
-  admin_keytab = /var/krb5kdc/kadm5.keytab
-  max_renewable_life = 7d 0h 0m 0s
-  supported_enctypes = aes256-cts:normal aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
-}
+from .kerberos import *

--- a/tests/security/kerberos.py
+++ b/tests/security/kerberos.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from airflow import configuration
+from airflow.security.kerberos import renew_from_kt
+
+
+@unittest.skipIf('KRB5_KTNAME' not in os.environ,
+                 'Skipping Kerberos API tests due to missing KRB5_KTNAME')
+class KerberosTest(unittest.TestCase):
+    def setUp(self):
+        configuration.load_test_config()
+
+        if not configuration.conf.has_section("kerberos"):
+            configuration.conf.add_section("kerberos")
+
+        configuration.conf.set("kerberos",
+                               "keytab",
+                               os.environ['KRB5_KTNAME'])
+
+    def test_renew_from_kt(self):
+        """
+        We expect no result, but a successful run. No more TypeError
+        """
+        self.assertIsNone(renew_from_kt())


### PR DESCRIPTION
 The return from the subprocess is in bytes when the universal
 newlines is set to False (default). This will fail in Py3 and
 works fine in Py2.

Please accept this PR that addresses the following issues:
- https://issues.apache.org/jira/browse/AIRFLOW-840