### PR TITLE
[AIRFLOW-995] Update GitHub PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,35 @@
-Please accept this PR that addresses the following issues:
-- *(MANDATORY - replace with a link to JIRA - e.g. https://issues.apache.org/jira/browse/AIRFLOW-XXX)*
+Dear Airflow maintainers,
 
-Testing Done:
-- Unittests are required, if you do not include new unit tests please
-specify why you think this is not required. We like to improve our
-coverage so a non existing test is even a better reason to include one.
+Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
 
-Reminders for contributors (REQUIRED!):
-* Your PR's title must reference an issue on 
-[Airflow's JIRA](https://issues.apache.org/jira/browse/AIRFLOW/). 
-For example, a PR called "[AIRFLOW-1] My Amazing PR" would close JIRA 
-issue #1. Please open a new issue if required!
+### Opened PR
+- [x] Opened a PR on Github
 
-* For all PRs with UI changes, you must provide screenshots. If the UI changes are not obvious, either annotate the images or provide before/after screenshots.
 
-* Please squash your commits when possible and follow the [How to write a good git commit message](http://chris.beams.io/posts/git-commit/). 
-Summarized as follows:
-  1. Separate subject from body with a blank line
-  2. Limit the subject line to 50 characters
-  3. Do not end the subject line with a period
-  4. Use the imperative mood in the subject line (add, not adding)
-  5. Wrap the body at 72 characters
-  6. Use the body to explain what and why vs. how
+### [JIRA](https://issues.apache.org/jira/browse/AIRFLOW/)
+- [ ] My PR addresses the following Airflow JIRA issues:
+    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
+- [ ] The PR title references the JIRA issues. For example, "[AIRFLOW-1] My Airflow PR"
+
+
+### Tests
+- [ ] My PR adds unit tests
+- [ ] __OR__ my PR does not need testing for this extremely good reason:
+
+
+### Description
+- [ ] Here are some details about my PR:
+- [ ] Here are screenshots of any UI changes, if appropriate:
+
+
+### Commits
+- [ ] Each commit subject references a JIRA issue. For example, "[AIRFLOW-1] Add new feature"
+- [ ] Multiple commits addressing the same JIRA issue have been squashed
+- [ ] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
+  1. Subject is separated from body by a blank line
+  2. Subject is limited to 50 characters
+  3. Subject does not end with a period
+  4. Subject uses the imperative mood ("add", not "adding")
+  5. Body wraps at 72 characters
+  6. Body explains "what" and "why", not "how"
 


### PR DESCRIPTION
*(this PR submits a new PR Template. I have filled it out here as an example!)*


Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### Opened PR
- [x] Opened a PR on Github


### [JIRA](https://issues.apache.org/jira/browse/AIRFLOW/)
- [X] My PR addresses the following Airflow JIRA issues:
    - https://issues.apache.org/jira/browse/AIRFLOW-995
- [x] The PR title references the JIRA issues. For example, "[AIRFLOW-1] My Airflow PR"

### Tests
- [ ] My PR adds unit tests
- [X] __OR__ my PR does not need testing for this extremely good reason:
- It's a lowly template adjustment, not new functionality


### Description
- [x] Here are some details about my PR:

The current PR template looks great when previewed but is harder to parse in "edit" mode, which is how all PR authors see it initially. My goal with this template is to make one that is very clear in both edit and preview and also includes explicit action (checking boxes) to engage authors with each required step

- [ ] Here are screenshots of any UI changes, if appropriate:


### Commits
- [x] Each commit subject references a JIRA issue. For example, "[AIRFLOW-1] Add new feature"
- [x] Multiple commits addressing the same JIRA issue have been squashed
- [x] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  2. Subject is limited to 50 characters
  3. Subject does not end with a period
  4. Subject uses the imperative mood ("add", not "adding")
  5. Body wraps at 72 characters
  6. Body explains "what" and "why", not "how"

