### PR TITLE
[AIRFLOW-2041] Syntax correction of python examples

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -47,7 +47,7 @@ scope.
 
     dag_1 = DAG('this_dag_will_be_discovered')
 
-    def my_function()
+    def my_function():
         dag_2 = DAG('but_this_dag_will_not')
 
     my_function()
@@ -64,9 +64,10 @@ any of its operators. This makes it easy to apply a common parameter to many ope
 
 .. code:: python
 
-    default_args=dict(
-        start_date=datetime(2016, 1, 1),
-        owner='Airflow')
+    default_args = {
+        'start_date': datetime(2016, 1, 1),
+        'owner': 'Airflow'
+    }
 
     dag = DAG('my_dag', default_args=default_args)
     op = DummyOperator(task_id='dummy', dag=dag)


### PR DESCRIPTION
### JIRA
Trivial change, no ticket. (happy to make one if needed).

### Description

I parsed the readme with the ol' eyeball compiler. Changes:

 - correct `def` syntax on line 50
 - use literal `dict` on line 67


### Tests
Text only additions. It's not impossible that a clever someone could automate linting the examples in the readme in the future.