### PR TITLE
[AIRFLOW-1665] Database reconnect logic

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -858,6 +858,19 @@ def scheduler(args):
         num_runs=args.num_runs,
         do_pickle=args.do_pickle)
 
+    db_reconnect_limit = 0
+    try:
+        db_reconnect_limit = conf.getint('scheduler', 'database_reconnect_limit')
+    except airflow.exceptions.AirflowConfigException as exc:
+        print("Unable to read database_reconnect_limit config; assuming no reconnect")
+
+    if (db_reconnect_limit == 0):
+        print("db_reconnect_limit is 0; disabling scheduler db reconnect")
+    else:
+        adjusted_db_reconnect_limit = db_reconnect_limit if db_reconnect_limit > 0 else None
+        print("db_reconnect_limit: ", adjusted_db_reconnect_limit)
+        db_utils.enable_connection_reconnect(adjusted_db_reconnect_limit)
+
     if args.daemon:
         pid, stdout, stderr, log_file = setup_locations("scheduler", args.pid, args.stdout, args.stderr, args.log_file)
         handle = setup_logging(log_file)

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -348,6 +348,10 @@ scheduler_heartbeat_sec = 5
 # -1 indicates to run continuously (see also num_runs)
 run_duration = -1
 
+# how long to retry if database disconnects (in seconds)
+# 0: No db reconnect; < 0: retry forever
+database_reconnect_limit = -1
+
 # after how much time a new DAGs should be picked up from the filesystem
 min_file_process_interval = 0
 

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -23,8 +23,6 @@ import logging
 import os
 import time
 
-import sys, traceback
-
 from alembic.config import Config
 from alembic import command
 from alembic.migration import MigrationContext

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -21,6 +21,9 @@ from datetime import datetime
 from functools import wraps
 import logging
 import os
+import time
+
+import sys, traceback
 
 from alembic.config import Config
 from alembic import command
@@ -28,6 +31,7 @@ from alembic.migration import MigrationContext
 
 from sqlalchemy import event, exc
 from sqlalchemy.pool import Pool
+from sqlalchemy import select
 
 from airflow import settings
 
@@ -57,6 +61,113 @@ def provide_session(func):
             session.close()
         return result
     return wrapper
+
+
+def enable_connection_reconnect(db_reconnect_limit):
+
+    # from: http://docs.sqlalchemy.org/en/rel_1_1/core/pooling.html#disconnect-handling-pessimistic
+    @event.listens_for(settings.engine, "engine_connect")
+    def reconnect_on_engine_connect(connection, branch):
+        logging.info("reconnect_on_engine_connect() Checking db connection; branch: {}".format(branch))
+
+        if branch:
+            logging.info("reconnect_on_engine_connect(): returning since branch: {}".format(branch))
+            # "branch" refers to a sub-connection of a connection,
+            # we don't want to bother pinging on these.
+            return
+
+        # turn off "close with result".  This flag is only used with
+        # "connectionless" execution, otherwise will be False in any case
+        save_should_close_with_result = connection.should_close_with_result
+        connection.should_close_with_result = False
+
+        try:
+            # run a SELECT 1.   use a core select() so that
+            # the SELECT of a scalar value without a table is
+            # appropriately formatted for the backend
+            connection.scalar(select([1]))
+        except exc.DBAPIError as err:
+            logging.warning("reconnect_on_engine_connect() exception: {}; connection_invalidated: {}"
+                            .format(err, err.connection_invalidated))
+            # catch SQLAlchemy's DBAPIError, which is a wrapper
+            # for the DBAPI's exception.  It includes a .connection_invalidated
+            # attribute which specifies if this connection is a "disconnect"
+            # condition, which is based on inspection of the original exception
+            # by the dialect in use.
+            if err.connection_invalidated:
+                if not retry_connection_for_period(connection, db_reconnect_limit):
+                    raise
+            else:
+                logging.warning("reconnect_on_engine_connect(): Not retrying as connection_invalidated is False")
+                raise
+        finally:
+            # restore "close with result"
+            logging.debug("reconnect_on_engine_connect() done")
+            connection.should_close_with_result = save_should_close_with_result
+
+    @event.listens_for(Pool, "checkout")
+    def reconnect_on_checkout(dbapi_connection, connection_record, connection_proxy):
+        """
+        Disconnect Handling - Pessimistic, taken from:
+        http://docs.sqlalchemy.org/en/rel_0_9/core/pooling.html
+        """
+
+        logging.info("reconnect_on_checkout()")
+
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("SELECT 1")
+        except exc.DBAPIError as err:
+            logging.info("reconnect_on_checkout(): connection_invalidated; not retrying", err)
+            raise exc.DisconnectionError()
+        except Exception as e:
+            logging.warning("reconnect_on_checkout(): Error type: ", type(e), "; ", e.args)
+
+            if not retry_connection_for_period(None, db_reconnect_limit):
+                raise exc.DisconnectionError()
+
+        cursor.close()
+
+
+def retry_connection_for_period(connection, db_reconnect_limit):
+    logging.debug("retryConnectionForPeriod")
+    retry_time_spent = 0
+    succeeded = False
+    retry_time_to_sleep = 10  # starts with 10 seconds; grows to 2 mins after 10 retries
+
+    logging.info("retry_connection_for_period(): Retry limit (seconds): {}"
+                 .format(db_reconnect_limit if db_reconnect_limit is not None else "infinite"))
+    while (not succeeded) and ((db_reconnect_limit is None) or
+                                       (retry_time_spent + retry_time_to_sleep) < db_reconnect_limit):
+        # run the same SELECT again - the connection will re-validate
+        # itself and establish a new connection.  The disconnect detection
+        # here also causes the whole connection pool to be invalidated
+        # so that all stale connections are discarded.
+
+        logging.info("retry_connection_for_period(): sleeping for {}s; retry_time_spent: {}s"
+                     .format(retry_time_to_sleep, retry_time_spent))
+        time.sleep(retry_time_to_sleep)
+        retry_time_spent += retry_time_to_sleep
+        logging.info("retry_connection_for_period(): calling select 1; retry_time_spent: {}"
+            .format(retry_time_spent))
+        try:
+            if connection is None:
+                connection = settings.engine.connect()
+            connection.scalar(select([1]))
+            logging.info("retry_connection_for_period(): SUCCESS calling select 1")
+            succeeded = True
+        except Exception as e:
+            logging.info("retry_connection_for_period(): ERROR calling select 1; Error type: ", type(e), "; ", e.args)
+
+        if retry_time_spent >= 100:
+            retry_time_to_sleep = 120
+
+    if succeeded:
+        logging.info("retry_connection_for_period(): Connection re-established")
+        return True
+
+    logging.error("retry_connection_for_period(): Connection could NOT be re-established")
+    return False
 
 
 def pessimistic_connection_handling():


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1665) issues and references them in the PR title. 

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
Currently when the scheduler gets a database error, the  scheduler errors out.  However, sometimes the database outage is a temporary network issue or a short lived outage that the server should try reconnect.  As part of this change, a new configuration entry is added allowing for specifying how to retry reconnecting to the database as well as us reconnect code for sqlalchemy.


### Tests
- [X] My PR does not need testing for this extremely good reason: The code added is for database reconnect/retry.  It cannot be tested using unit tests.


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

