### PR TITLE
[AIRFLOW-1057] fix class name that is changed at docker package version 2.0.0

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -14,12 +14,17 @@
 
 import json
 import logging
+import ast
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory
-from docker import Client, tls
-import ast
+from docker import tls
+try:
+    from docker import APIClient
+except ImportError:
+    # prior to version 2.0.0 of the module docker, the API client was called Client
+    from docker import Client as APIClient
 
 
 class DockerOperator(BaseOperator):
@@ -142,7 +147,7 @@ class DockerOperator(BaseOperator):
             )
             self.docker_url = self.docker_url.replace('tcp://', 'https://')
 
-        self.cli = Client(base_url=self.docker_url, version=self.api_version, tls=tls_config)
+        self.cli = APIClient(base_url=self.docker_url, version=self.api_version, tls=tls_config)
 
         if ':' not in self.image:
             image = self.image + ':latest'

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ doc = [
     'sphinx-rtd-theme>=0.1.6',
     'Sphinx-PyPI-upload>=0.2.1'
 ]
-docker = ['docker-py>=1.6.0']
+docker = ['docker>=2.0.0']
 druid = ['pydruid>=0.2.1']
 emr = ['boto3>=1.0.0']
 gcp_api = [

--- a/tests/operators/docker_operator.py
+++ b/tests/operators/docker_operator.py
@@ -17,9 +17,14 @@ import logging
 
 try:
     from airflow.operators.docker_operator import DockerOperator
-    from docker.client import Client
 except ImportError:
     pass
+
+try:
+    from docker import APIClient
+except ImportError:
+    # prior to version 2.0.0 of the module docker, the API client was called Client
+    from docker import Client as APIClient
 
 from airflow.exceptions import AirflowException
 
@@ -35,12 +40,12 @@ except ImportError:
 class DockerOperatorTestCase(unittest.TestCase):
     @unittest.skipIf(mock is None, 'mock package not present')
     @mock.patch('airflow.utils.file.mkdtemp')
-    @mock.patch('airflow.operators.docker_operator.Client')
+    @mock.patch('airflow.operators.docker_operator.APIClient')
     def test_execute(self, client_class_mock, mkdtemp_mock):
         host_config = mock.Mock()
         mkdtemp_mock.return_value = '/mkdtemp'
 
-        client_mock = mock.Mock(spec=Client)
+        client_mock = mock.Mock(spec=APIClient)
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.create_host_config.return_value = host_config
         client_mock.images.return_value = []
@@ -76,9 +81,9 @@ class DockerOperatorTestCase(unittest.TestCase):
 
     @unittest.skipIf(mock is None, 'mock package not present')
     @mock.patch('airflow.operators.docker_operator.tls.TLSConfig')
-    @mock.patch('airflow.operators.docker_operator.Client')
+    @mock.patch('airflow.operators.docker_operator.APIClient')
     def test_execute_tls(self, client_class_mock, tls_class_mock):
-        client_mock = mock.Mock(spec=Client)
+        client_mock = mock.Mock(spec=APIClient)
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.create_host_config.return_value = mock.Mock()
         client_mock.images.return_value = []
@@ -103,9 +108,9 @@ class DockerOperatorTestCase(unittest.TestCase):
                                              version=None)
 
     @unittest.skipIf(mock is None, 'mock package not present')
-    @mock.patch('airflow.operators.docker_operator.Client')
+    @mock.patch('airflow.operators.docker_operator.APIClient')
     def test_execute_unicode_logs(self, client_class_mock):
-        client_mock = mock.Mock(spec=Client)
+        client_mock = mock.Mock(spec=APIClient)
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.create_host_config.return_value = mock.Mock()
         client_mock.images.return_value = []
@@ -126,9 +131,9 @@ class DockerOperatorTestCase(unittest.TestCase):
             print_exception_mock.assert_not_called()
 
     @unittest.skipIf(mock is None, 'mock package not present')
-    @mock.patch('airflow.operators.docker_operator.Client')
+    @mock.patch('airflow.operators.docker_operator.APIClient')
     def test_execute_container_fails(self, client_class_mock):
-        client_mock = mock.Mock(spec=Client)
+        client_mock = mock.Mock(spec=APIClient)
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.create_host_config.return_value = mock.Mock()
         client_mock.images.return_value = []
@@ -145,7 +150,7 @@ class DockerOperatorTestCase(unittest.TestCase):
 
     @unittest.skipIf(mock is None, 'mock package not present')
     def test_on_kill(self):
-        client_mock = mock.Mock(spec=Client)
+        client_mock = mock.Mock(spec=APIClient)
 
         operator = DockerOperator(image='ubuntu', owner='unittest', task_id='unittest')
         operator.cli = client_mock


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [AIRFLOW-1057](https://issues.apache.org/jira/browse/AIRFLOW-1057) 


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
This fixes an incorrect reference to a class in the docker package

### Tests
- [X] My PR also changes the docker_operator test to check if the correct version of docker python is installed.


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
