### PR TITLE
[AIRFLOW-1122] increase node stroke width

### DIFF
--- a/airflow/www/static/graph.css
+++ b/airflow/www/static/graph.css
@@ -18,7 +18,7 @@
 */
 
 g.node rect {
-    stroke-width: 2;
+    stroke-width: 3;
     stroke: white;
     cursor: pointer;
 }


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this tiny PR and help to make Airflow more accessible.


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1122) issues and references them in the PR title.


### Description
- [x] Thicker strokes make it easier to determine the node state, especially for those of us with color blindness. 
![graph](https://cloud.githubusercontent.com/assets/5894642/25155464/f2391b8a-2449-11e7-9b7b-f3b8282bb039.PNG)


### Tests
- [x] does not need testing for this extremely good reason: proposed a 1-character-change to a `.css` file


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue.

