### PR TITLE
[AIRFLOW-1247] Fix ignore all dependencies argument ignored

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1307,7 +1307,7 @@ class CLIFactory(object):
         'ignore_all_dependencies': Arg(
             ("-A", "--ignore_all_dependencies"),
             "Ignores all non-critical dependencies, including ignore_ti_state and "
-            "ignore_task_deps"
+            "ignore_task_deps",
             "store_true"),
         # TODO(aoen): ignore_dependencies is a poor choice of name here because it is too
         # vague (e.g. a task being in the appropriate state to be run is also a dependency


### PR DESCRIPTION
@saguziel @bolkedebruin 

Copy of https://github.com/apache/incubator-airflow/pull/2327 without the tests since they seem broken.

### JIRA
- My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1247

### Tests
- No tests added for now, it's a small typo fix to unbreak the command. We should add CLI tests later like was attempted here: https://github.com/apache/incubator-airflow/pull/2327

