### PR TITLE
[AIRFLOW-1436, 1475] EmrJobFlowSensor consideres Cancelled step as Successful

### DIFF
--- a/airflow/contrib/sensors/emr_base_sensor.py
+++ b/airflow/contrib/sensors/emr_base_sensor.py
@@ -45,7 +45,7 @@ class EmrBaseSensor(BaseSensorOperator):
         if state in self.NON_TERMINAL_STATES:
             return False
 
-        if state == self.FAILED_STATE:
+        if state in self.FAILED_STATE:
             raise AirflowException('EMR job failed')
 
         return True

--- a/airflow/contrib/sensors/emr_job_flow_sensor.py
+++ b/airflow/contrib/sensors/emr_job_flow_sensor.py
@@ -26,7 +26,7 @@ class EmrJobFlowSensor(EmrBaseSensor):
     """
 
     NON_TERMINAL_STATES = ['STARTING', 'BOOTSTRAPPING', 'RUNNING', 'WAITING', 'TERMINATING']
-    FAILED_STATE = 'TERMINATED_WITH_ERRORS'
+    FAILED_STATE = ['TERMINATED_WITH_ERRORS']
     template_fields = ['job_flow_id']
     template_ext = ()
 

--- a/airflow/contrib/sensors/emr_step_sensor.py
+++ b/airflow/contrib/sensors/emr_step_sensor.py
@@ -21,14 +21,14 @@ class EmrStepSensor(EmrBaseSensor):
     Asks for the state of the step until it reaches a terminal state.
     If it fails the sensor errors, failing the task.
 
-    :param job_flow_id: job_flow_idwhich contains the step check the state of
+    :param job_flow_id: job_flow_id which contains the step check the state of
     :type job_flow_id: string
     :param step_id: step to check the state of
     :type step_id: string
     """
 
     NON_TERMINAL_STATES = ['PENDING', 'RUNNING', 'CONTINUE']
-    FAILED_STATE = 'FAILED'
+    FAILED_STATE = ['CANCELLED', 'FAILED']
     template_fields = ['job_flow_id', 'step_id']
     template_ext = ()
 


### PR DESCRIPTION
Change EmrBaseSensor NON_TERMINAL_STATES and FAILED_STATE to list
EmrJobFlowSensor consideres Cancelled step as Successful

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1436
    - https://issues.apache.org/jira/browse/AIRFLOW-1475


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
