### PR TITLE
[AIRFLOW-1583] Add a limit size of 1GB on XCom stored values to avoid Postgresql "invalid request size" error

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1790,7 +1790,7 @@ class TaskInstance(Base):
                     self.execution_date, execution_date))
 
         if sys.getsizeof(value) >= 1073741824:
-            logging.warning("Return value size is higher than 10MB, cannot be saved in XCom.")
+            logging.warning("Return value size is higher than 1GB, cannot be saved in XCom.")
             value = "This is a false value. The real value was too big to be saved."
             
         XCom.set(

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1789,6 +1789,10 @@ class TaskInstance(Base):
                 'execution_date is {}; received {})'.format(
                     self.execution_date, execution_date))
 
+        if sys.getsizeof(value) >= 1073741824:
+            logging.warning("Return value size is higher than 10MB, cannot be saved in XCom.")
+            value = "This is a false value. The real value was too big to be saved."
+            
         XCom.set(
             key=key,
             value=value,


### PR DESCRIPTION
Added a limit size of 1GB. When value is bigger, a default string "This
is a false value. The real value was too big to be saved" is stored
instead.