### PR TITLE
[AIRFLOW-1061] Remove BASE_URL from log_url and mark_success_url

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1141,9 +1141,8 @@ class TaskInstance(Base, LoggingMixin):
     @property
     def log_url(self):
         iso = quote(self.execution_date.isoformat())
-        BASE_URL = configuration.conf.get('webserver', 'BASE_URL')
         if settings.RBAC:
-            return BASE_URL + (
+            return (
                 "/log?"
                 "execution_date={iso}"
                 "&task_id={self.task_id}"
@@ -1160,9 +1159,8 @@ class TaskInstance(Base, LoggingMixin):
     @property
     def mark_success_url(self):
         iso = quote(self.execution_date.isoformat())
-        BASE_URL = configuration.conf.get('webserver', 'BASE_URL')
         if settings.RBAC:
-            return BASE_URL + (
+            return (
                 "/success"
                 "?task_id={self.task_id}"
                 "&dag_id={self.dag_id}"


### PR DESCRIPTION

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1061) issues and references them in the PR title. For example, "[AIRFLOW-1601] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1061


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
When the server is started with a port which is not 8080 the log visualizer lik still refers to that and the link doesn't work.
With this change the link in the DAG list uses relative paths and have the browser bring to the actual page.


### Tests
- [x] My PR passes the already existing tests and works in the browser


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

