### PR TITLE
[AIRFLOW-800] : Initialize default Google BigQuery Connection with valid conn_type

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -119,7 +119,8 @@ def initdb():
             schema='default'))
     merge_conn(
         models.Connection(
-            conn_id='bigquery_default', conn_type='google_cloud_platform'))
+            conn_id='bigquery_default', conn_type='google_cloud_platform', 
+            schema='default',))
     merge_conn(
         models.Connection(
             conn_id='local_mysql', conn_type='mysql',

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -119,7 +119,7 @@ def initdb():
             schema='default'))
     merge_conn(
         models.Connection(
-            conn_id='bigquery_default', conn_type='bigquery'))
+            conn_id='bigquery_default', conn_type='google_cloud_platform'))
     merge_conn(
         models.Connection(
             conn_id='local_mysql', conn_type='mysql',

--- a/tests/core.py
+++ b/tests/core.py
@@ -1125,7 +1125,7 @@ class CliTests(unittest.TestCase):
         # expected:
         self.assertIn(['aws_default', 'aws'], conns)
         self.assertIn(['beeline_default', 'beeline'], conns)
-        self.assertIn(['bigquery_default', 'bigquery'], conns)
+        self.assertIn(['bigquery_default', 'google_cloud_platform'], conns)
         self.assertIn(['emr_default', 'emr'], conns)
         self.assertIn(['mssql_default', 'mssql'], conns)
         self.assertIn(['mysql_default', 'mysql'], conns)


### PR DESCRIPTION


Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-800


### Description
- [x ] airflow initdb creates a connection with conn_id='bigquery_default' and conn_type='bigquery'. However, bigquery is not a valid conn_type, according to models.Connection._types, and BigQuery connections should use the google_cloud_platform conn_type. This commit changes the default bigquery connection type in the airflow.utils.db.initdb() and tests.core.CliTests.test_cli_connections_list() 

### Tests
- [x] My PR adds the following unit tests tests.core.CliTests.test_cli_connections_list() 


### Commits
- [ x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

