### PR TITLE
[AIRFLOW-1483] Making page size consistent in listing views

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -229,6 +229,9 @@ log_fetch_timeout_sec = 5
 # DAGs by default
 hide_paused_dags_by_default = False
 
+# Consistent page size across all listing views in the UI
+page_size = 100
+
 [email]
 email_backend = airflow.utils.email.send_email_smtp
 

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -56,6 +56,7 @@ dag_orientation = LR
 dag_default_view = tree
 log_fetch_timeout_sec = 5
 hide_paused_dags_by_default = False
+page_size = 100
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -91,6 +91,8 @@ logout_user = airflow.login.logout_user
 
 FILTER_BY_OWNER = False
 
+PAGE_SIZE = conf.getint('webserver', 'page_size')
+
 if conf.getboolean('webserver', 'FILTER_BY_OWNER'):
     # filter_by_owner if authentication is enabled and filter_by_owner is true
     FILTER_BY_OWNER = not current_app.config['LOGIN_DISABLED']
@@ -1966,7 +1968,7 @@ class AirflowModelView(ModelView):
     edit_template = 'airflow/model_edit.html'
     create_template = 'airflow/model_create.html'
     column_display_actions = True
-    page_size = 500
+    page_size = PAGE_SIZE
 
 
 class ModelViewOnly(wwwutils.LoginMixin, AirflowModelView):
@@ -2283,7 +2285,6 @@ class VariableView(wwwutils.DataProfilingMixin, AirflowModelView):
 class XComView(wwwutils.SuperUserMixin, AirflowModelView):
     verbose_name = "XCom"
     verbose_name_plural = "XComs"
-    page_size = 20
 
     form_columns = (
         'key',
@@ -2438,7 +2439,7 @@ class TaskInstanceModelView(ModelViewOnly):
         'unixname', 'priority_weight', 'queue', 'queued_dttm', 'try_number',
         'pool', 'log_url')
     can_delete = True
-    page_size = 500
+    page_size = PAGE_SIZE
 
     @action('set_running', "Set state to 'running'", None)
     def action_set_running(self, ids):
@@ -2704,7 +2705,7 @@ class DagModelView(wwwutils.SuperUserMixin, ModelView):
     )
     can_delete = False
     can_create = False
-    page_size = 50
+    page_size = PAGE_SIZE
     list_template = 'airflow/list_dags.html'
     named_filter_urls = True
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-1483] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1483


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Views showing model listings had large page sizes which made page
loading really slow client-side, mostly due to DOM processing and
JS plugin rendering.
Also, the page size was inconsistent across some listings.

This commit introduces a configurable page size, and by default
it'll use a page_size = 100. Also, the same page size is applied to
all the model views controlled by flask_admin to be consistent.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This is a fairly simple change but verified manually that the configured page size is being used.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

