### PR TITLE
[AIRFLOW-1321] Fix hidden field key to ignore case

### DIFF
--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -87,3 +87,6 @@ max_threads = 2
 catchup_by_default = True
 scheduler_zombie_task_threshold = 300
 dag_dir_list_interval = 0
+
+[admin]
+hide_sensitive_variable_fields = True

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -35,6 +35,20 @@ from airflow.utils.json import AirflowJsonEncoder
 
 AUTHENTICATE = configuration.getboolean('webserver', 'AUTHENTICATE')
 
+DEFAULT_SENSITIVE_VARIABLE_FIELDS = (
+    'password',
+    'secret',
+    'passwd',
+    'authorization',
+    'api_key',
+    'apikey',
+    'access_token',
+)
+
+def should_hide_value_for_key(key_name):
+    return any(s in key_name.lower() for s in DEFAULT_SENSITIVE_VARIABLE_FIELDS) \
+           and configuration.getboolean('admin', 'hide_sensitive_variable_fields')
+
 
 class LoginMixin(object):
     def is_accessible(self):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -90,16 +90,6 @@ logout_user = airflow.login.logout_user
 
 FILTER_BY_OWNER = False
 
-DEFAULT_SENSITIVE_VARIABLE_FIELDS = (
-    'password',
-    'secret',
-    'passwd',
-    'authorization',
-    'api_key',
-    'apikey',
-    'access_token',
-)
-
 if conf.getboolean('webserver', 'FILTER_BY_OWNER'):
     # filter_by_owner if authentication is enabled and filter_by_owner is true
     FILTER_BY_OWNER = not current_app.config['LOGIN_DISABLED']
@@ -279,12 +269,6 @@ def recurse_tasks(tasks, task_ids, dag_ids, task_id_to_dag):
         recurse_tasks(subtasks, task_ids, dag_ids, task_id_to_dag)
     if isinstance(tasks, BaseOperator):
         task_id_to_dag[tasks.task_id] = tasks.dag
-
-
-def should_hide_value_for_key(key_name):
-    return any(s in key_name for s in DEFAULT_SENSITIVE_VARIABLE_FIELDS) \
-           and conf.getboolean('admin', 'hide_sensitive_variable_fields')
-
 
 
 def get_chart_height(dag):
@@ -2282,7 +2266,7 @@ class VariableView(wwwutils.DataProfilingMixin, AirflowModelView):
     list_template = 'airflow/variable_list.html'
 
     def hidden_field_formatter(view, context, model, name):
-        if should_hide_value_for_key(model.key):
+        if wwwutils.should_hide_value_for_key(model.key):
             return Markup('*' * 8)
         return getattr(model, name)
 
@@ -2339,7 +2323,7 @@ class VariableView(wwwutils.DataProfilingMixin, AirflowModelView):
         return response
 
     def on_form_prefill(self, form, id):
-        if should_hide_value_for_key(form.key.data):
+        if wwwutils.should_hide_value_for_key(form.key.data):
             form.val.data = '*' * 8
 
 

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from airflow.www import utils
+
+
+class UtilsTest(unittest.TestCase):
+
+    def setUp(self):
+        super(UtilsTest, self).setUp()
+
+    def test_normal_variable_should_not_be_hidden(self):
+        self.assertFalse(utils.should_hide_value_for_key("key"))
+
+    def test_sensitive_variable_should_be_hidden(self):
+        self.assertTrue(utils.should_hide_value_for_key("google_api_key"))
+
+    def test_sensitive_variable_should_be_hidden_ic(self):
+        self.assertTrue(utils.should_hide_value_for_key("GOOGLE_API_KEY"))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1321


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Webserver has a feature to hide sensitive variable fields,
which key contain specific words. But its matching is
case-sensitive, so "google_api_key" is hidden but
"GOOGLE_API_KEY" is not. This behaviour is not intuitive,
so this PR fixes it to be case-insensitive.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added tests/www/test_utils.py.
In addition, I confirmed the feature behaved expectedly as the following screenshot:
![v](https://user-images.githubusercontent.com/898388/27528613-275e4b0a-5a8c-11e7-80da-2034421edf20.png)


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

