### PR TITLE
Reset default signal disposition

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -79,12 +79,18 @@ class BashOperator(BaseOperator):
                     "Temporary script location: %s",
                     script_location
                 )
+                def pre_exec():
+                    # Restore default signal disposition and invoke setsid
+                    for sig in ('SIGPIPE', 'SIGXFZ', 'SIGXFSZ'):
+                        if hasattr(signal, sig):
+                            signal.signal(getattr(signal, sig), signal.SIG_DFL)
+                    os.setsid()
                 self.log.info("Running command: %s", bash_command)
                 sp = Popen(
                     ['bash', fname],
                     stdout=PIPE, stderr=STDOUT,
                     cwd=tmp_dir, env=self.env,
-                    preexec_fn=os.setsid)
+                    preexec_fn=pre_exec)
 
                 self.sp = sp
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses:
    - https://issues.apache.org/jira/browse/AIRFLOW-1745


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
   reset default signal disposition for SIGPIPE, SIGXFZ and SIGXFSZ for python subprocess


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
current test coverage is adequate

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

