### PR TITLE
[AIRFLOW-1282] Fix known event column sorting

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2187,6 +2187,13 @@ class KnownEventView(wwwutils.DataProfilingMixin, AirflowModelView):
         'reported_by',
     )
     column_default_sort = ("start_date", True)
+    column_sortable_list = (
+        'label',
+        ('event_type', 'event_type.know_event_type'),
+        'start_date',
+        'end_date',
+        ('reported_by', 'reported_by.username'),
+    )
 
 
 class KnownEventTypeView(wwwutils.DataProfilingMixin, AirflowModelView):


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following:
    - [AIRFLOW-1282](https://issues.apache.org/jira/browse/AIRFLOW-1282) Fix known event column sorting


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Before:
![event_sorting](https://user-images.githubusercontent.com/2817012/26867936-d4e43e5a-4b6f-11e7-9371-a04927624365.jpg)

After:
![screenshot_20170607_105204](https://user-images.githubusercontent.com/2817012/26867941-dabc3b20-4b6f-11e7-80c1-0ee366b2349d.png)

### Tests
- [x] All existing tests pass.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

