### PR TITLE
[AIRFLOW-801] Remove outdated docstring on BaseOperator

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1822,12 +1822,6 @@ class BaseOperator(object):
     which ultimately becomes a node in DAG objects. Task dependencies should
     be set by using the set_upstream and/or set_downstream methods.
 
-    Note that this class is derived from SQLAlchemy's Base class, which
-    allows us to push metadata regarding tasks to the database. Deriving this
-    classes needs to implement the polymorphic specificities documented in
-    SQLAlchemy. This should become clear while reading the code for other
-    operators.
-
     :param task_id: a unique, meaningful id for the task
     :type task_id: string
     :param owner: the owner of the task, using the unix username is recommended


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-801


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

The docstring of the BaseOperator still makes reference to
it inheriting from SQL Alchemy's Base class,
which it no longer does. So that should be removed.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's just documentation fix.
Confirmed that the webpage is expectedly rendered.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

