### PR TITLE
[AIRFLOW-1199] Fix create modal

### DIFF
--- a/airflow/www/templates/airflow/model_create.html
+++ b/airflow/www/templates/airflow/model_create.html
@@ -15,7 +15,7 @@
   limitations under the License.
 
 #}
-{% extends 'admin/model/edit.html' %}
+{% extends 'admin/model/create.html' %}
 
 {% block body %}
   {% if admin_view.verbose_name %}


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following:
    - [AIRFLOW-1199](https://issues.apache.org/jira/browse/AIRFLOW-1199) Create modal looks like edit modal (edit tab selected)

### Description
- [x] Previously create modal template used edit modal template that caused incorrect look of the create modal.
![imageedit_4_9834649179](https://cloud.githubusercontent.com/assets/2817012/26060855/f2e6f818-398e-11e7-8975-5b6dcfec8438.jpg)

Now it looks correct:
![imageedit_6_5616967104](https://cloud.githubusercontent.com/assets/2817012/26060951/3c42d914-398f-11e7-9803-ea43c0e0fa9d.jpg)

### Tests
- [x] No tests changed

