### PR TITLE
[AIRFLOW-1167] Support microseconds in FTPHook modification time

### DIFF
--- a/airflow/contrib/hooks/ftp_hook.py
+++ b/airflow/contrib/hooks/ftp_hook.py
@@ -226,7 +226,12 @@ class FTPHook(BaseHook):
     def get_mod_time(self, path):
         conn = self.get_conn()
         ftp_mdtm = conn.sendcmd('MDTM ' + path)
-        return datetime.datetime.strptime(ftp_mdtm[4:], '%Y%m%d%H%M%S')
+        time_val = ftp_mdtm[4:]
+        # time_val optionally has microseconds
+        try:
+            return datetime.datetime.strptime(time_val, "%Y%m%d%H%M%S.%f")
+        except ValueError:
+            return datetime.datetime.strptime(time_val, '%Y%m%d%H%M%S')
 
 
 class FTPSHook(FTPHook):

--- a/tests/contrib/hooks/test_ftp_hook.py
+++ b/tests/contrib/hooks/test_ftp_hook.py
@@ -77,6 +77,24 @@ class TestFTPHook(unittest.TestCase):
 
         self.conn_mock.rename.assert_called_once_with(from_path, to_path)
         self.conn_mock.quit.assert_called_once_with()
+        
+    def test_mod_time(self):
+        self.conn_mock.sendcmd.return_value = '213 20170428010138'
+        
+        path = '/path/file'
+        with fh.FTPHook() as ftp_hook:
+            ftp_hook.get_mod_time(path)
+
+        self.conn_mock.sendcmd.assert_called_once_with('MDTM ' + path)
+        
+    def test_mod_time_micro(self):
+        self.conn_mock.sendcmd.return_value = '213 20170428010138.003'
+        
+        path = '/path/file'
+        with fh.FTPHook() as ftp_hook:
+            ftp_hook.get_mod_time(path)
+
+        self.conn_mock.sendcmd.assert_called_once_with('MDTM ' + path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/1167) issues and references them in the PR title. For example, "[AIRFLOW-1167] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1167


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
Fixup for modification time containing microseconds. Is allowed according to the RFC (https://tools.ietf.org/html/rfc3659#page-6)

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

