### PR TITLE
[AIRFLOW-1594] Don't install test packages into python path.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -213,7 +213,7 @@ def do_setup():
         description='Programmatically author, schedule and monitor data pipelines',
         license='Apache License 2.0',
         version=version,
-        packages=find_packages(),
+        packages=find_packages(exclude=['tests*']),
         package_data={'': ['airflow/alembic.ini', "airflow/git_version"]},
         include_package_data=True,
         zip_safe=False,


### PR DESCRIPTION
By default `find_packages()` will find _any_ valid python package,
including things under tests. We don't want to install the tests
packages into the python path, so exclude those.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following
    - [AIRFLOW-1594 Installing via pip copies test files into python library dirs](https://issues.apache.org/jira/browse/AIRFLOW-1594)


### Description
- [x] By default `find_packages()` will find _any_ valid python package, including things under tests. We don't want to install the tests packages into the python path, so exclude those.



### Tests
- [x] No tests needed, it is a change to setup.py which can't be tested.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

