### PR TITLE
[AIRFLOW-1294] Backfills can loose tasks to execute

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -50,6 +50,10 @@ class BaseExecutor(LoggingMixin):
             self.logger.info("Adding to queue: {}".format(command))
             self.queued_tasks[key] = (command, priority, queue, task_instance)
 
+            return True
+
+        return False
+
     def queue_task_instance(
             self,
             task_instance,
@@ -70,7 +74,8 @@ class BaseExecutor(LoggingMixin):
             ignore_ti_state=ignore_ti_state,
             pool=pool,
             pickle_id=pickle_id)
-        self.queue_command(
+
+        return self.queue_command(
             task_instance,
             command,
             priority=task_instance.task.priority_weight_total,

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from builtins import object
+import errno
 import logging
 import subprocess
 import ssl
@@ -71,7 +72,10 @@ def execute_command(command):
     try:
         subprocess.check_call(command, shell=True)
     except subprocess.CalledProcessError as e:
-        logging.error(e)
+        if e.returncode == errno.EBUSY:
+            logging.info("Task reported concurrency reached")
+        else:
+            logging.error(e)
         raise AirflowException('Celery command failed')
 
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -26,6 +26,7 @@ import copy
 from collections import namedtuple
 from datetime import datetime, timedelta
 import dill
+import errno
 import functools
 import getpass
 import imp
@@ -1343,6 +1344,7 @@ class TaskInstance(Base):
             logging.info(msg)
             session.merge(self)
             session.commit()
+            sys.exit(errno.EBUSY)
             return
 
         # Another worker might have started running this task instance while

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -41,6 +41,9 @@ class State(object):
     UPSTREAM_FAILED = "upstream_failed"
     SKIPPED = "skipped"
 
+    # used by executor
+    CONCURRENCY_REACHED = "concurrency_reached"
+
     task_states = (
         SUCCESS,
         RUNNING,

--- a/tests/core.py
+++ b/tests/core.py
@@ -667,7 +667,11 @@ class CoreTest(unittest.TestCase):
         ti = TI(
             task=self.runme_0, execution_date=DEFAULT_DATE)
         job = jobs.LocalTaskJob(task_instance=ti, ignore_ti_state=True)
-        job.run()
+
+        with self.assertRaises(SystemExit) as cm:
+            job.run()
+
+        self.assertEqual(cm.exception.code, 0)
 
     @mock.patch('airflow.utils.dag_processing.datetime', FakeDatetime)
     def test_scheduler_job(self):
@@ -1300,9 +1304,12 @@ class CliTests(unittest.TestCase):
             '-tp', '{"foo":"bar"}', DEFAULT_DATE.isoformat()]))
 
     def test_cli_run(self):
-        cli.run(self.parser.parse_args([
-            'run', 'example_bash_operator', 'runme_0', '-l',
-            DEFAULT_DATE.isoformat()]))
+        with self.assertRaises(SystemExit) as cm:
+            cli.run(self.parser.parse_args([
+                'run', 'example_bash_operator', 'runme_0', '-l',
+                DEFAULT_DATE.isoformat()]))
+
+        self.assertEqual(cm.exception.code, 0)
 
     def test_task_state(self):
         cli.task_state(self.parser.parse_args([

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import datetime
+import errno
 import logging
 import os
 import shutil
@@ -511,8 +512,12 @@ class LocalTaskJobTest(unittest.TestCase):
         session.commit()
 
         ti_run = TI(task=task, execution_date=DEFAULT_DATE)
+
         job1 = LocalTaskJob(task_instance=ti_run, ignore_ti_state=True, executor=SequentialExecutor())
-        self.assertRaises(AirflowException, job1.run)
+        with self.assertRaises(SystemExit) as cm:
+            job1.run()
+
+        self.assertEqual(cm.exception.code, errno.EEXIST)
 
         ti = dr.get_task_instance(task_id=task.task_id, session=session)
         self.assertEqual(ti.pid, 1)

--- a/tests/models.py
+++ b/tests/models.py
@@ -764,7 +764,11 @@ class TaskInstanceTest(unittest.TestCase):
         task = DummyOperator(task_id='test_requeue_over_concurrency_op', dag=dag)
 
         ti = TI(task=task, execution_date=datetime.datetime.now())
-        ti.run()
+
+        with self.assertRaises(SystemExit) as cm:
+            ti.run()
+
+        self.assertEqual(cm.exception.code, 16)
         self.assertEqual(ti.state, models.State.NONE)
 
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1294


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

In the backfills we can loose tasks to execute due to a task
setting its own state to NONE if concurrency limits are reached,
this makes them fall outside of the scope the backfill is
managing hence they will not be executed.

Several bugs are the cause for this. Firstly, the state
reported by the executor was always reported as success, ie.
the return code of the task instance was not propagated.
Next to that, if the executor already has a task instance
in its queue it will silently ignore the task instance
being added. The backfills did not guard against this, thus
tasks could get lost here as well.

This patch introduces CONCURRENCY_REACHED as an executor
state, which will be set if the task exits with EBUSY (16).
This allows the backfill to properly handle these tasks
and reschedule them. Please note that the CeleryExecutor
does not report back on executor states.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Looking at an approach to updated tests.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@aoen @saguziel @mistercrunch 
