### PR TITLE
[AIRFLOW-1210] Enable DbApiHook unit tests

### DIFF
--- a/tests/hooks/__init__.py
+++ b/tests/hooks/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/hooks/test_dbapi_hook.py
+++ b/tests/hooks/test_dbapi_hook.py
@@ -56,8 +56,7 @@ class TestDbApiHook(unittest.TestCase):
                 ("world",)]
         
         self.cur.fetchall.return_value = rows
-        
-        
+
         self.assertEqual(rows, self.db_hook.get_records(statement, parameters))
         
         self.conn.close.assert_called_once()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following
    - [AIRFLOW-1210](https://issues.apache.org/jira/browse/AIRFLOW-1210) Enable DbApiHook unit tests

### Description
- [x] Currently these tests are not running. Enabling them.

### Tests
- [x] All test are passing.
