### PR TITLE
[AIRFLOW-1453] Add 'steps' into template_fields in EmrAddSteps

### DIFF
--- a/airflow/contrib/operators/emr_add_steps_operator.py
+++ b/airflow/contrib/operators/emr_add_steps_operator.py
@@ -31,7 +31,7 @@ class EmrAddStepsOperator(BaseOperator):
     :param steps: boto3 style steps to be added to the jobflow
     :type steps: list
     """
-    template_fields = ['job_flow_id']
+    template_fields = ['job_flow_id', 'steps']
     template_ext = ()
     ui_color = '#f9c915'
 


### PR DESCRIPTION
Rendering templates which are in steps is especially useful if you 
want to pass execution time as one of the parameters of a step in 
an EMR cluster. All fields in template_fields will get rendered.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1453


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This feature only adds additional field which can contain templates. The rendering of templates should be covered in other unit tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

