### PR TITLE
[AIRFLOW-1182] & [AIRFLOW-1184]: Contrib Spark Submit operator should template fields & Contrib Spark Submit Hook does not split argument and argument value

### DIFF
--- a/airflow/contrib/hooks/spark_submit_hook.py
+++ b/airflow/contrib/hooks/spark_submit_hook.py
@@ -196,8 +196,11 @@ class SparkSubmitHook(BaseHook):
         # Append any application arguments
         if self._application_args:
             for arg in self._application_args:
-                connection_cmd += [arg]
-
+                if len(arg.split()) > 1:
+                    for splitted_option in arg.split():
+                        connection_cmd += [splitted_option]
+                else:
+                    connection_cmd += [arg]
         logging.debug("Spark-Submit cmd: {}".format(connection_cmd))
 
         return connection_cmd
@@ -257,7 +260,7 @@ class SparkSubmitHook(BaseHook):
 
             if self._yarn_application_id:
                 logging.info('Killing application on YARN')
-                yarn_kill = Popen("yarn application -kill {0}".format(self._yarn_application_id),
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.PIPE)
+                yarn_kill = subprocess.Popen("yarn application -kill {0}".format(self._yarn_application_id),
+                                             stdout=subprocess.PIPE,
+                                             stderr=subprocess.PIPE)
                 logging.info("YARN killed with return code: {0}".format(yarn_kill.wait()))

--- a/airflow/contrib/operators/spark_submit_operator.py
+++ b/airflow/contrib/operators/spark_submit_operator.py
@@ -17,6 +17,7 @@ import logging
 from airflow.contrib.hooks.spark_submit_hook import SparkSubmitHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
+from airflow.settings import WEB_COLORS
 
 log = logging.getLogger(__name__)
 
@@ -63,6 +64,8 @@ class SparkSubmitOperator(BaseOperator):
     :param verbose: Whether to pass the verbose flag to spark-submit process for debugging
     :type verbose: bool
     """
+    template_fields = ('_name', '_application_args',)
+    ui_color = WEB_COLORS['LIGHTORANGE']
 
     @apply_defaults
     def __init__(self,

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -177,4 +177,5 @@ configure_orm()
 
 KILOBYTE = 1024
 MEGABYTE = KILOBYTE * KILOBYTE
-WEB_COLORS = {'LIGHTBLUE': '#4d9de0'}
+WEB_COLORS = {'LIGHTBLUE': '#4d9de0',
+              'LIGHTORANGE': '#FF9933'}


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following
  - [Airflow-1182](https://issues.apache.org/jira/browse/AIRFLOW-1182) Contrib Spark Submit operator should template fields
  - [Airflow-1184](https://issues.apache.org/jira/browse/AIRFLOW-1184) Contrib Spark Submit Hook does not split argument and argument value
### Description
- [ ] Here are some details about my PR, : 
  - added template fields to the SparkSubmitOperator : ```_application_args``` & ```_name``` making them usable with macro. This enable to pass params based on dag execution to the Spark application
  - split spark application options as they should be for Popen in spark_submit_hook. Without, the spark application is complaining about missing & malformed option. See jira issu 1184

### Tests
- [ ] My PR adds the following unit tests :
  - refactored tests for spark_submit_operator & spark_submit_hook.




