### PR TITLE
[AIRFLOW-1002] Add ability to clean all dependencies of removed DAG

### DIFF
--- a/airflow/api/client/api_client.py
+++ b/airflow/api/client/api_client.py
@@ -32,6 +32,13 @@ class Client(object):
         """
         raise NotImplementedError()
 
+    def delete_dag(self, dag_id):
+        """Delete all DB records related to the specified dag.
+
+        :param dag_id:
+        """
+        raise NotImplementedError()
+
     def get_pool(self, name):
         """Get pool.
 

--- a/airflow/api/client/json_client.py
+++ b/airflow/api/client/json_client.py
@@ -50,6 +50,12 @@ class Client(api_client.Client):
                              })
         return data['message']
 
+    def delete_dag(self, dag_id):
+        endpoint = '/api/experimental/dags/{}/delete_dag'.format(dag_id)
+        url = urljoin(self._api_base_url, endpoint)
+        data = self._request(url, method='DELETE')
+        return data['message']
+
     def get_pool(self, name):
         endpoint = '/api/experimental/pools/{}'.format(name)
         url = urljoin(self._api_base_url, endpoint)

--- a/airflow/api/client/local_client.py
+++ b/airflow/api/client/local_client.py
@@ -15,6 +15,7 @@
 from airflow.api.client import api_client
 from airflow.api.common.experimental import pool
 from airflow.api.common.experimental import trigger_dag
+from airflow.api.common.experimental import delete_dag
 
 
 class Client(api_client.Client):
@@ -26,6 +27,10 @@ class Client(api_client.Client):
                                      conf=conf,
                                      execution_date=execution_date)
         return "Created {}".format(dr)
+
+    def delete_dag(self, dag_id):
+        count = delete_dag.delete_dag(dag_id)
+        return "Removed {} record(s)".format(count)
 
     def get_pool(self, name):
         p = pool.get_pool(name=name)

--- a/airflow/api/common/experimental/delete_dag.py
+++ b/airflow/api/common/experimental/delete_dag.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow import models, settings
+from airflow.exceptions import AirflowException
+from sqlalchemy import or_
+
+
+class DagFileExists(AirflowException):
+    status = 400
+
+
+class DagNotFound(AirflowException):
+    status = 404
+
+
+def delete_dag(dag_id):
+    session = settings.Session()
+
+    DM = models.DagModel
+    dag = session.query(DM).filter(DM.dag_id == dag_id).first()
+    if dag is None:
+        raise DagNotFound("Dag id {} not found".format(dag_id))
+
+    dagbag = models.DagBag()
+    if dag_id in dagbag.dags:
+        raise DagFileExists("Dag id {} is still in DagBag. "
+                            "Remove the DAG file first.".format(dag_id))
+
+    count = 0
+
+    for m in models.Base._decl_class_registry.values():
+        if hasattr(m, "dag_id"):
+            cond = or_(m.dag_id == dag_id, m.dag_id.like(dag_id + ".%"))
+            count += session.query(m).filter(cond).delete(synchronize_session='fetch')
+
+    if dag.is_subdag:
+        p, c = dag_id.rsplit(".", 1)
+        for m in models.DagRun, models.TaskFail, models.TaskInstance:
+            count += session.query(m).filter(m.dag_id == p, m.task_id == c).delete()
+
+    session.commit()
+
+    return count

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -203,6 +203,26 @@ def trigger_dag(args):
     log.info(message)
 
 
+def delete_dag(args):
+    """
+    Deletes all DB records related to the specified dag
+    :param args:
+    :return:
+    """
+    log = LoggingMixin().log
+    if args.yes or input(
+            "This will drop all existing records related to the specified DAG. "
+            "Proceed? (y/n)").upper() == "Y":
+        try:
+            message = api_client.delete_dag(dag_id=args.dag_id)
+        except IOError as err:
+            log.error(err)
+            raise AirflowException(err)
+        log.info(message)
+    else:
+        print("Bail.")
+
+
 def pool(args):
     log = LoggingMixin().log
 
@@ -1157,6 +1177,11 @@ class CLIFactory(object):
             ("--stdout",), "Redirect stdout to this file"),
         'log_file': Arg(
             ("-l", "--log-file"), "Location of the log file"),
+        'yes': Arg(
+            ("-y", "--yes"),
+            "Do not prompt to confirm reset. Use with care!",
+            "store_true",
+            default=False),
 
         # backfill
         'mark_success': Arg(
@@ -1374,12 +1399,6 @@ class CLIFactory(object):
             default=conf.get('webserver', 'ERROR_LOGFILE'),
             help="The logfile to store the webserver error log. Use '-' to print to "
                  "stderr."),
