### PR TITLE
[AIRFLOW-936] Add clear/mark success for DAG in the UI

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -216,6 +216,36 @@
       </div>
     </div>
   </div>
+  <!-- Modal for dag -->
+  <div class="modal fade" id="dagModal"
+        tabindex="-1" role="dialog"
+      aria-labelledby="dagModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h4 class="modal-title" id="dagModalLabel">
+            <span id='dag_id'></span>
+          </h4>
+        </div>
+        <div class="modal-body">
+          <button id="btn_edit_dagrun" type="button" class="btn btn-primary">
+            Edit
+          </button>
+          <button id="btn_dagrun_clear" type="button" class="btn btn-primary">
+            Clear
+          </button>
+          <button id="btn_dagrun_success" type="button" class="btn btn-primary">
+            Mark Success
+          </button>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
 {% endblock %}
 {% block tail %}
   {{ lib.form_js() }}
@@ -239,6 +269,7 @@ function updateQueryStringParameter(uri, key, value) {
       $('.never_active').removeClass('active');
     });
 
+    var id = '';
     var dag_id = '{{ dag.dag_id }}';
     var task_id = '';
     var exection_date = '';
@@ -261,6 +292,14 @@ function updateQueryStringParameter(uri, key, value) {
             $("#div_btn_subdag").show();
             subdag_id = "{{ dag.dag_id }}."+t;
         }
+    }
+
+    function call_modal_dag(dag) {
+      id = dag && dag.id;
+      execution_date = dag && dag.execution_date;
+      $('#dag_id').html(dag_id);
+      $('#dagModal').modal({});
+      $("#dagModal").css("margin-top","0px");
     }
 
     $("#btn_rendered").click(function(){
@@ -328,6 +367,15 @@ function updateQueryStringParameter(uri, key, value) {
       window.location = url;
     });
 
+    $("#btn_dagrun_clear").click(function(){
+      url = "{{ url_for('airflow.dagrun_clear') }}" +
+        "?task_id=" + encodeURIComponent(task_id) +
+        "&dag_id=" + encodeURIComponent(dag_id) +
+        "&execution_date=" + execution_date +
+        "&origin=" + encodeURIComponent(window.location);
+      window.location = url;
+    });
+
     $("#btn_success").click(function(){
       url = "{{ url_for('airflow.success') }}" +
         "?task_id=" + encodeURIComponent(task_id) +
@@ -339,6 +387,14 @@ function updateQueryStringParameter(uri, key, value) {
         "&execution_date=" + execution_date +
         "&origin=" + encodeURIComponent(window.location);
 
+      window.location = url;
+    });
+
+    $('#btn_dagrun_success').click(function(){
+      url = "{{ url_for('airflow.dagrun_success') }}" +
+        "?dag_id=" + encodeURIComponent(dag_id) +
+        "&execution_date=" + execution_date +
+        "&origin=" + encodeURIComponent(window.location);
       window.location = url;
     });
 
@@ -365,6 +421,10 @@ function updateQueryStringParameter(uri, key, value) {
       }
       url = "{{ url_for('airflow.paused') }}" + '?is_paused=' + is_paused + '&dag_id=' + dag_id;
       $.post(url);
+    });
+
+    $('#btn_edit_dagrun').click(function(){
+      window.location = '/admin/dagrun/edit/?id=' + id;
     });
 
   </script>

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -1,13 +1,13 @@
-{# 
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -232,9 +232,8 @@ function update(source) {
       .enter()
       .append('rect')
       .on("click", function(d){
-        if(d.task_id === undefined){
-          window.location = '/admin/dagrun/edit/?id=' + d.id;
-        }
+        if(d.task_id === undefined)
+            call_modal_dag(d);
         else if(nodeobj[d.task_id].operator=='SubDagOperator')
             call_modal(d.task_id, d.execution_date, true);
         else


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses [Airflow 936](https://issues.apache.org/jira/browse/AIRFLOW-936) issues and references them in the PR title. 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds a modal popup when clicking circle DAG icon in Airflow tree view UI. It adds the functionalities to clear/mark success of the entire DAG run. This behavior is equivalent to individually clear/mark each task instance in the DAG run. The original logic of editing DAG run page is moved to the button "Edit DAG Run".

![screen shot 2017-06-07 at 10 19 59 am](https://user-images.githubusercontent.com/5182499/26891746-ed241fda-4b6a-11e7-9179-e513f8abf530.png)
![screen shot 2017-06-01 at 10 42 14 am](https://cloud.githubusercontent.com/assets/5182499/26693003/8c355188-46b7-11e7-910f-bf1e09bf4418.png)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

 Tests are added under `test/api/common/mark_tasks.py` to test marking entire DAG as success. There is no test for clear the DAG since it is directly implemented in `views.py`.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@aoen @saguziel