### PR TITLE
[AIRFLOW-1232] Remove deprecated readfp warning

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -32,7 +32,7 @@ standard_library.install_aliases()
 
 from builtins import str
 from collections import OrderedDict
-from configparser import ConfigParser
+from six.moves import configparser
 
 from airflow.exceptions import AirflowConfigException
 
@@ -41,6 +41,8 @@ warnings.filterwarnings(
     action='default', category=DeprecationWarning, module='airflow')
 warnings.filterwarnings(
     action='default', category=PendingDeprecationWarning, module='airflow')
+
+ConfigParser = configparser.ConfigParser
 
 
 def generate_fernet_key():


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [AIRFLOW-1232](https://issues.apache.org/jira/browse/AIRFLOW-1232) Remove deprecated readfp warning


### Description
- [x] Using `six.moves.configparser.ConfigParser` to get rid of the following warning:

> /home/travis/build/apache/incubator-airflow/airflow/configuration.py:128: DeprecationWarning: This method will be removed in future versions.  Use 'parser.read_file()' instead.
>   self.readfp(StringIO.StringIO(string))


### Tests
- [x] All tests are passing.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

