### PR TITLE
[AIRFLOW-1245] Fix random failure in test_trigger_dag_for_date

### DIFF
--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -67,7 +67,6 @@ class TestHelpers(unittest.TestCase):
                 os.kill(child_pid.value, signal.SIGKILL) # terminate doesnt work here
             except OSError:
                 pass
-            child.terminate()
 
     def test_kill_using_shell(self):
         """Test when no process exists."""

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -11,23 +11,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
 
 from datetime import datetime, timedelta
-from urllib.parse import quote_plus
-from airflow.api.common.experimental.trigger_dag import trigger_dag
-from airflow.models import DagBag
-
 import json
+import unittest
+from urllib.parse import quote_plus
+
+from airflow import configuration
+from airflow.api.common.experimental.trigger_dag import trigger_dag
+from airflow.models import DagBag, DagRun, TaskInstance
+from airflow.settings import Session
+from airflow.www import app as application
 
 
 class ApiExperimentalTests(unittest.TestCase):
+
     def setUp(self):
-        from airflow import configuration
         configuration.load_test_config()
-        from airflow.www import app as application
         app = application.create_app(testing=True)
         self.app = app.test_client()
+        session = Session()
+        session.query(DagRun).delete()
+        session.query(TaskInstance).delete()
+        session.commit()
+        session.close()
 
     def test_task_info(self):
         url_template = '/api/experimental/dags/{}/tasks/{}'


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following:
    - [AIRFLOW-1245](https://issues.apache.org/jira/browse/AIRFLOW-1245) Fix random failure of test_trigger_dag_for_date unit test


### Description
- [x] This failure happens from time to time:
https://travis-ci.org/apache/incubator-airflow/jobs/235993912

```
======================================================================
14) FAIL: test_trigger_dag_for_date (tests.www.api.experimental.test_endpoints.ApiExperimentalTests)
----------------------------------------------------------------------
   Traceback (most recent call last):
    tests/www/api/experimental/test_endpoints.py line 87 in test_trigger_dag_for_date
      self.assertEqual(200, response.status_code)
   AssertionError: 200 != 404
```

### Tests
- [x] All existing tests pass.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

