### PR TITLE
[AIRFLOW-1737] Fix "set state" action for task instances view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2493,6 +2493,13 @@ class TaskInstanceModelView(ModelViewOnly):
         'pool', 'log_url')
     page_size = PAGE_SIZE
 
+    @staticmethod
+    def parse_datetime(dt_str):
+        dt_format = ('%Y-%m-%d %H:%M:%S.%f'
+                     if dt_str.find('.') > 0
+                     else '%Y-%m-%d %H:%M:%S')
+        return datetime.strptime(dt_str, dt_format)
+
     @action('set_running', "Set state to 'running'", None)
     def action_set_running(self, ids):
         self.set_task_instance_state(ids, State.RUNNING)
@@ -2523,7 +2530,7 @@ class TaskInstanceModelView(ModelViewOnly):
 
             for id in ids:
                 task_id, dag_id, execution_date = id.split(',')
-
+                execution_date = self.parse_datetime(execution_date)
                 ti = session.query(TI).filter(TI.task_id == task_id,
                                               TI.dag_id == dag_id,
                                               TI.execution_date == execution_date).one()
@@ -2550,7 +2557,7 @@ class TaskInstanceModelView(ModelViewOnly):
             count = len(ids)
             for id in ids:
                 task_id, dag_id, execution_date = id.split(',')
-                execution_date = datetime.strptime(execution_date, '%Y-%m-%d %H:%M:%S')
+                execution_date = self.parse_datetime(execution_date)
                 ti = session.query(TI).filter(TI.task_id == task_id,
                                               TI.dag_id == dag_id,
                                               TI.execution_date == execution_date).one()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1737


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

When trying to set the state of a task created by manually triggered DAGs, an exception was thrown: 

```
ValueError: unconverted data remains: ..372649
```

This was happening because `TaskInstanceModelView` was not expecting to parse **execution dates** containing some fractional number (which usually happens for manually triggered DAGs).

This fix adds a check for a fractional number and, if it is found, uses an alternative format string.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

```
tests.www.test_views:TestTaskInstanceStateView
```

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

