### PR TITLE
[AIRFLOW-1628] Fix docstring of sqlsensor

### DIFF
--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -87,7 +87,7 @@ class BaseSensorOperator(BaseOperator):
 
 class SqlSensor(BaseSensorOperator):
     """
-    Runs a sql statement until a criteria is met. It will keep trying until
+    Runs a sql statement until a criteria is met. It will keep trying while
     sql returns no row, or if the first cell in (0, '0', '').
 
     :param conn_id: The connection to run the sensor against


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1628


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
The description of keep trying condition for sqlsensor is strange. The condition should be while not until.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Fixed documentation only.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

