### PR TITLE
[AIRFLOW-1591] Fix bug caused by TaskInstance not having task attribute set

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -695,6 +695,7 @@ class Airflow(BaseView):
         dttm = dateutil.parser.parse(execution_date)
         form = DateTimeForm(data={'execution_date': dttm})
         dag = dagbag.get_dag(dag_id)
+        task = dag.get_task(task_id)
         session = Session()
         ti = session.query(models.TaskInstance).filter(
             models.TaskInstance.dag_id == dag_id,
@@ -703,6 +704,7 @@ class Airflow(BaseView):
         if ti is None:
             logs = ["*** Task instance did not exist in the DB\n"]
         else:
+            ti.task = task
             logger = logging.getLogger('airflow.task')
             task_log_reader = conf.get('core', 'task_log_reader')
             handler = next((handler for handler in logger.handlers


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1591

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

From looking through the code it appears that the logging file_task_handler expects the TaskInstance to contain a reference to it's task object.

I found another example in the code of the task being set on a TaskInstance after it has been retrieved from the db, and doing so here fixes this issue.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No current unit test coverage here to be updated.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

