### PR TITLE
[AIRFLOW-1357] fix scheduler zip file support

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -21,6 +21,7 @@ import logging
 import os
 import re
 import time
+import zipfile
 
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
@@ -187,7 +188,7 @@ def list_py_file_paths(directory, safe_mode=True):
                         continue
                     mod_name, file_ext = os.path.splitext(
                         os.path.split(file_path)[-1])
-                    if file_ext != '.py':
+                    if file_ext != '.py' and not zipfile.is_zipfile(file_path):
                         continue
                     if any([re.findall(p, file_path) for p in patterns]):
                         continue
@@ -195,7 +196,7 @@ def list_py_file_paths(directory, safe_mode=True):
                     # Heuristic that guesses whether a Python file contains an
                     # Airflow DAG definition.
                     might_contain_dag = True
-                    if safe_mode:
+                    if safe_mode and not zipfile.is_zipfile(file_path):
                         with open(file_path, 'rb') as f:
                             content = f.read()
                             might_contain_dag = all(


### PR DESCRIPTION
Dear Airflow maintainers,

As a follow up of [AIRFLOW-1357], here is the PR addressing the reported issue.


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-1357] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1357


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Users from 1.7 series of airflow using zipped DAGs are unable to migrate to 1.8+ series because the scheduler does not detect/run them.

The zipfile support is still present in the models.py file so the zipped DAGs do show up on `airflow list_dags` but they are never executed by the scheduler since it only cares for .py files.

Tested ok & in production here.


### Tests
- [x] My PR adds the following unit tests:

- jobs.test_scheduler_zip_dag_detection

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

