### PR TITLE
[AIRFLOW-1799] Fix log format string syntax

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2159,7 +2159,7 @@ class BaseOperator(LoggingMixin):
 
         if schedule_interval:
             self.log.warning(
-                "schedule_interval is used for {}, though it has "
+                "schedule_interval is used for %s, though it has "
                 "been deprecated as a task parameter, you need to "
                 "specify it as a DAG parameter instead",
                 self


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1799


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
   I have a task which uses `schedule_interval` in a deprecated way, and airflow attempts to warn against using the deprecated feature with a log message. Unfortunately, the message cannot be logged because the format syntax is incorrect. Instead of logging the warning, it instead logs an obscure string formatting error:
```
Logged from file models.py, line 2159
Traceback (most recent call last): 
File "/usr/lib/python2.7/logging/__init__.py", line 859, in emit msg = self.format(record) 
File "/usr/lib/python2.7/logging/__init__.py", line 732, in format return fmt.format(record) 
File "/usr/lib/python2.7/logging/__init__.py", line 471, in format record.message = record.getMessage() 
File "/usr/lib/python2.7/logging/__init__.py", line 335, in getMessage msg = msg % self.args 
TypeError: not all arguments converted during string formatting
```

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: This is a trivial fix to a logging message.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

