### PR TITLE
[AIRFLOW-1437] Modify BigQueryTableDeleteOperator 

### DIFF
--- a/airflow/contrib/operators/bigquery_table_delete_operator.py
+++ b/airflow/contrib/operators/bigquery_table_delete_operator.py
@@ -37,6 +37,7 @@ class BigQueryTableDeleteOperator(BaseOperator):
         requested table does not exist.
     :type ignore_if_missing: boolean
     """
+    template_fields = ('deletion_dataset_table')
     ui_color = '#ffd1dc'
 
     @apply_defaults


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

BigQueryTableDeleteOperator should define deletion_dataset_table as a template field. 
I know we should have unit tests for `BigQueryTableDeleteOperator`. However, personally, the tests should be going to be implemented in another issue.

### JIRA
[\[AIRFLOW\-1437\] BigQueryTableDeleteOperator should define deletion\_dataset\_table as a template field \- ASF JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1437)


### Description
BigQueryTableDeleteOperator should define deletion_dataset_table as a template field


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


