### PR TITLE
[AIRFLOW-1495] Fix migration on index on job_id

### DIFF
--- a/airflow/migrations/versions/947454bf1dff_add_ti_job_id_index.py
+++ b/airflow/migrations/versions/947454bf1dff_add_ti_job_id_index.py
@@ -14,15 +14,15 @@
 
 """add ti job_id index
 
-Revision ID: 7171349d4c73
-Revises: cc1e65623dc7
-Create Date: 2017-08-14 18:08:50.196042
+Revision ID: 947454bf1dff
+Revises: bdaa763e6c56
+Create Date: 2017-08-15 15:12:13.845074
 
 """
 
 # revision identifiers, used by Alembic.
-revision = '7171349d4c73'
-down_revision = 'cc1e65623dc7'
+revision = '947454bf1dff'
+down_revision = 'bdaa763e6c56'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

@aoen 

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1495

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

There was a merge conflict on the migration hash for down revision
at the time that two commits including migrations were merged.

This commit restores the chain of revisions for the migrations,
pointing to the last one. The job_id index migration was regenerated
from the top migration.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This is a fix for a migration that was already merged.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

