### PR TITLE
[AIRFLOW-1728] Add networkUri, subnetworkUri and tags to DataprocClus…

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -43,6 +43,9 @@ class DataprocClusterCreateOperator(BaseOperator):
                  project_id,
                  num_workers,
                  zone,
+                 network_uri=None,
+                 subnetwork_uri=None,
+                 tags=None,
                  storage_bucket=None,
                  init_actions_uris=None,
                  metadata=None,
@@ -105,6 +108,14 @@ class DataprocClusterCreateOperator(BaseOperator):
         :type labels: dict
         :param zone: The zone where the cluster will be located
         :type zone: string
+        :param network_uri: The network uri to be used for machine communication, cannot be
+            specified with subnetwork_uri
+        :type network_uri: string
+        :param subnetwork_uri: The subnetwork uri to be used for machine communication, cannot be
+            specified with network_uri
+        :type subnetwork_uri: string
+        :param tags: The GCE tags to add to all instances
+        :type tags: list[string]
         :param region: leave as 'global', might become relevant in the future
         :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
         :type gcp_conn_id: string
@@ -135,6 +146,9 @@ class DataprocClusterCreateOperator(BaseOperator):
         self.worker_disk_size = worker_disk_size
         self.labels = labels
         self.zone = zone
+        self.network_uri = network_uri
+        self.subnetwork_uri = subnetwork_uri
+        self.tags = tags
         self.region = region
         self.service_account = service_account
         self.service_account_scopes = service_account_scopes
@@ -246,6 +260,12 @@ class DataprocClusterCreateOperator(BaseOperator):
             cluster_data['config']['configBucket'] = self.storage_bucket
         if self.metadata:
             cluster_data['config']['gceClusterConfig']['metadata'] = self.metadata
+        if self.network_uri:
+            cluster_data['config']['gceClusterConfig']['networkUri'] = self.network_uri
+        if self.subnetwork_uri:
+            cluster_data['config']['gceClusterConfig']['subnetworkUri'] = self.subnetwork_uri
+        if self.tags:
+            cluster_data['config']['gceClusterConfig']['tags'] = self.tags
         if self.image_version:
             cluster_data['config']['softwareConfig']['imageVersion'] = self.image_version
         if self.properties:

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -44,6 +44,9 @@ CLUSTER_NAME = 'test-cluster-name'
 PROJECT_ID = 'test-project-id'
 NUM_WORKERS = 123
 ZONE = 'us-central1-a'
+NETWORK_URI = '/projects/project_id/regions/global/net'
+SUBNETWORK_URI = '/projects/project_id/regions/global/subnet'
+TAGS = ['tag1', 'tag2']
 STORAGE_BUCKET = 'gs://airflow-test-bucket/'
 IMAGE_VERSION = '1.1'
 MASTER_MACHINE_TYPE = 'n1-standard-2'
@@ -76,6 +79,9 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
                     project_id=PROJECT_ID,
                     num_workers=NUM_WORKERS,
                     zone=ZONE,
+                    network_uri=NETWORK_URI,
+                    subnetwork_uri=SUBNETWORK_URI,
+                    tags=TAGS,
                     storage_bucket=STORAGE_BUCKET,
                     image_version=IMAGE_VERSION,
                     master_machine_type=MASTER_MACHINE_TYPE,
@@ -103,6 +109,9 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
             self.assertEqual(dataproc_operator.project_id, PROJECT_ID)
             self.assertEqual(dataproc_operator.num_workers, NUM_WORKERS)
             self.assertEqual(dataproc_operator.zone, ZONE)
+            self.assertEqual(dataproc_operator.network_uri, NETWORK_URI)
+            self.assertEqual(dataproc_operator.subnetwork_uri, SUBNETWORK_URI)
+            self.assertEqual(dataproc_operator.tags, TAGS)
             self.assertEqual(dataproc_operator.storage_bucket, STORAGE_BUCKET)
             self.assertEqual(dataproc_operator.image_version, IMAGE_VERSION)
             self.assertEqual(dataproc_operator.master_machine_type, MASTER_MACHINE_TYPE)
@@ -125,6 +134,12 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
                              NUM_PREEMPTIBLE_WORKERS)
             self.assertEqual(cluster_data['config']['gceClusterConfig']['serviceAccountScopes'],
                 SERVICE_ACCOUNT_SCOPES)
+            self.assertEqual(cluster_data['config']['gceClusterConfig']['subnetworkUri'],
+                SUBNETWORK_URI)
+            self.assertEqual(cluster_data['config']['gceClusterConfig']['networkUri'],
+                NETWORK_URI)
+            self.assertEqual(cluster_data['config']['gceClusterConfig']['tags'],
+                TAGS)
             # test whether the default airflow-version label has been properly
             # set to the dataproc operator.
             merged_labels = {}


### PR DESCRIPTION
…terCreateOperator

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1728


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
    - Allows you to define networkUri, subnetworkUri, and tags upon dataproc cluster creation.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - Added relevant sections to tests/contrib/operators/test_dataproc_operator.py

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

