### PR TITLE
[AIRFLOW-926] Fix JDBC Hook

### DIFF
--- a/airflow/hooks/jdbc_hook.py
+++ b/airflow/hooks/jdbc_hook.py
@@ -52,9 +52,10 @@ class JdbcHook(DbApiHook):
         jdbc_driver_loc = conn.extra_dejson.get('extra__jdbc__drv_path')
         jdbc_driver_name = conn.extra_dejson.get('extra__jdbc__drv_clsname')
 
-        conn = jaydebeapi.connect(jdbc_driver_name,
-                                  [str(host), str(login), str(psw)],
-                                  jdbc_driver_loc,)
+        conn = jaydebeapi.connect(jclassname=jdbc_driver_name,
+                                  url=str(host),
+                                  driver_args=[str(login), str(psw)],
+                                  jars=jdbc_driver_loc.split(","))
         return conn
 
     def set_autocommit(self, conn, autocommit):

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ hive = [
     'impyla>=0.13.3',
     'unicodecsv>=0.14.1'
 ]
-jdbc = ['jaydebeapi>=0.2.0']
+jdbc = ['jaydebeapi>=1.1.1']
 mssql = ['pymssql>=2.1.1', 'unicodecsv>=0.14.1']
 mysql = ['mysqlclient>=1.3.6']
 rabbitmq = ['librabbitmq>=1.6.1']

--- a/tests/contrib/hooks/test_jdbc_hook.py
+++ b/tests/contrib/hooks/test_jdbc_hook.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from mock import Mock
+from mock import patch
+
+from airflow import configuration
+from airflow.hooks.jdbc_hook import JdbcHook
+from airflow import models
+from airflow.utils import db
+
+jdbc_conn_mock = Mock(
+        name="jdbc_conn"
+)
+
+
+class TestJdbcHook(unittest.TestCase):
+    def setUp(self):
+        configuration.load_test_config()
+        db.merge_conn(
+                models.Connection(
+                        conn_id='jdbc_default', conn_type='jdbc',
+                        host='jdbc://localhost/', port=443,
+                        extra='{"extra__jdbc__drv_path": "/path1/test.jar,/path2/t.jar2", "extra__jdbc__drv_clsname": "com.driver.main"}'))
+
+    @patch("airflow.hooks.jdbc_hook.jaydebeapi.connect", autospec=True,
+           return_value=jdbc_conn_mock)
+    def test_jdbc_conn_connection(self, jdbc_mock):
+        jdbc_hook = JdbcHook()
+        jdbc_conn = jdbc_hook.get_conn()
+        self.assertTrue(jdbc_mock.called)
+        self.assertIsInstance(jdbc_conn, Mock)
+        self.assertEqual(jdbc_conn.name, jdbc_mock.return_value.name)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [X] My PR addresses the following [Airflow-926](https://issues.apache.org/jira/browse/AIRFLOW-926) issues and references them in the PR title. 

### Description
- [X] JayDeBeAPI made a backwards [incompatible api change](https://github.com/baztian/jaydebeapi/commit/2640445de036def2169514aa56e5ad9ced246b16#diff-a51683c99849d299a6cb9e6c4bcec328R349), this change updates airflow's api call.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Small API Change with no existing tests to update.

### Commits
- [X] My commits all reference JIRA issues in their subject lines

Note: I've removed several unrelated changes from the [original pull request](https://github.com/apache/incubator-airflow/pull/2114) in the hopes that this would gain some traction.