### PR TITLE
[AIRFLOW-1017] get_task_instance shouldn't throw exception when no TI

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4017,7 +4017,7 @@ class DagRun(Base):
             TI.dag_id == self.dag_id,
             TI.execution_date == self.execution_date,
             TI.task_id == task_id
-        ).one()
+        ).first()
 
         return ti
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -310,6 +310,32 @@ class DagRunTest(unittest.TestCase):
         state = dr.update_state()
         self.assertEqual(State.FAILED, state)
 
+    def test_get_task_instance_on_empty_dagrun(self):
+        """
+        Make sure that a proper value is returned when a dagrun has no task instances
+        """
+        session = settings.Session()
+
+        # Any dag will work for this
+        dag = self.dagbag.get_dag('test_dagrun_short_circuit_false')
+        now = datetime.datetime.now()
+
+        # Don't use create_dagrun since it will create the task instances too which we
+        # don't want
+        dag_run = models.DagRun(
+            dag_id=dag.dag_id,
+            run_id='manual__' + now.isoformat(),
+            execution_date=now,
+            start_date=now,
+            state=State.RUNNING,
+            external_trigger=False,
+        )
+        session.add(dag_run)
+        session.commit()
+
+        ti = dag_run.get_task_instance('test_short_circuit_false')
+        self.assertEqual(None, ti)
+
 
 class DagBagTest(unittest.TestCase):
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [X] My PR addresses the following [Airflow JIRA]
    - https://issues.apache.org/jira/browse/AIRFLOW-1017


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

get_task_instance should return None instead of throwing exception in
the case where a dagrun does not have the task instance.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests added.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@saguziel @artwr 