### PR TITLE
[AIRFLOW-681] homepage doc link should pointing to apache repo not airbnb repo

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -102,7 +102,7 @@ def create_app(config=None, testing=False):
             url='http://pythonhosted.org/airflow/'))
         admin.add_link(
             base.MenuLink(category='Docs',
-                name='Github',url='https://github.com/airbnb/airflow'))
+                name='Github',url='https://github.com/apache/incubator-airflow'))
 
         av(vs.VersionView(name='Version', category="About"))
 


### PR DESCRIPTION
[AIRFLOW-681] homepage doc link should pointing to https://github.com/apache/incubator-airflow not https://github.com/airbnb/airflow

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### Opened PR
- [x] Opened a PR on Github


### [JIRA](https://issues.apache.org/jira/browse/AIRFLOW/)
- [x] My PR addresses the following Airflow JIRA issues:
    - https://issues.apache.org/jira/browse/AIRFLOW-681
- [x] The PR title references the JIRA issues. "[AIRFLOW-681] homepage doc link should pointing to apache's repo not airbnb's repo"


### Tests
- [] My PR adds unit tests
- [x] __OR__ my PR does not need testing for this extremely good reason:


### Description
- [x] Here are some details about my PR:
homepage doc link should pointing to https://github.com/apache/incubator-airflow not https://github.com/airbnb/airflow
- [ ] Here are screenshots of any UI changes, if appropriate:


### Commits
- [x] Each commit subject references a JIRA issue. For example, "[AIRFLOW-1] Add new feature"
- [ ] Multiple commits addressing the same JIRA issue have been squashed
- [x] My commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  2. Subject is limited to 50 characters
  3. Subject does not end with a period
  4. Subject uses the imperative mood ("add", not "adding")
  5. Body wraps at 72 characters
  6. Body explains "what" and "why", not "how"

