### PR TITLE
[AIRFLOW-1848] Fix DataFlowPythonOperator py_file extension doc comment

### DIFF
--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -155,8 +155,8 @@ class DataFlowPythonOperator(BaseOperator):
 
         https://cloud.google.com/dataflow/pipelines/specifying-exec-params
 
-        :param py_file: Reference to the python dataflow pipleline file, e.g.,
-            /some/local/file/path/to/your/python/pipeline/file.py.
+        :param py_file: Reference to the python dataflow pipleline file.py, e.g.,
+            /some/local/file/path/to/your/python/pipeline/file.
         :type py_file: string
         :param py_options: Additional python options.
         :type pyt_options: list of strings, e.g., ["-m", "-v"].


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [X] My PR addresses the following [Airflow-1848](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1848


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
Dataflow Python operator takes in a filename without `.py` extension, which was incorrectly documented previously.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
N/A, just a doc change.


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

