### PR TITLE
[AIRFLOW-1420][AIRFLOW-1473] Fix deadlock check

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4172,7 +4172,6 @@ class DagRun(Base):
 
     ID_PREFIX = 'scheduled__'
     ID_FORMAT_PREFIX = ID_PREFIX + '{0}'
-    DEADLOCK_CHECK_DEP_CONTEXT = DepContext(ignore_in_retry_period=True)
 
     id = Column(Integer, primary_key=True)
     dag_id = Column(String(ID_LEN))
@@ -4398,13 +4397,19 @@ class DagRun(Base):
         # small speed up
         if unfinished_tasks and none_depends_on_past:
             # todo: this can actually get pretty slow: one task costs between 0.01-015s
-            no_dependencies_met = all(
-                # Use a special dependency context that ignores task's up for retry
-                # dependency, since a task that is up for retry is not necessarily
-                # deadlocked.
-                not t.are_dependencies_met(dep_context=self.DEADLOCK_CHECK_DEP_CONTEXT,
-                                           session=session)
-                for t in unfinished_tasks)
+            no_dependencies_met = True
+            for ut in unfinished_tasks:
+                # We need to flag upstream and check for changes because upstream
+                # failures can result in deadlock false positives
+                old_state = ut.state
+                deps_met = ut.are_dependencies_met(
+                    dep_context=DepContext(
+                        flag_upstream_failed=True,
+                        ignore_in_retry_period=True),
+                    session=session)
+                if deps_met or old_state != ut.current_state(session=session):
+                    no_dependencies_met = False
+                    break
 
         duration = (datetime.now() - start_dttm).total_seconds() * 1000
         Stats.timing("dagrun.dependency-check.{}.{}".

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -124,8 +124,8 @@ class TriggerRuleDep(BaseTIDep):
         tr = task.trigger_rule
         upstream_done = done >= upstream
         upstream_tasks_state = {
-            "successes": successes, "skipped": skipped, "failed": failed,
-            "upstream_failed": upstream_failed, "done": done
+            "total": upstream, "successes": successes, "skipped": skipped,
+            "failed": failed, "upstream_failed": upstream_failed, "done": done
         }
         # TODO(aoen): Ideally each individual trigger rules would be it's own class, but
         # this isn't very feasible at the moment since the database queries need to be

--- a/tests/models.py
+++ b/tests/models.py
@@ -36,6 +36,7 @@ from airflow.operators.python_operator import PythonOperator
 from airflow.operators.python_operator import ShortCircuitOperator
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.utils.state import State
+from airflow.utils.trigger_rule import TriggerRule
 from mock import patch
 from parameterized import parameterized
 
@@ -482,10 +483,38 @@ class DagRunTest(unittest.TestCase):
         state = dr.update_state()
         self.assertEqual(State.SUCCESS, state)
 
-        # upstream dependency failed, root has not run
-        ti_op1.set_state(State.NONE, session)
-        state = dr.update_state()
-        self.assertEqual(State.FAILED, state)
+    def test_dagrun_deadlock(self):
+        session = settings.Session()
+        dag = DAG(
+            'text_dagrun_deadlock',
+            start_date=DEFAULT_DATE,
+            default_args={'owner': 'owner1'})
+
+        with dag:
+            op1 = DummyOperator(task_id='A')
+            op2 = DummyOperator(task_id='B')
+            op2.trigger_rule = TriggerRule.ONE_FAILED
+            op2.set_upstream(op1)
+
+        dag.clear()
+        now = datetime.datetime.now()
+        dr = dag.create_dagrun(run_id='test_dagrun_deadlock',
+                               state=State.RUNNING,
+                               execution_date=now,
+                               start_date=now)
+
+        ti_op1 = dr.get_task_instance(task_id=op1.task_id)
+        ti_op1.set_state(state=State.SUCCESS, session=session)
+        ti_op2 = dr.get_task_instance(task_id=op2.task_id)
+        ti_op2.set_state(state=State.NONE, session=session)
+
+        dr.update_state()
+        self.assertEqual(dr.state, State.RUNNING)
+
+        ti_op2.set_state(state=State.NONE, session=session)
+        op2.trigger_rule = 'invalid'
+        dr.update_state()
+        self.assertEqual(dr.state, State.FAILED)
 
     def test_get_task_instance_on_empty_dagrun(self):
         """


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1420
    - https://issues.apache.org/jira/browse/AIRFLOW-1473


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
    - Modify the deadlock check to flag task upstream conditions before assuming that a task is unrunnable. This resolves a deadlock false positive case where having a `ONE_FAILED` task mid-pipeline can cause the remainder of a pipeline to abort, even if a later `ALL_DONE` might be able to continue were the `ONE_FAILED` to be skipped.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - A test has been added for the interaction between `TriggerRule.ONE_FAILED` and the DagRun deadlock check.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

