### PR TITLE
[AIRFLOW-1243] DAGs table has no default entries to show

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -208,6 +208,7 @@
       $('#dags').dataTable({
         "iDisplayLength": 500,
         "bSort": false,
+        "pageLength": 25,
       });
       $("#main_content").show(250);
       diameter = 25;


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following:
    - [AIRFLOW-1243](https://issues.apache.org/jira/browse/AIRFLOW-1243) DAGs table has no default entries to show


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
There is no default value selected. It needs to be set.

Before:
![imageedit_1_3250112213](https://cloud.githubusercontent.com/assets/2817012/26448807/cc7dd39c-4157-11e7-87a2-777714ad26df.jpg)

After:
![screenshot_20170525_143905](https://cloud.githubusercontent.com/assets/2817012/26448834/ef7e57fe-4157-11e7-9946-89ed289818a9.png)

### Tests
- [x] All existing tests pass.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

