### PR TITLE
AIRFLOW-743 - LDAP enhancements (direct bind & username template)

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -49,6 +49,12 @@ s3_log_folder =
 # Logging level
 logging_level = INFO
 
+# Log format
+log_format = [%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s
+log_format_with_pid = [%%(asctime)s] [%%(process)d] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s
+log_format_with_thread_name = [%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(threadName)s %%(levelname)s - %%(message)s
+simple_log_format = %%(asctime)s %%(levelname)s - %%(message)s
+
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor, DaskExecutor
 executor = SequentialExecutor
@@ -115,6 +121,17 @@ security =
 # Turn unit test mode on (overwrites many configuration options with test
 # values at runtime)
 unit_test_mode = False
+
+# User defined logging configuration file path.
+logging_config_path =
+
+# Name of handler to read task instance logs.
+# Default to use file task handler.
+task_log_reader = file.task
+
+# Whether to enable pickling for xcom (note that this is insecure and allows for
+# RCE exploits). This will be deprecated in Airflow 2.0 (be forced to False).
+enable_xcom_pickling = True
 
 [cli]
 # In what way should the cli access the API. The LocalClient will use the
@@ -215,6 +232,9 @@ log_fetch_timeout_sec = 5
 # By default, the webserver shows paused DAGs. Flip this to hide paused
 # DAGs by default
 hide_paused_dags_by_default = False
+
+# Consistent page size across all listing views in the UI
+page_size = 100
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp
@@ -319,6 +339,11 @@ scheduler_zombie_task_threshold = 300
 # DAG definition (catchup)
 catchup_by_default = True
 
+# This changes the batch size of queries in the scheduling main loop.
+# This depends on query length limits and how long you are willing to hold locks.
+# 0 for no limit
+max_tis_per_query = 0
+
 # Statsd (https://github.com/etsy/statsd) integration settings
 statsd_on = False
 statsd_host = localhost
@@ -326,12 +351,30 @@ statsd_port = 8125
 statsd_prefix = airflow
 
 # The scheduler can run multiple threads in parallel to schedule dags.
-# This defines how many threads will run. However airflow will never
-# use more threads than the amount of cpu cores available.
+# This defines how many threads will run.
 max_threads = 2
 
 authenticate = False
 
+[ldap]
+uri = ldaps://<your.ldap.server>:<port>
+user_filter = objectClass=*
+user_name_attr = uid
+group_member_attr = memberOf
+superuser_filter = memberOf=CN=airflow-super-users,OU=Groups,OU=RWC,OU=US,OU=NORAM,DC=example,DC=com
+data_profiler_filter = memberOf=CN=airflow-data-profilers,OU=Groups,OU=RWC,OU=US,OU=NORAM,DC=example,DC=com
+
+# If True bind using the user and password of the user logging in, bind_user and bind_password properties aren't used in this case.
+direct_bind = False
+bind_user = cn=Manager,dc=example,dc=com
+bind_password = insecure
+basedn = dc=example,dc=com
+
+# Optional template to format the user login to
+#dn_template = {0}@gmail.com
+
+cacert = /etc/ca/ldap_ca.crt
+search_scope = LEVEL
 
 [mesos]
 # Mesos master address which MesosExecutor will connect to.

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -154,8 +154,18 @@ class LdapUser(models.User):
 
     @staticmethod
     def try_login(username, password):
-        conn = get_ldap_connection(configuration.get("ldap", "bind_user"),
-                                   configuration.get("ldap", "bind_password"))
+        if configuration.has_option("ldap", "direct_bind") and configuration.getboolean("ldap", "direct_bind") is True:
+            bind_user = username
+            bind_password = password
+        else:
+            bind_user = configuration.get("ldap", "bind_user")
+            bind_password = configuration.get("ldap", "bind_password")
+
+        if configuration.has_option("ldap", "dn_template"):
+            dn_template = configuration.get("ldap", "dn_template")
+            bind_user = dn_template.format(username)
+
+        conn = get_ldap_connection(bind_user, bind_password)
 
         search_filter = "(&({0})({1}={2}))".format(
             configuration.get("ldap", "user_filter"),

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -74,9 +74,13 @@ Valid search_scope options can be found in the `ldap3 Documentation <http://ldap
     user_name_attr = uid
     superuser_filter = memberOf=CN=airflow-super-users,OU=Groups,OU=RWC,OU=US,OU=NORAM,DC=example,DC=com
     data_profiler_filter = memberOf=CN=airflow-data-profilers,OU=Groups,OU=RWC,OU=US,OU=NORAM,DC=example,DC=com
+    # If True bind using the user and password of the user logging in, bind_user and bind_password properties aren't used in this case.
+    direct_bind = False
     bind_user = cn=Manager,dc=example,dc=com
     bind_password = insecure
     basedn = dc=example,dc=com
+    # Optional template to format the user login to
+    #dn_template = {0}@gmail.com
     cacert = /etc/ca/ldap_ca.crt
     # Set search_scope to one of them:  BASE, LEVEL , SUBTREE
     # Set search_scope to SUBTREE if using Active Directory, and not specifying an Organizational Unit


### PR DESCRIPTION
AIRFLOW-743 - Adding LDAP features to bind using the current user logging in and the ability to provide a template to apply the user id to.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses [AIRFLOW-743](https://issues.apache.org/jira/browse/AIRFLOW-743)

### Description
- [ ] * Bind to LDAP server using the user and password of the user logging in.
       * Apply a template to the user name such that the one matching the LDAP DN can be used.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: no test at the moment exist for contributed security backends

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

