### PR TITLE
[AIRFLOW-1670] Make Airflow Viewable By Red-green color-blind Users

### DIFF
--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -58,9 +58,9 @@ class State(object):
 
     state_color = {
         QUEUED: 'gray',
-        RUNNING: 'lime',
-        SUCCESS: 'green',
-        SHUTDOWN: 'blue',
+        RUNNING: 'aqua',
+        SUCCESS: 'darkblue',
+        SHUTDOWN: 'maroon',
         FAILED: 'red',
         UP_FOR_RETRY: 'gold',
         UPSTREAM_FAILED: 'orange',

--- a/airflow/www/static/graph.css
+++ b/airflow/www/static/graph.css
@@ -26,7 +26,7 @@ g.node text {
     cursor: pointer;
 }
 g.node.success rect {
-    stroke: green;
+    stroke: darkblue;
 }
 g.node.up_for_retry rect {
     stroke: gold;
@@ -37,13 +37,13 @@ g.node.queued rect {
 }
 
 g.node.running rect{
-    stroke: lime;
+    stroke: aqua;
 }
 g.node.failed rect {
     stroke: red;
 }
 g.node.shutdown rect{
-    stroke: blue;
+    stroke: maroon;
 }
 g.node.upstream_failed rect{
     stroke: orange;

--- a/airflow/www/static/main.css
+++ b/airflow/www/static/main.css
@@ -69,13 +69,13 @@ div.squares{
 div.task_row{
 }
 span.success{
-    background-color: green;
+    background-color: darkblue;
 }
 span.up_for_retry{
     background-color: gold;
 }
 span.started{
-    background-color: lime;
+    background-color: aqua;
 }
 span.error{
     background-color: red;

--- a/airflow/www/static/tree.css
+++ b/airflow/www/static/tree.css
@@ -42,10 +42,10 @@ rect.null, rect.scheduled, rect.undefined {
     fill: white;
 }
 rect.success {
-    fill: green;
+    fill: darkblue;
 }
 rect.running {
-    fill: lime;
+    fill: aqua;
 }
 rect.failed {
     fill: red;
@@ -54,7 +54,7 @@ rect.queued {
     fill: gray;
 }
 rect.shutdown {
-    fill: blue;
+    fill: maroon;
 }
 rect.upstream_failed {
     fill: orange;

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -66,8 +66,8 @@
     <div class="legend_item state" style="border-color:gold;">retry</div>
     <div class="legend_item state" style="border-color:pink;">skipped</div>
     <div class="legend_item state" style="border-color:red;">failed</div>
-    <div class="legend_item state" style="border-color:lime;">running</div>
-    <div class="legend_item state" style="border-color:green;">success</div>
+    <div class="legend_item state" style="border-color:aqua;">running</div>
+    <div class="legend_item state" style="border-color:darkblue;">success</div>
     </div>
     <div style="clear:both;"></div>
 </div>

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -52,9 +52,9 @@
     <div class="legend_item" style="border: none;">failed</div>
     <div class="square" style="background: red;"></div>
     <div class="legend_item" style="border: none;">running</div>
-    <div class="square" style="background: lime;"></div>
+    <div class="square" style="background: aqua;"></div>
     <div class="legend_item" style="border: none;">success</div>
-    <div class="square" style="background: green;"></div>
+    <div class="square" style="background: darkblue;"></div>
     {% for op in operators %}
         <div class="legend_circle" style="background:{{ op.ui_color }};">
         </div>


### PR DESCRIPTION
Fix Airflow task instance colors so that color blind users can see them. If people don't like this change or don't think they can get used to it we can implement an accessibility mode instead but that's a lot more work and I think these colors are fine. This change isn't perfect since there are other task instance states but this will solve the issue for 95%+ of the cases.

Here is what the new colors look like (in the order of failed/running/success), the dark blue circles don't have the strange outlines on the actual webserver:
![image](https://user-images.githubusercontent.com/1592778/31098383-3437019a-a777-11e7-8322-242bc4090633.png)

Shut down has been changed to maroon from blue.

JIRA: https://issues.apache.org/jira/browse/AIRFLOW-1670

@saguziel 