### PR TITLE
[AIRFLOW-1573] Remove `thrift < 0.10.0` requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -247,7 +247,7 @@ def do_setup():
             'setproctitle>=1.1.8, <2',
             'sqlalchemy>=0.9.8',
             'tabulate>=0.7.5, <0.8.0',
-            'thrift>=0.9.2, <0.10',
+            'thrift>=0.9.2',
             'zope.deprecation>=4.0, <5.0',
         ],
         extras_require={


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA]
    - https://issues.apache.org/jira/browse/AIRFLOW-1573


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
   - This removes the requirement that Thrift be < 0.10.0, so we can use dependencies that require Thrift 0.10.0


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   - Existing tests


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

