### PR TITLE
AIRFLOW-1445: changing HivePartitionSensor UI color to lighter shade

### DIFF
--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -347,7 +347,7 @@ class HivePartitionSensor(BaseSensorOperator):
     :type metastore_conn_id: str
     """
     template_fields = ('schema', 'table', 'partition',)
-    ui_color = '#2b2d42'
+    ui_color = '#C5CAE9'
 
     @apply_defaults
     def __init__(


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow-1445](https://issues.apache.org/jira/browse/AIRFLOW-1445) issues and references them in the PR title.

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

My PR is simply to improve the readability of the text using the HivePartitionSensor. The screen shots below show the before and after. The darker shade (nearly black) is the before, and the purple color is the after.
*After -- First suggestion (not being done but second suggestion is)*
<img width="1176" alt="screen shot 2017-07-23 at 6 19 24 pm" src="https://user-images.githubusercontent.com/10408007/28505428-add0c350-6fd8-11e7-816e-6d7a249b4d6d.png">

*After -- Second suggestion*
<img width="1162" alt="screen shot 2017-07-29 at 1 55 10 am" src="https://user-images.githubusercontent.com/10408007/28743806-c2e8ba08-7407-11e7-8298-61107e314464.png">

*Before*
<img width="1215" alt="screen shot 2017-07-23 at 6 30 06 pm" src="https://user-images.githubusercontent.com/10408007/28505427-add004f6-6fd8-11e7-9688-21903349c0a7.png">


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
There is no need for testing because it's simply an aesthetic improvement and doesn't affect functionality.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue.

