### PR TITLE
AIRFLOW-1460 clear "REMOVED" tis on DagRun update

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4255,6 +4255,7 @@ class DagRun(Base):
             # skip in db?
             if ti.state == State.REMOVED:
                 tis.remove(ti)
+                session.delete(ti)
             else:
                 ti.task = dag.get_task(ti.task_id)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -487,6 +487,34 @@ class DagRunTest(unittest.TestCase):
         state = dr.update_state()
         self.assertEqual(State.FAILED, state)
 
+    def test_dagrun_clear_removed(self):
+        session = settings.Session()
+
+        dag = DAG(
+            'test_dagrun_clear_removed',
+            start_date=DEFAULT_DATE,
+            default_args={'owner': 'owner1'})
+
+        with dag:
+            op = DummyOperator(task_id='A')
+
+        dag.clear()
+
+        now = datetime.datetime.now()
+        dr = dag.create_dagrun(run_id='test_dagrun_clear_removed',
+                               state=State.RUNNING,
+                               execution_date=now,
+                               start_date=now)
+
+        ti_op = dr.get_task_instance(task_id=op.task_id)
+        ti_op.set_state(state=State.REMOVED, session=session)
+
+        self.assertEqual(
+            dr.get_task_instance(task_id=op.task_id).state,
+            State.REMOVED)
+        dr.update_state()
+        self.assertIsNone(dr.get_task_instance(task_id=op.task_id))
+
     def test_get_task_instance_on_empty_dagrun(self):
         """
         Make sure that a proper value is returned when a dagrun has no task instances


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1460


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

  Remove "REMOVED" task instances from the airflow metadata db. This is necessary to avoid task instances being forever stuck in a "REMOVED" limbo should the old task show up again


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Tests that "REMOVED" task instances are removed (reset to None)


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

