### PR TITLE
[AIRFLOW-1780] Fix long task output lines with unicode from hanging parent process

### DIFF
--- a/airflow/task_runner/base_task_runner.py
+++ b/airflow/task_runner/base_task_runner.py
@@ -95,7 +95,7 @@ class BaseTaskRunner(LoggingMixin):
                 line = line.decode('utf-8')
             if len(line) == 0:
                 break
-            self.log.info('Subtask: %s', line.rstrip('\n'))
+            self.log.info(u'Subtask: %s', line.rstrip('\n'))
 
     def run_command(self, run_with, join_args=False):
         """


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1780

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
Fix long task output lines with unicode from hanging parent process. Tasks that create output that gets piped into a file in the parent airflow process would hang if they had long lines with unicode characters.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested by cherrypicking onto Airbnb production:
This is a bit tricky to test since it depends on OS-specific constants, and is likely caused by a bug in python 2.7/string format (not in Airflow itself).

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

@saguziel 