### PR TITLE
[AIRFLOW-1502] Implement possibility to search runs

### DIFF
--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -151,6 +151,14 @@ def task_instance_info(dag_id, execution_date, task_id):
     return jsonify(fields)
 
 
+@api_experimental.route('/dag_runs/search/<string:query>', methods=['GET'])
+@requires_authentication
+def dag_runs_search(query):
+    """Returns the list of DagRun items by a given query."""
+    from airflow.models import DagRun
+    return jsonify(items=[dr.to_json() for dr in DagRun.search(query=query)])
+
+
 @api_experimental.route('/latest_runs', methods=['GET'])
 @requires_authentication
 def latest_dag_runs():

--- a/tests/models.py
+++ b/tests/models.py
@@ -342,7 +342,8 @@ class DagStatTest(unittest.TestCase):
         for stat in res:
             self.assertFalse(stat.dirty)
 
-class DagRunTest(unittest.TestCase):
+
+class TestDagRun(unittest.TestCase):
 
     def create_dag_run(self, dag, state=State.RUNNING, task_states=None, execution_date=None):
         now = datetime.datetime.now()
@@ -364,6 +365,29 @@ class DagRunTest(unittest.TestCase):
             session.close()
 
         return dag_run
+
+    @patch("airflow.models.url_for")
+    def test_to_json(self, url_for_mock):
+        url_for_mock.return_value = 'url'
+        dr = models.DagRun(
+            dag_id='dag_id',
+            execution_date=datetime.datetime.strptime('2017-08-10 11:00',
+                                                      '%Y-%m-%d %H:%M'),
+            start_date=None,
+            state=State.RUNNING,
+            run_id='run_id',
+        )
+        self.assertDictEqual(
+            dr.to_json(),
+            {
+                'dag_id': 'dag_id',
+                'dag_run_url': 'url',
+                'execution_date': '2017-08-10 11:00',
+                'run_id': 'run_id',
+                'start_date': '',
+                'state': 'running',
+            }
+        )
 
     def test_id_for_date(self):
         run_id = models.DagRun.id_for_date(


### PR DESCRIPTION
Implement possibility to search runs via experimental api.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following:
    - [AIRFLOW-1502](https://issues.apache.org/jira/browse/AIRFLOW-1502) Implement possibility to search dag runs via experimental api


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Implement possibility to search dag runs via experimental api.

**Format:**
```
http://localhost:8080/api/experimental/dag_runs/search/<query>
```

**Example:**
```
http://localhost:8080/api/experimental/dag_runs/search/scheduled
```

**Response:**
```
{
  "items": [
    {
      "dag_id": "trigger_1", 
      "dag_run_url": "/admin/airflow/graph?execution_date=2017-08-10+09%3A03%3A00&dag_id=trigger_1", 
      "execution_date": "2017-08-10 09:03", 
      "run_id": "scheduled__2017-08-10T09:03:00", 
      "start_date": "2017-08-10 12:02", 
      "state": "running"
    }, 
    {
      "dag_id": "trigger_1", 
      "dag_run_url": "/admin/airflow/graph?execution_date=2017-08-10+09%3A04%3A00&dag_id=trigger_1", 
      "execution_date": "2017-08-10 09:04", 
      "run_id": "scheduled__2017-08-10T09:04:00", 
      "start_date": "2017-08-10 12:02", 
      "state": "running"
    }
  ]
}
```

### Tests
- [x] My PR adds the following unit tests:
    - tests.models:TestDagRun.test_to_json
    - tests.www.api.experimental.test_endpoints

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

