### PR TITLE
[AIRFLOW-1627] Only query pool in SubDAG init when necessary

### DIFF
--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -60,25 +60,27 @@ class SubDagOperator(BaseOperator):
         # validate that subdag operator and subdag tasks don't have a
         # pool conflict
         if self.pool:
-            pool = (
-                session
-                .query(Pool)
-                .filter(Pool.slots == 1)
-                .filter(Pool.pool == self.pool)
-                .first()
-            )
             conflicts = [t for t in subdag.tasks if t.pool == self.pool]
-            if pool and any(t.pool == self.pool for t in subdag.tasks):
-                raise AirflowException(
-                    'SubDagOperator {sd} and subdag task{plural} {t} both use '
-                    'pool {p}, but the pool only has 1 slot. The subdag tasks'
-                    'will never run.'.format(
-                        sd=self.task_id,
-                        plural=len(conflicts) > 1,
-                        t=', '.join(t.task_id for t in conflicts),
-                        p=self.pool
-                    )
+            if conflicts:
+                # only query for pool conflicts if one may exist
+                pool = (
+                    session
+                    .query(Pool)
+                    .filter(Pool.slots == 1)
+                    .filter(Pool.pool == self.pool)
+                    .first()
                 )
+                if pool and any(t.pool == self.pool for t in subdag.tasks):
+                    raise AirflowException(
+                        'SubDagOperator {sd} and subdag task{plural} {t} both '
+                        'use pool {p}, but the pool only has 1 slot. The '
+                        'subdag tasks will never run.'.format(
+                            sd=self.task_id,
+                            plural=len(conflicts) > 1,
+                            t=', '.join(t.task_id for t in conflicts),
+                            p=self.pool
+                        )
+                    )
 
         self.subdag = subdag
         self.executor = executor


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1627


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

When checking for pool conflicts in a SubDAG, ensure that a task in
the SubDAG is actually in the same pool as the SubDagOperator itself
to avoid querying the database unnecessarily.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

