### PR TITLE
[AIRFLOW-1326] Contrib SparkSubmitOperator should preserve spaces in arguments

### DIFF
--- a/airflow/contrib/hooks/spark_submit_hook.py
+++ b/airflow/contrib/hooks/spark_submit_hook.py
@@ -194,12 +194,8 @@ class SparkSubmitHook(BaseHook):
 
         # Append any application arguments
         if self._application_args:
-            for arg in self._application_args:
-                if len(arg.split()) > 1:
-                    for splitted_option in arg.split():
-                        connection_cmd += [splitted_option]
-                else:
-                    connection_cmd += [arg]
+            connection_cmd += self._application_args
+
         logging.debug("Spark-Submit cmd: {}".format(connection_cmd))
 
         return connection_cmd

--- a/tests/contrib/hooks/test_spark_submit_hook.py
+++ b/tests/contrib/hooks/test_spark_submit_hook.py
@@ -45,8 +45,9 @@ class TestSparkSubmitHook(unittest.TestCase):
         'driver_memory': '3g',
         'java_class': 'com.foo.bar.AppMain',
         'application_args': [
-            '-f foo',
-            '--bar bar',
+            '-f', 'foo',
+            '--bar', 'bar',
+            '--with-spaces', 'args should keep embdedded spaces',
             'baz'
         ]
     }
@@ -129,6 +130,7 @@ class TestSparkSubmitHook(unittest.TestCase):
             'test_application.py',
             '-f', 'foo',
             '--bar', 'bar',
+            '--with-spaces', 'args should keep embdedded spaces',
             'baz'
         ]
         self.assertEquals(expected_build_cmd, cmd)

--- a/tests/contrib/operators/test_spark_submit_operator.py
+++ b/tests/contrib/operators/test_spark_submit_operator.py
@@ -46,10 +46,11 @@ class TestSparkSubmitOperator(unittest.TestCase):
         'driver_memory': '3g',
         'java_class': 'com.foo.bar.AppMain',
         'application_args': [
-            '-f foo',
-            '--bar bar',
-            '--start {{ macros.ds_add(ds, -1)}}',
-            '--end {{ ds }}'
+            '-f', 'foo',
+            '--bar', 'bar',
+            '--start', '{{ macros.ds_add(ds, -1)}}',
+            '--end', '{{ ds }}',
+            '--with-spaces', 'args should keep embdedded spaces',
         ]
     }
 
@@ -95,10 +96,11 @@ class TestSparkSubmitOperator(unittest.TestCase):
             'driver_memory': '3g',
             'java_class': 'com.foo.bar.AppMain',
             'application_args': [
-                '-f foo',
-                '--bar bar',
-                '--start {{ macros.ds_add(ds, -1)}}',
-                '--end {{ ds }}'
+                '-f', 'foo',
+                '--bar', 'bar',
+                '--start', '{{ macros.ds_add(ds, -1)}}',
+                '--end', '{{ ds }}',
+                '--with-spaces', 'args should keep embdedded spaces',
             ]
 
         }
@@ -130,14 +132,15 @@ class TestSparkSubmitOperator(unittest.TestCase):
         ti.render_templates()
 
         # Then
-        expected_application_args = [u'-f foo',
-                                     u'--bar bar',
-                                     u'--start %s' % (DEFAULT_DATE - datetime.timedelta(days=1)).strftime("%Y-%m-%d"),
-                                     u'--end %s' % DEFAULT_DATE.strftime("%Y-%m-%d")]
+        expected_application_args = [u'-f', 'foo',
+                                     u'--bar', 'bar',
+                                     u'--start', (DEFAULT_DATE - datetime.timedelta(days=1)).strftime("%Y-%m-%d"),
+                                     u'--end', DEFAULT_DATE.strftime("%Y-%m-%d"),
+                                     u'--with-spaces', u'args should keep embdedded spaces',
+                                     ]
         expected_name = "spark_submit_job"
-        self.assertListEqual(sorted(expected_application_args), sorted(getattr(operator, '_application_args')))
+        self.assertListEqual(expected_application_args, getattr(operator, '_application_args'))
         self.assertEqual(expected_name, getattr(operator, '_name'))
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [[AIRFLOW-1326] Contrib Spark Submit Hook should be able to produce arguments containing spaces.](https://issues.apache.org/jira/browse/AIRFLOW-1326) 


### Description
This was broken in #2289/[AIRFLOW-1184](https://issues.apache.org/jira/browse/AIRFLOW-1184) and was a case of user error to me (probably caused by wrong/misleading tests).

Since application_args was already an array the correct way of providing an flag and a value is in two items, not one. (i.e. the correct way is `['--option', 'value']`, not `['--option value']`) Otherwise there is no way to include an argument that includes a space.


### Tests
- [x] My PR updates the following unit tests: `tests/contrib/operators/test_spark_submit_operator.py` to be less confusing (i.e. split the args as stated in the previous paragraph. This has no functional difference to the tests but will be correct if someone goes to look at it). Update tests to `tests/contrib/hooks/test_spark_submit_hook.py` to cover this case explicitly.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue.