### PR TITLE
Fix wrong wording in SqlSensor docstring

### DIFF
--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -85,7 +85,7 @@ class BaseSensorOperator(BaseOperator):
 
 class SqlSensor(BaseSensorOperator):
     """
-    Runs a sql statement until a criteria is met. It will keep trying until
+    Runs a sql statement until a criteria is met. It will keep trying while
     sql returns no row, or if the first cell in (0, '0', '').
 
     :param conn_id: The connection to run the sensor against


### PR DESCRIPTION
Dear Airflow maintainers,

This is a simple change in the meaning of the SqlSensor docstring. "Until" has the wrong meaning as it is, which is confusing.

Thanks!

