### PR TITLE
[AIRFLOW-1236] Slack Operator uses deprecated API, and should use Connection

### DIFF
--- a/airflow/contrib/example_dags/example_slack_webhook.py
+++ b/airflow/contrib/example_dags/example_slack_webhook.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timedelta
+
+from airflow import DAG, AirflowException
+from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
+from airflow.contrib.utils.slack_webhook import notify_task_success, notify_task_retry, \
+    notify_task_failure
+from airflow.operators.python_operator import PythonOperator
+
+# For test you have to create a connection and put the conn_id in `params.slack_conn_id`
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': datetime(2017, 10, 1),
+    'email': ['airflow@example.com'],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,  # retry once to see the retry message
+    'retry_delay': timedelta(seconds=10),
+    # will be annoying if every success tasks send notification
+    # You can set `on_failure_callback` here as common setting,
+    # then set other two on Operator initialization
+    'on_success_callback': notify_task_success,
+    'on_retry_callback': notify_task_retry,
+    'on_failure_callback': notify_task_failure,
+    'params': {
+        'slack_conn_id': 'slack_webhook_not_default'
+    }
+}
+
+dag = DAG('test_slack_notification', default_args=default_args, schedule_interval='@once')
+
+t1 = SlackWebhookOperator(
+    dag=dag,
+    task_id='notify_slack_channel_by_webhook'
+)
+
+
+def failed():
+    raise AirflowException("Raise this exception intentionally.")
+
+
+t2 = PythonOperator(
+    dag=dag,
+    task_id='notify_on_retry_and_failure',
+    python_callable=failed
+)

--- a/airflow/contrib/operators/slack_webhook_operator.py
+++ b/airflow/contrib/operators/slack_webhook_operator.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.contrib.utils.slack_webhook import get_webhook_urls, post_message_via_webhook
+from airflow.exceptions import AirflowException
+
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class SlackWebhookOperator(BaseOperator):
+    """
+    You can use this operator to sent a custom message to multiple channel or DM at same time.
+
+    Compare to old/builtin SlackOperator(), the Cons are:
+    - This implementation use webhook API instead of legacy API.
+    - You don't need to hard code your API token.
+    - The destination where the message will be sent to is managed by webhook, more secure.
+    - Webhook URLs are managed by Connections, more easier to reuse.
+    - Allow you to sent a message to multiple channels or DMs in 1 operator which old one can't,
+      this allow you manage the purposes and receivers.
+
+    What you need to do:
+    1. Create incoming webhook integrations to channels or users you want to send message to.
+    2. Create Airflow Connection via WebUI/Admin/Connections,
+       put those webhook URLs on `host` field with COMMA separated.
+    3. Init an instance with specifying the conn_id you created on step 1.
+    4. You're done.
+
+    For custom/beautify your message, refer to https://api.slack.com/docs/message-attachments
+    """
+
+
+    @apply_defaults
+    def __init__(self, slack_conn_id='slack_webhook_default',
+                 text="Airflow sent this message since no message has been set.",
+                 attachments=None,
+                 *args, **kwargs):
+        super(SlackWebhookOperator, self).__init__(*args, **kwargs)
+        self.slack_conn_id = slack_conn_id
+        self.text = text
+        self.attachments = attachments
+
+
+    def execute(self, context):
+        webhook_urls = get_webhook_urls(self.slack_conn_id)
+        message_json = {
+            'text': self.text,
+            'attachments': self.attachments
+        }
+        res = post_message_via_webhook(message_json, webhook_urls=webhook_urls)
+        if res:
+            raise AirflowException(
+                "Failed to post message through Slack webhook: {}".format(res.text))

