### PR TITLE
[AIRFLOW-1872] Set context for all handlers including parents

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -54,7 +54,8 @@ from airflow.models import (DagModel, DagBag, TaskInstance,
 
 from airflow.ti_deps.dep_context import (DepContext, SCHEDULER_DEPS)
 from airflow.utils import db as db_utils
-from airflow.utils.log.logging_mixin import LoggingMixin, redirect_stderr, redirect_stdout
+from airflow.utils.log.logging_mixin import (LoggingMixin, redirect_stderr,
+                                             redirect_stdout, set_context)
 from airflow.www.app import cached_app
 
 from sqlalchemy import func
@@ -367,13 +368,7 @@ def run(args, dag=None):
     if args.raw:
         log = logging.getLogger('airflow.task.raw')
 
-    for handler in log.handlers:
-        try:
-            handler.set_context(ti)
-        except AttributeError:
-            # Not all handlers need to have context passed in so we ignore
-            # the error when handlers do not have set_context defined.
-            pass
+    set_context(log, ti)
 
     hostname = socket.getfqdn()
     log.info("Running on host %s", hostname)

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -57,7 +57,7 @@ from airflow.utils.dag_processing import (AbstractDagFileProcessor,
 from airflow.utils.db import (
     create_session, provide_session, pessimistic_connection_handling)
 from airflow.utils.email import send_email
-from airflow.utils.log.logging_mixin import LoggingMixin, StreamLogWriter
+from airflow.utils.log.logging_mixin import LoggingMixin, set_context, StreamLogWriter
 from airflow.utils.state import State
 
 Base = models.Base
@@ -345,13 +345,7 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
             stdout = StreamLogWriter(log, logging.INFO)
             stderr = StreamLogWriter(log, logging.WARN)
 
-            for handler in log.handlers:
-                try:
-                    handler.set_context(file_path)
-                except AttributeError:
-                    # Not all handlers need to have context passed in so we ignore
-                    # the error when handlers do not have set_context defined.
-                    pass
+            set_context(log, file_path)
 
             try:
                 # redirect stdout/stderr to log

--- a/airflow/task_runner/base_task_runner.py
+++ b/airflow/task_runner/base_task_runner.py
@@ -38,8 +38,8 @@ class BaseTaskRunner(LoggingMixin):
         :type local_task_job: airflow.jobs.LocalTaskJob
         """
         # Pass task instance context into log handlers to setup the logger.
+        super(BaseTaskRunner, self).__init__(local_task_job.task_instance)
         self._task_instance = local_task_job.task_instance
-        self.set_log_contexts(self._task_instance)
 
         popen_prepend = []
         cfg_path = None

--- a/tests/utils/test_logging_mixin.py
+++ b/tests/utils/test_logging_mixin.py
@@ -17,7 +17,7 @@ import unittest
 import warnings
 
 from airflow.operators.bash_operator import BashOperator
-from airflow.utils.log.logging_mixin import StreamLogWriter
+from airflow.utils.log.logging_mixin import set_context, StreamLogWriter
 from tests.test_utils.reset_warning_registry import reset_warning_registry
 
 
@@ -47,6 +47,23 @@ class TestLoggingMixin(unittest.TestCase):
                     ' using logger(), which will be replaced by .log in Airflow 2.0',
                     str(warning.message)
                 )
+
+    def test_set_context(self):
+        handler1 = mock.MagicMock()
+        handler2 = mock.MagicMock()
+        parent = mock.MagicMock()
+        parent.propagate = False
+        parent.handlers = [handler1, ]
+        log = mock.MagicMock()
+        log.handlers = [handler2, ]
+        log.parent = parent
+        log.propagate = True
+
+        value = "test"
+        set_context(log, value)
+
+        handler1.set_context.assert_called_with(value)
+        handler2.set_context.assert_called_with(value)
 
     def tearDown(self):
         warnings.resetwarnings()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1872



### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

Previously setting the context was not propagated to the parent
loggers.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Will add

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

cc @jgao54 @ashb please take a look