### PR TITLE
[AIRFLOW-966]: Expose Celery broker transport options to config

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -279,6 +279,9 @@ worker_log_server_port = 8793
 # information.
 broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
 
+# Options specific to the broker in use. Value must be parseable as JSON.
+broker_transport_options = {{}}
+
 # Another key Celery setting
 celery_result_backend = db+mysql://airflow:airflow@localhost:3306/airflow
 

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from builtins import object
+import json
 import logging
 import subprocess
 import ssl
@@ -44,6 +45,7 @@ class CeleryConfig(object):
     CELERYD_PREFETCH_MULTIPLIER = 1
     CELERY_ACKS_LATE = True
     BROKER_URL = configuration.get('celery', 'BROKER_URL')
+    BROKER_TRANSPORT_OPTIONS = json.loads(configuration.get('celery', 'BROKER_TRANSPORT_OPTIONS'))
     CELERY_RESULT_BACKEND = configuration.get('celery', 'CELERY_RESULT_BACKEND')
     CELERYD_CONCURRENCY = configuration.getint('celery', 'CELERYD_CONCURRENCY')
     CELERY_DEFAULT_QUEUE = DEFAULT_QUEUE

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -139,6 +139,27 @@ Here are a few imperative requirements for your workers:
   Chef, Puppet, Ansible, or whatever you use to configure machines in your
   environment. If all your boxes have a common mount point, having your
   pipelines files shared there should work as well
+- You can configure the Celery broker transport options via the
+  ``broker_transport_options`` option in the ``celery`` section of the config
+  file. You might need this if you are using something other than RabbitMQ as
+  the trasport in a few cases.
+
+  For example, when using Redis with sub-dags, or when backfilling tasks, that
+  take longer than an hour to execute the default visiblity timeout will need
+  changing, otherwise the task will mysteriously be marked as failed, or end up
+  running two copies of the task at once.
+
+  .. code-block:: bash
+
+    [celery]
+    broker_transport_options = {"visibility_timeout": 86400}
+
+
+  This config option should be valid JSON and should be a directory. See the
+  Celery documentation for the brokers,
+  `Amazon SQS <http://docs.celeryproject.org/en/latest/getting-started/brokers/sqs.html>`_,
+  or `Redis <http://docs.celeryproject.org/en/latest/getting-started/brokers/redis.html>`_,
+  for possible values.
 
 
 To kick off a worker, you need to setup Airflow and kick off the worker

--- a/tests/executors/celery_executor.py
+++ b/tests/executors/celery_executor.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+
+from airflow import configuration
+
+
+class CeleryConfTest(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+
+    def tearDown(self):
+        # We need to un-import the module as it reads the config at import time. :(
+        del sys.modules['airflow.executors.celery_executor']
+
+    def test_broker_transport_options_default(self):
+        from airflow.executors.celery_executor import CeleryConfig
+
+        self.assertEqual(CeleryConfig.BROKER_TRANSPORT_OPTIONS, {})
+
+    def test_broker_transport_options_set(self):
+        configuration.set('celery', 'BROKER_TRANSPORT_OPTIONS', '{"visibility_timeout": 10000}')
+        from airflow.executors.celery_executor import CeleryConfig
+
+        self.assertEqual(CeleryConfig.BROKER_TRANSPORT_OPTIONS, {'visibility_timeout': 10000})


### PR DESCRIPTION
To use with long running sub-dags, or with backfilling tasks that take
longer than 1 hour when using Redis as the broker you need to specify
some options here otherwise the subdag will fail, or the backfill task
will get run twice.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - [AIRFLOW-966 Celery Broker Transport Options](https://issues.apache.org/jira/browse/AIRFLOW-966)
    - [AIRFLOW-1555 Backfill job gets killed 1 hour after starting](https://issues.apache.org/jira/browse/AIRFLOW-1555) will be fixed by being able to specify this
    - [AIRFLOW-1131 DockerOperator jobs time out and get stuck in "running" forever](https://issues.apache.org/jira/browse/AIRFLOW-1131) might be fixed by being able to specify this, at least in some cases.


### Description
- Expose a new config option to set `BROKER_TRANSPORT_OPTIONS` on the CeleryConfig object.
- Add a section to the docs about how to set this, and where it might be needed.


### Tests
- [x] I have added a new test file that adds some simple tests against the CeleryConfig object.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

Closes #2143