### PR TITLE
[AIRFLOW-1333] Enable copy function for Google Cloud Storage Hook

### DIFF
--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -43,6 +43,52 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         http_authorized = self._authorize()
         return build('storage', 'v1', http=http_authorized)
 
+
+    # pylint:disable=redefined-builtin
+    def copy(self, source_bucket, source_object, destination_bucket=None,
+             destination_object=None):
+        """
+        Copies an object from a bucket to another, with renaming if requested.
+
+        destination_bucket or destination_object can be omitted, in which case
+        source bucket/object is used, but not both.
+
+        :param bucket: The bucket of the object to copy from.
+        :type bucket: string
+        :param object: The object to copy.
+        :type object: string
+        :param destination_bucket: The destination of the object to copied to.
+            Can be omitted; then the same bucket is used.
+        :type destination_bucket: string
+        :param destination_object: The (renamed) path of the object if given.
+            Can be omitted; then the same name is used.
+        """
+        destination_bucket = destination_bucket or source_bucket
+        destination_object = destination_object or source_object
+        if (source_bucket == destination_bucket and
+            source_object == destination_object):
+            raise ValueError(
+                'Either source/destination bucket or source/destination object '
+                'must be different, not both the same: bucket=%s, object=%s' %
+                (source_bucket, source_object))
+        if not source_bucket or not source_object:
+            raise ValueError('source_bucket and source_object cannot be empty.')
+
+        service = self.get_conn()
+        try:
+            service \
+                .objects() \
+                .copy(sourceBucket=source_bucket, sourceObject=source_object,
+                      destinationBucket=destination_bucket,
+                      destinationObject=destination_object, body='') \
+                .execute()
+            return True
+        except errors.HttpError as ex:
+            if ex.resp['status'] == '404':
+                return False
+            raise
+
+
     # pylint:disable=redefined-builtin
     def download(self, bucket, object, filename=False):
         """
@@ -157,6 +203,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         """
         Delete an object if versioning is not enabled for the bucket, or if generation
         parameter is used.
+
         :param bucket: name of the bucket, where the object resides
         :type bucket: string
         :param object: name of the object to delete
@@ -181,6 +228,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
     def list(self, bucket, versions=None, maxResults=None, prefix=None):
         """
         List all objects from the bucket with the give string prefix in name
+
         :param bucket: bucket name
         :type bucket: string
         :param versions: if true, list all versions of the objects


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
@criccomini

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1333


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR adds a GoogleCloudStorageHook method to copy one GCS file
to another location.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested using local airflow workflow, calling this hook method from a python operator.
However it's not possible to create a test, as it's using GCS API directly.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

