### PR TITLE
[AIRFLOW-1121] Fix `airflow webserver --pid` to write out pid file

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -776,6 +776,7 @@ def webserver(args):
             '-t', str(worker_timeout),
             '-b', args.hostname + ':' + str(args.port),
             '-n', 'airflow-webserver',
+            '-p', str(pid),
             '-c', 'airflow.www.gunicorn_config'
         ]
 
@@ -786,7 +787,7 @@ def webserver(args):
             run_args += ['--error-logfile', str(args.error_logfile)]
 
         if args.daemon:
-            run_args += ['-D', '-p', str(pid)]
+            run_args += ['-D']
 
         if ssl_cert:
             run_args += ['--certfile', ssl_cert, '--keyfile', ssl_key]


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1121


### Description
- [x] Here are some details about my PR:

After AIRFLOW-1004, --pid option is no longer honored and
the pid file is not being written out. This PR fixes it.


### Tests
- [x] My PR adds the following unit tests:

tests.core:CliTests.test_cli_webserver_foreground_with_pid


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

