### PR TITLE
[AIRFLOW-1051] Add a test for resetdb to CliTests

### DIFF
--- a/tests/core.py
+++ b/tests/core.py
@@ -1087,6 +1087,9 @@ class CliTests(unittest.TestCase):
     def test_cli_initdb(self):
         cli.initdb(self.parser.parse_args(['initdb']))
 
+    def test_cli_resetdb(self):
+        cli.resetdb(self.parser.parse_args(['resetdb', '--yes']))
+
     def test_cli_connections_list(self):
         with mock.patch('sys.stdout',
                         new_callable=six.StringIO) as mock_stdout:


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1051


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

CliTests lacks a test for resetdb command for now. It should be added.


### Tests
- [x] My PR adds the following unit tests:

CliTests.test_cli_resetdb


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

