### PR TITLE
[AIRFLOW-1271] Add Google CloudML Training Operator

### DIFF
--- a/tests/contrib/operators/test_cloudml_operator.py
+++ b/tests/contrib/operators/test_cloudml_operator.py
@@ -26,41 +26,41 @@ import unittest
 
 from airflow import configuration, DAG
 from airflow.contrib.operators.cloudml_operator import CloudMLBatchPredictionOperator
+from airflow.contrib.operators.cloudml_operator import CloudMLTrainingOperator
 
+from mock import ANY
 from mock import patch
 
 DEFAULT_DATE = datetime.datetime(2017, 6, 6)
 
-INPUT_MISSING_ORIGIN = {
-    'dataFormat': 'TEXT',
-    'inputPaths': ['gs://legal-bucket/fake-input-path/*'],
-    'outputPath': 'gs://legal-bucket/fake-output-path',
-    'region': 'us-east1',
-}
-
-SUCCESS_MESSAGE_MISSING_INPUT = {
-    'jobId': 'test_prediction',
-    'predictionOutput': {
-        'outputPath': 'gs://fake-output-path',
-        'predictionCount': 5000,
-        'errorCount': 0,
-        'nodeHours': 2.78
-    },
-    'state': 'SUCCEEDED'
-}
-
-DEFAULT_ARGS = {
-    'project_id': 'test-project',
-    'job_id': 'test_prediction',
-    'region': 'us-east1',
-    'data_format': 'TEXT',
-    'input_paths': ['gs://legal-bucket-dash-Capital/legal-input-path/*'],
-    'output_path': 'gs://12_legal_bucket_underscore_number/legal-output-path',
-    'task_id': 'test-prediction'
-}
-
 
 class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
+    INPUT_MISSING_ORIGIN = {
+        'dataFormat': 'TEXT',
+        'inputPaths': ['gs://legal-bucket/fake-input-path/*'],
+        'outputPath': 'gs://legal-bucket/fake-output-path',
+        'region': 'us-east1',
+    }
+    SUCCESS_MESSAGE_MISSING_INPUT = {
+        'jobId': 'test_prediction',
+        'predictionOutput': {
+            'outputPath': 'gs://fake-output-path',
+            'predictionCount': 5000,
+            'errorCount': 0,
+            'nodeHours': 2.78
+        },
+        'state': 'SUCCEEDED'
+    }
+    BATCH_PREDICTION_DEFAULT_ARGS = {
+        'project_id': 'test-project',
+        'job_id': 'test_prediction',
+        'region': 'us-east1',
+        'data_format': 'TEXT',
+        'input_paths': ['gs://legal-bucket-dash-Capital/legal-input-path/*'],
+        'output_path':
+            'gs://12_legal_bucket_underscore_number/legal-output-path',
+        'task_id': 'test-prediction'
+    }
 
     def setUp(self):
         super(CloudMLBatchPredictionOperatorTest, self).setUp()
@@ -78,10 +78,10 @@ class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
         with patch('airflow.contrib.operators.cloudml_operator.CloudMLHook') \
                 as mock_hook:
 
-            input_with_model = INPUT_MISSING_ORIGIN.copy()
+            input_with_model = self.INPUT_MISSING_ORIGIN.copy()
             input_with_model['modelName'] = \
                 'projects/test-project/models/test_model'
-            success_message = SUCCESS_MESSAGE_MISSING_INPUT.copy()
+            success_message = self.SUCCESS_MESSAGE_MISSING_INPUT.copy()
             success_message['predictionInput'] = input_with_model
 
             hook_instance = mock_hook.return_value
@@ -104,12 +104,12 @@ class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
             prediction_output = prediction_task.execute(None)
 
             mock_hook.assert_called_with('google_cloud_default', None)
-            hook_instance.create_job.assert_called_with(
+            hook_instance.create_job.assert_called_once_with(
                 'test-project',
                 {
                     'jobId': 'test_prediction',
                     'predictionInput': input_with_model
-                })
+                }, ANY)
             self.assertEquals(
                 success_message['predictionOutput'],
                 prediction_output)
@@ -118,10 +118,10 @@ class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
         with patch('airflow.contrib.operators.cloudml_operator.CloudMLHook') \
                 as mock_hook:
 
-            input_with_version = INPUT_MISSING_ORIGIN.copy()
+            input_with_version = self.INPUT_MISSING_ORIGIN.copy()
             input_with_version['versionName'] = \
                 'projects/test-project/models/test_model/versions/test_version'
