### PR TITLE
[AIRFLOW-1188] Add max_bad_records param to GoogleCloudStorageToBigQueryOperator

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -369,6 +369,7 @@ class BigQueryBaseCursor(object):
                  skip_leading_rows=0,
                  write_disposition='WRITE_EMPTY',
                  field_delimiter=',',
+                 max_bad_records=0,
                  schema_update_options=()):
         """
         Executes a BigQuery load command to load data from Google Cloud Storage
@@ -400,6 +401,9 @@ class BigQueryBaseCursor(object):
         :type write_disposition: string
         :param field_delimiter: The delimiter to use when loading from a CSV.
         :type field_delimiter: string
+        :param max_bad_records: The maximum number of bad records that BigQuery can
+            ignore when running the job.
+        :type max_bad_records: int
         :param schema_update_options: Allows the schema of the desitination
             table to be updated as a side effect of the load job.
         :type schema_update_options: list
@@ -472,6 +476,9 @@ class BigQueryBaseCursor(object):
         if source_format == 'CSV':
             configuration['load']['skipLeadingRows'] = skip_leading_rows
             configuration['load']['fieldDelimiter'] = field_delimiter
+
+        if max_bad_records:
+            configuration['load']['maxBadRecords'] = max_bad_records
 
         return self.run_with_configuration(configuration)
 

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -43,6 +43,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         skip_leading_rows=0,
         write_disposition='WRITE_EMPTY',
         field_delimiter=',',
+        max_bad_records=0,
         max_id_key=None,
         bigquery_conn_id='bigquery_default',
         google_cloud_storage_conn_id='google_cloud_storage_default',
@@ -80,6 +81,9 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         :type write_disposition: string
         :param field_delimiter: The delimiter to use when loading from a CSV.
         :type field_delimiter: string
+        :param max_bad_records: The maximum number of bad records that BigQuery can
+            ignore when running the job.
+        :type max_bad_records: int
         :param max_id_key: If set, the name of a column in the BigQuery table
             that's to be loaded. Thsi will be used to select the MAX value from
             BigQuery after the load occurs. The results will be returned by the
@@ -115,6 +119,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         self.skip_leading_rows = skip_leading_rows
         self.write_disposition = write_disposition
         self.field_delimiter = field_delimiter
+        self.max_bad_records = max_bad_records
 
         self.max_id_key = max_id_key
         self.bigquery_conn_id = bigquery_conn_id
@@ -150,6 +155,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
             skip_leading_rows=self.skip_leading_rows,
             write_disposition=self.write_disposition,
             field_delimiter=self.field_delimiter,
+            max_bad_records=self.max_bad_records,
             schema_update_options=self.schema_update_options)
 
         if self.max_id_key:


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1188 Add max_bad_records param to GoogleCloudStorageToBigQueryOperator


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Add max_bad_records to GoogleCloudStorageToBigQueryOperator and to BigQueryHook.run_load method, it allows to ignore some error ratio for bulk loads. Default is 0.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit tests for GoogleCloudStorageToBigQueryOperator not found, I tested it manually.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

