### PR TITLE
[AIRFLOW-1125] Document encrypted connections

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -83,6 +83,31 @@ within the metadata database. The ``crypto`` package is highly recommended
 during installation. The ``crypto`` package does require that your operating
 system have libffi-dev installed.
 
+If ``crypto`` package was not installed initially, you can still enable encryption for 
+connections by following steps below:
+
+1. Install crypto package ``pip install airflow[crypto]``
+2. Generate fernet_key, using this code snippet below. fernet_key must be a base64-encoded 32-byte key.
+
+.. code:: python
+
+    from cryptography.fernet import Fernet
+    fernet_key= Fernet.generate_key()
+    print(fernet_key) # your fernet_key, keep it in secured place!
+    
+3. Replace ``airflow.cfg`` fernet_key value with the one from step 2. 
+Alternatively, you can store your fernet_key in OS environment variable. You
+do not need to change ``airflow.cfg`` in this case as AirFlow will use environment 
+variable over the value in ``airflow.cfg``:
+
+.. code-block:: bash
+  
+  # Note the double underscores
+  EXPORT AIRFLOW__CORE__FERNET_KEY = your_fernet_key
+ 
+4. Restart AirFlow webserver.
+5. For existing connections (the ones that you had defined before installing ``airflow[crypto]`` and creating a Fernet key), you need to open each connection in the connection admin UI, re-type the password, and save it.
+
 Connections in Airflow pipelines can be created using environment variables.
 The environment variable needs to have a prefix of ``AIRFLOW_CONN_`` for
 Airflow with the value in a URI format to use the connection properly. Please

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -66,8 +66,8 @@ documentation
 Why are connection passwords still not encrypted in the metadata db after I installed airflow[crypto]?
 ------------------------------------------------------------------------------------------------------
 
-- Verify that the ``fernet_key`` defined in ``$AIRFLOW_HOME/airflow.cfg`` is a valid Fernet key. It must be a base64-encoded 32-byte key. You need to restart the webserver after you update the key
-- For existing connections (the ones that you had defined before installing ``airflow[crypto]`` and creating a Fernet key), you need to open each connection in the connection admin UI, re-type the password, and save it
+Check out the ``Connections`` section in the Configuration section of the
+documentation
 
 What's the deal with ``start_date``?
 ------------------------------------


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [AIRFLOW-1125](https://issues.apache.org/jira/browse/AIRFLOW-1125) issues and references them in the PR title. 


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Clarify documentation regarding fernet_key and how to
enable encryption if it was not enabled during install.


### Tests
- [x] My PR does not need testing for this extremely good reason: documentation


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

