### PR TITLE
AIRFLOW-1041: Do not shadow xcom_push method

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -122,7 +122,7 @@ class DockerOperator(BaseOperator):
         self.tmp_dir = tmp_dir
         self.user = user
         self.volumes = volumes or []
-        self.xcom_push = xcom_push
+        self.xcom_push_flag = xcom_push
         self.xcom_all = xcom_all
 
         self.cli = None
@@ -184,7 +184,7 @@ class DockerOperator(BaseOperator):
             if exit_code != 0:
                 raise AirflowException('docker container failed')
 
-            if self.xcom_push:
+            if self.xcom_push_flag:
                 return self.cli.logs(container=self.container['Id']) if self.xcom_all else str(line)
 
     def get_command(self):


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1041 "[AIRFLOW-1041] DockerOperator replaces its xcom_push method with a boolean"

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
  Do not shadow inherited xcom_push method, thus allow its use in subclasses.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  No tests, trivial change. Effect only seen by subclassing DockerOperator.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
