### PR TITLE
[AIRFLOW-1089]  Add Spark application arguments

### DIFF
--- a/airflow/contrib/hooks/spark_submit_hook.py
+++ b/airflow/contrib/hooks/spark_submit_hook.py
@@ -56,6 +56,8 @@ class SparkSubmitHook(BaseHook):
     :type name: str
     :param num_executors: Number of executors to launch
     :type num_executors: int
+    :param application_args: Arguments for the application being submitted
+    :type application_args: list
     :param verbose: Whether to pass the verbose flag to spark-submit process for debugging
     :type verbose: bool
     """
@@ -74,6 +76,7 @@ class SparkSubmitHook(BaseHook):
                  principal=None,
                  name='default-name',
                  num_executors=None,
+                 application_args=None,
                  verbose=False):
         self._conf = conf
         self._conn_id = conn_id
@@ -88,6 +91,7 @@ class SparkSubmitHook(BaseHook):
         self._principal = principal
         self._name = name
         self._num_executors = num_executors
+        self._application_args = application_args
         self._verbose = verbose
         self._sp = None
         self._yarn_application_id = None
@@ -182,6 +186,11 @@ class SparkSubmitHook(BaseHook):
 
         # The actual script to execute
         connection_cmd += [application]
+
+        # Append any application arguments
+        if self._application_args:
+            for arg in self._application_args:
+                connection_cmd += [arg]
 
         logging.debug("Spark-Submit cmd: {}".format(connection_cmd))
 

--- a/airflow/contrib/operators/spark_submit_operator.py
+++ b/airflow/contrib/operators/spark_submit_operator.py
@@ -56,6 +56,8 @@ class SparkSubmitOperator(BaseOperator):
     :type name: str
     :param num_executors: Number of executors to launch
     :type num_executors: int
+    :param application_args: Arguments for the application being submitted
+    :type application_args: list
     :param verbose: Whether to pass the verbose flag to spark-submit process for debugging
     :type verbose: bool
     """
@@ -76,6 +78,7 @@ class SparkSubmitOperator(BaseOperator):
                  principal=None,
                  name='airflow-spark',
                  num_executors=None,
+                 application_args=None,
                  verbose=False,
                  *args,
                  **kwargs):
@@ -93,6 +96,7 @@ class SparkSubmitOperator(BaseOperator):
         self._principal = principal
         self._name = name
         self._num_executors = num_executors
+        self._application_args = application_args
         self._verbose = verbose
         self._hook = None
         self._conn_id = conn_id
@@ -115,6 +119,7 @@ class SparkSubmitOperator(BaseOperator):
             principal=self._principal,
             name=self._name,
             num_executors=self._num_executors,
+            application_args=self._application_args,
             verbose=self._verbose
         )
         self._hook.submit(self._application)

--- a/tests/contrib/hooks/test_spark_submit_hook.py
+++ b/tests/contrib/hooks/test_spark_submit_hook.py
@@ -42,7 +42,12 @@ class TestSparkSubmitHook(unittest.TestCase):
         'num_executors': 10,
         'verbose': True,
         'driver_memory': '3g',
-        'java_class': 'com.foo.bar.AppMain'
+        'java_class': 'com.foo.bar.AppMain',
+        'application_args': [
+            '-f foo',
+            '--bar bar',
+            'baz'
+        ]
     }
 
     def setUp(self):
@@ -101,6 +106,15 @@ class TestSparkSubmitHook(unittest.TestCase):
         # Check if all config settings are there
         for k in self._config['conf']:
             assert "--conf {0}={1}".format(k, self._config['conf'][k]) in cmd
+
+        # Check the application arguments are there
+        for a in self._config['application_args']:
+            assert a in cmd
+
+        # Check if application arguments are after the application
+        application_idx = cmd.find(self._spark_job_file)
+        for a in self._config['application_args']:
+            assert cmd.find(a) > application_idx
 
         if self._config['verbose']:
             assert "--verbose" in cmd

--- a/tests/contrib/operators/test_spark_submit_operator.py
+++ b/tests/contrib/operators/test_spark_submit_operator.py
@@ -41,7 +41,11 @@ class TestSparkSubmitOperator(unittest.TestCase):
         'verbose': True,
         'application': 'test_application.py',
         'driver_memory': '3g',
-        'java_class': 'com.foo.bar.AppMain'
+        'java_class': 'com.foo.bar.AppMain',
+        'application_args': [
+            '-f foo',
+            '--bar bar'
+        ]
     }
 
     def setUp(self):
@@ -80,6 +84,7 @@ class TestSparkSubmitOperator(unittest.TestCase):
         self.assertEqual(self._config['verbose'], operator._verbose)
         self.assertEqual(self._config['java_class'], operator._java_class)
         self.assertEqual(self._config['driver_memory'], operator._driver_memory)
+        self.assertEqual(self._config['application_args'], operator._application_args)
 
 
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
    - https://issues.apache.org/jira/browse/AIRFLOW-1089


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
This change allows us to pass application arguments to the Spark application be submitted.  For example:
- spark-submit --class foo.Bar foobar.jar arg1 arg2
- spark-submit app.py arg1 arg2


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Modifed:
contrib.hooks.test_spark_submit_hook.TestSparkSubmitHook#test_build_command
contrib.operators.test_spark_submit_operator.TestSparkSubmitOperator#test_execute



### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

