### PR TITLE
[AIRFLOW-1619] Add poll_sleep parameter to GCP dataflow operator

### DIFF
--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -70,6 +70,7 @@ class DataFlowJavaOperator(BaseOperator):
             options=None,
             gcp_conn_id='google_cloud_default',
             delegate_to=None,
+            poll_sleep=10,
             *args,
             **kwargs):
         """
@@ -96,6 +97,10 @@ class DataFlowJavaOperator(BaseOperator):
             For this to work, the service account making the request must have
             domain-wide delegation enabled.
         :type delegate_to: string
+        :param poll_sleep: The time in seconds to sleep between polling Google 
+            Cloud Platform for the dataflow job status while the job is in the
+            JOB_STATE_RUNNING state.
+        :type poll_sleep: int
         """
         super(DataFlowJavaOperator, self).__init__(*args, **kwargs)
 
@@ -107,13 +112,15 @@ class DataFlowJavaOperator(BaseOperator):
         self.jar = jar
         self.dataflow_default_options = dataflow_default_options
         self.options = options
+        self.poll_sleep = poll_sleep
 
     def execute(self, context):
         bucket_helper = GoogleCloudBucketHelper(
             self.gcp_conn_id, self.delegate_to)
         self.jar = bucket_helper.google_cloud_to_local(self.jar)
         hook = DataFlowHook(gcp_conn_id=self.gcp_conn_id,
-                            delegate_to=self.delegate_to)
+                            delegate_to=self.delegate_to,
+                            poll_sleep=self.poll_sleep)
 
         dataflow_options = copy.copy(self.dataflow_default_options)
         dataflow_options.update(self.options)
@@ -134,6 +141,7 @@ class DataFlowPythonOperator(BaseOperator):
             options=None,
             gcp_conn_id='google_cloud_default',
             delegate_to=None,
+            poll_sleep=10,
             *args,
             **kwargs):
         """
@@ -163,6 +171,10 @@ class DataFlowPythonOperator(BaseOperator):
             For this to work, the service account making the request must have
             domain-wide  delegation enabled.
         :type delegate_to: string
+        :param poll_sleep: The time in seconds to sleep between polling Google 
+            Cloud Platform for the dataflow job status while the job is in the
+            JOB_STATE_RUNNING state.
+        :type poll_sleep: int
         """
         super(DataFlowPythonOperator, self).__init__(*args, **kwargs)
 
@@ -172,6 +184,7 @@ class DataFlowPythonOperator(BaseOperator):
         self.options = options or {}
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.poll_sleep = poll_sleep
 
     def execute(self, context):
         """Execute the python dataflow job."""
@@ -179,7 +192,8 @@ class DataFlowPythonOperator(BaseOperator):
             self.gcp_conn_id, self.delegate_to)
         self.py_file = bucket_helper.google_cloud_to_local(self.py_file)
         hook = DataFlowHook(gcp_conn_id=self.gcp_conn_id,
-                            delegate_to=self.delegate_to)
+                            delegate_to=self.delegate_to,
+                            poll_sleep=self.poll_sleep)
         dataflow_options = self.dataflow_default_options.copy()
         dataflow_options.update(self.options)
         # Convert argument names from lowerCamelCase to snake case.

--- a/tests/contrib/operators/test_dataflow_operator.py
+++ b/tests/contrib/operators/test_dataflow_operator.py
@@ -36,6 +36,7 @@ DEFAULT_OPTIONS = {
 ADDITIONAL_OPTIONS = {
     'output': 'gs://test/output'
 }
+POLL_SLEEP = 30
 GCS_HOOK_STRING = 'airflow.contrib.operators.dataflow_operator.{}'
 
 
@@ -47,13 +48,15 @@ class DataFlowPythonOperatorTest(unittest.TestCase):
             py_file=PY_FILE,
             py_options=PY_OPTIONS,
             dataflow_default_options=DEFAULT_OPTIONS,
-            options=ADDITIONAL_OPTIONS)
+            options=ADDITIONAL_OPTIONS,
+            poll_sleep=POLL_SLEEP)
 
     def test_init(self):
         """Test DataFlowPythonOperator instance is properly initialized."""
         self.assertEqual(self.dataflow.task_id, TASK_ID)
         self.assertEqual(self.dataflow.py_file, PY_FILE)
         self.assertEqual(self.dataflow.py_options, PY_OPTIONS)
+        self.assertEqual(self.dataflow.poll_sleep, POLL_SLEEP)
         self.assertEqual(self.dataflow.dataflow_default_options,
                          DEFAULT_OPTIONS)
         self.assertEqual(self.dataflow.options,

--- a/tests/contrib/operators/test_mlengine_operator_utils.py
+++ b/tests/contrib/operators/test_mlengine_operator_utils.py
@@ -110,7 +110,7 @@ class CreateEvaluateOpsTest(unittest.TestCase):
             hook_instance.start_python_dataflow.return_value = None
             summary.execute(None)
             mock_dataflow_hook.assert_called_with(
-                gcp_conn_id='google_cloud_default', delegate_to=None)
+                gcp_conn_id='google_cloud_default', delegate_to=None, poll_sleep=10)
             hook_instance.start_python_dataflow.assert_called_once_with(
                 'eval-test-summary',
                 {


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1619


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes: Add parameter to set the time in seconds to sleep between polling GCP for the dataflow job status while the job is in the JOB_STATE_RUNNING state. Allows for a more reasonable poll interval than the previously hard coded 10 seconds for long running jobs.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Added to tests/contrib/operators/test_dataflow_operator.py

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

