### PR TITLE
[AIRFLOW-1234] Cover utils.operator_helpers with UTs

### DIFF
--- a/airflow/utils/operator_helpers.py
+++ b/airflow/utils/operator_helpers.py
@@ -22,18 +22,23 @@ def context_to_airflow_vars(context):
     :param context: The context for the task_instance of interest
     :type context: dict
     """
-    params = dict()
+    params = {}
     dag = context.get('dag')
     if dag and dag.dag_id:
         params['airflow.ctx.dag.dag_id'] = dag.dag_id
+
     dag_run = context.get('dag_run')
     if dag_run and dag_run.execution_date:
         params['airflow.ctx.dag_run.execution_date'] = dag_run.execution_date.isoformat()
+
     task = context.get('task')
     if task and task.task_id:
         params['airflow.ctx.task.task_id'] = task.task_id
+
     task_instance = context.get('task_instance')
     if task_instance and task_instance.execution_date:
-        params['airflow.ctx.task_instance.execution_date'] = \
+        params['airflow.ctx.task_instance.execution_date'] = (
             task_instance.execution_date.isoformat()
+        )
+
     return params

--- a/tests/utils/test_operator_helpers.py
+++ b/tests/utils/test_operator_helpers.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+import mock
+import unittest
+
+from airflow.utils import operator_helpers
+
+
+class TestOperatorHelpers(unittest.TestCase):
+
+    def setUp(self):
+        super(TestOperatorHelpers, self).setUp()
+        self.dag_id = 'dag_id'
+        self.task_id = 'task_id'
+        self.execution_date = '2017-05-21T00:00:00'
+        self.context = {
+            'dag': mock.MagicMock(name='dag', dag_id=self.dag_id),
+            'dag_run': mock.MagicMock(
+                name='dag_run',
+                execution_date=datetime.strptime(self.execution_date,
+                                                 '%Y-%m-%dT%H:%M:%S'),
+            ),
+            'task': mock.MagicMock(name='task', task_id=self.task_id),
+            'task_instance': mock.MagicMock(
+                name='task_instance',
+                execution_date=datetime.strptime(self.execution_date,
+                                                 '%Y-%m-%dT%H:%M:%S'),
+            ),
+        }
+
+    def test_context_to_airflow_vars_empty_context(self):
+        self.assertDictEqual(operator_helpers.context_to_airflow_vars({}), {})
+
+    def test_context_to_airflow_vars_all_context(self):
+        self.assertDictEqual(
+            operator_helpers.context_to_airflow_vars(self.context),
+            {
+                'airflow.ctx.dag.dag_id': self.dag_id,
+                'airflow.ctx.dag_run.execution_date': self.execution_date,
+                'airflow.ctx.task.task_id': self.task_id,
+                'airflow.ctx.task_instance.execution_date': self.execution_date,
+            }
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following
    - [AIRFLOW-1234](https://issues.apache.org/jira/browse/AIRFLOW-1234) Cover utils.operator_helpers with unit tests


### Description
- [x] Here are some details about my PR:
Cover `utils.operator_helpers` with unit tests to have 100% coverage.


### Tests
- [x] My PR adds the following unit tests:
Added `tests.utils.operator_helpers` tests.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

