### PR TITLE
[AIRFLOW-1601] Add configurable task cleanup time

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -133,6 +133,10 @@ task_log_reader = file.task
 # RCE exploits). This will be deprecated in Airflow 2.0 (be forced to False).
 enable_xcom_pickling = True
 
+# When a task is killed forcefully, this is the amount of time in seconds that
+# it has to cleanup after it is sent a SIGTERM, before it is SIGKILLED
+killed_task_cleanup_time = 60
+
 [cli]
 # In what way should the cli access the API. The LocalClient will use the
 # database directly, while the json_client will use the api running on the

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -38,6 +38,7 @@ dags_are_paused_at_creation = False
 fernet_key = {FERNET_KEY}
 non_pooled_task_slot_count = 128
 enable_xcom_pickling = False
+killed_task_cleanup_time = 5
 
 [cli]
 api_client = airflow.api.client.local_client

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -31,11 +31,12 @@ import subprocess
 import sys
 import warnings
 
+from airflow import configuration
 from airflow.exceptions import AirflowException
 
 # When killing processes, time to wait after issuing a SIGTERM before issuing a
 # SIGKILL.
-DEFAULT_TIME_TO_WAIT_AFTER_SIGTERM = 5
+DEFAULT_TIME_TO_WAIT_AFTER_SIGTERM = configuration.getint('core', 'KILLED_TASK_CLEANUP_TIME')
 
 
 def validate_key(k, max_length=250):


### PR DESCRIPTION
When task processes are SIGTERMed, they have by default 5 seconds to
cleanup before a SIGKILL arrives. This allows this value to be
configurable.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1601


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes: Allows configurable time between SIGTERM and SIGKILL in a process tree.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Tests exist already.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

