### PR TITLE
[AIRFLOW-1529] Support quoted newlines in Google BigQuery load jobs

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -385,6 +385,7 @@ class BigQueryBaseCursor(object):
                  field_delimiter=',',
                  max_bad_records=0,
                  quote_character=None,
+                 allow_quoted_newlines=False,
                  schema_update_options=()):
         """
         Executes a BigQuery load command to load data from Google Cloud Storage
@@ -421,6 +422,8 @@ class BigQueryBaseCursor(object):
         :type max_bad_records: int
         :param quote_character: The value that is used to quote data sections in a CSV file.
         :type quote_character: string
+        :param allow_quoted_newlines: Whether to allow quoted newlines (true) or not (false).
+        :type allow_quoted_newlines: boolean
         :param schema_update_options: Allows the schema of the desitination
             table to be updated as a side effect of the load job.
         :type schema_update_options: list
@@ -499,6 +502,9 @@ class BigQueryBaseCursor(object):
 
         if quote_character:
             configuration['load']['quote'] = quote_character
+
+        if allow_quoted_newlines:
+            configuration['load']['allowQuotedNewlines'] = allow_quoted_newlines
 
         return self.run_with_configuration(configuration)
 

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -45,6 +45,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         field_delimiter=',',
         max_bad_records=0,
         quote_character=None,
+        allow_quoted_newlines=False,
         max_id_key=None,
         bigquery_conn_id='bigquery_default',
         google_cloud_storage_conn_id='google_cloud_storage_default',
@@ -87,6 +88,8 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         :type max_bad_records: int
         :param quote_character: The value that is used to quote data sections in a CSV file.
         :type quote_character: string
+        :param allow_quoted_newlines: Whether to allow quoted newlines (true) or not (false).
+        :type allow_quoted_newlines: boolean
         :param max_id_key: If set, the name of a column in the BigQuery table
             that's to be loaded. Thsi will be used to select the MAX value from
             BigQuery after the load occurs. The results will be returned by the
@@ -124,6 +127,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         self.field_delimiter = field_delimiter
         self.max_bad_records = max_bad_records
         self.quote_character = quote_character
+        self.allow_quoted_newlines = allow_quoted_newlines
 
         self.max_id_key = max_id_key
         self.bigquery_conn_id = bigquery_conn_id
@@ -161,6 +165,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
             field_delimiter=self.field_delimiter,
             max_bad_records=self.max_bad_records,
             quote_character=self.quote_character,
+            allow_quoted_newlines=self.allow_quoted_newlines,
             schema_update_options=self.schema_update_options)
 
         if self.max_id_key:


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1529) issues and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
 - Support quoted newlines in Google BigQuery load jobs as described in REST API: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load

### Tests
- [x] My PR does not need testing for this extremely good reason:
 - Tested manually on Google Cloud project.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

