### PR TITLE
AIRFLOW-1491 Check celery queue before scheduling commands

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -132,7 +132,7 @@ class BaseExecutor(LoggingMixin):
         self.sync()
 
     def change_state(self, key, state):
-        self.running.pop(key)
+        self.running.pop(key, None)
         self.event_buffer[key] = state
 
     def fail(self, key):

--- a/tests/executors/celery_executor.py
+++ b/tests/executors/celery_executor.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from celery import states as cstates
+
+from airflow.executors.celery_executor import CeleryExecutor
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+
+class CeleryExecutorTest(unittest.TestCase):
+    """Unit tests for the CeleryExecutor."""
+
+    @unittest.skipIf(mock is None, 'mock package not present')
+    @mock.patch('airflow.executors.celery_executor.time')
+    @mock.patch('airflow.executors.celery_executor.execute_command')
+    @mock.patch('airflow.executors.celery_executor.app')
+    def test_executor(self, app, execute_command, time):
+        insp = mock.MagicMock(name='inspector')
+        insp.active.return_value = {}
+        insp.scheduled.return_value = {}
+        insp.reserved.return_value = {}
+        app.control.inspect.return_value = insp
+
+        async1 = mock.MagicMock(name='async1')
+        async1.state = cstates.PENDING
+        async2 = mock.MagicMock(name='async2')
+        async2.state = cstates.FAILURE
+        execute_command.apply_async.side_effect = [async1, async2]
+
+        executor = CeleryExecutor()
+        executor.start()
+
+        executor.execute_async(key='one', command='echo 1')
+        executor.execute_async(key='two', command='echo 2', queue='other')
+
+        self.assertEquals(executor.tasks, {'one': async1, 'two': async2})
+        self.assertEquals(executor.last_state,
+                          {'one': cstates.PENDING, 'two': cstates.PENDING})
+
+        self.assertEquals(execute_command.mock_calls, [
+            mock.call.apply_async(args=['echo 1'], queue='default'),
+            mock.call.apply_async(args=['echo 2'], queue='other'),
+        ])
+        self.assertFalse(async1.mock_calls)
+        self.assertFalse(async2.mock_calls)
+        self.assertFalse(time.mock_calls)
+
+        executor.sync()
+
+        self.assertFalse(async1.mock_calls)
+        self.assertFalse(async2.mock_calls)
+
+        self.assertEquals(executor.tasks, {'one': async1})
+        self.assertEquals(executor.last_state,
+                          {'one': cstates.PENDING, 'two': cstates.FAILURE})
+
+    @unittest.skipIf(mock is None, 'mock package not present')
+    @mock.patch('airflow.executors.celery_executor.execute_command')
+    @mock.patch('airflow.executors.celery_executor.app')
+    def test_repeat_key(self, app, execute_command):
+        insp = mock.MagicMock(name='inspector')
+        insp.active.return_value = {}
+        insp.scheduled.return_value = {}
+        insp.reserved.return_value = {}
+        app.control.inspect.return_value = insp
+
+        executor = CeleryExecutor()
+        executor.start()
+
+        executor.execute_async(key='one', command='echo 1')
+        executor.execute_async(key='two', command='echo 2', queue='other')
+        executor.execute_async(key='one', command='echo 3', queue='other')
+
+        self.assertEquals(execute_command.mock_calls, [
+            mock.call.apply_async(args=['echo 1'], queue='default'),
+            mock.call.apply_async(args=['echo 2'], queue='other'),
+        ])
+
+    @unittest.skipIf(mock is None, 'mock package not present')
+    @mock.patch('airflow.executors.celery_executor.AsyncResult')
+    @mock.patch('airflow.executors.celery_executor.execute_command')
+    @mock.patch('airflow.executors.celery_executor.app')
+    def test_existing_command(self, app, execute_command, result):
+        insp = mock.MagicMock(name='inspector')
+        insp.active.return_value = {
+            'worker1': [{
+                'id': 'id1',
+                'args': ['echo 1']}],
+        }
+        insp.scheduled.return_value = {
+            'worker2': [{
+                'id': 'id2',
+                'args': ['echo 2']}],
+        }
+        insp.reserved.return_value = {
+            'worker3': [{
+                'id': 'id3',
+                'args': ['echo 3']}],
+        }
+        app.control.inspect.return_value = insp
+
+        executor = CeleryExecutor()
+        executor.start()
+
+        executor.execute_async(key='one', command='echo 1')
+        executor.execute_async(key='two', command='echo 2', queue='other')
+        executor.execute_async(key='three', command='echo 3', queue='other')
+        executor.execute_async(key='four', command='echo 4')
+
+        self.assertEquals(execute_command.mock_calls, [
+            mock.call.apply_async(args=['echo 4'], queue='default'),
+        ])
+        self.assertEquals(result.mock_calls, [
+            mock.call(id='id1', app=app),
+            mock.call(id='id2', app=app),
+            mock.call(id='id3', app=app),
+        ])
+        self.assertEquals(executor.tasks, {
+            'one': result.return_value,
+            'two': result.return_value,
+            'three': result.return_value,
+            'four': execute_command.apply_async.return_value,
+        })


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1491


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
    - This PR introduces a celery introspection check to the celery executor to recover commands from the celery queue.
    - Doing so prevents the rescheduling of identical commands in celery.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - Basic tests for the celery executor
    - Tests of reschedule check


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

