### PR TITLE
[AIRFLOW-1047] Sanitize strings passed to Markup

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -24,6 +24,7 @@ from datetime import datetime, timedelta
 import dateutil.parser
 import copy
 import json
+import bleach
 
 import inspect
 from textwrap import dedent
@@ -102,11 +103,12 @@ if conf.getboolean('webserver', 'FILTER_BY_OWNER'):
 
 
 def dag_link(v, c, m, p):
+    dag_id = bleach.clean(m.dag_id)
     url = url_for(
         'airflow.graph',
-        dag_id=m.dag_id)
+        dag_id=dag_id)
     return Markup(
-        '<a href="{url}">{m.dag_id}</a>'.format(**locals()))
+        '<a href="{}">{}</a>'.format(url, dag_id))
 
 
 def log_url_formatter(v, c, m, p):
@@ -117,20 +119,22 @@ def log_url_formatter(v, c, m, p):
 
 
 def task_instance_link(v, c, m, p):
+    dag_id = bleach.clean(m.dag_id)
+    task_id = bleach.clean(m.task_id)
     url = url_for(
         'airflow.task',
-        dag_id=m.dag_id,
-        task_id=m.task_id,
+        dag_id=dag_id,
+        task_id=task_id,
         execution_date=m.execution_date.isoformat())
     url_root = url_for(
         'airflow.graph',
-        dag_id=m.dag_id,
-        root=m.task_id,
+        dag_id=dag_id,
+        root=task_id,
         execution_date=m.execution_date.isoformat())
     return Markup(
         """
         <span style="white-space: nowrap;">
-        <a href="{url}">{m.task_id}</a>
+        <a href="{url}">{task_id}</a>
         <a href="{url_root}" title="Filter on this task and upstream">
         <span class="glyphicon glyphicon-filter" style="margin-left: 0px;"
             aria-hidden="true"></span>

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -1,5 +1,6 @@
 alembic
 bcrypt
+bleach
 boto
 celery
 cgroupspy

--- a/setup.py
+++ b/setup.py
@@ -203,6 +203,7 @@ def do_setup():
         scripts=['airflow/bin/airflow'],
         install_requires=[
             'alembic>=0.8.3, <0.9',
+            'bleach==2.0.0',
             'configparser>=3.5.0, <3.6.0',
             'croniter>=0.3.8, <0.4',
             'dill>=0.2.2, <0.3',

--- a/tests/core.py
+++ b/tests/core.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function
 
+import bleach
 import doctest
 import json
 import os
@@ -1423,7 +1424,7 @@ class CliTests(unittest.TestCase):
         os.remove('variables1.json')
         os.remove('variables2.json')
 
-class CSRFTests(unittest.TestCase):
+class SecurityTests(unittest.TestCase):
     def setUp(self):
         configuration.load_test_config()
         configuration.conf.set("webserver", "authenticate", "False")
@@ -1457,6 +1458,15 @@ class CSRFTests(unittest.TestCase):
         csrf = self.get_csrf(response)
         response = self.app.post("/admin/queryview/", data=dict(csrf_token=csrf))
         self.assertEqual(200, response.status_code)
+
+    def test_xss(self):
+        try:
+            self.app.get("/admin/airflow/tree?dag_id=<script>alert(123456)</script>")
+        except:
+            # exception is expected here since dag doesnt exist
+            pass
+        response = self.app.get("/admin/log", follow_redirects=True)
+        self.assertIn(bleach.clean("<script>alert(123456)</script>"), response.data.decode('UTF-8'))
 
     def tearDown(self):
         configuration.conf.set("webserver", "expose_config", "False")


### PR DESCRIPTION
We add the Apache-licensed bleach library and use it to sanitize html
passed to Markup (which is supposed to be safe)

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1047


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes: Sanitize untrusted input. Bleach is from mozilla and has an Apache v2 license. https://pypi.python.org/pypi/bleach


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Added test that tests the specific case that was problematic.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@aoen @artwr @bolkedebruin @amaliujia