### PR TITLE
[AIRFLOW-351] Ensure python_callable is pickleable

### DIFF
--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 from builtins import str
+import copy
 from datetime import datetime
 import logging
+import pickle
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, TaskInstance
@@ -66,6 +68,10 @@ class PythonOperator(BaseOperator):
         super(PythonOperator, self).__init__(*args, **kwargs)
         if not callable(python_callable):
             raise AirflowException('`python_callable` param must be callable')
+        try:
+            pickle.dumps(copy.deepcopy(python_callable))
+        except TypeError:
+            raise AirflowException('`python_callable` param must be pickleable')
         self.python_callable = python_callable
         self.op_args = op_args or []
         self.op_kwargs = op_kwargs or {}


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-351


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

If `python_callable` cannot be dumped by pickle, it causes `TypeError` by running `airflow clear DAG_ID -t TASK_ID`:

```python
import threading

class MyTask(object):
    def __init__(self):
        self.lock = threading.Lock()
    def run(self):
        pass

PythonOperator(
    task_id='t1',
    python_callable=MyTask().run,
    dag=dag)
```
```bash
$ airflow clear mydag -t t1
...
TypeError: can't pickle thread.lock objects
```

With this PR, passing a non-pickleable `python_callable` raises `AirflowException`.
Note: this is an incompatible change.  A warning might be a better choice.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- tests.operators.python_operator.PythonOperatorTest
  - test_python_operator_python_callable_is_pickleable

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

