### PR TITLE
[AIRFLOW-1842] Add gcs to gcs copy operator with renaming if required

### DIFF
--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
+    """
+    Copies an object from a bucket to another, with renaming if requested.
+
+    :param source_bucket: The source Google cloud storage bucket where the object is.
+    :type source_bucket: string
+    :param source_object: The source name of the object to copy in the Google cloud
+        storage bucket.
+    :type source_object: string
+    :param destination_bucket: The destination Google cloud storage bucket where the object should be.
+    :type destination_bucket: string
+    :param destination_object: The destination name of the object in the destination Google cloud
+        storage bucket.
+    :type destination_object: string
+    :param google_cloud_storage_conn_id: The connection ID to use when
+        connecting to Google cloud storage.
+    :type google_cloud_storage_conn_id: string
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have domain-wide delegation enabled.
+    :type delegate_to: string
+    """
+    template_fields = ('source_bucket', 'source_object', 'destination_bucket', 'destination_object',)
+    ui_color = '#f0eee4'
+
+    @apply_defaults
+    def __init__(self,
+                 source_bucket,
+                 source_object,
+                 destination_bucket=None,
+                 destination_object=None,
+                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 delegate_to=None,
+                 *args,
+                 **kwargs):
+        super(GoogleCloudStorageOperatorToGoogleCloudStorageOperator, self).__init__(*args, **kwargs)
+        self.source_bucket = source_bucket
+        self.source_object = source_object
+        self.destination_bucket = destination_bucket
+        self.destination_object = destination_object
+        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.delegate_to = delegate_to
+
+    def execute(self, context):
+        self.log.info('Executing copy: %s, %s, %s, %s', self.source_bucket, self.source_object,
+                      self.destination_bucket or self.source_bucket,
+                      self.destination_object or self.source_object)
+        hook = GoogleCloudStorageHook(google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+                                      delegate_to=self.delegate_to)
+        hook.copy(self.source_bucket, self.source_object, self.destination_bucket, self.destination_object)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1842


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
New GoogleCloudStorageToGoogleCloudStorageOperator operator copies an object from a Google Cloud Storage bucket to another Google Cloud Storage bucket, with renaming if required.

### Tests
- [x] My PR does not need testing for this extremely good reason:
Google doesn't provide local stubs for testing google cloud storage api

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

