### PR TITLE
[AIRFLOW-914] Disable test_backfill_examples on Travis

### DIFF
--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -142,6 +142,8 @@ class BackfillJobTest(unittest.TestCase):
 
     @unittest.skipIf('sqlite' in configuration.get('core', 'sql_alchemy_conn'),
                      "concurrent access not supported in sqlite")
+    @unittest.skipIf("TRAVIS" in os.environ and bool(os.environ["TRAVIS"]),
+                     "Skipping on Travis since it's too time-consuming")
     def test_backfill_examples(self):
         """
         Test backfilling example dags


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-914


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

BackfillJobTest.test_backfill_examples takes over 5 minutes to execute
on Travis and it's about 25% of the entire time. Disabling it on Travis
makes more quick feedback for developers possible.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's modification for test code itself.
I confirmed on Travis that test_backfill_examples was skipped and the running time was significantly reduced. For example, the time for Python 2.7 x MySQL is reduced from 21 min 4 sec to 16 min 50 sec.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

