### PR TITLE
AIRFLOW-1772: Fix bug with handling cron expressions as an schedule i…

### DIFF
--- a/airflow/contrib/sensors/gcs_sensor.py
+++ b/airflow/contrib/sensors/gcs_sensor.py
@@ -14,9 +14,6 @@
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.operators.sensors import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
-from croniter import croniter
-from datetime import datetime
-
 
 class GoogleCloudStorageObjectSensor(BaseSensorOperator):
     """
@@ -69,12 +66,7 @@ def ts_function(context):
     behaviour is check for the object being updated after execution_date +
     schedule_interval.
     """
-    schedule_interval = context['dag'].schedule_interval
-    if isinstance(schedule_interval, str):
-        iterator = croniter(schedule_interval, context['execution_date'])
-        return iterator.get_next(datetime)
-    return context['execution_date'] + context['dag'].schedule_interval
-
+    return context['dag'].following_schedule(context['execution_date'])
 
 class GoogleCloudStorageObjectUpdatedSensor(BaseSensorOperator):
     """

--- a/airflow/contrib/sensors/gcs_sensor.py
+++ b/airflow/contrib/sensors/gcs_sensor.py
@@ -14,6 +14,8 @@
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.operators.sensors import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
+from croniter import croniter
+from datetime import datetime
 
 
 class GoogleCloudStorageObjectSensor(BaseSensorOperator):
@@ -67,6 +69,10 @@ def ts_function(context):
     behaviour is check for the object being updated after execution_date +
     schedule_interval.
     """
+    schedule_interval = context['dag'].schedule_interval
+    if isinstance(schedule_interval, str):
+        iterator = croniter(schedule_interval, context['execution_date'])
+        return iterator.get_next(datetime)
     return context['execution_date'] + context['dag'].schedule_interval
 
 

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,6 @@ gcp_api = [
     'oauth2client>=2.0.2, <2.1.0',
     'PyOpenSSL',
     'google-cloud-dataflow',
-    'croniter',
     'pandas-gbq'
 ]
 hdfs = ['snakebite>=2.7.8']

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ gcp_api = [
     'oauth2client>=2.0.2, <2.1.0',
     'PyOpenSSL',
     'google-cloud-dataflow',
+    'croniter',
     'pandas-gbq'
 ]
 hdfs = ['snakebite>=2.7.8']


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1772) issues and references them in the PR title. 
    - https://issues.apache.org/jira/browse/AIRFLOW-1772


### Description
- [ ] The schedule interval can be a timedelta OR a string, the sensor works fine when the interval is set to a time delta but dies when its a string because of [this](https://github.com/apache/incubator-airflow/blob/master/airflow/contrib/sensors/gcs_sensor.py#L70)




