### PR TITLE
Airflow 1639 Fix Fernet error handling

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -101,8 +101,7 @@ def get_fernet():
     try:
         return Fernet(configuration.get('core', 'FERNET_KEY').encode('utf-8'))
     except ValueError as ve:
-        raise AirflowException("Could not create Fernet object: {}"
-                               .format(ve.message))
+        raise AirflowException("Could not create Fernet object: {}".format(ve))
 
 
 if 'mysql' in settings.SQL_ALCHEMY_CONN:


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

When the encrypted string cannot be decryted using Fernet for some reason, an error will be thrown. In Python 3.6.2 the .message attr is not available. By casting the ValueError to a string, the message will be extracted from the Error.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1639


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

