### PR TITLE
User should be able to decide TemporaryDirectory root in a BashOperator

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -24,6 +24,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory
+from airflow import configuration as conf
 
 
 class BashOperator(BaseOperator):
@@ -68,8 +69,12 @@ class BashOperator(BaseOperator):
         which will be cleaned afterwards
         """
         bash_command = self.bash_command
-        logging.info("tmp dir root location: \n" + gettempdir())
-        with TemporaryDirectory(prefix='airflowtmp') as tmp_dir:
+        try:
+            tempdir = conf.get("core", "tempdir")
+        except conf.AirflowConfigException:
+            tempdir = gettempdir()
+        logging.info("tmp dir root location: \n" + tempdir)
+        with TemporaryDirectory(prefix='airflowtmp', dir=tempdir) as tmp_dir:
             with NamedTemporaryFile(dir=tmp_dir, prefix=self.task_id) as f:
 
                 f.write(bytes(bash_command, 'utf_8'))


### PR DESCRIPTION
I want the ability to decide the root of the `TemporaryDirectory` used within `airflow/operators/bash_operator/BashOperator.execute`. This PR does the trick, but I'm wondering if this might be better off within `airflow/utils/file/TemporaryDirectory` or as an additional parameter on `BashOperator.__init__`? Any feedback would be welcome!