### PR TITLE
[AIRFLOW-1035] Use binary exponential backoff

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1176,7 +1176,15 @@ class TaskInstance(Base):
         """
         delay = self.task.retry_delay
         if self.task.retry_exponential_backoff:
-            delay_backoff_in_seconds = delay.total_seconds() ** self.try_number
+            # timedelta has a maximum representable value. The exponentiation
+            # here means this value can be exceeded after a certain number
+            # of tries (around 50 if the initial delay is 1s, even fewer if
+            # the delay is larger). Cap the value here before creating a
+            # timedelta object so the operation doesn't fail.
+            delay_backoff_in_seconds = min(
+                delay.total_seconds() * (2 ** (self.try_number - 1)),
+                timedelta.max.total_seconds() - 1
+            )
             delay = timedelta(seconds=delay_backoff_in_seconds)
             if self.task.max_retry_delay:
                 delay = min(self.task.max_retry_delay, delay)

--- a/tests/models.py
+++ b/tests/models.py
@@ -681,9 +681,8 @@ class TaskInstanceTest(unittest.TestCase):
         self.assertEqual(ti.try_number, 4)
 
     def test_next_retry_datetime(self):
-        delay = datetime.timedelta(seconds=3)
-        delay_squared = datetime.timedelta(seconds=9)
-        max_delay = datetime.timedelta(seconds=10)
+        delay = datetime.timedelta(seconds=30)
+        max_delay = datetime.timedelta(minutes=60)
 
         dag = models.DAG(dag_id='fail_dag')
         task = BashOperator(
@@ -702,13 +701,17 @@ class TaskInstanceTest(unittest.TestCase):
 
         ti.try_number = 1
         dt = ti.next_retry_datetime()
-        self.assertEqual(dt, ti.end_date+delay)
+        self.assertEqual(dt, ti.end_date + delay)
 
-        ti.try_number = 2
+        ti.try_number = 6
         dt = ti.next_retry_datetime()
-        self.assertEqual(dt, ti.end_date+delay_squared)
+        self.assertEqual(dt, ti.end_date + (2 ** 5) * delay)
 
-        ti.try_number = 3
+        ti.try_number = 8
+        dt = ti.next_retry_datetime()
+        self.assertEqual(dt, ti.end_date+max_delay)
+
+        ti.try_number = 50
         dt = ti.next_retry_datetime()
         self.assertEqual(dt, ti.end_date+max_delay)
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title:
    - https://issues.apache.org/jira/browse/AIRFLOW-1035

### Description
- [x] Here are some details about my PR:
The way that exponential backoff is currently calculated is by exponentiating the initial `retry_delay` directly. This makes any `retry_delay` above a few seconds unusable for exponential backoff - for example, for the default delay of 5 minutes, the second retry will be after 25 hours, and the third one - after 312 days.
This PR replaces this calculation with a more standard exponential backoff algorithm - namely, using the initial `retry_delay` simply as a multiplier, and the base for the exponentiation is **2**.
See e.g. https://en.wikipedia.org/wiki/Exponential_backoff or https://www.awsarchitectureblog.com/2015/03/backoff.html for reference.

### Tests
- [x] My PR adds the following unit tests:
- modifies `TaskInstanceTest.test_next_retry_datetime` to verify the new behaviour.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