-            success_message = SUCCESS_MESSAGE_MISSING_INPUT.copy()
+            success_message = self.SUCCESS_MESSAGE_MISSING_INPUT.copy()
             success_message['predictionInput'] = input_with_version
 
             hook_instance = mock_hook.return_value
@@ -132,8 +132,7 @@ class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
             hook_instance.create_job.return_value = success_message
 
             prediction_task = CloudMLBatchPredictionOperator(
-                job_id='test_prediction',
-                project_id='test-project',
+                job_id='test_prediction', project_id='test-project',
                 region=input_with_version['region'],
                 data_format=input_with_version['dataFormat'],
                 input_paths=input_with_version['inputPaths'],
@@ -150,7 +149,7 @@ class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
                 {
                     'jobId': 'test_prediction',
                     'predictionInput': input_with_version
-                })
+                }, ANY)
             self.assertEquals(
                 success_message['predictionOutput'],
                 prediction_output)
@@ -159,9 +158,9 @@ class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
         with patch('airflow.contrib.operators.cloudml_operator.CloudMLHook') \
                 as mock_hook:
 
-            input_with_uri = INPUT_MISSING_ORIGIN.copy()
+            input_with_uri = self.INPUT_MISSING_ORIGIN.copy()
             input_with_uri['uri'] = 'gs://my_bucket/my_models/savedModel'
-            success_message = SUCCESS_MESSAGE_MISSING_INPUT.copy()
+            success_message = self.SUCCESS_MESSAGE_MISSING_INPUT.copy()
             success_message['predictionInput'] = input_with_uri
 
             hook_instance = mock_hook.return_value
@@ -189,14 +188,14 @@ class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
                 {
                     'jobId': 'test_prediction',
                     'predictionInput': input_with_uri
-                })
+                }, ANY)
             self.assertEquals(
                 success_message['predictionOutput'],
                 prediction_output)
 
     def testInvalidModelOrigin(self):
         # Test that both uri and model is given
-        task_args = DEFAULT_ARGS.copy()
+        task_args = self.BATCH_PREDICTION_DEFAULT_ARGS.copy()
         task_args['uri'] = 'gs://fake-uri/saved_model'
         task_args['model_name'] = 'fake_model'
         with self.assertRaises(ValueError) as context:
@@ -204,7 +203,7 @@ class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
         self.assertEquals('Ambiguous model origin.', str(context.exception))
 
         # Test that both uri and model/version is given
-        task_args = DEFAULT_ARGS.copy()
+        task_args = self.BATCH_PREDICTION_DEFAULT_ARGS.copy()
         task_args['uri'] = 'gs://fake-uri/saved_model'
         task_args['model_name'] = 'fake_model'
         task_args['version_name'] = 'fake_version'
@@ -213,7 +212,7 @@ class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
         self.assertEquals('Ambiguous model origin.', str(context.exception))
 
         # Test that a version is given without a model
-        task_args = DEFAULT_ARGS.copy()
+        task_args = self.BATCH_PREDICTION_DEFAULT_ARGS.copy()
         task_args['version_name'] = 'bare_version'
         with self.assertRaises(ValueError) as context:
             CloudMLBatchPredictionOperator(**task_args).execute(None)
@@ -222,7 +221,7 @@ class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
             str(context.exception))
 
         # Test that none of uri, model, model/version is given
-        task_args = DEFAULT_ARGS.copy()
+        task_args = self.BATCH_PREDICTION_DEFAULT_ARGS.copy()
         with self.assertRaises(ValueError) as context:
             CloudMLBatchPredictionOperator(**task_args).execute(None)
         self.assertEquals(
@@ -234,7 +233,7 @@ class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
 
         with patch('airflow.contrib.operators.cloudml_operator.CloudMLHook') \
                 as mock_hook:
-            input_with_model = INPUT_MISSING_ORIGIN.copy()
+            input_with_model = self.INPUT_MISSING_ORIGIN.copy()
             input_with_model['modelName'] = \
                 'projects/experimental/models/test_model'
 
@@ -263,7 +262,7 @@ class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
                     {
                         'jobId': 'test_prediction',
                         'predictionInput': input_with_model
-                    })
+                    }, ANY)
 
             self.assertEquals(http_error_code, context.exception.resp.status)
 
@@ -275,12 +274,98 @@ class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
                 'state': 'FAILED',
                 'errorMessage': 'A failure message'
             }
