### PR TITLE
[AIRFLOW-1323] Made Dataproc operator parameter names consistent

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -26,6 +26,7 @@ A new DaskExecutor allows Airflow tasks to be run in Dask Distributed clusters.
 ### Deprecated Features
 These features are marked for deprecation. They may still work (and raise a `DeprecationWarning`), but are no longer
 supported and will be removed entirely in Airflow 2.0
+- If you're using the `google_cloud_conn_id` or `dataproc_cluster` argument names explicitly in `contrib.operators.Dataproc{*}Operator`(s), be sure to rename them to `gcp_conn_id` or `cluster_name`, respectively. We've renamed these arguments for consistency. (AIRFLOW-1323)
 
 - `post_execute()` hooks now take two arguments, `context` and `result`
   (AIRFLOW-886)
@@ -37,7 +38,7 @@ supported and will be removed entirely in Airflow 2.0
 - The pickle type for XCom messages has been replaced by json to prevent RCE attacks.
   Note that JSON serialization is stricter than pickling, so if you want to e.g. pass
   raw bytes through XCom you must encode them using an encoding like base64.
-  By default pickling is still enabled until Airflow 2.0. To disable it 
+  By default pickling is still enabled until Airflow 2.0. To disable it
   Set enable_xcom_pickling = False in your Airflow config.
 
 ## Airflow 1.8.1

--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -74,7 +74,7 @@ class _DataProcJob(LoggingMixin):
 
 
 class _DataProcJobBuilder:
-    def __init__(self, project_id, task_id, dataproc_cluster, job_type, properties):
+    def __init__(self, project_id, task_id, cluster_name, job_type, properties):
         name = task_id + "_" + str(uuid.uuid1())[:8]
         self.job_type = job_type
         self.job = {
@@ -84,7 +84,7 @@ class _DataProcJobBuilder:
                     "jobId": name,
                 },
                 "placement": {
-                    "clusterName": dataproc_cluster
+                    "clusterName": cluster_name
                 },
                 job_type: {
                 }
@@ -159,6 +159,6 @@ class DataProcHook(GoogleCloudBaseHook):
         if not submitted.wait_for_done():
             submitted.raise_error("DataProcTask has errors")
 
-    def create_job_template(self, task_id, dataproc_cluster, job_type, properties):
-        return _DataProcJobBuilder(self.project_id, task_id, dataproc_cluster, job_type,
+    def create_job_template(self, task_id, cluster_name, job_type, properties):
+        return _DataProcJobBuilder(self.project_id, task_id, cluster_name, job_type,
                                    properties)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1323) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR cleans up Dataproc operators by renaming same parameters to be called by the same names:
* `gcp_conn_id` and `google_cloud_conn_id` are now both `gcp_conn_id`.
* `dataproc_cluster` and `cluster_name` are now both `cluster_name`. Because these parameters are all of type `Dataproc{*}Operator`, `cluster_name` seems more useful/less redundant.

These two are the only overlapping parameter names, based on a cursory look at the other arguments used in the `Dataproc{*}Operator`s.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No tests were added for this variable rename as no functionality is being changed; the unit tests referring to this particular class were already using a `gcp_conn_id` and `cluster_name` variable name. This change passes all local Travis builds.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

