### PR TITLE
[AIRFLOW-1887] Renamed AWS endpoint url variable and other PEP8 fixes

### DIFF
--- a/airflow/contrib/hooks/aws_hook.py
+++ b/airflow/contrib/hooks/aws_hook.py
@@ -33,9 +33,9 @@ def _parse_s3_config(config_file_name, config_format='boto', profile=None):
     :param profile: profile name in AWS type config file
     :type profile: str
     """
-    Config = configparser.ConfigParser()
-    if Config.read(config_file_name):  # pragma: no cover
-        sections = Config.sections()
+    config = configparser.ConfigParser()
+    if config.read(config_file_name):  # pragma: no cover
+        sections = config.sections()
     else:
         raise AirflowException("Couldn't read {0}".format(config_file_name))
     # Setting option names depending on file format
@@ -64,12 +64,12 @@ def _parse_s3_config(config_file_name, config_format='boto', profile=None):
         raise AirflowException("This config file format is not recognized")
     else:
         try:
-            access_key = Config.get(cred_section, key_id_option)
-            secret_key = Config.get(cred_section, secret_key_option)
+            access_key = config.get(cred_section, key_id_option)
+            secret_key = config.get(cred_section, secret_key_option)
         except:
             logging.warning("Option Error in parsing s3 config file")
             raise
-        return (access_key, secret_key)
+        return access_key, secret_key
 
 
 class AwsHook(BaseHook):
@@ -84,7 +84,7 @@ class AwsHook(BaseHook):
     def _get_credentials(self, region_name):
         aws_access_key_id = None
         aws_secret_access_key = None
-        s3_endpoint_url = None
+        endpoint_url = None
 
         if self.aws_conn_id:
             try:
@@ -105,14 +105,14 @@ class AwsHook(BaseHook):
                 if region_name is None:
                     region_name = connection_object.extra_dejson.get('region_name')
 
-                s3_endpoint_url = connection_object.extra_dejson.get('host')
+                endpoint_url = connection_object.extra_dejson.get('host')
 
             except AirflowException:
                 # No connection found: fallback on boto3 credential strategy
                 # http://boto3.readthedocs.io/en/latest/guide/configuration.html
                 pass
 
-        return aws_access_key_id, aws_secret_access_key, region_name, s3_endpoint_url
+        return aws_access_key_id, aws_secret_access_key, region_name, endpoint_url
 
     def get_client_type(self, client_type, region_name=None):
         aws_access_key_id, aws_secret_access_key, region_name, endpoint_url = \


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1887


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

Minor improvements to the `AwsHook` in `airflow.contrib.hooks`, specially renaming the variable for its more general semantic meaning and a few PEP8 fixes.


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No added functionality.


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

It does not pass flake, because there's a missing import for the `logging` symbol used in `_parse_s3_config`.
