### PR TITLE
[AIRFLOW-1518] Specify list of dag ids for scheduler

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -798,11 +798,12 @@ def webserver(args):
 def scheduler(args):
     print(settings.HEADER)
     job = jobs.SchedulerJob(
-        dag_id=args.dag_id,
+        dag_ids=args.dag_id,
         subdir=process_subdir(args.subdir),
         run_duration=args.run_duration,
         num_runs=args.num_runs,
-        do_pickle=args.do_pickle)
+        do_pickle=args.do_pickle,
+    )
 
     if args.daemon:
         pid, stdout, stderr, log_file = setup_locations("scheduler", args.pid, args.stdout, args.stderr, args.log_file)
@@ -1353,14 +1354,19 @@ class CLIFactory(object):
             "store_true",
             default=False),
         # scheduler
-        'dag_id_opt': Arg(("-d", "--dag_id"), help="The id of the dag to run"),
+        'dag_ids': Arg(
+            ("-d", "--dag_id"),
+            action='append',
+            help="The id of the dag to run"),
         'run_duration': Arg(
             ("-r", "--run-duration"),
-            default=None, type=int,
+            default=None,
+            type=int,
             help="Set number of seconds to execute before exiting"),
         'num_runs': Arg(
             ("-n", "--num_runs"),
-            default=-1, type=int,
+            default=-1,
+            type=int,
             help="Set the number of runs to execute before exiting"),
         # worker
         'do_pickle': Arg(
@@ -1537,7 +1543,7 @@ class CLIFactory(object):
         }, {
             'func': scheduler,
             'help': "Start a scheduler instance",
-            'args': ('dag_id_opt', 'subdir', 'run_duration', 'num_runs',
+            'args': ('dag_ids', 'subdir', 'run_duration', 'num_runs',
                      'do_pickle', 'pid', 'daemon', 'stdout', 'stderr',
                      'log_file'),
         }, {

--- a/tests/core.py
+++ b/tests/core.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 import bleach
 import doctest
 import json
-import logging
 import os
 import re
 import unittest
@@ -34,6 +33,7 @@ import warnings
 
 from dateutil.relativedelta import relativedelta
 import sqlalchemy
+import six
 
 from airflow import configuration
 from airflow.executors import SequentialExecutor
@@ -62,8 +62,6 @@ from airflow.exceptions import AirflowException
 from airflow.configuration import AirflowConfigException, run_command
 from jinja2.sandbox import SecurityError
 from jinja2 import UndefinedError
-
-import six
 
 NUM_EXAMPLE_DAGS = 18
 DEV_NULL = '/dev/null'
@@ -1539,6 +1537,27 @@ class CliTests(unittest.TestCase):
         # Assert that no process remains.
         self.assertEqual(1, subprocess.Popen(["pgrep", "-c", "airflow"]).wait())
         self.assertEqual(1, subprocess.Popen(["pgrep", "-c", "gunicorn"]).wait())
+
+    @mock.patch("airflow.bin.cli.jobs.SchedulerJob")
+    def test_scheduler(self, scheduler_job_mock):
+        args = self.parser.parse_args([
+            'scheduler',
+            '--dag_id', 'example_bash_operator',
+            '--subdir', '/sub/dir',
+            '--run-duration', '60',
+            '--num_runs', '1',
+            '--do_pickle',
+        ])
+        cli.scheduler(args)
+
+        scheduler_job_mock.assert_called_once_with(
+            dag_ids=['example_bash_operator'],
+            subdir='/sub/dir',
+            run_duration=60,
+            num_runs=1,
+            do_pickle=True,
+        )
+        scheduler_job_mock.return_value.run.assert_called_once_with()
 
 
 class SecurityTests(unittest.TestCase):


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following:
    - [AIRFLOW-1518](https://issues.apache.org/jira/browse/AIRFLOW-1518) Make it possible to specify list of dag ids for scheduler to run


### Description
- [x] Here are some details about my PR:
Make it possible to specify list of dag ids for scheduler to run.

```
airflow scheduler -d dag1 -d dag2 -d dag3
```

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

