### PR TITLE
[ARIFLOW-1414] Add support for retriggering dependent workflows

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3055,6 +3055,34 @@ class DAG(BaseDag, LoggingMixin):
         session.close()
         return execution_date
 
+    def descendants(self, dagbag, task_ids=None, include_downstream=False,
+                    include_upstream=False, recursive=False):
+        from airflow.operators.sensors import ExternalTaskSensor
+        if not task_ids:
+            task_ids = self.task_ids
+        descendants = []
+        for _, dag in dagbag.dags.items():
+            tasks = [task for task in dag.tasks if
+                     isinstance(task, ExternalTaskSensor) and
+                     task.external_dag_id == self.dag_id and
+                     task.external_task_id in task_ids]
+            if not tasks:
+                continue
+            task_regex = "|".join(map(
+                lambda x: "^{0}$".format(x.task_id), tasks))
+            dependent_dag = dag.sub_dag(
+                task_regex=r"{0}".format(task_regex),
+                include_downstream=include_downstream,
+                include_upstream=include_upstream)
+            descendants.append(dependent_dag)
+            if recursive:
+                descendants.extend(dependent_dag.descendants(
+                    dagbag,
+                    include_downstream=include_downstream,
+                    include_upstream=include_upstream,
+                    recursive=recursive))
+        return descendants
+
     @property
     def subdags(self):
         """

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -188,6 +188,10 @@
               type="button" class="btn active" data-toggle="button">
                Recursive
             </button>
+            <button id="btn_descendants"
+              type="button" class="btn" data-toggle="button">
+               Descendents
+            </button>
           </span>
           <hr/>
           <button id="btn_success" type="button" class="btn btn-primary">
@@ -362,6 +366,7 @@ function updateQueryStringParameter(uri, key, value) {
         "&upstream=" + $('#btn_upstream').hasClass('active') +
         "&downstream=" + $('#btn_downstream').hasClass('active') +
         "&recursive=" + $('#btn_recursive').hasClass('active') +
+        "&descendants=" + $('#btn_descendants').hasClass('active') +
         "&execution_date=" + execution_date +
         "&origin=" + encodeURIComponent(window.location);
       window.location = url;

--- a/tests/dags/test_descendant_dags.py
+++ b/tests/dags/test_descendant_dags.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow import DAG
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.sensors import ExternalTaskSensor
+from tests.core import TEST_DAG_ID, DEFAULT_DATE
+from datetime import timedelta
+
+args = {'owner': 'airflow', 'start_date': DEFAULT_DATE,
+        'depends_on_past': False, 'retries': 3}
+
+dag_core_id = TEST_DAG_ID + '_core'
+dag_core = DAG(dag_core_id, default_args=args,
+    schedule_interval=timedelta(seconds=1))
+task_core = DummyOperator(
+    task_id='task_core',
+    dag=dag_core)
+
+dag_first_child_id = TEST_DAG_ID + '_first_child'
+dag_first_child = DAG(dag_first_child_id, default_args=args,
+    schedule_interval=timedelta(seconds=1))
+t1_first_child = ExternalTaskSensor(
+    task_id='t1_first_child',
+    external_dag_id=dag_core_id,
+    external_task_id='task_core',
+    poke_interval=1,
+    dag=dag_first_child,
+    depends_on_past=True)
+t2_first_child = DummyOperator(
+    task_id='t2_first_child',
+    dag=dag_first_child,
+    depends_on_past=True)
+t2_first_child.set_upstream(t1_first_child)
+
+dag_second_child_id = TEST_DAG_ID + '_second_child'
+dag_second_child = DAG(dag_second_child_id, default_args=args,
+    schedule_interval=timedelta(seconds=1))
+t1_second_child = ExternalTaskSensor(
+    task_id='t1_second_child',
+    external_dag_id=dag_first_child_id,
+    external_task_id='t2_first_child',
+    poke_interval=1,
+    dag=dag_second_child,
+    depends_on_past=True)
+t2_second_child = DummyOperator(
+    task_id='t2_second_child',
+    dag=dag_second_child)


### PR DESCRIPTION
Currently when using an ExternalTaskSensor sensor, to have a dag wait
for the completion of a task in another dag, there is no way, when
clearing the task that is depended on, to also clear the ExternalTaskSensor
task (and its downstream/upstream tasks).

However, that might be important when teams have separate responsibilities
and create multi-staged data pipelines. Let's say there is a team responsible
for transforming logs to make them available in hadoop land. They maintain a
hourly dag processing the raw logs. Other teams wait on the completion of
this dag using an ExternalTaskSensor. If the logging team realizes that
some logs where corrupted, not only do they have to rerun the task that
processed these logs but also all the dags that use these logs to generate
higher level data.

This commit tries to solve this problem by introducing the notion of dag
descendants. The descendants of dag A are the dags that have an
ExternalTaskSensor pointing to a task of dag A.
Then, when clearing a task in the view, an option is added to also clear
the tasks of the descendants (having the upstream, downstream, recursive,
future and past flags act accordingly).

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow 1414](https://issues.apache.org/jira/browse/AIRFLOW-1414) issues and references them in the PR title. For example, "[AIRFLOW-1414] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1414


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests.models:DagTest.test_descendants
tests.models:DagTest.test_descendants_upstream
tests.models:DagTest.test_descendants_downstream
tests.models:DagTest.test_descendants_downstream_recursive
tests.core.WebUiTests.test_dag_clear_view_with_descendants


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

