### PR TITLE
[AIRFLOW-1735] Log files do not show up for unscheduled dags

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -696,8 +696,8 @@ class Airflow(BaseView):
     def log(self):
         dag_id = request.args.get('dag_id')
         task_id = request.args.get('task_id')
-        execution_date = request.args.get('execution_date')
-        dttm = dateutil.parser.parse(execution_date)
+        dttm = dateutil.parser.parse(request.args.get('execution_date'))
+        execution_date = dttm.isoformat()
         form = DateTimeForm(data={'execution_date': dttm})
         dag = dagbag.get_dag(dag_id)
         session = Session()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow 1735](https://issues.apache.org/jira/browse/AIRFLOW-1735) issues and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
The majority of the details are in the JIRA so I'll be brief here. If I run a task through the UI that was unscheduled the logs for the task don't show up even if it has run and the UI has reflected that it has run. It is missing the time component 00:00:00 and so one way to get that fixed is with this change I have in the PR. We can just get the dttm from the execution_date passed in the args (url) and then set the execution_date to be the isoformat of the dttm datetime object. This has worked out and fixed this issue for us. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Simple fix

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

