### PR TITLE
[AIRFLOW-1688] Automatically add load.time_partitioning to bigquery_hook when table name includes $

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -401,9 +401,10 @@ class BigQueryBaseCursor(LoggingMixin):
         For more details about these parameters.
 
         :param destination_project_dataset_table:
-            The dotted (<project>.|<project>:)<dataset>.<table> BigQuery table to load
+            The dotted (<project>.|<project>:)<dataset>.<table>($<partition>) BigQuery table to load
             data into. If <project> is not included, project will be the project defined
-            in the connection json.
+            in the connection json. If a partition is specified the operator will automatically 
+            append the data, create a new partition or create a new DAY partitioned table. 
         :type destination_project_dataset_table: string
         :param schema_fields: The schema field list as defined here:
             https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.load
@@ -486,6 +487,11 @@ class BigQueryBaseCursor(LoggingMixin):
                 'writeDisposition': write_disposition,
             }
         }
+        
+        # if it is a partitioned table ($ is in the table name) add partition load option
+        if '$' in destination_project_dataset_table:
+            configuration['load']['timePartitioning'] = dict(type='DAY')
+        
         if schema_fields:
             configuration['load']['schema'] = {
                 'fields': schema_fields


### PR DESCRIPTION
Allow automatic creation of a new partitioned tables when the '$' symbol is in the table name adding the option:

load.timePartitioning: {type: 'DAY'}

i.e. my_dataset.my_table$20170101 would be automatically loaded as a new partitioned table without the need of creating it manually.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-1688] Automatically add load.time_partitioning to bigquery_hook when table name includes $"
    - https://issues.apache.org/jira/browse/AIRFLOW-1688


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
The gcs_to_bq operator throws and exception when trying to auto-create a new date partitioned table. 
To allow the table creation the load configuration needs the api option:
load.timePartitioning:
{type: 'DAY'}
I will add a fix to identify date partitioned table from the presence of a $ in the table name and add the option.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
I can't unit test this change, but I performed multiple integration tests and the code is now running in our prod environment for the last few months without issue.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"