### PR TITLE
[AIRFLOW-1765] Make experimental API securable without needing Kerberos.

### DIFF
--- a/airflow/api/auth/backend/deny_all.py
+++ b/airflow/api/auth/backend/deny_all.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import wraps
+from flask import Response
+
+client_auth = None
+
+
+def init_app(app):
+    pass
+
+
+def requires_authentication(function):
+    @wraps(function)
+    def decorated(*args, **kwargs):
+        return Response("Forbidden", 403)
+
+    return decorated

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,16 +28,26 @@ configure as follows:
 Authentication
 --------------
 
-Only Kerberos authentication is currently supported for the API. To enable this set the following
-in the configuration:
+Authentication for the API is handled separately to the Web Authentication. The default is to not
+require any authentication on the API -- i.e. wide open by default. This is not recommended if your
+Airflow webserver is publicly accessible, and you should probably use the deny all backend:
 
-.. code-block:: bash
+.. code-block:: ini
 
     [api]
-    auth_backend = airflow.api.auth.backend.default
+    auth_backend = airflow.api.auth.backend.deny_all
+
+
+Kerberos is the only "real" authentication mechanism currently supported for the API. To enable
+this set the following in the configuration:
+
+.. code-block:: ini
+
+    [api]
+    auth_backend = airflow.api.auth.backend.kerberos_auth
 
     [kerberos]
     keytab = <KEYTAB>
 
-The Kerberos service is configured as `airflow/fully.qualified.domainname@REALM`. Make sure this
+The Kerberos service is configured as ``airflow/fully.qualified.domainname@REALM``. Make sure this
 principal exists in the keytab file.

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -8,6 +8,8 @@ SSH tunnels.
 It is however possible to switch on authentication by either using one of the supplied
 backends or creating your own.
 
+Be sure to checkout :doc:`api` for securing the API.
+
 Web Authentication
 ------------------
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following https://issues.apache.org/jira/browse/AIRFLOW-1765


### Description
- [x] Previously the experimental API was either wide-open only (allow any request) or secured behind Kerberos. This adds a third option of deny-all.

**For an alternative** approach that makes the API deny-by-default see #2736

### Tests
- [x] My PR does not need testing for this extremely good reason: simple change, already marginally covered by existing flows.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

