### PR TITLE
[AIRFLOW-1554] Fix wrong DagFileProcessor termination method call

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -430,7 +430,7 @@ class DagFileProcessorManager(LoggingMixin):
                 filtered_processors[file_path] = processor
             else:
                 self.log.warning("Stopping processor for %s", file_path)
-                processor.stop()
+                processor.terminate()
         self._processors = filtered_processors
 
     def processing_count(self):

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from mock import MagicMock
+
+from airflow.utils.dag_processing import DagFileProcessorManager
+
+
+class TestDagFileProcessorManager(unittest.TestCase):
+    def test_set_file_paths_when_processor_file_path_not_in_new_file_paths(self):
+        manager = DagFileProcessorManager(dag_directory='directory', file_paths=['abc.txt'],
+                                          parallelism=1, process_file_interval=1,
+                                          max_runs=1, processor_factory=MagicMock().return_value)
+
+        mock_processor = MagicMock()
+        mock_processor.stop.side_effect = AttributeError(
+            'DagFileProcessor object has no attribute stop')
+        mock_processor.terminate.side_effect = None
+
+        manager._processors['missing_file.txt'] = mock_processor
+
+        manager.set_file_paths(['abc.txt'])
+        self.assertDictEqual(manager._processors, {})
+
+    def test_set_file_paths_when_processor_file_path_is_in_new_file_paths(self):
+        manager = DagFileProcessorManager(dag_directory='directory', file_paths=['abc.txt'],
+                                          parallelism=1, process_file_interval=1,
+                                          max_runs=1, processor_factory=MagicMock().return_value)
+
+        mock_processor = MagicMock()
+        mock_processor.stop.side_effect = AttributeError(
+            'DagFileProcessor object has no attribute stop')
+        mock_processor.terminate.side_effect = None
+
+        manager._processors['abc.txt'] = mock_processor
+
+        manager.set_file_paths(['abc.txt'])
+        self.assertDictEqual(manager._processors, {'abc.txt': mock_processor})


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
    - https://issues.apache.org/jira/browse/AIRFLOW-1554


### Description
- [x] Copy of https://github.com/apache/incubator-airflow/pull/2656 with removed unrelated changes and tefferance to jira issue on commit message.

>The DagFileProcessorManager.set_file_paths() function was incorrectly calling processor.stop() instead of processor.terminate(). This would cause an AttributeError to be thrown and the scheduler to hang, not processing any future DAGs.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

