### PR TITLE
[AIRFLOW-1226] Remove empty column on the Jobs view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2239,6 +2239,7 @@ class XComView(wwwutils.SuperUserMixin, AirflowModelView):
 class JobModelView(ModelViewOnly):
     verbose_name_plural = "jobs"
     verbose_name = "job"
+    column_display_actions = False
     column_default_sort = ('start_date', True)
     column_filters = (
         'job_type', 'dag_id', 'state',


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following:
    - [AIRFLOW-1226](https://issues.apache.org/jira/browse/AIRFLOW-1226) Remove empty column on the Jobs view

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
First column on the Jobs view is redundant and should be removed.
Before:
![imageedit_9_5615772146](https://cloud.githubusercontent.com/assets/2817012/26198299/3604726a-3bce-11e7-86d8-9ad974bab13b.jpg)
Now:
![imageedit_11_6790655896](https://cloud.githubusercontent.com/assets/2817012/26198308/3bff2e80-3bce-11e7-9fc5-7b3220c224a8.jpg)

### Tests
- [x] All existing tests  passing.
