### PR TITLE
Update airflow-flower.conf

### DIFF
--- a/scripts/upstart/airflow-flower.conf
+++ b/scripts/upstart/airflow-flower.conf
@@ -18,7 +18,7 @@ stop on (deconfiguring-networking or runlevel [016])
 respawn
 respawn limit 5 30
 
-console output
+console log
 
 setuid airflow
 setgid airflow

--- a/scripts/upstart/airflow-flower.conf
+++ b/scripts/upstart/airflow-flower.conf
@@ -18,6 +18,8 @@ stop on (deconfiguring-networking or runlevel [016])
 respawn
 respawn limit 5 30
 
+console output
+
 setuid airflow
 setgid airflow
 
@@ -26,4 +28,4 @@ setgid airflow
 # export AIRFLOW_CONFIG
 # export AIRFLOW_HOME
 
-exec usr/local/bin/airflow flower
+exec /usr/local/bin/airflow flower


### PR DESCRIPTION
Following changes done:
- added the console output to get the logs in /var/log/upstart/airflow-flower.log
- updated the exec parameter to default location of airflow installation

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] JIRA Ticket
https://issues.apache.org/jira/browse/AIRFLOW-1800
### Description
- [x] With this change we can see the logs of airflow maintained by upstart in /var/log/upstart/<cofig-name>.log


### Tests
- [x] My PR does not need testing for this extremely good reason: 
 any user defined upstart conf files if have 


### Commits
- [x] Updated the upstart configuration file to include the upstart managed logs for the service

