### PR TITLE
Fix Pandas 0.2x breaking Google BigQuery change

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -24,7 +24,7 @@ import time
 from apiclient.discovery import build, HttpError
 from googleapiclient import errors
 from builtins import range
-from pandas.io.gbq import GbqConnector, \
+from pandas_gbq.gbq import GbqConnector, \
     _parse_data as gbq_parse_data, \
     _check_google_client_version as gbq_check_google_client_version, \
     _test_google_api_imports as gbq_test_google_api_imports

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -61,6 +61,7 @@ nose-ignore-docstring==0.2
 nose-parameterized
 nose-timer
 pandas
+pandas-gbq
 psutil>=4.2.0, <5.0.0
 psycopg2
 pydruid

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,7 @@ gcp_api = [
     'google-api-python-client>=1.5.0, <1.6.0',
     'oauth2client>=2.0.2, <2.1.0',
     'PyOpenSSL',
+    'pandas-gbq'
 ]
 hdfs = ['snakebite>=2.7.8']
 webhdfs = ['hdfs[dataframe,avro,kerberos]>=2.0.4']


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/1179) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1179


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
Added pandas-gbq to setup.py and change the import

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Only import path has changed, so I didn't add unit-tests

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