--- a/airflow/contrib/utils/__init__.py
+++ b/airflow/contrib/utils/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/airflow/contrib/utils/slack_webhook.py
+++ b/airflow/contrib/utils/slack_webhook.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+
+import requests
+from airflow import configuration, AirflowException
+from airflow.hooks.base_hook import BaseHook
+
+SLACK_WEBHOOK_HOST = "https://hooks.slack.com"
+
+
+def construct_attachment(text='',
+                         dag_id=None,
+                         task_id=None,
+                         owner='airflow',
+                         status=None,
+                         execution_time=None,
+                         duration=None,
+                         base_url=configuration.get('webserver', 'base_url'),
+                         color='',  # None will be invalid
+                         context=None):
+    if context:
+        ti = context['ti']
+        dag_id = ti.dag_id
+        task_id = ti.task_id
+        status = ti.state.upper()
+        owner = context['dag'].owner
+        execution_time = context['ts']  # 'ts' is string, 'execution_time' is datetime object
+        duration = ti.duration
+    # escape '{' '}' with '{{' '}}' since we apply str.format() to it
+    template = '''
+    {{
+      "color": "{color}",
+      "text": "{text}",
+      "fields": [
+        {{
+          "title": "DAG",
+          "value": "<{base_url}/admin/airflow/tree?dag_id={dag_id}|{dag_id}>",
+          "short": true
+        }},
+        {{
+          "title": "Owner",
+          "value": "{owner}",
+          "short": true
+        }},
+        {{
+          "title": "Task",
+          "value": "{task_id}",
+          "short": false
+        }},
+        {{
+          "title": "Status",
+          "value": "{status}",
+          "short": false
+        }},
+        {{
+          "title": "Execution Time",
+          "value": "{execution_time}",
+          "short": true
+        }},
+        {{
+          "title": "Duration",
+          "value": "{duration}",
+          "short": true
+        }},
+        {{
+          "value": "<{base_url}/admin/airflow/log?dag_id={dag_id}&task_id={task_id}&execution_date={execution_time}|View Task Log>",
+          "short": false
+        }}
+      ]
+    }}
+    '''
+    return json.loads(template.format(**locals()))
+
+
+def get_webhook_urls(slack_conn_id='slack_webhook_default'):
+    conn = BaseHook.get_connection(slack_conn_id)
+    if not conn.host:
+        raise AirflowException(
+            "Connection {} may not have host specified.".format(slack_conn_id))
+    webhook_urls = conn.host.split(',')
+    # check url if it's valid slack webhook url
+    for url in webhook_urls:
+        if not url.startswith(SLACK_WEBHOOK_HOST):
+            raise AirflowException(
+                "Connection {} contains invalid Slack Webhook URL {}".format(slack_conn_id, url))
+    return webhook_urls
+
+
+def post_message_via_webhook(message_json, webhook_urls=get_webhook_urls()):
+    logging.info("Message is prepared: \n{}".format(json.dumps(message_json)))
+    session = requests.Session()
+    for url in webhook_urls:
+        logging.info("Sending message to slack webhook: {}".format(url))
+        response = session.post(url, json=message_json)
+        if not response.status_code == 200:
+            logging.error("Failed to send message: {}".format(response.text))
+            return response
+    return None
+
+
+def get_webhook_urls_from_context(context):
+    """
+    Try to retrieve slack_conn_id from params applied when DAG initialization.
+    Use default if not found or not specified.
+    :param context:
+    :return:
+    """
+    try:
+        webhook_urls = get_webhook_urls(context['params']['slack_conn_id'])
+    except (KeyError, AttributeError):
+        logging.warning(
+            "Not found value of dag.params['slack_conn_id'], \
+            use fallback conn_id='slack_webhook_default' instead.")
+        webhook_urls = get_webhook_urls()
+    return webhook_urls
+
+
+def notify_task_failure(context):
+    """
+    Use as the callback function of task constructor, usually put this into DAG default_args
+    and apply to all tasks for the DAG, but you still can specify it for particular task.
+
+    :param context: passed from Task instance
+    :return:
+    """
+    post_message_via_webhook(
+        message_json={"attachments": [
+            construct_attachment(status='FAILURE', color='danger', context=context)]},
+        webhook_urls=get_webhook_urls_from_context(context))
+
+
+def notify_task_success(context):
+    post_message_via_webhook(
+        message_json={
+            "attachments": [construct_attachment(status='SUCCESS', color='good', context=context)]},
+        webhook_urls=get_webhook_urls_from_context(context))
+
+
+def notify_task_retry(context):
+    post_message_via_webhook(
+        message_json={"attachments": [
+            construct_attachment(status='RETRY', color='warning', context=context)]},
+        webhook_urls=get_webhook_urls_from_context(context))


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA AIRFLOW-1236](https://issues.apache.org/jira/browse/AIRFLOW-1236) issues and references them in the PR title.


### Description
- [x] Add new slack webhook operator, and slack notification callback for task success/retry/failure


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: I put them under `contrib` folder first


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

