### PR TITLE
[AIRFLOW-1587] bugfix: fix `ImportError: cannot import name 'CeleryExecutor'`,

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -871,7 +871,7 @@ class Airflow(BaseView):
 
         try:
             from airflow.executors import GetDefaultExecutor
-            from airflow.executors import CeleryExecutor
+            from airflow.executors.celery_executor import CeleryExecutor
             executor = GetDefaultExecutor()
             if not isinstance(executor, CeleryExecutor):
                 flash("Only works with the CeleryExecutor, sorry", "error")


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-1587] fix `ImportError: cannot import name 'CeleryExecutor'`"
    - [x] https://issues.apache.org/jira/browse/AIRFLOW-1587


### Description
-  [x] `CeleryExcutor` can not import directly from `airflow.executors`,
we should import from `airlfow.executors.celery_executor` instead.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

