### PR TITLE
[AIRFLOW-1394] Add quote_character parameter to GoogleCloudStorageToBigQueryOperator

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -375,6 +375,7 @@ class BigQueryBaseCursor(object):
                  write_disposition='WRITE_EMPTY',
                  field_delimiter=',',
                  max_bad_records=0,
+                 quote_character=None,
                  schema_update_options=()):
         """
         Executes a BigQuery load command to load data from Google Cloud Storage
@@ -409,6 +410,8 @@ class BigQueryBaseCursor(object):
         :param max_bad_records: The maximum number of bad records that BigQuery can
             ignore when running the job.
         :type max_bad_records: int
+        :param quote_character: The value that is used to quote data sections in a CSV file.
+        :type quote_character: string
         :param schema_update_options: Allows the schema of the desitination
             table to be updated as a side effect of the load job.
         :type schema_update_options: list
@@ -484,6 +487,9 @@ class BigQueryBaseCursor(object):
 
         if max_bad_records:
             configuration['load']['maxBadRecords'] = max_bad_records
+
+        if quote_character:
+            configuration['load']['quote'] = quote_character
 
         return self.run_with_configuration(configuration)
 

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -44,6 +44,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         write_disposition='WRITE_EMPTY',
         field_delimiter=',',
         max_bad_records=0,
+        quote_character=None,
         max_id_key=None,
         bigquery_conn_id='bigquery_default',
         google_cloud_storage_conn_id='google_cloud_storage_default',
@@ -84,6 +85,8 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         :param max_bad_records: The maximum number of bad records that BigQuery can
             ignore when running the job.
         :type max_bad_records: int
+        :param quote_character: The value that is used to quote data sections in a CSV file.
+        :type quote_character: string
         :param max_id_key: If set, the name of a column in the BigQuery table
             that's to be loaded. Thsi will be used to select the MAX value from
             BigQuery after the load occurs. The results will be returned by the
@@ -120,6 +123,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         self.write_disposition = write_disposition
         self.field_delimiter = field_delimiter
         self.max_bad_records = max_bad_records
+        self.quote_character = quote_character
 
         self.max_id_key = max_id_key
         self.bigquery_conn_id = bigquery_conn_id
@@ -156,6 +160,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
             write_disposition=self.write_disposition,
             field_delimiter=self.field_delimiter,
             max_bad_records=self.max_bad_records,
+            quote_character=self.quote_character,
             schema_update_options=self.schema_update_options)
 
         if self.max_id_key:


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1394


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
    - Add quote_character parameter to the GoogleCloudStorageToBigQueryOperator and the BigQueryHook.run_load method. This parameter will make it possible to set the value that is used to quote data sections in a CSV file.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - I tested this change locally without any problems.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

