### PR TITLE
[AIRFLOW-1237] Fix IN-predicate sqlalchemy warning

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -690,9 +690,12 @@ class SchedulerJob(BaseJob):
         :param known_file_paths: The list of existing files that are parsed for DAGs
         :type known_file_paths: list[unicode]
         """
-        session.query(models.ImportError).filter(
-            ~models.ImportError.filename.in_(known_file_paths)
-        ).delete(synchronize_session='fetch')
+        query = session.query(models.ImportError)
+        if known_file_paths:
+            query = query.filter(
+                ~models.ImportError.filename.in_(known_file_paths)
+            )
+        query.delete(synchronize_session='fetch')
         session.commit()
 
     @staticmethod

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -529,6 +529,7 @@ class SchedulerJobTest(unittest.TestCase):
     def setUp(self):
         self.dagbag = DagBag()
         session = settings.Session()
+        session.query(models.DagRun).delete()
         session.query(models.ImportError).delete()
         session.commit()
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following
    - [AIRFLOW-1237](https://issues.apache.org/jira/browse/AIRFLOW-1237) Fix IN-predicate sqlalchemy warning


### Description
- [x] Here are some details about my PR:
Getting rid of the following warning from sqlalchemy:

```
/home/travis/build/apache/incubator-airflow/.tox/py27-cdh-airflow_backend_mysql/lib/python2.7/site-packages/sqlalchemy/sql/default_comparator.py:161: SAWarning: The IN-predicate on "dag_stats.dag_id" was invoked with an empty sequence. This results in a contradiction, which nonetheless can be expensive to evaluate.  Consider alternative strategies for improved performance.
```


### Tests
- [x] All existing tests pass.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

