### PR TITLE
[AIRFLOW-1574] add 'to' attribute to templated variables of email ope…

### DIFF
--- a/airflow/operators/email_operator.py
+++ b/airflow/operators/email_operator.py
@@ -36,7 +36,7 @@ class EmailOperator(BaseOperator):
     :type bcc: list or string (comma or semicolon delimited)
     """
 
-    template_fields = ('subject', 'html_content')
+    template_fields = ('to', 'subject', 'html_content')
     template_ext = ('.html',)
     ui_color = '#e6faf9'
 


### PR DESCRIPTION
…rator

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-1574] add 'to' attribute to templated variables of email operator"
    - https://issues.apache.org/jira/browse/AIRFLOW-1574


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
The to field may sometimes want to be to be template-able when you have a DAG that is using XCOM to find the user to send the information to (i.e. we have a form that a user submits and based on the ldap user we send this specific user the information). It's a rather easy fix to add the 'to' user to the template-able options.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Just adding a template-able field nothing more.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

