### PR TITLE
[AIRFLOW-1556] Add support for SQL parameters in BigQueryBaseCursor

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -196,7 +196,8 @@ class BigQueryBaseCursor(object):
             udf_config = False,
             use_legacy_sql=True,
             maximum_billing_tier=None,
-            create_disposition='CREATE_IF_NEEDED'):
+            create_disposition='CREATE_IF_NEEDED',
+            query_params=None):
         """
         Executes a BigQuery SQL query. Optionally persists results in a BigQuery
         table. See here:
@@ -254,6 +255,9 @@ class BigQueryBaseCursor(object):
             configuration['query'].update({
                 'userDefinedFunctionResources': udf_config
             })
+
+        if query_params:
+            configuration['query']['queryParameters'] = query_params
 
         return self.run_with_configuration(configuration)
 

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -51,6 +51,10 @@ class BigQueryOperator(BaseOperator):
     :param maximum_billing_tier: Positive integer that serves as a multiplier of the basic price.
         Defaults to None, in which case it uses the value set in the project.
     :type maximum_billing_tier: integer
+    :param query_params: a dictionary containing query parameter types and values, passed to
+        BigQuery.
+    :type query_params: dict
+
     """
     template_fields = ('bql', 'destination_dataset_table')
     template_ext = ('.sql',)
@@ -68,6 +72,7 @@ class BigQueryOperator(BaseOperator):
                  use_legacy_sql=True,
                  maximum_billing_tier=None,
                  create_disposition='CREATE_IF_NEEDED',
+                 query_params=None,
                  *args,
                  **kwargs):
         super(BigQueryOperator, self).__init__(*args, **kwargs)
@@ -81,6 +86,7 @@ class BigQueryOperator(BaseOperator):
         self.udf_config = udf_config
         self.use_legacy_sql = use_legacy_sql
         self.maximum_billing_tier = maximum_billing_tier
+        self.query_params = query_params
 
     def execute(self, context):
         logging.info('Executing: %s', self.bql)
@@ -91,4 +97,4 @@ class BigQueryOperator(BaseOperator):
         cursor.run_query(self.bql, self.destination_dataset_table, self.write_disposition,
                          self.allow_large_results, self.udf_config,
                          self.use_legacy_sql, self.maximum_billing_tier,
-                         self.create_disposition)
+                         self.create_disposition, self.query_params)


### PR DESCRIPTION

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow 1556](https://issues.apache.org/jira/browse/AIRFLOW-1556/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1556


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
BigQuery supports running parameterized queries (https://cloud.google.com/bigquery/docs/parameterized-queries).

This PR adds this parameter to the BigQueryOperator, and the BigQueryBaseCursor, which sets this field on the query configuration prior to the api call.



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This PR adds a parameter and plumbs it through a couple of classes before setting it on the api. It's hard to test this given that there is no prior test coverage of the classes being changed.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

