### PR TITLE
[AIRFLOW-1171] Fix up encoding for Postgres

### DIFF
--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -67,4 +67,9 @@ class PostgresHook(DbApiHook):
         :rtype: str
         """
 
-        return psycopg2.extensions.adapt(cell).getquoted().decode('utf-8')
+        adapted = psycopg2.extensions.adapt(cell)
+        try:
+            adapted.prepare(conn)
+        except AttributeError:
+            pass
+        return adapted.getquoted()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1171


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

I referenced suggested solution from upstream psycopg/psycopg2#331.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No tests for hook and other builtin (non-contrib) hooks. I've tested it on our installation and the issue was fixed.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

