### PR TITLE
[AIRFLOW-995] Remove reference to actual Airflow issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,34 +2,26 @@ Dear Airflow maintainers,
 
 Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
 
-### Opened PR
-- [x] Opened a PR on Github
 
-
-### [JIRA](https://issues.apache.org/jira/browse/AIRFLOW/)
-- [ ] My PR addresses the following Airflow JIRA issues:
+### JIRA
+- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
     - https://issues.apache.org/jira/browse/AIRFLOW-XXX
-- [ ] The PR title references the JIRA issues. For example, "[AIRFLOW-1] My Airflow PR"
-
-
-### Tests
-- [ ] My PR adds unit tests
-- [ ] __OR__ my PR does not need testing for this extremely good reason:
 
 
 ### Description
-- [ ] Here are some details about my PR:
-- [ ] Here are screenshots of any UI changes, if appropriate:
+- [ ] Here are some details about my PR, including screenshots of any UI changes:
+
+
+### Tests
+- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 
 
 ### Commits
-- [ ] Each commit subject references a JIRA issue. For example, "[AIRFLOW-1] Add new feature"
-- [ ] Multiple commits addressing the same JIRA issue have been squashed
-- [ ] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
-  1. Subject is separated from body by a blank line
-  2. Subject is limited to 50 characters
-  3. Subject does not end with a period
-  4. Subject uses the imperative mood ("add", not "adding")
-  5. Body wraps at 72 characters
-  6. Body explains "what" and "why", not "how"
+- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
+    1. Subject is separated from body by a blank line
+    2. Subject is limited to 50 characters
+    3. Subject does not end with a period
+    4. Subject uses the imperative mood ("add", not "adding")
+    5. Body wraps at 72 characters
+    6. Body explains "what" and "why", not "how"
 


### PR DESCRIPTION
Remove example reference to AIRFLOW-[one] because it confuses merge tools.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### Opened PR
- [x] Opened a PR on Github


### [JIRA](https://issues.apache.org/jira/browse/AIRFLOW/)
- [x] My PR addresses the following Airflow JIRA issues:
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
- [x] The PR title references the JIRA issues. For example, "[AIRFLOW-XXX] My Airflow PR"


### Tests
- [ ] My PR adds unit tests
- [x] __OR__ my PR does not need testing for this extremely good reason:
- It just modifies the PR template


### Description
- [x] Here are some details about my PR:
- I created this template with "AIRFLOW-[one]" (but as numeral 1) as an example, but the PR Tool reads the template and thinks the PRs all reference AIRFLOW-[one] I'm replacing it with AIRFLOW-XXX instead.
- [ ] Here are screenshots of any UI changes, if appropriate:


### Commits
- [x] Each commit subject references a JIRA issue. For example, "[AIRFLOW-XXX] Add new feature"
- [x] Multiple commits addressing the same JIRA issue have been squashed
- [x] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  2. Subject is limited to 50 characters
  3. Subject does not end with a period
  4. Subject uses the imperative mood ("add", not "adding")
  5. Body wraps at 72 characters
  6. Body explains "what" and "why", not "how"

