### PR TITLE
[AIRFLOW-1541] Add channel to template fields of slack_operator

### DIFF
--- a/airflow/operators/slack_operator.py
+++ b/airflow/operators/slack_operator.py
@@ -86,7 +86,7 @@ class SlackAPIPostOperator(SlackAPIOperator):
     :type attachments: array of hashes
     """
 
-    template_fields = ('username', 'text', 'attachments')
+    template_fields = ('username', 'text', 'attachments', 'channel')
     ui_color = '#FFBA40'
 
     @apply_defaults


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1541


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Our company (unfortunately) doesn't stay consistent between ldap users and slack user id's, so we have to use a PythonOperator to get the slack user name and pass that via xcom. We want to DM the person on slack, and the channel field needs to be templated to run something like ```"{{ task_instance.xcom_pull(task_ids='get_slack_userid') }}"```
This PR is to allow for that.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
We're simply adding a template field, so testing isn't necessary though could be done.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

