### PR TITLE
[AIRFLOW-1495] Add TaskInstance index on job_id

### DIFF
--- a/airflow/migrations/versions/7171349d4c73_add_ti_job_id_index.py
+++ b/airflow/migrations/versions/7171349d4c73_add_ti_job_id_index.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""add ti job_id index
+
+Revision ID: 7171349d4c73
+Revises: cc1e65623dc7
+Create Date: 2017-08-14 18:08:50.196042
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '7171349d4c73'
+down_revision = 'cc1e65623dc7'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_index('ti_job_id', 'task_instance', ['job_id'], unique=False)
+
+
+def downgrade():
+    op.drop_index('ti_job_id', table_name='task_instance')


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1495

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Column job_id is unindexed in TaskInstance, it was used as
default sort column in TaskInstanceView.

This commit adds the required migration to add the index on
task_instance.job_id on future db upgrades.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Just the Alembic migration, I tested it manually with `airflow upgradedb` to verify the index creation.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

