### PR TITLE
[AIRFLOW-1182]: SparkSubmitOperator should render templates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,44 @@
+AIRFLOW 1.8.1, 2017-05-09
+-------------------------
+
+[AIRFLOW-1142] SubDAG Tasks Not Executed Even Though All Dependencies Met
+[AIRFLOW-1138] Add licenses to files in scripts directory
+[AIRFLOW-1127] Move license notices to LICENSE instead of NOTICE
+[AIRFLOW-1124] Do not set all task instances to scheduled on backfill
+[AIRFLOW-1120] Update version view to include Apache prefix
+[AIRFLOW-1062] DagRun#find returns wrong result if external_trigger=False is specified
+[AIRFLOW-1054] Fix broken import on test_dag
+[AIRFLOW-1050] Retries ignored - regression
+[AIRFLOW-1033] TypeError: can't compare datetime.datetime to None
+[AIRFLOW-1017] get_task_instance should return None instead of throw an exception for non-existent TIs
+[AIRFLOW-1011] Fix bug in BackfillJob._execute() for SubDAGs
+[AIRFLOW-1004] `airflow webserver -D` runs in foreground
+[AIRFLOW-1001] Landing Time shows "unsupported operand type(s) for -: 'datetime.datetime' and 'NoneType'" on example_subdag_operator
+[AIRFLOW-1000] Rebrand to Apache Airflow instead of Airflow
+[AIRFLOW-989] Clear Task Regression
+[AIRFLOW-974] airflow.util.file mkdir has a race condition
+[AIRFLOW-906] Update Code icon from lightning bolt to file
+[AIRFLOW-858] Configurable database name for DB operators
+[AIRFLOW-853] ssh_execute_operator.py stdout decode default to ASCII
+[AIRFLOW-832] Fix debug server
+[AIRFLOW-817] Trigger dag fails when using CLI + API
+[AIRFLOW-816] Make sure to pull nvd3 from local resources
+[AIRFLOW-815] Add previous/next execution dates to available default variables.
+[AIRFLOW-813] Fix unterminated unit tests in tests.job (tests/job.py)
+[AIRFLOW-812] Scheduler job terminates when there is no dag file
+[AIRFLOW-806] UI should properly ignore DAG doc when it is None
+[AIRFLOW-794] Consistent access to DAGS_FOLDER and SQL_ALCHEMY_CONN
+[AIRFLOW-785] ImportError if cgroupspy is not installed
+[AIRFLOW-784] Cannot install with funcsigs > 1.0.0
+[AIRFLOW-780] The UI no longer shows broken DAGs
+[AIRFLOW-777] dag_is_running is initlialized to True instead of False
+[AIRFLOW-719] Skipped operations make DAG finish prematurely
+[AIRFLOW-694] Empty env vars do not overwrite non-empty config values
+[AIRFLOW-492] Insert into dag_stats table results into failed task while task itself succeeded
+[AIRFLOW-139] Executing VACUUM with PostgresOperator
+[AIRFLOW-111] DAG concurrency is not honored
+[AIRFLOW-88] Improve clarity Travis CI reports
+
 AIRFLOW 1.8.0, 2017-03-12
 -------------------------
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Airflow
 
