### PR TITLE
[AIRFLOW-1035] Exponential backoff in tasks should be binary

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1176,7 +1176,8 @@ class TaskInstance(Base):
         """
         delay = self.task.retry_delay
         if self.task.retry_exponential_backoff:
-            delay_backoff_in_seconds = delay.total_seconds() ** self.try_number
+            delay_backoff_in_seconds = (
+                delay.total_seconds() * (2 ** max(0, self.try_number - 1)))
             delay = timedelta(seconds=delay_backoff_in_seconds)
             if self.task.max_retry_delay:
                 delay = min(self.task.max_retry_delay, delay)

--- a/tests/models.py
+++ b/tests/models.py
@@ -682,7 +682,7 @@ class TaskInstanceTest(unittest.TestCase):
 
     def test_next_retry_datetime(self):
         delay = datetime.timedelta(seconds=3)
-        delay_squared = datetime.timedelta(seconds=9)
+        delay_next = datetime.timedelta(seconds=6)
         max_delay = datetime.timedelta(seconds=10)
 
         dag = models.DAG(dag_id='fail_dag')
@@ -706,7 +706,7 @@ class TaskInstanceTest(unittest.TestCase):
 
         ti.try_number = 2
         dt = ti.next_retry_datetime()
-        self.assertEqual(dt, ti.end_date+delay_squared)
+        self.assertEqual(dt, ti.end_date+delay_next)
 
         ti.try_number = 3
         dt = ti.next_retry_datetime()


### PR DESCRIPTION
This changes exponential backoff to use 2 as the exponent base. The current way is dependent on the initial delay and is not the way exponential backoff should be implemented. (see https://en.wikipedia.org/wiki/Exponential_backoff )

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1035


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
I changed exponential backoff to use 2 as the base value.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tests are updated.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

cc: @aoen @bolkedebruin 