### PR TITLE
[AIRFLOW-1522] Increase text size for var field in variables for MySQL

### DIFF
--- a/airflow/migrations/versions/d2ae31099d61_increase_text_size_for_mysql.py
+++ b/airflow/migrations/versions/d2ae31099d61_increase_text_size_for_mysql.py
@@ -1,0 +1,41 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Increase text size for MySQL (not relevant for other DBs' text types)
+
+Revision ID: d2ae31099d61
+Revises: 947454bf1dff
+Create Date: 2017-08-18 17:07:16.686130
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd2ae31099d61'
+down_revision = '947454bf1dff'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+from alembic import context
+
+
+def upgrade():
+    if context.config.get_main_option('sqlalchemy.url').startswith('mysql'):
+        op.alter_column(table_name='variable', column_name='val', type_=mysql.MEDIUMTEXT)
+
+
+def downgrade():
+    if context.config.get_main_option('sqlalchemy.url').startswith('mysql'):
+        op.alter_column(table_name='variable', column_name='val', type_=mysql.TEXT)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1522


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes: Increases text size, which is not needed in non-MySQL dialects due to their text size not having a limit.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: schema change. will run schema change then report back


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@aoen @edgarRd 
