### PR TITLE
[AIRFLOW-1650] Fix custom celery config loading

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -23,7 +23,7 @@ from airflow.exceptions import AirflowException
 from airflow.executors.base_executor import BaseExecutor
 from airflow import configuration
 from airflow.utils.log.logging_mixin import LoggingMixin
-
+from airflow.utils.module_loading import import_string
 
 PARALLELISM = configuration.get('core', 'PARALLELISM')
 
@@ -33,7 +33,9 @@ airflow worker
 '''
 
 if configuration.has_option('celery', 'celery_config_options'):
-    celery_configuration = configuration.get('celery', 'celery_config_options')
+    celery_configuration = import_string(
+        configuration.get('celery', 'celery_config_options')
+    )
 else:
     celery_configuration = DEFAULT_CELERY_CONFIG
 

--- a/airflow/utils/module_loading.py
+++ b/airflow/utils/module_loading.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from importlib import import_module
+
+
+def import_string(dotted_path):
+    """
+    Import a dotted module path and return the attribute/class designated by the
+    last name in the path. Raise ImportError if the import failed.
+    """
+    try:
+        module_path, class_name = dotted_path.rsplit('.', 1)
+    except ValueError:
+        raise ImportError("{} doesn't look like a module path".format(dotted_path))
+
+    module = import_module(module_path)
+
+    try:
+        return getattr(module, class_name)
+    except AttributeError as err:
+        raise ImportError('Module "{}" does not define a "{}" attribute/class'.format(
+            module_path, class_name)
+        )

--- a/tests/utils/test_module_loading.py
+++ b/tests/utils/test_module_loading.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from airflow.utils.module_loading import import_string
+
+
+class ModuleImportTestCase(unittest.TestCase):
+    def test_import_string(self):
+        cls = import_string('airflow.utils.module_loading.import_string')
+        self.assertEqual(cls, import_string)
+
+        # Test exceptions raised
+        with self.assertRaises(ImportError):
+            import_string('no_dots_in_path')
+        msg = 'Module "airflow.utils" does not define a "nonexistent" attribute'
+        with self.assertRaisesRegexp(ImportError, msg):
+            import_string('airflow.utils.nonexistent')


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1650

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

Celery config loading was broken as it was just passing
a string. This fixes it by loading it as a module with an
attribute. Inspired by Django's module loading.


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Tests added.


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

cc: @Fokko @criccomini 
