### PR TITLE
[AIRFLOW-1021] Fix double logging for new users with LDAP

### DIFF
--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -290,9 +290,10 @@ def login(self, request, session=None):
             user = models.User(
                 username=username,
                 is_superuser=False)
+            session.add(user)
 
-        session.merge(user)
         session.commit()
+        session.merge(user)
         flask_login.login_user(LdapUser(user))
         session.commit()
 

--- a/airflow/contrib/hooks/__init__.py
+++ b/airflow/contrib/hooks/__init__.py
@@ -32,6 +32,7 @@ import sys
 #
 # ------------------------------------------------------------------------
 _hooks = {
+    'docker_hook': ['DockerHook'],
     'ftp_hook': ['FTPHook'],
     'ftps_hook': ['FTPSHook'],
     'vertica_hook': ['VerticaHook'],

--- a/airflow/hooks/docker_hook.py
+++ b/airflow/hooks/docker_hook.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from docker import Client
+from docker.errors import APIError
+
+from airflow.exceptions import AirflowException
+from airflow.hooks.base_hook import BaseHook
+from airflow.utils.log.logging_mixin import LoggingMixin
+
+class DockerHook(BaseHook, LoggingMixin):
+    """
+    Interact with a private Docker registry.
+
+    :param docker_conn_id: ID of the Airflow connection where
+        credentials and extra configuration are stored
+    :type docker_conn_id: str
+    """
+    def __init__(self,
+            docker_conn_id='docker_default',
+            base_url=None,
+            version=None,
+            tls=None
+            ):
+        if not base_url:
+            raise AirflowException('No Docker base URL provided')
+        if not version:
+            raise AirflowException('No Docker API version provided')
+
+        conn = self.get_connection(docker_conn_id)
+        if not conn.host:
+            raise AirflowException('No Docker registry URL provided')
+        if not conn.login:
+            raise AirflowException('No username provided')
+        extra_options = conn.extra_dejson
+
+        self.__base_url = base_url
+        self.__version = version
+        self.__tls = tls
+        self.__registry = conn.host
+        self.__username = conn.login
+        self.__password = conn.password
+        self.__email = extra_options.get('email')
+        self.__reauth = False if extra_options.get('reauth') == 'no' else True
+
+    def get_conn(self):
+        client = Client(
+            base_url=self.__base_url,
+            version=self.__version,
+            tls=self.__tls
+        )
+        self.__login(client)
+        return client
+
+    def __login(self, client):
+        self.log.debug('Logging into Docker registry')
+        try:
+            client.login(
+                username=self.__username,
+                password=self.__password,
+                registry=self.__registry,
+                email=self.__email,
+                reauth=self.__reauth
+            )
+            self.log.debug('Login successful')
+        except APIError as docker_error:
+            self.log.error('Docker registry login failed: %s', str(docker_error))
+            raise AirflowException('Docker registry login failed: %s', str(docker_error))

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -527,6 +527,7 @@ class Connection(Base, LoggingMixin):
     _extra = Column('extra', String(5000))
 
     _types = [
+        ('docker', 'Docker Registry',),
         ('fs', 'File (path)'),
         ('ftp', 'FTP',),
         ('google_cloud_platform', 'Google Cloud Platform'),
@@ -693,6 +694,9 @@ class Connection(Base, LoggingMixin):
             elif self.conn_type == 'wasb':
                 from airflow.contrib.hooks.wasb_hook import WasbHook
                 return WasbHook(wasb_conn_id=self.conn_id)
+            elif self.conn_type == 'docker':
+                from airflow.hooks.docker_hook import DockerHook
+                return DockerHook(docker_conn_id=self.conn_id)
         except:
             pass
 

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -14,11 +14,12 @@
 
 import json
 
+from airflow.hooks.docker_hook import DockerHook
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory
-from docker import APIClient as Client, tls
+from docker import Client, tls
 import ast
 
 
@@ -30,9 +31,14 @@ class DockerOperator(BaseOperator):
     that together exceed the default disk size of 10GB in a container. The path to the mounted
     directory can be accessed via the environment variable ``AIRFLOW_TMP_DIR``.
 
+    If a login to a private registry is required prior to pulling the image, a
+    Docker connection needs to be configured in Airflow and the connection ID
+    be provided with the parameter ``docker_conn_id``.
+
     :param image: Docker image from which to create the container.
     :type image: str
-    :param api_version: Remote API version.
+    :param api_version: Remote API version. Set to ``auto`` to automatically
+        detect the server's version.
     :type api_version: str
     :param command: Command to be run in the container.
     :type command: str or list
@@ -41,10 +47,11 @@ class DockerOperator(BaseOperator):
         https://docs.docker.com/engine/reference/run/#cpu-share-constraint
     :type cpus: float
     :param docker_url: URL of the host running the docker daemon.
+        Default is unix://var/run/docker.sock
     :type docker_url: str
     :param environment: Environment variables to set in the container.
     :type environment: dict
-    :param force_pull: Pull the docker image on every run.
+    :param force_pull: Pull the docker image on every run. Default is false.
     :type force_pull: bool
     :param mem_limit: Maximum amount of memory the container can use. Either a float value, which
         represents the limit in bytes, or a string like ``128m`` or ``1g``.
@@ -78,6 +85,8 @@ class DockerOperator(BaseOperator):
     :type xcom_push: bool
     :param xcom_all: Push all the stdout or just the last line. The default is False (last line).
     :type xcom_all: bool
+    :param docker_conn_id: ID of the Airflow connection to use
+    :type docker_conn_id: str
     """
     template_fields = ('command',)
     template_ext = ('.sh', '.bash',)
@@ -105,6 +114,7 @@ class DockerOperator(BaseOperator):
             working_dir=None,
             xcom_push=False,
             xcom_all=False,
+            docker_conn_id=None,
             *args,
             **kwargs):
 
@@ -129,25 +139,32 @@ class DockerOperator(BaseOperator):
         self.working_dir = working_dir
         self.xcom_push_flag = xcom_push
         self.xcom_all = xcom_all
+        self.docker_conn_id = docker_conn_id
 
         self.cli = None
         self.container = None
 
+    def get_hook(self):
+        return DockerHook(
+            docker_conn_id=self.docker_conn_id,
+            base_url=self.base_url,
+            version=self.api_version,
+            tls=self.__get_tls_config()
+        )
+
     def execute(self, context):
         self.log.info('Starting docker container from image %s', self.image)
 
-        tls_config = None
-        if self.tls_ca_cert and self.tls_client_cert and self.tls_client_key:
-            tls_config = tls.TLSConfig(
-                    ca_cert=self.tls_ca_cert,
-                    client_cert=(self.tls_client_cert, self.tls_client_key),
-                    verify=True,
-                    ssl_version=self.tls_ssl_version,
-                    assert_hostname=self.tls_hostname
-            )
-            self.docker_url = self.docker_url.replace('tcp://', 'https://')
+        tls_config = self.__get_tls_config()
 
-        self.cli = Client(base_url=self.docker_url, version=self.api_version, tls=tls_config)
+        if self.docker_conn_id:
+            self.cli = self.get_hook().get_conn()
+        else:
+            self.cli = Client(
+                base_url=self.docker_url,
+                version=self.api_version,
+                tls=tls_config
+            )
 
         if ':' not in self.image:
             image = self.image + ':latest'
@@ -204,3 +221,16 @@ class DockerOperator(BaseOperator):
         if self.cli is not None:
             self.log.info('Stopping docker container')
             self.cli.stop(self.container['Id'])
+
+    def __get_tls_config(self):
+        tls_config = None
+        if self.tls_ca_cert and self.tls_client_cert and self.tls_client_key:
+            tls_config = tls.TLSConfig(
+                ca_cert=self.tls_ca_cert,
+                client_cert=(self.tls_client_cert, self.tls_client_key),
+                verify=True,
+                ssl_version=self.tls_ssl_version,
+                assert_hostname=self.tls_hostname
+            )
+            self.docker_url = self.docker_url.replace('tcp://', 'https://')
+        return tls_config

--- a/airflow/www/static/connection_form.js
+++ b/airflow/www/static/connection_form.js
@@ -38,7 +38,14 @@
                 'login': 'Username (or API Key)',
                 'schema': 'Database'
             }
-        }
+        },
+        docker: {
+            hidden_fields: ['port', 'schema'],
+            relabeling: {
+                'host': 'Registry URL',
+                'login': 'Username',
+            },
+        },
       }
       function connTypeChange(connectionType) {
         $("div.form-group").removeClass("hide");

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -216,6 +216,7 @@ Hooks
     :show-inheritance:
     :members:
         DbApiHook,
+        DockerHook,
         HiveCliHook,
         HiveMetastoreHook,
         HiveServer2Hook,

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -53,7 +53,7 @@ ldap3
 lxml
 markdown
 mock
-moto
+moto==1.1.19
 mysqlclient
 nose
 nose-exclude

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ devel = [
     'jira',
     'lxml>=3.3.4',
     'mock',
-    'moto',
+    'moto==1.1.19',
     'nose',
     'nose-ignore-docstring==0.2',
     'nose-timer',

--- a/tests/core.py
+++ b/tests/core.py
@@ -1996,6 +1996,9 @@ class WebLdapAuthTest(unittest.TestCase):
         response = self.login('dataprofiler', 'dataprofiler')
         self.assertIn('Data Profiling', response.data.decode('utf-8'))
 
+        self.logout()
+        self.assertIn('form-signin', response.data.decode('utf-8'))
+
         response = self.login('superuser', 'superuser')
         self.assertIn('Connections', response.data.decode('utf-8'))
 

--- a/tests/hooks/test_docker_hook.py
+++ b/tests/hooks/test_docker_hook.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from airflow import configuration
+from airflow import models
+from airflow.exceptions import AirflowException
+from airflow.utils import db
+
+try:
+    from airflow.hooks.docker_hook import DockerHook
+    from docker import Client
+except ImportError:
+    pass
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+
+@mock.patch('airflow.hooks.docker_hook.Client', autospec=True)
+class DockerHookTest(unittest.TestCase):
+    def setUp(self):
+        configuration.load_test_config()
+        db.merge_conn(
+            models.Connection(
+                conn_id='docker_default',
+                conn_type='docker',
+                host='some.docker.registry.com',
+                login='some_user',
+                password='some_p4$$w0rd'
+            )
+        )
+        db.merge_conn(
+            models.Connection(
+                conn_id='docker_with_extras',
+                conn_type='docker',
+                host='some.docker.registry.com',
+                login='some_user',
+                password='some_p4$$w0rd',
+                extra='{"email": "some@example.com", "reauth": "no"}'
+            )
+        )
+
+    def test_init_fails_when_no_base_url_given(self, _):
+        with self.assertRaises(AirflowException):
+            DockerHook(
+                docker_conn_id='docker_default',
+                version='auto',
+                tls=None
+            )
+
+    def test_init_fails_when_no_api_version_given(self, _):
+        with self.assertRaises(AirflowException):
+            DockerHook(
+                docker_conn_id='docker_default',
+                base_url='unix://var/run/docker.sock',
+                tls=None
+            )
+
+    def test_get_conn_override_defaults(self, docker_client_mock):
+        hook = DockerHook(
+            docker_conn_id='docker_default',
+            base_url='https://index.docker.io/v1/',
+            version='1.23',
+            tls='someconfig'
+        )
+        hook.get_conn()
+        docker_client_mock.assert_called_with(
+            base_url='https://index.docker.io/v1/',
+            version='1.23',
+            tls='someconfig'
+        )
+
+    def test_get_conn_with_standard_config(self, _):
+        try:
+            hook = DockerHook(
+                docker_conn_id='docker_default',
+                base_url='unix://var/run/docker.sock',
+                version='auto'
+            )
+            client = hook.get_conn()
+            self.assertIsNotNone(client)
+        except:
+            self.fail('Could not get connection from Airflow')
+
+    def test_get_conn_with_extra_config(self, _):
+        try:
+            hook = DockerHook(
+                docker_conn_id='docker_with_extras',
+                base_url='unix://var/run/docker.sock',
+                version='auto'
+            )
+            client = hook.get_conn()
+            self.assertIsNotNone(client)
+        except:
+            self.fail('Could not get connection from Airflow')
+
+    def test_conn_with_standard_config_passes_parameters(self, _):
+        hook = DockerHook(
+            docker_conn_id='docker_default',
+            base_url='unix://var/run/docker.sock',
+            version='auto'
+        )
+        client = hook.get_conn()
+        client.login.assert_called_with(
+            username='some_user',
+            password='some_p4$$w0rd',
+            registry='some.docker.registry.com',
+            reauth=True,
+            email=None
+        )
+
+    def test_conn_with_extra_config_passes_parameters(self, _):
+        hook = DockerHook(
+            docker_conn_id='docker_with_extras',
+            base_url='unix://var/run/docker.sock',
+            version='auto'
+        )
+        client = hook.get_conn()
+        client.login.assert_called_with(
+            username='some_user',
+            password='some_p4$$w0rd',
+            registry='some.docker.registry.com',
+            reauth=False,
+            email='some@example.com'
+        )
+
+    def test_conn_with_broken_config_missing_username_fails(self, _):
+        db.merge_conn(
+            models.Connection(
+                conn_id='docker_without_username',
+                conn_type='docker',
+                host='some.docker.registry.com',
+                password='some_p4$$w0rd',
+                extra='{"email": "some@example.com"}'
+            )
+        )
+        with self.assertRaises(AirflowException):
+            hook = DockerHook(
+                docker_conn_id='docker_without_username',
+                base_url='unix://var/run/docker.sock',
+                version='auto'
+            )
+
+    def test_conn_with_broken_config_missing_host_fails(self, _):
+        db.merge_conn(
+            models.Connection(
+                conn_id='docker_without_host',
+                conn_type='docker',
+                login='some_user',
+                password='some_p4$$w0rd'
+            )
+        )
+        with self.assertRaises(AirflowException):
+            hook = DockerHook(
+                docker_conn_id='docker_without_host',
+                base_url='unix://var/run/docker.sock',
+                version='auto'
+            )


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1021) issues and references them in the PR title. For example, "[AIRFLOW-1021] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1021


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
By adding the new user to the session and commit
before merging, the correct user is returned by
`load_user(userid)` instead of `None` due to no
`id` assoicated with that user.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested thoroughly on our own airflow instances.
Fix test in tests/core.py test_with_filters

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

