### PR TITLE
[AIRFLOW-1765] Deny-by-default on experimental API endpoints

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -139,6 +139,15 @@ If you are using S3, the instructions should be largely the same as the Google c
  - Update the config by setting the path of `REMOTE_BASE_LOG_FOLDER` explicitly in the config. The `REMOTE_BASE_LOG_FOLDER` key is not used anymore.
  - Set the `logging_config_class` to the filename and dict. For example, if you place `custom_logging_config.py` on the base of your pythonpath, you will need to set `logging_config_class = custom_logging_config.LOGGING_CONFIG` in your config as Airflow 1.8.
 
+#### Experimental API is now configured to deny-by-default
+
+Previously the experimental API was configured with no authentication. The default behaviour has changed to deny all requests. If you are relying on the previous behaviour set the api config section:
+
+```
+[api]
+auth_backend = airflow.api.auth.backend.allow_all
+```
+
 ### New Features
 
 #### Dask Executor

--- a/airflow/api/auth/backend/allow_all.py
+++ b/airflow/api/auth/backend/allow_all.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 from functools import wraps
-from flask import Response
-
 
 client_auth = None
+
 
 def init_app(app):
     pass
@@ -25,6 +24,6 @@ def init_app(app):
 def requires_authentication(function):
     @wraps(function)
     def decorated(*args, **kwargs):
-        return Response("Forbidden", 403)
+        return function(*args, **kwargs)
 
     return decorated

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,16 +28,28 @@ configure as follows:
 Authentication
 --------------
 
-Only Kerberos authentication is currently supported for the API. To enable this set the following
-in the configuration:
+Authentication for the API is handled separately to the Web Authentication. The default setting is
+to deny every request.
 
-.. code-block:: bash
+If you wish to use the experimental you can use the "allow_all" auth backend. This is not
+recommended if your Airflow webserver is publicly accessible:
+
+.. code-block:: ini
 
     [api]
-    auth_backend = airflow.api.auth.backend.default
+    auth_backend = airflow.api.auth.backend.allow_all
+
+
+Kerberos is the only "real" authentication mechanism currently supported for the API. To enable
+this set the following in the configuration:
+
+.. code-block:: ini
+
+    [api]
+    auth_backend = airflow.api.auth.backend.kerberos_auth
 
     [kerberos]
     keytab = <KEYTAB>
 
-The Kerberos service is configured as `airflow/fully.qualified.domainname@REALM`. Make sure this
+The Kerberos service is configured as ``airflow/fully.qualified.domainname@REALM``. Make sure this
 principal exists in the keytab file.

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -8,6 +8,8 @@ SSH tunnels.
 It is however possible to switch on authentication by either using one of the supplied
 backends or creating your own.
 
+Be sure to checkout :doc:`api` for securing the API.
+
 Web Authentication
 ------------------
 

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -38,6 +38,13 @@ class TestApiExperimental(unittest.TestCase):
     def setUp(self):
         super(TestApiExperimental, self).setUp()
         configuration.load_test_config()
+        try:
+            configuration.conf.add_section("api")
+        except:
+            pass
+        configuration.conf.set("api",
+                               "auth_backend",
+                               "airflow.api.auth.backend.allow_all")
         app = application.create_app(testing=True)
         self.app = app.test_client()
 
@@ -195,6 +202,15 @@ class TestPoolApiExperimental(unittest.TestCase):
     def setUp(self):
         super(TestPoolApiExperimental, self).setUp()
         configuration.load_test_config()
+
+        configuration.load_test_config()
+        try:
+            configuration.conf.add_section("api")
+        except:
+            pass
+        configuration.conf.set("api",
+                               "auth_backend",
+                               "airflow.api.auth.backend.allow_all")
         app = application.create_app(testing=True)
         self.app = app.test_client()
         self.session = Session()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following https://issues.apache.org/jira/browse/AIRFLOW-1765


### Description
- [x] Change the authentication backend on the experimental API backend to deny all requests by default. To restore the old behaviour a new "allow_all" backend has been introduced.

**For an alternative** approach that leaves the default un-altered and simply adds an optional deny_all backend see #2737


### Tests
- [x] Already covered by existing tests.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

