### PR TITLE
[AIRFLOW-1674] Pass execution_date to the target from TriggerDagRunOperator

### DIFF
--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -48,11 +48,7 @@ class TriggerDagRunOperator(BaseOperator):
     ui_color = '#ffefeb'
 
     @apply_defaults
-    def __init__(
-            self,
-            trigger_dag_id,
-            python_callable=None,
-            *args, **kwargs):
+    def __init__(self, trigger_dag_id, python_callable=None, *args, **kwargs):
         super(TriggerDagRunOperator, self).__init__(*args, **kwargs)
         self.python_callable = python_callable
         self.trigger_dag_id = trigger_dag_id
@@ -68,6 +64,7 @@ class TriggerDagRunOperator(BaseOperator):
                 dr = trigger_dag.create_dagrun(
                     run_id=dro.run_id,
                     state=State.RUNNING,
+                    execution_date=context['execution_date'],
                     conf=dro.payload,
                     external_trigger=True)
                 self.log.info("Creating DagRun %s", dr)

--- a/tests/core.py
+++ b/tests/core.py
@@ -34,6 +34,7 @@ from email.mime.multipart import MIMEMultipart
 from freezegun import freeze_time
 from numpy.testing import assert_array_almost_equal
 from six.moves.urllib.parse import urlencode
+from sqlalchemy import and_
 from time import sleep
 
 from airflow import configuration
@@ -446,6 +447,37 @@ class CoreTest(unittest.TestCase):
             python_callable=trigga,
             dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+    def test_trigger_dagrun_with_same_execution_date(self):
+        trigger_dag_id = 'example_trigger_target_dag'
+        DR = models.DagRun
+        TI = models.TaskInstance
+
+        session = settings.Session()
+        session.query(DR).filter(DR.dag_id == trigger_dag_id).delete()
+        session.query(TI).filter(TI.dag_id == trigger_dag_id).delete()
+        session.commit()
+
+        t = TriggerDagRunOperator(
+            task_id='test_trigger_dagrun',
+            trigger_dag_id=trigger_dag_id,
+            python_callable=lambda context, obj: obj,
+            dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+        e = (
+            session.query(DR)
+                   .filter(DR.dag_id == trigger_dag_id)
+                   .join(TI, and_(DR.dag_id == TI.dag_id,
+                                  DR.execution_date == TI.execution_date))
+                   .first()
+        )
+        self.assertIsNotNone(e)
+
+        session.query(DR).filter(DR.dag_id == trigger_dag_id).delete()
+        session.query(TI).filter(TI.dag_id == trigger_dag_id).delete()
+        session.commit()
+        session.close()
 
     def test_dryrun(self):
         t = BashOperator(


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1674


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

example_trigger_controller_dag can't pass conf parameter properly
to example_trigger_target_dag at least with SQLite backend, since
the format for execution_date is inconsistent between dag_run and
task_instance. This PR makes TriggerDagRunOperator pass 
execution_date to DAG#create_dagrun so as to fix it.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

CoreTest.test_trigger_dagrun_with_same_execution_date


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

