### PR TITLE
[AIRFLOW-1196] Template trigger_dag_id field of TriggerDagRunOperator

### DIFF
--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -43,7 +43,7 @@ class TriggerDagRunOperator(BaseOperator):
         should look like ``def foo(context, dag_run_obj):``
     :type python_callable: python callable
     """
-    template_fields = tuple()
+    template_fields = ('trigger_dag_id', )
     template_ext = tuple()
     ui_color = '#ffefeb'
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -453,6 +453,28 @@ class CoreTest(unittest.TestCase):
             dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
+    @mock.patch('airflow.models.DagBag.get_dag')
+    def test_templated_trigger_dagrun(self, get_dag):
+        """
+        Test that the TriggerDagRunOperator properly retrieves the correct DAG
+        when specified as a templated variable.
+        """
+        get_dag.return_value = self.dag
+
+        def trigger(context, dro):
+            return dro
+
+        t = TriggerDagRunOperator(
+            task_id='test_templated_trigger_dagrun',
+            params={'trigger': 'example_bash_operator'},
+            trigger_dag_id='{{params["trigger"]}}',
+            python_callable=trigger,
+            dag=self.dag)
+
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+        get_dag.assert_called_with('example_bash_operator')
+
     def test_dryrun(self):
         t = BashOperator(
             task_id='time_sensor_check',


### PR DESCRIPTION
Add 'trigger_dag_id' field to the list of templated fields for
TriggerDagRunOperator to allow for more flexible triggering of
DAGs based on the local context.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1196


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Adds trigger_dag_id to the (previously empty) list of templated fields on the TriggerDagRunOperator to allow more dynamic triggering of external dags. Supercedes #2290 initiated under a deprecated github account of mine.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

test_templated_trigger_dagrun tests that a dag id passed as a DagRun param gets properly templated into the trigger_dag_id argument.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

