### PR TITLE
[AIRFLOW-1350] dataproc_operator: Add parameter query_uri to Hive and…

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -470,7 +470,8 @@ class DataProcHiveOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            query,
+            query=None,
+            query_uri=None,
             variables=None,
             job_name='{{task.task_id}}_{{ds_nodash}}',
             dataproc_cluster='cluster-1',
@@ -485,6 +486,8 @@ class DataProcHiveOperator(BaseOperator):
 
         :param query: The query or reference to the query file (q extension).
         :type query: string
+        :param query_uri: The uri of a hive script on Cloud Storage.
+        :type query_uri: string
         :param variables: Map of named parameters for the query.
         :type variables: dict
         :param job_name: The job name used in the DataProc cluster. This name by default
@@ -510,6 +513,7 @@ class DataProcHiveOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.query = query
+        self.query_uri = query_uri
         self.variables = variables
         self.job_name = job_name
         self.dataproc_cluster = dataproc_cluster
@@ -523,7 +527,10 @@ class DataProcHiveOperator(BaseOperator):
         job = hook.create_job_template(self.task_id, self.dataproc_cluster, "hiveJob",
                                        self.dataproc_properties)
 
-        job.add_query(self.query)
+        if self.query is None:
+            job.add_query_uri(self.query_uri)
+        else:
+            job.add_query(self.query)
         job.add_variables(self.variables)
         job.add_jar_file_uris(self.dataproc_jars)
         job.set_job_name(self.job_name)
@@ -542,7 +549,8 @@ class DataProcSparkSqlOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            query,
+            query=None,
+            query_uri=None,
             variables=None,
             job_name='{{task.task_id}}_{{ds_nodash}}',
             dataproc_cluster='cluster-1',
@@ -557,6 +565,8 @@ class DataProcSparkSqlOperator(BaseOperator):
 
         :param query: The query or reference to the query file (q extension).
         :type query: string
+        :param query_uri: The uri of a spark sql script on Cloud Storage.
+        :type query_uri: string
         :param variables: Map of named parameters for the query.
         :type variables: dict
         :param job_name: The job name used in the DataProc cluster. This name by default
@@ -582,6 +592,7 @@ class DataProcSparkSqlOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.query = query
+        self.query_uri = query_uri
         self.variables = variables
         self.job_name = job_name
         self.dataproc_cluster = dataproc_cluster
@@ -595,7 +606,10 @@ class DataProcSparkSqlOperator(BaseOperator):
         job = hook.create_job_template(self.task_id, self.dataproc_cluster, "sparkSqlJob",
                                        self.dataproc_properties)
 
-        job.add_query(self.query)
+        if self.query is None:
+            job.add_query_uri(self.query_uri)
+        else:
+            job.add_query(self.query)
         job.add_variables(self.variables)
         job.add_jar_file_uris(self.dataproc_jars)
         job.set_job_name(self.job_name)


### PR DESCRIPTION
… SparkSQL DataProc operator

Google cloud APIs allows users to submit jobs where the query
to be executed are stored in a separate file on GC storage.

In the current implementation this option is available only for
Pig jobs, whereas also Hive and SparkSQL should allow this. This
commit changes such a behavior by leveraging the same implementation
used for the Pig operator.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1350


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Google cloud APIs allows users to submit jobs where the query
to be executed are stored in a separate file on GC storage.

In the current implementation this option is available only for
Pig jobs, whereas also Hive and SparkSQL should allow this. This
commit changes such a behavior by leveraging the same implementation
used for the Pig operator.

No UI changes or doc changes required (docs have been updated)

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Since there was no unit test for this module and no relevant change, I did not change any test

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

