### PR TITLE
[AIRFLOW-1265] Fix exception while loading celery configurations

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -47,7 +47,7 @@ class CeleryConfig(object):
     CELERYD_CONCURRENCY = configuration.getint('celery', 'CELERYD_CONCURRENCY')
     CELERY_DEFAULT_QUEUE = DEFAULT_QUEUE
     CELERY_DEFAULT_EXCHANGE = DEFAULT_QUEUE
-    if configuration.get('celery', 'CELERY_SSL_ACTIVE'):
+    if configuration.getboolean('celery', 'CELERY_SSL_ACTIVE'):
         try:
             BROKER_USE_SSL = {'keyfile': configuration.get('celery', 'CELERY_SSL_KEY'),
                               'certfile': configuration.get('celery', 'CELERY_SSL_CERT'),


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x]  My PR addresses Airflow 1265 issues and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

> airflow@f300f25ced3a:/usr/local/script$ airflow
> [2017-06-02 02:25:59,263]
> {configuration.py:199}
> WARNING - section/key [celery/celery_ssl_key] not found in config
> Traceback (most recent call last):
> File "/incubator-airflow/airflow/executors/celery_executor.py", line 52, in CeleryConfig
> BROKER_USE_SSL = {'keyfile': configuration.get('celery', 'CELERY_SSL_KEY'),
> File "/incubator-airflow/airflow/configuration.py", line 398, in get
> return conf.get(section, key, **kwargs)
> File "/incubator-airflow/airflow/configuration.py", line 203, in get
> "in config".format(**locals()))
> airflow.exceptions.AirflowConfigException: section/key [celery/celery_ssl_key] not found in config
> During handling of the above exception, another exception occurred:
> Traceback (most recent call last):
> File "/usr/local/bin/airflow", line 6, in <module>
> exec(compile(open(_file).read(), __file_, 'exec'))
> File "/incubator-airflow/airflow/bin/airflow", line 18, in <module>
> from airflow.bin.cli import CLIFactory
> File "/incubator-airflow/airflow/bin/cli.py", line 46, in <module>
> from airflow import jobs, settings
> File "/incubator-airflow/airflow/jobs.py", line 66, in <module>
> class BaseJob(Base, LoggingMixin):
> File "/incubator-airflow/airflow/jobs.py", line 98, in BaseJob
> executor=executors.GetDefaultExecutor(),
> File "/incubator-airflow/airflow/executors/_init_.py", line 43, in GetDefaultExecutor
> DEFAULT_EXECUTOR = _get_executor(executor_name)
> File "/incubator-airflow/airflow/executors/_init_.py", line 60, in _get_executor
> from airflow.executors.celery_executor import CeleryExecutor
> File "/incubator-airflow/airflow/executors/celery_executor.py", line 38, in <module>
> class CeleryConfig(object):
> File "/incubator-airflow/airflow/executors/celery_executor.py", line 60, in CeleryConfig
> raise AirflowException('Exception: There was an unknown Celery SSL Error. Please ensure you want to use '
> airflow.exceptions.AirflowException: Exception: There was an unknown Celery SSL Error. Please ensure you want to use SSL and/or have all necessary certs and key.
> 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No need to test it, the bug is caused by using an incorrect function as the following description.

`configuration.get('celery', 'CELERY_SSL_ACTIVE')`

The CELERY_SSL_ACTIVE is a boolean, so it should be

`configuration.getboolean('celery', 'CELERY_SSL_ACTIVE')`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

