### PR TITLE
[AIRFLOW-1229] UI improvement: Make column 'Run id' clickable and jump to DAG 'graph' with execution_date

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -103,7 +103,8 @@ def dag_link(v, c, m, p):
     dag_id = bleach.clean(m.dag_id)
     url = url_for(
         'airflow.graph',
-        dag_id=dag_id)
+        dag_id=dag_id,
+        execution_date=m.execution_date)
     return Markup(
         '<a href="{}">{}</a>'.format(url, dag_id))
 
@@ -113,6 +114,16 @@ def log_url_formatter(v, c, m, p):
         '<a href="{m.log_url}">'
         '    <span class="glyphicon glyphicon-book" aria-hidden="true">'
         '</span></a>').format(**locals())
+
+
+def dag_run_link(v, c, m, p):
+    dag_id = bleach.clean(m.dag_id)
+    url = url_for(
+        'airflow.graph',
+        dag_id=m.dag_id,
+        run_id=m.run_id,
+        execution_date=m.execution_date)
+    return Markup('<a href="{url}">{m.run_id}</a>'.format(**locals()))
 
 
 def task_instance_link(v, c, m, p):
@@ -2380,7 +2391,9 @@ class DagRunModelView(ModelViewOnly):
         execution_date=datetime_f,
         state=state_f,
         start_date=datetime_f,
-        dag_id=dag_link)
+        dag_id=dag_link,
+        run_id=dag_run_link
+    )
 
     @action('new_delete', "Delete", "Are you sure you want to delete selected records?")
     @provide_session
@@ -2459,7 +2472,9 @@ class TaskInstanceModelView(ModelViewOnly):
         start_date=datetime_f,
         end_date=datetime_f,
         queued_dttm=datetime_f,
-        dag_id=dag_link, duration=duration_f)
+        dag_id=dag_link,
+        run_id=dag_run_link,
+        duration=duration_f)
     column_searchable_list = ('dag_id', 'task_id', 'state')
     column_default_sort = ('job_id', True)
     form_choices = {


### PR DESCRIPTION
Dear Airflow maintainers,

I wanted to be able to click trough from DAG-runs to the Dag instance (graph) corresponding to the execution_date of the run. Click on a DAG failed run jump directly to the Graph, its great.
 
When I finished my change I found a related/existing issue in JIRA from Erik Cederstrand.
https://issues.apache.org/jira/browse/AIRFLOW-1229

So in addition to the execution_date in the URL when clicking a DAG it also includes a new link for the Run-id's.

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
![image](https://user-images.githubusercontent.com/1022013/33041015-31576018-ce3d-11e7-8875-aa31d99cad06.png)

![image](https://user-images.githubusercontent.com/1022013/33041022-378ba91c-ce3d-11e7-89ae-56063a3475bb.png)


### Tests
- [x] My PR does not need testing for this extremely good reason:
Simple UI addition, Flask url_for(...) filters empty parameters


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

