### PR TITLE
Update airflow-worker.conf

### DIFF
--- a/scripts/upstart/airflow-worker.conf
+++ b/scripts/upstart/airflow-worker.conf
@@ -18,7 +18,7 @@ stop on (deconfiguring-networking or runlevel [016])
 respawn
 respawn limit 5 30
 
-console output
+console log
 
 setuid airflow
 setgid airflow

--- a/scripts/upstart/airflow-worker.conf
+++ b/scripts/upstart/airflow-worker.conf
@@ -18,6 +18,8 @@ stop on (deconfiguring-networking or runlevel [016])
 respawn
 respawn limit 5 30
 
+console output
+
 setuid airflow
 setgid airflow
 
@@ -26,4 +28,4 @@ setgid airflow
 # export AIRFLOW_CONFIG
 # export AIRFLOW_HOME
 
-exec usr/local/bin/airflow worker
+exec /usr/local/bin/airflow worker


### PR DESCRIPTION
Following changes done:
- updated the configuration to include the logs for service - in /var/log/upstart/<upstart-conf-name>.log
- updated the exec parameter to default location of airflow installation

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] JIRA Ticket
- https://issues.apache.org/jira/browse/AIRFLOW-1800

### Description
- [x] With this change we can see the logs of airflow maintained by upstart in /var/log/upstart/<cofig-name>.log


### Commits
- [X] Updated the upstart configuration file to include the upstart managed logs for the service

