### PR TITLE
[AIRFLOW-1569][WIP] Requeue tasks that stay in reserved state too long

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -362,6 +362,9 @@ max_threads = 2
 
 authenticate = False
 
+strict_mode = True
+job_max_time_queued = 180
+
 [ldap]
 uri = ldaps://<your.ldap.server>:<port>
 user_filter = objectClass=*

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -95,7 +95,7 @@ class CeleryExecutor(BaseExecutor):
     def _check_task_delayed(self, key):
         max_timedelta_secs = datetime.timedelta.max.total_seconds()
         max_delay = datetime.timedelta(
-                seconds=min(max_timedelta_secs, int(2**attempt[key] * configuration.getint('scheduler', 'JOB_MAX_TIME_QUEUED'))))
+                seconds=min(max_timedelta_secs, int(2**self.attempt[key] * configuration.getint('scheduler', 'JOB_MAX_TIME_QUEUED'))))
         return datetime.datetime.now() > self.enqueue_time[key] + max_delay
 
     def _delete_key(self, key):
@@ -134,7 +134,7 @@ class CeleryExecutor(BaseExecutor):
                                             .format(key=key))
                         async.revoke()
                         self.execute_async(key, self.command[key], queue=self.queue[key], attempt=self.attempt[key] + 1)
-                elif configuration.getboolean('scheduler', 'STRICT_MODE'):
+                elif state == celery_states.PENDING and configuration.getboolean('scheduler', 'STRICT_MODE'):
                     if self._check_task_delayed(key):
                         self.logger.warning("Requeueing task as it has not been executed")
                         async.revoke()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1569


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes: We should revoke and re-queue tasks that are RESERVED for too long.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Hard to unit test because it involves a very rare situation. Will repro locally and make sure it works


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


This is a little wonky atm because of the way celery reports state so I'll mark it as WIP.
