### PR TITLE
[AIRFLOW 1159] DockerOperator can use newer docker.

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -18,7 +18,8 @@ from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory
-from docker import Client, tls
+from docker import tls
+from docker.api import APIClient as DockerAPIClient
 import ast
 
 
@@ -142,7 +143,7 @@ class DockerOperator(BaseOperator):
             )
             self.docker_url = self.docker_url.replace('tcp://', 'https://')
 
-        self.cli = Client(base_url=self.docker_url, version=self.api_version, tls=tls_config)
+        self.cli = DockerAPIClient(base_url=self.docker_url, version=self.api_version, tls=tls_config)
 
         if ':' not in self.image:
             image = self.image + ':latest'

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -28,7 +28,7 @@ cryptography
 datadog
 dill
 distributed
-docker-py
+docker
 filechunkio
 flake8
 flask

--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,7 @@ doc = [
     'sphinx-rtd-theme>=0.1.6',
     'Sphinx-PyPI-upload>=0.2.1'
 ]
+websocket = ['websocket>=0.41.1']
 docker = ['docker>=2.3.0']
 druid = ['pydruid>=0.2.1']
 emr = ['boto3>=1.0.0']
@@ -286,6 +287,7 @@ def do_setup():
             'statsd': statsd,
             'vertica': vertica,
             'webhdfs': webhdfs,
+            'websocket': websocket,
             'jira': jira,
             'redis': redis,
         },

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ doc = [
     'sphinx-rtd-theme>=0.1.6',
     'Sphinx-PyPI-upload>=0.2.1'
 ]
-docker = ['docker-py>=1.6.0']
+docker = ['docker>=2.3.0']
 druid = ['pydruid>=0.2.1']
 emr = ['boto3>=1.0.0']
 gcp_api = [

--- a/tests/operators/docker_operator.py
+++ b/tests/operators/docker_operator.py
@@ -15,11 +15,8 @@
 import unittest
 import logging
 
-try:
-    from airflow.operators.docker_operator import DockerOperator
-    from docker.client import Client
-except ImportError:
-    pass
+from airflow.operators.docker_operator import DockerOperator
+from docker.api import APIClient as DockerAPIClient
 
 from airflow.exceptions import AirflowException
 
@@ -35,12 +32,12 @@ except ImportError:
 class DockerOperatorTestCase(unittest.TestCase):
     @unittest.skipIf(mock is None, 'mock package not present')
     @mock.patch('airflow.utils.file.mkdtemp')
-    @mock.patch('airflow.operators.docker_operator.Client')
+    @mock.patch('airflow.operators.docker_operator.DockerAPIClient')
     def test_execute(self, client_class_mock, mkdtemp_mock):
         host_config = mock.Mock()
         mkdtemp_mock.return_value = '/mkdtemp'
 
-        client_mock = mock.Mock(spec=Client)
+        client_mock = mock.Mock(spec=DockerAPIClient)
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.create_host_config.return_value = host_config
         client_mock.images.return_value = []
@@ -76,9 +73,9 @@ class DockerOperatorTestCase(unittest.TestCase):
 
     @unittest.skipIf(mock is None, 'mock package not present')
     @mock.patch('airflow.operators.docker_operator.tls.TLSConfig')
-    @mock.patch('airflow.operators.docker_operator.Client')
+    @mock.patch('airflow.operators.docker_operator.DockerAPIClient')
     def test_execute_tls(self, client_class_mock, tls_class_mock):
-        client_mock = mock.Mock(spec=Client)
+        client_mock = mock.Mock(spec=DockerAPIClient)
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.create_host_config.return_value = mock.Mock()
         client_mock.images.return_value = []
@@ -103,9 +100,9 @@ class DockerOperatorTestCase(unittest.TestCase):
                                              version=None)
 
     @unittest.skipIf(mock is None, 'mock package not present')
-    @mock.patch('airflow.operators.docker_operator.Client')
+    @mock.patch('airflow.operators.docker_operator.DockerAPIClient')
     def test_execute_unicode_logs(self, client_class_mock):
-        client_mock = mock.Mock(spec=Client)
+        client_mock = mock.Mock(spec=DockerAPIClient)
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.create_host_config.return_value = mock.Mock()
         client_mock.images.return_value = []
@@ -126,9 +123,9 @@ class DockerOperatorTestCase(unittest.TestCase):
             print_exception_mock.assert_not_called()
 
     @unittest.skipIf(mock is None, 'mock package not present')
-    @mock.patch('airflow.operators.docker_operator.Client')
+    @mock.patch('airflow.operators.docker_operator.DockerAPIClient')
     def test_execute_container_fails(self, client_class_mock):
-        client_mock = mock.Mock(spec=Client)
+        client_mock = mock.Mock(spec=DockerAPIClient)
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.create_host_config.return_value = mock.Mock()
         client_mock.images.return_value = []
@@ -145,7 +142,7 @@ class DockerOperatorTestCase(unittest.TestCase):
 
     @unittest.skipIf(mock is None, 'mock package not present')
     def test_on_kill(self):
-        client_mock = mock.Mock(spec=Client)
+        client_mock = mock.Mock(spec=DockerAPIClient)
 
         operator = DockerOperator(image='ubuntu', owner='unittest', task_id='unittest')
         operator.cli = client_mock

--- a/tests/operators/docker_operator.py
+++ b/tests/operators/docker_operator.py
@@ -15,8 +15,11 @@
 import unittest
 import logging
 
-from airflow.operators.docker_operator import DockerOperator
-from docker.api import APIClient as DockerAPIClient
+try:
+    from airflow.operators.docker_operator import DockerOperator
+    from docker.api import APIClient as DockerAPIClient
+except ImportError:
+    pass
 
 from airflow.exceptions import AirflowException
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-1159] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1159


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

'DockerOperator' can't run 'docker==2.3.0'(Docker API for python).

I think it was broken after [this commit](https://github.com/docker/docker-py/commit/f5ac10c469fca252e69ae780749f4ec6fe369789)

I fixed it. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

