### PR TITLE
[AIRFLOW-1749] Fix has_option to consider environment and cmd overrides

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -175,10 +175,10 @@ class AirflowConfigParser(ConfigParser):
         # if this is a valid command key...
         if (section, key) in AirflowConfigParser.as_command_stdout:
             # if the original key is present, return it no matter what
-            if self.has_option(section, key):
+            if ConfigParser.has_option(self, section, key):
                 return ConfigParser.get(self, section, key)
             # otherwise, execute the fallback key
-            elif self.has_option(section, fallback_key):
+            elif ConfigParser.has_option(self, section, fallback_key):
                 command = self.get(section, fallback_key)
                 return run_command(command)
 
@@ -192,7 +192,7 @@ class AirflowConfigParser(ConfigParser):
             return option
 
         # ...then the config file
-        if self.has_option(section, key):
+        if ConfigParser.has_option(self, section, key)
             return expand_env_var(
                 ConfigParser.get(self, section, key, **kwargs))
 
@@ -228,6 +228,11 @@ class AirflowConfigParser(ConfigParser):
 
     def getfloat(self, section, key):
         return float(self.get(section, key))
+
+    def has_option(self, section, key):
+        return ((self._get_env_var_option(section, key) is not None) or
+               ConfigParser.has_option(self, section, key) or
+               (self._get_cmd_option(section, key) is not None))
 
     def read(self, filenames):
         ConfigParser.read(self, filenames)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-1749] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1749


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

In `configuration.py`, class `AirflowConfigParser` fails to override `has_option` from `ConfigParser`.  This breaks the following in `ldap_auth.py`:

```python3
if configuration.has_option("ldap", "search_scope"):
            search_scope = SUBTREE if configuration.get("ldap", "search_scope") == "SUBTREE" else LEVEL
```

This code fails to consider whether any environment variable (e.g., `AIRFLOW__LDAP__SEARCH_SCOPE`) or command overrides are set, meaning that LDAP configuration cannot be entirely set up through environment variables.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

There's nothing to test.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

