### PR TITLE
[AIRFLOW-1398] Add ability for ExternalTaskSensor to wait on multiple…

### DIFF
--- a/tests/operators/sensors.py
+++ b/tests/operators/sensors.py
@@ -22,12 +22,18 @@ import unittest
 from mock import patch
 from datetime import datetime, timedelta
 
-from airflow import DAG, configuration
-from airflow.operators.sensors import HttpSensor, BaseSensorOperator, HdfsSensor
+from airflow import DAG, configuration, jobs, settings
+from airflow.jobs import BackfillJob, SchedulerJob
+from airflow.models import TaskInstance, DagModel, DagBag
+from airflow.operators.sensors import HttpSensor, BaseSensorOperator, HdfsSensor, ExternalTaskSensor
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.exceptions import (AirflowException,
                                 AirflowSensorTimeout,
                                 AirflowSkipException)
+from airflow.utils.state import State
+from tests.core import TEST_DAG_FOLDER
 configuration.load_test_config()
 
 DEFAULT_DATE = datetime(2015, 1, 1)
@@ -254,3 +260,103 @@ class HdfsSensorTests(unittest.TestCase):
         # Then
         with self.assertRaises(AirflowSensorTimeout):
             task.execute(None)
+
+
+class ExternalTaskSensorTests(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+        self.args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE,
+            'depends_on_past': False}
+
+    def test_external_task_sensor_fn_multiple_execution_dates(self):
+        bash_command_code = """
+{% set s=execution_date.time().second %}
+echo "second is {{ s }}"
+if [[ $(( {{ s }} % 60 )) == 1 ]]
+    then
+        exit 1
+fi
+exit 0
+"""
+        dag_external_id = TEST_DAG_ID + '_external'
+        dag_external = DAG(
+            dag_external_id,
+            default_args=self.args,
+            schedule_interval=timedelta(seconds=1))
+        task_external_with_failure = BashOperator(
+            task_id="task_external_with_failure",
+            bash_command=bash_command_code,
+            retries=0,
+            dag=dag_external)
+        task_external_without_failure = DummyOperator(
+            task_id="task_external_without_failure",
+            retries=0,
+            dag=dag_external)
+
+        task_external_without_failure.run(
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + timedelta(seconds=1),
+            ignore_ti_state=True)
+
+        session = settings.Session()
+        TI = TaskInstance
+        try:
+            task_external_with_failure.run(
+                start_date=DEFAULT_DATE,
+                end_date=DEFAULT_DATE + timedelta(seconds=1),
+                ignore_ti_state=True)
+            # The test_with_failure task is excepted to fail
+            # once per minute (the run on the first second of
+            # each minute).
+        except Exception as e:
+            failed_tis = session.query(TI).filter(
+                TI.dag_id == dag_external_id,
+                TI.state == State.FAILED,
+                TI.execution_date == DEFAULT_DATE + timedelta(seconds=1)).all()
+            if (len(failed_tis) == 1 and
+                    failed_tis[0].task_id == 'task_external_with_failure'):
+                pass
+            else:
+                raise e
+
+        dag_id = TEST_DAG_ID
+        dag = DAG(
+            dag_id,
+            default_args=self.args,
+            schedule_interval=timedelta(minutes=1))
+        task_without_failure = ExternalTaskSensor(
+            task_id='task_without_failure',
+            external_dag_id=dag_external_id,
+            external_task_id='task_external_without_failure',
+            execution_date_fn=lambda dt: [dt + timedelta(seconds=i)
+                                          for i in range(2)],
+            allowed_states=['success'],
+            retries=0,
+            timeout=1,
+            poke_interval=1,
+            dag=dag)
+        task_with_failure = ExternalTaskSensor(
+            task_id='task_with_failure',
+            external_dag_id=dag_external_id,
+            external_task_id='task_external_with_failure',
+            execution_date_fn=lambda dt: [dt + timedelta(seconds=i)
+                                          for i in range(2)],
+            allowed_states=['success'],
+            retries=0,
+            timeout=1,
+            poke_interval=1,
+            dag=dag)
+
+        task_without_failure.run(
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
+            ignore_ti_state=True)
+
+        with self.assertRaises(AirflowSensorTimeout):
+            task_with_failure.run(
+                start_date=DEFAULT_DATE,
+                end_date=DEFAULT_DATE,
+                ignore_ti_state=True)


### PR DESCRIPTION
… runs of a task

Currently using the execution_date_fn parameter of the ExternalTaskSensor
sensors only allows to wait for the completion of one given run of the
task the ExternalTaskSensor is sensing.

However, this prevents users to have setups where dags don't have the same
schedule frequency but still depend on one another. For example, let's say
you have a dag scheduled hourly that transforms log data and is owned by
the team in charge of logging. In the current setup you cannot have other
higher level teams, that want to use this transformed data, create
dags processing transformed log data in daily batches, while making sure
the logged transformed data was properly created.
Note that simply waiting for the data to be present (using e.g. the
HivePartitionSensor if the data is in hive) might not be satisfactory
because the data being present doesn't mean it is ready to be used.

This commit makes it possible to do exactly that by being able to have
an ExternalTaskSensor wait for multiple runs of the task it is sensing to
have finished. Now higher level teams can setup dags with an
ExternalTaskSensor sensing the end task of the dag that transforms the
log data and waiting for the successful completion of 24 of its hourly runs.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1398) issues and references them in the PR title. For example, "[AIRFLOW-1398] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1398


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
Add ability for ExternalTaskSensor to wait on multiple runs of a task

Currently using the execution_date_fn parameter of the ExternalTaskSensor
sensors only allows to wait for the completion of one given run of the
task the ExternalTaskSensor is sensing.

However, this prevents users to have setups where dags don't have the same
schedule frequency but still depend on one another. For example, let's say
you have a dag scheduled hourly that transforms log data and is owned by
the team in charge of logging. In the current setup you cannot have other
higher level teams, that want to use this transformed data, create
dags processing transformed log data in daily batches, while making sure
the logged transformed data was properly created.
Note that simply waiting for the data to be present (using e.g. the
HivePartitionSensor if the data is in hive) might not be satisfactory
because the data being present doesn't mean it is ready to be used.

This commit makes it possible to do exactly that by being able to have
an ExternalTaskSensor wait for multiple runs of the task it is sensing to
have finished. Now higher level teams can setup dags with an
ExternalTaskSensor sensing the end task of the dag that transforms the
log data and waiting for the successful completion of 24 of its hourly runs.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests.operators.sensors:ExternalTaskSensorTests.test_external_task_sensor_fn_multiple_execution_dates

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

