### PR TITLE
[WIP] Add timezone support 

### DIFF
--- a/airflow/api/common/experimental/mark_tasks.py
+++ b/airflow/api/common/experimental/mark_tasks.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
-
 from airflow.jobs import BackfillJob
 from airflow.models import DagRun, TaskInstance
 from airflow.operators.subdag_operator import SubDagOperator
 from airflow.settings import Session
+from airflow.utils import datetime
 from airflow.utils.state import State
 
 from sqlalchemy import or_
+
 
 def _create_dagruns(dag, execution_dates, state, run_id_template):
     """
@@ -39,7 +39,7 @@ def _create_dagruns(dag, execution_dates, state, run_id_template):
         dr = dag.create_dagrun(
             run_id=run_id_template.format(date.isoformat()),
             execution_date=date,
-            start_date=datetime.datetime.utcnow(),
+            start_date=datetime.utcnow(),
             external_trigger=False,
             state=state,
         )
@@ -67,7 +67,7 @@ def set_state(task, execution_date, upstream=False, downstream=False,
     :param commit: Commit tasks to be altered to the database
     :return: list of tasks that have been created and updated
     """
-    assert isinstance(execution_date, datetime.datetime)
+    assert execution_date.tzinfo is not None
 
     # microseconds are supported by the database, but is not handled
     # correctly by airflow on e.g. the filesystem and in other places

--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 import json
 
 from airflow.exceptions import AirflowException
 from airflow.models import DagRun, DagBag
+from airflow.utils import datetime
 from airflow.utils.state import State
 
 
 def trigger_dag(dag_id, run_id=None, conf=None, execution_date=None):
+    assert execution_date.tzinfo is not None
+
     dagbag = DagBag()
 
     if dag_id not in dagbag.dags:
@@ -29,9 +31,8 @@ def trigger_dag(dag_id, run_id=None, conf=None, execution_date=None):
     dag = dagbag.get_dag(dag_id)
 
     if not execution_date:
-        execution_date = datetime.datetime.utcnow()
+        execution_date = datetime.utcnow()
 
-    assert isinstance(execution_date, datetime.datetime)
     execution_date = execution_date.replace(microsecond=0)
 
     if not run_id:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -291,7 +291,7 @@ worker_log_server_port = 8793
 
 # The Celery broker URL. Celery supports RabbitMQ, Redis and experimentally
 # a sqlalchemy database. Refer to the Celery documentation for more
-# information.
+# information.  
 broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
 
 # Another key Celery setting

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -35,6 +35,11 @@ dags_folder = {AIRFLOW_HOME}/dags
 # This path must be absolute
 base_log_folder = {AIRFLOW_HOME}/logs
 
+# Default timezone in case supplied timezones are naive
+# can be utc (default), system, or any IANA timezone string (e.g. Europe/Amsterdam)
+# Timezone is evaluated per worker in case of "system"
+default_timezone = utc
+
 # Airflow can store logs remotely in AWS S3 or Google Cloud Storage. Users
 # must supply an Airflow connection id that provides access to the storage
 # location.
@@ -370,12 +375,12 @@ authenticate = False
 
 [ldap]
 # set this to ldaps://<your.ldap.server>:<port>
-uri = 
+uri =
 user_filter = objectClass=*
 user_name_attr = uid
 group_member_attr = memberOf
-superuser_filter = 
-data_profiler_filter = 
+superuser_filter =
+data_profiler_filter =
 bind_user = cn=Manager,dc=example,dc=com
 bind_password = insecure
 basedn = dc=example,dc=com

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -822,7 +822,6 @@ class SchedulerJob(BaseJob):
                 # The logic is that we move start_date up until
                 # one period before, so that datetime.utcnow() is AFTER
                 # the period end, and the job can be created...
-                # todo: localize this to the timezone and add from there
                 now = datetime.utcnow()
                 next_start = dag.following_schedule(now)
                 last_start = dag.previous_schedule(now)

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -822,6 +822,7 @@ class SchedulerJob(BaseJob):
                 # The logic is that we move start_date up until
                 # one period before, so that datetime.utcnow() is AFTER
                 # the period end, and the job can be created...
