### PR TITLE
[AIRFLOW-1769] Add support for templates in VirtualenvOperator

### DIFF
--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -84,7 +84,7 @@ class PythonOperator(BaseOperator):
     def execute(self, context):
         if self.provide_context:
             context.update(self.op_kwargs)
-            self.op_kwargs['templates_dict'] = self.templates_dict
+            context['templates_dict'] = self.templates_dict
             self.op_kwargs = context
 
         return_value = self.execute_callable()

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -83,12 +83,9 @@ class PythonOperator(BaseOperator):
 
     def execute(self, context):
         if self.provide_context:
-            print(context)
-            for val in context.values():
-                print(type(val))
-            #context.update(self.op_kwargs)
+            context.update(self.op_kwargs)
             self.op_kwargs['templates_dict'] = self.templates_dict
-            #self.op_kwargs = context
+            self.op_kwargs = context
 
         return_value = self.execute_callable()
         self.log.info("Done. Returned value was: %s", return_value)

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -54,6 +54,7 @@ class PythonOperator(BaseOperator):
     :type templates_dict: dict of str
     :param templates_exts: a list of file extensions to resolve while
         processing templated fields, for examples ``['.sql', '.hql']``
+    :type templates_exts: list(str)
     """
     template_fields = ('templates_dict',)
     template_ext = tuple()
@@ -82,9 +83,12 @@ class PythonOperator(BaseOperator):
 
     def execute(self, context):
         if self.provide_context:
-            context.update(self.op_kwargs)
-            context['templates_dict'] = self.templates_dict
-            self.op_kwargs = context
+            print(context)
+            for val in context.values():
+                print(type(val))
+            #context.update(self.op_kwargs)
+            self.op_kwargs['templates_dict'] = self.templates_dict
+            #self.op_kwargs = context
 
         return_value = self.execute_callable()
         self.log.info("Done. Returned value was: %s", return_value)
@@ -194,15 +198,25 @@ class PythonVirtualenvOperator(PythonOperator):
         available to python_callable at runtime as a list(str). Note that args are split
         by newline.
     :type string_args: list(str)
-
+    :param templates_dict: a dictionary where the values are templates that
+        will get templated by the Airflow engine sometime between
+        ``__init__`` and ``execute`` takes place and are made available
+        in your callable's context after the template has been applied
+    :type templates_dict: dict of str
+    :param templates_exts: a list of file extensions to resolve while
+        processing templated fields, for examples ``['.sql', '.hql']``
+    :type templates_exts: list(str)
     """
     def __init__(self, python_callable, requirements=None, python_version=None, use_dill=False,
                  system_site_packages=True, op_args=None, op_kwargs=None, string_args=None,
-                 *args, **kwargs):
+                 templates_dict=None, templates_exts=None, *args, **kwargs):
         super(PythonVirtualenvOperator, self).__init__(
             python_callable=python_callable,
             op_args=op_args,
             op_kwargs=op_kwargs,
+            templates_dict=templates_dict,
+            templates_exts=templates_exts,
+            provide_context=False,
             *args,
             **kwargs)
         self.requirements = requirements or []
@@ -230,6 +244,8 @@ class PythonVirtualenvOperator(PythonOperator):
 
     def execute_callable(self):
         with TemporaryDirectory(prefix='venv') as tmp_dir:
+            if self.templates_dict:
+                self.op_kwargs['templates_dict'] = self.templates_dict
             # generate filenames
             input_filename = os.path.join(tmp_dir, 'script.in')
             output_filename = os.path.join(tmp_dir, 'script.out')

--- a/tests/operators/test_virtualenv_operator.py
+++ b/tests/operators/test_virtualenv_operator.py
@@ -186,3 +186,9 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
         def f(a):
             return None
         self._run_as_operator(f, op_args=[datetime.datetime.now()])
+
+    def test_context(self):
+        def f(**kwargs):
+            return kwargs['templates_dict']['ds']
+        self._run_as_operator(f, templates_dict={'ds': '{{ ds }}'})
+


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1769


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes: add templates_dict to pass in certain template vars to pythonvirtualenvoperator. We can't use context normally because it includes many non-serializable objects.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Adds a test that uses a ds provided.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@aoen 