### PR TITLE
[AIRFLOW-1631] Fix timing issue in unit test

### DIFF
--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -160,7 +160,7 @@ class LocalExecutor(BaseExecutor):
         def end(self):
             while self.executor.workers_active > 0:
                 self.executor.sync()
-                time.sleep(1)
+                time.sleep(0.5)
 
     class _LimitedParallelism(object):
         """Implements LocalExecutor with limited parallelism using a task queue to

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -860,7 +860,7 @@ class LocalTaskJobTest(unittest.TestCase):
         session.merge(ti)
         session.commit()
 
-        process.join(timeout=5)
+        process.join(timeout=10)
         self.assertFalse(process.is_alive())
         ti.refresh_from_db()
         self.assertEqual(State.SUCCESS, ti.state)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1631

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This is a followup PR of https://github.com/apache/incubator-airflow/pull/2658

LocalWorker instances wait 1 sec for each unit of work they perform, so
getting the response of a processor takes at least 1 sec after the unit
of work.
Increasing timeout in `LocalTaskJobTest.test_mark_success_no_kill` and
decreasing the poking time on local executor checking for results in the
unlimited implementation.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This PR is to fix already existing tests: `LocalTaskJobTest. test_mark_success_no_kill`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

