### PR TITLE
[AIRFLOW-1850] Copy cmd before masking

### DIFF
--- a/airflow/contrib/hooks/sqoop_hook.py
+++ b/airflow/contrib/hooks/sqoop_hook.py
@@ -21,6 +21,7 @@ import subprocess
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin
+from copy import deepcopy
 
 
 class SqoopHook(BaseHook, LoggingMixin):
@@ -70,7 +71,8 @@ class SqoopHook(BaseHook, LoggingMixin):
     def get_conn(self):
         return self.conn
 
-    def cmd_mask_password(self, cmd):
+    def cmd_mask_password(self, cmd_orig):
+        cmd = deepcopy(cmd_orig)
         try:
             password_index = cmd.index('--password')
             cmd[password_index + 1] = 'MASKED'


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

The cmd is first copied before the password is masked. This ensures
that the orignal cmd isn't changed. Replacing the password with a
masked value replaces the password in the original command since it
is passed by reference.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-1850] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1850


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

