### PR TITLE
[AIRFLOW-1711] Real fix for ldap attributes not always a "list"

### DIFF
--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -77,13 +77,13 @@ def group_contains_user(conn, search_base, group_filter, user_name_attr, usernam
         log.warning("Unable to find group for %s %s", search_base, search_filter)
     else:
         for resp in conn.response:
-            if (
-                        'attributes' in resp and (
-                            resp['attributes'].get(user_name_attr)[0] == username or
-                            resp['attributes'].get(user_name_attr) == username
-                )
-            ):
-                return True
+            if 'attributes' in resp:
+                if hasattr(resp['attributes'].get(user_name_attr),'__getitem__'):
+                    if (resp['attributes'].get(user_name_attr)[0] == username):
+                        return True
+                else:
+                    if (resp['attributes'].get(user_name_attr) == username):
+                        return True
     return False
 
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -2032,7 +2032,8 @@ class LdapGroupTest(unittest.TestCase):
     def test_group_belonging(self):
         from airflow.contrib.auth.backends.ldap_auth import LdapUser
         users = {"user1": ["group1", "group3"],
-                 "user2": ["group2"]
+                 "user2": ["group2"],
+                 "user3:": "group2"
                  }
         for user in users:
             mu = models.User(username=user,

--- a/tests/core.py
+++ b/tests/core.py
@@ -2032,8 +2032,7 @@ class LdapGroupTest(unittest.TestCase):
     def test_group_belonging(self):
         from airflow.contrib.auth.backends.ldap_auth import LdapUser
         users = {"user1": ["group1", "group3"],
-                 "user2": ["group2"],
-                 "user3:": "group2"
+                 "user2": ["group2"]
                  }
         for user in users:
             mu = models.User(username=user,


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [AIRFLOW-1711]
   - https://issues.apache.org/jira/browse/AIRFLOW-1711


### Description
- [ ] This properly checks if the returned user attribute value from ldap is a list or not. 


### Tests
- [ ] I could not find where to add tests for contrib code auth plugins. Given the place to do it I will happily add to this PR. I've tested this code on my ldap install and the fix is fairly straight forward.


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

