### PR TITLE
[AIRFLOW-1658] Kill Druid task on timeout 

### DIFF
--- a/airflow/hooks/druid_hook.py
+++ b/airflow/hooks/druid_hook.py
@@ -73,6 +73,8 @@ class DruidHook(BaseHook):
             sec = sec + 1
 
             if sec > self.max_ingestion_time:
+                # ensure that the job gets killed if the max ingestion time is exceeded
+                requests.post("{0}/{1}/shutdown".format(url, druid_task_id))
                 raise AirflowException('Druid ingestion took more than %s seconds', self.max_ingestion_time)
 
             time.sleep(self.timeout)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [AIRFLOW-1658](https://issues.apache.org/jira/browse/AIRFLOW-1658) issues and references them in the PR title. 


### Description
- [ ] If the total execution time of a Druid task exceeds the max timeout
defined, the Airflow task fails, but the Druid task may still keep
running. This can cause undesired behaviour if Airflow retries the
task. This patch calls the shutdown endpoint on the Druid task to
kill any still running Druid task.


### Tests
- [ ] Added mock to test call to Druid task shutdown endpoint is correct.


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

