### PR TITLE
[AIRFLOW-1794] Remove uses of Exception.message for Python 3

### DIFF
--- a/airflow/hooks/webhdfs_hook.py
+++ b/airflow/hooks/webhdfs_hook.py
@@ -61,7 +61,7 @@ class WebHDFSHook(BaseHook):
                 return client
             except HdfsError as e:
                 self.log.debug(
-                    "Read operation on namenode {nn.host} failed witg error: {e.message}".format(**locals())
+                    "Read operation on namenode {nn.host} failed with error: {e}".format(**locals())
                 )
         nn_hosts = [c.host for c in nn_connections]
         no_nn_error = "Read operations failed on the namenodes below:\n{}".format("\n".join(nn_hosts))

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -712,7 +712,7 @@ class Airflow(BaseView):
                 logs = handler.read(ti)
             except AttributeError as e:
                 logs = ["Task log handler {} does not support read logs.\n{}\n" \
-                            .format(task_log_reader, e.message)]
+                            .format(task_log_reader, str(e))]
 
         for i, log in enumerate(logs):
             if PY2 and not isinstance(log, unicode):


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1794


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In Python 3, `message` is no longer an attribute for the Exception class.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

