### PR TITLE
[AIRFLOW-1521] Template rendering broken for BigqueryTableDeleteOperator

### DIFF
--- a/airflow/contrib/operators/bigquery_table_delete_operator.py
+++ b/airflow/contrib/operators/bigquery_table_delete_operator.py
@@ -37,7 +37,7 @@ class BigQueryTableDeleteOperator(BaseOperator):
         requested table does not exist.
     :type ignore_if_missing: boolean
     """
-    template_fields = ('deletion_dataset_table')
+    template_fields = ('deletion_dataset_table',)
     ui_color = '#ffd1dc'
 
     @apply_defaults


### PR DESCRIPTION
Add comma to avoid the template fields list to be interpreted as a list of characters

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1521


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
Almost no changes, just fix the list of template_fields for bigquery_table_delete_operator. A PR added the deleted_table_field to the list, but python interpret the list as a list of character as it contains only one string. 


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No new test written as I don't know how to write test for operators (and more generally in python) but one could be added easily to check that render_template work properly on bigquery_table_delete_operator

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

