### PR TITLE
[AIRFLOW-1891] Fix non-ascii typo in default configuration template

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -314,7 +314,7 @@ celery_config_options = airflow.config_templates.default_celery.DEFAULT_CELERY_C
 # The visibility timeout defines the number of seconds to wait for the worker
 # to acknowledge the task before the message is redelivered to another worker.
 # Make sure to increase the visibility timeout to match the time of the longest
-# ETA you’re planning to use. Especially important in case of using Redis or SQS
+# ETA you're planning to use. Especially important in case of using Redis or SQS
 visibility_timeout = 21600
 
 [dask]


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1891) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1891


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
  - There is a non-ascii character in the default configuration template `default_airflow.cfg` that blocks Airflow from running from scratch (when there is no prior configuration).


### Tests
- [x] My PR does not need testing for this extremely good reason:
  - Trivial though tested to work locally (Travis is passing anyways and that implies the fix)


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
