### PR TITLE
[AIRFLOW-1489] Fix typo in BigQueryCheckOperator

### DIFF
--- a/airflow/contrib/operators/bigquery_check_operator.py
+++ b/airflow/contrib/operators/bigquery_check_operator.py
@@ -19,7 +19,7 @@ from airflow.utils.decorators import apply_defaults
 
 class BigQueryCheckOperator(CheckOperator):
     """
-    Performs checks against Presto. The ``BigQueryCheckOperator`` expects
+    Performs checks against BigQuery. The ``BigQueryCheckOperator`` expects
     a sql query that will return a single row. Each value on that
     first row is evaluated using python ``bool`` casting. If any of the
     values return ``False`` the check is failed and errors out.
@@ -48,7 +48,7 @@ class BigQueryCheckOperator(CheckOperator):
     :param sql: the sql to be executed
     :type sql: string
     :param bigquery_conn_id: reference to the BigQuery database
-    :type presto_conn_id: string
+    :type bigquery_conn_id: string
     """
 
     @apply_defaults


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/1489) issues and references them in the PR title. 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In 'airflow/contrib/operators/bigquery_check_operator.py', some descriptions remain as 'Presto'.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Fixed only trivial typo in docs.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

