### PR TITLE
[AIRFLOW-1642] Use scoped_session in alembic revision cc1e65623dc7

### DIFF
--- a/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
+++ b/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
@@ -46,8 +46,7 @@ def upgrade():
 
     if 'task_instance' in tables:
         # Get current session
-        sessionmaker = sa.orm.sessionmaker()
-        session = sessionmaker(bind=connection)
+        session = settings.Session()
         dagbag = DagBag(settings.DAGS_FOLDER)
         query = session.query(sa.func.count(TaskInstance.max_tries)).filter(
             TaskInstance.max_tries == -1
@@ -79,9 +78,7 @@ def upgrade():
 def downgrade():
     engine = settings.engine
     if engine.dialect.has_table(engine, 'task_instance'):
-        connection = op.get_bind()
-        sessionmaker = sa.orm.sessionmaker()
-        session = sessionmaker(bind=connection)
+        session = settings.Session()
         dagbag = DagBag(settings.DAGS_FOLDER)
         query = session.query(sa.func.count(TaskInstance.max_tries)).filter(
             TaskInstance.max_tries != -1


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1642


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
The alembic script does not use a [scoped_session](http://docs.sqlalchemy.org/en/latest/orm/contextual.html#sqlalchemy.orm.scoping.scoped_session), which could potentially cause deadlocks (see JIRA for an example scenario of this). Using settings.Session() instead will create a scoped session.
Note: This alembic script is introduced after the current stable release, so *should* be safe to modify. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Ran migration script locally for testing. Unit tests not applicable here.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

