### PR TITLE
[AIRFLOW-1683] Cancel BigQuery job on timeout

### DIFF
--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -85,14 +85,23 @@ class BigQueryOperator(BaseOperator):
         self.use_legacy_sql = use_legacy_sql
         self.maximum_billing_tier = maximum_billing_tier
         self.query_params = query_params
+        self.bq_cursor = None
 
     def execute(self, context):
-        self.log.info('Executing: %s', self.bql)
-        hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
-                            delegate_to=self.delegate_to)
-        conn = hook.get_conn()
-        cursor = conn.cursor()
-        cursor.run_query(self.bql, self.destination_dataset_table, self.write_disposition,
+        if(self.bq_cursor == None):
+            self.log.info('Executing: %s', self.bql)
+            hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
+                                delegate_to=self.delegate_to)
+            conn = hook.get_conn()
+            self.bq_cursor = conn.cursor()
+        self.bq_cursor.run_query(self.bql, self.destination_dataset_table, self.write_disposition,
                          self.allow_large_results, self.udf_config,
                          self.use_legacy_sql, self.maximum_billing_tier,
                          self.create_disposition, self.query_params)
+        
+                         
+    def on_kill(self):
+        super(BigQueryOperator, self).on_kill()
+        if(self.bq_cursor!=None):
+            self.log.info('Canceling running query due to execution timeout')
+            self.bq_cursor.cancel_query()


### PR DESCRIPTION
This change causes the BigQuery job to be canceled when the task that
started it is killed, for example on execution timeout, reducing wasted
resources.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1683


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR is to cancel the BigQuery job when the task that started it is killed. Otherwise the job would keep running on Google Cloud using up resources, even though the result of the computation would never be used.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
test_cancel_queries in tests/contrib/hooks/test_bigquery_hook.py
Tests calling cancel on the running BigQuery job and waiting for the response that the job was canceled.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

