### PR TITLE
[AIRFLOW-646] Add docutils to setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -241,6 +241,9 @@ def do_setup():
             'thrift>=0.9.2',
             'zope.deprecation>=4.0, <5.0',
         ],
+        setup_requires=[
+            'docutils>=0.14, <1.0',
+        ],
         extras_require={
             'all': devel_all,
             'all_dbs': all_dbs,


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] 
    - https://issues.apache.org/jira/browse/AIRFLOW-646


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
   python-daemon requires docutils, but declares that dependency in setup_requires. 'python setup.py install' in airflow fails because of this.  By declaring the dependency explicitly in setup_requires, the installation will work.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:  This is a problem with installation, so unit tests don't really apply.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