+                # todo: localize this to the timezone and add from there
                 now = datetime.utcnow()
                 next_start = dag.following_schedule(now)
                 last_start = dag.previous_schedule(now)

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -28,7 +28,6 @@ import sys
 import threading
 import time
 from collections import defaultdict
-from datetime import datetime
 from past.builtins import basestring
 from sqlalchemy import (
     Column, Integer, String, DateTime, func, Index, or_, and_, not_)
@@ -51,6 +50,7 @@ from airflow.utils.dag_processing import (AbstractDagFileProcessor,
                                           SimpleDag,
                                           SimpleDagBag,
                                           list_py_file_paths)
+from airflow.utils import datetime
 from airflow.utils.db import provide_session, pessimistic_connection_handling
 from airflow.utils.email import send_email
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -2496,7 +2496,8 @@ class LocalTaskJob(BaseJob):
             *args, **kwargs):
         self.task_instance = task_instance
         self.ignore_all_deps = ignore_all_deps
-        self.ignore_depends_on_past = ignore_depends_on_past
+        self.past = ignore_depends_on_past
+        self.ignore_depends_on_past = self.past
         self.ignore_task_deps = ignore_task_deps
         self.ignore_ti_state = ignore_ti_state
         self.pool = pool

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -33,6 +33,7 @@ from sqlalchemy import (
     Column, Integer, String, DateTime, func, Index, or_, and_, not_)
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm.session import make_transient
+from sqlalchemy_utc import UtcDateTime
 from tabulate import tabulate
 from time import sleep
 
@@ -74,9 +75,9 @@ class BaseJob(Base, LoggingMixin):
     dag_id = Column(String(ID_LEN),)
     state = Column(String(20))
     job_type = Column(String(30))
-    start_date = Column(DateTime())
-    end_date = Column(DateTime())
-    latest_heartbeat = Column(DateTime())
+    start_date = Column(UtcDateTime())
+    end_date = Column(UtcDateTime())
+    latest_heartbeat = Column(UtcDateTime())
     executor_class = Column(String(500))
     hostname = Column(String(500))
     unixname = Column(String(1000))
@@ -1614,7 +1615,7 @@ class SchedulerJob(BaseJob):
         execute_start_time = datetime.utcnow()
 
         # Last time stats were printed
-        last_stat_print_time = datetime(2000, 1, 1)
+        last_stat_print_time = datetime.localized_datetime(2000, 1, 1)
         # Last time that self.heartbeat() was called.
         last_self_heartbeat_time = datetime.utcnow()
         # Last time that the DAG dir was traversed to look for files

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -68,7 +68,7 @@ from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.ti_deps.deps.task_concurrency_dep import TaskConcurrencyDep
 
 from airflow.ti_deps.dep_context import DepContext, QUEUE_DEPS, RUN_DEPS
-from airflow.utils.dates import cron_presets, date_range as utils_date_range
+from airflow.utils.datetime import cron_presets, date_range as utils_date_range
 from airflow.utils.db import provide_session
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.email import send_email

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
-
 from airflow.models import BaseOperator, DagBag
+from airflow.utils import datetime
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.state import State
 from airflow import settings

--- a/airflow/operators/latest_only_operator.py
+++ b/airflow/operators/latest_only_operator.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
-
 from airflow.models import BaseOperator, SkipMixin
+from airflow.utils import datetime
 
 
 class LatestOnlyOperator(BaseOperator, SkipMixin):
@@ -35,7 +34,7 @@ class LatestOnlyOperator(BaseOperator, SkipMixin):
             self.log.info("Externally triggered DAG_Run: allowing execution to proceed.")
             return
 
-        now = datetime.datetime.utcnow()
+        now = datetime.utcnow()
         left_window = context['dag'].following_schedule(
             context['execution_date'])
         right_window = context['dag'].following_schedule(left_window)

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -33,6 +33,7 @@ from airflow.models import BaseOperator, TaskInstance
 from airflow.hooks.base_hook import BaseHook
 from airflow.hooks.hdfs_hook import HDFSHook
 from airflow.hooks.http_hook import HttpHook
