### PR TITLE
Rename wrong DagFileProcessor method call, from stop to terminate

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -445,7 +445,7 @@ class DagFileProcessorManager(LoggingMixin):
                 filtered_processors[file_path] = processor
             else:
                 self.logger.warning("Stopping processor for {}".format(file_path))
-                processor.stop()
+                processor.terminate()
         self._processors = filtered_processors
 
     @staticmethod


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1554


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Inside DagFileProcessorManager, on the method set_file_paths(), it tries to call the method stop() from DagFileProcessor, which doesn't exist. The correct name is terminate().
This issues causes the scheduler to hang and not take anymore tasks.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Nothing new added.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