-[![PyPI version](https://badge.fury.io/py/airflow.svg)](https://badge.fury.io/py/airflow)
+[![PyPI version](https://badge.fury.io/py/apache-airflow.svg)](https://badge.fury.io/py/apache-airflow)
 [![Build Status](https://travis-ci.org/apache/incubator-airflow.svg)](https://travis-ci.org/apache/incubator-airflow)
 [![Coverage Status](https://img.shields.io/codecov/c/github/apache/incubator-airflow/master.svg)](https://codecov.io/github/apache/incubator-airflow?branch=master)
 [![Code Health](https://landscape.io/github/apache/incubator-airflow/master/landscape.svg?style=flat)](https://landscape.io/github/apache/incubator-airflow/master)
 [![Requirements Status](https://requires.io/github/apache/incubator-airflow/requirements.svg?branch=master)](https://requires.io/github/apache/incubator-airflow/requirements/?branch=master)
 [![Documentation](https://img.shields.io/badge/docs-pythonhosted-blue.svg)](http://pythonhosted.org/airflow/)
 [![Join the chat at https://gitter.im/apache/incubator-airflow](https://badges.gitter.im/apache/incubator-airflow.svg)](https://gitter.im/apache/incubator-airflow?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+_NOTE: The transition from 1.8.0 (or before) to 1.8.1 (or after) requires uninstalling Airflow before installing the new version. The package name was changed from `airflow` to `apache-airflow` as of version 1.8.1._
 
 Airflow is a platform to programmatically author, schedule and monitor
 workflows.

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -20,6 +20,11 @@ supported and will be removed entirely in Airflow 2.0
 
   Previously, post_execute() only took one argument, `context`.
 
+## Airflow 1.8.1
+
+The Airflow package name was changed from `airflow` to `apache-airflow` during this release. You must uninstall your
+previously installed version of Airflow before installing 1.8.1.
+
 ## Airflow 1.8
 
 ### Database

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -24,7 +24,7 @@ import time
 from apiclient.discovery import build, HttpError
 from googleapiclient import errors
 from builtins import range
-from pandas.io.gbq import GbqConnector, \
+from pandas_gbq.gbq import GbqConnector, \
     _parse_data as gbq_parse_data, \
     _check_google_client_version as gbq_check_google_client_version, \
     _test_google_api_imports as gbq_test_google_api_imports

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -152,3 +152,72 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                 raise
 
         return False
+
+    def delete(self, bucket, object, generation=None):
+        """
+        Delete an object if versioning is not enabled for the bucket, or if generation
+        parameter is used.
+        :param bucket: name of the bucket, where the object resides
+        :type bucket: string
+        :param object: name of the object to delete
+        :type object: string
+        :param generation: if present, permanently delete the object of this generation
+        :type generation: string
+        :return: True if succeeded
+        """
+        service = self.get_conn()
+
+        try:
+            service \
+                .objects() \
+                .delete(bucket=bucket, object=object, generation=generation) \
+                .execute()
+            return True
+        except errors.HttpError as ex:
+            if ex.resp['status'] == '404':
+                return False
+            raise
+
+    def list(self, bucket, versions=None, maxResults=None, prefix=None):
+        """
+        List all objects from the bucket with the give string prefix in name
+        :param bucket: bucket name
+        :type bucket: string
+        :param versions: if true, list all versions of the objects
+        :type versions: boolean
+        :param maxResults: max count of items to return in a single page of responses
+        :type maxResults: integer
+        :param prefix: prefix string which filters objects whose name begin with this prefix
+        :type prefix: string
+        :return: a stream of object names matching the filtering criteria
+        """
+        service = self.get_conn()
+
+        ids = list()
+        pageToken = None
+        while(True):
+            response = service.objects().list(
+                bucket=bucket,
+                versions=versions,
+                maxResults=maxResults,
+                pageToken=pageToken,
+                prefix=prefix
+            ).execute()
+
+            if 'items' not in response:
+                logging.info("No items found for prefix:{}".format(prefix))
+                break
+
+            for item in response['items']:
+                if item and 'name' in item:
+                    ids.append(item['name'])
+
+            if 'nextPageToken' not in response:
+                # no further pages of results, so stop the loop
+                break
+
+            pageToken = response['nextPageToken']
+            if not pageToken:
+                # empty next page token
+                break
+        return ids

--- a/airflow/contrib/operators/spark_submit_operator.py
+++ b/airflow/contrib/operators/spark_submit_operator.py
@@ -17,6 +17,7 @@ import logging
 from airflow.contrib.hooks.spark_submit_hook import SparkSubmitHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
+from airflow.settings import WEB_COLORS
 
 log = logging.getLogger(__name__)
 
@@ -63,6 +64,8 @@ class SparkSubmitOperator(BaseOperator):
     :param verbose: Whether to pass the verbose flag to spark-submit process for debugging
     :type verbose: bool
     """
+    template_fields = ('_application_args',)
+    ui_color = WEB_COLORS['LIGHTORANGE']
 
     @apply_defaults
     def __init__(self,

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -177,4 +177,5 @@ configure_orm()
 
 KILOBYTE = 1024
 MEGABYTE = KILOBYTE * KILOBYTE
-WEB_COLORS = {'LIGHTBLUE': '#4d9de0'}
+WEB_COLORS = {'LIGHTBLUE': '#4d9de0',
+              'LIGHTORANGE': '#FF9933'}

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -61,6 +61,7 @@ nose-ignore-docstring==0.2
 nose-parameterized
 nose-timer
 pandas
+pandas-gbq
 psutil>=4.2.0, <5.0.0
 psycopg2
 pydruid

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,7 @@ gcp_api = [
     'google-api-python-client>=1.5.0, <1.6.0',
     'oauth2client>=2.0.2, <2.1.0',
     'PyOpenSSL',
+    'pandas-gbq'
 ]
 hdfs = ['snakebite>=2.7.8']
 webhdfs = ['hdfs[dataframe,avro,kerberos]>=2.0.4']


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [AIRFLOW-1182] My PR addresses the following
  - [Airflow-1182](https://issues.apache.org/jira/browse/AIRFLOW-1182) Contrib Spark Submit operator should template fields

### Description
- [ ] Here are some details about my PR, : 
  - added template field to the SparkSubmitOperator : ```_application_args```

this enable to pass params based on dag execution date to the Spark application


### Tests
- [ ] My PR adds the following unit tests :
  - TestSparkSubmitOperator/test_render_template, which basically test that the application arguments based on a macro are templated.



