### PR TITLE
[AIRFLOW-1657] Handle failure of qubole operator on hadoopcmd s3distcp

### DIFF
--- a/airflow/contrib/hooks/qubole_hook.py
+++ b/airflow/contrib/hooks/qubole_hook.py
@@ -202,9 +202,6 @@ class QuboleHook(BaseHook, LoggingMixin):
         args.append("--tags={0}".format(','.join(filter(None,tags))))
 
         if inplace_args is not None:
-            if cmd_type == 'hadoopcmd':
-                args += inplace_args.split(' ', 1)
-            else:
-                args += inplace_args.split(' ')
+            args += inplace_args.split(' ')
 
         return args

--- a/tests/contrib/operators/test_qubole_operator.py
+++ b/tests/contrib/operators/test_qubole_operator.py
@@ -89,6 +89,19 @@ class QuboleOperatorTest(unittest.TestCase):
         self.assertEqual(task.get_hook().create_cmd_args({'run_id':'dummy'})[2],
                          "key2=value2")
 
+        task = QuboleOperator(task_id=TASK_ID, command_type='hadoopcmd',
+                          sub_command="s3distcp --src s3n://airflow/source_hadoopcmd " +
+                                      "--dest s3n://airflow/destination_hadoopcmd", dag=dag)
 
+        self.assertEqual(task.get_hook().create_cmd_args({'run_id': 'dummy'})[1],
+                         "s3distcp")
+        self.assertEqual(task.get_hook().create_cmd_args({'run_id': 'dummy'})[2],
+                         "--src")
+        self.assertEqual(task.get_hook().create_cmd_args({'run_id': 'dummy'})[3],
+                         "s3n://airflow/source_hadoopcmd")
+        self.assertEqual(task.get_hook().create_cmd_args({'run_id': 'dummy'})[4],
+                         "--dest")
+        self.assertEqual(task.get_hook().create_cmd_args({'run_id': 'dummy'})[5],
+                         "s3n://airflow/destination_hadoopcmd")
 
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1657/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes: This PR is to handle the failing qubole operator with hadoopcmd s3distcp arguments. Its because this case is now handled in qds-sdk, where the Qubole commands are submitted, and hence we dont need to take care of it here.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: We are here removing the hardcoded part of parsing the string in a different manner for hadoopcmd types of commands. Hence no special test cases are needed


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

