### PR TITLE
[AIRFLOW-1050] Do not count up_for_retry as not ready

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1925,6 +1925,15 @@ class BackfillJob(BaseJob):
                             started.pop(key)
                         continue
 
+                    # special case
+                    if ti.state == State.UP_FOR_RETRY:
+                        self.logger.debug("Task instance {} retry period not expired yet"
+                                          .format(ti))
+                        if key in started:
+                            started.pop(key)
+                        tasks_to_run[key] = ti
+                        continue
+
                     # all remaining tasks
                     self.logger.debug('Adding {} to not_ready'.format(ti))
                     not_ready.add(key)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1050


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

up_for_retry tasks were incorrectly counted towards not_ready
therefore marking a dag run deadlocked instead of retrying.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

* should be covered by existing tests

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@s7anley 

cc: @saguziel @criccomini 