### PR TITLE
[AIRFLOW-1884] Ensure scheduler is crash safe for externally triggered dagruns

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -238,7 +238,6 @@ class BaseJob(Base, LoggingMixin):
                         TI.execution_date == DR.execution_date))
                 .filter(
                     DR.state == State.RUNNING,
-                    DR.external_trigger == False,
                     DR.run_id.notlike(BackfillJob.ID_PREFIX + '%'),
                     TI.state.in_(resettable_states))).all()
         else:

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -2826,7 +2826,8 @@ class SchedulerJobTest(unittest.TestCase):
         session.merge(dr1)
         session.commit()
 
-        self.assertEquals(0, len(scheduler.reset_state_for_orphaned_tasks(session=session)))
+        reset_tis = scheduler.reset_state_for_orphaned_tasks(session=session)
+        self.assertEquals(1, len(reset_tis))
 
     def test_reset_orphaned_tasks_backfill_dag(self):
         dag_id = 'test_reset_orphaned_tasks_backfill_dag'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.

- https://issues.apache.org/jira/browse/AIRFLOW-1884


### Description
- [x] Here are some details about my PR

This came out of the mailing list discussion about crash safety of the scheduler and resetting orphaned tasks. From digging in more, I found that we only reset orphaned task state for dagruns that are both not externally triggered and not backfilled. This violates the crash safety property of the scheduler, ie) if the scheduler crashes in the middle of one of these dagruns then tasks will be "Queued" forever and never executed. 

I found the changeset this regression happened in, it is this one:
https://issues.apache.org/jira/browse/AIRFLOW-1059

Before this changeset, there was no special casing of the backfilled/externally triggered dags and then after this changeset there is. I don't think this change was intended, as it adversely affects the crash safety of the scheduler. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No new unit tests, but modifies the existing unit tests around resetting orphaned tasks to reflect the fact that backfilled dagruns and externally triggered dagruns now are crash safe. 


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

