### PR TITLE
[AIRFLOW-1006] Add config_templates to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,4 +21,4 @@ graft airflow/www/static
 include airflow/alembic.ini
 graft scripts/systemd
 graft scripts/upstart
-
+graft airflow/config_templates


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1006


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
@bolkedebruin [pointed out](https://github.com/apache/incubator-airflow/commit/1da7450c96c631a75da96ba00f6d3ad116c9061b#commitcomment-21392365) that the new config templates are not included when Airflow is installed, something I didn't catch because I run Airflow out of the dev directory (and I guess unit tests do too?). The solution is to add them to Airflow's `MANIFEST`.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  Airflow is already being installed in the test environment, but clearly with access to all files.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

