### PR TITLE
[AIRFLOW-1386] - add SLEEP state for task instance

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -34,3 +34,7 @@ class AirflowTaskTimeout(AirflowException):
 
 class AirflowSkipException(AirflowException):
     pass
+
+
+class AirflowSleepException(AirflowException):
+    pass

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -62,9 +62,10 @@ import six
 from airflow import settings, utils
 from airflow.executors import GetDefaultExecutor, LocalExecutor
 from airflow import configuration
-from airflow.exceptions import AirflowException, AirflowSkipException, AirflowTaskTimeout
+from airflow.exceptions import AirflowException, AirflowSkipException, AirflowSleepException, AirflowTaskTimeout
 from airflow.dag.base_dag import BaseDag, BaseDagBag
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
+from airflow.ti_deps.deps.not_in_sleep_period_dep import NotInSleepPeriodDep
 from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 
@@ -1056,10 +1057,11 @@ class TaskInstance(Base):
     def is_premature(self):
         """
         Returns whether a task is in UP_FOR_RETRY state and its retry interval
-        has elapsed.
+        has elapsed or is in SLEEP state and its sleep interval has elapsed.
         """
         # is the task still in the retry waiting period?
-        return self.state == State.UP_FOR_RETRY and not self.ready_for_retry()
+        return (self.state == State.UP_FOR_RETRY and not self.ready_for_retry() or
+                self.state == State.SLEEP and not self.ready_for_wake_up())
 
     @provide_session
     def are_dependents_done(self, session=None):
@@ -1206,6 +1208,13 @@ class TaskInstance(Base):
                 delay = min(self.task.max_retry_delay, delay)
         return self.end_date + delay
 
+    def next_wake_up_datetime(self):
+        """
+        Get datetime of the next wake up if the task instance sleeps.
+        """
+        delay = self.task.sleep_delay
+        return self.end_date + delay
+
     def ready_for_retry(self):
         """
         Checks on whether the task instance is in the right state and timeframe
@@ -1213,6 +1222,14 @@ class TaskInstance(Base):
         """
         return (self.state == State.UP_FOR_RETRY and
                 self.next_retry_datetime() < datetime.now())
+
+    def ready_for_wake_up(self):
+        """
+        Checks on whether the task instance is in the right state and timeframe
+        to be waked up.
+        """
+        return (self.state == State.SLEEP and
+                self.next_wake_up_datetime() < datetime.now())
 
     @provide_session
     def pool_full(self, session):
@@ -1438,6 +1455,8 @@ class TaskInstance(Base):
             self.state = State.SUCCESS
         except AirflowSkipException:
             self.state = State.SKIPPED
+        except AirflowSleepException:
+            self.state = State.SLEEP
         except (Exception, KeyboardInterrupt) as e:
             self.handle_failure(e, test_mode, context)
             raise
@@ -1452,7 +1471,7 @@ class TaskInstance(Base):
 
         # Success callback
         try:
-            if task.on_success_callback:
+            if self.state != State.SLEEP and task.on_success_callback:
                 task.on_success_callback(context)
         except Exception as e3:
             logging.error("Failed when executing success callback")
@@ -1879,6 +1898,8 @@ class BaseOperator(object):
     :type retry_exponential_backoff: bool
     :param max_retry_delay: maximum delay interval between retries
     :type max_retry_delay: timedelta
+    :param sleep_delay: delay between wake ups
+    :type sleep_delay: timedelta
     :param start_date: The ``start_date`` for the task, determines
         the ``execution_date`` for the first task instance. The best practice
         is to have the start_date rounded
@@ -1983,6 +2004,7 @@ class BaseOperator(object):
             retry_delay=timedelta(seconds=300),
             retry_exponential_backoff=False,
             max_retry_delay=None,
+            sleep_delay=timedelta(seconds=300),
             start_date=None,
             end_date=None,
             schedule_interval=None,  # not hooked as of now
@@ -2061,6 +2083,11 @@ class BaseOperator(object):
             logging.debug("retry_delay isn't timedelta object, assuming secs")
             self.retry_delay = timedelta(seconds=retry_delay)
         self.retry_exponential_backoff = retry_exponential_backoff
+        if isinstance(sleep_delay, timedelta):
+            self.sleep_delay = sleep_delay
+        else:
+            logging.debug("sleep_delay isn't timedelta object, assuming secs")
+            self.sleep_delay = timedelta(seconds=sleep_delay)
         self.max_retry_delay = max_retry_delay
         self.params = params or {}  # Available in templates!
         self.adhoc = adhoc
