### PR TITLE
[AIRFLOW-1401] Standardize cloud ml operator arguments

### DIFF
--- a/tests/contrib/hooks/test_gcp_cloudml_hook.py
+++ b/tests/contrib/hooks/test_gcp_cloudml_hook.py
@@ -121,7 +121,7 @@ class TestCloudMLHook(unittest.TestCase):
                 responses=[succeeded_response] * 2,
                 expected_requests=expected_requests) as cml_hook:
             create_version_response = cml_hook.create_version(
-                project_name=project, model_name=model_name,
+                project_id=project, model_name=model_name,
                 version_spec=version)
             self.assertEquals(create_version_response, response_body)
 
@@ -147,7 +147,7 @@ class TestCloudMLHook(unittest.TestCase):
                 responses=[succeeded_response],
                 expected_requests=expected_requests) as cml_hook:
             set_default_version_response = cml_hook.set_default_version(
-                project_name=project, model_name=model_name,
+                project_id=project, model_name=model_name,
                 version_name=version)
             self.assertEquals(set_default_version_response, response_body)
 
@@ -187,7 +187,7 @@ class TestCloudMLHook(unittest.TestCase):
                 responses=responses,
                 expected_requests=expected_requests) as cml_hook:
             list_versions_response = cml_hook.list_versions(
-                project_name=project, model_name=model_name)
+                project_id=project, model_name=model_name)
             self.assertEquals(list_versions_response, versions)
 
     @_SKIP_IF
@@ -220,7 +220,7 @@ class TestCloudMLHook(unittest.TestCase):
                 responses=[not_done_response, succeeded_response],
                 expected_requests=expected_requests) as cml_hook:
             delete_version_response = cml_hook.delete_version(
-                project_name=project, model_name=model_name,
+                project_id=project, model_name=model_name,
                 version_name=version)
             self.assertEquals(delete_version_response, done_response_body)
 
@@ -245,7 +245,7 @@ class TestCloudMLHook(unittest.TestCase):
                 responses=[succeeded_response],
                 expected_requests=expected_requests) as cml_hook:
             create_model_response = cml_hook.create_model(
-                project_name=project, model=model)
+                project_id=project, model=model)
             self.assertEquals(create_model_response, response_body)
 
     @_SKIP_IF
@@ -266,7 +266,7 @@ class TestCloudMLHook(unittest.TestCase):
                 responses=[succeeded_response],
                 expected_requests=expected_requests) as cml_hook:
             get_model_response = cml_hook.get_model(
-                project_name=project, model_name=model_name)
+                project_id=project, model_name=model_name)
             self.assertEquals(get_model_response, response_body)
 
     @_SKIP_IF
@@ -302,7 +302,7 @@ class TestCloudMLHook(unittest.TestCase):
                 responses=responses,
                 expected_requests=expected_requests) as cml_hook:
             create_job_response = cml_hook.create_job(
-                project_name=project, job=my_job)
+                project_id=project, job=my_job)
             self.assertEquals(create_job_response, my_job)
 
     @_SKIP_IF
@@ -334,7 +334,7 @@ class TestCloudMLHook(unittest.TestCase):
                 responses=responses,
                 expected_requests=expected_requests) as cml_hook:
             create_job_response = cml_hook.create_job(
-                project_name=project, job=my_job)
+                project_id=project, job=my_job)
             self.assertEquals(create_job_response, my_job)
 
     @_SKIP_IF
@@ -386,7 +386,7 @@ class TestCloudMLHook(unittest.TestCase):
                 expected_requests=expected_requests) as cml_hook:
             with self.assertRaises(errors.HttpError):
                 cml_hook.create_job(
-                    project_name=project, job=my_job,
+                    project_id=project, job=my_job,
                     use_existing_job_fn=check_input)
 
         my_job_response = ({'status': '200'}, my_job_response_body)
@@ -404,7 +404,7 @@ class TestCloudMLHook(unittest.TestCase):
                 responses=responses,
                 expected_requests=expected_requests) as cml_hook:
             create_job_response = cml_hook.create_job(
-                project_name=project, job=my_job,
+                project_id=project, job=my_job,
                 use_existing_job_fn=check_input)
             self.assertEquals(create_job_response, my_job)
 

--- a/tests/contrib/operators/test_cloudml_operator.py
+++ b/tests/contrib/operators/test_cloudml_operator.py
@@ -285,7 +285,7 @@ class CloudMLBatchPredictionOperatorTest(unittest.TestCase):
 
 class CloudMLTrainingOperatorTest(unittest.TestCase):
     TRAINING_DEFAULT_ARGS = {
-        'project_name': 'test-project',
+        'project_id': 'test-project',
         'job_id': 'test_training',
         'package_uris': ['gs://some-bucket/package1'],
         'training_python_module': 'trainer',


### PR DESCRIPTION
Standardize on project_id, to be consistent with other cloud operators,
better-supporting default arguments.

This is one of multiple commits that will be required to resolve
AIRFLOW-1401.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

