### PR TITLE
[AIRFLOW-342] Do not use amqp, rpc as result backend

### DIFF
--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -18,6 +18,7 @@ from airflow.exceptions import AirflowConfigException, AirflowException
 from airflow import configuration
 from airflow.utils.log.logging_mixin import LoggingMixin
 
+log = LoggingMixin().log
 
 DEFAULT_CELERY_CONFIG = {
     'accept_content': ['json', 'pickle'],
@@ -37,7 +38,6 @@ celery_ssl_active = False
 try:
     celery_ssl_active = configuration.getboolean('celery', 'CELERY_SSL_ACTIVE')
 except AirflowConfigException as e:
-    log = LoggingMixin().log
     log.warning("Celery Executor will run without SSL")
 
 try:
@@ -56,3 +56,7 @@ except Exception as e:
                            'Please ensure you want to use '
                            'SSL and/or have all necessary certs and key ({}).'.format(e))
 
+result_backend = DEFAULT_CELERY_CONFIG['result_backend']
+if 'amqp' in result_backend or 'redis' in result_backend or 'rpc' in result_backend:
+    log.warning("You have configured a result_backend of %s, it is highly recommended "
+                "to use an alternative result_backend (i.e. a database).", result_backend)


### PR DESCRIPTION

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-342

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

amqp and rpc (and redis most likely) cannot store results for tasks
long enough. This shows a warning when those result backend have been configured.


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

