### PR TITLE
Update airflow-scheduler.conf

### DIFF
--- a/scripts/upstart/airflow-scheduler.conf
+++ b/scripts/upstart/airflow-scheduler.conf
@@ -18,6 +18,8 @@ stop on (deconfiguring-networking or runlevel [016])
 respawn
 respawn limit 5 10
 
+console output
+
 setuid airflow
 setgid airflow
 
@@ -30,4 +32,4 @@ setgid airflow
 env SCHEDULER_RUNS=5
 export SCHEDULER_RUNS
 
-exec usr/local/bin/airflow scheduler -n ${SCHEDULER_RUNS}
+exec /usr/local/bin/airflow scheduler -n ${SCHEDULER_RUNS}

--- a/scripts/upstart/airflow-scheduler.conf
+++ b/scripts/upstart/airflow-scheduler.conf
@@ -18,7 +18,7 @@ stop on (deconfiguring-networking or runlevel [016])
 respawn
 respawn limit 5 10
 
-console output
+console log
 
 setuid airflow
 setgid airflow

--- a/scripts/upstart/airflow-scheduler.conf
+++ b/scripts/upstart/airflow-scheduler.conf
@@ -32,4 +32,4 @@ setgid airflow
 env SCHEDULER_RUNS=5
 export SCHEDULER_RUNS
 
-exec /usr/local/bin/airflow scheduler -n ${SCHEDULER_RUNS}
+exec /usr/local/bin/airflow  scheduler -n ${SCHEDULER_RUNS}


### PR DESCRIPTION
Following changes done:
- updated the configuration to include the logs for service - in /var/log/upstart/<upstart-conf-name>.log
- updated the exec parameter to default location of airflow installation

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] JIRA Ticket
https://issues.apache.org/jira/browse/AIRFLOW-1800
### Description
- [x] With this change we can see the logs of airflow maintained by upstart in /var/log/upstart/<cofig-name>.log


### Tests
- [x] My PR does not need testing for this extremely good reason: 
the console output is managed by upstart doesn't affect airflow functionality in any way


### Commits
- [x] Updated the upstart configuration file to include the upstart managed logs for the service

