### PR TITLE
[AIRFLOW-1842] Fixed Super class name for the gcs to gcs copy operator

### DIFF
--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -51,7 +51,7 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
                  delegate_to=None,
                  *args,
                  **kwargs):
-        super(GoogleCloudStorageOperatorToGoogleCloudStorageOperator, self).__init__(*args, **kwargs)
+        super(GoogleCloudStorageToGoogleCloudStorageOperator, self).__init__(*args, **kwargs)
         self.source_bucket = source_bucket
         self.source_object = source_object
         self.destination_bucket = destination_bucket


### PR DESCRIPTION
Fixed incorrect Super class name in gcs to gcs copy operator from `GoogleCloudStorageOperatorToGoogleCloudStorageOperator` to `GoogleCloudStorageToGoogleCloudStorageOperator`.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1842


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Renamed the super class from `GoogleCloudStorageOperatorToGoogleCloudStorageOperator` to `GoogleCloudStorageToGoogleCloudStorageOperator`.

This fixes the error 
```
NameError: global name 'GoogleCloudStorageOperatorToGoogleCloudStorageOperator' is not defined
```

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

The change is minor change of already Pulled commit [Link](https://github.com/apache/incubator-airflow/pull/2808/) Hence, no more tests are required.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

