### PR TITLE
[AIRFLOW-1432] Charts label for Y axis not visible

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1444,8 +1444,10 @@ class Airflow(BaseView):
         # update the y Axis on both charts to have the correct time units
         chart.create_y_axis('yAxis', format='.02f', custom_format=False,
                             label='Duration ({})'.format(y_unit))
+        chart.axislist['yAxis']['axisLabelDistance'] = '40'
         cum_chart.create_y_axis('yAxis', format='.02f', custom_format=False,
                                 label='Duration ({})'.format(cum_y_unit))
+        cum_chart.axislist['yAxis']['axisLabelDistance'] = '40'
         for task in dag.tasks:
             if x[task.task_id]:
                 chart.add_serie(name=task.task_id, x=x[task.task_id],
@@ -1594,6 +1596,7 @@ class Airflow(BaseView):
         # update the y Axis to have the correct time units
         chart.create_y_axis('yAxis', format='.02f', custom_format=False,
                             label='Landing Time ({})'.format(y_unit))
+        chart.axislist['yAxis']['axisLabelDistance'] = '40'
         for task in dag.tasks:
             if x[task.task_id]:
                 chart.add_serie(name=task.task_id, x=x[task.task_id],


### PR DESCRIPTION

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] https://issues.apache.org/jira/browse/AIRFLOW-1432


### Description

The NVD3 charts did _have_ labels on the y-axis saying the unit (hours,
minutes etc) but they weren't _visible_. nvd3.js correctly places labels
on the xAxis, but it doesn't correctly space them on the vertical axis.



### Tests
- [x] My PR does not need testing for this extremely good reason: it's a visual only change.

But here are some before and after screenshots

**Before:**

<img width="1340" alt="screen shot 2017-10-20 at 17 40 54" src="https://user-images.githubusercontent.com/34150/31832249-3a4ec1a8-b5be-11e7-9978-18502188c28a.png">

**After:**

<img width="1340" alt="screen shot 2017-10-20 at 17 41 45" src="https://user-images.githubusercontent.com/34150/31832261-42d9babc-b5be-11e7-9a13-efda8df91a8d.png">



### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

