### PR TITLE
[AIRFLOW-1785] Enable Python 3 tests

### DIFF
--- a/tests/contrib/operators/test_spark_submit_operator.py
+++ b/tests/contrib/operators/test_spark_submit_operator.py
@@ -61,11 +61,6 @@ class TestSparkSubmitOperator(unittest.TestCase):
     }
 
     def setUp(self):
-
-        if sys.version_info[0] == 3:
-            raise unittest.SkipTest('TestSparkSubmitOperator won\'t work with '
-                                    'python3. No need to test anything here')
-
         configuration.load_test_config()
         args = {
             'owner': 'airflow',

--- a/tests/contrib/sensors/test_hdfs_sensors.py
+++ b/tests/contrib/sensors/test_hdfs_sensors.py
@@ -22,8 +22,6 @@ from airflow.exceptions import AirflowSensorTimeout
 
 class HdfsSensorFolderTests(unittest.TestCase):
     def setUp(self):
-        if sys.version_info[0] == 3:
-            raise unittest.SkipTest('HdfsSensor won\'t work with python3. No need to test anything here')
         from tests.core import FakeHDFSHook
         self.hook = FakeHDFSHook
         self.log = logging.getLogger()
@@ -120,8 +118,6 @@ class HdfsSensorFolderTests(unittest.TestCase):
 
 class HdfsSensorRegexTests(unittest.TestCase):
     def setUp(self):
-        if sys.version_info[0] == 3:
-            raise unittest.SkipTest('HdfsSensor won\'t work with python3. No need to test anything here')
         from tests.core import FakeHDFSHook
         self.hook = FakeHDFSHook
         self.log = logging.getLogger()

--- a/tests/operators/sensors.py
+++ b/tests/operators/sensors.py
@@ -200,8 +200,6 @@ class HttpSensorTests(unittest.TestCase):
 class HdfsSensorTests(unittest.TestCase):
 
     def setUp(self):
-        if sys.version_info[0] == 3:
-            raise unittest.SkipTest('HdfsSensor won\'t work with python3. No need to test anything here')
         from tests.core import FakeHDFSHook
         self.hook = FakeHDFSHook
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

Enable tests under Python 3 to make sure that tests run under Python 3.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1785


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

