### PR TITLE
[AIRFLOW-1584] Remove insecure /headers endpoint

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -629,20 +629,6 @@ class Airflow(BaseView):
     def noaccess(self):
         return self.render('airflow/noaccess.html')
 
-    @expose('/headers')
-    def headers(self):
-        d = {
-            'headers': {k: v for k, v in request.headers},
-        }
-        if hasattr(current_user, 'is_superuser'):
-            d['is_superuser'] = current_user.is_superuser()
-            d['data_profiling'] = current_user.data_profiling()
-            d['is_anonymous'] = current_user.is_anonymous()
-            d['is_authenticated'] = current_user.is_authenticated()
-        if hasattr(current_user, 'username'):
-            d['username'] = current_user.username
-        return wwwutils.json_response(d)
-
     @expose('/pickle_info')
     @login_required
     def pickle_info(self):

--- a/tests/core.py
+++ b/tests/core.py
@@ -1686,10 +1686,6 @@ class WebUiTests(unittest.TestCase):
         response = self.app.get('/health')
         self.assertIn('The server is healthy!', response.data.decode('utf-8'))
 
-    def test_headers(self):
-        response = self.app.get('/admin/airflow/headers')
-        self.assertIn('"headers":', response.data.decode('utf-8'))
-
     def test_noaccess(self):
         response = self.app.get('/admin/airflow/noaccess')
         self.assertIn("You don't seem to have access.", response.data.decode('utf-8'))


### PR DESCRIPTION
@saguziel 
cc @bolkedebruin 

### JIRA
https://issues.apache.org/jira/browse/AIRFLOW-1584

### Description
Remove the insecure /headers endpoint since it is insecure (see JIRA for details). If some of the headers are important they can be added to the gunicorn request log format which is the proper place for them.