### PR TITLE
[AIRFLOW-1764] The web interface should not use the experimental API

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -118,6 +118,15 @@
 
                 <!-- Column 7: Last Run -->
                 <td class="text-nowrap latest_dag_run {{ dag.dag_id }}">
+                  {% if dag %}
+                    {% set last_run = dag.get_last_dagrun() %}
+                    {% if last_run and last_run.execution_date %}
+                      <a href="{{ url_for('airflow.graph', dag_id=dag.dag_id, execution_date=last_run.execution_date) }}">
+                        {{ last_run.execution_date.strftime("%Y-%m-%d %H:%M") }}
+                      </a>
+                      <span aria-hidden="true" id="statuses_info" title="Start Date: {{ last_run.start_date.strftime("%Y-%m-%d %H:%M") }}" class="glyphicon glyphicon-info-sign"></span>
+                    {% endif %}
+                  {% endif %}
                 </td>
 
                 <!-- Column 8: Dag Runs -->
@@ -294,21 +303,6 @@
             $('.label.schedule.' + this.dag_id)
             .css('background-color', 'red');
           }
-        });
-      });
-      $.getJSON("{{ url_for('api_experimental.latest_dag_runs') }}", function(data) {
-        $.each(data["items"], function() {
-          var link = $("<a>", {
-            href: this.dag_run_url,
-            text: this.execution_date
-          });
-          var info_icon = $('<span>', {
-            "aria-hidden": "true",
-            id: "statuses_info",
-            title: "Start Date: " + this.start_date,
-            "class": "glyphicon glyphicon-info-sign"
-          });
-          $('.latest_dag_run.' + this.dag_id).append(link).append(info_icon);
         });
       });
       d3.json("{{ url_for('airflow.dag_stats') }}", function(error, json) {

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -476,6 +476,7 @@ class Airflow(BaseView):
             embed=embed)
 
     @expose('/dag_stats')
+    @login_required
     def dag_stats(self):
         ds = models.DagStat
         session = Session()
@@ -510,6 +511,7 @@ class Airflow(BaseView):
         return wwwutils.json_response(payload)
 
     @expose('/task_stats')
+    @login_required
     def task_stats(self):
         TI = models.TaskInstance
         DagRun = models.DagRun


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. https://issues.apache.org/jira/browse/AIRFLOW-1764


### Description
- [x] The web interface should not use the experimental api as the authentication options differ between the two. Additionally, rather than having an API call to get the last run data we can easily include it in the generated HMTL response. One less round-trip, less endpoints, and less time before the page has fully rendered.

  This is based original off @NielsZeilemaker's PR for the same Jira issue (#2734)

  I haven't entirely removed the experimental latest_runs endpoint, but it could potentially be removed now as nothing (core) is using it.



### Tests
- [x] My PR adds the following unit tests: Updated test_index in core tests.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

