### PR TITLE
[AIRFLOW-1011] Fix bug in BackfillJob._execute() for SubDAGs

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2716,6 +2716,7 @@ class DAG(BaseDag, LoggingMixin):
         self.default_view = default_view
         self.orientation = orientation
         self.catchup = catchup
+        self.is_subdag = False  # DagBag.bag_dag() will set this to True if appropriate
 
         self.partial = False
 


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issue:

- https://issues.apache.org/jira/browse/AIRFLOW-1011

Testing Done:

- Unit tests pass on Travis

BackfillJob._execute() checks that the next run date is less than
or equal to the end date before creating a DAG run and task
instances. For SubDAGs, the next run date is not relevant,
i.e. schedule_interval can be anything other than None
or '@once' and should be ignored. However, current code calculates
the next run date for a SubDAG and the condition check mentioned
above always fails for a SubDAG triggered manually, hence the tasks
in the SubDAG will never be executed.

This change adds a simple check to determine if this is a SubDAG
and, if so, sets next run date to DAG run's start date.
