### PR TITLE
[AIRFLOW-1387] Add unicode string prefix

### DIFF
--- a/airflow/task_runner/base_task_runner.py
+++ b/airflow/task_runner/base_task_runner.py
@@ -94,7 +94,7 @@ class BaseTaskRunner(LoggingMixin):
                 line = line.decode('utf-8')
             if len(line) == 0:
                 break
-            self.logger.info('Subtask: {}'.format(line.rstrip('\n')))
+            self.logger.info(u'Subtask: {}'.format(line.rstrip('\n')))
 
     def run_command(self, run_with, join_args=False):
         """


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-1387] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1387


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Python's format function has a feature of encoding the supplied
variable with the same encoding as a string where substitution will
take place. In case the string is not originally specified as unicode
default encoding will be used. This will yield an error if
sys.getdefaultencoding() is not 'utf-8' because it will try to encode
previously utf8 decoded string (with unicode chars) as non unicode.
Solution based on SO 5082452.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Does not add any unit tests as it affects function's side effects (not sure how to test it). I tested it on default vagrant ubuntu 16.04 machine using the task which was crashing before and it worked.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
