### PR TITLE
[AIRFLOW-1412] Add config to truncate the task log file

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -457,6 +457,20 @@ def run(args, dag=None):
     logging.root.handlers[0].flush()
     logging.root.handlers = []
 
+    # truncate log files
+    max_log_file_size = conf.get('core', 'MAX_LOG_FILE_SIZE_BYTES')
+    if (
+        max_log_file_size and
+        os.path.exists(filename) and
+        os.path.getsize(filename) > int(max_log_file_size)
+    ):
+        command = 'truncate -s %s %s' % (max_log_file_size, filename)
+        try:
+            subprocess.check_call(command, shell=True)
+        except subprocess.CalledProcessError as e:
+            # don't fail the process just because log file truncate fails
+            logging.error(e)
+
     # store logs remotely
     remote_base = conf.get('core', 'REMOTE_BASE_LOG_FOLDER')
 

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -35,6 +35,9 @@ dags_folder = {AIRFLOW_HOME}/dags
 # This path must be absolute
 base_log_folder = {AIRFLOW_HOME}/logs
 
+# The max size of each task log file
+max_log_file_size_bytes =
+
 # Airflow can store logs remotely in AWS S3 or Google Cloud Storage. Users
 # must supply a remote location URL (starting with either 's3://...' or
 # 'gs://...') and an Airflow connection id that provides access to the storage


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1412


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

Reasons for doing this:
    1. webserver would hang if you try to view log that is too big
    2. unlimited log size could be bad for disk space

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I didn't see unit tests for logs in the code base

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
