### PR TITLE
try to enable password for sshpass

### DIFF
--- a/airflow/contrib/hooks/ssh_hook.py
+++ b/airflow/contrib/hooks/ssh_hook.py
@@ -72,8 +72,8 @@ class SSHHook(BaseHook):
 
     def _prepare_command(self, cmd):
         connection_cmd = ["ssh", self._host_ref(), "-o", "ControlMaster=no"]
-        if self.sshpass:
-            connection_cmd = ["sshpass", "-e"] + connection_cmd
+        if self.conn.password:
+            connection_cmd = ["sshpass", "-p", self.conn.password] + connection_cmd
         else:
             connection_cmd += ["-o", "BatchMode=yes"]  # no password prompts
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-495


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
when user set the `password` in `Admin->Connections`, it does not work for the ssh remote server, `sshpass` not used the password saved before, so when you connect to remote server, you will got the issue, due to not connect to remote server, you can't create `tmpfile`, make sure your system installed `sshpass`.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

