### PR TITLE
[Airflow-1640]: Add qubole_default connection in connection table

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -263,6 +263,10 @@ def initdb():
         models.Connection(
             conn_id='databricks_default', conn_type='databricks',
             host='localhost'))
+    merge_conn(
+        models.Connection(
+            conn_id='qubole_default', conn_type='qubole',
+            host= 'localhost'))
 
     # Known event types
     KET = models.KnownEventType


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1640/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes: This is to add a default connection entry with Qubole. This will help users at Qubole to get started with Airflow with minimum setup from their end. Since Qubole Operator in already present in airflow, adding this will come in handy


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: 
This PR just adds a default connection. An extra entry in connection table wouldn't affect codebase


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

