### PR TITLE
[AIRFLOW-1580] Error in string formating

### DIFF
--- a/airflow/operators/check_operator.py
+++ b/airflow/operators/check_operator.py
@@ -214,9 +214,9 @@ class IntervalCheckOperator(BaseOperator):
         logging.info('Executing SQL check: ' + self.sql1)
         row1 = hook.get_first(self.sql1)
         if not row2:
-            raise AirflowException("The query {q} returned None").format(q=self.sql2)
+            raise AirflowException("The query {q} returned None".format(q=self.sql2))
         if not row1:
-            raise AirflowException("The query {q} returned None").format(q=self.sql1)
+            raise AirflowException("The query {q} returned None".format(q=self.sql1))
         current = dict(zip(self.metrics_sorted, row1))
         reference = dict(zip(self.metrics_sorted, row2))
         ratios = {}


### PR DESCRIPTION
Dear Airflow maintainers,

The string formatting should be done on the string, and not on the exception that is being raised. This will cause an unhandled exception and probably kill the whole execution unexpectedly.

Cheers, Fokko


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

