### PR TITLE
[AIRFLOW-1722] Fix typo in scheduler autorestart output filename

### DIFF
--- a/airflow/bin/airflow_scheduler_autorestart.sh
+++ b/airflow/bin/airflow_scheduler_autorestart.sh
@@ -14,6 +14,6 @@
 while echo "Running"; do
     airflow scheduler -n 5
     echo "Scheduler crashed with exit code $?.  Respawning.." >&2
-    date >> /tmp/airflow_scheduler_errrors.txt
+    date >> /tmp/airflow_scheduler_errors.txt
     sleep 1
 done


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [AIRFLOW-1722]

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
No UI changes. Simply changing the temp filename that is written to 

### Tests
- [X] My PR does not need testing for this extremely good reason:
No actual functionality changed. That filename is not referenced anywhere.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

