### PR TITLE
[AIRFLOW-1248] Fix wrong conf name for worker timeout

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -736,7 +736,7 @@ def webserver(args):
     error_logfile = args.error_logfile or conf.get('webserver', 'error_logfile')
     num_workers = args.workers or conf.get('webserver', 'workers')
     worker_timeout = (args.worker_timeout or
-                      conf.get('webserver', 'webserver_worker_timeout'))
+                      conf.get('webserver', 'web_server_worker_timeout'))
     ssl_cert = args.ssl_cert or conf.get('webserver', 'web_server_ssl_cert')
     ssl_key = args.ssl_key or conf.get('webserver', 'web_server_ssl_key')
     if not ssl_cert and ssl_key:


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1248


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

The parameter `web_server_worker_timeout` is wrongly
referenced by airflow/bin/cli.py. This PR fixes it.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I think no additional test is needed since this is a really trivial fix.
I locally ran webserver and confirmed that it started with the right timeout value.
And I grepped and confirmed that there's no the same typo in the source.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

