### PR TITLE
[AIRFLOW-1698][systemd] Remove confusing SCHEDULER_RUNS env var

### DIFF
--- a/scripts/systemd/airflow
+++ b/scripts/systemd/airflow
@@ -16,6 +16,4 @@
 #
 # AIRFLOW_CONFIG=
 # AIRFLOW_HOME=
-#
-# required setting, 0 sets it to unlimited. Scheduler will get restart after every X runs
-SCHEDULER_RUNS=5
+

--- a/scripts/systemd/airflow-scheduler.service
+++ b/scripts/systemd/airflow-scheduler.service
@@ -21,7 +21,7 @@ EnvironmentFile=/etc/sysconfig/airflow
 User=airflow
 Group=airflow
 Type=simple
-ExecStart=/bin/airflow scheduler -n ${SCHEDULER_RUNS}
+ExecStart=/bin/airflow scheduler
 Restart=always
 RestartSec=5s
 


### PR DESCRIPTION
### JIRA
    - https://issues.apache.org/jira/browse/AIRFLOW-1698

### Description
In the very early days, the Airflow scheduler needed to be restarted
every so often to take new DAG_FOLDERS mutations into account properly.
This is no longer needed, so I'm removing artifacts in the
systemd scripts.

I'm unclear whether daemon scripts belong here. I can see how it's
useful to have this somewhere,
but it sits on the edge of what should be in the repo and can get
out-of-sync.
As a result it ends up creating more confusion than help.