### PR TITLE
[AIRFLOW-1457] fix user-defined log import

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -21,6 +21,7 @@ import logging
 import logging.config
 import os
 import sys
+import json
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -176,7 +177,8 @@ configure_orm()
 # TODO: Unify airflow logging setups. Please see AIRFLOW-1457.
 logging_config_path = conf.get('core', 'logging_config_path')
 try:
-    from logging_config_path import LOGGING_CONFIG
+    with open(logging_config_path) as f:
+        LOGGING_CONFIG = json.load(f)
     log.debug("Successfully imported user-defined logging config.")
 except Exception as e:
     # Import default logging configurations.


### PR DESCRIPTION
We can use `json.load` to import a user defined json config for passing into `logging.config.dictConfig`

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1457


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

user-defined logging configuration provided as part of AIRFLOW-1457 is broken- current code tries to import a string value pulled from the config. This always fails and results in the default config being loaded.

Since contents of `logging_config_path` will get passed to `logging.config.DictConfig` as a dictionary, it should be json de/serializable and so we can use `json.load` to read the file instead.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
I can add tests at some point if you want, but settings.py currently does not have any unit tests and this is a pretty core functionality that is broken so I really just want to get it working :)

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

