### PR TITLE
[AIRFLOW-1289] Removes restriction on number of scheduler threads

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -326,8 +326,7 @@ statsd_port = 8125
 statsd_prefix = airflow
 
 # The scheduler can run multiple threads in parallel to schedule dags.
-# This defines how many threads will run. However airflow will never
-# use more threads than the amount of cpu cores available.
+# This defines how many threads will run.
 max_threads = 2
 
 authenticate = False

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -528,7 +528,7 @@ class SchedulerJob(BaseJob):
         super(SchedulerJob, self).__init__(*args, **kwargs)
 
         self.heartrate = conf.getint('scheduler', 'SCHEDULER_HEARTBEAT_SEC')
-        self.max_threads = min(conf.getint('scheduler', 'max_threads'), multiprocessing.cpu_count())
+        self.max_threads = conf.getint('scheduler', 'max_threads')
         self.using_sqlite = False
         if 'sqlite' in conf.get('core', 'sql_alchemy_conn'):
             if self.max_threads > 1:


### PR DESCRIPTION
This removes the restriction that the number of threads can be at most
the number of CPU cores. There's no reason to have this restriction.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

@aoen @bolkedebruin

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1289


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes: Removes restriction on num threads


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Tests test existing behavior.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

