### PR TITLE
[AIRFLOW-1281] Sort variables by key field by default

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2188,6 +2188,7 @@ class VariableView(wwwutils.DataProfilingMixin, AirflowModelView):
     column_list = ('key', 'val', 'is_encrypted',)
     column_filters = ('key', 'val')
     column_searchable_list = ('key', 'val')
+    column_default_sort = ('key', False)
     form_widget_args = {
         'is_encrypted': {'disabled': True},
         'val': {


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following:
    - [AIRFLOW-1281](https://issues.apache.org/jira/browse/AIRFLOW-1281) Sort variables by key field by default


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Before:
![variables](https://cloud.githubusercontent.com/assets/2817012/26824788/683c0b0c-4abb-11e7-9c59-8cfa801e6fe6.jpg)

After:
![screenshot_20170606_132204](https://cloud.githubusercontent.com/assets/2817012/26824804/6ecf2260-4abb-11e7-93d2-a26ad6b0cd6f.png)

### Tests
- [x] All existing tests pass.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

