### PR TITLE
[AIRFLOW-1045] Make log level configurable via airflow.cfg

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -46,6 +46,9 @@ encrypt_s3_logs = False
 # DEPRECATED option for remote log storage, use remote_base_log_folder instead!
 s3_log_folder =
 
+# Logging level
+logging_level = INFO
+
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor, DaskExecutor
 executor = SequentialExecutor

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -28,6 +28,7 @@ airflow_home = {AIRFLOW_HOME}
 dags_folder = {TEST_DAGS_FOLDER}
 plugins_folder = {TEST_PLUGINS_FOLDER}
 base_log_folder = {AIRFLOW_HOME}/logs
+logging_level = INFO
 executor = SequentialExecutor
 sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/unittests.db
 load_examples = True

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -118,9 +118,24 @@ def policy(task_instance):
 
 
 def configure_logging(log_format=LOG_FORMAT):
-    logging.root.handlers = []
-    logging.basicConfig(
-        format=log_format, stream=sys.stdout, level=LOGGING_LEVEL)
+
+    def _configure_logging(logging_level):
+        global LOGGING_LEVEL
+        logging.root.handlers = []
+        logging.basicConfig(
+            format=log_format, stream=sys.stdout, level=logging_level)
+        LOGGING_LEVEL = logging_level
+
+    if "logging_level" in conf.as_dict()["core"]:
+        logging_level = conf.get('core', 'LOGGING_LEVEL').upper()
+    else:
+        logging_level = LOGGING_LEVEL
+    try:
+        _configure_logging(logging_level)
+    except ValueError:
+        logging.warning("Logging level {} is not defined. "
+                        "Use default.".format(logging_level))
+        _configure_logging(logging.INFO)
 
 
 def configure_vars():

--- a/tests/core.py
+++ b/tests/core.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 
 import doctest
 import json
+import logging
 import os
 import re
 import unittest
@@ -2331,6 +2332,55 @@ class EmailSmtpTest(unittest.TestCase):
         utils.email.send_MIME_email('from', 'to', MIMEMultipart(), dryrun=True)
         self.assertFalse(mock_smtp.called)
         self.assertFalse(mock_smtp_ssl.called)
+
+class LogTest(unittest.TestCase):
+    def setUp(self):
+        configuration.load_test_config()
+
+    def _log(self):
+        settings.configure_logging()
+
+        sio = six.StringIO()
+        handler = logging.StreamHandler(sio)
+        logger = logging.getLogger()
+        logger.addHandler(handler)
+
+        logging.debug("debug")
+        logging.info("info")
+        logging.warn("warn")
+
+        sio.flush()
+        return sio.getvalue()
+
+    def test_default_log_level(self):
+        s = self._log()
+        self.assertFalse("debug" in s)
+        self.assertTrue("info" in s)
+        self.assertTrue("warn" in s)
+
+    def test_change_log_level_to_debug(self):
+        configuration.set("core", "LOGGING_LEVEL", "DEBUG")
+        s = self._log()
+        self.assertTrue("debug" in s)
+        self.assertTrue("info" in s)
+        self.assertTrue("warn" in s)
+
+    def test_change_log_level_to_info(self):
+        configuration.set("core", "LOGGING_LEVEL", "INFO")
+        s = self._log()
+        self.assertFalse("debug" in s)
+        self.assertTrue("info" in s)
+        self.assertTrue("warn" in s)
+
+    def test_change_log_level_to_warn(self):
+        configuration.set("core", "LOGGING_LEVEL", "WARNING")
+        s = self._log()
+        self.assertFalse("debug" in s)
+        self.assertFalse("info" in s)
+        self.assertTrue("warn" in s)
+
+    def tearDown(self):
+        configuration.set("core", "LOGGING_LEVEL", "INFO")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1045


### Description
- [x] Here are some details about my PR:

For now, changing log level needs to modify settings.py directly.
It's inconvenient. This PR makes it configurable via airflow.cfg.


### Tests
- [x] My PR adds the following unit tests: 

core:LogTest


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
