### PR TITLE
[AIRFLOW-1102] Upgrade Gunicorn >=19.4.0

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -715,7 +715,7 @@ def webserver(args):
             '-b', args.hostname + ':' + str(args.port),
             '-n', 'airflow-webserver',
             '-p', str(pid),
-            '-c', 'airflow.www.gunicorn_config'
+            '-c', 'python:airflow.www.gunicorn_config'
         ]
 
         if args.access_logfile:

--- a/setup.py
+++ b/setup.py
@@ -233,7 +233,7 @@ def do_setup():
             'funcsigs==1.0.0',
             'future>=0.16.0, <0.17',
             'gitpython>=2.0.2',
-            'gunicorn>=19.3.0, <19.4.0',  # 19.4.? seemed to have issues
+            'gunicorn>=19.4.0, <20.0',
             'jinja2>=2.7.3, <2.9.0',
             'lxml>=3.6.0, <4.0',
             'markdown>=2.5.2, <3.0',


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1102


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR upgrades the version of Gunicorn used by the webserver to `>=19.4.0`. This is necessary to use the `gevent` worker with Python 3. 19.4.0 included a breaking change that requires appending a `python:` prefix when using a Python config file.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This is a dependency change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

