### PR TITLE
[AIRFLOW-1559] Add sqlalchemy engine disposal

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -746,6 +746,7 @@ def webserver(args):
         gunicorn_master_proc = None
 
         def kill_proc(dummy_signum, dummy_frame):
+            settings.engine.dispose()
             gunicorn_master_proc.terminate()
             gunicorn_master_proc.wait()
             sys.exit(0)

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -352,6 +352,10 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
                     pass
 
             try:
+                # engine gets copied from parent, so call dispose here to
+                # new connections are local to fork
+                settings.engine.dispose()
+
                 # redirect stdout/stderr to log
                 sys.stdout = stdout
                 sys.stderr = stderr
@@ -382,6 +386,8 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
             finally:
                 sys.stdout = sys.__stdout__
                 sys.stderr = sys.__stderr__
+                # child is done with connection pool
+                settings.engine.dispose()
 
         p = multiprocessing.Process(target=helper,
                                     args=(),


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1559


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Ensure `settings.engine.dispose()` is called where appropriate,
particularly when the scheduler processes DAGs and the webserver
refreshes workers. This is to prevent MySQL warnings about aborted
connections.

References:
* http://docs.sqlalchemy.org/en/latest/core/connections.html#engine-disposal
* http://docs.sqlalchemy.org/en/latest/core/pooling.html#using-connection-pools-with-multiprocessing

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

