### PR TITLE
[AIRFLOW-1422] Customize File Handler for logging module via airflow.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ ENV/
 
 # Spark
 rat-results.txt
+
+# IDE History
+.history

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -90,7 +90,17 @@ def sigquit_handler(sig, frame):
 
 def setup_logging(filename):
     root = logging.getLogger()
-    handler = logging.FileHandler(filename)
+    log_handler_kargs = None
+    lh_mod_name, lh_cls_name = conf.get('core', 'log_handler_class').rsplit('.', 1)
+    lh_mod = __import__(lh_mod_name, globals(), locals(), [lh_cls_name], 0)
+    log_handler = getattr(lh_mod, lh_cls_name)
+    try:
+        log_handler_kargs = json.loads(conf.get('core', 'log_handler_params'))
+        handler = log_handler(filename, **log_handler_kargs)
+    except ValueError:
+        handler = log_handler(filename)
+    logging.info('log_handler: {}'.format(log_handler))
+    logging.info('log_handler_kargs: {}'.format(log_handler_kargs))
     formatter = logging.Formatter(settings.SIMPLE_LOG_FORMAT)
     handler.setFormatter(formatter)
     root.addHandler(handler)

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -55,6 +55,10 @@ log_format_with_pid = [%%(asctime)s] [%%(process)d] {{%%(filename)s:%%(lineno)d}
 log_format_with_thread_name = [%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(threadName)s %%(levelname)s - %%(message)s
 simple_log_format = %%(asctime)s %%(levelname)s - %%(message)s
 
+# Log Handler (supports TimedRotatingFileHandler, RotatingFileHandler, WatchedFileHandler, FileHandler or StreamHandler)
+log_handler_class = logging.FileHandler
+log_handler_params = None  # valid json format required or ignored.
+
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor, DaskExecutor
 executor = SequentialExecutor


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1422) issues and references them in the PR title. For example, "[AIRFLOW-1422] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1422


### Description
- [x] # Allow log files generated by the scheduler, webserver and workers be more organized based on time interval, size etc.   Make it easier for analysis, maintenance and cleanup. 
- [x] # Log Handler - it supports all file handlers:  TimedRotatingFileHandler, RotatingFileHandler, WatchedFileHandler, FileHandler or StreamHandler.  
- [x] #Two configuration keys are added: log_handler_class and log_handler_params.  Default is using logging.FileHandler with None. 
e.g. 1
`log_handler_class = logging.handlers.RotatingFileHandler`
`log_handler_params = {"maxBytes":"100000"}`
e.g. 2
`log_handler_class = logging.handlers.TimedRotatingFileHandler`
`log_handler_params = {"backupCount":7,"interval":1,"when":"d"}`
default:
`log_handler_class = logging.FileHandler`
`log_handler_params = None`


### Tests
- [x] ./run_unit_tests.sh python2.7.x and python3.5.x 

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

