### PR TITLE
[AIRFLOW-1016] Allow HTTP HEAD request method on HTTPSensor

### DIFF
--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -66,6 +66,11 @@ class HttpHook(BaseHook):
                                    url,
                                    params=data,
                                    headers=headers)
+        elif self.method == 'HEAD':
+            # HEAD doesn't use params
+            req = requests.Request(self.method,
+                                   url,
+                                   headers=headers)
         else:
             # Others use data
             req = requests.Request(self.method,
@@ -100,7 +105,7 @@ class HttpHook(BaseHook):
             # to get reason and code for failure by checking first 3 chars
             # for the code, or do a split on ':'
             logging.error("HTTP error: " + response.reason)
-            if self.method != 'GET':
+            if self.method not in ('GET', 'HEAD'):
                 # The sensor uses GET, so this prevents filling up the log
                 # with the body every time the GET 'misses'.
                 # That's ok to do, because GETs should be repeatable and

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -629,6 +629,8 @@ class HttpSensor(BaseSensorOperator):
 
     :param http_conn_id: The connection to run the sensor against
     :type http_conn_id: string
+    :param method: The HTTP request method to use
+    :type method: string
     :param endpoint: The relative part of the full url
     :type endpoint: string
     :param params: The parameters to be added to the GET url
@@ -650,6 +652,7 @@ class HttpSensor(BaseSensorOperator):
     def __init__(self,
                  endpoint,
                  http_conn_id='http_default',
+                 method='GET',
                  params=None,
                  headers=None,
                  response_check=None,
@@ -662,7 +665,9 @@ class HttpSensor(BaseSensorOperator):
         self.extra_options = extra_options or {}
         self.response_check = response_check
 
-        self.hook = HttpHook(method='GET', http_conn_id=http_conn_id)
+        self.hook = HttpHook(
+            method=method,
+            http_conn_id=http_conn_id)
 
     def poke(self, context):
         logging.info('Poking: ' + self.endpoint)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1016


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
As commented on the JIRA ticket,  the HTTPSensor hardcodes the HTTP request method to `GET`, so this PR allows `HEAD` method as well.

### Tests
- [x] My PR adds the following unit tests 


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

