### PR TITLE
[AIRFLOW-1158] handle remaining bytes of the multipart upload

### DIFF
--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -378,6 +378,21 @@ class S3Hook(BaseHook):
                         logging.info('Sending chunk {c} of {tc}...'.format(
                             c=chunk + 1, tc=total_chunks))
                         mp.upload_part_from_file(fp, part_num=chunk + 1)
+
+                    final_chunk = chunk + 1
+
+                # handle the remaining bytes
+                offset = final_chunk * multipart_bytes
+                remainder = key_size - offset
+                if remainder > 0:
+                    with FileChunkIO(filename,
+                                     'r',
+                                     offset=offset,
+                                     bytes=remainder) as fp:
+                        logging.info('Sending remaining {remainder}'.format(
+                            remainder=remainder))
+                        mp.upload_part_from_file(fp, part_num=final_chunk + 1)
+
             except:
                 mp.cancel_upload()
                 raise


### PR DESCRIPTION
Dear Airflow maintainers,

This fixes multipart upload to S3 where the remaining bytes after multiples of 5*1024**3 bytes don't get uploaded.

### JIRA
- https://issues.apache.org/jira/browse/AIRFLOW-1158

### Tests
- Please note that no tests were added as the existing S3_Hook
doesn't have tests
- However, this was tested locally and is being used in our production environment
