### PR TITLE
[AIRFLOW-1038] Specify celery serialization options

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -36,6 +36,9 @@ DEFAULT_QUEUE = configuration.get('celery', 'DEFAULT_QUEUE')
 
 class CeleryConfig(object):
     CELERY_ACCEPT_CONTENT = ['json', 'pickle']
+    CELERY_EVENT_SERIALIZER = 'json'
+    CELERY_RESULT_SERIALIZER = 'pickle'
+    CELERY_TASK_SERIALIZER = 'pickle'
     CELERYD_PREFETCH_MULTIPLIER = 1
     CELERY_ACKS_LATE = True
     BROKER_URL = configuration.get('celery', 'BROKER_URL')


### PR DESCRIPTION
Specify the CELERY_TASK_SERIALIZER and CELERY_RESULT_SERIALIZER as
pickle explicitly, and CELERY_EVENT_SERIALIZER as json.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1038


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes: We should specify the serializers explicitly as it causes an issue when different processes run different versions of celery, and not all types are supported by json.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: The issue is only observable across multiple hosts and is hard to test. Either way, the celery_executor tests should test whether this is sane and all this does it keep it the same as the defaults in <4.0


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@bolkedebruin @plypaul @artwr @aoen @amaliujia