### PR TITLE
Make FileSensor detect file or folder

### DIFF
--- a/airflow/contrib/operators/fs_operator.py
+++ b/airflow/contrib/operators/fs_operator.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from os import walk
+import os
 import logging
 
 from airflow.operators.sensors import BaseSensorOperator
@@ -51,8 +51,5 @@ class FileSensor(BaseSensorOperator):
         full_path = "/".join([basepath, self.filepath])
         logging.info(
             'Poking for file {full_path} '.format(**locals()))
-        try:
-            files = [f for f in walk(full_path)]
-        except:
-            return False
-        return True
+        
+        return os.path.exists(full_path)


### PR DESCRIPTION
The current implementation for poke() will return true even if the specified path does not exist.  This causes the sensor to not wait until the desired condition is true.

The change is to use the os.path.exists() instead of os.walk().  This returns false if the path does not exist, hence causes the sensor to wait.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

