### PR TITLE
[AIRFLOW-1560] Add AWS DynamoDB hook and operator for inserting batch…

### DIFF
--- a/airflow/contrib/hooks/__init__.py
+++ b/airflow/contrib/hooks/__init__.py
@@ -47,7 +47,8 @@ _hooks = {
     'cloudant_hook': ['CloudantHook'],
     'fs_hook': ['FSHook'],
     'wasb_hook': ['WasbHook'],
-    'gcp_pubsub_hook': ['PubSubHook']
+    'gcp_pubsub_hook': ['PubSubHook'],
+    'aws_dynamodb_hook': ['AwsDynamoDBHook']
 }
 
 import os as _os

--- a/airflow/contrib/hooks/aws_dynamodb_hook.py
+++ b/airflow/contrib/hooks/aws_dynamodb_hook.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.exceptions import AirflowException
+from airflow.contrib.hooks.aws_hook import AwsHook
+
+
+class AwsDynamoDBHook(AwsHook):
+    """
+    Interact with AWS DynamoDB.
+
+    :param table_keys: partition key and sort key
+    :type table_keys: list
+    :param table_name: target DynamoDB table
+    :type table_name: str
+    :param region_name: aws region name (example: us-east-1)
+    :type region_name: str
+    """
+
+    def __init__(self, table_keys=None, table_name=None, region_name=None, *args, **kwargs):
+        self.table_keys = table_keys
+        self.table_name = table_name
+        self.region_name = region_name
+        super(AwsDynamoDBHook, self).__init__(*args, **kwargs)
+
+    def get_conn(self):
+        self.conn = self.get_resource_type('dynamodb', self.region_name)
+        return self.conn
+
+    def write_batch_data(self, items):
+        """
+        Write batch items to dynamodb table with provisioned throughout capacity.
+        """
+
+        dynamodb_conn = self.get_conn()
+
+        try:
+            table = dynamodb_conn.Table(self.table_name)
+
+            with table.batch_writer(overwrite_by_pkeys=self.table_keys) as batch:
+                for item in items:
+                    batch.put_item(Item=item)
+            return True
+        except Exception as general_error:
+            raise AirflowException(
+                'Failed to insert items in dynamodb, error: {error}'.format(
+                    error=str(general_error)
+                )
+            )

