### PR TITLE
[AIRFLOW-1813] Make SSH Operator cope with no-output bash commands

### DIFF
--- a/tests/contrib/operators/test_ssh_operator.py
+++ b/tests/contrib/operators/test_ssh_operator.py
@@ -107,5 +107,23 @@ class SSHOperatorTest(unittest.TestCase):
         self.assertIsNotNone(ti.duration)
         self.assertEqual(ti.xcom_pull(task_ids='test', key='return_value'), b'airflow')
 
+    def test_no_output_command(self):
+        configuration.set("core", "enable_xcom_pickling", "True")
+        task = SSHOperator(
+            task_id="test",
+            ssh_hook=self.hook,
+            command="sleep 1",
+            do_xcom_push=True,
+            dag=self.dag,
+        )
+
+        self.assertIsNotNone(task)
+
+        ti = TaskInstance(
+            task=task, execution_date=datetime.now())
+        ti.run()
+        self.assertIsNotNone(ti.duration)
+        self.assertEqual(ti.xcom_pull(task_ids='test', key='return_value'), b'')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1813


### Description
- [ ] The SSH Operator currently throws an empty "SSH operator error" when running commands
that do not immediately log something to the terminal. This is due to a call to
stdout.channel.recv when the channel currently has a 0-size buffer, either because
the command has not yet logged anything, or never will (e.g. sleep 5). Fixed this issue with a buffer
size check.

- [ ] Made code PEP8 compliant


### Tests
- [ ] Added test for shell commands with no stdout output


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

