### PR TITLE
[AIRFLOW-1187] Fix PyPi package names in documents

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -86,7 +86,7 @@ system have libffi-dev installed.
 If ``crypto`` package was not installed initially, you can still enable encryption for 
 connections by following steps below:
 
-1. Install crypto package ``pip install airflow[crypto]``
+1. Install crypto package ``pip install apache-airflow[crypto]``
 2. Generate fernet_key, using this code snippet below. fernet_key must be a base64-encoded 32-byte key.
 
 .. code:: python

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,18 +8,18 @@ The easiest way to install the latest stable version of Airflow is with ``pip``:
 
 .. code-block:: bash
 
-    pip install airflow
+    pip install apache-airflow
 
 You can also install Airflow with support for extra features like ``s3`` or ``postgres``:
 
 .. code-block:: bash
 
-    pip install "airflow[s3, postgres]"
+    pip install "apache-airflow[s3, postgres]"
 
 Extra Packages
 ''''''''''''''
 
-The ``airflow`` PyPI basic package only installs what's needed to get started.
+The ``apache-airflow`` PyPI basic package only installs what's needed to get started.
 Subpackages can be installed depending on what will be useful in your
 environment. For instance, if you don't need connectivity with Postgres,
 you won't have to go through the trouble of installing the ``postgres-devel``
@@ -30,63 +30,63 @@ these extra dependencies.
 
 Here's the list of the subpackages and what they enable:
 
