### PR TITLE
[AIRFLOW-1013] Skip manage_sla check for @once DAGs

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -592,6 +592,10 @@ class SchedulerJob(BaseJob):
             dttm = ti.execution_date
             if task.sla:
                 dttm = dag.following_schedule(dttm)
+                # Skip tasks for @once dags
+                if not dttm and dag.schedule_interval == '@once':
+                    self.logger.warn(' --------------> SLAs not supported in @once DAGs')
+                    continue;
                 while dttm < datetime.now():
                     following_schedule = dag.following_schedule(dttm)
                     if following_schedule + task.sla < datetime.now():


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- My PR addresses the following issue:
    - [AIRFLOW-1013](https://issues.apache.org/jira/browse/AIRFLOW-1013)

### Description
For `@once` DAGs, SLAs don't make sense. The manage_SLAs machinery now ignores but logs a warning message that SLAs_missed reporting is not supported for `@once` DAGs.

