### PR TITLE
[AIRFLOW-964] Allow Airflow to live in a subpath

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -168,6 +168,10 @@ default_gpus = 0
 # airflow sends to point links to the right web server
 base_url = http://localhost:8080
 
+# The path where airflow is configured to live, in case you are not
+# alone on the domain
+root_path =
+
 # The ip specified when starting the web server
 web_server_host = 0.0.0.0
 

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -34,7 +34,9 @@ from airflow import configuration
 
 
 def create_app(config=None, testing=False):
-    app = Flask(__name__)
+    root_path = configuration.get('webserver', 'ROOT_PATH')
+
+    app = Flask(__name__, static_url_path=root_path+'/static')
     app.secret_key = configuration.get('webserver', 'SECRET_KEY')
     app.config['LOGIN_DISABLED'] = not configuration.getboolean('webserver', 'AUTHENTICATE')
 
@@ -52,7 +54,7 @@ def create_app(config=None, testing=False):
     cache = Cache(
         app=app, config={'CACHE_TYPE': 'filesystem', 'CACHE_DIR': '/tmp'})
 
-    app.register_blueprint(routes)
+    app.register_blueprint(routes, url_prefix=root_path)
 
     configure_logging()
 
@@ -61,8 +63,8 @@ def create_app(config=None, testing=False):
 
         admin = Admin(
             app, name='Airflow',
-            static_url_path='/admin',
-            index_view=views.HomeView(endpoint='', url='/admin', name="DAGs"),
+            static_url_path=root_path + '/admin',
+            index_view=views.HomeView(endpoint='', url=root_path + '/admin', name="DAGs"),
             template_mode='bootstrap3',
         )
         av = admin.add_view
@@ -80,8 +82,8 @@ def create_app(config=None, testing=False):
         av(vs.SlaMissModelView(
             models.SlaMiss,
             Session, name="SLA Misses", category="Browse"))
-        av(vs.TaskInstanceModelView(models.TaskInstance,
-            Session, name="Task Instances", category="Browse"))
+        av(vs.TaskInstanceModelView(
+            models.TaskInstance, Session, name="Task Instances", category="Browse"))
         av(vs.LogModelView(
             models.Log, Session, name="Logs", category="Browse"))
         av(vs.JobModelView(
@@ -141,7 +143,7 @@ def create_app(config=None, testing=False):
                 import importlib
                 importlib.reload(e)
 
-        app.register_blueprint(e.api_experimental, url_prefix='/api/experimental')
+        app.register_blueprint(e.api_experimental, url_prefix=root_path + '/api/experimental')
 
         @app.context_processor
         def jinja_globals():
@@ -154,6 +156,7 @@ def create_app(config=None, testing=False):
             settings.Session.remove()
 
         return app
+
 
 app = None
 

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -224,7 +224,7 @@
   <script src="{{ url_for('static', filename='bootstrap3-typeahead.min.js') }}"></script>
   <script>
 
-      const DAGS_INDEX = {{ url_for('admin.index') }}
+      const DAGS_INDEX = '{{ url_for('admin.index') }}'
       const ENTER_KEY_CODE = 13
 
       $('#dag_query').on('keypress', function (e) {


### PR DESCRIPTION
This commit allows Airflow to live in a subpath
under the domain. This is useful in case the application
is served by a proxy (e.g https://tools.example.com/airflow).

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-964


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
It adds a new configuration option to set the root path where the application lives. As stated 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