-            task_args = DEFAULT_ARGS.copy()
+            task_args = self.BATCH_PREDICTION_DEFAULT_ARGS.copy()
             task_args['uri'] = 'a uri'
 
             with self.assertRaises(RuntimeError) as context:
                 CloudMLBatchPredictionOperator(**task_args).execute(None)
 
+            self.assertEquals('A failure message', str(context.exception))
+
+
+class CloudMLTrainingOperatorTest(unittest.TestCase):
+    TRAINING_DEFAULT_ARGS = {
+        'project_name': 'test-project',
+        'job_id': 'test_training',
+        'package_uris': ['gs://some-bucket/package1'],
+        'training_python_module': 'trainer',
+        'training_args': '--some_arg=\'aaa\'',
+        'region': 'us-east1',
+        'scale_tier': 'STANDARD_1',
+        'task_id': 'test-training'
+    }
+    TRAINING_INPUT = {
+        'jobId': 'test_training',
+        'trainingInput': {
+            'scaleTier': 'STANDARD_1',
+            'packageUris': ['gs://some-bucket/package1'],
+            'pythonModule': 'trainer',
+            'args': '--some_arg=\'aaa\'',
+            'region': 'us-east1'
+        }
+    }
+
+    def testSuccessCreateTrainingJob(self):
+        with patch('airflow.contrib.operators.cloudml_operator.CloudMLHook') \
+                as mock_hook:
+            success_response = self.TRAINING_INPUT.copy()
+            success_response['state'] = 'SUCCEEDED'
+            hook_instance = mock_hook.return_value
+            hook_instance.create_job.return_value = success_response
+
+            training_op = CloudMLTrainingOperator(**self.TRAINING_DEFAULT_ARGS)
+            training_op.execute(None)
+
+            mock_hook.assert_called_with(gcp_conn_id='google_cloud_default',
+                                         delegate_to=None)
+            # Make sure only 'create_job' is invoked on hook instance
+            self.assertEquals(len(hook_instance.mock_calls), 1)
+            hook_instance.create_job.assert_called_with(
+                'test-project', self.TRAINING_INPUT, ANY)
+
+    def testHttpError(self):
+        http_error_code = 403
+        with patch('airflow.contrib.operators.cloudml_operator.CloudMLHook') \
+                as mock_hook:
+            hook_instance = mock_hook.return_value
+            hook_instance.create_job.side_effect = errors.HttpError(
+                resp=httplib2.Response({
+                    'status': http_error_code
+                }), content=b'Forbidden')
+
+            with self.assertRaises(errors.HttpError) as context:
+                training_op = CloudMLTrainingOperator(
+                    **self.TRAINING_DEFAULT_ARGS)
+                training_op.execute(None)
+
+            mock_hook.assert_called_with(
+                gcp_conn_id='google_cloud_default', delegate_to=None)
+            # Make sure only 'create_job' is invoked on hook instance
+            self.assertEquals(len(hook_instance.mock_calls), 1)
+            hook_instance.create_job.assert_called_with(
+                'test-project', self.TRAINING_INPUT, ANY)
+            self.assertEquals(http_error_code, context.exception.resp.status)
+
+    def testFailedJobError(self):
+        with patch('airflow.contrib.operators.cloudml_operator.CloudMLHook') \
+                as mock_hook:
+            failure_response = self.TRAINING_INPUT.copy()
+            failure_response['state'] = 'FAILED'
+            failure_response['errorMessage'] = 'A failure message'
+            hook_instance = mock_hook.return_value
+            hook_instance.create_job.return_value = failure_response
+
+            with self.assertRaises(RuntimeError) as context:
+                training_op = CloudMLTrainingOperator(
+                    **self.TRAINING_DEFAULT_ARGS)
+                training_op.execute(None)
+
+            mock_hook.assert_called_with(
+                gcp_conn_id='google_cloud_default', delegate_to=None)
+            # Make sure only 'create_job' is invoked on hook instance
+            self.assertEquals(len(hook_instance.mock_calls), 1)
+            hook_instance.create_job.assert_called_with(
+                'test-project', self.TRAINING_INPUT, ANY)
             self.assertEquals('A failure message', str(context.exception))
 
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1271


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
This change added an operator for launching Google CloudML-Engine training jobs


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests.contrib.operators.test_cloudml_operator:CloudMLTrainingOperatorTest


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

