### PR TITLE
AIRFLOW-1119 - Fix unload query so headers are on first row

### DIFF
--- a/airflow/operators/redshift_to_s3_operator.py
+++ b/airflow/operators/redshift_to_s3_operator.py
@@ -93,7 +93,8 @@ class RedshiftToS3Transfer(BaseOperator):
         unload_query = """
                         UNLOAD ('SELECT {0}
                         UNION ALL
-                        SELECT {1} FROM {2}.{3}')
+                        SELECT {1} FROM {2}.{3}
+                        ORDER BY 1 DESC')
                         TO 's3://{4}/{5}/{3}_'
                         with
                         credentials 'aws_access_key_id={6};aws_secret_access_key={7}'


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1119


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Fixes unload query so headers are on first row. Previously headers could be in any row.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

