### PR TITLE
[AIRFLOW-1593] expose load_string in WasbHook

### DIFF
--- a/airflow/contrib/hooks/wasb_hook.py
+++ b/airflow/contrib/hooks/wasb_hook.py
@@ -92,3 +92,21 @@ class WasbHook(BaseHook):
         # Reorder the argument order from airflow.hooks.S3_hook.load_file.
         self.connection.create_blob_from_path(container_name, blob_name,
                                               file_path, **kwargs)
+
+    def load_string(self, string_data, container_name, blob_name, **kwargs):
+        """
+        Upload a string to Azure Blob Storage.
+        
+        :param string_data: String to load.
+        :type string_data: str
+        :param container_name: Name of the container.
+        :type container_name: str
+        :param blob_name: Name of the blob.
+        :type blob_name: str
+        :param kwargs: Optional keyword arguments that
+            `BlockBlobService.create_blob_from_text()` takes.
+        :type kwargs: object
+        """
+        # Reorder the argument order from airflow.hooks.S3_hook.load_string.
+        self.connection.create_blob_from_text(container_name, blob_name,
+                                              string_data, **kwargs)

--- a/tests/contrib/hooks/test_wasb_hook.py
+++ b/tests/contrib/hooks/test_wasb_hook.py
@@ -87,7 +87,7 @@ class TestWasbHook(unittest.TestCase):
         self.assertTrue(hook.check_for_prefix('container', 'prefix',
                                               timeout=3))
         mock_instance.list_blobs.assert_called_once_with(
-            'container', 'prefix', timeout=3
+            'container', 'prefix', num_results=1, timeout=3
         )
 
     @mock.patch('airflow.contrib.hooks.wasb_hook.BlockBlobService',
@@ -100,12 +100,22 @@ class TestWasbHook(unittest.TestCase):
 
     @mock.patch('airflow.contrib.hooks.wasb_hook.BlockBlobService',
                 autospec=True)
-    def test_check_for_prefix(self, mock_service):
+    def test_load_file(self, mock_service):
         mock_instance = mock_service.return_value
         hook = WasbHook(wasb_conn_id='wasb_test_sas_token')
         hook.load_file('path', 'container', 'blob', max_connections=1)
         mock_instance.create_blob_from_path.assert_called_once_with(
             'container', 'blob', 'path', max_connections=1
+        )
+
+    @mock.patch('airflow.contrib.hooks.wasb_hook.BlockBlobService',
+                autospec=True)
+    def test_load_string(self, mock_service):
+        mock_instance = mock_service.return_value
+        hook = WasbHook(wasb_conn_id='wasb_test_sas_token')
+        hook.load_string('big string', 'container', 'blob', max_connections=1)
+        mock_instance.create_blob_from_text.assert_called_once_with(
+            'container', 'blob', 'big string', max_connections=1
         )
 
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1593


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
I exposed the load_string method in the WasbHook, to be able to upload a string to the blobstore.
Additionally, I fixed the tests, some of them were broken.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

