### PR TITLE
[AIRFLOW-1145] Fix closest_date_partition before

### DIFF
--- a/airflow/macros/hive.py
+++ b/airflow/macros/hive.py
@@ -61,8 +61,8 @@ def _closest_date(target_dt, date_list, before_target=None):
     :returns: The closest date
     :rtype: datetime.date or None
     '''
-    fb = lambda d: d - target_dt if d >= target_dt else datetime.timedelta.max
-    fa = lambda d: d - target_dt if d <= target_dt else datetime.timedelta.min
+    fb = lambda d: target_dt - d if d <= target_dt else datetime.timedelta.max
+    fa = lambda d: d - target_dt if d >= target_dt else datetime.timedelta.max
     fnone = lambda d: target_dt - d if d < target_dt else d - target_dt
     if before_target is None:
         return min(date_list, key=fnone).date()

--- a/tests/macros/__init__.py
+++ b/tests/macros/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/tests/macros/test_hive.py
+++ b/tests/macros/test_hive.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timedelta
+import unittest
+
+from airflow.macros import hive
+
+
+class Hive(unittest.TestCase):
+    def test_closest_ds_partition(self):
+        d1 = datetime.strptime('2017-04-24', '%Y-%m-%d')
+        d2 = datetime.strptime('2017-04-25', '%Y-%m-%d')
+        d3 = datetime.strptime('2017-04-26', '%Y-%m-%d')
+        d4 = datetime.strptime('2017-04-28', '%Y-%m-%d')
+        d5 = datetime.strptime('2017-04-29', '%Y-%m-%d')
+        target_dt = datetime.strptime('2017-04-27', '%Y-%m-%d')
+        date_list = [d1, d2, d3, d4, d5]
+
+        self.assertEquals("2017-04-26", str(hive._closest_date(target_dt, date_list, True)))
+        self.assertEquals("2017-04-28", str(hive._closest_date(target_dt, date_list, False)))
+
+        # when before is not set, the closest date should be returned
+        self.assertEquals("2017-04-26", str(hive._closest_date(target_dt, [d1, d2, d3, d5], None)))
+        self.assertEquals("2017-04-28", str(hive._closest_date(target_dt, [d1, d2, d4, d5])))
+        self.assertEquals("2017-04-26", str(hive._closest_date(target_dt, date_list)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
If we're looking for the closest date before, we should take the latest date in the list of date before (instead of min asof now)

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issue and references it in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1145


### Description
- [x] Here are some details about my PR:
When using the closest_date_partition with the parameter "before" set to True, the function always returns the oldest date for this partition. It was caused by returning the `datetime.timedelta.min` instead of `max`. Also, `fa` and `fb` where switched.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - closest_date with before = True
  - closest_date with before = False
  - closest_date with before = None when answer is obvious and when there is an equality  between the target date and the dates before and after.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

