### PR TITLE
[AIRFLOW-1349] Fix backfill to respect limits

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -179,7 +179,8 @@ def backfill(args, dag=None):
                           conf.getboolean('core', 'donot_pickle')),
             ignore_first_depends_on_past=args.ignore_first_depends_on_past,
             ignore_task_deps=args.ignore_dependencies,
-            pool=args.pool)
+            pool=args.pool,
+            delay_on_limit_secs=args.delay_on_limit)
 
 
 def trigger_dag(args):
@@ -1234,6 +1235,14 @@ class CLIFactory(object):
                 "DO respect depends_on_past)."),
             "store_true"),
         'pool': Arg(("--pool",), "Resource pool to use"),
+        'delay_on_limit': Arg(
+            ("--delay_on_limit",),
+            help=("Amount of time in seconds to wait when the limit "
+                  "on maximum active dag runs (max_active_runs) has "
+                  "been reached before trying to execute a dag run "
+                  "again."),
+            type=float,
+            default=1.0),
         # list_tasks
         'tree': Arg(("-t", "--tree"), "Tree view", "store_true"),
         # list_dags
@@ -1491,7 +1500,7 @@ class CLIFactory(object):
                 'dag_id', 'task_regex', 'start_date', 'end_date',
                 'mark_success', 'local', 'donot_pickle', 'include_adhoc',
                 'bf_ignore_dependencies', 'bf_ignore_first_depends_on_past',
-                'subdir', 'pool', 'dry_run')
+                'subdir', 'pool', 'delay_on_limit', 'dry_run')
         }, {
             'func': list_tasks,
             'help': "List the tasks within a DAG",

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -24,6 +24,7 @@ import shutil
 import unittest
 import six
 import socket
+import threading
 from tempfile import mkdtemp
 
 from airflow import AirflowException, settings, models
@@ -303,6 +304,23 @@ class BackfillJobTest(unittest.TestCase):
         self.assertEqual(ti.state, State.SUCCESS)
         dag.clear()
 
+    def test_cli_receives_delay_arg(self):
+        """
+        Tests that the --delay argument is passed correctly to the BackfillJob
+        """
+        dag_id = 'example_bash_operator'
+        run_date = DEFAULT_DATE
+        args = [
+            'backfill',
+            dag_id,
+            '-s',
+            run_date.isoformat(),
+            '--delay_on_limit',
+            '0.5',
+        ]
+        parsed_args = self.parser.parse_args(args)
+        self.assertEqual(0.5, parsed_args.delay_on_limit)
+
     def _get_dag_test_max_active_limits(self, dag_id, max_active_runs=1):
         dag = DAG(
             dag_id=dag_id,
@@ -328,7 +346,7 @@ class BackfillJobTest(unittest.TestCase):
             'test_backfill_max_limit_check_within_limit',
             max_active_runs=16)
 
-        start_date = DEFAULT_DATE - datetime.timedelta(hours=3)
+        start_date = DEFAULT_DATE - datetime.timedelta(hours=1)
         end_date = DEFAULT_DATE
 
         executor = TestExecutor(do_update=True)
@@ -339,22 +357,91 @@ class BackfillJobTest(unittest.TestCase):
                           donot_pickle=True)
         job.run()
 
-        # dag run could not run since the max_active_runs has been reached
         dagruns = DagRun.find(dag_id=dag.dag_id)
-        self.assertEqual(4, len(dagruns))
+        self.assertEqual(2, len(dagruns))
         self.assertTrue(all([run.state == State.SUCCESS for run in dagruns]))
 
     def test_backfill_max_limit_check(self):
-        dag = self._get_dag_test_max_active_limits('test_backfill_max_limit_check')
-
-        start_date = DEFAULT_DATE - datetime.timedelta(hours=3)
+        dag_id = 'test_backfill_max_limit_check'
+        run_id = 'test_dagrun'
+        start_date = DEFAULT_DATE - datetime.timedelta(hours=1)
         end_date = DEFAULT_DATE
 
