### PR TITLE
[AIRFLOW-997] Update setup.cfg to point to Apache

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,8 @@
 name = Airflow
 summary = Airflow is a system to programmatically author, schedule and monitor data pipelines.
 description-file = README.md
-author = Maxime Beauchemin
-author-email = maximebeauchemin@gmail.com
+author = Apache Airflow PMC
+author-email = dev@airflow.incubator.apache.org
 license = Apache License, Version 2.0
 
 [files]


### PR DESCRIPTION
The setup.cfg should point to the Apache PMC as "author" and the
dev mailing list as contact email.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### Opened PR
- [x] Opened a PR on Github


### [JIRA](https://issues.apache.org/jira/browse/AIRFLOW/)
- [x] My PR addresses the following Airflow JIRA issues:
    - https://issues.apache.org/jira/browse/AIRFLOW-997
- [x] The PR title references the JIRA issues. For example, "[AIRFLOW-1] My Airflow PR"


### Tests
- [ ] My PR adds unit tests
- [x] __OR__ my PR does not need testing for this extremely good reason:
  - The PR is focused on changing contact info in a config file.


### Description
- [x] Here are some details about my PR:
  - Changed the Author Tag to point to the the Apache Airflow PMC and the author-email to the dev mailing list.
- [ ] Here are screenshots of any UI changes, if appropriate:


### Commits
- [x] Each commit subject references a JIRA issue. For example, "[AIRFLOW-xxx] Add new feature"
- [ ] Multiple commits addressing the same JIRA issue have been squashed
- [ ] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  2. Subject is limited to 50 characters
  3. Subject does not end with a period
  4. Subject uses the imperative mood ("add", not "adding")
  5. Body wraps at 72 characters
  6. Body explains "what" and "why", not "how"