@@ -2222,6 +2249,7 @@ class BaseOperator(object):
         """
         return {
             NotInRetryPeriodDep(),
+            NotInSleepPeriodDep(),
             PrevDagrunDep(),
             TriggerRuleDep(),
         }
@@ -4028,7 +4056,9 @@ class DagRun(Base):
 
     ID_PREFIX = 'scheduled__'
     ID_FORMAT_PREFIX = ID_PREFIX + '{0}'
-    DEADLOCK_CHECK_DEP_CONTEXT = DepContext(ignore_in_retry_period=True)
+    DEADLOCK_CHECK_DEP_CONTEXT = DepContext(
+        ignore_in_retry_period=True,
+        ignore_in_sleep_period=True)
 
     id = Column(Integer, primary_key=True)
     dag_id = Column(String(ID_LEN))
@@ -4256,8 +4286,8 @@ class DagRun(Base):
             # todo: this can actually get pretty slow: one task costs between 0.01-015s
             no_dependencies_met = all(
                 # Use a special dependency context that ignores task's up for retry
-                # dependency, since a task that is up for retry is not necessarily
-                # deadlocked.
+                # and sleep dependency, since a task that is up for retry or sleeping
+                # is not necessarily deadlocked.
                 not t.are_dependencies_met(dep_context=self.DEADLOCK_CHECK_DEP_CONTEXT,
                                            session=session)
                 for t in unfinished_tasks)

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -26,7 +26,7 @@ import re
 import sys
 
 from airflow import settings
-from airflow.exceptions import AirflowException, AirflowSensorTimeout, AirflowSkipException
+from airflow.exceptions import AirflowException, AirflowSensorTimeout, AirflowSkipException, AirflowSleepException
 from airflow.models import BaseOperator, TaskInstance
 from airflow.hooks.base_hook import BaseHook
 from airflow.hooks.hdfs_hook import HDFSHook
@@ -59,6 +59,7 @@ class BaseSensorOperator(BaseOperator):
             timeout=60*60*24*7,
             soft_fail=False,
             *args, **kwargs):
+        kwargs['sleep_delay'] = poke_interval
         super(BaseSensorOperator, self).__init__(*args, **kwargs)
         self.poke_interval = poke_interval
         self.soft_fail = soft_fail
@@ -79,7 +80,7 @@ class BaseSensorOperator(BaseOperator):
                     raise AirflowSkipException('Snap. Time is OUT.')
                 else:
                     raise AirflowSensorTimeout('Snap. Time is OUT.')
-            sleep(self.poke_interval)
+            raise AirflowSleepException('Snap. Time is OUT.')
         logging.info("Success criteria met. Exiting.")
 
 

--- a/airflow/ti_deps/dep_context.py
+++ b/airflow/ti_deps/dep_context.py
@@ -51,6 +51,8 @@ class DepContext(object):
     :type ignore_depends_on_past: boolean
     :param ignore_in_retry_period: Ignore the retry period for task instances
     :type ignore_in_retry_period: boolean
+    :param ignore_in_sleep_period: Ignore the sleep period for task instances
+    :type ignore_in_sleep_period: boolean
     :param ignore_task_deps: Ignore task-specific dependencies such as depends_on_past and
         trigger rule
     :type ignore_task_deps: boolean
@@ -64,6 +66,7 @@ class DepContext(object):
             ignore_all_deps=False,
             ignore_depends_on_past=False,
             ignore_in_retry_period=False,
+            ignore_in_sleep_period=False,
             ignore_task_deps=False,
             ignore_ti_state=False):
         self.deps = deps or set()
@@ -71,6 +74,7 @@ class DepContext(object):
         self.ignore_all_deps = ignore_all_deps
         self.ignore_depends_on_past = ignore_depends_on_past
         self.ignore_in_retry_period = ignore_in_retry_period
+        self.ignore_in_sleep_period = ignore_in_sleep_period
         self.ignore_task_deps = ignore_task_deps
         self.ignore_ti_state = ignore_ti_state
 
@@ -83,6 +87,7 @@ QUEUEABLE_STATES = {
     State.SKIPPED,
     State.UPSTREAM_FAILED,
     State.UP_FOR_RETRY,
+    State.SLEEP,
 }
 
 # Context to get the dependencies that need to be met in order for a task instance to

--- a/airflow/ti_deps/deps/not_in_sleep_period_dep.py
+++ b/airflow/ti_deps/deps/not_in_sleep_period_dep.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import datetime
+
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils.db import provide_session
+from airflow.utils.state import State
+
+
+class NotInSleepPeriodDep(BaseTIDep):
+    NAME = "Not In Sleep Period"
+    IGNOREABLE = True
+    IS_TASK_DEP = True
+
+    @provide_session
+    def _get_dep_statuses(self, ti, session, dep_context):
+        if dep_context.ignore_in_sleep_period:
+            yield self._passing_status(
+                reason="The context specified that being in a sleep period was "
+                       "permitted.")
+            return
+
+        if ti.state != State.SLEEP:
+            yield self._passing_status(
+                reason="The task instance was not sleeping.")
+            return
+
+        # Calculate the date first so that it is always smaller than the timestamp used by
+        # ready_for_wake_up
+        cur_date = datetime.now()
+        next_task_wake_up_date = ti.next_wake_up_datetime()
+        if ti.is_premature:
+            yield self._failing_status(
+                reason="Task is not ready to wake up yet but will be waked up "
+                       "automatically. Current date is {0} and task will be waked up "
+                       "at {1}.".format(cur_date.isoformat(),
+                                        next_task_wake_up_date.isoformat()))

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -38,6 +38,7 @@ class State(object):
     SHUTDOWN = "shutdown"  # External request to shut down
     FAILED = "failed"
     UP_FOR_RETRY = "up_for_retry"
+    SLEEP = "sleep"
     UPSTREAM_FAILED = "upstream_failed"
     SKIPPED = "skipped"
 
@@ -47,6 +48,7 @@ class State(object):
         FAILED,
         UPSTREAM_FAILED,
         UP_FOR_RETRY,
+        SLEEP,
         QUEUED,
     )
 
@@ -63,6 +65,7 @@ class State(object):
         SHUTDOWN: 'blue',
         FAILED: 'red',
         UP_FOR_RETRY: 'gold',
+        SLEEP: 'lightgray',
         UPSTREAM_FAILED: 'orange',
         SKIPPED: 'pink',
         REMOVED: 'lightgrey',
@@ -109,5 +112,6 @@ class State(object):
             cls.SCHEDULED,
             cls.QUEUED,
             cls.RUNNING,
-            cls.UP_FOR_RETRY
+            cls.UP_FOR_RETRY,
+            cls.SLEEP
         ]

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2503,6 +2503,10 @@ class TaskInstanceModelView(ModelViewOnly):
     def action_set_retry(self, ids):
         self.set_task_instance_state(ids, State.UP_FOR_RETRY)
 
+    @action('set_sleep', "Set state to 'sleep'", None)
+    def action_set_sleep(self, ids):
+        self.set_task_instance_state(ids, State.SLEEP)
+
     @action('delete',
             lazy_gettext('Delete'),
             lazy_gettext('Are you sure you want to delete selected records?'))


### PR DESCRIPTION
Dear Airflow maintainers,

I realized that this might be a huge change, therefore instead of rushing into completing the code, I would like to open a  PR for discussion purposes.

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1386


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:

Currently when the sensor is sleeping, the task process stays in RUNNING state and it still consumes resources such as memory (because the process does not terminate). This is waste of resource, especially when there are thousands of sensors sleeping and poking. Preferably when it sleeps, it would enter a SLEEP state and terminate, waiting for scheduler to reschedule it.

We encountered this issue when we were using S3KeySensors to sense some s3 paths that might not be present for days. (The exact time for them to be present could not be predicted because they were generated by external sources.) The running queue was quickly filled up with these S3KeySensors. Moreover, these sensors took a lot of memory even while they were sleeping.

Although we might mimic the SLEEP state with UP_FOR_RETRY by using the following settings:
```
timeout=0,
retry_limit=99999999999999,
```

There are still some cases that we would like to distinguish between SLEEP and UP_FOR_RETRY. For example, we may submit a certain command to a remote API service, and start polling for the running state of that command. Since the command might take long time to complete, we also want to leave RUNNING state so we could run other tasks on the local machine. However, when the remote API returns failure status, we would like to actually retry by submitting API request again.

There are some design choices that must be made:

- Should sensors support both sleeping in RUNNING state and sleeping in SLEEP state? Or just drop the old behavior?
- Should we reuse `poke_interval` for this purpose or create new parameters?
- Should we implement it in `BaseOperator` so all tasks could sleep, or just `BaseSenorOperator`?

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

