### PR TITLE
[AIRFLOW-1562] Spark-sql logging contains deadlock

### DIFF
--- a/airflow/contrib/operators/spark_sql_operator.py
+++ b/airflow/contrib/operators/spark_sql_operator.py
@@ -58,6 +58,7 @@ class SparkSqlOperator(BaseOperator):
                  executor_cores=None,
                  executor_memory=None,
                  keytab=None,
+                 principal=None,
                  master='yarn',
                  name='default-name',
                  num_executors=None,
@@ -72,6 +73,7 @@ class SparkSqlOperator(BaseOperator):
         self._executor_cores = executor_cores
         self._executor_memory = executor_memory
         self._keytab = keytab
+        self._principal = principal
         self._master = master
         self._name = name
         self._num_executors = num_executors
@@ -89,6 +91,7 @@ class SparkSqlOperator(BaseOperator):
                                   executor_cores=self._executor_cores,
                                   executor_memory=self._executor_memory,
                                   keytab=self._keytab,
+                                  principal=self._principal,
                                   name=self._name,
                                   num_executors=self._num_executors,
                                   master=self._master,

--- a/tests/contrib/operators/test_spark_sql_operator.py
+++ b/tests/contrib/operators/test_spark_sql_operator.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import datetime
+import unittest
+
+from airflow import DAG, configuration
+from airflow.contrib.operators.spark_sql_operator import SparkSqlOperator
+
+DEFAULT_DATE = datetime.datetime(2017, 1, 1)
+
+
+class TestSparkSqlOperator(unittest.TestCase):
+
+    _config = {
+        'sql': 'SELECT 22',
+        'conn_id': 'spark_special_conn_id',
+        'total_executor_cores': 4,
+        'executor_cores': 4,
+        'executor_memory': '22g',
+        'keytab': 'privileged_user.keytab',
+        'principal': 'user/spark@airflow.org',
+        'master': 'yarn-client',
+        'name': 'special-application-name',
+        'num_executors': 8,
+        'yarn_queue': 'special-queue'
+    }
+
+    def setUp(self):
+        configuration.load_test_config()
+        args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE
+        }
+        self.dag = DAG('test_dag_id', default_args=args)
+
+    def test_execute(self):
+        # Given / When
+        operator = SparkSqlOperator(
+            task_id='spark_sql_job',
+            dag=self.dag,
+            **self._config
+        )
+
+        self.assertEqual(self._config['sql'], operator._sql)
+        self.assertEqual(self._config['conn_id'], operator._conn_id)
+        self.assertEqual(self._config['total_executor_cores'], operator._total_executor_cores)
+        self.assertEqual(self._config['executor_cores'], operator._executor_cores)
+        self.assertEqual(self._config['executor_memory'], operator._executor_memory)
+        self.assertEqual(self._config['keytab'], operator._keytab)
+        self.assertEqual(self._config['principal'], operator._principal)
+        self.assertEqual(self._config['executor_memory'], operator._executor_memory)
+        self.assertEqual(self._config['keytab'], operator._keytab)
+        self.assertEqual(self._config['principal'], operator._principal)
+        self.assertEqual(self._config['master'], operator._master)
+        self.assertEqual(self._config['name'], operator._name)
+        self.assertEqual(self._config['num_executors'], operator._num_executors)
+        self.assertEqual(self._config['yarn_queue'], operator._yarn_queue)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi All,

Logging in SparkSqlOperator does not work as intended. Spark-sql internally redirects all logs to stdout (including stderr), which causes the current two iterator logging to get stuck with empty stderr pipe. Also this situation can lead to a deadlock because the std-err can grow too big and it will start to block until it gets consumed, which will only happen when the process ends, so the process stalls.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-1562] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1562


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

