### PR TITLE
[AIRFLOW-1726] Add copy_expert psycopg2 method to PostgresHook

### DIFF
--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -14,6 +14,7 @@
 
 import psycopg2
 import psycopg2.extensions
+from contextlib import closing
 
 from airflow.hooks.dbapi_hook import DbApiHook
 
@@ -52,6 +53,16 @@ class PostgresHook(DbApiHook):
 
         psycopg2_conn = psycopg2.connect(**conn_args)
         return psycopg2_conn
+
+    def copy_expert(self, sql, filename, open=open):
+        '''
+        Executes SQL using psycopg2 copy_expert method
+        Necessary to execute COPY command without access to a superuser
+        '''
+        f = open(filename, 'w')
+        with closing(self.get_conn()) as conn:
+            with closing(conn.cursor()) as cur:
+                cur.copy_expert(sql, f)
 
     @staticmethod
     def _serialize_cell(cell, conn):

--- a/tests/hooks/test_postgres_hook.py
+++ b/tests/hooks/test_postgres_hook.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import unittest
+
+from airflow.hooks.postgres_hook import PostgresHook
+
+
+class TestPostgresHook(unittest.TestCase):
+
+    def setUp(self):
+        super(TestPostgresHook, self).setUp()
+
+        self.cur = mock.MagicMock()
+        self.conn = conn = mock.MagicMock()
+        self.conn.cursor.return_value = self.cur
+
+        class UnitTestPostgresHook(PostgresHook):
+            conn_name_attr = 'test_conn_id'
+
+            def get_conn(self):
+                return conn
+
+        self.db_hook = UnitTestPostgresHook()
+
+    def test_copy_expert(self):
+        m = mock.mock_open(read_data='{"some": "json"}')
+        with mock.patch('airflow.hooks.postgres_hook.open', m, create=True) as m:
+            statement = "SQL"
+            filename = "filename"
+
+            self.cur.fetchall.return_value = None
+            f = m(filename, 'w')
+            def test_open(filename, mode):
+                return f
+
+            self.assertEqual(None, self.db_hook.copy_expert(statement, filename, open=test_open))
+
+            self.conn.close.assert_called_once()
+            self.cur.close.assert_called_once()
+            self.cur.copy_expert.assert_called_once_with(statement, f)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1726


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- Adds copy query capability using psycopg2 copy_expert method to PostgresHook

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

