### PR TITLE
[AIRFLOW-1822] Add gaiohttp and gthread gunicorn worker class to webserver cli

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -728,7 +728,10 @@ def webserver(args):
             '-p', str(pid),
             '-c', 'python:airflow.www.gunicorn_config'
         ]
-
+        
+        if args.workerclass == 'gthread':
+            run_args += ['--threads', str(args.threads)]
+            
         if args.access_logfile:
             run_args += ['--access-logfile', str(args.access_logfile)]
 
@@ -1342,10 +1345,15 @@ class CLIFactory(object):
             default=conf.get('webserver', 'WORKERS'),
             type=int,
             help="Number of workers to run the webserver on"),
+        'threads': Arg(
+            ("--threads",),
+            default=conf.get('webserver', 'THREADS'),
+            type=int,
+            help="Number of workers threads for handling webserver requests"),
         'workerclass': Arg(
             ("-k", "--workerclass"),
             default=conf.get('webserver', 'WORKER_CLASS'),
-            choices=['sync', 'eventlet', 'gevent', 'tornado'],
+            choices=['sync', 'eventlet', 'gevent', 'tornado', 'gaiohttp', 'gthread'],
             help="The worker class to use for Gunicorn"),
         'worker_timeout': Arg(
             ("-t", "--worker_timeout"),
@@ -1571,7 +1579,7 @@ class CLIFactory(object):
         }, {
             'func': webserver,
             'help': "Start a Airflow webserver instance",
-            'args': ('port', 'workers', 'workerclass', 'worker_timeout', 'hostname',
+            'args': ('port', 'workers', 'workerclass', 'worker_timeout', 'threads','hostname',
                      'pid', 'daemon', 'stdout', 'stderr', 'access_logfile',
                      'error_logfile', 'log_file', 'ssl_cert', 'ssl_key', 'debug'),
         }, {

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -192,6 +192,10 @@ secret_key = temporary_key
 # Number of workers to run the Gunicorn web server
 workers = 4
 
+# Number of worker threads for handling requests
+# This setting only affects the Gthread worker type
+threads = 1
+
 # The worker class gunicorn should use. Choices include
 # sync (default), eventlet, gevent
 worker_class = sync

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -83,6 +83,8 @@ Here's the list of the subpackages and what they enable:
 +---------------+----------------------------------------------+-------------------------------------------------+
 |  slack        | ``pip install apache-airflow[slack]``        | ``SlackAPIPostOperator``                        |
 +---------------+----------------------------------------------+-------------------------------------------------+
+|  aiohttp      | ``pip install apache-airflow[aiohttp]``      | Gaiohttp worker class for gunicorn              |
++---------------+----------------------------------------------+-------------------------------------------------+
 |  vertica      | ``pip install apache-airflow[vertica]``      | Vertica hook                                    |
 |               |                                              | support as an Airflow backend                   |
 +---------------+----------------------------------------------+-------------------------------------------------+

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,9 @@ def write_version(filename=os.path.join(*['airflow',
     with open(filename, 'w') as a:
         a.write(text)
 
+aiohttp = [
+    'aiohttp>=0.21.5'
+]
 async = [
     'greenlet>=0.4.9',
     'eventlet>= 0.9.7',
@@ -244,6 +247,7 @@ def do_setup():
         extras_require={
             'all': devel_all,
             'all_dbs': all_dbs,
+            'aiohttp': aiohttp,
             'async': async,
             'azure': azure,
             'celery': celery,


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1822


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
   Add aitohttp and gthread workerclass option to webserver cli as gunicorn min version is now 19.4.0
 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 couldn't find any unit test related to this part.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

