### PR TITLE
[AIRFLOW-1579] - Adds support for jagged rows in Bigquery hook for BQ load jobs.

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -386,6 +386,7 @@ class BigQueryBaseCursor(object):
                  max_bad_records=0,
                  quote_character=None,
                  allow_quoted_newlines=False,
+                 allow_jagged_rows=False,
                  schema_update_options=()):
         """
         Executes a BigQuery load command to load data from Google Cloud Storage
@@ -424,6 +425,12 @@ class BigQueryBaseCursor(object):
         :type quote_character: string
         :param allow_quoted_newlines: Whether to allow quoted newlines (true) or not (false).
         :type allow_quoted_newlines: boolean
+        :param allow_jagged_rows: Accept rows that are missing trailing optional columns.
+            The missing values are treated as nulls. If false, records with missing trailing columns
+            are treated as bad records, and if there are too many bad records, an invalid error is
+            returned in the job result. The default value is false. Only applicable to CSV, ignored
+            for other formats.
+        :type allow_jagged_rows: bool
         :param schema_update_options: Allows the schema of the desitination
             table to be updated as a side effect of the load job.
         :type schema_update_options: list
@@ -505,6 +512,9 @@ class BigQueryBaseCursor(object):
 
         if allow_quoted_newlines:
             configuration['load']['allowQuotedNewlines'] = allow_quoted_newlines
+
+        if allow_jagged_rows:
+            configuration['load']['allowJaggedRows'] = allow_jagged_rows
 
         return self.run_with_configuration(configuration)
 

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -391,7 +391,6 @@ class BigQueryBaseCursor(object):
                  quote_character=None,
                  allow_quoted_newlines=False,
                  allow_jagged_rows=False,
-                 schema_update_options=()):
                  schema_update_options=(),
                  src_fmt_configs={}):
         """

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -434,8 +434,7 @@ class BigQueryBaseCursor(object):
         :param allow_jagged_rows: Accept rows that are missing trailing optional columns.
             The missing values are treated as nulls. If false, records with missing trailing columns
             are treated as bad records, and if there are too many bad records, an invalid error is
-            returned in the job result. The default value is false. Only applicable to CSV, ignored
-            for other formats.
+            returned in the job result. Only applicable when soure_format is CSV.
         :type allow_jagged_rows: bool
         :param schema_update_options: Allows the schema of the desitination
             table to be updated as a side effect of the load job.

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -46,6 +46,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         max_bad_records=0,
         quote_character=None,
         allow_quoted_newlines=False,
+        allow_jagged_rows=False,
         max_id_key=None,
         bigquery_conn_id='bigquery_default',
         google_cloud_storage_conn_id='google_cloud_storage_default',
@@ -90,6 +91,11 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         :type quote_character: string
         :param allow_quoted_newlines: Whether to allow quoted newlines (true) or not (false).
         :type allow_quoted_newlines: boolean
+        :param allow_jagged_rows: Accept rows that are missing trailing optional columns.
+            The missing values are treated as nulls. If false, records with missing trailing columns
+            are treated as bad records, and if there are too many bad records, an invalid error is
+            returned in the job result. Only applicable to CSV, ignored for other formats.
+        :type allow_jagged_rows: bool
         :param max_id_key: If set, the name of a column in the BigQuery table
             that's to be loaded. Thsi will be used to select the MAX value from
             BigQuery after the load occurs. The results will be returned by the
@@ -106,7 +112,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
             work, the service account making the request must have domain-wide
             delegation enabled.
         :type delegate_to: string
-        :param schema_update_options: Allows the schema of the desitination 
+        :param schema_update_options: Allows the schema of the desitination
             table to be updated as a side effect of the load job.
         :type schema_update_options: list
         """
@@ -128,6 +134,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         self.max_bad_records = max_bad_records
         self.quote_character = quote_character
         self.allow_quoted_newlines = allow_quoted_newlines
+        self.allow_jagged_rows = allow_jagged_rows
 
         self.max_id_key = max_id_key
         self.bigquery_conn_id = bigquery_conn_id
@@ -166,6 +173,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
             max_bad_records=self.max_bad_records,
             quote_character=self.quote_character,
             allow_quoted_newlines=self.allow_quoted_newlines,
+            allow_jagged_rows=self.allow_jagged_rows,
             schema_update_options=self.schema_update_options)
 
         if self.max_id_key:

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -181,7 +181,6 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
             quote_character=self.quote_character,
             allow_quoted_newlines=self.allow_quoted_newlines,
             allow_jagged_rows=self.allow_jagged_rows,
-            schema_update_options=self.schema_update_options)
             schema_update_options=self.schema_update_options,
             src_fmt_configs=self.src_fmt_configs)
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    
- https://issues.apache.org/jira/browse/AIRFLOW-1579

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
1. Facilitates the job option allowJaggedRows available in the api, that has not been included in the BQ hook.
1. Updates the GoogleCloudStorageToBigQueryOperator operator to reflect these updates.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR does not need testing because:
1. This PR matches the pattern of the other parameters available in the BQ hook. Many of these parameters do not have tests. These include quote_character, allow_quoted_newlines, max_bad_records, skipleadingrows and more.
1. This PR will not affect any api calls unless allow_jagged_rows is set to true. Therefore, this is not a breaking change for anyone currently using this Operator or Hook.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

