### PR TITLE
[AIRFLOW-1078] Fix latest_runs endpoint for old flask versions

### DIFF
--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -130,4 +130,4 @@ def latest_dag_runs():
                 'dag_run_url': url_for('airflow.graph', dag_id=dagrun.dag_id,
                                        execution_date=dagrun.execution_date)
             })
-    return jsonify(payload)
+    return jsonify(items=payload) # old flask versions dont support jsonifying arrays

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -226,7 +226,7 @@
         });
       });
       $.getJSON("{{ url_for('api_experimental.latest_dag_runs') }}", function(data) {
-        $.each(data, function() {
+        $.each(data["items"], function() {
           var link = $("<a>", {
             href: this.dag_run_url,
             text: this.execution_date


### PR DESCRIPTION
Old versions of flask (<0.11) dont support jsonify on arrays due an
ECMAScript 4 vulnerability in older browsers. This should work on old
flask versions as well.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1078

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes: see http://flask.pocoo.org/docs/0.12/security/


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Unit tests exist for the homepage. Tested this by downgrading flask and verifying that it worked.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

