### PR TITLE
[AIRFLOW-1845] Modal background now covers long or tall pages

### DIFF
--- a/airflow/www/static/main.css
+++ b/airflow/www/static/main.css
@@ -26,6 +26,7 @@ a.navbar-brand span {
 }
 .modal-backdrop{
     z-index: 0;
+    position: fixed;
 }
 .modal-content{
     z-index: 5;


### PR DESCRIPTION
If the page was scrolled before the dialog was displayed then the grey
background would not cover the whole page correctly.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1845


### Description
- [x] 

  **Before**
  <img width="1777" alt="screen shot 2017-11-24 at 12 19 50" src="https://user-images.githubusercontent.com/34150/33210592-cc9ff18e-d112-11e7-9291-4a6b30da873f.png">

  **After**
  <img width="1777" alt="screen shot 2017-11-24 at 12 20 04" src="https://user-images.githubusercontent.com/34150/33210600-d3e7cd86-d112-11e7-81c0-d6094e73f755.png">


### Tests
- [x] No tests -- UI only CSS change.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

