### PR TITLE
[AIRFLOW-1239] fix unicode error for logs in base_task_runner

### DIFF
--- a/airflow/task_runner/base_task_runner.py
+++ b/airflow/task_runner/base_task_runner.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import unicode_literals
 
 import getpass
 import os


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow 1239](https://issues.apache.org/jira/browse/AIRFLOW-1239) issue and references it in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
The details here are that there exists a PR for this JIRA already, [PR 2318](https://github.com/apache/incubator-airflow/pull/2318), but like @AllisonWang mentioned in the comments, it doesn't address the root cause of the issue. The issue is that in python 2.7 not all literals are automatically unicode like they are in python 3. That's what's the root cause, and that can simply be fixed by just explicitly stating all literals should be treated as unicode, which is an import from the `__future__` module. There is a [stack overflow post](https://stackoverflow.com/questions/3235386/python-using-format-on-a-unicode-escaped-string) that also explains this same solution, which I found helpful.
The reason I created a new PR is that the original person working on this ticket seemed to be unresponsive to comments, and I would like to work on getting this fix in.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
I am going to add some code snippets for before and after adding this import:

**Before**
```
[2017-07-28 23:03:03,358] {driver.py:120} INFO - Generating grammar tables from /usr/lib/python2.7/lib2to3/PatternGrammar.txt
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/ahaidrey/.virtualenvs/airflow/local/lib/python2.7/site-packages/airflow/task_runner/base_task_runner.py", line 95, in _read_task_logs
    self.logger.info('Subtask: {}'.format(line.rstrip('\n')))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2018' in position 66: ordinal not in range(128)
```
**After**
```
[2017-07-29 03:57:05,707] {__init__.py:57} INFO - Using executor CeleryExecutor
[2017-07-29 03:57:05,833] {driver.py:120} INFO - Generating grammar tables from /usr/lib/python2.7/lib2to3/Grammar.txt
[2017-07-29 03:57:05,879] {driver.py:120} INFO - Generating grammar tables from /usr/lib/python2.7/lib2to3/PatternGrammar.txt
```

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

