### PR TITLE
[AIRFLOW-1669] Fix Docker import

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -18,7 +18,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory
-from docker import Client, tls
+from docker import APIClient as Client, tls
 import ast
 
 

--- a/tests/operators/docker_operator.py
+++ b/tests/operators/docker_operator.py
@@ -17,7 +17,7 @@ import logging
 
 try:
     from airflow.operators.docker_operator import DockerOperator
-    from docker.client import Client
+    from docker import APIClient as Client
 except ImportError:
     pass
 


### PR DESCRIPTION
Dear Airflow maintainers,

We want to fix the Docker import. At the revert of AIRFLOW-1368 something went wrong. Currently master is not building. I've checked, and before AIRFLOW-1368 we've used `docker-py` (not `docker`) package. This package exposes the APIClient for the low-level docker communication.

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1669

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

