### PR TITLE
[AIRFLOW-1575] Add AWS Kinesis Firehose Hook for inserting batch records

### DIFF
--- a/airflow/contrib/hooks/__init__.py
+++ b/airflow/contrib/hooks/__init__.py
@@ -47,7 +47,8 @@ _hooks = {
     'cloudant_hook': ['CloudantHook'],
     'fs_hook': ['FSHook'],
     'wasb_hook': ['WasbHook'],
-    'gcp_pubsub_hook': ['PubSubHook']
+    'gcp_pubsub_hook': ['PubSubHook'],
+    'aws_dynamodb_hook': ['AwsDynamoDBHook']
 }
 
 import os as _os

--- a/airflow/contrib/hooks/aws_firehose_hook.py
+++ b/airflow/contrib/hooks/aws_firehose_hook.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.contrib.hooks.aws_hook import AwsHook
+
+
+class AwsFirehoseHook(AwsHook):
+    """
+    Interact with AWS Kinesis Firehose.
+
+
+    :param delivery_stream: Name of the delivery stream
+    :type delivery_stream: str
+    :param region_name: AWS region name (example: us-east-1)
+    :type region_name: str
+    """
+
+    def __init__(self, delivery_stream, region_name=None, *args, **kwargs):
+        self.delivery_stream = delivery_stream
+        self.region_name = region_name
+        super(AwsFirehoseHook, self).__init__(*args, **kwargs)
+
+    def get_conn(self):
+        """
+        Returns AwsHook connection object.
+        """
+
+        self.conn = self.get_client_type('firehose', self.region_name)
+        return self.conn
+
+    def put_records(self, records):
+        """
+        Write batch records to Kinesis Firehose
+        """
+
+        firehose_conn = self.get_conn()
+
+        response = firehose_conn.put_record_batch(
+            DeliveryStreamName=self.delivery_stream,
+            Records=records
+        )
+
+        return response

--- a/tests/contrib/hooks/test_aws_firehose_hook.py
+++ b/tests/contrib/hooks/test_aws_firehose_hook.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import uuid
+
+from airflow.contrib.hooks.aws_firehose_hook import AwsFirehoseHook
+
+try:
+    from moto import mock_kinesis
+except ImportError:
+    mock_kinesis = None
+
+
+class TestAwsFirehoseHook(unittest.TestCase):
+
+    @unittest.skipIf(mock_kinesis is None, 'mock_kinesis package not present')
+    @mock_kinesis
+    def test_get_conn_returns_a_boto3_connection(self):
+        hook = AwsFirehoseHook(aws_conn_id='aws_default',
+                               delivery_stream="test_airflow", region_name="us-east-1")
+        self.assertIsNotNone(hook.get_conn())
+
+    @unittest.skipIf(mock_kinesis is None, 'mock_kinesis package not present')
+    @mock_kinesis
+    def test_insert_batch_records_kinesis_firehose(self):
+        hook = AwsFirehoseHook(aws_conn_id='aws_default',
+                               delivery_stream="test_airflow", region_name="us-east-1")
+
+        response = hook.get_conn().create_delivery_stream(
+            DeliveryStreamName="test_airflow",
+            S3DestinationConfiguration={
+                'RoleARN': 'arn:aws:iam::123456789012:role/firehose_delivery_role',
+                'BucketARN': 'arn:aws:s3:::kinesis-test',
+                'Prefix': 'airflow/',
+                'BufferingHints': {
+                    'SizeInMBs': 123,
+                    'IntervalInSeconds': 124
+                },
+                'CompressionFormat': 'UNCOMPRESSED',
+            }
+        )
+
+        stream_arn = response['DeliveryStreamARN']
+        self.assertEquals(
+            stream_arn, "arn:aws:firehose:us-east-1:123456789012:deliverystream/test_airflow")
+
+        records = [{"Data": str(uuid.uuid4())}
+                   for _ in range(100)]
+
+        response = hook.put_records(records)
+
+        self.assertEquals(response['FailedPutCount'], 0)
+        self.assertEquals(response['ResponseMetadata']['HTTPStatusCode'], 200)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1575


### Description
- [x] Here are some details about my PR, (no UI changes)
Description is in above Jira. This PR creates a hook in contrib directory to integrate airflow with aws kinesis firehose for inserting batch items. 

### Tests
- [x] My PR adds the following unit tests 

1. test_aws_firehose_hook
This unit test checks airflow integration with AWS Kinesis Firehose. 1. checks if the connection is established using client API 2. checks batch insertion of data. We have to first create a kinesis firehose stream and then insert data

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

