### PR TITLE
[AIRFLOW-1263] Dynamic height for charts

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -284,6 +284,16 @@ def should_hide_value_for_key(key_name):
            and conf.getboolean('admin', 'hide_sensitive_variable_fields')
 
 
+
+def get_chart_height(dag):
+    """
+    TODO(aoen): See [AIRFLOW-1263] We use the number of tasks in the DAG as a heuristic to
+    approximate the size of generated chart (otherwise the charts are tiny and unreadable
+    when DAGs have a large number of tasks). Ideally nvd3 should allow for dynamic-height
+    charts, that is charts that take up space based on the size of the components within.
+    """
+    return 600 + len(dag.tasks) * 10
+
 class Airflow(BaseView):
 
     def is_visible(self):
@@ -1411,10 +1421,12 @@ class Airflow(BaseView):
                 include_upstream=True,
                 include_downstream=False)
 
+
+        chart_height = get_chart_height(dag)
         chart = nvd3.lineChart(
-            name="lineChart", x_is_date=True, height=600, width="1200")
+            name="lineChart", x_is_date=True, height=chart_height, width="1200")
         cum_chart = nvd3.lineChart(
-            name="cumLineChart", x_is_date=True, height=600, width="1200")
+            name="cumLineChart", x_is_date=True, height=chart_height, width="1200")
 
         y = defaultdict(list)
         x = defaultdict(list)
@@ -1516,8 +1528,10 @@ class Airflow(BaseView):
                 include_upstream=True,
                 include_downstream=False)
 
+        chart_height = get_chart_height(dag)
         chart = nvd3.lineChart(
-            name="lineChart", x_is_date=True, y_axis_format='d', height=600, width="1200")
+            name="lineChart", x_is_date=True, y_axis_format='d', height=chart_height,
+            width="1200")
 
         for task in dag.tasks:
             y = []
@@ -1578,8 +1592,9 @@ class Airflow(BaseView):
                 include_upstream=True,
                 include_downstream=False)
 
+        chart_height = get_chart_height(dag)
         chart = nvd3.lineChart(
-            name="lineChart", x_is_date=True, height=600, width="1200")
+            name="lineChart", x_is_date=True, height=chart_height, width="1200")
         y = {}
         x = {}
         for task in dag.tasks:
@@ -1622,7 +1637,7 @@ class Airflow(BaseView):
             'airflow/chart.html',
             dag=dag,
             chart=chart.htmlcontent,
-            height="700px",
+            height=str(chart_height + 100) + "px",
             demo_mode=conf.getboolean('webserver', 'demo_mode'),
             root=root,
             form=form,


### PR DESCRIPTION
Dynamic heights for webserver charts so that longer task names fit.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1263


### Description
Dynamic heights for webserver charts so that longer task names fit.

### Tests
No tests added since it's a UI change. This is a bit of a stopgap solution.


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@saguziel @artwr 