### PR TITLE
Add configuration option to override visible hostname.

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -909,6 +909,9 @@ def worker(args):
         'concurrency': args.concurrency,
     }
 
+    hostname = args.hostname or conf.get('celery', 'WORKER_LOG_SERVER_HOSTNAME', socket.getfqdn())
+    conf.set('worker', 'WORKER_LOG_SERVER_HOSTNAME', hostname)
+
     if args.daemon:
         pid, stdout, stderr, log_file = setup_locations("worker", args.pid, args.stdout, args.stderr, args.log_file)
         handle = setup_logging(log_file)
@@ -1415,6 +1418,11 @@ class CLIFactory(object):
             type=int,
             help="The number of worker processes",
             default=conf.get('celery', 'celeryd_concurrency')),
+        'hostname': Arg(
+            ('-H', '--hostname'),
+            help='Hostname to set in task instances (eg to access log server)',
+            type=str,
+            default=conf.get('celery', 'WORKER_LOG_SERVER_HOSTNAME', socket.getfqdn())),
         # flower
         'broker_api': Arg(("-a", "--broker_api"), help="Broker api"),
         'flower_hostname': Arg(

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -373,7 +373,7 @@ def run(args, dag=None):
             level=settings.LOGGING_LEVEL,
             format=settings.LOG_FORMAT)
 
-    hostname = socket.getfqdn()
+    hostname = get_hostname()
     logging.info("Running on host {}".format(hostname))
 
     if not args.pickle and not dag:
@@ -909,9 +909,6 @@ def worker(args):
         'concurrency': args.concurrency,
     }
 
-    hostname = args.hostname or conf.get('celery', 'WORKER_LOG_SERVER_HOSTNAME', socket.getfqdn())
-    conf.set('celery', 'WORKER_LOG_SERVER_HOSTNAME', hostname)
-
     if args.daemon:
         pid, stdout, stderr, log_file = setup_locations("worker", args.pid, args.stdout, args.stderr, args.log_file)
         handle = setup_logging(log_file)
@@ -1418,11 +1415,6 @@ class CLIFactory(object):
             type=int,
             help="The number of worker processes",
             default=conf.get('celery', 'celeryd_concurrency')),
-        'hostname': Arg(
-            ('-H', '--hostname'),
-            help='Hostname to set in task instances (eg to access log server)',
-            type=str,
-            default=conf.get('celery', 'WORKER_LOG_SERVER_HOSTNAME', socket.getfqdn())),
         # flower
         'broker_api': Arg(("-a", "--broker_api"), help="Broker api"),
         'flower_hostname': Arg(

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -54,6 +54,7 @@ from airflow.ti_deps.dep_context import (DepContext, SCHEDULER_DEPS)
 from airflow.utils import db as db_utils
 from airflow.utils import logging as logging_utils
 from airflow.utils.file import mkdirs
+from airflow.utils.net import get_hostname
 from airflow.www.app import cached_app
 
 from sqlalchemy import func

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -910,7 +910,7 @@ def worker(args):
     }
 
     hostname = args.hostname or conf.get('celery', 'WORKER_LOG_SERVER_HOSTNAME', socket.getfqdn())
-    conf.set('worker', 'WORKER_LOG_SERVER_HOSTNAME', hostname)
+    conf.set('celery', 'WORKER_LOG_SERVER_HOSTNAME', hostname)
 
     if args.daemon:
         pid, stdout, stderr, log_file = setup_locations("worker", args.pid, args.stdout, args.stderr, args.log_file)

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -58,7 +58,7 @@ from airflow.utils.dag_processing import (AbstractDagFileProcessor,
 from airflow.utils.email import send_email
 from airflow.utils.logging import LoggingMixin
 from airflow.utils import asciiart
-
+from airflow.utils.net import get_hostname
 
 Base = models.Base
 ID_LEN = models.ID_LEN
@@ -99,7 +99,7 @@ class BaseJob(Base, LoggingMixin):
             executor=executors.GetDefaultExecutor(),
             heartrate=conf.getfloat('scheduler', 'JOB_HEARTBEAT_SEC'),
             *args, **kwargs):
-        self.hostname = socket.getfqdn()
+        self.hostname = get_hostname()
         self.executor = executor
         self.executor_class = executor.__class__.__name__
         self.start_date = datetime.now()
@@ -2324,7 +2324,7 @@ class LocalTaskJob(BaseJob):
         ti = self.task_instance
         if ti.state == State.RUNNING:
             self.was_running = True
