### PR TITLE
[AIRFLOW-1382] Add working dir option

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -70,6 +70,9 @@ class DockerOperator(BaseOperator):
     :type user: int or str
     :param volumes: List of volumes to mount into the container, e.g.
         ``['/host/path:/container/path', '/host/path2:/container/path2:ro']``.
+    :param working_dir: Working directory to set on the container (equivalent to the -w switch
+        the docker client)
+    :type working_dir: str
     :param xcom_push: Does the stdout will be pushed to the next step using XCom.
            The default is False.
     :type xcom_push: bool
@@ -99,6 +102,7 @@ class DockerOperator(BaseOperator):
             tmp_dir='/tmp/airflow',
             user=None,
             volumes=None,
+            working_dir=None,
             xcom_push=False,
             xcom_all=False,
             *args,
@@ -122,6 +126,7 @@ class DockerOperator(BaseOperator):
         self.tmp_dir = tmp_dir
         self.user = user
         self.volumes = volumes or []
+        self.working_dir = working_dir
         self.xcom_push_flag = xcom_push
         self.xcom_all = xcom_all
 
@@ -169,7 +174,8 @@ class DockerOperator(BaseOperator):
                                                             network_mode=self.network_mode),
                     image=image,
                     mem_limit=self.mem_limit,
-                    user=self.user
+                    user=self.user,
+                    working_dir=self.working_dir
             )
             self.cli.start(self.container['Id'])
 

--- a/tests/operators/docker_operator.py
+++ b/tests/operators/docker_operator.py
@@ -52,7 +52,8 @@ class DockerOperatorTestCase(unittest.TestCase):
 
         operator = DockerOperator(api_version='1.19', command='env', environment={'UNIT': 'TEST'},
                                   image='ubuntu:latest', network_mode='bridge', owner='unittest',
-                                  task_id='unittest', volumes=['/host/path:/container/path'])
+                                  task_id='unittest', volumes=['/host/path:/container/path'],
+                                  working_dir='/container/path')
         operator.execute(None)
 
         client_class_mock.assert_called_with(base_url='unix://var/run/docker.sock', tls=None,
@@ -65,7 +66,9 @@ class DockerOperatorTestCase(unittest.TestCase):
                                                         },
                                                         host_config=host_config,
                                                         image='ubuntu:latest',
-                                                        mem_limit=None, user=None)
+                                                        mem_limit=None, user=None,
+                                                        working_dir='/container/path'
+                                                        )
         client_mock.create_host_config.assert_called_with(binds=['/host/path:/container/path',
                                                                  '/mkdtemp:/tmp/airflow'],
                                                           network_mode='bridge')


### PR DESCRIPTION
Allow the user to specify the working directory to be used in the
created container. Equivalent to docker run/create -w.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1382


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Docker containers can have a default working directory set, done using docker run/create -w on the command line. This PR updates the DockerOperator to provide that option.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Parameter added into existing unit test.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

