### PR TITLE
[AIRFLOW-1021] Fix double logging for new users with LDAP

### DIFF
--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -290,9 +290,10 @@ def login(self, request, session=None):
             user = models.User(
                 username=username,
                 is_superuser=False)
+            session.add(user)
 
-        session.merge(user)
         session.commit()
+        session.merge(user)
         flask_login.login_user(LdapUser(user))
         session.commit()
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -1996,6 +1996,9 @@ class WebLdapAuthTest(unittest.TestCase):
         response = self.login('dataprofiler', 'dataprofiler')
         self.assertIn('Data Profiling', response.data.decode('utf-8'))
 
+        response = self.logout()
+        self.assertIn('form-signin', response.data.decode('utf-8'))
+
         response = self.login('superuser', 'superuser')
         self.assertIn('Connections', response.data.decode('utf-8'))
 


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1021


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
By adding the new user to the session and commit
before merging, the correct user is returned by
`load_user(userid)` instead of `None` due to no
`id` assoicated with that user.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Fixed test in tests/core.py test_with_filters

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

