### PR TITLE
[AIRFLOW-1764] Move latest_runs api call to web ui

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -296,7 +296,7 @@
           }
         });
       });
-      $.getJSON("{{ url_for('api_experimental.latest_dag_runs') }}", function(data) {
+      $.getJSON("{{ url_for('airflow.latest_dag_runs') }}", function(data) {
         $.each(data["items"], function() {
           var link = $("<a>", {
             href: this.dag_run_url,

--- a/tests/core.py
+++ b/tests/core.py
@@ -1772,6 +1772,9 @@ class WebUiTests(unittest.TestCase):
         response = self.app.get(
             '/admin/airflow/task_stats')
         self.assertIn("example_bash_operator", response.data.decode('utf-8'))
+        response = self.app.get(
+            '/admin/airflow/latest_runs')
+        self.assertIn("example_bash_operator", response.data.decode('utf-8'))
         url = (
             "/admin/airflow/success?task_id=run_this_last&"
             "dag_id=test_example_bash_operator&upstream=false&downstream=false&"


### PR DESCRIPTION
Add @login-required to dag and tasks stats call

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1764

### Description
- [X Here are some details about my PR, including screenshots of any UI changes:
I've copies the latest dag runs api call to the web uit, because the web ui should use the experimental api internally. The authentication methods differ, and hence, we cannot link them without breaking some authentication methods.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

