### PR TITLE
[AIRFLOW-1150] Fix scripts execution in sparksql hook

### DIFF
--- a/airflow/contrib/hooks/spark_sql_hook.py
+++ b/airflow/contrib/hooks/spark_sql_hook.py
@@ -98,10 +98,11 @@ class SparkSqlHook(BaseHook):
         if self._num_executors:
             connection_cmd += ["--num-executors", str(self._num_executors)]
         if self._sql:
-            if self._sql.endswith('.sql') or self._sql.endswith(".hql"):
-                connection_cmd += ["-f", self._sql]
+            sql = self._sql.strip()
+            if sql.endswith(".sql") or sql.endswith(".hql"):
+                connection_cmd += ["-f", sql]
             else:
-                connection_cmd += ["-e", self._sql]
+                connection_cmd += ["-e", sql]
         if self._master:
             connection_cmd += ["--master", self._master]
         if self._name:

--- a/tests/contrib/hooks/test_spark_sql_hook.py
+++ b/tests/contrib/hooks/test_spark_sql_hook.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import sys
+import unittest
+from io import StringIO
+from itertools import dropwhile
+
+import mock
+
+from airflow import configuration, models
+from airflow.utils import db
+from airflow.contrib.hooks.spark_sql_hook import SparkSqlHook
+
+
+def get_after(sentinel, iterable):
+    "Get the value after `sentinel` in an `iterable`"
+    truncated = dropwhile(lambda el: el != sentinel, iterable)
+    next(truncated)
+    return next(truncated)
+
+class TestSparkSqlHook(unittest.TestCase):
+
+    _config = {
+        'conn_id': 'spark_default',
+        'executor_cores': 4,
+        'executor_memory': '22g',
+        'keytab': 'privileged_user.keytab',
+        'name': 'spark-job',
+        'num_executors': 10,
+        'verbose': True,
+        'sql': ' /path/to/sql/file.sql ',
+        'conf': 'key=value,PROP=VALUE'
+    }
+
+    def setUp(self):
+
+        configuration.load_test_config()
+        db.merge_conn(
+            models.Connection(
+                conn_id='spark_default', conn_type='spark',
+                host='yarn://yarn-master')
+        )
+
+    def test_build_command(self):
+        hook = SparkSqlHook(**self._config)
+
+        # The subprocess requires an array but we build the cmd by joining on a space
+        cmd = ' '.join(hook._prepare_command(""))
+
+        # Check all the parameters
+        assert "--executor-cores {}".format(self._config['executor_cores']) in cmd
+        assert "--executor-memory {}".format(self._config['executor_memory']) in cmd
+        assert "--keytab {}".format(self._config['keytab']) in cmd
+        assert "--name {}".format(self._config['name']) in cmd
+        assert "--num-executors {}".format(self._config['num_executors']) in cmd
+        sql_path = get_after('-f', hook._prepare_command(""))
+        assert self._config['sql'].strip() == sql_path
+
+        # Check if all config settings are there
+        for kv in self._config['conf'].split(","):
+            k, v = kv.split('=')
+            assert "--conf {0}={1}".format(k, v) in cmd
+
+        if self._config['verbose']:
+            assert "--verbose" in cmd
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION

Dear Airflow maintainers, Dear @bolkedebruin 


Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1150) issue and reference it in the PR title

### Description
- [x ] Here are some details about my PR, ~including screenshots of any UI changes~:
When using the the SparkSqlOperator and submitting
a file (ending with `.sql` or `.hql`), a whitespace need to 
be appended, otherwise a Jinja error will be raised.

However the trailing whitespace confused the hook as
those files will not end with `.sql` and `.hql`, but with
`.sql ` and `.hql `. This PR fixes this.


### Tests
- [x ] My PR adds the following unit tests:
test_spark_sql_hook.py

### Commits
- [x ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


