### PR TITLE
[AIRFLOW-1239] Fixes base_task_runner logging with unicode values on Py27

### DIFF
--- a/airflow/task_runner/base_task_runner.py
+++ b/airflow/task_runner/base_task_runner.py
@@ -92,7 +92,7 @@ class BaseTaskRunner(LoggingMixin):
             line = stream.readline().decode('utf-8')
             if len(line) == 0:
                 break
-            self.logger.info('Subtask: {}'.format(line.rstrip('\n')))
+            self.logger.info('Subtask: {}'.format(line.rstrip('\n').encode('utf-8')).decode('utf-8'))
 
     def run_command(self, run_with, join_args=False):
         """


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!