### PR TITLE
[AIRFLOW-102] Fix test_complex_template always succeeds

### DIFF
--- a/tests/core.py
+++ b/tests/core.py
@@ -561,7 +561,10 @@ class CoreTest(unittest.TestCase):
 
     def test_complex_template(self):
         def verify_templated_field(context):
-            self.assertEqual(context['ti'].task.some_templated_field['bar'][1], context['ds'])
+            try:
+                self.assertEqual(context['ti'].task.some_templated_field['bar'][1], context['ds'])
+            except AssertionError as e:
+                raise BaseException(e)
 
         t = OperatorSubclass(
             task_id='test_complex_template',


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-102


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

test_complex_template always succeeds, since if AssertionError
is raised in verify_templated_field, TaskInstance.run consumes it.
This PR makes verify_templated_field raise BaseException
when the test fails, so as not to be consumed by TaskInstance.run.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's a fix for a wrong test case.
I changed the value passed to some_templated_field manually and confirmed the test fails expectedly.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

