### PR TITLE
[AIRFLOW-957] Add execution_date parameter to TriggerDagRunOperator

### DIFF
--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
 import logging
 
 from airflow.models import BaseOperator, DagBag
@@ -23,9 +22,27 @@ from airflow import configuration as conf
 
 
 class DagRunOrder(object):
-    def __init__(self, run_id=None, payload=None):
-        self.run_id = run_id
+    def __init__(self, execution_date, run_id=None, payload=None):
+        self._run_id = run_id
         self.payload = payload
+        self.execution_date = execution_date
+
+    @property
+    def run_id(self):
+        return self._run_id or self._auto_run_id
+
+    @run_id.setter
+    def run_id(self, value):
+        self._run_id = value
+
+    @property
+    def execution_date(self):
+        return self._execution_date
+
+    @execution_date.setter
+    def execution_date(self, dt):
+        self._execution_date = dt
+        self._auto_run_id = 'trig__%s' % dt.isoformat()
 
 
 class TriggerDagRunOperator(BaseOperator):
@@ -37,8 +54,11 @@ class TriggerDagRunOperator(BaseOperator):
     :param python_callable: a reference to a python function that will be
         called while passing it the ``context`` object and a placeholder
         object ``obj`` for your callable to fill and return if you want
-        a DagRun created. This ``obj`` object contains a ``run_id`` and
-        ``payload`` attribute that you can modify in your function.
+        a DagRun created. This ``obj`` object contains an
+        ``execution_date``, a ``run_id`` and ``payload`` attribute that
+        you can modify in your function.
+        The ``execution_date`` is by default the current
+        task's instance ``execution_date``.
         The ``run_id`` should be a unique identifier for that DAG run, and
         the payload has to be a picklable object that will be made available
         to your tasks while executing that DAG run. Your function header
@@ -60,7 +80,7 @@ class TriggerDagRunOperator(BaseOperator):
         self.trigger_dag_id = trigger_dag_id
 
     def execute(self, context):
-        dro = DagRunOrder(run_id='trig__' + datetime.now().isoformat())
+        dro = DagRunOrder(context['execution_date'])
         dro = self.python_callable(context, dro)
         if dro:
             session = settings.Session()
@@ -70,6 +90,7 @@ class TriggerDagRunOperator(BaseOperator):
                 run_id=dro.run_id,
                 state=State.RUNNING,
                 conf=dro.payload,
+                execution_date=dro.execution_date,
                 external_trigger=True)
             logging.info("Creating DagRun {}".format(dr))
             session.add(dr)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-957


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
`DagRunOrder` now has an `execution_date` property that can be changed.
Also, by default, this `execution_date` is no longer `datetime.now()`,
as it is using `execution_date` from `TriggerDagRunOperator`'s
task instance.


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`test_trigger_dagrun` now checks that `execution_date` is kept, and
new `test_trigger_dagrun_order_modified` checks `DagRunOrder` modifications.


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

