### PR TITLE
[AIRFLOW-1476] add INSTALL instruction for source releases

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -25,3 +25,13 @@ CHANGELOG.txt
 kerberos_auth.py
 airflow_api_auth_backend_kerberos_auth_py.html
 licenses/*
+airflow/www/static/docs
+parallel.js
+underscore.js
+jquery.dataTables.min.js
+jqClock.min.js
+dagre-d3.min.js
+bootstrap-toggle.min.js
+bootstrap-toggle.min.css
+d3.v3.min.js
+ace.js

--- a/INSTALL
+++ b/INSTALL
@@ -1,0 +1,9 @@
+# INSTALL / BUILD instruction for Apache Airflow (incubating)
+# fetch the tarball and untar the source
+
+# [optional] run Apache RAT (release audit tool) to validate license headers
+# RAT docs here: https://creadur.apache.org/rat/
+java -jar apache-rat.jar -E ./.rat-excludes -d .
+
+# install the release
+python setup.py install


### PR DESCRIPTION
Also added js files to .rat-excludes after validating the licenses manually.

https://issues.apache.org/jira/browse/AIRFLOW-1476