### PR TITLE
FIX bleach 2.0.0 <> html5lib incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,7 @@ def do_setup():
         scripts=['airflow/bin/airflow'],
         install_requires=[
             'alembic>=0.8.3, <0.9',
-            'bleach==2.0.0',
+            'bleach==2.1.2',
             'configparser>=3.5.0, <3.6.0',
             'croniter>=0.3.17, <0.4',
             'dill>=0.2.2, <0.3',


### PR DESCRIPTION
Running airflow with bleach 2.0.0 can cause: `ImportError: No module named base`
https://github.com/mozilla/bleach/issues/267

This was resolved in https://github.com/mozilla/bleach/releases/tag/v2.1.2

https://issues.apache.org/jira/browse/AIRFLOW-1896
