### PR TITLE
[AIRFLOW-1694] Stop using itertools.izip as this is not a thing in Py…

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -14,7 +14,7 @@
 #
 
 from __future__ import print_function
-from builtins import zip
+from six.moves import zip
 from past.builtins import basestring
 
 import unicodecsv as csv
@@ -144,11 +144,9 @@ class HiveCliHook(BaseHook):
         if not d:
             return []
         return as_flattened_list(
-            itertools.izip(
-                ["-hiveconf"] * len(d),
-                ["{}={}".format(k, v) for k, v in d.items()]
-                )
-            )
+            zip(["-hiveconf"] * len(d),
+                ["{}={}".format(k, v) for k, v in d.items()])
+        )
 
     def run_cli(self, hql, schema=None, verbose=True, hive_conf=None):
         """


### PR DESCRIPTION
…thon 3

six.moves exists for exactly this reason -- to allow use of
functions/classes that were moved around in Python 3.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1694


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

`itertools` no longer contains `izip()`, but the builtin `zip()` now returns an iterator. We had a use of `itertools.izip()` in hive_hooks.py, which I've changed to use `siz.moves.zip` (so it works with both python 2/3)


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

That part of the code is already unit-tested, and this change only makes it work with Python 3.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

