### PR TITLE
[AIRFLOW-1744] Make sure max_tries can be set

### DIFF
--- a/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
+++ b/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
@@ -33,6 +33,7 @@ from sqlalchemy.engine.reflection import Inspector
 
 BATCH_SIZE = 5000
 
+
 def upgrade():
     op.add_column('task_instance', sa.Column('max_tries', sa.Integer,
         server_default="-1"))
@@ -69,8 +70,12 @@ def upgrade():
                     ti.max_tries = ti.try_number
                 else:
                     task = dag.get_task(ti.task_id)
-                    ti.max_tries = task.retries
+                    if task.retries:
+                        ti.max_tries = task.retries
+                    else:
+                        ti.max_tries = ti.try_number
                 session.merge(ti)
+
             session.commit()
         # Commit the current session.
         session.commit()


### PR DESCRIPTION

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1744


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

task.retries can be False. Which is not acceptable for
and integer field.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Migrations only no separate tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

cc @criccomini 