### PR TITLE
[AIRFLOW-1235] Fix webserver's odd behaviour

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -198,6 +198,9 @@ web_server_port = 8080
 web_server_ssl_cert =
 web_server_ssl_key =
 
+# Number of seconds the webserver waits before killing gunicorn master that doesn't respond
+web_server_master_timeout = 120
+
 # Number of seconds the gunicorn webserver waits before timing out on a worker
 web_server_worker_timeout = 120
 

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -32,6 +32,10 @@ class AirflowTaskTimeout(AirflowException):
     pass
 
 
+class AirflowWebServerTimeout(AirflowException):
+    pass
+
+
 class AirflowSkipException(AirflowException):
     pass
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -1475,6 +1475,16 @@ class CliTests(unittest.TestCase):
         self.assertEqual(1, subprocess.Popen(["pgrep", "-c", "airflow"]).wait())
         self.assertEqual(1, subprocess.Popen(["pgrep", "-c", "gunicorn"]).wait())
 
+    # Patch for causing webserver timeout
+    @mock.patch("airflow.bin.cli.get_num_workers_running", return_value=0)
+    def test_cli_webserver_shutdown_when_gunicorn_master_is_killed(self, _):
+        # Shorten timeout so that this test doesn't take too long time
+        configuration.conf.set("webserver", "web_server_master_timeout", "10")
+        args = self.parser.parse_args(['webserver'])
+        with self.assertRaises(SystemExit) as e:
+            cli.webserver(args)
+        self.assertEqual(e.exception.code, 1)
+
 
 class SecurityTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1235


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

In some cases, the gunicorn master shuts down
but the webserver monitor process doesn't.
This PR add timeout functionality to shutdown
all related processes in such cases.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

tests.core:CliTests.test_cli_webserver_shutdown_when_gunicorn_master_is_killed


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

