### PR TITLE
[AIRFLOW-1200] Forbid creation of a variable with an empty key

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2172,13 +2172,20 @@ class VariableView(wwwutils.DataProfilingMixin, AirflowModelView):
             'rows': 20,
         }
     }
+    form_args = {
+        'key': {
+            'validators': {
+                validators.DataRequired(),
+            },
+        },
+    }
     column_sortable_list = (
         'key',
         'val',
         'is_encrypted',
     )
     column_formatters = {
-        'val': hidden_field_formatter
+        'val': hidden_field_formatter,
     }
 
     # Default flask-admin export functionality doesn't handle serialized json


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following
    - [AIRLFOW-1200](https://issues.apache.org/jira/browse/AIRFLOW-1200) Forbid creation of a variable with an empty key

### Description
- [x] Previously creation a variable with an empty key lead to the following exception. This PR adds key field validator so it is not possible to create a variable with an empty key.

![imageedit_8_4967114590](https://cloud.githubusercontent.com/assets/2817012/26098654/22e65674-3a31-11e7-8f4d-5adb1f51f20a.jpg)

### Tests
- [x] Existing tests passed.
