### PR TITLE
[AIRFLOW-1576] Added region param to Dataproc{*}Operators

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -503,6 +503,7 @@ class DataProcHiveOperator(BaseOperator):
             dataproc_hive_jars=None,
             gcp_conn_id='google_cloud_default',
             delegate_to=None,
+            region='global',
             *args,
             **kwargs):
         """
@@ -532,6 +533,8 @@ class DataProcHiveOperator(BaseOperator):
             For this to work, the service account making the request must have domain-wide
             delegation enabled.
         :type delegate_to: string
+        :param region: The specified region where the dataproc cluster is created.
+        :type region: string
         """
         super(DataProcHiveOperator, self).__init__(*args, **kwargs)
         self.gcp_conn_id = gcp_conn_id
@@ -543,6 +546,7 @@ class DataProcHiveOperator(BaseOperator):
         self.dataproc_cluster = dataproc_cluster
         self.dataproc_properties = dataproc_hive_properties
         self.dataproc_jars = dataproc_hive_jars
+        self.region = region
 
     def execute(self, context):
         hook = DataProcHook(gcp_conn_id=self.gcp_conn_id,
@@ -559,7 +563,7 @@ class DataProcHiveOperator(BaseOperator):
         job.add_jar_file_uris(self.dataproc_jars)
         job.set_job_name(self.job_name)
 
-        hook.submit(hook.project_id, job.build())
+        hook.submit(hook.project_id, job.build(), self.region)
 
 
 class DataProcSparkSqlOperator(BaseOperator):
@@ -663,6 +667,7 @@ class DataProcSparkOperator(BaseOperator):
             dataproc_spark_jars=None,
             gcp_conn_id='google_cloud_default',
             delegate_to=None,
+            region='global',
             *args,
             **kwargs):
         """
@@ -699,6 +704,8 @@ class DataProcSparkOperator(BaseOperator):
             For this to work, the service account making the request must have domain-wide
             delegation enabled.
         :type delegate_to: string
+        :param region: The specified region where the dataproc cluster is created.
+        :type region: string
         """
         super(DataProcSparkOperator, self).__init__(*args, **kwargs)
         self.gcp_conn_id = gcp_conn_id
@@ -712,6 +719,7 @@ class DataProcSparkOperator(BaseOperator):
         self.dataproc_cluster = dataproc_cluster
         self.dataproc_properties = dataproc_spark_properties
         self.dataproc_jars = dataproc_spark_jars
+        self.region = region
 
     def execute(self, context):
         hook = DataProcHook(gcp_conn_id=self.gcp_conn_id,
@@ -726,7 +734,7 @@ class DataProcSparkOperator(BaseOperator):
         job.add_file_uris(self.files)
         job.set_job_name(self.job_name)
 
-        hook.submit(hook.project_id, job.build())
+        hook.submit(hook.project_id, job.build(), self.region)
 
 
 class DataProcHadoopOperator(BaseOperator):
@@ -751,6 +759,7 @@ class DataProcHadoopOperator(BaseOperator):
             dataproc_hadoop_jars=None,
             gcp_conn_id='google_cloud_default',
             delegate_to=None,
+            region='global',
             *args,
             **kwargs):
         """
@@ -787,6 +796,8 @@ class DataProcHadoopOperator(BaseOperator):
             For this to work, the service account making the request must have domain-wide
             delegation enabled.
         :type delegate_to: string
+        :param region: The specified region where the dataproc cluster is created.
+        :type region: string
         """
         super(DataProcHadoopOperator, self).__init__(*args, **kwargs)
         self.gcp_conn_id = gcp_conn_id
@@ -800,6 +811,7 @@ class DataProcHadoopOperator(BaseOperator):
         self.dataproc_cluster = dataproc_cluster
         self.dataproc_properties = dataproc_hadoop_properties
         self.dataproc_jars = dataproc_hadoop_jars
+        self.region = region
 
     def execute(self, context):
         hook = DataProcHook(gcp_conn_id=self.gcp_conn_id,
@@ -814,7 +826,7 @@ class DataProcHadoopOperator(BaseOperator):
         job.add_file_uris(self.files)
         job.set_job_name(self.job_name)
 
-        hook.submit(hook.project_id, job.build())
+        hook.submit(hook.project_id, job.build(), self.region)
 
 
 class DataProcPySparkOperator(BaseOperator):
@@ -839,6 +851,7 @@ class DataProcPySparkOperator(BaseOperator):
             dataproc_pyspark_jars=None,
             gcp_conn_id='google_cloud_default',
             delegate_to=None,
+            region='global',
             *args,
             **kwargs):
         """
@@ -875,6 +888,8 @@ class DataProcPySparkOperator(BaseOperator):
             For this to work, the service account making the request must have
             domain-wide delegation enabled.
         :type delegate_to: string
+        :param region: The specified region where the dataproc cluster is created.
+        :type region: string
          """
         super(DataProcPySparkOperator, self).__init__(*args, **kwargs)
         self.gcp_conn_id = gcp_conn_id
@@ -888,6 +903,7 @@ class DataProcPySparkOperator(BaseOperator):
         self.dataproc_cluster = dataproc_cluster
         self.dataproc_properties = dataproc_pyspark_properties
         self.dataproc_jars = dataproc_pyspark_jars
