### PR TITLE
[AIRFLOW-1280] Fix Gantt chart height

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1788,7 +1788,7 @@ class Airflow(BaseView):
             'taskNames': [ti.task_id for ti in tis],
             'tasks': tasks,
             'taskStatus': states,
-            'height': len(tis) * 25,
+            'height': len(tis) * 25 + 25,
         }
 
         session.commit()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [AIRFLOW-1280](https://issues.apache.org/jira/browse/AIRFLOW-1280) issues and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
**Current:**
![gantt](https://user-images.githubusercontent.com/2817012/29029701-3eb2f21c-7b91-11e7-9cb7-b6ca6394c1e7.jpg)

**Expected:**
![gantt2](https://user-images.githubusercontent.com/2817012/29029676-2f7ca23e-7b91-11e7-9643-947d809349e1.jpg)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No tests needed.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

