### PR TITLE
AIRFLOW-1340 Create operator to copy data from S3 to Redshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Currently **officially** using Airflow:
 1. [Sidecar](https://hello.getsidecar.com/) [[@getsidecar](https://github.com/getsidecar)]
 1. [SimilarWeb](https://www.similarweb.com/) [[@similarweb](https://github.com/similarweb)]
 1. [SmartNews](https://www.smartnews.com/) [[@takus](https://github.com/takus)]
+1. [SpotHero](https://spothero.com)
 1. [Spotify](https://github.com/spotify) [[@znichols](https://github.com/znichols)]
 1. [Stackspace](https://beta.stackspace.io/)
 1. Stripe [[@jbalogh](https://github.com/jbalogh)]

--- a/airflow/operators/s3_to_redshift_operator.py
+++ b/airflow/operators/s3_to_redshift_operator.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
+import logging
+
+from airflow.exceptions import AirflowException
+from airflow.hooks.postgres_hook import PostgresHook
+from airflow.hooks.S3_hook import S3Hook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+COPY_SQL = ("COPY {schema}.{table} {column_names}"
+            "FROM 's3://{s3_bucket}/{s3_key}' "
+            "CREDENTIALS 'aws_access_key_id={aws_access_key};"
+            "aws_secret_access_key={aws_secret_access_key}' {options}")
+
+
+class S3ToRedshiftCopy(BaseOperator):
+    """Runs a COPY command to load data from S3 to Redshift
+
+    :param s3_bucket: S3 bucket in which the files are stored
+    :type s3_bucket: string
+    :param s3_key: S3 key where the CSV is stored
+    :type s3_key: string
+    :param redshift_conn_id: Redshift connection ID
+    :type redshift_conn_id: string
+    :param schema: Schema in Redshift where the data will be loaded
+    :type schema: string
+    :param table: Table in redshift where the data will be loaded
+    :type table: string
+    :param s3_conn_id: S3 connection id
+    :type s3_conn_id: string
+    :param infer_column_names: If set to true, it is assumed that the data
+        file is a CSV and the first row of the CSV will be used verbatim as
+        the column names for the COPY command. Defaults to False.
+    :type infer_column_names: boolean
+    :param column_names: Column ordering to provide to the COPY command.
+        Note: If column_names is provided, infer_column_names must
+        be False.
+    :type column_names: list of strings
+    :param copy_options: Extra options to pass to the COPY command, for example
+        DELIMITER, CSV, BLANKSASNULL, etc.
+    :type copy_options: A dictionary of options where the key is the option
+        name. If the option is a flag, pass either an empty string or None
+        as the value.
+    :param autocommit: Whether or not to autocommit the transaction. Defaults
+        to True.
+    :type autocommit: boolean
+    """
+
+    template_fields = ()
+    template_ext = ()
+    ui_color = '#ededed'
+
+    @apply_defaults
+    def __init__(
+            self,
+            s3_bucket,
+            s3_key,
+            schema,
+            table,
+            redshift_conn_id='redshift_default',
+            s3_conn_id='s3_default',
+            infer_column_names=False,
+            copy_options=None,
+            column_names=None,
+            autocommit=True,
+            *args,
+            **kwargs):
+        super(S3ToRedshiftCopy, self).__init__(*args, **kwargs)
+        self.autocommit = autocommit
+        self.column_names = column_names
+        self.copy_options = {} if copy_options is None else copy_options
+        self.infer_column_names = infer_column_names
+        self.redshift_conn_id = redshift_conn_id
+        self.s3_bucket = s3_bucket
+        self.s3_conn_id = s3_conn_id
+        self.s3_key = s3_key
+        self.schema = schema
+        self.table = table
+
+        if self.column_names is not None and self.infer_column_names:
+            raise AirflowException(
+                'column_names and infer_column_names are mutually exclusive '
+                'options.')
+
+    def execute(self, context):
+        pg_hook = PostgresHook(postgres_conn_id=self.redshift_conn_id)
+        s3_hook = S3Hook(s3_conn_id=self.s3_conn_id)
+        aws_access_key, aws_secret_access_key = s3_hook.get_credentials()
+
+        if not s3_hook.check_for_key(self.s3_key, bucket_name=self.s3_bucket):
+            raise AirflowException(
+                'Key %s does not exist in bucket %s', self.s3_key,
+                self.s3_bucket)
+
+        # Get column names if available
+        column_names = None
+        if self.infer_column_names:
+            logging.info(
+                'Reading source S3 file %s from bucket %s to infer column '
+                'names', self.s3_key, self.s3_bucket)
+            key = s3_hook.get_key(self.s3_key, bucket_name=self.s3_bucket)
+            buf = StringIO()
+            key.get_contents_to_file(buf)
+            buf.seek(0)
+            column_names = buf.readline()
+            # We can assume that since we're inferring column names from the
+            # first row, we should ignore the header when copying data
+            if self.copy_options.get('IGNOREHEADER') is None:
+                self.copy_options['IGNOREHEADER'] = 1
+        elif self.column_names is not None:
+            column_names = ','.join(self.column_names)
+
+        options = []
+        for option, value in self.copy_options.items():
+            if value is None or value == '':
+                options.append(option)
+            else:
+                options.append("{} {}".format(option, value))
+        options_string = ' '.join(options)
+
+        copy_params = {
+            'aws_access_key': aws_access_key,
+            'aws_secret_access_key': aws_secret_access_key,
+            'column_names': '({}) '.format(column_names)
+                            if column_names is not None else '',
+            'options': options_string,
+            's3_bucket': self.s3_bucket,
+            's3_key': self.s3_key,
+            'schema': self.schema,
+            'table': self.table,
+        }
+        logging.info(
+            'Staring COPY from s3://%s/%s to redshift table %s.%s',
+            self.s3_bucket, self.s3_key, self.schema, self.table)
+        pg_hook.run(COPY_SQL.format(**copy_params), self.autocommit)
+        logging.info(
+            'Done executing COPY from s3://%s/%s to redshift table %s.%s',
+            self.s3_bucket, self.s3_key, self.schema, self.table)

--- a/tests/operators/__init__.py
+++ b/tests/operators/__init__.py
@@ -20,4 +20,4 @@ from .hive_operator import *
 from .s3_to_hive_operator import *
 from .python_operator import *
 from .latest_only_operator import *
-
+from .s3_to_redshift_operator import *

--- a/tests/operators/s3_to_redshift_operator.py
+++ b/tests/operators/s3_to_redshift_operator.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+try:
+    from unittest.mock import MagicMock, patch
+except ImportError:
+    try:
+        from mock import MagicMock, patch
+    except ImportError:
+        patch = None
+
+from airflow.exceptions import AirflowException
+from airflow.operators.s3_to_redshift_operator import S3ToRedshiftCopy
+
+class S3ToRedshiftCopyTest(unittest.TestCase):
+    def setUp(self):
+        self.logging_patcher = patch(
+            'airflow.operators.s3_to_redshift_operator.logging')
+        self.logging_patcher.start()
+        self.pg_hook_patcher = patch(
+            'airflow.operators.s3_to_redshift_operator.PostgresHook')
+        self.mock_pg_hook = self.pg_hook_patcher.start()
+        self.s3_hook_patcher = patch(
+            'airflow.operators.s3_to_redshift_operator.S3Hook')
+        self.mock_s3_hook = self.s3_hook_patcher.start()
+
+        self.mock_s3 = MagicMock()
+        self.mock_s3_hook.return_value = self.mock_s3
+        self.mock_s3.get_credentials.return_value = 'key', 'secret'
+        self.mock_s3.check_for_key.return_value = True
+
+    def tearDown(self):
+        self.logging_patcher.stop()
+        self.pg_hook_patcher.stop()
+        self.s3_hook_patcher.stop()
+
+    @unittest.skipIf(patch is None, 'mock package not present')
+    def test_copy_from_s3(self):
+        operator = S3ToRedshiftCopy(
+            s3_bucket='bucket', s3_key='key', redshift_conn_id='conn_id',
+            schema='schema', table='table', copy_options={'OPTION': 'VALUE'},
+            task_id='unittest')
+        operator.execute(None)
+
+        expected_sql = ("COPY schema.table FROM 's3://bucket/key' CREDENTIALS "
+                        "'aws_access_key_id=key;aws_secret_access_key=secret' "
+                        "OPTION VALUE")
+        self.mock_pg_hook.return_value.run.assert_called_once_with(
+            expected_sql, True)
+
+    @unittest.skipIf(patch is None, 'mock package not present')
+    def test_copy_from_s3__option_flag(self):
+        operator = S3ToRedshiftCopy(
+            s3_bucket='bucket', s3_key='key', redshift_conn_id='conn_id',
+            schema='schema', table='table',
+            copy_options={'FLAG': None}, task_id='unittest')
+        operator.execute(None)
+
+        expected_sql = ("COPY schema.table FROM 's3://bucket/key' CREDENTIALS "
+                        "'aws_access_key_id=key;aws_secret_access_key=secret' "
+                        "FLAG")
+        self.mock_pg_hook.return_value.run.assert_called_once_with(
+            expected_sql, True)
+
+    @unittest.skipIf(patch is None, 'mock package not present')
+    def test_copy_from_s3__provided_col_names(self):
+        operator = S3ToRedshiftCopy(
+            s3_bucket='bucket', s3_key='key', redshift_conn_id='conn_id',
+            schema='schema', table='table',
+            column_names=['a', 'b', 'c'], copy_options={'OPTION': 'VALUE'},
+            task_id='unittest')
+        operator.execute(None)
+
+        expected_sql = ("COPY schema.table (a,b,c) FROM 's3://bucket/key' "
+                        "CREDENTIALS 'aws_access_key_id=key;"
+                        "aws_secret_access_key=secret' OPTION VALUE")
+        self.mock_pg_hook.return_value.run.assert_called_once_with(
+            expected_sql, True)
+
+    @unittest.skipIf(patch is None, 'mock package not present')
+    @patch('airflow.operators.s3_to_redshift_operator.StringIO')
+    def test_copy_from_s3__inferred_col_names(self, mock_stringio):
+        mock_stringio.return_value.readline.return_value = 'a,b,c'
+
+        operator = S3ToRedshiftCopy(
+            s3_bucket='bucket', s3_key='key', redshift_conn_id='conn_id',
+            schema='schema', table='table',
+            infer_column_names=True, task_id='unittest')
+        operator.execute(None)
+
+        expected_sql = ("COPY schema.table (a,b,c) FROM 's3://bucket/key' "
+                        "CREDENTIALS 'aws_access_key_id=key;"
+                        "aws_secret_access_key=secret' "
+                        "IGNOREHEADER 1")
+        self.mock_pg_hook.return_value.run.assert_called_once_with(
+            expected_sql, True)
+
+    @unittest.skipIf(patch is None, 'mock package not present')
+    def test_copy_from_s3__infer_and_provided_col_names(self):
+        with self.assertRaises(AirflowException):
+            S3ToRedshiftCopy(
+                s3_bucket='bucket', s3_key='key', redshift_conn_id='conn_id',
+                schema='schema', table='table',
+                column_names=['a', 'b', 'c'], infer_column_names=True,
+                task_id='unittest')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/1340) issues and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
   * This PR adds a `S3ToRedshiftCopy` operator that is a wrapper around Redshift's `COPY` operation for loading data from files in S3.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  * `tests.operator.s3_to_redshift_operator`


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
