### PR TITLE
[AIRFLOW-1775] Remote File Task Handler

### DIFF
--- a/airflow/utils/log/gcs_task_handler.py
+++ b/airflow/utils/log/gcs_task_handler.py
@@ -29,7 +29,6 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
     def __init__(self, base_log_folder, gcs_log_folder, filename_template):
         super(GCSTaskHandler, self).__init__(base_log_folder, filename_template)
         self.remote_base = gcs_log_folder
-        self.log_relative_path = ''
         self._hook = None
         self.closed = False
         self.upload_on_close = True
@@ -59,7 +58,6 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
         # Log relative path is used to construct local and remote
         # log path to upload log files into GCS and read from the
         # remote location.
-        self.log_relative_path = self._render_filename(ti, ti.try_number)
         self.upload_on_close = not ti.is_raw
 
     def close(self):

--- a/airflow/utils/log/remote_file_task_handler.py
+++ b/airflow/utils/log/remote_file_task_handler.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import shutil
+
+from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.log.file_task_handler import FileTaskHandler
+
+
+class RemoteFileTaskHandler(FileTaskHandler, LoggingMixin):
+    """
+    RemoteFileTaskHandler is a python log handler that handles and reads
+    task instance logs. It provides the same functionality as the
+    FileTaskHandler, but copies the log file to a second log folder on close.
+    This can be usefull for archiving purposes, or when dealing with
+    mounted cloud storage which is paid per action.
+    """
+    def __init__(self, base_log_folder, secondary_log_folder, filename_template):
+        super(RemoteFileTaskHandler, self).__init__(base_log_folder, filename_template)
+        self.secondary_log_folder = secondary_log_folder
+        self.closed = False
+
+    def close(self):
+        """
+        Close and copy the local log file to the secondary location
+        """
+        # When application exit, system shuts down all handlers by
+        # calling close method. Here we check if logger is already
+        # closed to prevent uploading the log to remote storage multiple
+        # times when `logging.shutdown` is called.
+        if self.closed:
+            return
+
+        super(RemoteFileTaskHandler, self).close()
+
+        primary_loc = os.path.join(self.local_base, self.log_relative_path)
+        secondary_loc = os.path.join(self.secondary_log_folder, self.log_relative_path)
+        if os.path.exists(primary_loc):
+            shutil.copyfile(primary_loc, secondary_loc)
+
+        # Mark closed so we don't double write if close is called twice
+        self.closed = True
+
+    def _init_file(self):
+        self._init_file_path(os.path.join(self.secondary_log_folder,
+                                          self.log_relative_path))
+
+        return super(RemoteFileTaskHandler, self)._init_file()
+
+    def _read(self, ti, try_number):
+        """
+        Read logs of given task instance and try_number from the secondary location.
+        If that does not exist, fallback to the default FileTaskHandler.
+        :param ti: task instance object
+        :param try_number: task instance try_number to read logs from
+        """
+        # Explicitly getting log relative path is necessary as the given
+        # task instance might be different than task instance passed in
+        # in set_context method.
+        log_relative_path = self._render_filename(ti, try_number + 1)
+        secondary_loc = os.path.join(self.secondary_log_folder, log_relative_path)
+
+        if os.path.exists(secondary_loc):
+            try:
+                with open(secondary_loc) as f:
+                    log = "*** Reading secondary log.\n" + "".join(f.readlines())
+            except Exception as e:
+                log = "*** Failed to load secondary log file: {}. {}\n" \
+                    .format(secondary_loc, str(e))
+        else:
+            log = super(RemoteFileTaskHandler, self)._read(ti, try_number)
+
+        return log

--- a/airflow/utils/log/s3_task_handler.py
+++ b/airflow/utils/log/s3_task_handler.py
@@ -54,7 +54,6 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         super(S3TaskHandler, self).set_context(ti)
         # Local location and remote location is needed to open and
         # upload local log file to S3 remote storage.
-        self.log_relative_path = self._render_filename(ti, ti.try_number)
         self.upload_on_close = not ti.is_raw
 
     def close(self):

--- a/tests/utils/log/test_remote_file_task_handler.py
+++ b/tests/utils/log/test_remote_file_task_handler.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+import os
+import unittest
+
+from airflow.utils.log.remote_file_task_handler import RemoteFileTaskHandler
+from datetime import datetime
+from datetime import timedelta
+
+
+class TestRemoteFileTaskHandler(unittest.TestCase):
+    def setUp(self):
+        super(TestRemoteFileTaskHandler, self).setUp()
+        self.base_log_folder = "/tmp/log_test"
+        self.remote_base_log_folder = "/tmp/log_test2"
+        self.filename_template = "output.log"
+
+    def test_remote_close(self):
+        rfth = RemoteFileTaskHandler(self.base_log_folder,
+                                     self.remote_base_log_folder,
+                                     self.filename_template)
+        rfth.log_relative_path = self.filename_template
+        full_path = rfth._init_file()
+
+        with open(full_path, 'w') as fp:
+            fp.write('testing')
+
+        rfth.close()
+
+        secondary_path = os.path.join(self.remote_base_log_folder, self.filename_template)
+        self.assertTrue(os.path.exists(secondary_path))
+
+        with open(secondary_path) as fp:
+            line = fp.read()
+            self.assertEqual(line, 'testing')
+
+    def tearDown(self):
+        shutil.rmtree(self.base_log_folder, ignore_errors=True)
+        shutil.rmtree(self.remote_base_log_folder, ignore_errors=True)


### PR DESCRIPTION
Extension of the File Task Handler which copies the file on close

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1775


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
A remote file task handler which is an extension to the file task handler. It provides the same functionality as the file task handler, but copies the log file to another directory on close.
This is usefull when storing logs on a mounted cloud disk for archiving purposes. 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

