### PR TITLE
[AIRFLOW-1465] Fix serialization error of chart data when X is Date

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -424,7 +424,7 @@ class Airflow(BaseView):
                 nvd3_chart = NVd3ChartClass(x_is_date=chart.x_is_date)
 
                 for col in df.columns:
-                    nvd3_chart.add_serie(name=col, y=df[col].tolist(), x=df[col].index.tolist())
+                    nvd3_chart.add_serie(name=col, y=df[col].tolist(), x=df[col].index.get_values().tolist())
                 try:
                     nvd3_chart.buildcontent()
                     payload['chart_type'] = nvd3_chart.__class__.__name__


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1465


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In Python 3, the example on https://airflow.incubator.apache.org/profiling.html#chart-screenshot fails with the error message like `1496268000000 is not JSON serializable` or `Object of type 'int64' is not JSON serializable`.
The `numpy.int64` values can't be converted to native types in `df[col].index.tolist()`, but `df[col].index.get_values()` returns `pandas.Series` and `pandas.Series.tolist()` can convert them to native types.
See below.
* https://github.com/pandas-dev/pandas/blob/master/pandas/core/indexes/base.py#L572
* https://github.com/pandas-dev/pandas/blob/master/pandas/core/series.py#L1124

![chart error](https://user-images.githubusercontent.com/6421289/29811284-e7141a5a-8cdd-11e7-8e4a-83d94b85c89c.png)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

There are no tests of rendering chart originally, and that's hard to test.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

