### PR TITLE
AIRFLOW-1586: Add mapping for date type to mysql_to_gcs operator

### DIFF
--- a/airflow/contrib/operators/mysql_to_gcs.py
+++ b/airflow/contrib/operators/mysql_to_gcs.py
@@ -210,6 +210,7 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
             FIELD_TYPE.TINY: 'INTEGER',
             FIELD_TYPE.BIT: 'INTEGER',
             FIELD_TYPE.DATETIME: 'TIMESTAMP',
+            FIELD_TYPE.DATE: 'TIMESTAMP',
             FIELD_TYPE.DECIMAL: 'FLOAT',
             FIELD_TYPE.NEWDECIMAL: 'FLOAT',
             FIELD_TYPE.DOUBLE: 'FLOAT',


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1586


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds `FIELD_TYPE.DATE` as a mapping for MySQL to BigQuery data types conversion.

Seems like this was just a simple oversight in the section of `airflow/contrib/operators/mysql_to_gcs.py` where the types get converted. In `convert_types` both `date` and `datetime` types get converted to timestamps but in `type_map` there is no mapping for `FIELD_TYPE.DATE`. This small bug almost turned my team off from using airflow because we had a lot of tables that didn't flow into BigQuery because we used the `date` type a lot.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I did not see a test for the `MySqlToGoogleCloudStorageOperator` and it was not obvious to me how to create one. I would be happy to create one if someone can give me some guidance to get me started. I figured this was a good reason not to create a test.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

