### PR TITLE
AIRFLOW-743 - Adding LDAP features (bind user and username template)

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -368,8 +368,8 @@ direct_bind = False
 bind_user = cn=Manager,dc=example,dc=com
 bind_password = insecure
 basedn = dc=example,dc=com
-# Optional template to format the user login to
-#dn_template = {0}@gmail.com
+# Optional template to format the user login string. %% replaced with user id
+#dn_template = %%@gmail.com
 cacert = /etc/ca/ldap_ca.crt
 search_scope = LEVEL
 

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -363,9 +363,13 @@ user_name_attr = uid
 group_member_attr = memberOf
 superuser_filter = memberOf=CN=airflow-super-users,OU=Groups,OU=RWC,OU=US,OU=NORAM,DC=example,DC=com
 data_profiler_filter = memberOf=CN=airflow-data-profilers,OU=Groups,OU=RWC,OU=US,OU=NORAM,DC=example,DC=com
+# If True bind using the user and password of the user logging in, bind_user and bind_password properties aren't used in this case.
+direct_bind = False
 bind_user = cn=Manager,dc=example,dc=com
 bind_password = insecure
 basedn = dc=example,dc=com
+# Optional template to format the user login to
+#dn_template = {0}@gmail.com
 cacert = /etc/ca/ldap_ca.crt
 search_scope = LEVEL
 

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -167,7 +167,7 @@ class LdapUser(models.User):
 
         if configuration.has_option("ldap", "dn_template"):
             dn_template = configuration.get("ldap", "dn_template")
-            bind_user = dn_template.format(username)
+            bind_user = dn_template.replace('%%', username)
 
         conn = get_ldap_connection(bind_user, bind_password)
 

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -158,8 +158,18 @@ class LdapUser(models.User):
 
     @staticmethod
     def try_login(username, password):
-        conn = get_ldap_connection(configuration.get("ldap", "bind_user"),
-                                   configuration.get("ldap", "bind_password"))
+        if configuration.has_option("ldap", "direct_bind") and configuration.getboolean("ldap", "direct_bind") is True:
+            bind_user = username
+            bind_password = password
+        else:
+            bind_user = configuration.get("ldap", "bind_user")
+            bind_password = configuration.get("ldap", "bind_password")
+
+        if configuration.has_option("ldap", "dn_template"):
+            dn_template = configuration.get("ldap", "dn_template")
+            bind_user = dn_template.format(username)
+
+        conn = get_ldap_connection(bind_user, bind_password)
 
         search_filter = "(&({0})({1}={2}))".format(
             configuration.get("ldap", "user_filter"),

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -79,9 +79,13 @@ Valid search_scope options can be found in the `ldap3 Documentation <http://ldap
     group_member_attr = memberOf
     superuser_filter = memberOf=CN=airflow-super-users,OU=Groups,OU=RWC,OU=US,OU=NORAM,DC=example,DC=com
     data_profiler_filter = memberOf=CN=airflow-data-profilers,OU=Groups,OU=RWC,OU=US,OU=NORAM,DC=example,DC=com
+    # If True bind using the user and password of the user logging in, bind_user and bind_password properties aren't used in this case.
+    direct_bind = False
     bind_user = cn=Manager,dc=example,dc=com
     bind_password = insecure
     basedn = dc=example,dc=com
+    # Optional template to format the user login to
+    #dn_template = {0}@gmail.com
     cacert = /etc/ca/ldap_ca.crt
     # Set search_scope to one of them:  BASE, LEVEL , SUBTREE
     # Set search_scope to SUBTREE if using Active Directory, and not specifying an Organizational Unit

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -84,8 +84,8 @@ Valid search_scope options can be found in the `ldap3 Documentation <http://ldap
     bind_user = cn=Manager,dc=example,dc=com
     bind_password = insecure
     basedn = dc=example,dc=com
-    # Optional template to format the user login to
-    #dn_template = {0}@gmail.com
+    # Optional template to format the user login string. %% replaced with user id
+    #dn_template = %%@gmail.com
     cacert = /etc/ca/ldap_ca.crt
     # Set search_scope to one of them:  BASE, LEVEL , SUBTREE
     # Set search_scope to SUBTREE if using Active Directory, and not specifying an Organizational Unit


### PR DESCRIPTION
AIRFLOW-743 - Adding LDAP features to bind using the current user logging in and the ability to provide a template to apply the user id to.
Dear Airflow maintainers,
Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
JIRA

*  My PR addresses [AIRFLOW-743](https://issues.apache.org/jira/browse/AIRFLOW-743)
Description

*  * Bind to LDAP server using the user and password of the user logging in.

* Apply a template to the user name such that the one matching the LDAP DN can be used.
Tests

*  My PR adds the following unit tests OR does not need testing for this extremely good reason: no test at the moment exist for contributed security backends
Commits

*  My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "How to write a good git commit message":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
