### PR TITLE
[AIRFLOW-1164] No example connections if load_examples is False

### DIFF
--- a/tests/core.py
+++ b/tests/core.py
@@ -2210,7 +2210,32 @@ class ConnectionTest(unittest.TestCase):
         assert conns[0].host == 'localhost'
         assert conns[0].schema == 'airflow'
         assert conns[0].login == 'root'
+        
+    def test_get_connections_example_db(self):
+        conns = BaseHook.get_connections(conn_id='beeline_default')
+        assert len(conns) == 1
+        assert conns[0].host == 'localhost'
+        assert conns[0].port == 10000
+        assert conns[0].schema == 'default'
+        
+    def test_get_connections_unknown_db(self):
+        with self.assertRaises(AirflowException):
+            BaseHook.get_connections(conn_id='airflow_db_NOT_EXISTING')
+            
+        
+class NoExampleConnectionsTest(unittest.TestCase):
+    
+    def setUp(self):
+        configuration.load_test_config()
+        utils.db.resetdb(include_examples=False)
+        
+    def tearDown(self):
+        utils.db.resetdb()
 
+    def test_get_connections_db(self):
+        with self.assertRaises(AirflowException):
+            BaseHook.get_connections(conn_id='beeline_default')
+            
 
 class WebHDFSHookTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/1164) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1164


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
If core/load_examples is set to false, the example connections are not added to the database when calling `airflow initdb`

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

