### PR TITLE
[AIRFLOW-1424] add a next_scheduler_run property to DAGs

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -872,6 +872,13 @@ class SchedulerJob(BaseJob):
             elif next_run_date:
                 period_end = dag.following_schedule(next_run_date)
 
+            # update the DAG's next scheduler run property so users can get
+            # a clear view of the next expected run period of the job
+            if dag.next_scheduler_run != period_end:
+                session.query(models.DagModel).filter_by(
+                    dag_id=dag.dag_id).update(
+                    {models.DagModel.next_scheduler_run : period_end})
+
             # Don't schedule a dag beyond its end_date (as specified by the dag param)
             if next_run_date and dag.end_date and next_run_date > dag.end_date:
                 return

--- a/airflow/migrations/versions/258d7101c452_add_next_scheduler_run_field_to_dag.py
+++ b/airflow/migrations/versions/258d7101c452_add_next_scheduler_run_field_to_dag.py
@@ -1,0 +1,37 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""[AIRFLOW-1424] add next_scheduler_run field to dag
+
+Revision ID: 258d7101c452
+Revises: cc1e65623dc7
+Create Date: 2017-07-18 11:37:53.890462
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '258d7101c452'
+down_revision = 'cc1e65623dc7'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('dag', sa.Column('next_scheduler_run', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('dag', 'next_scheduler_run')

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2634,6 +2634,8 @@ class DagModel(Base):
     fileloc = Column(String(2000))
     # String representing the owners
     owners = Column(String(2000))
+    # Next time the scheduler will run this DAG
+    next_scheduler_run = Column(DateTime)
 
     def __repr__(self):
         return "<DAG: {self.dag_id}>".format(self=self)
@@ -3007,6 +3009,16 @@ class DAG(BaseDag, LoggingMixin):
         qry = session.query(DagModel).filter(
             DagModel.dag_id == self.dag_id)
         return qry.value('is_paused')
+
+    @property
+    @provide_session
+    def next_scheduler_run(self, session=None):
+        """
+        Returns a boolean indicating whether this DAG is paused
+        """
+        qry = session.query(DagModel).filter(
+            DagModel.dag_id == self.dag_id)
+        return qry.value('next_scheduler_run')
 
     @provide_session
     def get_active_runs(self, session=None):


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1424


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

The scheduler's DAG run creation logic can be tricky and one is
easily confused with the start_date + interval
and period end scheduling way of thinking.

It would ease airflow's usage to add a *next_scheduler_run* property to DAGs
so that we can very easily see the (un)famous *period end* after which
the scheduler will create a new DAG run for our workflows.

These patches add such a field to the *dag* table and the DagModel
property + scheduler logic to update it when calculated.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Tests are proposed along this patches.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

