### PR TITLE
[AIRFLOW-1402] Cleanup SafeConfigParser DeprecationWarning

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -42,7 +42,10 @@ warnings.filterwarnings(
 warnings.filterwarnings(
     action='default', category=PendingDeprecationWarning, module='airflow')
 
-ConfigParser = configparser.SafeConfigParser
+if six.PY3:
+    ConfigParser = configparser.ConfigParser
+else:
+    ConfigParser = configparser.SafeConfigParser
 
 
 def generate_fernet_key():


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA]https://issues.apache.org/jira/browse/AIRFLOW-1402) issues and references them in the PR title.

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- use ConfigParser for python 3.x 
`DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.`

### Tests
- [x] Test done with ./run_unit_tests.sh on python 2.x and python 3.x pyenv


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

