### PR TITLE
[AIRFLOW-922] Update PrestoHook to enable synchronous execution

### DIFF
--- a/airflow/hooks/presto_hook.py
+++ b/airflow/hooks/presto_hook.py
@@ -19,10 +19,12 @@
 
 import time
 from builtins import str
+import past.builtins
 
 from pyhive import presto
 from pyhive.exc import DatabaseError
 from requests.auth import HTTPBasicAuth
+from requests.exceptions import RequestException
 
 from airflow.hooks.dbapi_hook import DbApiHook
 
@@ -132,7 +134,7 @@ class PrestoHook(DbApiHook):
             status of each statement; set to None
         :type poll_interval: int or float
         """
-        if isinstance(sql, str):
+        if isinstance(sql, past.builtins.basestring):
             sql = [sql]
 
         cursor = self.get_conn().cursor()
@@ -157,7 +159,7 @@ class PrestoHook(DbApiHook):
         """
         try:
             return cursor.poll() is None
-        except Exception as ex:
+        except RequestException as ex:
             msg = "Couldn't determine statement execution status: ".format(ex)
             self.log.error(msg)
             return None

--- a/airflow/hooks/presto_hook.py
+++ b/airflow/hooks/presto_hook.py
@@ -146,16 +146,21 @@ class PrestoHook(DbApiHook):
                 while not self.execution_finished(cursor):
                     time.sleep(poll_interval)
 
-    @classmethod
-    def execution_finished(cls, cursor):
+    def execution_finished(self, cursor):
         """
         Return a bool indicating whether the latest statement executed by
-        cursor has finished executing.
+        cursor has finished executing. If the execution status can't be
+        determined, e.g. because of a network problem, returns None.
 
         :param cursor: a cursor
         :type cursor: presto.Cursor
         """
-        return cursor.poll() is None
+        try:
+            return cursor.poll() is None
+        except Exception as ex:
+            msg = "Couldn't determine statement execution status: ".format(ex)
+            self.log.error(msg)
+            return None
 
     # TODO Enable commit_every once PyHive supports transaction.
     # Unfortunately, PyHive 0.5.1 doesn't support transaction for now,

--- a/airflow/hooks/presto_hook.py
+++ b/airflow/hooks/presto_hook.py
@@ -146,7 +146,7 @@ class PrestoHook(DbApiHook):
 
             if poll_interval is not None:
                 while not self.execution_finished(cursor):
-                    time.sleep(poll_interval)
+                    self.wait(poll_interval)
 
     def execution_finished(self, cursor):
         """
@@ -163,6 +163,20 @@ class PrestoHook(DbApiHook):
             msg = "Couldn't determine statement execution status: ".format(ex)
             self.log.error(msg)
             return None
+
+    @staticmethod
+    def wait(interval):
+        """
+        Wait for the specified interval. Wraps time.sleep.
+
+        Exists to be mocked in testing. Mocking time.sleep directly can be
+        problematic when other packages, e.g. pymongo, also call it during
+        test execution.
+
+        :param interval: how often, in seconds, to wait
+        :type interval: int or float
+        """
+        time.sleep(interval)
 
     # TODO Enable commit_every once PyHive supports transaction.
     # Unfortunately, PyHive 0.5.1 doesn't support transaction for now,

--- a/airflow/hooks/presto_hook.py
+++ b/airflow/hooks/presto_hook.py
@@ -17,7 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import sys
 import time
 from builtins import str
 

--- a/tests/hooks/test_presto_hook.py
+++ b/tests/hooks/test_presto_hook.py
@@ -20,11 +20,8 @@
 
 import mock
 import unittest
-import time
 
 from mock import patch
-
-import pyhive.presto
 
 from airflow.hooks.presto_hook import PrestoHook
 
@@ -74,4 +71,3 @@ class TestPrestoHook(unittest.TestCase):
         with self.assertRaises(RuntimeError, msg=ERROR_MSG):
             hook.run(sql="", poll_interval=POLL_INTERVAL)
             mock_sleep.assert_called_once_with(POLL_INTERVAL)
-


### PR DESCRIPTION
### JIRA
https://issues.apache.org/jira/browse/AIRFLOW-922

### Description
This updates [`PrestoHook`](https://github.com/apache/incubator-airflow/blob/b55f41f2c22e210d130a0b42586f0385bd5515a7/airflow/hooks/presto_hook.py) so that it can block until a statement finishes executing. Currently, [`PrestoHook.run`](https://github.com/apache/incubator-airflow/blob/b55f41f2c22e210d130a0b42586f0385bd5515a7/airflow/hooks/presto_hook.py#L104-L108) returns as soon as it sends a statement, so Operators that use it won't [run synchronously](https://github.com/apache/incubator-airflow/blob/b55f41f2c22e210d130a0b42586f0385bd5515a7/airflow/models.py#L1788-L1789).

There are other, minor changes too that seemed worth making (hence the separate commits), though they're unrelated to the primary goal of this PR. Of course if you'd rather jettison those, or put them in a separate PR, that's fine by me.

### Tests
I added [some](https://github.com/apache/incubator-airflow/blob/58ed2995867d9dc89b589270642849b6841b4b9b/tests/contrib/hooks/presto_hook_test.py) under `tests/contrib/hooks`, though I wasn't sure if that was the proper location. (`PrestoHook` is built in, not user-contributed, but AFAICT there are no existing tests for it.) 

### Commits
I haven't squashed commits yet, because I wanted to keep the history easy to see until the code is in a satisfactory state. Once it is, I'm happy to rewrite the commit history (unless you plan to just squash and merge to take care of that?).