### PR TITLE
[AIRFLOW-1337] log_format key names should be lowercase.

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -50,10 +50,10 @@ s3_log_folder =
 logging_level = INFO
 
 # Log format
-LOG_FORMAT = [%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s
-LOG_FORMAT_WITH_PID = [%%(asctime)s] [%%(process)d] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s
-LOG_FORMAT_WITH_THREAD_NAME = [%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(threadName)s %%(levelname)s - %%(message)s
-SIMPLE_LOG_FORMAT = %%(asctime)s %%(levelname)s - %%(message)s
+log_format = [%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s
+log_format_with_pid = [%%(asctime)s] [%%(process)d] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s
+log_format_with_thread_name = [%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(threadName)s %%(levelname)s - %%(message)s
+simple_log_format = %%(asctime)s %%(levelname)s - %%(message)s
 
 # Size of logging buffer
 logging_buffer_size = 4096

--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -152,7 +152,7 @@ class DataFlowHook(GoogleCloudBaseHook):
             task_id, variables, dataflow, name, ["python"] + py_options)
 
     def _build_cmd(self, task_id, variables, dataflow):
-        command = [dataflow, "--runner=DataflowPipelineRunner"]
+        command = [dataflow, "--runner=DataflowRunner"]
         if variables is not None:
             for attr, value in variables.iteritems():
                 command.append("--" + attr + "=" + value)

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -73,10 +73,10 @@ LOGGING_LEVEL = logging.INFO
 # the prefix to append to gunicorn worker processes after init
 GUNICORN_WORKER_READY_PREFIX = "[ready] "
 
-LOG_FORMAT = conf.get('core', 'LOG_FORMAT')
-LOG_FORMAT_WITH_PID = conf.get('core', 'LOG_FORMAT_WITH_PID')
-LOG_FORMAT_WITH_THREAD_NAME = conf.get('core', 'LOG_FORMAT_WITH_THREAD_NAME')
-SIMPLE_LOG_FORMAT = conf.get('core', 'SIMPLE_LOG_FORMAT')
+LOG_FORMAT = conf.get('core', 'log_format')
+LOG_FORMAT_WITH_PID = conf.get('core', 'log_format_with_pid')
+LOG_FORMAT_WITH_THREAD_NAME = conf.get('core', 'log_format_with_thread_name')
+SIMPLE_LOG_FORMAT = conf.get('core', 'simple_log_format')
 
 AIRFLOW_HOME = None
 SQL_ALCHEMY_CONN = None

--- a/airflow/task_runner/base_task_runner.py
+++ b/airflow/task_runner/base_task_runner.py
@@ -89,7 +89,9 @@ class BaseTaskRunner(LoggingMixin):
 
     def _read_task_logs(self, stream):
         while True:
-            line = stream.readline().decode('utf-8')
+            line = stream.readline()
+            if isinstance(line, bytes):
+                line = line.decode('utf-8')
             if len(line) == 0:
                 break
             self.logger.info('Subtask: {}'.format(line.rstrip('\n')))

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,7 @@ gcp_api = [
     'google-api-python-client>=1.5.0, <1.6.0',
     'oauth2client>=2.0.2, <2.1.0',
     'PyOpenSSL',
+    'google-cloud-dataflow',
     'pandas-gbq'
 ]
 hdfs = ['snakebite>=2.7.8']


### PR DESCRIPTION
Dear Airflow maintainers,

follow-up to PR: https://github.com/apache/incubator-airflow/pull/2392

### JIRA
    - https://issues.apache.org/jira/browse/AIRFLOW-1337


### Description
     - log_format key names should be lowercase in airflow.cfg

### Tests
     - run_unit_test.sh (1.9.x) in local env python3.5