### PR TITLE
[AIRFLOW-1885] Fix access of cmdline when a gunicorn workers becomes a zombie

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -564,6 +564,22 @@ def clear(args):
         include_subdags=not args.exclude_subdags)
 
 
+def get_num_ready_workers_running(gunicorn_master_proc):
+    workers = psutil.Process(gunicorn_master_proc.pid).children()
+
+    def ready_prefix_on_cmdline(proc):
+        try:
+            cmdline = proc.cmdline()
+            if len(cmdline) > 0:
+                return settings.GUNICORN_WORKER_READY_PREFIX in cmdline[0]
+        except psutil.NoSuchProcess:
+            pass
+        return False
+
+    ready_workers = [proc for proc in workers if ready_prefix_on_cmdline(proc)]
+    return len(ready_workers)
+
+
 def restart_workers(gunicorn_master_proc, num_workers_expected):
     """
     Runs forever, monitoring the child processes of @gunicorn_master_proc and
@@ -600,14 +616,6 @@ def restart_workers(gunicorn_master_proc, num_workers_expected):
     def get_num_workers_running(gunicorn_master_proc):
         workers = psutil.Process(gunicorn_master_proc.pid).children()
         return len(workers)
-
-    def get_num_ready_workers_running(gunicorn_master_proc):
-        workers = psutil.Process(gunicorn_master_proc.pid).children()
-        ready_workers = [
-            proc for proc in workers
-            if settings.GUNICORN_WORKER_READY_PREFIX in proc.cmdline()[0]
-        ]
-        return len(ready_workers)
 
     def start_refresh(gunicorn_master_proc):
         batch_size = conf.getint('webserver', 'worker_refresh_batch_size')

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from mock import patch, Mock, MagicMock
+
+import psutil
+
+from airflow import settings
+from airflow.bin.cli import get_num_ready_workers_running
+
+
+class TestCLI(unittest.TestCase):
+
+    def setUp(self):
+        self.gunicorn_master_proc = Mock(pid=None)
+        self.children = MagicMock()
+        self.child = MagicMock()
+        self.process = MagicMock()
+
+    def test_ready_prefix_on_cmdline(self):
+        self.child.cmdline.return_value = [settings.GUNICORN_WORKER_READY_PREFIX]
+        self.process.children.return_value = [self.child]
+
+        with patch('psutil.Process', return_value=self.process):
+            self.assertEqual(get_num_ready_workers_running(self.gunicorn_master_proc), 1)
+
+    def test_ready_prefix_on_cmdline_no_children(self):
+        self.process.children.return_value = []
+
+        with patch('psutil.Process', return_value=self.process):
+            self.assertEqual(get_num_ready_workers_running(self.gunicorn_master_proc), 0)
+
+    def test_ready_prefix_on_cmdline_zombie(self):
+        self.child.cmdline.return_value = []
+        self.process.children.return_value = [self.child]
+
+        with patch('psutil.Process', return_value=self.process):
+            self.assertEqual(get_num_ready_workers_running(self.gunicorn_master_proc), 0)
+
+    def test_ready_prefix_on_cmdline_dead_process(self):
+        self.child.cmdline.side_effect = psutil.NoSuchProcess(11347)
+        self.process.children.return_value = [self.child]
+
+        with patch('psutil.Process', return_value=self.process):
+            self.assertEqual(get_num_ready_workers_running(self.gunicorn_master_proc), 0)


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX

https://issues.apache.org/jira/browse/AIRFLOW-1885

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

If while trying to obtain a list of ready gunicorn workers, one of them
becomes a zombie, psutil.cmdline returns [] (see here:
https://github.com/giampaolo/psutil/blob/release-4.2.0/psutil/_pslinux.py#L1007)

Boom:

    Traceback (most recent call last):
      File "/usr/local/bin/airflow", line 28, in <module>
        args.func(args)
      File "/usr/local/lib/python3.5/dist-packages/airflow/bin/cli.py", line 803, in webserver
        restart_workers(gunicorn_master_proc, num_workers)
      File "/usr/local/lib/python3.5/dist-packages/airflow/bin/cli.py", line 687, in restart_workers
        num_ready_workers_running = get_num_ready_workers_running(gunicorn_master_proc)
      File "/usr/local/lib/python3.5/dist-packages/airflow/bin/cli.py", line 663, in get_num_ready_workers_running
        proc for proc in workers
      File "/usr/local/lib/python3.5/dist-packages/airflow/bin/cli.py", line 664, in <listcomp>
        if settings.GUNICORN_WORKER_READY_PREFIX in proc.cmdline()[0]
    IndexError: list index out of range

So ensure a cmdline is actually returned before doing the cmdline prefix
check in ready_prefix_on_cmdline.

Also treats psutil.NoSuchProcess error as non ready worker.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

My PR adds 4 unit tests for the `get_num_ready_workers_running` function within cli.py, this module previously had no unit testing and I moved `get_num_ready_workers_running` into a higher scope in order to test it.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`