### PR TITLE
[AIRFLOW-1564] Use Jinja2 to render logging filename

### DIFF
--- a/airflow/config_templates/default_airflow_logging.py
+++ b/airflow/config_templates/default_airflow_logging.py
@@ -37,7 +37,7 @@ if REMOTE_BASE_LOG_FOLDER.startswith('s3:/'):
 elif REMOTE_BASE_LOG_FOLDER.startswith('gs:/'):
     GCS_LOG_FOLDER = REMOTE_BASE_LOG_FOLDER
 
-FILENAME_TEMPLATE = '{dag_id}/{task_id}/{execution_date}/{try_number}.log'
+FILENAME_TEMPLATE = '{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log'
 
 DEFAULT_LOGGING_CONFIG = {
     'version': 1,

--- a/airflow/utils/log/gcs_task_handler.py
+++ b/airflow/utils/log/gcs_task_handler.py
@@ -39,9 +39,7 @@ class GCSTaskHandler(FileTaskHandler):
         # Log relative path is used to construct local and remote
         # log path to upload log files into GCS and read from the
         # remote location.
-        self.log_relative_path = self.filename_template(
-            dag_id=ti.dag_id, task_id=ti.task_id,
-            execution_date=ti.execution_date.isoformat(), try_number=ti.try_number + 1)
+        self.log_relative_path = self._render_filename(ti, ti.try_number + 1)
 
     def close(self):
         """
@@ -76,9 +74,7 @@ class GCSTaskHandler(FileTaskHandler):
         # Explicitly getting log relative path is necessary as the given
         # task instance might be different than task instance passed in
         # in set_context method.
-        log_relative_path = self.filename_template.format(
-            dag_id=ti.dag_id, task_id=ti.task_id,
-            execution_date=ti.execution_date.isoformat(), try_number=try_number + 1)
+        log_relative_path = self._render_filename(ti, try_number + 1)
         remote_loc = os.path.join(self.remote_base, log_relative_path)
 
         gcs_log = logging_utils.GCSLog()

--- a/airflow/utils/log/s3_task_handler.py
+++ b/airflow/utils/log/s3_task_handler.py
@@ -35,9 +35,7 @@ class S3TaskHandler(FileTaskHandler):
         super(S3TaskHandler, self).set_context(ti)
         # Local location and remote location is needed to open and
         # upload local log file to S3 remote storage.
-        self.log_relative_path = self.filename_template.format(
-            dag_id=ti.dag_id, task_id=ti.task_id,
-            execution_date=ti.execution_date.isoformat(), try_number=ti.try_number + 1)
+        self.log_relative_path = self._render_filename(ti, ti.try_number + 1)
 
     def close(self):
         """
@@ -72,9 +70,7 @@ class S3TaskHandler(FileTaskHandler):
         # Explicitly getting log relative path is necessary as the given
         # task instance might be different than task instance passed in
         # in set_context method.
-        log_relative_path = self.filename_template.format(
-            dag_id=ti.dag_id, task_id=ti.task_id,
-            execution_date=ti.execution_date.isoformat(), try_number=try_number + 1)
+        log_relative_path = self._render_filename(ti, try_number + 1)
         remote_loc = os.path.join(self.remote_base, log_relative_path)
 
         s3_log = logging_utils.S3Log()


### PR DESCRIPTION
Still backwards compatible with python format

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1564


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
We had some problems with the filename used for logging. Azure fileshares use windows backed machines, which do not support colons in the filename. Modified the logging filename rendering to use jinja2 and hence be more flexible. Allowing us to replace the colons by dots using jijna2.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Covered by existing tests

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

