### PR TITLE
[AIRFLOW-1844] task would not be executed when celery broker recovery

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -120,8 +120,8 @@ class BaseExecutor(LoggingMixin):
             self.queued_tasks.pop(key)
             ti.refresh_from_db()
             if ti.state != State.RUNNING:
-                self.running[key] = command
                 self.execute_async(key, command=command, queue=queue)
+                self.running[key] = command
             else:
                 self.log.debug(
                     'Task is already running, not sending to executor: %s',


### PR DESCRIPTION
After “execute_async” succeed and no exception, then add the task into “running” queue.
When the  celery broker is not working , the function “execute_async” will throw exception and will try again until broker recovery .

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1844


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
When the scheduler fail to send task during celery broker not working , then the task will never send again and never be executed when celery broker recovery.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

