### PR TITLE
[AIRFLOW-1729] Ignore whole directories from .airflowignore

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -174,11 +174,11 @@ def list_py_file_paths(directory, safe_mode=True):
     elif os.path.isdir(directory):
         patterns = []
         for root, dirs, files in os.walk(directory, followlinks=True):
-            ignore_file = [f for f in files if f == '.airflowignore']
-            if ignore_file:
-                f = open(os.path.join(root, ignore_file[0]), 'r')
-                patterns += [p for p in f.read().split('\n') if p]
-                f.close()
+            if '.airflowignore' in files:
+                with open(os.path.join(root, '.airflowignore'), 'r') as f:
+                    patterns += [p for p in f if p]
+            dirs[:] = [d for d in dirs if not any(
+                [re.findall(p, os.path.join(root, d)) for p in patterns])]
             for f in files:
                 try:
                     file_path = os.path.join(root, f)


### PR DESCRIPTION
Add ignore directories from .airflowignore.
Simplyfi and unified loading patternd from .airflowignore

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1729


### Description
- [x] The .airflowignore file allows to prevent scanning files for DAG. But even if we blacklist fulldirectory the os.walk will still go through them no matter how deep they are and skip files one by one, which can be an issue when you keep around big .git or virtualvenv directories.
This PR add skipping directories that should be ignored and unified code a little.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: n/a


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

