### PR TITLE
[AIRFLOW-1227] Remove empty column on the Logs view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2333,6 +2333,7 @@ class DagRunModelView(ModelViewOnly):
 class LogModelView(ModelViewOnly):
     verbose_name_plural = "logs"
     verbose_name = "log"
+    column_display_actions = False
     column_default_sort = ('dttm', True)
     column_filters = ('dag_id', 'task_id', 'execution_date')
     column_formatters = dict(


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following
    - [AIRFLOW-1227](https://issues.apache.org/jira/browse/AIRFLOW-1227) Remove empty column on the Logs view

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
First column on the Logs view is redundant and should be removed.
Before:
![imageedit_14_8306586340](https://cloud.githubusercontent.com/assets/2817012/26198583/33e7d61a-3bcf-11e7-800c-430b0eea8fe2.jpg)
Now:
![imageedit_16_4076055534](https://cloud.githubusercontent.com/assets/2817012/26198624/5e5a7ede-3bcf-11e7-8e41-5137882623e6.jpg)

### Tests
- [x] All existing tests passing.
