### PR TITLE
[AIRFLOW-1668] Expose keepalives_idle for Postgres connections

### DIFF
--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -23,6 +23,9 @@ class PostgresHook(DbApiHook):
     Interact with Postgres.
     You can specify ssl parameters in the extra field of your connection
     as ``{"sslmode": "require", "sslcert": "/path/to/cert.pem", etc}``.
+
+    Note: For Redshift, use keepalives_idle in the extra connection parameters
+    and set it to less than 300 seconds.
     """
     conn_name_attr = 'postgres_conn_id'
     default_conn_name = 'postgres_default'
@@ -42,8 +45,11 @@ class PostgresHook(DbApiHook):
             port=conn.port)
         # check for ssl parameters in conn.extra
         for arg_name, arg_val in conn.extra_dejson.items():
-            if arg_name in ['sslmode', 'sslcert', 'sslkey', 'sslrootcert', 'sslcrl', 'application_name']:
+            if arg_name in ['sslmode', 'sslcert', 'sslkey',
+                            'sslrootcert', 'sslcrl', 'application_name',
+                            'keepalives_idle']:
                 conn_args[arg_name] = arg_val
+
         psycopg2_conn = psycopg2.connect(**conn_args)
         return psycopg2_conn
 
@@ -52,8 +58,8 @@ class PostgresHook(DbApiHook):
         """
         Postgresql will adapt all arguments to the execute() method internally,
         hence we return cell without any conversion.
-        
-        See http://initd.org/psycopg/docs/advanced.html#adapting-new-types for 
+
+        See http://initd.org/psycopg/docs/advanced.html#adapting-new-types for
         more information.
 
         :param cell: The cell to insert into the table


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1668


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
Controls the number of seconds of inactivity after which TCP
should send a keepalive message to the server.
A value of zero uses the system default.

Important for Redshift which requires a setting lower than 300.


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No updated tests

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

cc: @apurvis @davoscollective @saguziel @Fokko 
