### PR TITLE
[AIRFLOW-1774] Better handling of templated parameters in Google ML batch prediction/training operators

### DIFF
--- a/tests/contrib/operators/test_mlengine_operator_utils.py
+++ b/tests/contrib/operators/test_mlengine_operator_utils.py
@@ -158,14 +158,14 @@ class CreateEvaluateOpsTest(unittest.TestCase):
             'dag': dag,
         }
 
-        with self.assertRaisesRegexp(ValueError, 'Missing model origin'):
+        with self.assertRaisesRegexp(AirflowException, 'Missing model origin'):
             _ = create_evaluate_ops(**other_params_but_models)
 
-        with self.assertRaisesRegexp(ValueError, 'Ambiguous model origin'):
+        with self.assertRaisesRegexp(AirflowException, 'Ambiguous model origin'):
             _ = create_evaluate_ops(model_uri='abc', model_name='cde',
                                     **other_params_but_models)
 
-        with self.assertRaisesRegexp(ValueError, 'Ambiguous model origin'):
+        with self.assertRaisesRegexp(AirflowException, 'Ambiguous model origin'):
             _ = create_evaluate_ops(model_uri='abc', version_name='vvv',
                                     **other_params_but_models)
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1774) issues and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

The creation of an `MLEngineBatchPredictionOperator` is handled in a way that templates cannot be really used in the `job_id` parameter because there is a function that does some cleansing removing the patterns needed for templating.
Moreover, the `job_id` parameter must be unique as per the Google Cloud ML documentation and a customisation (for example, per day) gets complicated due to the cleansing function.

The PR simplifies the creation of such object, in a similar manner as `MLEngineTrainingOperator` and improves the cleansing support when using templates in the `job_id` parameter.

### Tests
- [x] My PR does not add any new unit tests but adapts the available ones to the changes done in the code.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

