### PR TITLE
[AIRFLOW-1027] Fix error in task details when using functools.partial in PythonOperator

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -19,7 +19,7 @@ import ast
 import os
 import pkg_resources
 import socket
-from functools import wraps
+from functools import wraps, partial
 from datetime import datetime, timedelta
 import dateutil.parser
 import copy
@@ -220,7 +220,7 @@ attr_renderer = {
     'doc_yaml': lambda x: render(x, lexers.YamlLexer),
     'doc_md': wrapped_markdown,
     'python_callable': lambda x: render(
-        inspect.getsource(x), lexers.PythonLexer),
+        inspect.getsource(x if not isinstance(x, partial) else x.func), lexers.PythonLexer),
 }
 
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -1652,6 +1652,13 @@ class WebUiTests(unittest.TestCase):
         response = self.app.get(url)
         self.assertIn("run_this_last", response.data.decode('utf-8'))
 
+    def test_dag_view_task_with_python_operator_using_partial(self):
+        response = self.app.get(
+            '/admin/airflow/task?'
+            'task_id=test_dagrun_functool_partial&dag_id=test_issue_AIRFLOW_1027_dag&'
+            'execution_date={}'.format(DEFAULT_DATE_DS))
+        self.assertEquals(response.status_code, 200)
+
     def tearDown(self):
         configuration.conf.set("webserver", "expose_config", "False")
         self.dag_bash.clear(start_date=DEFAULT_DATE, end_date=datetime.now())

--- a/tests/dags/test_issue_AIRFLOW_1027.py
+++ b/tests/dags/test_issue_AIRFLOW_1027.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+DAG designed to test a PythonOperator that calls a functool.partial
+"""
+import functools
+
+from datetime import datetime
+
+from airflow.models import DAG
+from airflow.operators.python_operator import PythonOperator
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+default_args = dict(
+    start_date=DEFAULT_DATE,
+    owner='airflow')
+
+
+def func_with_two_args(arg_1, arg_2):
+    pass
+
+
+partial_func = functools.partial(func_with_two_args, arg_1=1)
+
+
+dag = DAG(dag_id='test_issue_AIRFLOW_1027_dag', default_args=default_args)
+
+dag_task1 = PythonOperator(
+    task_id='test_dagrun_functool_partial',
+    dag=dag,
+    python_callable=partial_func)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title:

   https://issues.apache.org/jira/browse/AIRFLOW-1027

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR fixes an issue when a functools.partial function was used in a PythonOperator. The task details view crashed due to being unable to resolve the partial functions source code. The fix now loads the partial function source accordingly, if a partial function is supplied with a PythonOperator.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR adds the following untittest:

core tests: `test_dag_view_task_with_python_operator_using_partial` by using a DAG that contains a PythonOperator which uses a functools.partial


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

