### PR TITLE
[AIRFLOW-1112] Log which pool when pool is full in scheduler

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1029,9 +1029,6 @@ class SchedulerJob(BaseJob):
                              "with {open_slots} open slots and {num_queued} "
                              "task instances in queue".format(**locals()))
 
-            if open_slots <= 0:
-                continue
-
             priority_sorted_task_instances = sorted(
                 task_instances, key=lambda ti: (-ti.priority_weight, ti.execution_date))
 
@@ -1040,7 +1037,8 @@ class SchedulerJob(BaseJob):
 
             for task_instance in priority_sorted_task_instances:
                 if open_slots <= 0:
-                    self.logger.info("No more slots free")
+                    self.logger.info("Not scheduling since there are {} open slots in pool {}"
+                        .format(open_slots, pool))
                     # Can't schedule any more since there are no more open slots.
                     break
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1112


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes: Add the pool and slots when we log.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: just change logging


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@plypaul @aoen @bolkedebruin 