### PR TITLE
[AIRFLOW-1276][AIRFLOW-1277] Add field validators to the known event modal

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -72,7 +72,7 @@ def create_app(config=None, testing=False):
         av(vs.QueryView(name='Ad Hoc Query', category="Data Profiling"))
         av(vs.ChartModelView(
             models.Chart, Session, name="Charts", category="Data Profiling"))
-        av(vs.KnowEventView(
+        av(vs.KnownEventView(
             models.KnownEvent,
             Session, name="Known Events", category="Data Profiling"))
         av(vs.SlaMissModelView(

--- a/airflow/www/validators.py
+++ b/airflow/www/validators.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from wtforms.validators import EqualTo
+from wtforms.validators import ValidationError
+
+
+class GreaterEqualThan(EqualTo):
+    """Compares the values of two fields.
+
+    :param fieldname:
+        The name of the other field to compare to.
+    :param message:
+        Error message to raise in case of a validation error. Can be
+        interpolated with `%(other_label)s` and `%(other_name)s` to provide a
+        more helpful error.
+    """
+
+    def __call__(self, form, field):
+        try:
+            other = form[self.fieldname]
+        except KeyError:
+            raise ValidationError(
+                field.gettext("Invalid field name '%s'." % self.fieldname)
+            )
+
+        if field.data is None or other.data is None:
+            return
+
+        if field.data < other.data:
+            d = {
+                'other_label': hasattr(other, 'label') and other.label.text
+                               or self.fieldname,
+                'other_name': self.fieldname,
+            }
+            message = self.message
+            if message is None:
+                message = field.gettext('Field must be greater than or equal '
+                                        'to %(other_label)s.' % d)
+            else:
+                message = message % d
+
+            raise ValidationError(message)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2140,7 +2140,7 @@ chart_mapping = (
 chart_mapping = dict(chart_mapping)
 
 
-class KnowEventView(wwwutils.DataProfilingMixin, AirflowModelView):
+class KnownEventView(wwwutils.DataProfilingMixin, AirflowModelView):
     verbose_name = "known event"
     verbose_name_plural = "known events"
     form_columns = (
@@ -2152,10 +2152,31 @@ class KnowEventView(wwwutils.DataProfilingMixin, AirflowModelView):
         'description',
     )
     form_args = {
+        'label': {
+            'validators': [
+                validators.DataRequired(),
+            ],
+        },
+        'event_type': {
+            'validators': [
+                validators.DataRequired(),
+            ],
+        },
+        'start_date': {
+            'validators': [
+                validators.DataRequired(),
+            ],
+        },
         'end_date': {
-            'validators': {
+            'validators': [
+                validators.DataRequired(),
                 GreaterEqualThan(fieldname='start_date'),
-            }
+            ],
+        },
+        'reported_by': {
+            'validators': [
+                validators.DataRequired(),
+            ],
         }
     }
     column_list = (
@@ -2168,7 +2189,7 @@ class KnowEventView(wwwutils.DataProfilingMixin, AirflowModelView):
     column_default_sort = ("start_date", True)
 
 
-class KnowEventTypeView(wwwutils.DataProfilingMixin, AirflowModelView):
+class KnownEventTypeView(wwwutils.DataProfilingMixin, AirflowModelView):
     pass
 
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -75,6 +75,7 @@ from airflow.utils import logging as log_utils
 from airflow.utils.dates import infer_time_unit, scale_time_units
 from airflow.www import utils as wwwutils
 from airflow.www.forms import DateTimeForm, DateTimeWithNumRunsForm
+from airflow.www.validators import GreaterEqualThan
 from airflow.configuration import AirflowConfigException
 
 QUERY_LIMIT = 100000
@@ -2148,9 +2149,22 @@ class KnowEventView(wwwutils.DataProfilingMixin, AirflowModelView):
         'start_date',
         'end_date',
         'reported_by',
-        'description')
+        'description',
+    )
+    form_args = {
+        'end_date': {
+            'validators': {
+                GreaterEqualThan(fieldname='start_date'),
+            }
+        }
+    }
     column_list = (
-        'label', 'event_type', 'start_date', 'end_date', 'reported_by')
+        'label',
+        'event_type',
+        'start_date',
+        'end_date',
+        'reported_by',
+    )
     column_default_sort = ("start_date", True)
 
 

--- a/tests/www/test_validators.py
+++ b/tests/www/test_validators.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import unittest
+
+from airflow.www import validators
+
+
+class TestGreaterEqualThan(unittest.TestCase):
+
+    def setUp(self):
+        super(TestGreaterEqualThan, self).setUp()
+        self.form_field_mock = mock.MagicMock(data='2017-05-06')
+        self.form_field_mock.gettext.side_effect = lambda msg: msg
+        self.other_field_mock = mock.MagicMock(data='2017-05-05')
+        self.other_field_mock.gettext.side_effect = lambda msg: msg
+        self.other_field_mock.label.text = 'other field'
+        self.form_stub = {'other_field': self.other_field_mock}
+        self.form_mock = mock.MagicMock(spec_set=dict)
+        self.form_mock.__getitem__.side_effect = self.form_stub.__getitem__
+
+    def _validate(self, fieldname=None, message=None):
+        if fieldname is None:
+            fieldname = 'other_field'
+
+        validator = validators.GreaterEqualThan(fieldname=fieldname,
+                                                message=message)
+
+        return validator(self.form_mock, self.form_field_mock)
+
+    def test_field_not_found(self):
+        self.assertRaisesRegexp(
+            validators.ValidationError,
+            "^Invalid field name 'some'.$",
+            self._validate,
+            fieldname='some',
+        )
+
+    def test_form_field_is_none(self):
+        self.form_field_mock.data = None
+
+        self.assertIsNone(self._validate())
+
+    def test_other_field_is_none(self):
+        self.other_field_mock.data = None
+
+        self.assertIsNone(self._validate())
+
+    def test_both_fields_are_none(self):
+        self.form_field_mock.data = None
+        self.other_field_mock.data = None
+
+        self.assertIsNone(self._validate())
+
+    def test_validation_pass(self):
+        self.assertIsNone(self._validate())
+
+    def test_validation_raises(self):
+        self.form_field_mock.data = '2017-05-04'
+
+        self.assertRaisesRegexp(
+            validators.ValidationError,
+            "^Field must be greater than or equal to other field.$",
+            self._validate,
+        )
+
+    def test_validation_raises_custom_message(self):
+        self.form_field_mock.data = '2017-05-04'
+
+        self.assertRaisesRegexp(
+            validators.ValidationError,
+            "^This field must be greater than or equal to MyField.$",
+            self._validate,
+            message="This field must be greater than or equal to MyField.",
+        )
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -15,9 +15,66 @@
 import unittest
 
 from airflow import configuration
-from airflow.models import Pool
+from airflow.models import KnownEvent, Pool
 from airflow.settings import Session
 from airflow.www import app as application
+
+
+class TestKnownEventView(unittest.TestCase):
+
+    CREATE_ENDPOINT = '/admin/knownevent/new/?url=/admin/knownevent/'
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestKnownEventView, cls).setUpClass()
+        session = Session()
+        session.query(KnownEvent).delete()
+        session.commit()
+        session.close()
+
+    def setUp(self):
+        super(TestKnownEventView, self).setUp()
+        configuration.load_test_config()
+        app = application.create_app(testing=True)
+        app.config['WTF_CSRF_METHODS'] = []
+        self.app = app.test_client()
+        self.session = Session()
+        self.known_event = {
+            'label': 'event-label',
+            'event_type': 1,
+            'start_date': '2017-06-05 12:00:00',
+            'end_date': '2017-06-05 13:00:00',
+            'reported_by': 'airflow',
+            'description': '',
+        }
+
+    def tearDown(self):
+        self.session.query(KnownEvent).delete()
+        self.session.commit()
+        self.session.close()
+        super(TestKnownEventView, self).tearDown()
+
+    def test_create_known_event(self):
+        response = self.app.post(
+            self.CREATE_ENDPOINT,
+            data=self.known_event,
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.session.query(KnownEvent).count(), 1)
+
+    def test_create_known_event_with_end_data_earlier_than_start_date(self):
+        self.known_event['end_date'] = '2017-06-05 11:00:00'
+        response = self.app.post(
+            self.CREATE_ENDPOINT,
+            data=self.known_event,
+            follow_redirects=True,
+        )
+        self.assertIn(
+            'Field must be greater than or equal to Start Date.',
+            response.data.decode('utf-8'),
+        )
+        self.assertEqual(self.session.query(KnownEvent).count(), 0)
 
 
 class TestPoolModelView(unittest.TestCase):


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following:
    - [AIRFLOW-1276](https://issues.apache.org/jira/browse/AIRFLOW-1276) Forbid event creation with end_data earlier than start_date
    - [AIRFLOW-1277](https://issues.apache.org/jira/browse/AIRFLOW-1277) Forbid creation of a known event with empty fields


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

AIRFLOW-1276:
![imageedit_2_5108357500](https://cloud.githubusercontent.com/assets/2817012/26831456/08a0a490-4ad5-11e7-86f7-3369a75ee794.jpg)



AIRFLOW-1277:
![screenshot_20170606_162112](https://cloud.githubusercontent.com/assets/2817012/26831471/169a8e26-4ad5-11e7-9a85-e797dc47db7d.png)


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

