### PR TITLE
[AIRFLOW-1076] Add get method for template variable accessor

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1699,20 +1699,31 @@ class TaskInstance(Base, LoggingMixin):
 
         class VariableAccessor:
             """
-            Wrapper around Variable. This way you can get variables in templates by using
-            {var.variable_name}.
+            Wrapper around Variable. This way you can get variables in
+            templates by using {{ var.value.variable_name }} or
+            {{ var.value.get('variable_name', 'backup') }}.
             """
             def __init__(self):
                 self.var = None
 
-            def __getattr__(self, item):
+            def __getattr__(self, item, default_var=None):
                 self.var = Variable.get(item)
                 return self.var
 
             def __repr__(self):
                 return str(self.var)
 
+            @staticmethod
+            def get(item, default_var=None):
+                self.var = Variable.get(item, default_var=default_var)
+                return self.var
+
         class VariableJsonAccessor:
+            """
+            Wrapper around Variable. This way you can get variables in
+            templates by using {{ var.json.variable_name }} or
+            {{ var.json.get('variable_name', 'backup') }}.
+            """
             def __init__(self):
                 self.var = None
 
@@ -1722,6 +1733,12 @@ class TaskInstance(Base, LoggingMixin):
 
             def __repr__(self):
                 return str(self.var)
+
+            @staticmethod
+            def get(item, default_var=None):
+                self.var = Variable.get(item, default_var=default_var,
+                                        deserialize_json=True)
+                return self.var
 
         return {
             'dag': task.dag,

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -193,6 +193,11 @@ UI. You can access them as either plain-text or JSON. If you use JSON, you are
 also able to walk nested structures, such as dictionaries like:
 ``{{ var.json.my_dict_var.key1 }}``
 
+It is also possible to fetch a variable by string if
+needed with ``{{ var.value.get('my_var', 'fallback') }}`` or
+``{{ var.json.get('my_dict_var', {'key1': 'val1'}).key1 }}``. Defaults can be
+supplied in case the variable does not exist.
+
 Macros
 ''''''
 Macros are a way to expose objects to your templates and live under the

--- a/tests/core.py
+++ b/tests/core.py
@@ -520,7 +520,54 @@ class CoreTest(unittest.TestCase):
             some_templated_field='{{ var.value.a_variable }}',
             on_success_callback=verify_templated_field,
             dag=self.dag)
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE,
+              ignore_ti_state=True)
+        self.assertTrue(val['success'])
+
+    def test_template_with_variable_get(self):
+        """
+        Test the availability of variables in templates using get() method
+        """
+        val = {
+            'success': False,
+            'test_value': 'a test value'
+        }
+        Variable.set('a_variable', val['test_value'])
+
+        def verify_templated_field(context):
+            self.assertEqual(context['ti'].task.some_templated_field,
+                             val['test_value'])
+            val['success'] = True
+
+        t = OperatorSubclass(
+            task_id='test_complex_template',
+            some_templated_field='{{ var.value.get("a_variable") }}',
+            on_success_callback=verify_templated_field,
+            dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE,
+              ignore_ti_state=True)
+        self.assertTrue(val['success'])
+
+    def test_template_with_variable_get_with_default(self):
+        """
+        Test the availability of variables in templates using get() method with
+        a default value
+        """
+        val = {
+            'success': False,
+        }
+
+        def verify_templated_field(context):
+            self.assertEqual(context['ti'].task.some_templated_field, 'N/A')
+            val['success'] = True
+
+        t = OperatorSubclass(
+            task_id='test_complex_template',
+            some_templated_field='{{ var.value.get("bad_variable", "N/A") }}',
+            on_success_callback=verify_templated_field,
+            dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE,
+              ignore_ti_state=True)
         self.assertTrue(val['success'])
 
     def test_template_with_json_variable(self):
@@ -543,7 +590,58 @@ class CoreTest(unittest.TestCase):
             some_templated_field='{{ var.json.a_variable.obj.v2 }}',
             on_success_callback=verify_templated_field,
             dag=self.dag)
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE,
+              ignore_ti_state=True)
+        self.assertTrue(val['success'])
+
+    def test_template_with_json_variable_get(self):
+        """
+        Test the availability of variables (serialized as JSON) in templates
+        using get() method
+        """
+        val = {
+            'success': False,
+            'test_value': {'foo': 'bar', 'obj': {'v1': 'yes', 'v2': 'no'}}
+        }
+        Variable.set('a_variable', val['test_value'], serialize_json=True)
+
+        def verify_templated_field(context):
+            self.assertEqual(context['ti'].task.some_templated_field,
+                             val['test_value']['obj']['v2'])
+            val['success'] = True
+
+        t = OperatorSubclass(
+            task_id='test_complex_template',
+            some_templated_field='{{ var.json.get("a_variable").obj.v2 }}',
+            on_success_callback=verify_templated_field,
+            dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE,
+              ignore_ti_state=True)
+        self.assertTrue(val['success'])
+
+    def test_template_with_json_variable_get_with_default(self):
+        """
+        Test the availability of variables (serialized as JSON) in templates
+        using get() method with a default value
+        """
+        val = {
+            'success': False,
+        }
+
+        def verify_templated_field(context):
+            self.assertEqual(context['ti'].task.some_templated_field,
+                             'unknown')
+            val['success'] = True
+
+        t = OperatorSubclass(
+            task_id='test_complex_template',
+            some_templated_field=(
+                '{{ var.json.get("bad_variable", {"obj": {"v2": "unknown"}})'
+                '.obj.v2 }}'),
+            on_success_callback=verify_templated_field,
+            dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE,
+              ignore_ti_state=True)
         self.assertTrue(val['success'])
 
     def test_template_with_json_variable_as_value(self):


### PR DESCRIPTION
Support getting variables in templates by string. This is necessary when
fetching variables with characters not allowed in a class attribute name.
We can then also support returning default values when a variable does
not exist.

Possible alternative is making the method available under `var.value_get()` and `var.json_get()` instead.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1076


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
See above.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
* Added unit tests for calling `var.value.get()` and `var.json.get()`, with or without default

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

