### PR TITLE
[AIRFLOW-1181] add delete and list functionality to gcs_hook

### DIFF
--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -15,8 +15,8 @@
 
 import logging
 
-from googleapiclient.discovery import build
-from googleapiclient.http import MediaFileUpload
+from apiclient.discovery import build
+from apiclient.http import MediaFileUpload
 from googleapiclient import errors
 
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -15,8 +15,8 @@
 
 import logging
 
-from apiclient.discovery import build
-from apiclient.http import MediaFileUpload
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
 from googleapiclient import errors
 
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
@@ -152,3 +152,72 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                 raise
 
         return False
+
+    def delete(self, bucket, object, generation=None):
+        """
+        Delete an object if versioning is not enabled for the bucket, or if generation
+        parameter is used.
+        :param bucket: name of the bucket, where the object resides
+        :type bucket: string
+        :param object: name of the object to delete
+        :type object: string
+        :param generation: if present, permanently delete the object of this generation
+        :type generation: string
+        :return: True if succeeded
+        """
+        service = self.get_conn()
+
+        try:
+            service \
+                .objects() \
+                .delete(bucket=bucket, object=object, generation=generation) \
+                .execute()
+            return True
+        except errors.HttpError as ex:
+            if ex.resp['status'] == '404':
+                return False
+            raise
+
+    def list(self, bucket, versions=None, maxResults=None, prefix=None):
+        """
+        List all objects from the bucket with the give string prefix in name
+        :param bucket: bucket name
+        :type bucket: string
+        :param versions: if true, list all versions of the objects
+        :type versions: boolean
+        :param maxResults: max count of items to return in a single page of responses
+        :type maxResults: integer
+        :param pageToken: previously returned page token
+        :param prefix: prefix string which filters objects whose name begin with this prefix
+        :return: a stream of object names matching the filtering criteria
+        """
+        service = self.get_conn()
+
+        ids = list()
+        pageToken = None
+        while(True):
+            response = service.objects().list(
+                bucket=bucket,
+                versions=versions,
+                maxResults=maxResults,
+                pageToken=pageToken,
+                prefix=prefix
+            ).execute()
+
+            if 'items' not in response:
+                logging.warning("No items found for prefix:{}".format(prefix))
+                break
+
+            for item in response['items']:
+                if item and 'name' in item:
+                    ids.append(item['name'])
+
+            if 'nextPageToken' not in response:
+                # no further pages of results, so stop the loop
+                break
+
+            pageToken = response['nextPageToken']
+            if not pageToken:
+                # empty next page token
+                break
+        yield ids

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -187,8 +187,8 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         :type versions: boolean
         :param maxResults: max count of items to return in a single page of responses
         :type maxResults: integer
-        :param pageToken: previously returned page token
         :param prefix: prefix string which filters objects whose name begin with this prefix
+        :type prefix: string
         :return: a stream of object names matching the filtering criteria
         """
         service = self.get_conn()
@@ -205,7 +205,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
             ).execute()
 
             if 'items' not in response:
-                logging.warning("No items found for prefix:{}".format(prefix))
+                logging.info("No items found for prefix:{}".format(prefix))
                 break
 
             for item in response['items']:
@@ -220,4 +220,4 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
             if not pageToken:
                 # empty next page token
                 break
-        yield ids
+        return ids


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) 
Enable delete and list function for Google Cloud Storage Hook
    - https://issues.apache.org/jira/browse/AIRFLOW-1181


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
current `GoogleCloudStorageHook` does not support delete of a file, nor does it support listing of files based on prefix. We would like to have these features available for our use-case.
The delete function should be able to return true if successfully deleted the object, based on generation etc.
The list function should be able to list all objects with the given prefix, able to page through large result pages and return a list of all file names satisfying the given prefix criteria

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
I have tested these new features locally on a running airflow instance, with python operators calling into the hook and run the methods. result seems successful @criccomini 

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. 
203088f5a27e207fc4319993cbfb8fa210afdb3c
8715a4dba18b8f2b560e99dc55b0a397a62896ac


