### PR TITLE
[AIRFLOW-1514] Truncate large logs in webui, add raw log link

### DIFF
--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -34,6 +34,7 @@
     {% for log in logs %}
       <div role="tabpanel" class="tab-pane {{ 'active' if loop.last else '' }}" id="{{ loop.index }}">
         <pre id="attempt-{{ loop.index }}">{{ log }}</pre>
+        <a href="{{ url_for("airflow.log_raw", dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date, log_index=loop.index0) }}">Open raw log</a>
       </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1514


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
We had a problem with very large logs (out of memory errors). This PR truncates the log to the last X lines in the view logs view. But adds a link to download/view the raw logs of a task attempt.

![log_truncate](https://user-images.githubusercontent.com/3777585/29359695-fa807682-827f-11e7-8f52-aff7bde395c9.png)

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

