### PR TITLE
[AIRFLOW-1741] Correctly hide second chart on task duration page

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1466,7 +1466,7 @@ class Airflow(BaseView):
         cum_chart.buildcontent()
         s_index = cum_chart.htmlcontent.rfind('});')
         cum_chart.htmlcontent = (cum_chart.htmlcontent[:s_index] +
-                                 "$( document ).trigger('chartload')" +
+                                 "$(function() {$( document ).trigger('chartload') })" +
                                  cum_chart.htmlcontent[s_index:])
 
         return self.render(


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] https://issues.apache.org/jira/browse/AIRFLOW-1741


### Description
A timing/load order bug meant that this ".trigger" call was happening
too early, resulting in a trigger being sent before the hook callback
had been registered, meaning we didn't hide the second chart correctly
on page load.

**Before:**

<img width="1340" alt="screen shot 2017-10-20 at 18 16 21" src="https://user-images.githubusercontent.com/34150/31833617-0c9b0e38-b5c3-11e7-8b22-ef91b912f246.png">

**After:**

<img width="1340" alt="screen shot 2017-10-20 at 18 17 34" src="https://user-images.githubusercontent.com/34150/31833620-11a8a5ac-b5c3-11e7-93b9-c85cf0104689.png">


### Tests
- [x] My PR does not need testing for this extremely good reason: UI only javascript change


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

