### PR TITLE
[AIRFLOW-1878] Fix stderr/stdout redirection for tasks

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -367,7 +367,7 @@ def run(args, dag=None):
     hostname = socket.getfqdn()
     log.info("Running %s on host %s", ti, hostname)
 
-    with redirect_stdout(log, logging.INFO), redirect_stderr(log, logging.WARN):
+    with redirect_stdout(ti.log, logging.INFO), redirect_stderr(ti.log, logging.WARN):
         if args.local:
             run_job = jobs.LocalTaskJob(
                 task_instance=ti,

--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -43,9 +43,9 @@ DEFAULT_LOGGING_CONFIG = {
     },
     'handlers': {
         'console': {
-            'class': 'logging.StreamHandler',
+            'class': 'airflow.utils.log.logging_mixin.RedirectStdHandler',
             'formatter': 'airflow.task',
-            'stream': 'ext://sys.stdout'
+            'stream': 'sys.stdout'
         },
         'file.task': {
             'class': 'airflow.utils.log.file_task_handler.FileTaskHandler',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1878


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

logging.StreamHandler keeps a reference to the initial stream
it has been assigned. This prevent redirection after initalization
to a logging facility.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Will add

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

cc: @Fokko @ashb @jgao54 