### PR TITLE
[AIRFLOW-1563] Catch OSError while symlinking the latest log directory

### DIFF
--- a/airflow/utils/log/file_processor_handler.py
+++ b/airflow/utils/log/file_processor_handler.py
@@ -100,19 +100,23 @@ class FileProcessorHandler(logging.Handler):
         log_directory = self._get_log_directory()
         latest_log_directory_path = os.path.join(self.base_log_folder, "latest")
         if os.path.isdir(log_directory):
-            # if symlink exists but is stale, update it
-            if os.path.islink(latest_log_directory_path):
-                if os.readlink(latest_log_directory_path) != log_directory:
-                    os.unlink(latest_log_directory_path)
+            try:
+                # if symlink exists but is stale, update it
+                if os.path.islink(latest_log_directory_path):
+                    if os.readlink(latest_log_directory_path) != log_directory:
+                        os.unlink(latest_log_directory_path)
+                        os.symlink(log_directory, latest_log_directory_path)
+                elif (os.path.isdir(latest_log_directory_path) or
+                          os.path.isfile(latest_log_directory_path)):
+                    self.log.warning(
+                        "%s already exists as a dir/file. Skip creating symlink.",
+                        latest_log_directory_path
+                    )
+                else:
                     os.symlink(log_directory, latest_log_directory_path)
-            elif (os.path.isdir(latest_log_directory_path) or
-                      os.path.isfile(latest_log_directory_path)):
-                self.log.warning(
-                    "%s already exists as a dir/file. Skip creating symlink.",
-                    latest_log_directory_path
-                )
-            else:
-                os.symlink(log_directory, latest_log_directory_path)
+            except OSError:
+                self.logger.warning("OSError while attempting to symlink "
+                                    "the latest log directory")
 
     def _init_file(self, filename):
         """


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1563


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
While running airflow on azure, with a file share mounted for its logs we got the following exception:
```
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 28, in <module>
    args.func(args)
  File "/usr/local/lib/python2.7/dist-packages/airflow/bin/cli.py", line 882, in scheduler
    job.run()
  File "/usr/local/lib/python2.7/dist-packages/airflow/jobs.py", line 200, in run
    self._execute()
  File "/usr/local/lib/python2.7/dist-packages/airflow/jobs.py", line 1312, in _execute
    self._execute_helper(processor_manager)
  File "/usr/local/lib/python2.7/dist-packages/airflow/jobs.py", line 1409, in _execute_helper
    simple_dags = processor_manager.heartbeat()
  File "/usr/local/lib/python2.7/dist-packages/airflow/utils/dag_processing.py", line 631, in heartbeat
    self.symlink_latest_log_directory()
  File "/usr/local/lib/python2.7/dist-packages/airflow/utils/dag_processing.py", line 525, in symlink_latest_log_directory
    os.symlink(log_directory, latest_log_directory_path)
OSError: [Errno 95] Operation not supported
```
I've added a try catch to solve this

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

