### PR TITLE
[AIRFLOW-1185] Fix PyPi URL in templates

### DIFF
--- a/airflow/www/templates/airflow/version.html
+++ b/airflow/www/templates/airflow/version.html
@@ -20,7 +20,7 @@
     <h2>{{ title }}</h2>
 	{% set version_label = 'Version' %}
     {% if airflow_version %}
-        <h4>{{ version_label }} : <a href="https://pypi.python.org/pypi/airflow/{{ airflow_version }}">{{ airflow_version }}</a></h4>
+        <h4>{{ version_label }} : <a href="https://pypi.python.org/pypi/apache-airflow/{{ airflow_version }}">{{ airflow_version }}</a></h4>
     {% else %}
         <h4>{{ version_label }} : Not Available</h4>
     {% endif %}


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [AIRFLOW-1185](https://issues.apache.org/jira/browse/AIRFLOW-1185) 
    - https://issues.apache.org/jira/browse/AIRFLOW-1185


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
  - After changing the package name "apache-airflow" link on PyPi points to the old name. This PR fix it.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - This PR does not require tests