### PR TITLE
AIRFLOW-1614 Replace inspect.stack() with sys._getframe()

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -31,7 +31,6 @@ import getpass
 import imp
 import importlib
 import itertools
-import inspect
 import zipfile
 import jinja2
 import json
@@ -2859,7 +2858,7 @@ class DAG(BaseDag, LoggingMixin):
 
         self._description = description
         # set file location to caller source path
-        self.fileloc = inspect.getsourcefile(inspect.stack()[1][0])
+        self.fileloc = sys._getframe().f_back.f_code.co_filename
         self.task_dict = dict()
         self.start_date = start_date
         self.end_date = end_date


### PR DESCRIPTION
inspect.stack() is really expensive, and slows down processing of dags
having large numbers (100s, 1000s) of subdags.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This patch simply swaps one method of getting the caller's file name for another.  There should be no change in behavior (other than performance-wise) for either tests or production code.


