### PR TITLE
[AIRFLOW-1497] Reset hidden fields when changing connection type

### DIFF
--- a/airflow/www/static/connection_form.js
+++ b/airflow/www/static/connection_form.js
@@ -41,7 +41,7 @@
         }
       }
       function connTypeChange(connectionType) {
-        $("div.form_group").removeClass("hide");
+        $("div.form-group").removeClass("hide");
         $.each($("[id^='extra__']"), function() {
             $(this).parent().parent().addClass('hide')
         });


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1497


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Some fields in connection form are hidden when selecting specific connection type. The fields once hidden are cannot be shown again by changing connection type.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Changed only JavaScript code.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

