### PR TITLE
[AIRFLOW-1062] Fix DagRun#find to return correct result

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3968,7 +3968,7 @@ class DagRun(Base):
                 qry = qry.filter(DR.execution_date == execution_date)
         if state:
             qry = qry.filter(DR.state == state)
-        if external_trigger:
+        if external_trigger is not None:
             qry = qry.filter(DR.external_trigger == external_trigger)
 
         dr = qry.order_by(DR.execution_date).all()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1062


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

    DagRun#find returns wrong result if external_trigger=False is specified,
    because adding filter is skipped on that condition. This PR fixes it.


### Tests
- [x] My PR adds the following unit test:

    test_dagrun_find


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

