### PR TITLE
[AIRFLOW-1768] add if to show trigger only if not paused

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -130,10 +130,14 @@
                 {% if dag %}
 
                 <!-- Trigger Dag -->
-                <a href="{{ url_for('airflow.trigger', dag_id=dag.dag_id) }}"
-                   onclick="return confirmTriggerDag('{{ dag.safe_dag_id }}')">
-                    <span class="glyphicon glyphicon-play-circle" aria-hidden="true" data-original-title="Trigger Dag"></span>
-                </a>
+                {% if dag_id in orm_dags %}
+                  {% if not orm_dags[dag_id].is_paused %}
+                    <a href="{{ url_for('airflow.trigger', dag_id=dag.dag_id) }}"
+                       onclick="return confirmTriggerDag('{{ dag.safe_dag_id }}')">
+                        <span class="glyphicon glyphicon-play-circle" aria-hidden="true" data-original-title="Trigger Dag"></span>
+                    </a>
+                  {% endif %}
+                {% endif %}
 
                 <!-- Tree -->
                 <a href="{{ url_for('airflow.tree', dag_id=dag.dag_id, num_runs=25) }}">


### PR DESCRIPTION

Right now you can manually trigger a DAG that is paused which will show
as running indefinitely without running any tasks and confuses the
user. This hides the “Trigger DAG” action from the user if the DAG is
paused. This is done by taking the if statement from the “Pause” column
and adds it to the “Trigger DAG” action in the links column.

Resolves: https://issues.apache.org/jira/browse/AIRFLOW-1768