### PR TITLE
fix a text encoding bug

### DIFF
--- a/airflow/task_runner/base_task_runner.py
+++ b/airflow/task_runner/base_task_runner.py
@@ -89,7 +89,9 @@ class BaseTaskRunner(LoggingMixin):
 
     def _read_task_logs(self, stream):
         while True:
-            line = stream.readline().decode('utf-8')
+            line = stream.readline()
+            if isinstance(line, bytes):
+                line = line.decode('utf-8')
             if len(line) == 0:
                 break
             self.logger.info('Subtask: {}'.format(line.rstrip('\n')))


### PR DESCRIPTION
Dear Airflow maintainers,

When running airflow under python 3.5.2, it says: "AttributeError: 'str' object has no attribute 'decode'"
I have fixed this issue with a minor change.

Please accept this PR in case you find it is useful.

Thanks,
Yu