### PR TITLE
[AIRFLOW-251] added option SQL_ALCHEMY_SCHEMA parameter

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -63,6 +63,10 @@ executor = SequentialExecutor
 # their website
 sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/airflow.db
 
+# The schema to use for the metadata database
+# SqlAlchemy supports databases with the concept of multiple schemas.
+sql_alchemy_schema =
+
 # The SqlAlchemy pool size is the maximum number of database connections
 # in the pool.
 sql_alchemy_pool_size = 5

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -31,6 +31,7 @@ base_log_folder = {AIRFLOW_HOME}/logs
 logging_level = INFO
 executor = SequentialExecutor
 sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/unittests.db
+sql_alchemy_schema =
 load_examples = True
 donot_pickle = False
 dag_concurrency = 16

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -111,6 +111,7 @@ class AirflowConfigParser(ConfigParser):
     # is to not store password on boxes in text files.
     as_command_stdout = {
         ('core', 'sql_alchemy_conn'),
+        ('core', 'sql_alchemy_schema'),
         ('core', 'fernet_key'),
         ('celery', 'broker_url'),
         ('celery', 'celery_result_backend')

--- a/airflow/migrations/env.py
+++ b/airflow/migrations/env.py
@@ -69,15 +69,21 @@ def run_migrations_online():
 
     """
     connectable = settings.engine
-
     with connectable.connect() as connection:
         context.configure(
             connection=connection,
             target_metadata=target_metadata,
+            version_table_schema=target_metadata.schema,
+            include_schemas=True,
             compare_type=COMPARE_TYPE,
         )
 
         with context.begin_transaction():
+            if target_metadata.schema and 'postgres' in settings.SQL_ALCHEMY_CONN:
+                context.execute('CREATE SCHEMA IF NOT EXISTS {}'.format(
+                    target_metadata.schema))
+                context.execute('SET search_path TO {}'.format(
+                    target_metadata.schema))
             context.run_migrations()
 
 if context.is_offline_mode():

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -50,7 +50,7 @@ from urllib.parse import urlparse
 from sqlalchemy import (
     Column, Integer, String, DateTime, Text, Boolean, ForeignKey, PickleType,
     Index, Float, LargeBinary)
-from sqlalchemy import func, or_, and_
+from sqlalchemy import func, or_, and_, MetaData
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.dialects.mysql import LONGTEXT
 from sqlalchemy.orm import reconstructor, relationship, synonym
@@ -81,7 +81,12 @@ from airflow.utils.timeout import timeout
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.log.logging_mixin import LoggingMixin
 
-Base = declarative_base()
+SQL_ALCHEMY_SCHEMA = configuration.get('core', 'sql_alchemy_schema')
+if SQL_ALCHEMY_SCHEMA.strip():
+    Base = declarative_base(metadata=MetaData(schema=SQL_ALCHEMY_SCHEMA))
+else:
+    Base = declarative_base()
+
 ID_LEN = 250
 XCOM_RETURN_KEY = 'return_value'
 


### PR DESCRIPTION
Dear Airflow maintainers,

This PR adds an optional parameter SQL_ALCHEMY_SCHEMA to cfg and env vars, which can be used to specify a schema. This is useful to separate Airflow tables out of the default dbo schema. This feature was thinking for postgresql schema.

https://issues.apache.org/jira/browse/AIRFLOW-251

