### PR TITLE
[AIRFLOW-940] Handle error on variable decrypt

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3829,7 +3829,12 @@ class Variable(Base):
                 raise AirflowException(
                     "Can't decrypt _val for key={}, FERNET_KEY configuration \
                     missing".format(self.key))
-            return fernet.decrypt(bytes(self._val, 'utf-8')).decode()
+            try:
+                return fernet.decrypt(bytes(self._val, 'utf-8')).decode()
+            except:
+                raise AirflowException(
+                    "Can't decrypt _val for key={}, invalid token or value"
+                    .format(self.key))
         else:
             return self._val
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2283,7 +2283,10 @@ class VariableView(wwwutils.DataProfilingMixin, AirflowModelView):
     def hidden_field_formatter(view, context, model, name):
         if wwwutils.should_hide_value_for_key(model.key):
             return Markup('*' * 8)
-        return getattr(model, name)
+        try:
+            return getattr(model, name)
+        except AirflowException:
+            return Markup('<span class="label label-danger">Invalid</span>')
 
     form_columns = (
         'key',


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-940


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Invalid variables could break the variable view by unhandled
InvalidToken exception from Fernet.

This commit converts the fernet error into an AirflowException, given
that fernet is loaded dynamically. Also, the exception is handled in
the VariableView by showing the token "INVALID" in the UI render.

![screen shot 2017-08-09 at 3 00 48 pm](https://user-images.githubusercontent.com/266670/29149773-263880da-7d2b-11e7-892c-b37df974f76f.png)


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
```
./run_unit_tests.sh -s tests/www/test_views.py:TestVariableView
```

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

