### PR TITLE
[AIRFLOW-1507] Make src, dst and bucket params of file_to_gcs operator as templated

### DIFF
--- a/airflow/contrib/operators/file_to_gcs.py
+++ b/airflow/contrib/operators/file_to_gcs.py
@@ -35,7 +35,8 @@ class FileToGoogleCloudStorageOperator(BaseOperator):
     :param delegate_to: The account to impersonate, if any
     :type delegate_to: string
     """
-
+    template_fields = ('src', 'dst', 'bucket')
+    
     @apply_defaults
     def __init__(self,
                  src,


### PR DESCRIPTION
…emplated

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1507


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
       Our use case requires 'src' and 'dst' parameters in the file_to_gcs operator to be able to parse 
       templates. Apart from 'src' and 'dst', having the 'bucket' parameter also to be one of the 
       templated parameters would be useful.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: This has been tested locally. This is a simple change that just marks the 'src', 'dst' and 
             'bucket' parameters of file_to_gcs operator to be templated fields.


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

