### PR TITLE
[AIRFLOW-1393] Python3 tests in contrib/spark_submit_hook

### DIFF
--- a/airflow/contrib/hooks/spark_submit_hook.py
+++ b/airflow/contrib/hooks/spark_submit_hook.py
@@ -212,9 +212,11 @@ class SparkSubmitHook(BaseHook):
         self._sp = subprocess.Popen(spark_submit_cmd,
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT,
+                                    bufsize=-1,
+                                    universal_newlines=True,
                                     **kwargs)
 
-        self._process_log(iter(self._sp.stdout.readline, b''))
+        self._process_log(iter(self._sp.stdout.readline, ''))
         returncode = self._sp.wait()
 
         if returncode:
@@ -232,7 +234,7 @@ class SparkSubmitHook(BaseHook):
         """
         # Consume the iterator
         for line in itr:
-            line = line.decode('utf-8').strip()
+            line = line.strip()
             # If we run yarn cluster mode, we want to extract the application id from
             # the logs so we can kill the application when we stop it unexpectedly
             if self._is_yarn and self._connection['deploy_mode'] == 'cluster':

--- a/tests/contrib/hooks/test_spark_submit_hook.py
+++ b/tests/contrib/hooks/test_spark_submit_hook.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import six
 import sys
 import unittest
-from io import StringIO
 
 from airflow import configuration, models
 from airflow.utils import db
@@ -62,10 +62,6 @@ class TestSparkSubmitHook(unittest.TestCase):
         return return_dict
 
     def setUp(self):
-
-        if sys.version_info[0] == 3:
-            raise unittest.SkipTest('TestSparkSubmitHook won\'t work with '
-                                    'python3. No need to test anything here')
 
         configuration.load_test_config()
         db.merge_conn(
@@ -135,11 +131,11 @@ class TestSparkSubmitHook(unittest.TestCase):
         ]
         self.assertEquals(expected_build_cmd, cmd)
 
-    @patch('subprocess.Popen')
+    @patch('airflow.contrib.hooks.spark_submit_hook.subprocess.Popen')
     def test_spark_process_runcmd(self, mock_popen):
         # Given
-        mock_popen.return_value.stdout = StringIO(u'stdout')
-        mock_popen.return_value.stderr = StringIO(u'stderr')
+        mock_popen.return_value.stdout = six.StringIO('stdout')
+        mock_popen.return_value.stderr = six.StringIO('stderr')
         mock_popen.return_value.wait.return_value = 0
 
         # When
@@ -147,7 +143,7 @@ class TestSparkSubmitHook(unittest.TestCase):
         hook.submit()
 
         # Then
-        self.assertEqual(mock_popen.mock_calls[0], call(['spark-submit', '--master', 'yarn', '--name', 'default-name', ''], stdout=-1, stderr=-2))
+        self.assertEqual(mock_popen.mock_calls[0], call(['spark-submit', '--master', 'yarn', '--name', 'default-name', ''], stderr=-2, stdout=-1, universal_newlines=True, bufsize=-1))
 
     def test_resolve_connection_yarn_default(self):
         # Given
@@ -309,11 +305,11 @@ class TestSparkSubmitHook(unittest.TestCase):
 
         self.assertEqual(hook._yarn_application_id, 'application_1486558679801_1820')
 
-    @patch('subprocess.Popen')
+    @patch('airflow.contrib.hooks.spark_submit_hook.subprocess.Popen')
     def test_spark_process_on_kill(self, mock_popen):
         # Given
-        mock_popen.return_value.stdout = StringIO(u'stdout')
-        mock_popen.return_value.stderr = StringIO(u'stderr')
+        mock_popen.return_value.stdout = six.StringIO('stdout')
+        mock_popen.return_value.stderr = six.StringIO('stderr')
         mock_popen.return_value.poll.return_value = None
         mock_popen.return_value.wait.return_value = 0
         log_lines = [


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [[AIRFLOW-1393] Enable Python3 tests on contrib Spark Submit Hook](https://issues.apache.org/jira/browse/AIRFLOW-1393)


### Description

The unit tests in `tests/contrib/hooks/test_spark_submit_hook.py`
currently skip if run in Python3 because some test cases  loop forever
due to a mismatch/misunderstanding about bytes vs string (i.e. the
mocked data for `subprocess.Popen` doesn't behave the same as actually
running Popen)

The fix is to use bytes and `six.ByteIO` so that the tests work on Py2
and Py3. Alsowe had to patch `subprocess.Popen` in the right place so
the mocks are picked up.

### Tests
- This PR removes the "skip" for Python3 for this test file.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

