### PR TITLE
[AIRFLOW-670] Make Airflow home page configurable

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -133,6 +133,32 @@ default_ram = 512
 default_disk = 512
 default_gpus = 0
 
+[suppressible_default_views]
+# If value is 'F', a view will be hidden;
+# Otherwise, to be backward compatible, a view will be present.
+data_profiling.ad_hoc_query = T
+data_profiling.charts = T
+data_profiling.known_events = T
+browse.sla_misses = T
+browse.task_instances = T
+browse.logs = T
+browse.jobs = T
+admin.pools = T
+admin.configuration = T
+admin.users = T
+admin.connections = T
+admin.variables = T
+admin.xcoms = T
+about.versions = T
+
+[custom_external_links]
+# Format: <key> = <category_name>::<tab_name>::<url>
+# The reason being that you may want to keep special characters or upper cases as
+# catergory name and tab name. But <key> here doesn't provide this capability.
+# Thus we put all inputs as values, and won't process the key.
+# But you still need to ensure keys are unique for app to take them
+# production_environment = Environment::Production Environment::<your_prod_env_url>
+# staging_environment = Environment::Staging Environment::<your_staging_env_url>
 
 [webserver]
 # The base url of your website as airflow cannot guess what domain or

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -47,6 +47,23 @@ auth_backend = airflow.api.auth.backend.default
 [operators]
 default_owner = airflow
 
+[suppressible_default_views]
+# If value is 'F', a view will be hidden; otherwise, a view will be present
+data_profiling.ad_hoc_query = T
+data_profiling.charts = T
+data_profiling.known_events = T
+browse.sla_misses = T
+browse.task_instances = T
+browse.logs = T
+browse.jobs = T
+admin.pools = T
+admin.configuration = T
+admin.users = T
+admin.connections = T
+admin.variables = T
+admin.xcoms = T
+about.versions = F
+
 [webserver]
 base_url = http://localhost:8080
 web_server_host = 0.0.0.0

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -416,6 +416,13 @@ def remove_option(section, option):
     return conf.remove_option(section, option)
 
 
+def has_expected_value(section, key, expected_value):
+    if not conf.has_option(section, key):
+        return False
+    else:
+        return conf.get(section, key) == expected_value
+
+
 def as_dict(display_source=False, display_sensitive=False):
     return conf.as_dict(
         display_source=display_source, display_sensitive=display_sensitive)

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from __future__ import print_function
-import os
 import unittest
 
 from airflow import configuration
@@ -27,6 +26,19 @@ class ConfTest(unittest.TestCase):
     def test_env_var_config(self):
         opt = conf.get('testsection', 'testkey')
         self.assertEqual(opt, 'testvalue')
+
+    def test_has_expected_value(self):
+        # if a key doesn't exist, return false
+        opt = configuration.has_expected_value('suppressible_default_views', 'testkey', 'F')
+        self.assertFalse(opt)
+
+        # if a key exist but doesn't have expected value, return false
+        opt = configuration.has_expected_value('suppressible_default_views', 'browse.logs', 'F')
+        self.assertFalse(opt)
+
+        # if a key exist and have expected value, return true
+        opt = configuration.has_expected_value('suppressible_default_views', 'about.versions', 'F')
+        self.assertTrue(opt)
 
     def test_conf_as_dict(self):
         cfg_dict = conf.as_dict()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA 670](https://issues.apache.org/jira/browse/AIRFLOW-670)
    - https://issues.apache.org/jira/browse/AIRFLOW-670


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Example: screenshot that hides 'Configuration' tab by setting 'admin.configuration = F' in airflow/configuration.py

![image](https://cloud.githubusercontent.com/assets/1892692/24084795/53f9f29e-0cae-11e7-805f-b8d619604dfb.png)

Example: screenshot that add 'Environment' tabs by uncommenting example links in section [custom_external_links] in airflow/configuration.py

![image](https://cloud.githubusercontent.com/assets/1892692/24084797/5a8deb88-0cae-11e7-861e-b3bb09e21370.png)


### Tests
- [x] My PR adds the following unit tests
    - tests.configuration:ConfTest.test_has_expected_value


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

