### PR TITLE
[AIRFLOW-1608] Handle pending job state in GCP Dataflow hook

### DIFF
--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -69,6 +69,8 @@ class _DataflowJob(object):
                         self._job['name']))
                 elif 'JOB_STATE_RUNNING' == self._job['currentState']:
                     time.sleep(10)
+                elif 'JOB_STATE_PENDING' == self._job['currentState']:
+                    time.sleep(15)
                 else:
                     logging.debug(str(self._job))
                     raise Exception(


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1608


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes: Handle JOB_STATE_PENDING in the GCP Dataflow hook so that a task using the dataflow operator will not immediately fail if it is in the pending state.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Small fix that does not need testing.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

