### PR TITLE
[AIRFLOW-1096] Add conn_ids to template_fields

### DIFF
--- a/airflow/operators/mysql_operator.py
+++ b/airflow/operators/mysql_operator.py
@@ -33,7 +33,7 @@ class MySqlOperator(BaseOperator):
     :type database: string
     """
 
-    template_fields = ('sql',)
+    template_fields = ('sql', 'mysql_conn_id',)
     template_ext = ('.sql',)
     ui_color = '#ededed'
 

--- a/airflow/operators/postgres_operator.py
+++ b/airflow/operators/postgres_operator.py
@@ -33,7 +33,7 @@ class PostgresOperator(BaseOperator):
     :type database: string
     """
 
-    template_fields = ('sql',)
+    template_fields = ('sql', 'postgres_conn_id',)
     template_ext = ('.sql',)
     ui_color = '#ededed'
 

--- a/tests/operators/operators.py
+++ b/tests/operators/operators.py
@@ -89,6 +89,16 @@ class MySqlTest(unittest.TestCase):
                 results = tuple(result[0] for result in c.fetchall())
                 self.assertEqual(sorted(results), sorted(records))
 
+    def test_mysql_conn_id_template(self):
+        conn = 'airflow_db'
+
+        import airflow.operators.mysql_operator
+        t = operators.mysql_operator.MySqlOperator(
+            task_id='test_mysql_conn_id_template',
+            mysql_conn_id='{{ conn }}',
+            sql='SELECT count(1) FROM INFORMATION_SCHEMA.TABLES',
+            dag=self.dag)
+
     def test_mysql_to_mysql(self):
         sql = "SELECT * FROM INFORMATION_SCHEMA.TABLES LIMIT 100;"
         import airflow.operators.generic_transfer
@@ -174,6 +184,16 @@ class PostgresTest(unittest.TestCase):
         t = operators.postgres_operator.PostgresOperator(
             task_id='postgres_operator_test_multi', sql=sql, dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+    
+    def test_postgres_conn_id_template(self):
+        conn = 'postgres_default'
+
+        import airflow.operators.postgres_operator
+        t = operators.postgres_operator.PostgresOperator(
+            task_id='test_postgres_conn_id_template', 
+            postgres_conn_id='{{ conn }}',
+            sql='SELECT count(1) FROM INFORMATION_SCHEMA.TABLES', 
+            dag=self.dag)
 
     def test_postgres_to_postgres(self):
         sql = "SELECT * FROM INFORMATION_SCHEMA.TABLES LIMIT 100;"


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    
https://issues.apache.org/jira/browse/AIRFLOW-1096

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Add `postgres_conn_id` to `PostgresOperator` and `mysql_conn_id` to `MySqlOperator` `template_fields`. Our team has run into several instances where dynamic connections IDs would be beneficial.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Tests added for both PostgreSQL and MySql operators.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

