### PR TITLE
[AIRFLOW-1018] Sanitize logging format and allow stdout for scheduler

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -304,6 +304,8 @@ dag_dir_list_interval = 300
 # How often should stats be printed to the logs
 print_stats_interval = 30
 
+# Where the scheduler logs its parsing of the DAGs
+# if you want to log this to stdout, use "stdout"
 child_process_log_directory = {AIRFLOW_HOME}/logs/scheduler
 
 # Local task jobs periodically heartbeat to the DB. If the job has

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -75,11 +75,11 @@ GUNICORN_WORKER_READY_PREFIX = "[ready] "
 
 # can't move this to conf due to ConfigParser interpolation
 LOG_FORMAT = (
-    '[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s')
+    '[%(asctime)s] [%(process)d]: {%(filename)s:%(lineno)d} %(levelname)s - %(message)s')
 LOG_FORMAT_WITH_PID = (
-    '[%(asctime)s] [%(process)d] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s')
+    '[%(asctime)s] [%(process)d]: {%(filename)s:%(lineno)d} %(levelname)s - %(message)s')
 LOG_FORMAT_WITH_THREAD_NAME = (
-    '[%(asctime)s] {%(filename)s:%(lineno)d} %(threadName)s %(levelname)s - %(message)s')
+    '[%(asctime)s] [%(process)d]: {%(filename)s:%(lineno)d} %(threadName)s %(levelname)s - %(message)s')
 SIMPLE_LOG_FORMAT = '%(asctime)s %(levelname)s - %(message)s'
 
 AIRFLOW_HOME = None

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -619,7 +619,13 @@ class DagFileProcessorManager(LoggingMixin):
         while (self._parallelism - len(self._processors) > 0 and
                len(self._file_path_queue) > 0):
             file_path = self._file_path_queue.pop(0)
-            log_file_path = self._get_log_file_path(file_path)
+
+            # FIXME (bolke): This is a hack until we fix the mess that is logging
+            if "stdout" not in self._child_process_log_directory:
+                log_file_path = self._get_log_file_path(file_path)
+            else:
+                log_file_path = self._child_process_log_directory
+
             processor = self._processor_factory(file_path, log_file_path)
 
             processor.start()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1018


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

Airflow was using serveral logging formats which were difficult to
parse. The patch makes sure we always log PID.

Also the scheduler did not allow for stdout/stderr output for its
parsing of dags, this was a regression. Until we fix logging
properly - by not creating arbitrary files in arbitrary modules,
this is a workaround to allow logging to stdout/stderr.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- Cannot add tests to cover stdout in a sane way

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@criccomini @poulainv 
