### PR TITLE
[AIRFLOW-1644] Parse comments in hive dry_run

### DIFF
--- a/tests/operators/hive_operator.py
+++ b/tests/operators/hive_operator.py
@@ -193,6 +193,22 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
                 task_id='dry_run_basic_hql', hql=self.hql, dag=self.dag)
             t.dry_run()
 
+        def test_hive_dryrun_with_comments(self):
+            import airflow.operators.hive_operator
+            t = operators.hive_operator.HiveOperator(
+                task_id='dry_run_hql_with_comments',
+                hql="""
+                -- A line commenting before the drop.
+                DROP TABLE static_babynames_partitioned;
+                CREATE TABLE IF NOT EXISTS static_babynames_states (
+                    state string
+                );
+                INSERT OVERWRITE TABLE static_babynames_states
+                SELECT state FROM static_babynames_partitioned;
+                """
+            )
+            t.dry_run()
+
         def test_beeline(self):
             import airflow.operators.hive_operator
             t = operators.hive_operator.HiveOperator(


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1644

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

HiveOperator dry_run recognizes as a set up any hql preceeded by
comments. As such by adding a comment one can execute arbitrary code
during a dry_run. Modifying hive_hook test_hql to properly identify
statements and ignore comments.

### Tests
- [x] My PR adds the following unit tests: HivePrestoTest:test_hive_dryrun_with_comments


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

