### PR TITLE
[AIRFLOW-1023] reconnect to S3 bucket location

### DIFF
--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -25,6 +25,7 @@ from urllib.parse import urlparse
 import warnings
 
 import boto
+from boto.s3 import connect_to_region
 from boto.s3.connection import S3Connection, NoHostProvided
 from boto.sts import STSConnection
 boto.set_stream_logger('boto')
@@ -227,7 +228,12 @@ class S3Hook(BaseHook):
         :param bucket_name: the name of the bucket
         :type bucket_name: str
         """
-        return self.connection.get_bucket(bucket_name)
+        bucket = self.connection.get_bucket(bucket_name)
+        bucket_location = bucket.get_location()
+        if bucket_location:
+            connection = connect_to_region(bucket_location)
+            bucket = connection.get_bucket(bucket_name)
+        return bucket
 
     def list_keys(self, bucket_name, prefix='', delimiter=''):
         """

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -53,7 +53,7 @@ ldap3
 lxml
 markdown
 mock
-moto
+moto==0.4.31
 mysqlclient
 nose
 nose-exclude

--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ devel = [
     'jira',
     'lxml>=3.3.4',
     'mock',
-    'moto',
+    'moto==0.4.31',
     'nose',
     'nose-ignore-docstring==0.2',
     'nose-timer',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -21,6 +21,7 @@ from .core import *
 from .executors import *
 from .jobs import *
 from .impersonation import *
+from .hooks import *
 from .models import *
 from .operators import *
 from .security import *

--- a/tests/core.py
+++ b/tests/core.py
@@ -2277,26 +2277,6 @@ class HDFSHookTest(unittest.TestCase):
         self.assertIsInstance(client, snakebite.client.HAClient)
 
 
-try:
-    from airflow.hooks.S3_hook import S3Hook
-except ImportError:
-    S3Hook = None
-
-
-@unittest.skipIf(S3Hook is None,
-                 "Skipping test because S3Hook is not installed")
-class S3HookTest(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-        self.s3_test_url = "s3://test/this/is/not/a-real-key.txt"
-
-    def test_parse_s3_url(self):
-        parsed = S3Hook.parse_s3_url(self.s3_test_url)
-        self.assertEqual(parsed,
-                         ("test", "this/is/not/a-real-key.txt"),
-                         "Incorrect parsing of the s3 url")
-
-
 HELLO_SERVER_CMD = """
 import socket, sys
 listener = socket.socket()

--- a/tests/hooks/S3_hook.py
+++ b/tests/hooks/S3_hook.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import mock
+import boto
+
+from airflow import configuration
+from airflow import models
+
+try:
+    from airflow.hooks.S3_hook import S3Hook
+except ImportError:
+    S3Hook = None
+
+try:
+    from moto import mock_s3
+except ImportError:
+    mock_s3 = None
+
+
+@unittest.skipIf(S3Hook is None,
+                 "Skipping test because S3Hook is not installed")
+class S3HookTest(unittest.TestCase):
+    def setUp(self):
+        configuration.load_test_config()
+        self.s3_test_url = "s3://test/this/is/not/a-real-key.txt"
+
+    def test_parse_s3_url(self):
+        parsed = S3Hook.parse_s3_url(self.s3_test_url)
+        self.assertEqual(parsed,
+                         ("test", "this/is/not/a-real-key.txt"),
+                         "Incorrect parsing of the s3 url")
+
+
+@unittest.skipIf(S3Hook is None,
+                 "Skipping test because S3Hook is not installed")
+@unittest.skipIf(mock_s3 is None, 'Skipping test because mock_s3 package not present')
+class S3HookMotoTest(unittest.TestCase):
+    def setUp(self):
+        configuration.load_test_config()
+
+    @mock.patch('airflow.hooks.S3_hook.S3Hook.get_connections')
+    @mock_s3
+    def test_s3_hook_load_file(self, mock_get_connections):
+        conn = boto.connect_s3()
+        conn.create_bucket('test_bucket')
+
+        c = models.Connection(conn_id='s3_conn', conn_type='S3')
+        mock_get_connections.return_value = [c]
+
+        s3_hook = S3Hook(s3_conn_id='s3_conn')
+        s3_hook.load_file(filename=__file__, key="test_s3_key.tmp",
+                          bucket_name="test_bucket", replace=True)
+
+        keys = s3_hook.list_keys(bucket_name="test_bucket")
+        self.assertIn("test_s3_key.tmp", keys)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/hooks/__init__.py
+++ b/tests/hooks/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .S3_hook import *


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title:

   https://issues.apache.org/jira/browse/AIRFLOW-1023

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR provides a work around in the S3 hook to a boto issue that results in `Connection reset by peer` errors when uploading files to S3 buckets that are located in non standard US locations (e.g. eu-west-1).

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No unit test is provided, since the S3 related functionality in `S3_hook.py` is not covered with unit tests and this is inherent to S3 and will be hard (if not impossible) to mock.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

