### PR TITLE
[AIRFLOW-1252] API - Fix when conf is in JSON body

### DIFF
--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -59,7 +59,10 @@ def _trigger_dag(
 
     run_conf = None
     if conf:
-        run_conf = json.loads(conf)
+        if type(conf) is dict:
+            run_conf = conf
+        else:
+            run_conf = json.loads(conf)
 
     triggers = list()
     dags_to_trigger = list()

--- a/tests/api/common/experimental/trigger_dag_tests.py
+++ b/tests/api/common/experimental/trigger_dag_tests.py
@@ -19,6 +19,7 @@
 
 import mock
 import unittest
+import json
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun
@@ -87,6 +88,44 @@ class TriggerDagTests(unittest.TestCase):
             replace_microseconds=True)
 
         self.assertEqual(3, len(triggers))
+
+    @mock.patch('airflow.models.DagBag')
+    def test_trigger_dag_with_str_conf(self, dag_bag_mock):
+        dag_id = "trigger_dag_with_str_conf"
+        dag = DAG(dag_id)
+        dag_bag_mock.dags = [dag_id]
+        dag_bag_mock.get_dag.return_value = dag
+        conf = "{\"foo\": \"bar\"}"
+        dag_run = DagRun()
+        triggers = _trigger_dag(
+            dag_id,
+            dag_bag_mock,
+            dag_run,
+            run_id=None,
+            conf=conf,
+            execution_date=None,
+            replace_microseconds=True)
+
+        self.assertEquals(triggers[0].conf, json.loads(conf))
+
+    @mock.patch('airflow.models.DagBag')
+    def test_trigger_dag_with_dict_conf(self, dag_bag_mock):
+        dag_id = "trigger_dag_with_dict_conf"
+        dag = DAG(dag_id)
+        dag_bag_mock.dags = [dag_id]
+        dag_bag_mock.get_dag.return_value = dag
+        conf = dict(foo="bar")
+        dag_run = DagRun()
+        triggers = _trigger_dag(
+            dag_id,
+            dag_bag_mock,
+            dag_run,
+            run_id=None,
+            conf=conf,
+            execution_date=None,
+            replace_microseconds=True)
+
+        self.assertEquals(triggers[0].conf, conf)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-1252] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1252


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
  When user use experimental API to create a DagRun, if conf is present in Json sent to Airflow, it will never generate the DagRun due to a exception in trigger_dag method (it is expecting a string instead of dictionary).


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  tests.api.common.experimental.trigger_dag_tests:TriggerDagTests.test_trigger_dag_with_str_conf
  tests.api.common.experimental.trigger_dag_tests:TriggerDagTests.test_trigger_dag_with_dict_conf


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

