### PR TITLE
[AIRFLOW-1727] Add unit tests for DataProcHook

### DIFF
--- a/tests/contrib/hooks/test_gcp_dataproc_hook.py
+++ b/tests/contrib/hooks/test_gcp_dataproc_hook.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+from airflow.contrib.hooks.gcp_dataproc_hook import DataProcHook
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+JOB = 'test-job'
+PROJECT_ID = 'test-project-id'
+REGION = 'global'
+TASK_ID = 'test-task-id'
+
+BASE_STRING = 'airflow.contrib.hooks.gcp_api_base_hook.{}'
+DATAPROC_STRING = 'airflow.contrib.hooks.gcp_dataproc_hook.{}'
+
+def mock_init(self, gcp_conn_id, delegate_to=None):
+    pass
+
+class DataProcHookTest(unittest.TestCase):
+    def setUp(self):
+        with mock.patch(BASE_STRING.format('GoogleCloudBaseHook.__init__'),
+                        new=mock_init):
+            self.dataproc_hook = DataProcHook()
+
+    @mock.patch(DATAPROC_STRING.format('_DataProcJob'))
+    def test_submit(self, job_mock):
+      with mock.patch(DATAPROC_STRING.format('DataProcHook.get_conn', return_value=None)):
+        self.dataproc_hook.submit(PROJECT_ID, JOB)
+        job_mock.assert_called_once_with(mock.ANY, PROJECT_ID, JOB, REGION)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1727


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Adds a test for GCP DataProcHook, currently makes sure jobs are called with the correct arguments on hook submission.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
[tests/contrib/hooks/test_gcp_dataproc_hook.py](https://github.com/apache/incubator-airflow/compare/master...cjqian:1727?expand=1#diff-ceb0e4e341450ddaa0af42d78a12952b)

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

