### PR TITLE
[AIRFLOW-1201] Update deprecated 'nose-parameterized'

### DIFF
--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -58,11 +58,11 @@ mysqlclient
 nose
 nose-exclude
 nose-ignore-docstring==0.2
-nose-parameterized
 nose-timer
 oauth2client>=2.0.2,<2.1.0
 pandas
 pandas-gbq
+parameterized
 psutil>=4.2.0, <5.0.0
 psycopg2
 pydruid

--- a/setup.py
+++ b/setup.py
@@ -193,8 +193,8 @@ devel = [
     'moto',
     'nose',
     'nose-ignore-docstring==0.2',
-    'nose-parameterized',
     'nose-timer',
+    'parameterized',
     'rednose'
 ]
 devel_minreq = devel + mysql + doc + password + s3 + cgroups

--- a/tests/models.py
+++ b/tests/models.py
@@ -35,7 +35,7 @@ from airflow.operators.python_operator import ShortCircuitOperator
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.utils.state import State
 from mock import patch
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 
 DEFAULT_DATE = datetime.datetime(2016, 1, 1)


### PR DESCRIPTION
The 'parameterized' package should be used now,

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [AIRFLOW-1201](https://issues.apache.org/jira/browse/AIRFLOW-1201) Update deprecated 'nose-parameterized' library to 'parameterized'

### Description
- [x] Currently there is the following deprecation warning:

> /home/travis/build/apache/incubator-airflow/.tox/py27-cdh-airflow_backend_mysql/lib/python2.7/site-packages/nose_parameterized/__init__.py:7: UserWarning: The 'nose-parameterized' package has been renamed 'parameterized'. For the two step migration instructions, see: https://github.com/wolever/parameterized#migrating-from-nose-parameterized-to-parameterized (set NOSE_PARAMETERIZED_NO_WARN=1 to suppress this warning)

This PR upgrades library to 'parameterized' and gets rid of this warning.

### Tests
- [x] Existing tests are passing.
