### PR TITLE
[AIRFLOW-1635]: Allow creating GCP connection without requiring a JSON file

### DIFF
--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -64,14 +64,14 @@ class GoogleCloudBaseHook(BaseHook):
         service hook connection.
         """
         key_path = self._get_field('key_path', False)
-        key_json = self._get_field('key_json', False)
+        keyfile_dict = self._get_field('keyfile_dict', False)
         scope = self._get_field('scope', False)
 
         kwargs = {}
         if self.delegate_to:
             kwargs['sub'] = self.delegate_to
 
-        if not key_path and not key_json:
+        if not key_path and not keyfile_dict:
             logging.info('Getting connection using `gcloud auth` user, since no key file '
                          'is defined for hook.')
             credentials = GoogleCredentials.get_application_default()
@@ -97,7 +97,7 @@ class GoogleCloudBaseHook(BaseHook):
 
             # Get credentials from JSON data provided in the UI.
             try:
-                keyfile_dict = json.loads(key_json)
+                keyfile_dict = json.loads(keyfile_dict)
 
                 # Depending on how the JSON was formatted, it may contain
                 # escaped newlines. Convert those to actual newlines.

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2469,6 +2469,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
         'extra__jdbc__drv_clsname',
         'extra__google_cloud_platform__project',
         'extra__google_cloud_platform__key_path',
+        'extra__google_cloud_platform__key_json',
         'extra__google_cloud_platform__scope',
     )
     verbose_name = "Connection"
@@ -2490,6 +2491,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
         'extra__jdbc__drv_clsname': StringField('Driver Class'),
         'extra__google_cloud_platform__project': StringField('Project Id'),
         'extra__google_cloud_platform__key_path': StringField('Keyfile Path'),
+        'extra__google_cloud_platform__key_json': StringField('Key JSON'),
         'extra__google_cloud_platform__scope': StringField('Scopes (comma seperated)'),
 
     }

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2469,7 +2469,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
         'extra__jdbc__drv_clsname',
         'extra__google_cloud_platform__project',
         'extra__google_cloud_platform__key_path',
-        'extra__google_cloud_platform__key_json',
+        'extra__google_cloud_platform__keyfile_dict',
         'extra__google_cloud_platform__scope',
     )
     verbose_name = "Connection"
@@ -2491,7 +2491,7 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
         'extra__jdbc__drv_clsname': StringField('Driver Class'),
         'extra__google_cloud_platform__project': StringField('Project Id'),
         'extra__google_cloud_platform__key_path': StringField('Keyfile Path'),
-        'extra__google_cloud_platform__key_json': StringField('Key JSON'),
+        'extra__google_cloud_platform__keyfile_dict': PasswordField('Keyfile JSON'),
         'extra__google_cloud_platform__scope': StringField('Scopes (comma seperated)'),
 
     }


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1635) issue and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Adds a new field to the Connections screen for GCP connections, allowing the user to provide key credentials as JSON data, rather than a JSON file. This allows creating or managing GCP connections without requiring access to the Airflow server and worker(s).

![Screenshot of the updated "Create connection" form](https://github.com/barrywhart/incubator-airflow/blob/master/AIRFLOW-1635.png?raw=true)


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

The changes are small enhancements to existing code that does not have tests. It only affects GCP connections, which is "contrib" code.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

