### PR TITLE
[AIRFLOW-1611] Customize logging config

### DIFF
--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -26,17 +26,6 @@ LOG_FORMAT = conf.get('core', 'log_format')
 
 BASE_LOG_FOLDER = conf.get('core', 'BASE_LOG_FOLDER')
 
-# TODO: REMOTE_BASE_LOG_FOLDER should be deprecated and
-# directly specify in the handler definitions. This is to
-# provide compatibility to older remote log folder settings.
-REMOTE_BASE_LOG_FOLDER = conf.get('core', 'REMOTE_BASE_LOG_FOLDER')
-S3_LOG_FOLDER = ''
-GCS_LOG_FOLDER = ''
-if REMOTE_BASE_LOG_FOLDER.startswith('s3:/'):
-    S3_LOG_FOLDER = REMOTE_BASE_LOG_FOLDER
-elif REMOTE_BASE_LOG_FOLDER.startswith('gs:/'):
-    GCS_LOG_FOLDER = REMOTE_BASE_LOG_FOLDER
-
 FILENAME_TEMPLATE = '{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log'
 
 DEFAULT_LOGGING_CONFIG = {
@@ -58,21 +47,24 @@ DEFAULT_LOGGING_CONFIG = {
             'formatter': 'airflow.task',
             'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
             'filename_template': FILENAME_TEMPLATE,
-        },
-        's3.task': {
-            'class': 'airflow.utils.log.s3_task_handler.S3TaskHandler',
-            'formatter': 'airflow.task',
-            'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
-            's3_log_folder': S3_LOG_FOLDER,
-            'filename_template': FILENAME_TEMPLATE,
-        },
-        'gcs.task': {
-            'class': 'airflow.utils.log.gcs_task_handler.GCSTaskHandler',
-            'formatter': 'airflow.task',
-            'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
-            'gcs_log_folder': GCS_LOG_FOLDER,
-            'filename_template': FILENAME_TEMPLATE,
-        },
+        }
+        # When using s3 or gcs, provide a customized LOGGING_CONFIG
+        # in airflow_local_settings within your PYTHONPATH, see UPDATING.md
+        # for details
+        # 's3.task': {
+        #     'class': 'airflow.utils.log.s3_task_handler.S3TaskHandler',
+        #     'formatter': 'airflow.task',
+        #     'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
+        #     's3_log_folder': S3_LOG_FOLDER,
+        #     'filename_template': FILENAME_TEMPLATE,
+        # },
+        # 'gcs.task': {
+        #     'class': 'airflow.utils.log.gcs_task_handler.GCSTaskHandler',
+        #     'formatter': 'airflow.task',
+        #     'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
+        #     'gcs_log_folder': GCS_LOG_FOLDER,
+        #     'filename_template': FILENAME_TEMPLATE,
+        # },
     },
     'loggers': {
         'airflow.task': {
@@ -85,7 +77,7 @@ DEFAULT_LOGGING_CONFIG = {
             'level': LOG_LEVEL,
             'propagate': True,
         },
-        'airflow.task.raw': {
+        'airflow': {
             'handlers': ['console'],
             'level': LOG_LEVEL,
             'propagate': False,

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -36,23 +36,22 @@ dags_folder = {AIRFLOW_HOME}/dags
 base_log_folder = {AIRFLOW_HOME}/logs
 
 # Airflow can store logs remotely in AWS S3 or Google Cloud Storage. Users
-# must supply a remote location URL (starting with either 's3://...' or
-# 'gs://...') and an Airflow connection id that provides access to the storage
+# must supply an Airflow connection id that provides access to the storage
 # location.
-remote_base_log_folder =
 remote_log_conn_id =
-# Use server-side encryption for logs stored in S3
 encrypt_s3_logs = False
-# DEPRECATED option for remote log storage, use remote_base_log_folder instead!
-s3_log_folder =
 
 # Logging level
 logging_level = INFO
 
+# Logging class
+# Specify the class that will specify the logging configuration
+# This class has to be on the python classpath
+# logging_config_class = my.path.default_local_settings.LOGGING_CONFIG
+logging_config_class =
+
 # Log format
 log_format = [%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s
-log_format_with_pid = [%%(asctime)s] [%%(process)d] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s
-log_format_with_thread_name = [%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(threadName)s %%(levelname)s - %%(message)s
 simple_log_format = %%(asctime)s %%(levelname)s - %%(message)s
 
 # The executor class that airflow should use. Choices include
@@ -121,9 +120,6 @@ security =
 # Turn unit test mode on (overwrites many configuration options with test
 # values at runtime)
 unit_test_mode = False
-
-# User defined logging configuration file path.
-logging_config_path =
 
 # Name of handler to read task instance logs.
 # Default to use file task handler.

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -40,6 +40,7 @@ from time import sleep
 from airflow import configuration as conf
 from airflow import executors, models, settings
 from airflow.exceptions import AirflowException
+from airflow.logging_config import configure_logging
 from airflow.models import DAG, DagRun
 from airflow.settings import Stats
 from airflow.task_runner import get_task_runner
@@ -372,9 +373,7 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
             sys.stderr = f
 
             try:
-                # Re-configure logging to use the new output streams
-                log_format = settings.LOG_FORMAT_WITH_THREAD_NAME
-                settings.configure_logging(log_format=log_format)
+                configure_logging()
                 # Re-configure the ORM engine as there are issues with multiple processes
                 settings.configure_orm()
 

--- a/airflow/logging_config.py
+++ b/airflow/logging_config.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import logging
+import sys
+from logging.config import dictConfig
+
+from airflow import configuration as conf
+from airflow.exceptions import AirflowConfigException
+from airflow.utils.module_loading import import_string
+
+log = logging.getLogger(__name__)
+
+
+def configure_logging():
+    logging_class_path = ''
+    try:
+        logging_class_path = conf.get('core', 'logging_config_class')
+    except AirflowConfigException:
+        log.debug('Could not find key logging_config_class in config')
+
+    if logging_class_path:
+        try:
+            logging_config = import_string(logging_class_path)
+
+            # Make sure that the variable is in scope
+            assert (isinstance(logging_config, dict))
+
+            log.info(
+                'Successfully imported user-defined logging config from %s',
+                logging_class_path
+            )
+        except Exception:
+            # Import default logging configurations.
+            raise ImportError(
+                'Unable to load custom logging from {}'.format(logging_class_path)
+            )
+    else:
+        from airflow.config_templates.airflow_local_settings import (
+            DEFAULT_LOGGING_CONFIG as logging_config
+        )
+        log.debug('Unable to load custom logging, using default config instead')
+
+    try:
+        # Try to init logging
+        dictConfig(logging_config)
+    except ValueError as e:
+        log.warning('Unable to load the config, contains a configuration error.')
+        # When there is an error in the config, escalate the exception
+        # otherwise Airflow would silently fall back on the default config
+        raise e
+
+    return logging_config

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -26,6 +26,7 @@ from airflow import models, LoggingMixin
 from airflow.settings import Session
 
 from airflow.www.blueprints import routes
+from airflow.logging_config import configure_logging
 from airflow import jobs
 from airflow import settings
 from airflow import configuration
@@ -52,8 +53,7 @@ def create_app(config=None, testing=False):
 
     app.register_blueprint(routes)
 
-    log_format = airflow.settings.LOG_FORMAT_WITH_PID
-    airflow.settings.configure_logging(log_format=log_format)
+    configure_logging()
 
     with app.app_context():
         from airflow.www import views

--- a/tests/core.py
+++ b/tests/core.py
@@ -2500,54 +2500,6 @@ class EmailSmtpTest(unittest.TestCase):
         self.assertFalse(mock_smtp.called)
         self.assertFalse(mock_smtp_ssl.called)
 
-class LogTest(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-
-    def _log(self):
-        settings.configure_logging()
-
-        sio = six.StringIO()
-        handler = logging.StreamHandler(sio)
-        logger = logging.getLogger()
-        logger.addHandler(handler)
-
-        logging.debug("debug")
-        logging.info("info")
-        logging.warn("warn")
-
-        sio.flush()
-        return sio.getvalue()
-
-    def test_default_log_level(self):
-        s = self._log()
-        self.assertFalse("debug" in s)
-        self.assertTrue("info" in s)
-        self.assertTrue("warn" in s)
-
-    def test_change_log_level_to_debug(self):
-        configuration.set("core", "LOGGING_LEVEL", "DEBUG")
-        s = self._log()
-        self.assertTrue("debug" in s)
-        self.assertTrue("info" in s)
-        self.assertTrue("warn" in s)
-
-    def test_change_log_level_to_info(self):
-        configuration.set("core", "LOGGING_LEVEL", "INFO")
-        s = self._log()
-        self.assertFalse("debug" in s)
-        self.assertTrue("info" in s)
-        self.assertTrue("warn" in s)
-
-    def test_change_log_level_to_warn(self):
-        configuration.set("core", "LOGGING_LEVEL", "WARNING")
-        s = self._log()
-        self.assertFalse("debug" in s)
-        self.assertFalse("info" in s)
-        self.assertTrue("warn" in s)
-
-    def tearDown(self):
-        configuration.set("core", "LOGGING_LEVEL", "INFO")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from mock import patch, mock
+
+from airflow import configuration as conf
+from airflow.configuration import mkdir_p
+from airflow.exceptions import AirflowConfigException
+
+SETTINGS_FILE_VALID = """
+LOGGING_CONFIG = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'airflow.task': {
+            'format': '[%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s'
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'airflow.task',
+            'stream': 'ext://sys.stdout'
+        }
+    },
+    'loggers': {
+        'airflow': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': False
+        }
+    }
+}
+"""
+
+SETTINGS_FILE_INVALID = """
+LOGGING_CONFIG = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'airflow.task': {
+            'format': '[%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s'
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'airflow.task',
+            'stream': 'ext://sys.stdout'
+        }
+    },
+    'loggers': {
+        'airflow': {
+            'handlers': ['file.handler'], # this handler does not exists
+            'level': 'INFO',
+            'propagate': False
+        }
+    }
+}
+"""
+
+SETTINGS_FILE_EMPTY = """
+# Other settings here
+"""
+
+SETTINGS_DEFAULT_NAME = 'custom_airflow_local_settings'
+
+
+class settings_context(object):
+    """
+    Sets a settings file and puts it in the Python classpath
+
+    :param content:
+          The content of the settings file
+    """
+
+    def __init__(self, content, dir=None, name='LOGGING_CONFIG'):
+        self.content = content
+        self.settings_root = tempfile.mkdtemp()
+        filename = "{}.py".format(SETTINGS_DEFAULT_NAME)
+
+        if dir:
+            # Replace slashes by dots
+            self.module = dir.replace('/', '.') + '.' + SETTINGS_DEFAULT_NAME + '.' + name
+
+            # Create the directory structure
+            dir_path = os.path.join(self.settings_root, dir)
+            mkdir_p(dir_path)
+
+            # Add the __init__ for the directories
+            # This is required for Python 2.7
+            basedir = self.settings_root
+            for part in dir.split('/'):
+                open(os.path.join(basedir, '__init__.py'), 'w').close()
+                basedir = os.path.join(basedir, part)
+            open(os.path.join(basedir, '__init__.py'), 'w').close()
+
+            self.settings_file = os.path.join(dir_path, filename)
+        else:
+            self.module = SETTINGS_DEFAULT_NAME + '.' + name
+            self.settings_file = os.path.join(self.settings_root, filename)
+
+    def __enter__(self):
+        with open(self.settings_file, 'w') as handle:
+            handle.writelines(self.content)
+        sys.path.append(self.settings_root)
+        conf.set(
+            'core',
+            'logging_config_class',
+            self.module
+        )
+        return self.settings_file
+
+    def __exit__(self, *exc_info):
+        #shutil.rmtree(self.settings_root)
+        # Reset config
+        conf.set('core', 'logging_config_class', '')
+        sys.path.remove(self.settings_root)
+
+
+class TestLoggingSettings(unittest.TestCase):
+    # Make sure that the configure_logging is not cached
+    def setUp(self):
+        self.old_modules = dict(sys.modules)
+
+    def tearDown(self):
+        # Remove any new modules imported during the test run. This lets us
+        # import the same source files for more than one test.
+        for m in [m for m in sys.modules if m not in self.old_modules]:
+            del sys.modules[m]
+
+    # When we try to load an invalid config file, we expect an error
+    def test_loading_invalid_local_settings(self):
+        from airflow.logging_config import configure_logging, log
+        with settings_context(SETTINGS_FILE_INVALID):
+            with patch.object(log, 'warning') as mock_info:
+                # Load config
+                with self.assertRaises(ValueError):
+                    configure_logging()
+
+                mock_info.assert_called_with(
+                    'Unable to load the config, contains a configuration error.'
+                )
+
+    def test_loading_valid_complex_local_settings(self):
+        # Test what happens when the config is somewhere in a subfolder
+        module_structure = 'etc.airflow.config'
+        dir_structure = module_structure.replace('.', '/')
+        with settings_context(SETTINGS_FILE_VALID, dir_structure):
+            from airflow.logging_config import configure_logging, log
+            with patch.object(log, 'info') as mock_info:
+                configure_logging()
+                mock_info.assert_called_with(
+                    'Successfully imported user-defined logging config from %s',
+                    'etc.airflow.config.{}.LOGGING_CONFIG'.format(
+                        SETTINGS_DEFAULT_NAME
+                    )
+                )
+
+    # When we try to load a valid config
+    def test_loading_valid_local_settings(self):
+        with settings_context(SETTINGS_FILE_VALID):
+            from airflow.logging_config import configure_logging, log
+            with patch.object(log, 'info') as mock_info:
+                configure_logging()
+                mock_info.assert_called_with(
+                    'Successfully imported user-defined logging config from %s',
+                    '{}.LOGGING_CONFIG'.format(
+                        SETTINGS_DEFAULT_NAME
+                    )
+                )
+
+    # When we load an empty file, it should go to default
+    def test_loading_no_local_settings(self):
+        with settings_context(SETTINGS_FILE_EMPTY):
+            from airflow.logging_config import configure_logging
+            with self.assertRaises(ImportError):
+                configure_logging()
+
+    # When the key is not available in the configuration
+    def test_when_the_config_key_does_not_exists(self):
+        from airflow import logging_config
+
+        logging_config.conf.get = mock.Mock(side_effect=AirflowConfigException('boom'))
+
+        with patch.object(logging_config.log, 'debug') as mock_debug:
+            logging_config.configure_logging()
+            mock_debug.assert_any_call('Could not find key logging_config_class in config')
+
+    # Just default
+    def test_loading_local_settings_without_logging_config(self):
+        from airflow.logging_config import configure_logging, log
+        with patch.object(log, 'debug') as mock_info:
+            configure_logging()
+            mock_info.assert_called_with(
+                'Unable to load custom logging, using default config instead'
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -21,7 +21,7 @@ import unittest
 
 from datetime import datetime
 from airflow.models import TaskInstance, DAG
-from airflow.config_templates.default_airflow_logging import DEFAULT_LOGGING_CONFIG
+from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.log.file_task_handler import FileTaskHandler
 
@@ -73,24 +73,24 @@ class TestFileTaskLogHandler(unittest.TestCase):
         # Remove the generated tmp log file.
         os.remove(log_filename)
 
-    
+
 class TestFilenameRendering(unittest.TestCase):
-    
+
     def setUp(self):
         dag = DAG('dag_for_testing_filename_rendering', start_date=DEFAULT_DATE)
         task = DummyOperator(task_id='task_for_testing_filename_rendering', dag=dag)
         self.ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
-    
+
     def test_python_formatting(self):
         expected_filename = 'dag_for_testing_filename_rendering/task_for_testing_filename_rendering/%s/42.log' % DEFAULT_DATE.isoformat()
-        
+
         fth = FileTaskHandler('', '{dag_id}/{task_id}/{execution_date}/{try_number}.log')
         rendered_filename = fth._render_filename(self.ti, 42)
         self.assertEqual(expected_filename, rendered_filename)
-        
+
     def test_jinja_rendering(self):
         expected_filename = 'dag_for_testing_filename_rendering/task_for_testing_filename_rendering/%s/42.log' % DEFAULT_DATE.isoformat()
-        
+
         fth = FileTaskHandler('', '{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log')
         rendered_filename = fth._render_filename(self.ti, 42)
         self.assertEqual(expected_filename, rendered_filename)

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -12,18 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import copy
 import logging.config
 import os
-import copy
+import shutil
+import tempfile
+import unittest
 from datetime import datetime
+import sys
 
 from airflow import models, configuration, settings
+from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.models import DAG, TaskInstance
+from airflow.operators.dummy_operator import DummyOperator
 from airflow.settings import Session
 from airflow.www import app as application
-from airflow.operators.dummy_operator import DummyOperator
-from airflow.config_templates.default_airflow_logging import DEFAULT_LOGGING_CONFIG
+from airflow import configuration as conf
 
 
 class TestChartModelView(unittest.TestCase):
@@ -295,7 +299,6 @@ class TestPoolModelView(unittest.TestCase):
 
 
 class TestLogView(unittest.TestCase):
-
     DAG_ID = 'dag_for_testing_log_view'
     TASK_ID = 'task_for_testing_log_view'
     DEFAULT_DATE = datetime(2017, 9, 1)
@@ -319,12 +322,21 @@ class TestLogView(unittest.TestCase):
     def setUp(self):
         super(TestLogView, self).setUp()
 
+        # Create a custom logging configuration
         configuration.load_test_config()
         logging_config = copy.deepcopy(DEFAULT_LOGGING_CONFIG)
         current_dir = os.path.dirname(os.path.abspath(__file__))
         logging_config['handlers']['file.task']['base_log_folder'] = os.path.normpath(
             os.path.join(current_dir, 'test_logs'))
-        logging.config.dictConfig(logging_config)
+
+        # Write the custom logging configuration to a file
+        self.settings_folder = tempfile.mkdtemp()
+        settings_file = os.path.join(self.settings_folder, "airflow_local_settings.py")
+        new_logging_file = "LOGGING_CONFIG = {}".format(logging_config)
+        with open(settings_file, 'w') as handle:
+            handle.writelines(new_logging_file)
+        sys.path.append(self.settings_folder)
+        conf.set('core', 'logging_config_class', 'airflow_local_settings.LOGGING_CONFIG')
 
         app = application.create_app(testing=True)
         self.app = app.test_client()
@@ -347,6 +359,11 @@ class TestLogView(unittest.TestCase):
             TaskInstance.execution_date == self.DEFAULT_DATE).delete()
         self.session.commit()
         self.session.close()
+
+        sys.path.remove(self.settings_folder)
+        shutil.rmtree(self.settings_folder)
+        conf.set('core', 'logging_config_class', '')
+
         super(TestLogView, self).tearDown()
 
     def test_get_file_task_log(self):


### PR DESCRIPTION
Dear Airflow maintainers,

The current way of loading a custom logging config using the logging_config_path does not work:
https://codecov.io/gh/Fokko/incubator-airflow/src/master/airflow/settings.py#L180

Therefore I would like suggest to change this so we can import a logger configuration that is defined in Python using a dict. The logging_config_path property in the config file can be used to point to a custom logging configuration which will be imported.

Change the configuration of the logging to make use of the python logging and make the configuration easy configurable. Some of the settings which are now not needed anymore since they can easily be implemented in the Python config dict itself.

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1611

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