+from airflow.utils.datetime import utcnow
 from airflow.utils.state import State
 from airflow.utils.decorators import apply_defaults
 
@@ -74,9 +75,9 @@ class BaseSensorOperator(BaseOperator):
         raise AirflowException('Override me.')
 
     def execute(self, context):
-        started_at = datetime.utcnow()
+        started_at = utcnow()
         while not self.poke(context):
-            if (datetime.utcnow() - started_at).total_seconds() > self.timeout:
+            if (utcnow() - started_at).total_seconds() > self.timeout:
                 if self.soft_fail:
                     raise AirflowSkipException('Snap. Time is OUT.')
                 else:
@@ -602,7 +603,7 @@ class TimeSensor(BaseSensorOperator):
 
     def poke(self, context):
         self.log.info('Checking if the time (%s) has come', self.target_time)
-        return datetime.utcnow().time() > self.target_time
+        return utcnow().time() > self.target_time
 
 
 class TimeDeltaSensor(BaseSensorOperator):
@@ -627,7 +628,7 @@ class TimeDeltaSensor(BaseSensorOperator):
         target_dttm = dag.following_schedule(context['execution_date'])
         target_dttm += self.delta
         self.log.info('Checking if the time (%s) has come', target_dttm)
-        return datetime.utcnow() > target_dttm
+        return utcnow() > target_dttm
 
 
 class HttpSensor(BaseSensorOperator):

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -19,9 +19,12 @@ from __future__ import unicode_literals
 
 import logging
 import os
+import pytz
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.pool import NullPool
+from tzlocal import get_localzone
 
 from airflow import configuration as conf
 from airflow.logging_config import configure_logging
@@ -83,6 +86,17 @@ DAGS_FOLDER = None
 
 engine = None
 Session = None
+
+TIMEZONE=pytz.utc
+try:
+    tz = conf.get("core", "default_timezone")
+    if tz == "system":
+        TIMEZONE = get_localzone()
+    else:
+        TIMEZONE = pytz.timezone(tz)
+except:
+    pass
+log.info("Configured default timezone %s" % TIMEZONE)
 
 
 def policy(task_instance):

--- a/airflow/ti_deps/deps/not_in_retry_period_dep.py
+++ b/airflow/ti_deps/deps/not_in_retry_period_dep.py
@@ -11,9 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from datetime import datetime
-
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils import datetime
 from airflow.utils.db import provide_session
 from airflow.utils.state import State
 

--- a/airflow/ti_deps/deps/runnable_exec_date_dep.py
+++ b/airflow/ti_deps/deps/runnable_exec_date_dep.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from datetime import datetime
 
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.utils import datetime
 from airflow.utils.db import provide_session
 
 

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -23,10 +23,10 @@ import time
 import zipfile
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
-from datetime import datetime
 
 from airflow.dag.base_dag import BaseDag, BaseDagBag
 from airflow.exceptions import AirflowException
+from airflow.utils import datetime
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 

--- a/airflow/utils/datetime.py
+++ b/airflow/utils/datetime.py
@@ -17,12 +17,13 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from croniter import croniter
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta  # for doctest
 import pytz
 import six
 
