### PR TITLE
[AIRFLOW-1213] Add hcatalog parameters to sqoop

### DIFF
--- a/airflow/contrib/hooks/sqoop_hook.py
+++ b/airflow/contrib/hooks/sqoop_hook.py
@@ -52,7 +52,8 @@ class SqoopHook(BaseHook):
     """
 
     def __init__(self, conn_id='sqoop_default', verbose=False,
-                 num_mappers=None, properties=None):
+                 num_mappers=None, hcatalog_database=None,
+                 hcatalog_table=None, properties=None):
         # No mutable types in the default parameters
         if properties is None:
             properties = {}
@@ -64,6 +65,8 @@ class SqoopHook(BaseHook):
         self.files = connection_parameters.get('files', None)
         self.archives = connection_parameters.get('archives', None)
         self.password_file = connection_parameters.get('password_file', None)
+        self.hcatalog_database = hcatalog_database
+        self.hcatalog_table = hcatalog_table
         self.verbose = verbose
         self.num_mappers = str(num_mappers)
         self.properties = properties
@@ -118,6 +121,10 @@ class SqoopHook(BaseHook):
             connection_cmd += ["-archives", self.archives]
         if self.num_mappers:
             connection_cmd += ["--num-mappers", self.num_mappers]
+        if self.hcatalog_database:
+            connection_cmd += ["--hcatalog-database", self.hcatalog_database]
+        if self.hcatalog_table:
+            connection_cmd += ["--hcatalog-table", self.hcatalog_table]
 
         for key, value in self.properties.items():
             connection_cmd += ["-D", "{}={}".format(key, value)]
@@ -257,8 +264,10 @@ class SqoopHook(BaseHook):
         if relaxed_isolation:
             cmd += ["--relaxed-isolation"]
 
-        # The required options
-        cmd += ["--export-dir", export_dir]
+        if export_dir:
+            cmd += ["--export-dir", export_dir]
+
+        # The required option
         cmd += ["--table", table]
 
         return cmd

--- a/airflow/contrib/operators/sqoop_operator.py
+++ b/airflow/contrib/operators/sqoop_operator.py
@@ -57,6 +57,8 @@ class SqoopOperator(BaseOperator):
                  verbose=False,
                  relaxed_isolation=False,
                  properties=None,
+                 hcatalog_database=None,
+                 hcatalog_table=None,
                  *args,
                  **kwargs):
         """
@@ -91,6 +93,8 @@ class SqoopOperator(BaseOperator):
         :param driver: Manually specify JDBC driver class to use
         :param verbose: Switch to more verbose logging for debug purposes
         :param relaxed_isolation: use read uncommitted isolation level
+        :param hcatalog_database: Specifies the database name for the HCatalog table
+        :param hcatalog_table: The argument value for this option is the HCatalog table
         :param properties: additional JVM properties passed to sqoop
         """
         super(SqoopOperator, self).__init__(*args, **kwargs)
@@ -120,6 +124,8 @@ class SqoopOperator(BaseOperator):
         self.driver = driver
         self.verbose = verbose
         self.relaxed_isolation = relaxed_isolation
+        self.hcatalog_database = hcatalog_database
+        self.hcatalog_table = hcatalog_table
         # No mutable types in the default parameters
         if properties is None:
             properties = {}
@@ -132,6 +138,8 @@ class SqoopOperator(BaseOperator):
         hook = SqoopHook(conn_id=self.conn_id,
                          verbose=self.verbose,
                          num_mappers=self.num_mappers,
+                         hcatalog_database=self.hcatalog_database,
+                         hcatalog_table=self.hcatalog_table,
                          properties=self.properties)
 
         if self.cmd_type == 'export':

--- a/tests/contrib/hooks/test_sqoop_hook.py
+++ b/tests/contrib/hooks/test_sqoop_hook.py
@@ -29,7 +29,9 @@ class TestSqoopHook(unittest.TestCase):
         'verbose': True,
         'properties': {
             'mapred.map.max.attempts': '1'
-        }
+        },
+        'hcatalog_database': 'hive_database',
+        'hcatalog_table': 'hive_table'
     }
     _config_export = {
         'table': 'domino.export_data_to',
@@ -106,6 +108,9 @@ class TestSqoopHook(unittest.TestCase):
             self.assertIn(
                 "-archives {}".format(self._config_json['archives']), cmd
             )
+
+        self.assertIn("--hcatalog-database {}".format(self._config['hcatalog_database']), cmd)
+        self.assertIn("--hcatalog-table {}".format(self._config['hcatalog_table']), cmd)
 
         # Check the regulator stuff passed by the default constructor
         if self._config['verbose']:

--- a/tests/contrib/operators/test_sqoop_operator.py
+++ b/tests/contrib/operators/test_sqoop_operator.py
@@ -46,6 +46,8 @@ class TestSqoopOperator(unittest.TestCase):
         'relaxed_isolation': True,
         'direct': True,
         'driver': 'com.microsoft.jdbc.sqlserver.SQLServerDriver',
+        'hcatalog_database': 'hive_database',
+        'hcatalog_table': 'hive_table',
         'properties': {
             'mapred.map.max.attempts': '1'
         }
@@ -88,6 +90,8 @@ class TestSqoopOperator(unittest.TestCase):
         self.assertEqual(self._config['direct'], operator.direct)
         self.assertEqual(self._config['driver'], operator.driver)
         self.assertEqual(self._config['properties'], operator.properties)
+        self.assertEqual(self._config['hcatalog_database'], operator.hcatalog_database)
+        self.assertEqual(self._config['hcatalog_table'], operator.hcatalog_table)
 
     def test_invalid_cmd_type(self):
         operator = SqoopOperator(task_id='sqoop_job', dag=self.dag,


### PR DESCRIPTION
Dear Airflow maintainers,

This commit will add additional parameters to specify a hive table instead of a hdfs directory. This will also source the schema from the hive metastore.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-1213] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1213


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
This commit will add additional parameters to specify a hive table instead of a hdfs directory. This will also source the schema from the hive metastore.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
