### PR TITLE
[AIRFLOW-1343] add airflow label to dataproc op

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -19,6 +19,7 @@ import time
 from airflow.contrib.hooks.gcp_dataproc_hook import DataProcHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
+from airflow.version import version
 from googleapiclient.errors import HttpError
 
 
@@ -226,8 +227,9 @@ class DataprocClusterCreateOperator(BaseOperator):
                 },
                 'isPreemptible': True
             }
-        if self.labels:
-            cluster_data['labels'] = self.labels
+
+        cluster_data['labels'] = self.labels if self.labels else {}
+        cluster_data['labels'].update({'airflow_version': version})
         if self.storage_bucket:
             cluster_data['config']['configBucket'] = self.storage_bucket
         if self.metadata:


### PR DESCRIPTION
Add a default label "airflow_version" to the dataproc operator 
and merge this label with the user defined labels passed from
the operator's init(). Adding this default label facilitates 
measuring the impact of airflow. 

To check this pull request, cd incubator-airflow and Run:
nosetests tests.contrib.operators.test_dataproc_operator

Passed Travis 
![travis](https://user-images.githubusercontent.com/16809719/27502366-5763b0ee-5828-11e7-9cab-8d006d28b095.png)
