### PR TITLE
[AIRFLOW-1712] Log SSHOperator output

### DIFF
--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -86,6 +86,12 @@ class SSHOperator(BaseOperator):
                                                             get_pty=get_pty,
                                                             timeout=self.timeout
                                                             )
+            stdin.close()
+            output=b''
+            for line in stdout:
+                output+=line.encode('utf-8')
+                self.log.info(line.strip('\n'))
+
             exit_status = stdout.channel.recv_exit_status()
             if exit_status is 0:
                 # only returning on output if do_xcom_push is set
@@ -94,9 +100,9 @@ class SSHOperator(BaseOperator):
                     enable_pickling = configuration.getboolean('core',
                                                                'enable_xcom_pickling')
                     if enable_pickling:
-                        return stdout.read()
+                        return output
                     else:
-                        return b64encode(stdout.read()).decode('utf-8')
+                        return b64encode(output).decode('utf-8')
 
             else:
                 error_msg = stderr.read()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1712


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
  - After commiting AIRFLOW-756 and AIRFLOW-751, SSHOperator does not log stdout like SSHExecutor did. This commit logs SSHOperator stdout again.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - There are already SSHOperator tests to assert that do_xcom_push keeps saving output.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

