### PR TITLE
[AIRFLOW-1792] Missing intervals DruidOperator

### DIFF
--- a/airflow/contrib/operators/druid_operator.py
+++ b/airflow/contrib/operators/druid_operator.py
@@ -34,10 +34,12 @@ class DruidOperator(BaseOperator):
             self,
             json_index_file,
             druid_ingest_conn_id='druid_ingest_default',
+            intervals=None,
             *args, **kwargs):
 
         super(DruidOperator, self).__init__(*args, **kwargs)
         self.conn_id = druid_ingest_conn_id
+        self.intervals=intervals
 
         with open(json_index_file) as data_file:
             self.index_spec = json.load(data_file)


### PR DESCRIPTION
Dear Airflow maintainers,

The DruidOperator allows you to template the intervals field which is important when you are doing backfills with Druid. This field was  missing in the constructor and Airflow threw a warning

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1792


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

