### PR TITLE
[AIRFLOW-1491] Recover celery queue on restart

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -120,7 +120,7 @@ class BaseExecutor(LoggingMixin):
             self.queued_tasks.pop(key)
             ti.refresh_from_db()
             if ti.state != State.RUNNING:
-                self.running[key] = command
+                self.running[key] = True
                 self.execute_async(key, command=command, queue=queue)
             else:
                 self.logger.debug(

--- a/airflow/migrations/versions/a7006f20d0e0_add_executor_queue.py
+++ b/airflow/migrations/versions/a7006f20d0e0_add_executor_queue.py
@@ -1,0 +1,42 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""add executor queue
+
+Revision ID: a7006f20d0e0
+Revises: 947454bf1dff
+Create Date: 2017-08-22 10:54:07.425417
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'a7006f20d0e0'
+down_revision = '947454bf1dff'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('executor_queue',
+                    sa.Column('key', sa.String(length=250), nullable=False),
+                    sa.Column('id', sa.String(length=250), nullable=False),
+                    sa.Column('updated', sa.DateTime(), nullable=True),
+                    sa.PrimaryKeyConstraint('key')
+                    )
+
+
+def downgrade():
+    op.drop_table('executor_queue')

--- a/scripts/ci/airflow_travis.cfg
+++ b/scripts/ci/airflow_travis.cfg
@@ -44,8 +44,8 @@ smtp_mail_from = airflow@example.com
 celery_app_name = airflow.executors.celery_executor
 celeryd_concurrency = 16
 worker_log_server_port = 8793
-broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
-celery_result_backend = db+mysql://airflow:airflow@localhost:3306/airflow
+broker_url = sqla+mysql://root@localhost:3306/airflow
+celery_result_backend = db+mysql://root@localhost:3306/airflow
 flower_port = 5555
 default_queue = default
 

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from airflow.executors.celery_executor import app
+from airflow.executors.celery_executor import CeleryExecutor
+from airflow.utils.state import State
+from celery.contrib.testing.worker import start_worker
+
+# leave this it is used by the test worker
+import celery.contrib.testing.tasks
+
+
+class CeleryExecutorTest(unittest.TestCase):
+    def test_celery_recovery(self):
+        with start_worker(app=app):
+            executor = CeleryExecutor()
+            executor.start()
+
+            delay_command = 'echo test && sleep 2'
+
+            executor.execute_async(key='delay', command=delay_command)
+            executor.running['delay'] = True
+            executor.sync()
+
+            del executor.running['delay']
+            executor.start()
+            self.assertTrue(executor.running['delay'])
+
+            executor.end(synchronous=True)
+            self.assertTrue(executor.event_buffer['delay'], State.SUCCESS)
+
+            # needs to be combined
+            executor.start()
+
+            success_command = 'echo 1'
+            fail_command = 'exit 1'
+
+            executor.execute_async(key='success', command=success_command)
+            # errors are propagated fpr some reason
+            try:
+                executor.execute_async(key='fail', command=fail_command)
+            except:
+                pass
+            executor.running['success'] = True
+            executor.running['fail'] = True
+
+            executor.end(synchronous=True)
+
+            self.assertTrue(executor.event_buffer['success'], State.SUCCESS)
+            self.assertTrue(executor.event_buffer['fail'], State.FAILED)
+
+            self.assertIsNone(executor.tasks['success'])
+            self.assertIsNone(executor.tasks['fail'])


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1491


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

If the scheduler (re)starts it will start from a clean slate.
This is not a problem for a synchronous executor (e.g. LocalExecutor),
but it is for an asynchronous one as worker might still be executing
tasks, while the scheduler will requeue them.

This patch makes sure the queue is recovered from the workers, by
inpsecting them.


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Unit tests for celery added. Working on the recovery method testing

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

cc: @gwax @saguziel 