-        # Existing dagrun that is not within the backfill range
-        dr = dag.create_dagrun(run_id="test_dagrun",
-                               state=State.RUNNING,
-                               execution_date=DEFAULT_DATE + datetime.timedelta(hours=1),
-                               start_date=DEFAULT_DATE)
+        dag_run_created_cond = threading.Condition()
+
+        def run_backfill(cond):
+            cond.acquire()
+            try:
+                dag = self._get_dag_test_max_active_limits(dag_id)
+
+                # this session object is different than the one in the main thread
+                thread_session = settings.Session()
+
+                # Existing dagrun that is not within the backfill range
+                dag.create_dagrun(
+                    run_id=run_id,
+                    state=State.RUNNING,
+                    execution_date=DEFAULT_DATE + datetime.timedelta(hours=1),
+                    start_date=DEFAULT_DATE,
+                )
+
+                thread_session.commit()
+                cond.notify()
+            finally:
+                cond.release()
+
+            executor = TestExecutor(do_update=True)
+            job = BackfillJob(dag=dag,
+                              start_date=start_date,
+                              end_date=end_date,
+                              executor=executor,
+                              donot_pickle=True)
+            job.run()
+
+            thread_session.close()
+
+        backfill_job_thread = threading.Thread(target=run_backfill,
+                                               name="run_backfill",
+                                               args=(dag_run_created_cond,))
+
+        dag_run_created_cond.acquire()
+        session = settings.Session()
+        backfill_job_thread.start()
+        try:
+            # at this point backfill can't run since the max_active_runs has been
+            # reached, so it is waiting
+            dag_run_created_cond.wait(timeout=1.5)
+            dagruns = DagRun.find(dag_id=dag_id)
+            dr = dagruns[0]
+            self.assertEqual(1, len(dagruns))
+            self.assertEqual(dr.run_id, run_id)
+
+            # allow the backfill to execute by setting the existing dag run to SUCCESS,
+            # backfill will execute dag runs 1 by 1
+            dr.set_state(State.SUCCESS)
+            session.merge(dr)
+            session.commit()
+            session.close()
+
+            backfill_job_thread.join()
+
+            dagruns = DagRun.find(dag_id=dag_id)
+            self.assertEqual(3, len(dagruns))  # 2 from backfill + 1 existing
+            self.assertEqual(dagruns[-1].run_id, dr.run_id)
+        finally:
+            dag_run_created_cond.release()
+
+    def test_backfill_max_limit_check_no_count_existing(self):
+        dag = self._get_dag_test_max_active_limits(
+            'test_backfill_max_limit_check_no_count_existing')
+        start_date = DEFAULT_DATE
+        end_date = DEFAULT_DATE
+
+        # Existing dagrun that is within the backfill range
+        dag.create_dagrun(run_id="test_existing_backfill",
+                          state=State.RUNNING,
+                          execution_date=DEFAULT_DATE,
+                          start_date=DEFAULT_DATE)
 
         executor = TestExecutor(do_update=True)
         job = BackfillJob(dag=dag,
@@ -364,10 +451,35 @@ class BackfillJobTest(unittest.TestCase):
                           donot_pickle=True)
         job.run()
 
-        # dag run could not run since the max_active_runs has been reached
+        # BackfillJob will run since the existing DagRun does not count for the max
+        # active limit since it's within the backfill date range.
         dagruns = DagRun.find(dag_id=dag.dag_id)
+        # will only be able to run 1 (the existing one) since there's just
+        # one dag run slot left given the max_active_runs limit
         self.assertEqual(1, len(dagruns))
-        self.assertEqual(dagruns[0].run_id, dr.run_id)
+        self.assertEqual(State.SUCCESS, dagruns[0].state)
+
+    def test_backfill_max_limit_check_complete_loop(self):
+        dag = self._get_dag_test_max_active_limits(
+            'test_backfill_max_limit_check_complete_loop')
+        start_date = DEFAULT_DATE - datetime.timedelta(hours=1)
+        end_date = DEFAULT_DATE
+
+        # Given the max limit to be 1 in active dag runs, we need to run the
+        # backfill job 3 times
+        success_expected = 2
+        executor = TestExecutor(do_update=True)
+        job = BackfillJob(dag=dag,
+                          start_date=start_date,
+                          end_date=end_date,
+                          executor=executor,
+                          donot_pickle=True)
+        job.run()
+
+        success_dagruns = len(DagRun.find(dag_id=dag.dag_id, state=State.SUCCESS))
+        running_dagruns = len(DagRun.find(dag_id=dag.dag_id, state=State.RUNNING))
+        self.assertEqual(success_expected, success_dagruns)
+        self.assertEqual(0, running_dagruns)  # no dag_runs in running state are left
 
     def test_sub_set_subdag(self):
         dag = DAG(
@@ -389,7 +501,7 @@ class BackfillJobTest(unittest.TestCase):
 
         dag.clear()
         dr = dag.create_dagrun(run_id="test",
-                               state=State.SUCCESS,
+                               state=State.RUNNING,
                                execution_date=DEFAULT_DATE,
                                start_date=DEFAULT_DATE)
 
@@ -433,7 +545,7 @@ class BackfillJobTest(unittest.TestCase):
 
         dag.clear()
         dr = dag.create_dagrun(run_id='test',
-                               state=State.SUCCESS,
+                               state=State.RUNNING,
                                execution_date=DEFAULT_DATE,
                                start_date=DEFAULT_DATE)
         executor = TestExecutor(do_update=True)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1349


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Before, if a backfill job was triggered that would include a dag run
already in a RUNNING state, the dag run within the backfill would be
included in the count agains the max_active_runs limit. Also, if a
backfill job generated multiple dag runs it could potentially
violate max_active_runs limits by executing all dag runs.

Now the limit is checked per dag run to be created, and the backfill job
will only run the dag runs within the backfill job that could be
included within the limits.
Also, if the max_active_runs limit has already been reached, the
BackfillJob will wait and loop trying to create the required dag runs as
soon as a dag run slot within the limit is available until all dag runs
are completed.

These changes provide a more consistent behavior according to the
max_active_runs limits definition and allows the user to run backfill
jobs with existing RUNNING state when already considered within the
limits.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - `BackfillJobTest.test_backfill_max_limit_check*`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

