### PR TITLE
[AIRFLOW-1595] Change to construct sqlite_hook from connection schema

### DIFF
--- a/airflow/hooks/sqlite_hook.py
+++ b/airflow/hooks/sqlite_hook.py
@@ -32,5 +32,5 @@ class SqliteHook(DbApiHook):
         Returns a sqlite connection object
         """
         conn = self.get_connection(self.sqlite_conn_id)
-        conn = sqlite3.connect(conn.host)
+        conn = sqlite3.connect(conn.schema)
         return conn

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -160,7 +160,7 @@ def initdb():
     merge_conn(
         models.Connection(
             conn_id='sqlite_default', conn_type='sqlite',
-            host='/tmp/sqlite_default.db'))
+            schema='/tmp/sqlite_default.db'))
     merge_conn(
         models.Connection(
             conn_id='http_default', conn_type='http',

--- a/tests/hooks/test_sqlite_hook.py
+++ b/tests/hooks/test_sqlite_hook.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import unittest
+import os
+
+from airflow import settings, models
+from airflow.settings import Session
+from airflow.hooks.sqlite_hook import SqliteHook
+
+
+@unittest.skipIf(not settings.SQL_ALCHEMY_CONN.startswith('sqlite'), 'SqliteHook won\'t work without backend SQLite. No need to test anything here')
+class TestSqliteHook(unittest.TestCase):
+
+    CONN_ID = 'sqlite_hook_test'
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestSqliteHook, cls).setUpClass()
+        session = Session()
+        session.query(models.Connection).filter_by(conn_id=cls.CONN_ID).delete()
+        session.commit()
+        connection = models.Connection(conn_id=cls.CONN_ID, uri=settings.SQL_ALCHEMY_CONN)
+        session.add(connection)
+        session.commit()
+        session.close()
+
+    def test_sql_hook(self):
+        hook = SqliteHook(sqlite_conn_id=self.CONN_ID)
+        conn_id, = hook.get_first('SELECT conn_id FROM connection WHERE conn_id = :conn_id',
+                                  {'conn_id': self.CONN_ID})
+        self.assertEqual(conn_id, self.CONN_ID)
+
+    @classmethod
+    def tearDownClass(cls):
+        session = Session()
+        session.query(models.Connection).filter_by(conn_id=cls.CONN_ID).delete()
+        session.commit()
+        session.close()
+        super(TestSqliteHook, cls).tearDownClass()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1595


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
SqliteHook is built using the host attribute of connection, but correctly we should use the schema attribute. The connection created from URI has no host attribute.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
* tests/hooks/test_sqlite_hook.py

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

