### PR TITLE
[AIRFLOW-1170] DbApiHook insert_rows inserts parameters separately

### DIFF
--- a/airflow/hooks/mysql_hook.py
+++ b/airflow/hooks/mysql_hook.py
@@ -87,14 +87,15 @@ class MySqlHook(DbApiHook):
     @staticmethod
     def _serialize_cell(cell, conn):
         """
-        Returns the MySQL literal of the cell as a string.
+        MySQLdb converts an argument to a literal when passing those seperately to execute.
+        Hence, this method does nothing.
 
         :param cell: The cell to insert into the table
         :type cell: object
         :param conn: The database connection
         :type conn: connection object
-        :return: The serialized cell
-        :rtype: str
+        :return: The same cell
+        :rtype: object
         """
 
-        return conn.literal(cell)
+        return cell

--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -50,14 +50,17 @@ class PostgresHook(DbApiHook):
     @staticmethod
     def _serialize_cell(cell, conn):
         """
-        Returns the Postgres literal of the cell as a string.
+        Postgresql will adapt all arguments to the execute() method internally,
+        hence we return cell without any conversion.
+        
+        See http://initd.org/psycopg/docs/advanced.html#adapting-new-types for 
+        more information.
 
         :param cell: The cell to insert into the table
         :type cell: object
         :param conn: The database connection
         :type conn: connection object
-        :return: The serialized cell
-        :rtype: str
+        :return: The cell
+        :rtype: object
         """
-
-        return psycopg2.extensions.adapt(cell).getquoted().decode('utf-8')
+        return cell


### PR DESCRIPTION
Instead of creating a sql statement with all values, we send the values
separately to prevent sql injection

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/1170) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1170


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
DbApiHook was inserting rows by creating a sql query containing the values to be inserted. Modified it to prevent sql injection.


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Only refactor

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

