### PR TITLE
[AIRFLOW-1617] Fix XSS vulnerability in Variable endpoint

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -47,6 +47,8 @@ from flask_login import flash
 from flask._compat import PY2
 
 from jinja2.sandbox import ImmutableSandboxedEnvironment
+from jinja2 import escape
+
 import markdown
 import nvd3
 
@@ -1760,6 +1762,8 @@ class Airflow(BaseView):
                     'airflow/variables/{}.html'.format(form)
                 )
         except:
+            # prevent XSS
+            form = escape(form)
             return ("Error: form airflow/variables/{}.html "
                     "not found.").format(form), 404
 

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -139,6 +139,17 @@ class TestVariableView(unittest.TestCase):
         self.assertIn('<span class="label label-danger">Invalid</span>',
                       response.data.decode('utf-8'))
 
+    def test_xss_prevention(self):
+        xss = "/admin/airflow/variables/asdf<img%20src=''%20onerror='alert(1);'>"
+
+        response = self.app.get(
+            xss,
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertNotIn("<img src='' onerror='alert(1);'>",
+                         response.data.decode("utf-8"))
+
 
 class TestKnownEventView(unittest.TestCase):
 


### PR DESCRIPTION


Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1617


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

In case a Variable form was accessed by a get request and
the form did not exist as a template, the input was
returned as is to the user.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Test added.


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
