### PR TITLE
[AIRFLOW-1484] Fix set task instance state

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2479,7 +2479,16 @@ class TaskInstanceModelView(ModelViewOnly):
             count = len(ids)
             for id in ids:
                 task_id, dag_id, execution_date = id.split(',')
-                execution_date = datetime.strptime(execution_date, '%Y-%m-%d %H:%M:%S')
+
+                # NOTE: Handling case when execution date has milliseconds.
+                if '.' in execution_date:
+                    fmt = '%Y-%m-%d %H:%M:%S.%f'
+                    execution_date = execution_date.split('.')
+                    execution_date = '.'.join([execution_date[0], execution_date[-1]])
+                else:
+                    fmt = '%Y-%m-%d %H:%M:%S'
+
+                execution_date = datetime.strptime(execution_date, fmt)
                 ti = session.query(TI).filter(TI.task_id == task_id,
                                               TI.dag_id == dag_id,
                                               TI.execution_date == execution_date).one()


### PR DESCRIPTION
Fix set task instance state when execution_date has milliseconds.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following:
    - [AIRFLOW-1484](https://issues.apache.org/jira/browse/AIRFLOW-1484) Updating Tasks through UI crash when execution_date has milliseconds


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
When task instance contains milliseconds - setting task instance state fails with crash:

```python
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/flask/app.py", line 1988, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib64/python2.7/site-packages/flask/app.py", line 1641, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib64/python2.7/site-packages/flask/app.py", line 1544, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib64/python2.7/site-packages/flask/app.py", line 1639, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib64/python2.7/site-packages/flask/app.py", line 1625, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/lib/python2.7/site-packages/flask_admin/base.py", line 69, in inner
    return self._run_view(f, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/flask_admin/base.py", line 368, in _run_view
    return fn(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/flask_admin/model/base.py", line 2068, in action_view
    return self.handle_action()
  File "/usr/lib/python2.7/site-packages/flask_admin/actions.py", line 113, in handle_action
    response = handler[0](ids)
  File "/usr/lib/python2.7/site-packages/airflow/www/views.py", line 2593, in action_set_retry
    self.set_task_instance_state(ids, State.UP_FOR_RETRY)
  File "/usr/lib/python2.7/site-packages/airflow/utils/db.py", line 53, in wrapper
    result = func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/airflow/www/views.py", line 2628, in set_task_instance_state
    raise Exception("Ooops")
Exception: Ooops
```
This PR fixed this.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - No tests were added since there is not views.py tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

