### PR TITLE
[AIRFLOW-1383] Add no_dag_reset option to airflow clear command

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Currently **officially** using Airflow:
 1. [LendUp](https://www.lendup.com/) [[@lendup](https://github.com/lendup)]
 1. [LetsBonus](http://www.letsbonus.com) [[@jesusfcr](https://github.com/jesusfcr) & [@OpringaoDoTurno](https://github.com/OpringaoDoTurno)]
 1. [Liberty Global](https://www.libertyglobal.com/) [[@LibertyGlobal](https://github.com/LibertyGlobal/)]
+1. [Lifesum](https://lifesum.com)
 1. [liligo](http://liligo.com/) [[@tromika](https://github.com/tromika)]
 1. [LingoChamp](http://www.liulishuo.com/) [[@haitaoyao](https://github.com/haitaoyao)]
 1. [Lucid](http://luc.id) [[@jbrownlucid](https://github.com/jbrownlucid) & [@kkourtchikov](https://github.com/kkourtchikov)]

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -699,6 +699,7 @@ def clear(args):
         confirm_prompt=not args.no_confirm,
         include_subdags=not args.exclude_subdags,
         include_parentdag=not args.exclude_parentdag,
+        reset_dag_runs=not args.no_dag_reset,
     )
 
 
@@ -1615,6 +1616,9 @@ class CLIFactory(object):
         'dag_regex': Arg(
             ("-dx", "--dag_regex"),
             "Search dag_id as regex instead of exact string", "store_true"),
+        'no_dag_reset': Arg(
+            ("--no_dag_reset", ),
+            "Do not reset DAG state after clearing tasks", "store_true"),
         # trigger_dag
         'run_id': Arg(("-r", "--run_id"), "Helps to identify this run"),
         'conf': Arg(
@@ -1971,7 +1975,8 @@ class CLIFactory(object):
             'args': (
                 'dag_id', 'task_regex', 'start_date', 'end_date', 'subdir',
                 'upstream', 'downstream', 'no_confirm', 'only_failed',
-                'only_running', 'exclude_subdags', 'exclude_parentdag', 'dag_regex'),
+                'only_running', 'exclude_subdags', 'exclude_parentdag',
+                'dag_regex', 'no_dag_reset'),
         }, {
             'func': pause,
             'help': "Pause a DAG",

--- a/tests/core.py
+++ b/tests/core.py
@@ -1472,6 +1472,11 @@ class CliTests(unittest.TestCase):
         with self.assertRaises(AirflowException):
             cli.get_dags(self.parser.parse_args(['clear', 'foobar', '-dx', '-c']))
 
+    def test_clear_no_reset(self):
+        args = self.parser.parse_args([
+            'clear', 'example_python_operator', '--no_dag_reset', '--no_confirm'])
+        cli.clear(args)
+
     def test_backfill(self):
         cli.backfill(self.parser.parse_args([
             'backfill', 'example_bash_operator',

--- a/tests/core.py
+++ b/tests/core.py
@@ -1473,9 +1473,20 @@ class CliTests(unittest.TestCase):
             cli.get_dags(self.parser.parse_args(['clear', 'foobar', '-dx', '-c']))
 
     def test_clear_no_reset(self):
+        # create an already-successful run of example_python_operator
+        run = self.dagbag.dags['example_python_operator'].create_dagrun(
+            run_id="reset_run",
+            execution_date=DEFAULT_DATE,
+            state=State.SUCCESS
+        )
+
+        # clear this DAG, with no_dag_reset
         args = self.parser.parse_args([
             'clear', 'example_python_operator', '--no_dag_reset', '--no_confirm'])
         cli.clear(args)
+
+        # the run should still have state=SUCCESS (ie, not set to RUNNING again)
+        self.assertEqual(run.state, State.SUCCESS)
 
     def test_backfill(self):
         cli.backfill(self.parser.parse_args([


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1383


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

The CLI command `airflow clear` does not expose any way to set the `reset_dag_runs` parameter of the underlying `DAG.clear()` method.

This means that `airflow clear` will always cause affected DAG runs to be set to `state=RUNNING`, and immediately try and re-run the cleared tasks. In some circumstances it might not be desirable to immediately re-run everything.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

A simple test for the CLI syntax is added to `tests/core.py`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

