### PR TITLE
[AIRFLOW-1231] Use CSRFProtect instead of CsrfProtect

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -19,8 +19,8 @@ import six
 from flask import Flask
 from flask_admin import Admin, base
 from flask_cache import Cache
-from flask_wtf.csrf import CsrfProtect
-csrf = CsrfProtect()
+from flask_wtf.csrf import CSRFProtect
+csrf = CSRFProtect()
 
 import airflow
 from airflow import models


### PR DESCRIPTION
Use `flask_wtf.CSRFProtect` instead of `flask_wtf.CsrfProtect` to remove deprecation warning.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following
    - [AIRFLOW-1231](https://issues.apache.org/jira/browse/AIRFLOW-1231) Use flask_wtf.CSRFProtect instead of flask_wtf.CsrfProtect to remove deprecation warning.

### Description
- [x] Removed the following deprecation warning:

`FlaskWTFDeprecationWarning: "flask_wtf.CsrfProtect" has been renamed to "CSRFProtect" and will be removed in 1.0.
  csrf = CsrfProtect()`

### Tests
- [x] All tests passing.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

