### PR TITLE
AIRFLOW-1399 dont read logfile in memory if remote base isn't specified

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -316,7 +316,7 @@ def run(args, dag=None):
     # Load custom airflow config
     if args.cfg_path:
         with open(args.cfg_path, 'r') as conf_file:
-           conf_dict = json.load(conf_file)
+            conf_dict = json.load(conf_file)
 
         if os.path.exists(args.cfg_path):
             os.remove(args.cfg_path)
@@ -458,6 +458,10 @@ def run(args, dag=None):
     logging.root.handlers = []
 
     # store logs remotely
+    _store_logs_remotely(log_base, filename)
+
+
+def _store_logs_remotely(log_base, filename):
     remote_base = conf.get('core', 'REMOTE_BASE_LOG_FOLDER')
 
     # deprecated as of March 2016
@@ -469,7 +473,10 @@ def run(args, dag=None):
             DeprecationWarning)
         remote_base = conf.get('core', 'S3_LOG_FOLDER')
 
-    if os.path.exists(filename):
+    if remote_base == 'None':
+        remote_base = None
+
+    if remote_base and os.path.exists(filename):
         # read log and remove old logs to get just the latest additions
 
         with open(filename, 'r') as logfile:
@@ -483,7 +490,7 @@ def run(args, dag=None):
         elif remote_base.startswith('gs:/'):
             logging_utils.GCSLog().write(log, remote_log_location)
         # Other
-        elif remote_base and remote_base != 'None':
+        else:
             logging.error(
                 'Unsupported remote log location: {}'.format(remote_base))
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1399

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Small two line change

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

