### PR TITLE
[AIRFLOW-1855] Add Google Cloud Storage Copy Operator to copy multiple files with a delimiter

### DIFF
--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -38,7 +38,6 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         http_authorized = self._authorize()
         return build('storage', 'v1', http=http_authorized)
 
-
     # pylint:disable=redefined-builtin
     def copy(self, source_bucket, source_object, destination_bucket=None,
              destination_object=None):
@@ -48,10 +47,10 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         destination_bucket or destination_object can be omitted, in which case
         source bucket/object is used, but not both.
 
-        :param bucket: The bucket of the object to copy from.
-        :type bucket: string
-        :param object: The object to copy.
-        :type object: string
+        :param source_bucket: The bucket of the object to copy from.
+        :type source_bucket: string
+        :param source_object: The object to copy.
+        :type source_object: string
         :param destination_bucket: The destination of the object to copied to.
             Can be omitted; then the same bucket is used.
         :type destination_bucket: string

--- a/airflow/contrib/operators/gcs_copy_operator.py
+++ b/airflow/contrib/operators/gcs_copy_operator.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class GoogleCloudStorageCopyOperator(BaseOperator):
+    """
+    Copies objects (optionally from a directory) filtered by 'delimiter' (file extension for e.g .json) from a bucket
+    to another bucket in a different directory, if required.
+
+    :param source_bucket: The source Google cloud storage bucket where the object is.
+    :type source_bucket: string
+    :param source_object: The source name of the object to copy in the Google cloud
+        storage bucket.
+    :type source_object: string
+    :param source_files_delimiter: The delimiter by which you want to filter the files to copy.
+        For e.g to copy the CSV files from in a directory in GCS you would use source_files_delimiter='.csv'.
+    :type source_files_delimiter: string
+    :param destination_bucket: The destination Google cloud storage bucket where the object should be.
+    :type destination_bucket: string
+    :param destination_directory: The destination name of the directory in the destination Google cloud
+        storage bucket.
+    :type destination_directory: string
+    :param google_cloud_storage_conn_id: The connection ID to use when
+        connecting to Google cloud storage.
+    :type google_cloud_storage_conn_id: string
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have domain-wide delegation enabled.
+    :type delegate_to: string
+
+    Example: The following Operator would move all the CSV files from `sales/sales-2017` folder in `data` bucket to
+    `sales` folder in `archive` bucket.
+
+    move_file = GoogleCloudStorageCopyOperator(
+        task_id='move_file',
+        source_bucket='data',
+        source_object='sales/sales-2017/',
+        source_files_delimiter='.csv'
+        destination_bucket='archive',
+        destination_directory='sales',
+        google_cloud_storage_conn_id='airflow-service-account'
+    )
+    """
+    template_fields = ('source_bucket', 'source_object', 'source_files_delimiter',
+                       'destination_bucket', 'destination_directory')
+    ui_color = '#f0eee4'
+
+    @apply_defaults
+    def __init__(self,
+                 source_bucket,
+                 source_object,
+                 source_files_delimiter=None,
+                 destination_bucket=None,
+                 destination_directory='',
+                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 delegate_to=None,
+                 *args,
+                 **kwargs):
+        super(GoogleCloudStorageCopyOperator, self).__init__(*args, **kwargs)
+        self.source_bucket = source_bucket
+        self.source_object = source_object
+        self.source_files_delimiter = source_files_delimiter
+        self.files_to_copy = list()
+        self.destination_bucket = destination_bucket
+        self.destination_directory = destination_directory
+        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.delegate_to = delegate_to
+
+    def execute(self, context):
+
+        self.log.info('Executing copy - Source_Bucket: %s, Source_directory: %s, '
+                      'Destination_bucket: %s, Destination_directory: %s',
+                      self.source_bucket, self.source_object,
+                      self.destination_bucket or self.source_bucket,
+                      self.destination_directory or self.source_object)
+
+        hook = GoogleCloudStorageHook(google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+                                      delegate_to=self.delegate_to)
+
+        self.log.info('Getting list of the files to copy. Source Bucket: %s; Source Object: %s',
+                      self.source_bucket, self.source_object)
+
+        # Create a list of objects to copy from Source bucket. The function uses prefix keyword to pass the name of
+        # the object to copy.
+        self.files_to_copy = hook.list(bucket=self.source_bucket, prefix=self.source_object,
+                                       delimiter=self.source_files_delimiter)
+
+        # Log the names of all objects to be copied
+        self.log.info('Files to copy: %s', self.files_to_copy)
+
+        if self.files_to_copy is not None:
+            for file_to_copy in self.files_to_copy:
+                self.log.info('Source_Bucket: %s, Source_Object: %s, '
+                              'Destination_bucket: %s, Destination_Directory: %s',
+                              self.source_bucket, file_to_copy,
+                              self.destination_bucket or self.source_bucket,
+                              self.destination_directory + file_to_copy)
+                hook.copy(self.source_bucket, file_to_copy,
+                          self.destination_bucket, self.destination_directory + file_to_copy)
+        else:
+            self.log.info('No Files to copy.')


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1855


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

    1. Added 'delimiter' argument in GCS hook to filter files with a particular delimiter.
    2. Added a GCS operator that copies objects (optionally from a directory) filtered by 'delimiter' (file extension for e.g .json or .csv) from a bucket to another bucket in a different directory, if required.
    The feature in Airflow currently to Copy GCS objects is `GoogleCloudStorageToGoogleCloudStorageOperator` in `gcs_to_gcs.py` that can only copy a single object and cannot filter files based on delimiter or extension. Most users would want to copy multiple files with some extension to a different directory (possibly in different bucket).


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Google doesn't provide local unittest for GCS.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

