### PR TITLE
[AIRFLOW-1297] add db name to RedshiftToS3Transfer operator

### DIFF
--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -31,6 +31,7 @@ class PostgresHook(DbApiHook):
     def __init__(self, *args, **kwargs):
         super(PostgresHook, self).__init__(*args, **kwargs)
         self.schema = kwargs.pop("schema", None)
+        self.db_name = kwargs.pop("db_name", None)
 
     def get_conn(self):
         conn = self.get_connection(self.postgres_conn_id)
@@ -38,7 +39,7 @@ class PostgresHook(DbApiHook):
             host=conn.host,
             user=conn.login,
             password=conn.password,
-            dbname=self.schema or conn.schema,
+            dbname=self.db_name or conn.schema,
             port=conn.port)
         # check for ssl parameters in conn.extra
         for arg_name, arg_val in conn.extra_dejson.items():
@@ -52,8 +53,8 @@ class PostgresHook(DbApiHook):
         """
         Postgresql will adapt all arguments to the execute() method internally,
         hence we return cell without any conversion.
-        
-        See http://initd.org/psycopg/docs/advanced.html#adapting-new-types for 
+
+        See http://initd.org/psycopg/docs/advanced.html#adapting-new-types for
         more information.
 
         :param cell: The cell to insert into the table

--- a/airflow/operators/redshift_to_s3_operator.py
+++ b/airflow/operators/redshift_to_s3_operator.py
@@ -46,6 +46,7 @@ class RedshiftToS3Transfer(BaseOperator):
     @apply_defaults
     def __init__(
             self,
+            db_name,
             schema,
             table,
             s3_bucket,
@@ -58,6 +59,7 @@ class RedshiftToS3Transfer(BaseOperator):
             *args, **kwargs):
         super(RedshiftToS3Transfer, self).__init__(*args, **kwargs)
         self.schema = schema
+        self.db_name = db_name
         self.table = table
         self.s3_bucket = s3_bucket
         self.s3_key = s3_key
@@ -85,7 +87,7 @@ class RedshiftToS3Transfer(BaseOperator):
         cursor = self.hook.get_conn().cursor()
         cursor.execute(columns_query)
         rows = cursor.fetchall()
-        columns = map(lambda row: row[0], rows)
+        columns = [row[0] for row in rows]
         column_names = (', ').join(map(lambda c: "\\'{0}\\'".format(c), columns))
         column_castings = (', ').join(map(lambda c: "CAST({0} AS text) AS {0}".format(c),
                                             columns))


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
https://issues.apache.org/jira/browse/AIRFLOW-1297

### Description
- In myredshift I have two different db_name and schema. code copy always schema into db_name which is not flexible.


