### PR TITLE
[AIRFLOW-1168] Add closing() to all connections and cursors

### DIFF
--- a/tests/hooks/test_dbapi_hook.py
+++ b/tests/hooks/test_dbapi_hook.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import unittest
+
+from airflow.hooks.dbapi_hook import DbApiHook
+
+
+class TestDbApiHook(unittest.TestCase):
+
+    def setUp(self):
+        super(TestDbApiHook, self).setUp()
+        
+        self.cur = mock.MagicMock()
+        self.conn = conn = mock.MagicMock()
+        self.conn.cursor.return_value = self.cur
+        
+        class TestDBApiHook(DbApiHook):
+            conn_name_attr = 'test_conn_id'
+            
+            def get_conn(self):
+                return conn
+        
+        self.db_hook = TestDBApiHook()
+
+    def test_get_records(self):
+        statement = "SQL"
+        rows = [("hello",),
+                ("world",)]
+        
+        self.cur.fetchall.return_value = rows
+        
+        self.assertEqual(rows, self.db_hook.get_records(statement))
+        
+        self.conn.close.assert_called_once()
+        self.cur.close.assert_called_once()
+        self.cur.execute.assert_called_once_with(statement)
+        
+    def test_get_records_parameters(self):
+        statement = "SQL"
+        parameters = ["X", "Y", "Z"]
+        rows = [("hello",),
+                ("world",)]
+        
+        self.cur.fetchall.return_value = rows
+        
+        
+        self.assertEqual(rows, self.db_hook.get_records(statement, parameters))
+        
+        self.conn.close.assert_called_once()
+        self.cur.close.assert_called_once()
+        self.cur.execute.assert_called_once_with(statement, parameters)
+        
+    def test_get_records_exception(self):
+        statement = "SQL"
+        self.cur.fetchall.side_effect = RuntimeError('Great Problems')
+        
+        with self.assertRaises(RuntimeError):
+            self.db_hook.get_records(statement)
+        
+        self.conn.close.assert_called_once()
+        self.cur.close.assert_called_once()
+        self.cur.execute.assert_called_once_with(statement)


### PR DESCRIPTION
This will prevent any left-open connections whenever an exception occurs

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/1168) issues and references them in the PR title. For example, "[AIRFLOW-1168] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1168


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
Wrapped all connection and cursors in the dbapi hook to prevent left open connections

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Only refactored stuffs

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

