### PR TITLE
[AIRFLOW-1255] Fix SparkSubmitHook logging deadlock

### DIFF
--- a/tests/contrib/hooks/test_spark_submit_hook.py
+++ b/tests/contrib/hooks/test_spark_submit_hook.py
@@ -140,15 +140,14 @@ class TestSparkSubmitHook(unittest.TestCase):
         # Given
         mock_popen.return_value.stdout = StringIO(u'stdout')
         mock_popen.return_value.stderr = StringIO(u'stderr')
-        mock_popen.return_value.returncode = 0
-        mock_popen.return_value.communicate.return_value = [StringIO(u'stdout\nstdout'), StringIO(u'stderr\nstderr')]
+        mock_popen.return_value.wait.return_value = 0
 
         # When
         hook = SparkSubmitHook(conn_id='')
         hook.submit()
 
         # Then
-        self.assertEqual(mock_popen.mock_calls[0], call(['spark-submit', '--master', 'yarn', '--name', 'default-name', ''], stderr=-1, stdout=-1))
+        self.assertEqual(mock_popen.mock_calls[0], call(['spark-submit', '--master', 'yarn', '--name', 'default-name', ''], stdout=-1, stderr=-2))
 
     def test_resolve_connection_yarn_default(self):
         # Given
@@ -315,9 +314,8 @@ class TestSparkSubmitHook(unittest.TestCase):
         # Given
         mock_popen.return_value.stdout = StringIO(u'stdout')
         mock_popen.return_value.stderr = StringIO(u'stderr')
-        mock_popen.return_value.returncode = 0
         mock_popen.return_value.poll.return_value = None
-        mock_popen.return_value.communicate.return_value = [StringIO(u'stderr\nstderr'), StringIO(u'stderr\nstderr')]
+        mock_popen.return_value.wait.return_value = 0
         log_lines = [
             'SPARK_MAJOR_VERSION is set to 2, using Spark2',
             'WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable',


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1255


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

The `SparkSubmitHook` implementation currently deadlocks if the Spark job logs "too much" output to stderr. This occurs because the current implementation tries to read from both stdout and stderr, but has been implemented incorrectly. Specifically the current implementation assumes it can read all of stdout in a blocking manner before looking at stderr. This fails if the job logs to stderr more than the kernel 'pipe buffer' limit (e.g. 64KB on modern Linux), causing the Spark job to be suspended as per Unix pipe semantics. At this point Airflow is waiting for EOF from Spark stdout and Spark is waiting on Airflow to drain the stderr pipe. That's a deadlock.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
