### PR TITLE
[AIRFLOW-1342] enable S3Hook to use host from connection

### DIFF
--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -105,7 +105,9 @@ class S3Hook(BaseHook):
         self._creds_in_conn = 'aws_secret_access_key' in self.extra_params
         self._creds_in_config_file = 's3_config_file' in self.extra_params
         self._default_to_boto = False
-        if 'host' in self.extra_params:
+        if self.s3_conn.host is not None:
+            self.s3_host = self.s3_conn.host
+        elif 'host' in self.extra_params:
             self.s3_host = self.extra_params['host']
         if self._creds_in_conn:
             self._a_key = self.extra_params['aws_access_key_id']

--- a/tests/core.py
+++ b/tests/core.py
@@ -23,6 +23,7 @@ import re
 import unittest
 import multiprocessing
 import mock
+from mock.mock import patch, MagicMock
 from numpy.testing import assert_array_almost_equal
 import tempfile
 from datetime import datetime, time, timedelta
@@ -38,7 +39,7 @@ import sqlalchemy
 
 from airflow import configuration
 from airflow.executors import SequentialExecutor, LocalExecutor
-from airflow.models import Variable
+from airflow.models import Variable, Connection
 from tests.test_utils.fake_datetime import FakeDatetime
 
 configuration.load_test_config()
@@ -2379,6 +2380,24 @@ class S3HookTest(unittest.TestCase):
         self.assertEqual(parsed,
                          ("test", "this/is/not/a-real-key.txt"),
                          "Incorrect parsing of the s3 url")
+
+    def test_get_host_from_connection(self):
+        host_value = "some_host"
+        connection_obj = MagicMock(
+            spec_set=Connection,
+            host=host_value
+        )
+
+        with patch.object(
+            S3Hook,
+            "get_connection",
+            return_value=connection_obj) as mocked_get_connection,\
+            patch.object(
+                S3Hook,
+                "get_conn",
+                return_value=None) as mocked_get_coon:
+            hook = S3Hook()
+            self.assertEqual(host_value, hook.s3_host)
 
 
 send_email_test = mock.Mock()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [AIRFLOW-1342](https://issues.apache.org/jira/browse/AIRFLOW-1342) issue and references them in the PR title.


### Description
- [x] Change S3Hook to first try to get host from connection, then, if it is None, get it from extra_params


### Tests
- [x] My PR adds an new test method `test_get_host_from_connection` in `S3HookTest` to test host extraction from connection 


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

