### PR TITLE
[AIRFLOW-1711] Use ldap3 dict for group membership

### DIFF
--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -76,14 +76,10 @@ def group_contains_user(conn, search_base, group_filter, user_name_attr, usernam
                        attributes=[native(user_name_attr)]):
         log.warning("Unable to find group for %s %s", search_base, search_filter)
     else:
-        for resp in conn.response:
-            if (
-                        'attributes' in resp and (
-                            resp['attributes'].get(user_name_attr)[0] == username or
-                            resp['attributes'].get(user_name_attr) == username
-                )
-            ):
+        for entry in conn.entries:
+            if username in getattr(entry, user_name_attr).values:
                 return True
+
     return False
 
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

Certain schemas for group membership return a string
instead of a list. Instead of using a check we now
use the entries API from ldap3.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No new tests as they are schema dependent, relying on ldap3 API specification.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@brokenjacobs @criccomini 

@criccomini we should eventually rework the ldap integration to use the "entries" API from ldap3 which is cleaner.