### PR TITLE
[AIRFLOW-1869] Do not emit spurious warning on missing logs

### DIFF
--- a/airflow/utils/log/gcs_task_handler.py
+++ b/airflow/utils/log/gcs_task_handler.py
@@ -134,7 +134,8 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
             try:
                 old_log = self.gcs_read(remote_log_location)
             except Exception as e:
-                old_log = '*** Previous log discarded: {}\n\n'.format(str(e))
+                if not hasattr(e, 'resp') or e.resp.get('status') != '404':
+                    old_log = '*** Previous log discarded: {}\n\n'.format(str(e))
             log = '\n'.join([old_log, log]) if old_log else log
 
         try:


### PR DESCRIPTION
If the log does not already exist then we are not discarding it, and
this message is more confusing than helpful.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1869


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
If the remote log does not exist, then it is not being truncated.  A message indicating that it has been truncated is confusing and unnecessary.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
