### PR TITLE
[AIRFLOW-1064] Change default sort to job_id for TaskInstanceModelView

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2335,7 +2335,7 @@ class TaskInstanceModelView(ModelViewOnly):
         queued_dttm=datetime_f,
         dag_id=dag_link, duration=duration_f)
     column_searchable_list = ('dag_id', 'task_id', 'state')
-    column_default_sort = ('start_date', True)
+    column_default_sort = ('job_id', True)
     form_choices = {
         'state': [
             ('success', 'success'),


### PR DESCRIPTION
The TaskInstanceModelView default sort column is on an unindexed column.
We shouldn't need an index on start_date, and job_id is just as logical
of a default sort.

FYI this changes the query execution time from 40s to 90ms for us because start_date desc does a full table scan.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1064


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes: This changes the default sort.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: This is a UI change. Change can be verified by visiting UI. There's no real reason for a test as this behavior (old or new) doesn't really affect much.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@amaliujia @plypaul @bolkedebruin @artwr 