### PR TITLE
[AIRFLOW-1242] Allow : in project_id for BQ hook

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -934,13 +934,22 @@ def _split_tablename(table_input, default_project_id, var_name=None):
         else:
             return "Format exception for {var}: ".format(var=var_name)
 
-    cmpt = table_input.split(':')
+    if table_input.count('.') + table_input.count(':') > 3:
+        raise Exception((
+            '{var}Use either : or . to specify project '
+            'got {input}'
+        ).format(var=var_print(var_name), input=table_input))
+
+    cmpt = table_input.rsplit(':', 1)
+    project_id = None
+    rest = table_input
     if len(cmpt) == 1:
         project_id = None
         rest = cmpt[0]
-    elif len(cmpt) == 2:
-        project_id = cmpt[0]
-        rest = cmpt[1]
+    elif len(cmpt) == 2 and cmpt[0].count(':') <= 1:
+        if cmpt[-1].count('.') != 2:
+            project_id = cmpt[0]
+            rest = cmpt[1]
     else:
         raise Exception((
             '{var}Expect format of (<project:)<dataset>.<table>, '

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -88,25 +88,35 @@ class TestBigQueryTableSplitter(unittest.TestCase):
         self.assertEqual("dataset", dataset)
         self.assertEqual("table", table)
 
-    def test_invalid_syntax_column_double_project(self):
+    def test_colon_in_project(self):
+        project, dataset, table = hook._split_tablename('alt1:alt.dataset.table',
+                                                        'project')
+
+        self.assertEqual('alt1:alt', project)
+        self.assertEqual("dataset", dataset)
+        self.assertEqual("table", table)
+
+
+    def test_valid_double_column(self):
+        project, dataset, table = hook._split_tablename('alt1:alt:dataset.table',
+                                  'project')
+
+        self.assertEqual('alt1:alt', project)
+        self.assertEqual("dataset", dataset)
+        self.assertEqual("table", table)
+
+
+    def test_invalid_syntax_triple_colon(self):
         with self.assertRaises(Exception) as context:
-            hook._split_tablename('alt1:alt.dataset.table',
+            hook._split_tablename('alt1:alt2:alt3:dataset.table',
                                   'project')
 
         self.assertIn('Use either : or . to specify project',
                       str(context.exception), "")
         self.assertFalse('Format exception for' in str(context.exception))
 
-    def test_invalid_syntax_double_column(self):
-        with self.assertRaises(Exception) as context:
-            hook._split_tablename('alt1:alt:dataset.table',
-                                  'project')
 
-        self.assertIn('Expect format of (<project:)<dataset>.<table>',
-                      str(context.exception), "")
-        self.assertFalse('Format exception for' in str(context.exception))
-
-    def test_invalid_syntax_tiple_dot(self):
+    def test_invalid_syntax_triple_dot(self):
         with self.assertRaises(Exception) as context:
             hook._split_tablename('alt1.alt.dataset.table',
                                   'project')
@@ -117,7 +127,7 @@ class TestBigQueryTableSplitter(unittest.TestCase):
 
     def test_invalid_syntax_column_double_project_var(self):
         with self.assertRaises(Exception) as context:
-            hook._split_tablename('alt1:alt.dataset.table',
+            hook._split_tablename('alt1:alt2:alt.dataset.table',
                                   'project', 'var_x')
 
         self.assertIn('Use either : or . to specify project',
@@ -125,17 +135,17 @@ class TestBigQueryTableSplitter(unittest.TestCase):
         self.assertIn('Format exception for var_x:',
                       str(context.exception), "")
 
-    def test_invalid_syntax_double_column_var(self):
+    def test_invalid_syntax_triple_colon_project_var(self):
         with self.assertRaises(Exception) as context:
-            hook._split_tablename('alt1:alt:dataset.table',
+            hook._split_tablename('alt1:alt2:alt:dataset.table',
                                   'project', 'var_x')
 
-        self.assertIn('Expect format of (<project:)<dataset>.<table>',
+        self.assertIn('Use either : or . to specify project',
                       str(context.exception), "")
         self.assertIn('Format exception for var_x:',
                       str(context.exception), "")
 
-    def test_invalid_syntax_tiple_dot_var(self):
+    def test_invalid_syntax_triple_dot_var(self):
         with self.assertRaises(Exception) as context:
             hook._split_tablename('alt1.alt.dataset.table',
                                   'project', 'var_x')
@@ -178,3 +188,4 @@ class TestBigQueryBaseCursor(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AIRFLOW-1242

### Description
- [ ] This change allows project_ids to contain a ':' character, by
modifying _split_tablename to split by ':' just once starting from the
end of the string.
- [ ] The unittests were adjusted accordingly to test valid and
non-valid inputs.


### Tests
- [ ] Relevant tests were modified and passed with the changes:
[success] 0.00%
tests.contrib.hooks.test_bigquery_hook.TestBigQueryTableSplitter.test_in
valid_syntax_triple_dot: 0.0003s
[success] 0.00%
tests.contrib.hooks.test_bigquery_hook.TestBigQueryTableSplitter.test_va
lid_double_column: 0.0002s
[success] 0.00%
tests.contrib.hooks.test_bigquery_hook.TestBigQueryTableSplitter.test_co
lon_in_project: 0.0001s
[success] 0.00%
tests.contrib.hooks.test_bigquery_hook.TestBigQueryTableSplitter.test_in
valid_syntax_triple_dot_var: 0.0001s
[success] 0.00%
tests.contrib.hooks.test_bigquery_hook.TestBigQueryTableSplitter.test_in
valid_syntax_column_double_project_var: 0.0001s
[success] 0.00%
tests.contrib.hooks.test_bigquery_hook.TestBigQueryTableSplitter.test_sq
l_split_project_dataset_table: 0.0001s
[success] 0.00%
tests.contrib.hooks.test_bigquery_hook.TestBigQueryTableSplitter.test_sp
lit_dataset_table: 0.0001s
[success] 0.00%
tests.contrib.hooks.test_bigquery_hook.TestBigQueryTableSplitter.test_sp
lit_project_dataset_table: 0.0001s
[success] 0.00%
tests.contrib.hooks.test_bigquery_hook.TestBigQueryTableSplitter.test_in
ternal_need_default_project: 0.0001s