### PR TITLE
[AIRFLOW-1177] Fix Variable.setdefault when var exists.

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3886,7 +3886,7 @@ class Variable(Base):
         :return: Mixed
         """
         default_sentinel = object()
-        obj = Variable.get(key, default_var=default_sentinel, deserialize_json=False)
+        obj = Variable.get(key, default_var=default_sentinel, deserialize_json=deserialize_json)
         if obj is default_sentinel:
             if default is not None:
                 Variable.set(key, default, serialize_json=deserialize_json)
@@ -3894,10 +3894,7 @@ class Variable(Base):
             else:
                 raise ValueError('Default Value must be set')
         else:
-            if deserialize_json:
-                return json.loads(obj.val)
-            else:
-                return obj.val
+            return obj
 
     @classmethod
     @provide_session

--- a/tests/core.py
+++ b/tests/core.py
@@ -731,6 +731,15 @@ class CoreTest(unittest.TestCase):
         Variable.setdefault(key, value, deserialize_json=True)
         self.assertEqual(value, Variable.get(key, deserialize_json=True))
 
+    def test_variable_setdefault_existing_json(self):
+        key = "tested_var_setdefault_2_id"
+        value = {"city": 'Paris', "Hapiness": True}
+        Variable.set(key, value, serialize_json=True)
+        val = Variable.setdefault(key, value, deserialize_json=True)
+        # Check the returned value, and the stored value are handled correctly.
+        self.assertEqual(value, val)
+        self.assertEqual(value, Variable.get(key, deserialize_json=True))
+
     def test_parameterized_config_gen(self):
 
         cfg = configuration.parameterized_config(configuration.DEFAULT_CONFIG)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [[AIRFLOW-1177] variable json deserialize does not work at set defaults](https://issues.apache.org/jira/browse/AIRFLOW-1177)


### Description
- [x] Previously due to a logic error if you attempt to use `Variable.setdefault()` with `deserialize_json=True` and the value already existed it would die with:

      ...
          my = Variable.setdefault('regions', ['uk'], deserialize_json=True)
        File "/usr/local/lib/python3.5/site-packages/airflow/models.py", line 3623, in setdefault
          return json.loads(obj.val)
    AttributeError: 'str' object has no attribute 'val'

  The problem was that the `Variable.get()` call was returning the value, not a variable object.

  This closes #2278 too. (The original author was requested to add tests and confirm with commit guidelines but hasn't done so in 3 months, and I ran in to this bug)


### Tests
- [x] My PR adds the following unit tests: Extra case in core.py along side existing setdefault tests


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters (_a little longer, 67_)
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

