### PR TITLE
[AIRFLOW-1338] Fix incompatible GCP dataflow hook

### DIFF
--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -152,7 +152,7 @@ class DataFlowHook(GoogleCloudBaseHook):
             task_id, variables, dataflow, name, ["python"] + py_options)
 
     def _build_cmd(self, task_id, variables, dataflow):
-        command = [dataflow, "--runner=DataflowPipelineRunner"]
+        command = [dataflow, "--runner=DataflowRunner"]
         if variables is not None:
             for attr, value in variables.iteritems():
                 command.append("--" + attr + "=" + value)

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,7 @@ gcp_api = [
     'google-api-python-client>=1.5.0, <1.6.0',
     'oauth2client>=2.0.2, <2.1.0',
     'PyOpenSSL',
+    'google-cloud-dataflow',
     'pandas-gbq'
 ]
 hdfs = ['snakebite>=2.7.8']


### PR DESCRIPTION
GCP dataflow hook is incompatible with recent google-cloud-dataflow
/apache-beam release (>=2.0.0). The DataflowPipelineRunner has 
renamed to DataflowRunner, which breaks the existing 
gcp_dataflow_hook. This PR updates the runner name.

FYI- this is the apache beam commit (https://goo.gl/9PhGQ6) that
introduces the incompatible change.