### PR TITLE
[AIRFLOW-1760] Password authentication for experimental rest API

### DIFF
--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -16,18 +16,18 @@ from __future__ import unicode_literals
 
 from sys import version_info
 
+import base64
 import flask_login
-from flask_login import login_required, current_user, logout_user
-from flask import flash
-from wtforms import (
-    Form, PasswordField, StringField)
+from flask_login import current_user
+from flask import flash, Response
+from wtforms import Form, PasswordField, StringField
 from wtforms.validators import InputRequired
+from functools import wraps
 
-from flask import url_for, redirect
+from flask import url_for, redirect, make_response
 from flask_bcrypt import generate_password_hash, check_password_hash
 
-from sqlalchemy import (
-    Column, String, DateTime)
+from sqlalchemy import Column, String
 from sqlalchemy.ext.hybrid import hybrid_property
 
 from airflow import settings
@@ -102,6 +102,34 @@ def load_user(userid, session=None):
     return PasswordUser(user)
 
 
+def authenticate(session, username, password):
+    """
+    Authenticate a PasswordUser with the specified
+    username/password.
+
+    :param session: An active SQLAlchemy session
+    :param username: The username
+    :param password: The password
+
+    :raise AuthenticationError: if an error occurred
+    :return: a PasswordUser
+    """
+    if not username or not password:
+        raise AuthenticationError()
+
+    user = session.query(PasswordUser).filter(
+        PasswordUser.username == username).first()
+
+    if not user:
+        raise AuthenticationError()
+
+    if not user.authenticate(password):
+        raise AuthenticationError()
+
+    log.info("User %s successfully authenticated", username)
+    return user
+
+
 @provide_session
 def login(self, request, session=None):
     if current_user.is_authenticated():
@@ -117,26 +145,9 @@ def login(self, request, session=None):
         username = request.form.get("username")
         password = request.form.get("password")
 
-    if not username or not password:
-        return self.render('airflow/login.html',
-                           title="Airflow - Login",
-                           form=form)
-
     try:
-        user = session.query(PasswordUser).filter(
-            PasswordUser.username == username).first()
-
-        if not user:
-            session.close()
-            raise AuthenticationError()
-
-        if not user.authenticate(password):
-            session.close()
-            raise AuthenticationError()
-        log.info("User %s successfully authenticated", username)
-
+        user = authenticate(session, username, password)
         flask_login.login_user(user)
-        session.commit()
 
         return redirect(request.args.get("next") or url_for("admin.index"))
     except AuthenticationError:
@@ -144,8 +155,55 @@ def login(self, request, session=None):
         return self.render('airflow/login.html',
                            title="Airflow - Login",
                            form=form)
+    finally:
+        session.commit()
+        session.close()
 
 
 class LoginForm(Form):
     username = StringField('Username', [InputRequired()])
     password = PasswordField('Password', [InputRequired()])
+
+
+def _unauthorized():
+    """
+    Indicate that authorization is required
+    :return:
+    """
+    return Response("Unauthorized", 401, {"WWW-Authenticate": "Basic"})
+
+
+def _forbidden():
+    return Response("Forbidden", 403)
+
+
+def init_app(app):
+    pass
+
+
+def requires_authentication(function):
+    @wraps(function)
+    def decorated(*args, **kwargs):
+        from flask import request
+
+        header = request.headers.get("Authorization")
+        if header:
+            userpass = ''.join(header.split()[1:])
+            username, password = base64.b64decode(userpass).decode("utf-8").split(":", 1)
+
+            session = settings.Session()
+            try:
+                authenticate(session, username, password)
+
+                response = function(*args, **kwargs)
+                response = make_response(response)
+                return response
+
+            except AuthenticationError:
+                return _forbidden()
+
+            finally:
+                session.commit()
+                session.close()
+        return _unauthorized()
+    return decorated

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -37,9 +37,18 @@ Airflow webserver is publicly accessible, and you should probably use the deny a
     [api]
     auth_backend = airflow.api.auth.backend.deny_all
 
+Two "real" methods for authentication are currently supported for the API.
 
-Kerberos is the only "real" authentication mechanism currently supported for the API. To enable
-this set the following in the configuration:
+To enabled Password authentication, set the following in the configuration:
+
+.. code-block:: bash
+
+    [api]
+    auth_backend = airflow.contrib.auth.backends.password_auth
+
+It's usage is similar to the Password Authentication used for the Web interface.
+
+To enable Kerberos authentication, set the following in the configuration:
 
 .. code-block:: ini
 

--- a/tests/www/api/experimental/test_password_endpoints.py
+++ b/tests/www/api/experimental/test_password_endpoints.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import unittest
+
+from datetime import datetime
+
+from airflow import models
+from airflow import configuration
+from airflow.www import app as application
+from airflow.settings import Session
+from airflow.contrib.auth.backends.password_auth import PasswordUser
+
+try:
+    from ConfigParser import DuplicateSectionError
+except ImportError:
+    from configparser import DuplicateSectionError
+
+
+class ApiPasswordTests(unittest.TestCase):
+    def setUp(self):
+        configuration.load_test_config()
+        try:
+            configuration.conf.add_section("api")
+        except DuplicateSectionError:
+            pass
+
+        configuration.conf.set("api",
+                               "auth_backend",
+                               "airflow.contrib.auth.backends.password_auth")
+
+        self.app = application.create_app(testing=True)
+
+        session = Session()
+        user = models.User()
+        password_user = PasswordUser(user)
+        password_user.username = 'hello'
+        password_user.password = 'world'
+        session.add(password_user)
+        session.commit()
+        session.close()
+
+    def test_authorized(self):
+        with self.app.test_client() as c:
+            url_template = '/api/experimental/dags/{}/dag_runs'
+            response = c.post(
+                url_template.format('example_bash_operator'),
+                data=json.dumps(dict(run_id='my_run' + datetime.now().isoformat())),
+                content_type="application/json",
+                headers={'Authorization': 'Basic aGVsbG86d29ybGQ='}  # hello:world
+            )
+            self.assertEqual(200, response.status_code)
+
+    def test_unauthorized(self):
+        with self.app.test_client() as c:
+            url_template = '/api/experimental/dags/{}/dag_runs'
+            response = c.post(
+                url_template.format('example_bash_operator'),
+                data=json.dumps(dict(run_id='my_run' + datetime.now().isoformat())),
+                content_type="application/json"
+            )
+
+            self.assertEqual(401, response.status_code)
+
+    def tearDown(self):
+        session = Session()
+        session.query(models.User).delete()
+        session.commit()
+        session.close()


### PR DESCRIPTION
Modified the Password authentication to support HTTP Basic auth

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1760


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
Implemented HTTP Basic auth to allow Password authentication to be used to secure the experimental api.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
None, the current passwor auth in contrib does not have any tests either

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