-from croniter import croniter
+from airflow.settings import TIMEZONE
 
 
 cron_presets = {
@@ -234,3 +235,52 @@ def utcnow():
     :return:
     """
     return datetime.now(tz=pytz.utc)
+
+
+def localize(dt):
+    """
+    Returns the datetime with the default timezone added if timezone
+    information was not associated
+
+    :param dt: datetime
+    :return: datetime with tzinfo
+    """
+    dt = TIMEZONE.localize(dt)
+
+    return dt
+
+
+def islocalized(dt):
+    """
+    Check if a datetime object has timezone information
+    :param dt: datetime
+    :return: True if it has timezone information, False if not
+    """
+    if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
+        return False
+
+    return True
+
+
+def localized_datetime(year, month, day,
+                       hour=0, minute=0, second=0,
+                       microsecond=0):
+    """
+    Creates a localized datetime object
+    :param year:
+    :param month:
+    :param day:
+    :param hour:
+    :param minute:
+    :param second:
+    :param microsecond:
+    :param tzinfo:
+    :return:
+    """
+    dt = datetime(
+        year=year, month=month, day=day,
+        hour=hour, minute=minute, second=second,
+        microsecond=microsecond
+    )
+
+    return TIMEZONE.localize(dt)

--- a/airflow/utils/datetime.py
+++ b/airflow/utils/datetime.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals
 
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta  # for doctest
+import pytz
 import six
 
 from croniter import croniter
@@ -219,9 +220,17 @@ def days_ago(n, hour=0, minute=0, second=0, microsecond=0):
     Get a datetime object representing `n` days ago. By default the time is
     set to midnight.
     """
-    today = datetime.utcnow().replace(
+    today = utcnow().replace(
         hour=hour,
         minute=minute,
         second=second,
         microsecond=microsecond)
     return today - timedelta(days=n)
+
+
+def utcnow():
+    """
+    Get utcnow including timezone information
+    :return: 
+    """
+    return datetime.now(tz=pytz.utc)

--- a/airflow/utils/datetime.py
+++ b/airflow/utils/datetime.py
@@ -289,5 +289,6 @@ def localized_datetime(year, month, day,
 
     return TIMEZONE.localize(dt)
 
-def localize(dt):
-    return dt.astimezone()
+
+def localize(dt, timezone):
+    return dt.astimezone(timezone)

--- a/airflow/utils/datetime.py
+++ b/airflow/utils/datetime.py
@@ -67,7 +67,7 @@ def date_range(
     if end_date and num:
         raise Exception("Wait. Either specify end_date OR num")
     if not end_date and not num:
-        end_date = datetime.utcnow()
+        end_date = utcnow()
 
     delta_iscron = False
     if isinstance(delta, six.string_types):
@@ -231,6 +231,6 @@ def days_ago(n, hour=0, minute=0, second=0, microsecond=0):
 def utcnow():
     """
     Get utcnow including timezone information
-    :return: 
+    :return:
     """
     return datetime.now(tz=pytz.utc)

--- a/airflow/utils/datetime.py
+++ b/airflow/utils/datetime.py
@@ -237,7 +237,7 @@ def utcnow():
     return datetime.now(tz=pytz.utc)
 
 
-def localize(dt):
+def convert_to_utc(dt):
     """
     Returns the datetime with the default timezone added if timezone
     information was not associated
@@ -245,9 +245,13 @@ def localize(dt):
     :param dt: datetime
     :return: datetime with tzinfo
     """
-    dt = TIMEZONE.localize(dt)
+    if not dt:
+        return dt
 
-    return dt
+    if not islocalized(dt):
+        dt = TIMEZONE.localize(dt)
+
+    return dt.astimezone(pytz.utc)
 
 
 def islocalized(dt):

--- a/airflow/utils/datetime.py
+++ b/airflow/utils/datetime.py
@@ -288,3 +288,6 @@ def localized_datetime(year, month, day,
     )
 
     return TIMEZONE.localize(dt)
+
+def localize(dt):
+    return dt.astimezone()

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -17,7 +17,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from datetime import datetime
+from airflow.utils import datetime
 from flask_admin.form import DateTimePickerWidget
 from wtforms import DateTimeField, SelectField
 from flask_wtf import Form

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -304,39 +304,39 @@ function updateQueryStringParameter(uri, key, value) {
 
     $("#btn_rendered").click(function(){
       url = "{{ url_for('airflow.rendered') }}" +
-        "?task_id=" + task_id +
-        "&dag_id=" + dag_id +
-        "&execution_date=" + execution_date;
+        "?task_id=" + encodeURIComponent(task_id) +
+        "&dag_id=" + encodeURIComponent(dag_id) +
+        "&execution_date=" + encodeURIComponent(execution_date);
       window.location = url;
     });
 
     $("#btn_subdag").click(function(){
       url = "{{ url_for('airflow.graph') }}" +
-        "?dag_id=" + subdag_id +
-        "&execution_date=" + execution_date;
+        "?dag_id=" + encodeURIComponent(subdag_id) +
+        "&execution_date=" + encodeURIComponent(execution_date);
       window.location = url;
     });
 
     $("#btn_log").click(function(){
       url = "{{ url_for('airflow.log') }}" +
-        "?task_id=" + task_id +
-        "&dag_id=" + dag_id +
-        "&execution_date=" + execution_date;
+        "?task_id=" + encodeURIComponent(task_id) +
+        "&dag_id=" + encodeURIComponent(dag_id) +
+        "&execution_date=" + encodeURIComponent(execution_date);
       window.location = url;
     });
 
     $("#btn_task").click(function(){
       url = "{{ url_for('airflow.task') }}" +
-        "?task_id=" + task_id +
-        "&dag_id=" + dag_id +
-        "&execution_date=" + execution_date;
+        "?task_id=" + encodeURIComponent(task_id) +
+        "&dag_id=" + encodeURIComponent(dag_id) +
+        "&execution_date=" + encodeURIComponent(execution_date);
       window.location = url;
     });
 
     $("#btn_ti").click(function(){
       url = "/admin/taskinstance/" +
-        "?flt1_dag_id_equals=" + dag_id +
-        "&flt2_task_id_equals=" + task_id +
+        "?flt1_dag_id_equals=" + encodeURIComponent(dag_id) +
+        "&flt2_task_id_equals=" + encodeURIComponent(task_id) +
         "&sort=3&desc=1";
       window.location = url;
     });
@@ -348,7 +348,7 @@ function updateQueryStringParameter(uri, key, value) {
         "&ignore_all_deps=" + $('#btn_ignore_all_deps').hasClass('active') +
         "&ignore_task_deps=" + $('#btn_ignore_task_deps').hasClass('active') +
         "&ignore_ti_state=" + $('#btn_ignore_ti_state').hasClass('active') +
-        "&execution_date=" + execution_date +
+        "&execution_date=" + encodeURIComponent(execution_date) +
         "&origin=" + encodeURIComponent(window.location);
       window.location = url;
     });
@@ -362,7 +362,7 @@ function updateQueryStringParameter(uri, key, value) {
         "&upstream=" + $('#btn_upstream').hasClass('active') +
         "&downstream=" + $('#btn_downstream').hasClass('active') +
         "&recursive=" + $('#btn_recursive').hasClass('active') +
-        "&execution_date=" + execution_date +
+        "&execution_date=" + encodeURIComponent(execution_date) +
         "&origin=" + encodeURIComponent(window.location);
       window.location = url;
     });
@@ -371,7 +371,7 @@ function updateQueryStringParameter(uri, key, value) {
       url = "{{ url_for('airflow.dagrun_clear') }}" +
         "?task_id=" + encodeURIComponent(task_id) +
         "&dag_id=" + encodeURIComponent(dag_id) +
-        "&execution_date=" + execution_date +
+        "&execution_date=" + encodeURIComponent(execution_date) +
         "&origin=" + encodeURIComponent(window.location);
       window.location = url;
     });
@@ -384,7 +384,7 @@ function updateQueryStringParameter(uri, key, value) {
         "&downstream=" + $('#btn_success_downstream').hasClass('active') +
         "&future=" + $('#btn_success_future').hasClass('active') +
         "&past=" + $('#btn_success_past').hasClass('active') +
-        "&execution_date=" + execution_date +
+        "&execution_date=" + encodeURIComponent(execution_date) +
         "&origin=" + encodeURIComponent(window.location);
 
       window.location = url;
@@ -393,22 +393,22 @@ function updateQueryStringParameter(uri, key, value) {
     $('#btn_dagrun_success').click(function(){
       url = "{{ url_for('airflow.dagrun_success') }}" +
         "?dag_id=" + encodeURIComponent(dag_id) +
-        "&execution_date=" + execution_date +
+        "&execution_date=" + encodeURIComponent(execution_date) +
         "&origin=" + encodeURIComponent(window.location);
       window.location = url;
     });
 
     $("#btn_gantt").click(function(){
       url = "{{ url_for('airflow.gantt') }}" +
-        "?dag_id=" + dag_id +
-        "&execution_date=" + execution_date;
+        "?dag_id=" + encodeURIComponent(dag_id) +
+        "&execution_date=" + encodeURIComponent(execution_date);
       window.location = url;
     });
 
     $("#btn_graph").click(function(){
       url = "{{ url_for('airflow.graph') }}" +
-        "?dag_id=" + dag_id +
-        "&execution_date=" + execution_date;
+        "?dag_id=" + encodeURIComponent(dag_id) +
+        "&execution_date=" + encodeURIComponent(execution_date);
       window.location = url;
     });
 

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -21,7 +21,7 @@ from cgi import escape
 from io import BytesIO as IO
 import functools
 import gzip
-import dateutil.parser as dateparser
+import iso8601
 import json
 import time
 
@@ -253,8 +253,8 @@ def action_logging(f):
             dag_id=request.args.get('dag_id'))
 
         if 'execution_date' in request.args:
-            log.execution_date = dateparser.parse(
-                request.args.get('execution_date'))
+            log.execution_date = iso8601.parse_date(
+                request.args.get('execution_date'), settings.TIMEZONE)
 
         session.add(log)
         session.commit()

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -76,7 +76,7 @@ from airflow.utils.json import json_ser
 from airflow.utils.state import State
 from airflow.utils.db import provide_session
 from airflow.utils.helpers import alchemy_to_dict
-from airflow.utils.dates import infer_time_unit, scale_time_units
+from airflow.utils.datetime import infer_time_unit, scale_time_units
 from airflow.www import utils as wwwutils
 from airflow.www.forms import DateTimeForm, DateTimeWithNumRunsForm
 from airflow.www.validators import GreaterEqualThan

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -21,7 +21,7 @@ import os
 import pkg_resources
 import socket
 from functools import wraps
-from datetime import datetime, timedelta
+from datetime import timedelta
 import dateutil.parser
 import copy
 import math
@@ -72,6 +72,7 @@ from airflow.ti_deps.dep_context import DepContext, QUEUE_DEPS, SCHEDULER_DEPS
 from airflow.models import BaseOperator
 from airflow.operators.subdag_operator import SubDagOperator
 
+from airflow.utils import datetime
 from airflow.utils.json import json_ser
 from airflow.utils.state import State
 from airflow.utils.db import provide_session

--- a/setup.py
+++ b/setup.py
@@ -233,6 +233,7 @@ def do_setup():
             'python-daemon>=2.1.1, <2.2',
             'python-dateutil>=2.3, <3',
             'python-nvd3==0.14.2',
+            'pytz>=2017.2',
             'requests>=2.5.1, <3',
             'setproctitle>=1.1.8, <2',
             'sqlalchemy>=0.9.8',

--- a/setup.py
+++ b/setup.py
@@ -237,8 +237,10 @@ def do_setup():
             'requests>=2.5.1, <3',
             'setproctitle>=1.1.8, <2',
             'sqlalchemy>=0.9.8',
+            'sqlalchemy-utc>=0.9.0',
             'tabulate>=0.7.5, <0.8.0',
             'thrift>=0.9.2',
+            'tzlocal>=1.4',
             'zope.deprecation>=4.0, <5.0',
         ],
         extras_require={

--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,7 @@ def do_setup():
             'croniter>=0.3.17, <0.4',
             'dill>=0.2.2, <0.3',
             'flask>=0.11, <0.12',
-            'flask-admin==1.4.1',
+            'flask-admin==1.5.0',
             'flask-cache>=0.13.1, <0.14',
             'flask-login==0.2.11',
             'flask-swagger==0.2.13',
@@ -224,6 +224,7 @@ def do_setup():
             'future>=0.16.0, <0.17',
             'gitpython>=2.0.2',
             'gunicorn>=19.3.0, <19.4.0',  # 19.4.? seemed to have issues
+            'iso8601>=0.1.12',
             'jinja2>=2.7.3, <2.9.0',
             'lxml>=3.6.0, <4.0',
             'markdown>=2.5.2, <3.0',

--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,7 @@ def do_setup():
             'alembic>=0.8.3, <0.9',
             'bleach==2.0.0',
             'configparser>=3.5.0, <3.6.0',
-            'croniter>=0.3.17, <0.4',
+            'croniter>=0.3.19, <0.4',
             'dill>=0.2.2, <0.3',
             'flask>=0.11, <0.12',
             'flask-admin==1.5.0',

--- a/tests/api/common/experimental/mark_tasks.py
+++ b/tests/api/common/experimental/mark_tasks.py
@@ -18,7 +18,7 @@ from airflow import models
 from airflow.api.common.experimental.mark_tasks import (
     set_state, _create_dagruns, set_dag_run_state)
 from airflow.settings import Session
-from airflow.utils.dates import days_ago
+from airflow.utils.datetime import days_ago
 from airflow.utils.state import State
 from datetime import datetime, timedelta
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -56,7 +56,7 @@ from airflow.bin import cli
 from airflow.www import app as application
 from airflow.settings import Session
 from airflow.utils.state import State
-from airflow.utils.dates import infer_time_unit, round_time, scale_time_units
+from airflow.utils.datetime import infer_time_unit, round_time, scale_time_units
 from lxml import html
 from airflow.exceptions import AirflowException
 from airflow.configuration import AirflowConfigException, run_command

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -37,7 +37,7 @@ from airflow.models import DAG, DagModel, DagBag, DagRun, Pool, TaskInstance as 
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.bash_operator import BashOperator
 from airflow.task_runner.base_task_runner import BaseTaskRunner
-from airflow.utils.dates import days_ago
+from airflow.utils.datetime import days_ago
 from airflow.utils.db import provide_session
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout

--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -15,7 +15,7 @@
 from datetime import datetime, timedelta
 import unittest
 
-from airflow.utils import dates
+from airflow.utils import datetime
 
 
 class Dates(unittest.TestCase):
@@ -24,19 +24,19 @@ class Dates(unittest.TestCase):
         today = datetime.today()
         today_midnight = datetime.fromordinal(today.date().toordinal())
 
-        self.assertTrue(dates.days_ago(0) == today_midnight)
+        self.assertTrue(datetime.days_ago(0) == today_midnight)
 
         self.assertTrue(
-            dates.days_ago(100) == today_midnight + timedelta(days=-100))
+            datetime.days_ago(100) == today_midnight + timedelta(days=-100))
 
         self.assertTrue(
-            dates.days_ago(0, hour=3) == today_midnight + timedelta(hours=3))
+            datetime.days_ago(0, hour=3) == today_midnight + timedelta(hours=3))
         self.assertTrue(
-            dates.days_ago(0, minute=3)
+            datetime.days_ago(0, minute=3)
             == today_midnight + timedelta(minutes=3))
         self.assertTrue(
-            dates.days_ago(0, second=3)
+            datetime.days_ago(0, second=3)
             == today_midnight + timedelta(seconds=3))
         self.assertTrue(
-            dates.days_ago(0, microsecond=3)
+            datetime.days_ago(0, microsecond=3)
             == today_midnight + timedelta(microseconds=3))


### PR DESCRIPTION
This PR in WIP to add timezone support to Airflow. It addresses the following tasks:

- [X] Use non naive UTC everywhere
- [ ] Convert datetime fields to timezone aware fields

Airflow currently stores naive UTC. Before moving to non naive we most likely need to convert current database fields to non naive fields as well. Otherwise we need to verify that the database is already running in UTC

- [X] Use iso8601 conversion for API/views
- [X] Make sure to url encode all execution_dates

Airflow current does not correctly put execution_dates in URLs and conversion for Timezones therefore fails.

- [X] Allow naive - backward compatible, datetime settings in DAGs
- [x] Allow non system local / utc for time zone configuration

Converts to the pre-configured timezone setting from airflow.cfg

References:

- Best practice: [python timezones](https://julien.danjou.info/blog/2015/python-and-timezones)
- [Timezone Conversion for Postgres](https://stackoverflow.com/questions/21277170/postgresql-wrong-converting-from-timestamp-without-time-zone-to-timestamp-with-t)
- [Timezone conversion for mysql](https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_convert-tz)

cc: @JohnCulver @criccomini @jgao54 