-        # resetdb
-        'yes': Arg(
-            ("-y", "--yes"),
-            "Do not prompt to confirm reset. Use with care!",
-            "store_true",
-            default=False),
         # scheduler
         'dag_id_opt': Arg(("-d", "--dag_id"), help="The id of the dag to run"),
         'run_duration': Arg(
@@ -1515,6 +1534,10 @@ class CLIFactory(object):
             'func': trigger_dag,
             'help': "Trigger a DAG run",
             'args': ('dag_id', 'subdir', 'run_id', 'conf', 'exec_date'),
+        }, {
+            'func': delete_dag,
+            'help': "Delete all DB records related to the specified DAG",
+            'args': ('dag_id', 'yes',),
         }, {
             'func': pool,
             'help': "CRUD operations on pools",

--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -15,6 +15,7 @@ import airflow.api
 
 from airflow.api.common.experimental import pool as pool_api
 from airflow.api.common.experimental import trigger_dag as trigger
+from airflow.api.common.experimental import delete_dag as delete
 from airflow.api.common.experimental.get_task import get_task
 from airflow.api.common.experimental.get_task_instance import get_task_instance
 from airflow.exceptions import AirflowException
@@ -83,6 +84,23 @@ def trigger_dag(dag_id):
 
     response = jsonify(message="Created {}".format(dr))
     return response
+
+
+@csrf.exempt
+@api_experimental.route('/dags/<string:dag_id>', methods=['DELETE'])
+@requires_authentication
+def delete_dag(dag_id):
+    """
+    Delete all DB records related to the specified Dag.
+    """
+    try:
+        count = delete.delete_dag(dag_id)
+    except AirflowException as e:
+        _log.error(e)
+        response = jsonify(error="{}".format(e))
+        response.status_code = getattr(e, 'status', 500)
+        return response
+    return jsonify(message="Removed {} record(s)".format(count), count=count)
 
 
 @api_experimental.route('/test', methods=['GET'])

--- a/tests/api/client/test_local_client.py
+++ b/tests/api/client/test_local_client.py
@@ -98,6 +98,19 @@ class TestLocalClient(unittest.TestCase):
                                          external_trigger=True)
             mock.reset_mock()
 
+    def test_delete_dag(self):
+        key = "my_dag_id"
+        session = settings.Session()
+        DM = models.DagModel
+        self.assertEqual(session.query(DM).filter(DM.dag_id == key).count(), 0)
+
+        session.add(DM(dag_id=key))
+        session.commit()
+        self.assertEqual(session.query(DM).filter(DM.dag_id == key).count(), 1)
+
+        self.client.delete_dag(dag_id=key)
+        self.assertEqual(session.query(DM).filter(DM.dag_id == key).count(), 0)
+
     def test_get_pool(self):
         self.client.create_pool(name='foo', slots=1, description='')
         pool = self.client.get_pool(name='foo')

--- a/tests/core.py
+++ b/tests/core.py
@@ -1334,6 +1334,24 @@ class CliTests(unittest.TestCase):
                 '-c', 'NOT JSON'])
         )
 
+    def test_delete_dag(self):
+        DM = models.DagModel
+        key = "my_dag_id"
+        session = settings.Session()
+        session.add(DM(dag_id=key))
+        session.commit()
+        cli.delete_dag(self.parser.parse_args([
+            'delete_dag', key, '--yes']))
+        self.assertEqual(session.query(DM).filter_by(dag_id=key).count(), 0)
+        self.assertRaises(
+            AirflowException,
+            cli.delete_dag,
+            self.parser.parse_args([
+                'delete_dag',
+                'does_not_exist_dag',
+                '--yes'])
+        )
+
     def test_pool_create(self):
         cli.pool(self.parser.parse_args(['pool', '-s', 'foo', '1', 'test']))
         self.assertEqual(self.session.query(models.Pool).count(), 1)

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -19,7 +19,7 @@ from urllib.parse import quote_plus
 
 from airflow import configuration
 from airflow.api.common.experimental.trigger_dag import trigger_dag
-from airflow.models import DagBag, DagRun, Pool, TaskInstance
+from airflow.models import DagBag, DagModel, DagRun, Pool, TaskInstance
 from airflow.settings import Session
 from airflow.utils.timezone import datetime, utcnow
 from airflow.www import app as application
@@ -85,6 +85,26 @@ class TestApiExperimental(unittest.TestCase):
         response = self.app.post(
             url_template.format('does_not_exist_dag'),
             data=json.dumps({}),
+            content_type="application/json"
+        )
+        self.assertEqual(404, response.status_code)
+
+    def test_delete_dag(self):
+        url_template = '/api/experimental/dags/{}'
+
+        from airflow import settings
+        session = settings.Session()
+        key = "my_dag_id"
+        session.add(DagModel(dag_id=key))
+        session.commit()
+        response = self.app.delete(
+            url_template.format(key),
+            content_type="application/json"
+        )
+        self.assertEqual(200, response.status_code)
+
+        response = self.app.delete(
+            url_template.format('does_not_exist_dag'),
             content_type="application/json"
         )
         self.assertEqual(404, response.status_code)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1002

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

After removing a dag file, there is no way to clean database
except for removing corresponding records directly for now.
This PR enables user to do this via command line.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

CliTests.test_cli_remove_dag


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