-+---------------+-------------------------------------+-------------------------------------------------+
-| subpackage    |     install command                 | enables                                         |
-+===============+=====================================+=================================================+
-|  all          | ``pip install airflow[all]``        | All Airflow features known to man               |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  all_dbs      | ``pip install airflow[all_dbs]``    | All databases integrations                      |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  async        | ``pip install airflow[async]``      | Async worker classes for gunicorn               |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  devel        | ``pip install airflow[devel]``      | Minimum dev tools requirements                  |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  devel_hadoop |``pip install airflow[devel_hadoop]``| Airflow + dependencies on the Hadoop stack      |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  celery       | ``pip install airflow[celery]``     | CeleryExecutor                                  |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  crypto       | ``pip install airflow[crypto]``     | Encrypt connection passwords in metadata db     |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  druid        | ``pip install airflow[druid]``      | Druid.io related operators & hooks              |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  gcp_api      | ``pip install airflow[gcp_api]``    | Google Cloud Platform hooks and operators       |
-|               |                                     | (using ``google-api-python-client``)            |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  jdbc         | ``pip install airflow[jdbc]``       | JDBC hooks and operators                        |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  hdfs         | ``pip install airflow[hdfs]``       | HDFS hooks and operators                        |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  hive         | ``pip install airflow[hive]``       | All Hive related operators                      |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  kerberos     | ``pip install airflow[kerberos]``   | kerberos integration for kerberized hadoop      |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  ldap         | ``pip install airflow[ldap]``       | ldap authentication for users                   |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  mssql        | ``pip install airflow[mssql]``      | Microsoft SQL operators and hook,               |
-|               |                                     | support as an Airflow backend                   |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  mysql        | ``pip install airflow[mysql]``      | MySQL operators and hook, support as            |
-|               |                                     | an Airflow backend                              |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  password     | ``pip install airflow[password]``   | Password Authentication for users               |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  postgres     | ``pip install airflow[postgres]``   | Postgres operators and hook, support            |
-|               |                                     | as an Airflow backend                           |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  qds          | ``pip install airflow[qds]``        | Enable QDS (qubole data services) support       |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  rabbitmq     | ``pip install airflow[rabbitmq]``   | Rabbitmq support as a Celery backend            |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  s3           | ``pip install airflow[s3]``         | ``S3KeySensor``, ``S3PrefixSensor``             |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  samba        | ``pip install airflow[samba]``      | ``Hive2SambaOperator``                          |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  slack        | ``pip install airflow[slack]``      | ``SlackAPIPostOperator``                        |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  vertica      | ``pip install airflow[vertica]``    | Vertica hook                                    |
-|               |                                     | support as an Airflow backend                   |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  cloudant     | ``pip install airflow[cloudant]``   | Cloudant hook                                   |
-+---------------+-------------------------------------+-------------------------------------------------+
-|  redis        | ``pip install airflow[redis]``      | Redis hooks and sensors                         |
-+---------------+-------------------------------------+-------------------------------------------------+
++---------------+----------------------------------------------+-------------------------------------------------+
+| subpackage    | install command                              | enables                                         |
++===============+==============================================+=================================================+
+|  all          | ``pip install apache-airflow[all]``          | All Airflow features known to man               |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  all_dbs      | ``pip install apache-airflow[all_dbs]``      | All databases integrations                      |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  async        | ``pip install apache-airflow[async]``        | Async worker classes for gunicorn               |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  devel        | ``pip install apache-airflow[devel]``        | Minimum dev tools requirements                  |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  devel_hadoop | ``pip install apache-airflow[devel_hadoop]`` | Airflow + dependencies on the Hadoop stack      |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  celery       | ``pip install apache-airflow[celery]``       | CeleryExecutor                                  |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  crypto       | ``pip install apache-airflow[crypto]``       | Encrypt connection passwords in metadata db     |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  druid        | ``pip install apache-airflow[druid]``        | Druid.io related operators & hooks              |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  gcp_api      | ``pip install apache-airflow[gcp_api]``      | Google Cloud Platform hooks and operators       |
+|               |                                              | (using ``google-api-python-client``)            |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  jdbc         | ``pip install apache-airflow[jdbc]``         | JDBC hooks and operators                        |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  hdfs         | ``pip install apache-airflow[hdfs]``         | HDFS hooks and operators                        |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  hive         | ``pip install apache-airflow[hive]``         | All Hive related operators                      |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  kerberos     | ``pip install apache-airflow[kerberos]``     | kerberos integration for kerberized hadoop      |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  ldap         | ``pip install apache-airflow[ldap]``         | ldap authentication for users                   |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  mssql        | ``pip install apache-airflow[mssql]``        | Microsoft SQL operators and hook,               |
+|               |                                              | support as an Airflow backend                   |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  mysql        | ``pip install apache-airflow[mysql]``        | MySQL operators and hook, support as            |
+|               |                                              | an Airflow backend                              |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  password     | ``pip install apache-airflow[password]``     | Password Authentication for users               |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  postgres     | ``pip install apache-airflow[postgres]``     | Postgres operators and hook, support            |
+|               |                                              | as an Airflow backend                           |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  qds          | ``pip install apache-airflow[qds]``          | Enable QDS (qubole data services) support       |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  rabbitmq     | ``pip install apache-airflow[rabbitmq]``     | Rabbitmq support as a Celery backend            |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  s3           | ``pip install apache-airflow[s3]``           | ``S3KeySensor``, ``S3PrefixSensor``             |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  samba        | ``pip install apache-airflow[samba]``        | ``Hive2SambaOperator``                          |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  slack        | ``pip install apache-airflow[slack]``        | ``SlackAPIPostOperator``                        |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  vertica      | ``pip install apache-airflow[vertica]``      | Vertica hook                                    |
+|               |                                              | support as an Airflow backend                   |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  cloudant     | ``pip install apache-airflow[cloudant]``     | Cloudant hook                                   |
++---------------+----------------------------------------------+-------------------------------------------------+
+|  redis        | ``pip install apache-airflow[redis]``        | Redis hooks and sensors                         |
++---------------+----------------------------------------------+-------------------------------------------------+

--- a/docs/start.rst
+++ b/docs/start.rst
@@ -11,7 +11,7 @@ The installation is quick and straightforward.
     export AIRFLOW_HOME=~/airflow
 
     # install from pypi using pip
-    pip install airflow
+    pip install apache-airflow
 
     # initialize the database
     airflow initdb


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1187


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

As well as AIRFLOW-1185, install commands in documents should be updated as "pip install apache-airflow".


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

It requires no test since it's just a documentation fix.
I ran docs/build.sh locally and confirmed that the modified files were properly rendered as html.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