--- a/airflow/contrib/hooks/aws_hook.py
+++ b/airflow/contrib/hooks/aws_hook.py
@@ -24,6 +24,7 @@ class AwsHook(BaseHook):
     Interact with AWS.
     This class is a thin wrapper around the boto3 python library.
     """
+
     def __init__(self, aws_conn_id='aws_default'):
         self.aws_conn_id = aws_conn_id
 
@@ -44,6 +45,28 @@ class AwsHook(BaseHook):
 
         return boto3.client(
             client_type,
+            region_name=region_name,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key
+        )
+
+    def get_resource_type(self, resource_type, region_name=None):
+        try:
+            connection_object = self.get_connection(self.aws_conn_id)
+            aws_access_key_id = connection_object.login
+            aws_secret_access_key = connection_object.password
+
+            if region_name is None:
+                region_name = connection_object.extra_dejson.get('region_name')
+
+        except AirflowException:
+            # No connection found: fallback on boto3 credential strategy
+            # http://boto3.readthedocs.io/en/latest/guide/configuration.html
+            aws_access_key_id = None
+            aws_secret_access_key = None
+
+        return boto3.resource(
+            resource_type,
             region_name=region_name,
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key

--- a/airflow/contrib/operators/__init__.py
+++ b/airflow/contrib/operators/__init__.py
@@ -38,7 +38,8 @@ _operators = {
     'qubole_operator': ['QuboleOperator'],
     'spark_submit_operator': ['SparkSubmitOperator'],
     'file_to_wasb': ['FileToWasbOperator'],
-    'fs_operator': ['FileSensor']
+    'fs_operator': ['FileSensor'],
+    'hive_to_dynamodb': ['HiveToDynamoDBTransferOperator']
 }
 
 import os as _os

--- a/airflow/contrib/operators/hive_to_dynamodb.py
+++ b/airflow/contrib/operators/hive_to_dynamodb.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+
+from airflow.contrib.hooks.aws_dynamodb_hook import AwsDynamoDBHook
+from airflow.hooks.hive_hooks import HiveServer2Hook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class HiveToDynamoDBTransferOperator(BaseOperator):
+    """
+    Moves data from Hive to DynamoDB, note that for now the data is loaded
+    into memory before being pushed to DynamoDB, so this operator should
+    be used for smallish amount of data.
+
+    :param sql: SQL query to execute against the hive database
+    :type sql: str
+    :param table_name: target DynamoDB table
+    :type table_name: str
+    :param table_keys: partition key and sort key
+    :type table_keys: list
+    :param pre_process: implement pre-processing of source data
+    :type pre_process: function
+    :param pre_process_args: list of pre_process function arguments
+    :type pre_process_args: list
+    :param pre_process_kwargs: dict of pre_process function arguments
+    :type pre_process_kwargs: dict
+    :param region_name: aws region name (example: us-east-1)
+    :type region_name: str
+    :param schema: hive database schema
+    :type schema: str
+    :param hiveserver2_conn_id: source hive connection
+    :type hiveserver2_conn_id: str
+    :param aws_conn_id: aws connection
+    :type aws_conn_id: str
+    """
+
+    template_fields = ('sql',)
+    template_ext = ('.sql',)
+    ui_color = '#a0e08c'
+
+    @apply_defaults
+    def __init__(
+            self,
+            sql,
+            table_name,
+            table_keys,
+            pre_process=None,
+            pre_process_args=None,
+            pre_process_kwargs=None,
+            region_name=None,
+            schema='default',
+            hiveserver2_conn_id='hiveserver2_default',
+            aws_conn_id='aws_default',
+            *args, **kwargs):
+        super(HiveToDynamoDBTransferOperator, self).__init__(*args, **kwargs)
+        self.sql = sql
+        self.table_name = table_name
+        self.table_keys = table_keys
+        self.pre_process = pre_process
+        self.pre_process_args = pre_process_args
+        self.pre_process_kwargs = pre_process_kwargs
+        self.region_name = region_name
+        self.schema = schema
+        self.hiveserver2_conn_id = hiveserver2_conn_id
+        self.aws_conn_id = aws_conn_id
+
+    def execute(self, context):
+        hive = HiveServer2Hook(hiveserver2_conn_id=self.hiveserver2_conn_id)
+
+        logging.info('Extracting data from Hive')
+        logging.info(self.sql)
+
+        data = hive.get_pandas_df(self.sql, schema=self.schema)
+        dynamodb = AwsDynamoDBHook(aws_conn_id=self.aws_conn_id,
+                                   table_name=self.table_name, table_keys=self.table_keys, region_name=self.region_name)
+
+        logging.info('Inserting rows into dynamodb')
+
+        if self.pre_process is None:
+            dynamodb.write_batch_data(
+                json.loads(data.to_json(orient='records')))
+        else:
+            dynamodb.write_batch_data(
+                self.pre_process(data=data, args=self.pre_process_args, kwargs=self.pre_process_kwargs))
+
+        logging.info('Done.')

--- a/tests/contrib/operators/test_hive_to_dynamodb_operator.py
+++ b/tests/contrib/operators/test_hive_to_dynamodb_operator.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import unittest
+
+import mock
+import pandas as pd
+
+from airflow import configuration, DAG
+
+configuration.load_test_config()
+import datetime
+from airflow.contrib.hooks.aws_dynamodb_hook import AwsDynamoDBHook
+import airflow.contrib.operators.hive_to_dynamodb
+
+DEFAULT_DATE = datetime.datetime(2015, 1, 1)
+DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
+DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
+
+try:
+    from moto import mock_dynamodb2
+except ImportError:
+    mock_dynamodb2 = None
+
+
+class HiveToDynamoDBTransferOperatorTest(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+        args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
+        dag = DAG('test_dag_id', default_args=args)
+        self.dag = dag
+        self.sql = 'SELECT 1'
+        self.hook = AwsDynamoDBHook(
+            aws_conn_id='aws_default', region_name='us-east-1')
+
+    def process_data(self, data, *args, **kwargs):
+        return json.loads(data.to_json(orient='records'))
+
+    @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamodb2 package not present')
+    @mock_dynamodb2
+    def test_get_conn_returns_a_boto3_connection(self):
+        hook = AwsDynamoDBHook(aws_conn_id='aws_default')
+        self.assertIsNotNone(hook.get_conn())
+
+    @mock.patch('airflow.hooks.hive_hooks.HiveServer2Hook.get_pandas_df',
+                return_value=pd.DataFrame(data=[('1', 'sid')], columns=['id', 'name']))
+    @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamodb2 package not present')
+    @mock_dynamodb2
+    def test_get_records_with_schema(self, get_results_mock):
+
+        # this table needs to be created in production
+        table = self.hook.get_conn().create_table(
+            TableName='test_airflow',
+            KeySchema=[
+                {
+                    'AttributeName': 'id',
+                    'KeyType': 'HASH'
+                },
+            ],
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'name',
+                    'AttributeType': 'S'
+                }
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 10,
+                'WriteCapacityUnits': 10
+            }
+        )
+
+        operator = airflow.contrib.operators.hive_to_dynamodb.HiveToDynamoDBTransferOperator(
+            sql=self.sql,
+            table_name="test_airflow",
+            task_id='hive_to_dynamodb_check',
+            table_keys=['id'],
+            dag=self.dag)
+
+        operator.execute(None)
+
+        table = self.hook.get_conn().Table('test_airflow')
+        table.meta.client.get_waiter(
+            'table_exists').wait(TableName='test_airflow')
+        self.assertEqual(table.item_count, 1)
+
+    @mock.patch('airflow.hooks.hive_hooks.HiveServer2Hook.get_pandas_df',
+                return_value=pd.DataFrame(data=[('1', 'sid'), ('1', 'gupta')], columns=['id', 'name']))
+    @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamodb2 package not present')
+    @mock_dynamodb2
+    def test_pre_process_records_with_schema(self, get_results_mock):
+
+         # this table needs to be created in production
+        table = self.hook.get_conn().create_table(
+            TableName='test_airflow',
+            KeySchema=[
+                {
+                    'AttributeName': 'id',
+                    'KeyType': 'HASH'
+                },
+            ],
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'name',
+                    'AttributeType': 'S'
+                }
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 10,
+                'WriteCapacityUnits': 10
+            }
+        )
+
+        operator = airflow.contrib.operators.hive_to_dynamodb.HiveToDynamoDBTransferOperator(
+            sql=self.sql,
+            table_name='test_airflow',
+            task_id='hive_to_dynamodb_check',
+            table_keys=['id'],
+            pre_process=self.process_data,
+            dag=self.dag)
+
+        operator.execute(None)
+
+        table = self.hook.get_conn().Table('test_airflow')
+        table.meta.client.get_waiter(
+            'table_exists').wait(TableName='test_airflow')
+        self.assertEqual(table.item_count, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1560


### Description
- [x] Here are some details about my PR, (No UI Changes):

The PR addresses airflow integration with AWS Dynamodb.  

Currently there is no hook to interact with DynamoDb for reading or writing items (single or batch insertions). To get started, we want to push data in DynamoDB using airflow jobs (scheduled daily). Idea is to read aggregates from Hive and push in DynamoDB (write data job will run everyday to make this happen). First we want to create DynamoDB hooks (this PR addressed the same) and then create operator to move data from Hive to DynamoDB.
http://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#service-resource

Something to think about - *Performance*
I think airflow's generic approach for reading all data from source and then transferring to the destination by either storing source data in memory or disk is not the best optimized approach (in cases of big data with potential performance issues). When I started my initial design - I categorized it into 2 use cases a) small data b) big data.. The operators written in airflow code right now mostly handle small data (so does this PR). My approach would be to start with this operator (small data) and then handle big data use case if we see performance issues. I have some thoughts on how we can handle big data operations (using batching mechanism). For instance: 

1. Fetch all distinct id's (primary key) from source 
2. Create N buckets and assign bucket number to all the id's
3. For each bucket : fetch data from source and then insert into destination. 

Plan to handle this in subsequent PR.


Something to think about - *Other ways of transferring data from hive to dynamodb*

There can be multiple ways for this data transfer to occur and here are some of the thoughts on current design decisions (KISS - keep it simple and sweet):

1. Lambda function : You can write a lambda function to transfer data and trigger the function using AwsLambdaHook (https://github.com/apache/incubator-airflow/pull/2570) but lambda lifetime is 5 mins and if the data transfer takes longer lambda will die.

2. Amazon Ecosystem (Amazon EMR, Big Data Pipeline, AWS Glue): Not to forget adding these systems create additional complexities (aws dependencies, aws limits, system complexities, IAM issues, airflow integrations with additonal dependencies and ofcourse $$)
 
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBPipeline.html

3. Not to forget insertions in dynamodb are tricky because of WCU's and boto handles the insertions gracefully by automatically throttling insertions (buffering etc)

### Tests
- [x] My PR adds the following unit tests :

1. test_aws_hook.py
adds mock_dynamodb2 from moto (https://github.com/spulec/moto). Wrote a test case to get aws resource object for dynamodb and create table via resource object and assert if count of items in table is 0 (implies table was created).

2. test_dynamodb_hook.py
adds mock_dynamodb2 from moto (https://github.com/spulec/moto). Wrote a test case to get aws resource object for dynamodb and create/insert data in dynamodb table. Then this unit test writes 10 items in the table using write_batch_data operation 

3. HiveToDynamoDBTransferTest
this unit test checks the workings of HiveToDynamoDB operator by inserting 1 record in dynamodb table via write operation.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