+        self.region = region
 
     def execute(self, context):
         hook = DataProcHook(gcp_conn_id=self.gcp_conn_id,
@@ -903,4 +919,4 @@ class DataProcPySparkOperator(BaseOperator):
         job.add_python_file_uris(self.pyfiles)
         job.set_job_name(self.job_name)
 
-        hook.submit(hook.project_id, job.build())
+        hook.submit(hook.project_id, job.build(), self.region)

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -20,13 +20,24 @@ import unittest
 from airflow import DAG
 from airflow.contrib.operators.dataproc_operator import DataprocClusterCreateOperator
 from airflow.contrib.operators.dataproc_operator import DataprocClusterDeleteOperator
+from airflow.contrib.operators.dataproc_operator import DataProcHadoopOperator
+from airflow.contrib.operators.dataproc_operator import DataProcHiveOperator
+from airflow.contrib.operators.dataproc_operator import DataProcPySparkOperator
+from airflow.contrib.operators.dataproc_operator import DataProcSparkOperator
 from airflow.version import version
 
 from copy import deepcopy
 
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
 from mock import Mock
 from mock import patch
-
 
 TASK_ID = 'test-dataproc-operator'
 CLUSTER_NAME = 'test-cluster-name'
@@ -47,9 +58,11 @@ SERVICE_ACCOUNT_SCOPES = [
     'https://www.googleapis.com/auth/bigtable.data'
 ]
 DEFAULT_DATE = datetime.datetime(2017, 6, 6)
+REGION = 'test-region'
+MAIN_URI = 'test-uri'
 
 class DataprocClusterCreateOperatorTest(unittest.TestCase):
-    # Unitest for the DataprocClusterCreateOperator
+    # Unit test for the DataprocClusterCreateOperator
     def setUp(self):
         # instantiate two different test cases with different labels.
         self.labels = [LABEL1, LABEL2]
@@ -158,7 +171,7 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
                 mock_info.assert_called_with('Creating cluster: %s', u'smoke-cluster-testnodash')
 
 class DataprocClusterDeleteOperatorTest(unittest.TestCase):
-    # Unitest for the DataprocClusterDeleteOperator
+    # Unit test for the DataprocClusterDeleteOperator
     def setUp(self):
         self.mock_execute = Mock()
         self.mock_execute.execute = Mock(return_value={'done' : True})
@@ -213,3 +226,52 @@ class DataprocClusterDeleteOperatorTest(unittest.TestCase):
                 with self.assertRaises(TypeError) as _:
                     dataproc_task.execute(None)
                 mock_info.assert_called_with('Deleting cluster: %s', u'smoke-cluster-testnodash')
+
+class DataProcHadoopOperatorTest(unittest.TestCase):
+    # Unit test for the DataProcHadoopOperator
+    def test_hook_correct_region(self):
+       with patch('airflow.contrib.operators.dataproc_operator.DataProcHook') as mock_hook:
+            dataproc_task = DataProcHadoopOperator(
+                task_id=TASK_ID,
+                region=REGION
+            )
+
+            dataproc_task.execute(None)
+            mock_hook.return_value.submit.assert_called_once_with(mock.ANY, mock.ANY, REGION)
+
+class DataProcHiveOperatorTest(unittest.TestCase):
+    # Unit test for the DataProcHiveOperator
+    def test_hook_correct_region(self):
+       with patch('airflow.contrib.operators.dataproc_operator.DataProcHook') as mock_hook:
+            dataproc_task = DataProcHiveOperator(
+                task_id=TASK_ID,
+                region=REGION
+            )
+
+            dataproc_task.execute(None)
+            mock_hook.return_value.submit.assert_called_once_with(mock.ANY, mock.ANY, REGION)
+
+class DataProcPySparkOperatorTest(unittest.TestCase):
+    # Unit test for the DataProcPySparkOperator
+    def test_hook_correct_region(self):
+       with patch('airflow.contrib.operators.dataproc_operator.DataProcHook') as mock_hook:
+            dataproc_task = DataProcPySparkOperator(
+                task_id=TASK_ID,
+                main=MAIN_URI,
+                region=REGION
+            )
+
+            dataproc_task.execute(None)
+            mock_hook.return_value.submit.assert_called_once_with(mock.ANY, mock.ANY, REGION)
+
+class DataProcSparkOperatorTest(unittest.TestCase):
+    # Unit test for the DataProcSparkOperator
+    def test_hook_correct_region(self):
+       with patch('airflow.contrib.operators.dataproc_operator.DataProcHook') as mock_hook:
+            dataproc_task = DataProcSparkOperator(
+                task_id=TASK_ID,
+                region=REGION
+            )
+
+            dataproc_task.execute(None)
+            mock_hook.return_value.submit.assert_called_once_with(mock.ANY, mock.ANY, REGION)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1576) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    -https://issues.apache.org/jira/browse/AIRFLOW-1576


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently, the `DataProcHadoopOperator`, `DataProcSparkOperator`, `DataProcPySparkOperator`, and `DataProcHiveOperator` (found in [`dataproc_operator.py`](https://github.com/apache/incubator-airflow/blob/master/airflow/contrib/operators/dataproc_operator.py)) default to using a `global` cluster. We add a region parameter to these operators with support in the corresponding [`gcp_dataproc_hook.py`](https://github.com/apache/incubator-airflow/blob/master/airflow/contrib/hooks/gcp_dataproc_hook.py) so that users can specify cluster regions (ex. _us-central1_, etc.)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

My PR adds tests to [`test_dataproc_operator.py`](https://github.com/apache/incubator-airflow/blob/master/tests/contrib/operators/test_dataproc_operator.py) to ensure that the region parameter is passed through to the appropriate hook. Also, I've integraton-tested this by running a HadoopOperator with the new region param as follows.
```
    RUN_CENTRAL1_DATAPROC_HADOOP = DataProcHadoopOperator(
        task_id='run_central1_dataproc_hadoop',
        main_jar=WORDCOUNT_JAR,
        dataproc_cluster='test-cluster-a',
        region='us-central1',
        arguments=WORDCOUNT_ARGS
        )
```
[Here](https://screenshot.googleplex.com/vcdUQtd1i8Q) is the successful result in Cloud Console.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"