### PR TITLE
[AIRFLOW-1690] Add detail to gcs error messages

### DIFF
--- a/airflow/utils/log/gcs_task_handler.py
+++ b/airflow/utils/log/gcs_task_handler.py
@@ -167,8 +167,8 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
                 # closed).
                 tmpfile.flush()
                 self.hook.upload(bkt, blob, tmpfile.name)
-        except:
-            self.log.error('Could not write logs to %s', remote_log_location)
+        except Exception as e:
+            self.log.error('Could not write logs to %s: %s', remote_log_location, e)
 
     def parse_gcs_url(self, gsurl):
         """


### PR DESCRIPTION
It is difficult to distinguish permission errors on the local
host with connection issues.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
https://issues.apache.org/jira/browse/AIRFLOW-1690

### Description
New logs provide details about error


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This is a minor change, and should already be covered by the test suite


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

