### PR TITLE
[AIRFLOW-1356] add `--celery_hostname` to `airflow worker`

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -919,6 +919,7 @@ def worker(args):
         'O': 'fair',
         'queues': args.queues,
         'concurrency': args.concurrency,
+        'hostname': args.celery_hostname,
     }
 
     if args.daemon:
@@ -1427,6 +1428,10 @@ class CLIFactory(object):
             type=int,
             help="The number of worker processes",
             default=conf.get('celery', 'celeryd_concurrency')),
+        'celery_hostname': Arg(
+            ("-cn", "--celery_hostname"),
+            help=("Set the hostname of celery worker "
+                  "if you have multiple workers on a single machine.")),
         # flower
         'broker_api': Arg(("-a", "--broker_api"), help="Broker api"),
         'flower_hostname': Arg(
@@ -1586,7 +1591,7 @@ class CLIFactory(object):
         }, {
             'func': worker,
             'help': "Start a Celery worker node",
-            'args': ('do_pickle', 'queues', 'concurrency',
+            'args': ('do_pickle', 'queues', 'concurrency', 'celery_hostname',
                      'pid', 'daemon', 'stdout', 'stderr', 'log_file'),
         }, {
             'func': flower,


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1356


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

If we start multiple `celery worker` on the same machine, each worker should have individual hostname to distinguish each other. Otherwise, some tools might not work correctly. E.g. celery flower would show only one worker if all workers are of the same hostname.

This PR add `--celery_hostname` or `-cn` option on `airflow worker` subcommand. The option should accept an argument with the syntax as same as the option `-n` of `celery worker` command.
celery worker doc: http://docs.celeryproject.org/en/latest/userguide/workers.html

For example, one can add the `-cn` option as following.
```sh
airflow worker -c 1 -q highmem -cn highmem@%h
```


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR is simple enough and there's no airflow worker related unittests.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

