### PR TITLE
[AIRFLOW-1841] change False to None in gcs operator and hook

### DIFF
--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -85,7 +85,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
 
 
     # pylint:disable=redefined-builtin
-    def download(self, bucket, object, filename=False):
+    def download(self, bucket, object, filename=None):
         """
         Get a file from Google Cloud Storage.
 

--- a/airflow/contrib/operators/gcs_download_operator.py
+++ b/airflow/contrib/operators/gcs_download_operator.py
@@ -30,12 +30,12 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
     :type object: string
     :param filename: The file path on the local file system (where the
         operator is being executed) that the file should be downloaded to.
-        If false, the downloaded data will not be stored on the local file
+        If no filename passed, the downloaded data will not be stored on the local file
         system.
     :type filename: string
     :param store_to_xcom_key: If this param is set, the operator will push
         the contents of the downloaded file to XCom with the key set in this
-        parameter. If false, the downloaded data will not be pushed to XCom.
+        parameter. If not set, the downloaded data will not be pushed to XCom.
     :type store_to_xcom_key: string
     :param google_cloud_storage_conn_id: The connection ID to use when
         connecting to Google cloud storage.
@@ -51,8 +51,8 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
     def __init__(self,
                  bucket,
                  object,
-                 filename=False,
-                 store_to_xcom_key=False,
+                 filename=None,
+                 store_to_xcom_key=None,
                  google_cloud_storage_conn_id='google_cloud_storage_default',
                  delegate_to=None,
                  *args,


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [AIRFLOW-1841](https://issues.apache.org/jira/browse/AIRFLOW-1841) issues and references them in the PR title


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In GoogleCloudStorageDownloadOperator and GoogleCloudStorageHook "filename" and "store_to_xcom_key" parameter are complex types in code but documentation stated it's String type but in the code it is union of String and Bool. I changed it to simple String by substituting False to None since in the operator and the hook, code checks only for presence of value in a variable.
Make it more predictable by using simpler String type rather than Union of String and Bool.


### Tests
- [x] My PR does not need testing for this extremely good reason:
It doesn't add new fuctionality.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

