### PR TITLE
[AIRFLOW-1883] Get File Size for objects in Google Cloud Storage

### DIFF
--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -279,7 +279,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
             storage bucket.
         :type object: string
         """
-        self.log.info('Checking the file size of %s', object)
+        self.log.info('Checking the file size of object: %s in bucket: %s', object, bucket)
         service = self.get_conn()
         try:
             response = service.objects().get(

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -269,3 +269,32 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                 # empty next page token
                 break
         return ids
+
+    def get_size(self, bucket, object):
+        """
+        Gets the size of a file in Google Cloud Storage.
+        :param bucket: The Google cloud storage bucket where the object is.
+        :type bucket: string
+        :param object: The name of the object to check in the Google cloud
+            storage bucket.
+        :type object: string
+        """
+        service = self.get_conn()
+        try:
+            response = service.objects().get(
+                bucket=bucket,
+                object=object
+            ).execute()
+
+            if 'name' in response and response['name'][-1] != '/':
+                # Remove Directories & Just check size of files
+                if 'size' in response:
+                    size = response['size']
+                    self.log.info('Checking the file size of %s', object)
+                    self.log.info('The file size of %s is %s', object, size)
+                    return size
+            else:
+                raise ValueError('Object is not a file')
+        except errors.HttpError as ex:
+            if ex.resp['status'] == '404':
+                raise ValueError('Object Not Found')

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -279,6 +279,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
             storage bucket.
         :type object: string
         """
+        self.log.info('Checking the file size of %s', object)
         service = self.get_conn()
         try:
             response = service.objects().get(
@@ -288,11 +289,9 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
 
             if 'name' in response and response['name'][-1] != '/':
                 # Remove Directories & Just check size of files
-                if 'size' in response:
-                    size = response['size']
-                    self.log.info('Checking the file size of %s', object)
-                    self.log.info('The file size of %s is %s', object, size)
-                    return size
+                size = response['size']
+                self.log.info('The file size of %s is %s', object, size)
+                return size
             else:
                 raise ValueError('Object is not a file')
         except errors.HttpError as ex:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1883


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Added `get_size()` method to `gcs_hook` to get the file size for objects in Google Cloud Storage.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Google doesn't provide local unit test for GCS.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
