### PR TITLE
[AIRFLOW-1359] Use default_args in CloudML eval

### DIFF
--- a/airflow/contrib/operators/cloudml_operator.py
+++ b/airflow/contrib/operators/cloudml_operator.py
@@ -341,6 +341,12 @@ class CloudMLVersionOperator(BaseOperator):
         If it is None, the only `operation` possible would be `list`.
     :type version: dict
 
+    :param version_name: A name to use for the version being operated upon. If
+        not None and the `version` argument is None or does not have a value for
+        the `name` key, then this will be populated in the payload for the
+        `name` key.
+    :type version_name: string
+
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: string
 
@@ -372,13 +378,15 @@ class CloudMLVersionOperator(BaseOperator):
     template_fields = [
         '_model_name',
         '_version',
+        '_version_name',
     ]
 
     @apply_defaults
     def __init__(self,
                  model_name,
                  project_id,
-                 version,
+                 version=None,
+                 version_name=None,
                  gcp_conn_id='google_cloud_default',
                  operation='create',
                  delegate_to=None,
@@ -387,13 +395,17 @@ class CloudMLVersionOperator(BaseOperator):
 
         super(CloudMLVersionOperator, self).__init__(*args, **kwargs)
         self._model_name = model_name
-        self._version = version
+        self._version = version or {}
+        self._version_name = version_name
         self._gcp_conn_id = gcp_conn_id
         self._delegate_to = delegate_to
         self._project_id = project_id
         self._operation = operation
 
     def execute(self, context):
+        if 'name' not in self._version:
+            self._version['name'] = self._version_name
+
         hook = CloudMLHook(
             gcp_conn_id=self._gcp_conn_id, delegate_to=self._delegate_to)
 

--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -123,6 +123,8 @@ class DataFlowJavaOperator(BaseOperator):
 
 class DataFlowPythonOperator(BaseOperator):
 
+    template_fields = ['options', 'dataflow_default_options']
+
     @apply_defaults
     def __init__(
             self,

--- a/tests/contrib/operators/test_cloudml_operator_utils.py
+++ b/tests/contrib/operators/test_cloudml_operator_utils.py
@@ -40,6 +40,7 @@ class CreateEvaluateOpsTest(unittest.TestCase):
         'inputPaths': ['gs://legal-bucket/fake-input-path/*'],
         'outputPath': 'gs://legal-bucket/fake-output-path',
         'region': 'us-east1',
+        'versionName': 'projects/test-project/models/test_model/versions/test_version',
     }
     SUCCESS_MESSAGE_MISSING_INPUT = {
         'jobId': 'eval_test_prediction',
@@ -61,30 +62,27 @@ class CreateEvaluateOpsTest(unittest.TestCase):
                 'owner': 'airflow',
                 'start_date': DEFAULT_DATE,
                 'end_date': DEFAULT_DATE,
+                'project_id': 'test-project',
+                'region': 'us-east1',
+                'model_name': 'test_model',
+                'version_name': 'test_version',
             },
             schedule_interval='@daily')
         self.metric_fn = lambda x: (0.1,)
         self.metric_fn_encoded = cloudml_operator_utils.base64.b64encode(
             cloudml_operator_utils.dill.dumps(self.metric_fn, recurse=True))
 
-
     def testSuccessfulRun(self):
         input_with_model = self.INPUT_MISSING_ORIGIN.copy()
-        input_with_model['modelName'] = (
-            'projects/test-project/models/test_model')
 
         pred, summary, validate = create_evaluate_ops(
             task_prefix='eval-test',
-            project_id='test-project',
-            job_id='eval-test-prediction',
-            region=input_with_model['region'],
+            batch_prediction_job_id='eval-test-prediction',
             data_format=input_with_model['dataFormat'],
             input_paths=input_with_model['inputPaths'],
             prediction_path=input_with_model['outputPath'],
-            model_name=input_with_model['modelName'].split('/')[-1],
             metric_fn_and_keys=(self.metric_fn, ['err']),
             validate_fn=(lambda x: 'err=%.1f' % x['err']),
-            dataflow_options=None,
             dag=self.dag)
 
         with patch('airflow.contrib.operators.cloudml_operator.'
@@ -100,8 +98,9 @@ class CreateEvaluateOpsTest(unittest.TestCase):
                 'test-project',
                 {
                     'jobId': 'eval_test_prediction',
-                    'predictionInput': input_with_model
-                }, ANY)
+                    'predictionInput': input_with_model,
+                },
+                ANY)
             self.assertEqual(success_message['predictionOutput'], result)
 
         with patch('airflow.contrib.operators.dataflow_operator.'
@@ -133,22 +132,27 @@ class CreateEvaluateOpsTest(unittest.TestCase):
             self.assertEqual('err=0.9', result)
 
     def testFailures(self):
-        input_with_model = self.INPUT_MISSING_ORIGIN.copy()
-        input_with_model['modelName'] = (
-            'projects/test-project/models/test_model')
+        dag = DAG(
+            'test_dag',
+            default_args={
+                'owner': 'airflow',
+                'start_date': DEFAULT_DATE,
+                'end_date': DEFAULT_DATE,
+                'project_id': 'test-project',
+                'region': 'us-east1',
+            },
+            schedule_interval='@daily')
 
+        input_with_model = self.INPUT_MISSING_ORIGIN.copy()
         other_params_but_models = {
             'task_prefix': 'eval-test',
-            'project_id': 'test-project',
-            'job_id': 'eval-test-prediction',
-            'region': input_with_model['region'],
+            'batch_prediction_job_id': 'eval-test-prediction',
             'data_format': input_with_model['dataFormat'],
             'input_paths': input_with_model['inputPaths'],
             'prediction_path': input_with_model['outputPath'],
             'metric_fn_and_keys': (self.metric_fn, ['err']),
             'validate_fn': (lambda x: 'err=%.1f' % x['err']),
-            'dataflow_options': None,
-            'dag': self.dag,
+            'dag': dag,
         }
 
         with self.assertRaisesRegexp(ValueError, 'Missing model origin'):


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

This change makes the create_evaluate_ops utility method make use of the
default_args parameters of the DAG when possible. This simplifies the
usage of the create_evaluate_ops method, and improves the usefulness of
a variety of default_args.

To further the usefulness of default_args for Cloud ML Operators, this
change also introduces version_name to the CloudMLVersionOperator,
allowing model_name and version_name to be specified across an entire
pipeline.

This change also resolves a small TODO by making the
DataFlowPythonOperator's `options` and `dataflow_default_options`
variables templatized.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

