### PR TITLE
[AIRFLOW-1172] Support nth weekday of the month cron expression

### DIFF
--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -23,7 +23,7 @@ chartkick
 cloudant
 coverage
 coveralls
-croniter
+croniter>=0.3.17
 cryptography
 datadog
 dill

--- a/setup.py
+++ b/setup.py
@@ -219,7 +219,7 @@ def do_setup():
             'alembic>=0.8.3, <0.9',
             'bleach==2.0.0',
             'configparser>=3.5.0, <3.6.0',
-            'croniter>=0.3.8, <0.4',
+            'croniter>=0.3.17, <0.4',
             'dill>=0.2.2, <0.3',
             'flask>=0.11, <0.12',
             'flask-admin==1.4.1',


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1172


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

"nth weekday of the month" cron expression is available
from croniter 0.3.17. This PR updates croniter and
enables that feature.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I think no additional unit test is needed, since
croniter itself has unit tests for this feature.
I locally run scheduler with the new expression
and confirmed that it behaved as expected.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

