### PR TITLE
[AIRFLOW-1673] Fix name of dagrun.dependency-check stat

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4560,8 +4560,7 @@ class DagRun(Base, LoggingMixin):
                     break
 
         duration = (datetime.utcnow() - start_dttm).total_seconds() * 1000
-        Stats.timing("dagrun.dependency-check.{}.{}".
-                     format(self.dag_id, self.execution_date), duration)
+        Stats.timing("dagrun.dependency-check.{}".format(self.dag_id), duration)
 
         # future: remove the check on adhoc tasks (=active_tasks)
         if len(tis) == len(dag.active_tasks):


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA

https://issues.apache.org/jira/browse/AIRFLOW-1673


### Description
The name of the dagrun.dependency-check stat isn't valid, as it contains a space and colons when it appends the datetime to the name.

I don't think the datetime should to be in the stat name, so simply removed it.

### Tests

Currently no tests around the stats. This is a trivial fix, so haven't added tests for it.

