### PR TITLE
[AIRFLOW-1244] Forbid creation of a pool with empty name

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1986,6 +1986,13 @@ class PoolModelView(wwwutils.SuperUserMixin, AirflowModelView):
     column_formatters = dict(
         pool=pool_link, used_slots=fused_slots, queued_slots=fqueued_slots)
     named_filter_urls = True
+    form_args = {
+        'pool': {
+            'validators': [
+                validators.DataRequired(),
+            ]
+        }
+    }
 
 
 class SlaMissModelView(wwwutils.SuperUserMixin, ModelViewOnly):

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from airflow import configuration
+from airflow.models import Pool
+from airflow.settings import Session
+from airflow.www import app as application
+
+
+class TestPoolModelView(unittest.TestCase):
+
+    CREATE_ENDPOINT = '/admin/pool/new/?url=/admin/pool/'
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestPoolModelView, cls).setUpClass()
+        session = Session()
+        session.query(Pool).delete()
+        session.commit()
+        session.close()
+
+    def setUp(self):
+        super(TestPoolModelView, self).setUp()
+        configuration.load_test_config()
+        app = application.create_app(testing=True)
+        app.config['WTF_CSRF_METHODS'] = []
+        self.app = app.test_client()
+        self.session = Session()
+        self.pool = {
+            'pool': 'test-pool',
+            'slots': 777,
+            'description': 'test-pool-description',
+        }
+
+    def tearDown(self):
+        self.session.query(Pool).delete()
+        self.session.commit()
+        self.session.close()
+        super(TestPoolModelView, self).tearDown()
+
+    def test_create_pool(self):
+        response = self.app.post(
+            self.CREATE_ENDPOINT,
+            data=self.pool,
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.session.query(Pool).count(), 1)
+
+    def test_create_pool_with_same_name(self):
+        # create test pool
+        self.app.post(
+            self.CREATE_ENDPOINT,
+            data=self.pool,
+            follow_redirects=True,
+        )
+        # create pool with the same name
+        response = self.app.post(
+            self.CREATE_ENDPOINT,
+            data=self.pool,
+            follow_redirects=True,
+        )
+        self.assertIn('Already exists.', response.data.decode('utf-8'))
+        self.assertEqual(self.session.query(Pool).count(), 1)
+
+    def test_create_pool_with_empty_name(self):
+        self.pool['pool'] = ''
+        response = self.app.post(
+            self.CREATE_ENDPOINT,
+            data=self.pool,
+            follow_redirects=True,
+        )
+        self.assertIn('This field is required.', response.data.decode('utf-8'))
+        self.assertEqual(self.session.query(Pool).count(), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following:
    - [AIRFLOW-1244](https://issues.apache.org/jira/browse/AIRFLOW-1244) Forbid creation of a pool with empty name


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
    - Currently creation of a pool with empty name fails with exception. This needs to be fixed.

```
Traceback (most recent call last):
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask/app.py", line 2000, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask/app.py", line 1991, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask/app.py", line 1567, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask/app.py", line 1988, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask/app.py", line 1641, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask/app.py", line 1544, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask/app.py", line 1639, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask/app.py", line 1625, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask_admin/base.py", line 69, in inner
    return self._run_view(f, *args, **kwargs)
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask_admin/base.py", line 368, in _run_view
    return fn(self, *args, **kwargs)
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask_admin/model/base.py", line 1900, in index_view
    return_url=self._get_list_url(view_args),
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask_admin/base.py", line 308, in render
    return render_template(template, **kwargs)
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask/templating.py", line 134, in render_template
    context, ctx.app)
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask/templating.py", line 116, in _render
    rv = template.render(context)
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/stas/Work/incubator-airflow/airflow/www/templates/airflow/model_list.html", line 18, in top-level template code
    {% extends 'admin/model/list.html' %}
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask_admin/templates/bootstrap3/admin/model/list.html", line 6, in top-level template code
    {% import 'admin/model/row_actions.html' as row_actions with context %}
  File "/home/stas/Work/incubator-airflow/airflow/www/templates/admin/master.html", line 18, in top-level template code
    {% extends 'admin/base.html' %}
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask_admin/templates/bootstrap3/admin/base.html", line 30, in top-level template code
    {% block page_body %}
  File "/home/stas/Work/incubator-airflow/airflow/www/templates/admin/master.html", line 104, in block "page_body"
    {% block body %}
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask_admin/templates/bootstrap3/admin/model/list.html", line 62, in block "body"
    {% block model_list_table %}
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask_admin/templates/bootstrap3/admin/model/list.html", line 110, in block "model_list_table"
    {% block list_row scoped %}
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask_admin/templates/bootstrap3/admin/model/list.html", line 138, in block "list_row"
    {{ get_value(row, c) }}
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask_admin/model/base.py", line 1742, in get_list_value
    self.column_type_formatters,
  File "/home/stas/Work/incubator-airflow/.venv/lib/python2.7/site-packages/flask_admin/model/base.py", line 1707, in _get_list_value
    value = column_fmt(self, context, model, name)
  File "/home/stas/Work/incubator-airflow/airflow/www/views.py", line 187, in pool_link
    url = '/admin/taskinstance/?flt1_pool_equals=' + m.pool
TypeError: cannot concatenate 'str' and 'NoneType' objects
```

### Tests
- [x] The following tests added:
 - tests.www.test_views:TestViews.test_pool_model_view_create_pool
 - tests.www.test_views:TestViews.test_pool_model_view_create_pool_already_exists
 - tests.www.test_views:TestViews.test_pool_model_view_create_pool_with_empty_name


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

