### PR TITLE
[AIRFLOW-1469] Don't get aws connection if connection_id is unspecified

### DIFF
--- a/airflow/contrib/hooks/aws_hook.py
+++ b/airflow/contrib/hooks/aws_hook.py
@@ -28,19 +28,22 @@ class AwsHook(BaseHook):
         self.aws_conn_id = aws_conn_id
 
     def get_client_type(self, client_type, region_name=None):
-        try:
-            connection_object = self.get_connection(self.aws_conn_id)
-            aws_access_key_id = connection_object.login
-            aws_secret_access_key = connection_object.password
-
-            if region_name is None:
-                region_name = connection_object.extra_dejson.get('region_name')
-
-        except AirflowException:
-            # No connection found: fallback on boto3 credential strategy
-            # http://boto3.readthedocs.io/en/latest/guide/configuration.html
-            aws_access_key_id = None
-            aws_secret_access_key = None
+        aws_access_key_id = None
+        aws_secret_access_key = None
+        
+        if self.aws_conn_id:
+            try:
+                connection_object = self.get_connection(self.aws_conn_id)
+                aws_access_key_id = connection_object.login
+                aws_secret_access_key = connection_object.password
+    
+                if region_name is None:
+                    region_name = connection_object.extra_dejson.get('region_name')
+    
+            except AirflowException:
+                # No connection found: fallback on boto3 credential strategy
+                # http://boto3.readthedocs.io/en/latest/guide/configuration.html
+                pass
 
         return boto3.client(
             client_type,


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1469


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
If no aws_conn_id was specified (eg aws_conn_id == None), then the get_connection method would raise an AttributeError (AttributeError: 'NoneType' object has no attribute 'upper').
Changed the behaviour into not attempting to get a connection for an empty/unspecified conn_id

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

