### PR TITLE
[AIRFLOW-1074] Don't count queued tasks for concurrency limits

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1064,11 +1064,12 @@ class SchedulerJob(BaseJob):
                 dag_id = task_instance.dag_id
 
                 if dag_id not in dag_id_to_possibly_running_task_count:
+                    # TODO(saguziel): also check against QUEUED state, see AIRFLOW-1104
                     dag_id_to_possibly_running_task_count[dag_id] = \
                         DAG.get_num_task_instances(
                             dag_id,
                             simple_dag_bag.get_dag(dag_id).task_ids,
-                            states=[State.RUNNING, State.QUEUED],
+                            states=[State.RUNNING],
                             session=session)
 
                 current_task_concurrency = dag_id_to_possibly_running_task_count[dag_id]

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -504,14 +504,14 @@ class SchedulerJobTest(unittest.TestCase):
         ti1.refresh_from_db()
         ti2.refresh_from_db()
         ti1.state = State.RUNNING
-        ti2.state = State.QUEUED
+        ti2.state = State.RUNNING
         session.merge(ti1)
         session.merge(ti2)
         session.commit()
 
         self.assertEqual(State.RUNNING, dr1.state)
         self.assertEqual(2, DAG.get_num_task_instances(dag_id, dag.task_ids,
-            states=[State.RUNNING, State.QUEUED], session=session))
+            states=[State.RUNNING], session=session))
 
         # create second dag run
         dr2 = scheduler.create_dag_run(dag)
@@ -538,7 +538,7 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertEqual(3, DAG.get_num_task_instances(dag_id, dag.task_ids,
             states=[State.RUNNING, State.QUEUED], session=session))
         self.assertEqual(State.RUNNING, ti1.state)
-        self.assertEqual(State.QUEUED, ti2.state)
+        self.assertEqual(State.RUNNING, ti2.state)
         six.assertCountEqual(self, [State.QUEUED, State.SCHEDULED], [ti3.state, ti4.state])
 
         session.close()


### PR DESCRIPTION
I hate to do this, but I changed my mind on counting queued tasks. 

1. Queued tasks that are actually queued generally get set to running pretty quickly.
2. Because of the worker-side check, we won't actually pass concurrency.

I don't think the queued thing is a big deal because of this, I'm more worried about orphaned tasks that are in QUEUED state but not in a running dag_run (so they wont get reset) interfering with concurrency.

There may be orphaned tasks queued but not in a running dag run that
will not cleared. We should not count these as they will interfere.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1074

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes: See above


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Tests amended


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@bolkedebruin @plypaul @artwr 