### PR TITLE
[AIRFLOW-1779] Add keepalive packets to ssh hook

### DIFF
--- a/airflow/contrib/hooks/ssh_hook.py
+++ b/airflow/contrib/hooks/ssh_hook.py
@@ -46,6 +46,8 @@ class SSHHook(BaseHook, LoggingMixin):
     :type key_file: str
     :param timeout: timeout for the attempt to connect to the remote_host.
     :type timeout: int
+    :param keepalive_interval: send a keepalive packet to remote host every keepalive_interval seconds
+    :type keepalive_interval: int
     """
 
     def __init__(self,
@@ -54,7 +56,8 @@ class SSHHook(BaseHook, LoggingMixin):
                  username=None,
                  password=None,
                  key_file=None,
-                 timeout=10
+                 timeout=10,
+                 keepalive_interval=30
                  ):
         super(SSHHook, self).__init__(ssh_conn_id)
         self.ssh_conn_id = ssh_conn_id
@@ -63,6 +66,7 @@ class SSHHook(BaseHook, LoggingMixin):
         self.password = password
         self.key_file = key_file
         self.timeout = timeout
+        self.keepalive_interval = keepalive_interval
         # Default values, overridable from Connection
         self.compress = True
         self.no_host_key_check = True
@@ -139,6 +143,9 @@ class SSHHook(BaseHook, LoggingMixin):
                                    timeout=self.timeout,
                                    compress=self.compress,
                                    sock=host_proxy)
+
+                if self.keepalive_interval:
+                    client.get_transport().set_keepalive(self.keepalive_interval)
 
                 self.client = client
             except paramiko.AuthenticationException as auth_error:

--- a/tests/contrib/hooks/test_ssh_hook.py
+++ b/tests/contrib/hooks/test_ssh_hook.py
@@ -33,7 +33,7 @@ class SSHHookTest(unittest.TestCase):
     def setUp(self):
         configuration.load_test_config()
         from airflow.contrib.hooks.ssh_hook import SSHHook
-        self.hook = SSHHook(ssh_conn_id='ssh_default')
+        self.hook = SSHHook(ssh_conn_id='ssh_default', keepalive_interval=10)
         self.hook.no_host_key_check = True
 
     def test_ssh_connection(self):


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1779


### Description
- [ ] Make use of paramiko's set_keepalive method to send keepalive packets every
keepalive_interval seconds.  This will prevent long running queries with no terminal
output from being termanated as idle, for example by an intermediate NAT.
- [ ] Set on by default with a 30 second interval.


### Tests
- [ ] Small extension to the existing SSHHook tests to set the keepalive_interval parameter


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

