### PR TITLE
[AIRFLOW-945] Remove psycopg2 connection workaround

### DIFF
--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -36,17 +36,10 @@ class PostgresHook(DbApiHook):
         conn = self.get_connection(self.postgres_conn_id)
         conn_args = dict(
             host=conn.host,
-            dbname=self.schema or conn.schema)
-        # work around for https://github.com/psycopg/psycopg2/issues/517
-        # todo: remove when psycopg2 2.7.1 is released
-        # https://issues.apache.org/jira/browse/AIRFLOW-945
-        if conn.port:
-            conn_args['port'] = conn.port
-        if conn.login:
-            conn_args['user'] = conn.login
-        if conn.password:
-            conn_args['password'] = conn.password
-
+            user=conn.login,
+            password=conn.password,
+            dbname=self.schema or conn.schema,
+            port=conn.port)
         # check for ssl parameters in conn.extra
         for arg_name, arg_val in conn.extra_dejson.items():
             if arg_name in ['sslmode', 'sslcert', 'sslkey', 'sslrootcert', 'sslcrl', 'application_name']:

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ mssql = ['pymssql>=2.1.1', 'unicodecsv>=0.14.1']
 mysql = ['mysqlclient>=1.3.6']
 rabbitmq = ['librabbitmq>=1.6.1']
 oracle = ['cx_Oracle>=5.1.2']
-postgres = ['psycopg2>=2.6']
+postgres = ['psycopg2>=2.7.1']
 salesforce = ['simple-salesforce>=0.72']
 s3 = [
     'boto>=2.36.0',


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

As psycopg2 2.7.1 released, we can remove the workaround now. See also:

1. incubator-airflow#2126
2. https://issues.apache.org/jira/browse/AIRFLOW-941

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Since no test was added previously, so nothing needs to be removed this time as well.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
