### PR TITLE
[AIRFLOW-1117] Change default min_file_process_interval

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -327,7 +327,7 @@ scheduler_heartbeat_sec = 5
 run_duration = -1
 
 # after how much time a new DAGs should be picked up from the filesystem
-min_file_process_interval = 0
+min_file_process_interval = 6
 
 dag_dir_list_interval = 300
 


### PR DESCRIPTION
The default min_file_process_interval=0 causes inordinately high CPU
consumption on small DAG sets.

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1117


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
    - min_file_process_interval=0 causes the scheduler to rapidly loop over DAGs and consume inordinate processor time. Setting the default to 6 seconds slows the looping and avoids aligning with heartbeats. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
     - This config change should not affect test coverage.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

