### PR TITLE
[AIRFLOW-1236] SlackPostOperator using Slack Incoming WebHook

### DIFF
--- a/airflow/hooks/slack_webhook_hook.py
+++ b/airflow/hooks/slack_webhook_hook.py
@@ -1,0 +1,24 @@
+import logging
+import requests
+from airflow.hooks.base_hook import BaseHook
+
+class SlackWebHookHook(BaseHook):
+    """Slack WebHook hook. Connects to a slack webhook URL using a Connection.
+
+    The Slack WebHook URL should be defined in the 'extra' field of the connection as defined
+    in the Airflow admin interface.
+    """
+    def __init__(self, conn_id):
+        self.conn_id = conn_id
+
+    def _get_webhook_url(self):
+        webhook_url = self.get_connection(self.conn_id).extra
+        if not webhook_url:
+            logging.error("'extra' not defined on connection '%s'. SlackWebHookHook will fail" % self.conn_id)
+        return webhook_url
+
+    def post(self, json):
+        response = requests.post(self._get_webhook_url(), json=json,
+                                 headers={'Content-Type': 'application/json'})
+        response.raise_for_status()
+

--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -88,7 +88,7 @@ _operators = {
     'jdbc_operator': ['JdbcOperator'],
     'mssql_operator': ['MsSqlOperator'],
     'mssql_to_hive': ['MsSqlToHiveTransfer'],
-    'slack_operator': ['SlackAPIOperator', 'SlackAPIPostOperator'],
+    'slack_operator': ['SlackAPIOperator', 'SlackAPIPostOperator', 'SlackPostOperator'],
     'generic_transfer': ['GenericTransfer'],
     'oracle_operator': ['OracleOperator']
 }

--- a/airflow/operators/slack_operator.py
+++ b/airflow/operators/slack_operator.py
@@ -16,9 +16,10 @@ from slackclient import SlackClient
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.exceptions import AirflowException
+from airflow.hooks.slack_webhook_hook import SlackWebHookHook
 import json
 import logging
-import requests
+
 
 
 class SlackAPIOperator(BaseOperator):
@@ -118,21 +119,6 @@ class SlackAPIPostOperator(SlackAPIOperator):
             'icon_url': self.icon_url,
             'attachments': json.dumps(self.attachments),
         }
-
-class SlackWebHookHook(BaseHook):
-    """Slack WebHook hook. Connects to a slack webhook URL using a Connection.
-
-    The Slack WebHook URL should be defined in the 'extra' field of the connection as defined
-    in the Airflow admin interface.
-    """
-    def __init__(self, conn_id):
-        self.conn_id = conn_id
-        self.webhook_url = self.get_connection(conn_id).extra
-
-    def post(self, json):
-        response = requests.post(self.webhook_url, json=json,
-                                 headers={'Content-Type': 'application/json'})
-        response.raise_for_status()
 
 
 class SlackPostOperator(BaseOperator):

--- a/tests/hooks/test_slack_webhook_hook.py
+++ b/tests/hooks/test_slack_webhook_hook.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import unittest
+import requests
+from airflow.hooks.slack_webhook_hook import SlackWebHookHook
+
+class SlackWebhookHookTest(unittest.TestCase):
+    @mock.patch('requests.post')
+    def test_post(self, requests_post):
+        webhook_url = object()
+
+        hook = SlackWebHookHook(None)
+        hook._get_webhook_url = mock.Mock()
+        hook._get_webhook_url.return_value = webhook_url
+
+        data = {'attr':'value'}
+        hook.post(data)
+
+        requests_post.assert_called_once_with(webhook_url, json=data,
+                                              headers={'Content-Type': 'application/json'})
+
+    @mock.patch('logging.error')
+    def test_get_webhook_url(self, error):
+        conn_id = object()
+        webhook_url = mock.Mock()
+        connection = mock.Mock()
+        connection.extra = webhook_url
+
+        hook = SlackWebHookHook(conn_id)
+
+        hook.get_connection = mock.Mock()
+        hook.get_connection.return_value = connection
+
+        self.assertEqual(hook._get_webhook_url(), webhook_url)
+        hook.get_connection.assert_called_once_with(conn_id)
+
+        error.assert_not_called()
+
+    @mock.patch('logging.error')
+    def test_get_webhook_url_no_extra(self, error):
+        conn_id = 'connection name'
+        webhook_url = None
+        connection = mock.Mock()
+        connection.extra = None
+
+        hook = SlackWebHookHook(conn_id)
+
+        hook.get_connection = mock.Mock()
+        hook.get_connection.return_value = connection
+
+        self.assertEqual(hook._get_webhook_url(), None)
+        hook.get_connection.assert_called_once_with(conn_id)
+
+        error.assert_called_with("'extra' not defined on connection 'connection name'. SlackWebHookHook will fail")
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/operators/test_slack_operator.py
+++ b/tests/operators/test_slack_operator.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import unittest
+
+from airflow.operators.slack_operator import SlackPostOperator
+
+class TestSlackPostOperator(unittest.TestCase):
+    @mock.patch('airflow.hooks.slack_webhook_hook.SlackWebHookHook.post')
+    def test_execute(self, hook_post):
+        operator = SlackPostOperator(task_id='test_task_id', text='something',
+                                     icon_url='icon_url')
+        operator.execute({})
+
+        hook_post.assert_called_once_with({'text': 'something',
+                                           'channel': '#general',
+                                           'username': 'Airflow',
+                                           'icon': 'icon_url',
+                                           'attachments': None})
+
+
+


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1236


### Description
- [x] Improved operator for posting messages to Slack. Does not use deprecated slack token to authenticate. Uses Airflow Connection to keep credentials. 


### Tests
- [x] Did not add any tests. Code is trivial, but you will probably tell me to add tests anyway? :-)


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

