### PR TITLE
[AIRFLOW-1793] fix DockerOperator using docker_conn_id

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -147,7 +147,7 @@ class DockerOperator(BaseOperator):
     def get_hook(self):
         return DockerHook(
             docker_conn_id=self.docker_conn_id,
-            base_url=self.base_url,
+            base_url=self.docker_url,
             version=self.api_version,
             tls=self.__get_tls_config()
         )

--- a/tests/operators/docker_operator.py
+++ b/tests/operators/docker_operator.py
@@ -188,7 +188,8 @@ class DockerOperatorTestCase(unittest.TestCase):
         )
 
     @mock.patch('airflow.operators.docker_operator.Client')
-    def test_execute_with_docker_conn_id_use_hook(self, operator_client_mock):
+    @mock.patch('airflow.operators.docker_operator.DockerHook')
+    def test_execute_with_docker_conn_id_use_hook(self, docker_hook_mock, operator_client_mock):
         # Mock out a Docker client, so operations don't raise errors
         client_mock = mock.Mock(name='DockerOperator.Client mock', spec=Client)
         client_mock.images.return_value = []
@@ -198,6 +199,9 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock.wait.return_value = 0
         operator_client_mock.return_value = client_mock
 
+        # Mock out the DockerHook
+        docker_hook_mock.return_value.get_conn.return_value = client_mock
+
         # Create the DockerOperator
         operator = DockerOperator(
             image='publicregistry/someimage',
@@ -206,28 +210,20 @@ class DockerOperatorTestCase(unittest.TestCase):
             docker_conn_id='some_conn_id'
         )
 
-        # Mock out the DockerHook
-        hook_mock = mock.Mock(name='DockerHook mock', spec=DockerHook)
-        hook_mock.get_conn.return_value = client_mock
-        operator.get_hook = mock.Mock(
-            name='DockerOperator.get_hook mock',
-            spec=DockerOperator.get_hook,
-            return_value=hook_mock
-        )
-
         operator.execute(None)
         self.assertEqual(
             operator_client_mock.call_count, 0,
             'Client was called on the operator instead of the hook'
         )
         self.assertEqual(
-            operator.get_hook.call_count, 1,
+            docker_hook_mock.call_count, 1,
             'Hook was not called although docker_conn_id configured'
         )
         self.assertEqual(
             client_mock.pull.call_count, 1,
             'Image was not pulled using operator client'
         )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

There was a typo when instantiating the DockerHook from `docker_conn_id` using `base_url` instead of `docker_url`.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

The test `test_execute_with_docker_conn_id_use_hook` exists already.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

