### PR TITLE
[AIRFLOW-1153] Fix issue ' params ' don't pass to HiveOperator execution context

### DIFF
--- a/airflow/utils/operator_helpers.py
+++ b/airflow/utils/operator_helpers.py
@@ -43,7 +43,8 @@ def context_to_airflow_vars(context, in_env_var_format=False):
     :type in_env_var_format: bool
     :return task_instance context as dict.
     """
-    params = dict()
+    params = context.get('params')
+
     if in_env_var_format:
         name_format = 'env_var_format'
     else:


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

I make this in order to pass params in HiveOperator can be passed into hql. for example:
test_hiveoperator = HiveOperator(
        task_id='hive_test',
        hiveconf_jinja_translate=True,
        hql = '''
                use myDB;
                INSERT OVERWRITE TABLE t2
                select * from t1 where t1.x > ' ${hiveconf:mynumber}'
                ''',
        params={'mynumber': 2},
        dag=dag
)


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1153


### Description
- [ ] Pass 'params' into Hive execution context in HiveOperator task.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

