### PR TITLE
[AIRFLOW-1442] Remove extra space from ignore_all_deps generated command

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -934,7 +934,7 @@ class TaskInstance(Base):
         cmd.extend(["--mark_success"]) if mark_success else None
         cmd.extend(["--pickle", str(pickle_id)]) if pickle_id else None
         cmd.extend(["--job_id", str(job_id)]) if job_id else None
-        cmd.extend(["-A "]) if ignore_all_deps else None
+        cmd.extend(["-A"]) if ignore_all_deps else None
         cmd.extend(["-i"]) if ignore_task_deps else None
         cmd.extend(["-I"]) if ignore_depends_on_past else None
         cmd.extend(["--force"]) if ignore_ti_state else None


### PR DESCRIPTION
My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1442) issues and references them in the PR title.

Fix extra whitespace in the ignore_all_deps arg which was causing commands to fail.

@saguziel 