-            fqdn = socket.getfqdn()
+            fqdn = get_hostname()
             if fqdn != ti.hostname:
                 logging.warning("The recorded hostname {ti.hostname} "
                                 "does not match this instance's hostname "

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1291,7 +1291,7 @@ class TaskInstance(Base):
         self.test_mode = test_mode
         self.refresh_from_db(session=session, lock_for_update=True)
         self.job_id = job_id
-        self.hostname = socket.getfqdn()
+        self.hostname = configuration.get('celery', 'WORKER_LOG_SERVER_HOSTNAME', socket.getfqdn())
         self.operator = task.__class__.__name__
 
         if not ignore_all_deps and not ignore_ti_state and self.state == State.SUCCESS:

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -80,6 +80,7 @@ from airflow.utils.operator_resources import Resources
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 from airflow.utils.trigger_rule import TriggerRule
+from airflow.utils.net import get_hostname
 
 Base = declarative_base()
 ID_LEN = 250
@@ -1291,7 +1292,7 @@ class TaskInstance(Base):
         self.test_mode = test_mode
         self.refresh_from_db(session=session, lock_for_update=True)
         self.job_id = job_id
-        self.hostname = configuration.get('celery', 'WORKER_LOG_SERVER_HOSTNAME', socket.getfqdn())
+        self.hostname = get_hostname()
         self.operator = task.__class__.__name__
 
         if not ignore_all_deps and not ignore_ti_state and self.state == State.SUCCESS:

--- a/airflow/utils/net.py
+++ b/airflow/utils/net.py
@@ -1,7 +1,5 @@
-from airflow.configuration import conf
+from airflow.configuration import conf, AirflowConfigException
 import socket
-
-_sentinel = object()
 
 
 def get_hostname(default=socket.getfqdn):
@@ -10,7 +8,9 @@ def get_hostname(default=socket.getfqdn):
 
     :param callable|str default: Default if config does not specify. If a callable is given it will be called.
     """
-    hostname = conf.get('core', 'HOSTNAME', default)
-    if callable(hostname):
-        hostname = hostname()
+    try:
+        # If this is called `get`, why does it not match python semantics?
+        hostname = conf.get('core', 'hostname')
+    except AirflowConfigException:
+        hostname = callable(default) and default() or default
     return hostname

--- a/airflow/utils/net.py
+++ b/airflow/utils/net.py
@@ -1,0 +1,16 @@
+from airflow.configuration import conf
+import socket
+
+_sentinel = object()
+
+
+def get_hostname(default=socket.getfqdn):
+    """
+    A replacement for `socket.getfqdn` that allows configuration to override it's value.
+
+    :param callable|str default: Default if config does not specify. If a callable is given it will be called.
+    """
+    hostname = conf.get('core', 'HOSTNAME', default)
+    if callable(hostname):
+        hostname = hostname()
+    return hostname

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -30,6 +30,7 @@ from airflow.www.blueprints import routes
 from airflow import jobs
 from airflow import settings
 from airflow import configuration
+from airflow.utils.net import get_hostname
 
 
 def create_app(config=None, testing=False):
@@ -143,7 +144,7 @@ def create_app(config=None, testing=False):
         @app.context_processor
         def jinja_globals():
             return {
-                'hostname': socket.getfqdn(),
+                'hostname': get_hostname(),
             }
 
         @app.teardown_appcontext

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -74,6 +74,7 @@ from airflow.utils.db import provide_session
 from airflow.utils.helpers import alchemy_to_dict
 from airflow.utils import logging as log_utils
 from airflow.utils.dates import infer_time_unit, scale_time_units
+from airflow.utils.net import get_hostname
 from airflow.www import utils as wwwutils
 from airflow.www.forms import DateTimeForm, DateTimeWithNumRunsForm
 from airflow.www.validators import GreaterEqualThan
@@ -609,14 +610,14 @@ class Airflow(BaseView):
     @current_app.errorhandler(404)
     def circles(self):
         return render_template(
-            'airflow/circles.html', hostname=socket.getfqdn()), 404
+            'airflow/circles.html', hostname=get_hostname()), 404
 
     @current_app.errorhandler(500)
     def show_traceback(self):
         from airflow.utils import asciiart as ascii_
         return render_template(
             'airflow/traceback.html',
-            hostname=socket.getfqdn(),
+            hostname=get_hostname(),
             nukular=ascii_.nukular,
             info=traceback.format_exc()), 500
 

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -37,6 +37,7 @@ from airflow.utils.db import provide_session
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 from airflow.utils.dag_processing import SimpleDagBag, list_py_file_paths
+from airflow.utils.net import get_hostname
 
 from mock import Mock, patch
 from sqlalchemy.orm.session import make_transient
@@ -563,7 +564,7 @@ class LocalTaskJobTest(unittest.TestCase):
 
         is_descendant.return_value = True
         ti.state = State.RUNNING
-        ti.hostname = socket.getfqdn()
+        ti.hostname = get_hostname()
         ti.pid = 1
         session.merge(ti)
         session.commit()
@@ -592,7 +593,7 @@ class LocalTaskJobTest(unittest.TestCase):
                                session=session)
         ti = dr.get_task_instance(task_id=task.task_id, session=session)
         ti.state = State.RUNNING
-        ti.hostname = socket.getfqdn()
+        ti.hostname = get_hostname()
         ti.pid = 1
         session.commit()
 


### PR DESCRIPTION
This makes running Airflow tremendously easier in common
production deployments that need a little more than just
a bare `socket.getfqdn()` hostname for service discovery
per running instance.

Personally, I just place the Kubernetes Pod FQDN here.

Question: Since the web server calls out to the individual
worker nodes to snag logs, what happens if one dies midway?
I may later look into that, because that scares me slightly.

Thanks,
Trevor