### PR TITLE
[AIRFLOW-1831] Add driver-classpath spark submit

### DIFF
--- a/airflow/contrib/hooks/spark_submit_hook.py
+++ b/airflow/contrib/hooks/spark_submit_hook.py
@@ -36,6 +36,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     :type files: str
     :param py_files: Additional python files used by the job, can be .zip, .egg or .py.
     :type py_files: str
+    :param driver_classpath: Additional, driver-specific, classpath settings.
+    :type driver_classpath: str
     :param jars: Submit additional jars to upload and place them in executor classpath.
     :type jars: str
     :param java_class: the main class of the Java application
@@ -72,6 +74,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                  conn_id='spark_default',
                  files=None,
                  py_files=None,
+                 driver_classpath=None,
                  jars=None,
                  java_class=None,
                  packages=None,
@@ -91,6 +94,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         self._conn_id = conn_id
         self._files = files
         self._py_files = py_files
+        self._driver_classpath = driver_classpath
         self._jars = jars
         self._java_class = java_class
         self._packages = packages
@@ -170,6 +174,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             connection_cmd += ["--files", self._files]
         if self._py_files:
             connection_cmd += ["--py-files", self._py_files]
+        if self._driver_classpath:
+            connection_cmd += ["--driver-classpath", self._driver_classpath]
         if self._jars:
             connection_cmd += ["--jars", self._jars]
         if self._packages:

--- a/airflow/contrib/operators/spark_submit_operator.py
+++ b/airflow/contrib/operators/spark_submit_operator.py
@@ -37,6 +37,8 @@ class SparkSubmitOperator(BaseOperator):
     :param py_files: Additional python files used by the job, can be .zip, .egg or .py.
     :type py_files: str
     :param jars: Submit additional jars to upload and place them in executor classpath.
+    :param driver_classpath: Additional, driver-specific, classpath settings.
+    :type driver_classpath: str
     :type jars: str
     :param java_class: the main class of the Java application
     :type java_class: str
@@ -77,6 +79,7 @@ class SparkSubmitOperator(BaseOperator):
                  conn_id='spark_default',
                  files=None,
                  py_files=None,
+                 driver_classpath=None,
                  jars=None,
                  java_class=None,
                  packages=None,
@@ -99,6 +102,7 @@ class SparkSubmitOperator(BaseOperator):
         self._conf = conf
         self._files = files
         self._py_files = py_files
+        self._driver_classpath = driver_classpath
         self._jars = jars
         self._java_class = java_class
         self._packages = packages
@@ -126,6 +130,7 @@ class SparkSubmitOperator(BaseOperator):
             conn_id=self._conn_id,
             files=self._files,
             py_files=self._py_files,
+            driver_classpath=self._driver_classpath,
             jars=self._jars,
             java_class=self._java_class,
             packages=self._packages,

--- a/tests/contrib/operators/test_spark_submit_operator.py
+++ b/tests/contrib/operators/test_spark_submit_operator.py
@@ -33,6 +33,7 @@ class TestSparkSubmitOperator(unittest.TestCase):
         },
         'files': 'hive-site.xml',
         'py_files': 'sample_library.py',
+        'driver_classpath': 'parquet.jar',
         'jars': 'parquet.jar',
         'packages': 'com.databricks:spark-avro_2.11:3.2.0',
         'exclude_packages': 'org.bad.dependency:1.0.0',
@@ -86,6 +87,7 @@ class TestSparkSubmitOperator(unittest.TestCase):
             },
             'files': 'hive-site.xml',
             'py_files': 'sample_library.py',
+            'driver_classpath': 'parquet.jar',
             'jars': 'parquet.jar',
             'packages': 'com.databricks:spark-avro_2.11:3.2.0',
             'exclude_packages': 'org.bad.dependency:1.0.0',
@@ -116,6 +118,7 @@ class TestSparkSubmitOperator(unittest.TestCase):
         self.assertEqual(expected_dict['conf'], operator._conf)
         self.assertEqual(expected_dict['files'], operator._files)
         self.assertEqual(expected_dict['py_files'], operator._py_files)
+        self.assertEqual(expected_dict['driver_classpath'], operator._driver_classpath)
         self.assertEqual(expected_dict['jars'], operator._jars)
         self.assertEqual(expected_dict['packages'], operator._packages)
         self.assertEqual(expected_dict['exclude_packages'], operator._exclude_packages)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [AIRFLOW-1831](https://issues.apache.org/jira/browse/AIRFLOW-1831)


### Description
- [ ] Add the ability to set the driver-classpath for the spark_submit
operator and hook.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Update the existing tests to include driver-classpath


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

