### PR TITLE
[AIRFLOW-1221] Fix templating bug with DatabricksSubmitRunOperator

### DIFF
--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -204,7 +204,7 @@ class DatabricksSubmitRunOperator(BaseOperator):
             # Databricks can tolerate either numeric or string types in the API backend.
             return str(content)
         elif isinstance(content, (list, tuple)):
-            return [c(e, '{0}[{1}]'.format(json_path, i)) for e, i in enumerate(content)]
+            return [c(e, '{0}[{1}]'.format(json_path, i)) for i, e in enumerate(content)]
         elif isinstance(content, dict):
             return {k: c(v, '{0}[{1}]'.format(json_path, k))
                     for k, v in list(content.items())}

--- a/tests/contrib/operators/test_databricks_operator.py
+++ b/tests/contrib/operators/test_databricks_operator.py
@@ -145,6 +145,24 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
         with self.assertRaisesRegexp(AirflowException, exception_message):
             op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
 
+    def test_deep_string_coerce(self):
+        op = DatabricksSubmitRunOperator(task_id='test')
+        test_json = {
+            'test_int': 1,
+            'test_float': 1.0,
+            'test_dict': {'key': 'value'},
+            'test_list': [1, 1.0, 'a', 'b'],
+            'test_tuple': (1, 1.0, 'a', 'b')
+        }
+        expected = {
+            'test_int': '1',
+            'test_float': '1.0',
+            'test_dict': {'key': 'value'},
+            'test_list': ['1', '1.0', 'a', 'b'],
+            'test_tuple': ['1', '1.0', 'a', 'b']
+        }
+        self.assertDictEqual(op._deep_string_coerce(test_json), expected)
+
     @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
     def test_exec_success(self, db_mock_class):
         """


### PR DESCRIPTION


Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

In our implementation of DatabricksSubmitRunOperator we mistakenly
switched the order of the tuples returned by enumerate. The bug
is fixed in this commit and an additional unit test is added to
verify that this bug is fixed.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

