### PR TITLE
[AIRFLOW-1182] Spark operators should render templates

### DIFF
--- a/airflow/contrib/operators/spark_sql_operator.py
+++ b/airflow/contrib/operators/spark_sql_operator.py
@@ -46,7 +46,7 @@ class SparkSqlOperator(BaseOperator):
     :type yarn_queue: str
     """
 
-    template_fields = ["_sql"]
+    template_fields = ["_sql", "_name"]
     template_ext = [".sql", ".hql"]
 
     @apply_defaults

--- a/airflow/contrib/operators/spark_submit_operator.py
+++ b/airflow/contrib/operators/spark_submit_operator.py
@@ -64,6 +64,8 @@ class SparkSubmitOperator(BaseOperator):
     :type verbose: bool
     """
 
+    template_fields = ("_application_args", "_name")
+
     @apply_defaults
     def __init__(self,
                  application='',


### PR DESCRIPTION
Added jinja template rendering to arguments of the Spark operators

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [AIRFLOW-1182] My PR addresses the following [AIRFLOW-1182](https://issues.apache.org/jira/browse/AIRFLOW-1182)
    - https://issues.apache.org/jira/browse/AIRFLOW-1182

### Description
- [ ] Here are some details about my PR:
added jinja template rendering to the following arguments of the SparkSubmitOperator:
    - _application_args
    - _name
added jinja template rendering to the following arguments of the SparkSqlOperator:
    - _name

this enables to pass params based on dag execution date to the Spark application

### Tests
- [ ] My PR adds the following unit tests: 
    - TestSparkSubmitOperator/test_execute_with_template_in_name, which basically tests that the name argument based on a macro is templated.
    - TestSparkSubmitOperator/test_execute_with_template_in_application_args, which basically tests that the application_args argument based on a macro is templated.


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

