### PR TITLE
[AIRFLOW-1583] Add a limit size of 1GB on XCom stored values to avoid Postgresql "invalid request size" error

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1789,6 +1789,10 @@ class TaskInstance(Base):
                 'execution_date is {}; received {})'.format(
                     self.execution_date, execution_date))
 
+        if sys.getsizeof(value) >= 1073741824:
+            logging.warning("Return value size is higher than 10MB, cannot be saved in XCom.")
+            value = "This is a false value. The real value was too big to be saved."
+            
         XCom.set(
             key=key,
             value=value,


### PR DESCRIPTION
Added a limit size of 1GB. When value is bigger, a default string "This
is a false value. The real value was too big to be saved" is stored
instead.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

