### PR TITLE
[AIRFLOW-1629] make extra a text area so that you can actually see what you are doing

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2588,7 +2588,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
     verbose_name_plural = "Connections"
     column_default_sort = ('conn_id', False)
     column_list = ('conn_id', 'conn_type', 'host', 'port', 'is_encrypted', 'is_extra_encrypted',)
-    form_overrides = dict(_password=PasswordField)
+    form_overrides = dict(_password=PasswordField, _extra=TextAreaField)
     form_widget_args = {
         'is_extra_encrypted': {'disabled': True},
         'is_encrypted': {'disabled': True},


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1629


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
The extra field in the connection is almost always used to store json.  This string is often large and it is extremely difficult to work with in a text field
Old:
![image](https://user-images.githubusercontent.com/806458/30712956-c49d716e-9edb-11e7-99af-cb5b0a6871b9.png)
New:
![image](https://user-images.githubusercontent.com/806458/30712860-6f672c44-9edb-11e7-8e32-32b386e93886.png)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Not sure what you would change to test this since it is visual

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

