### PR TITLE
[AIRFLOW-1897] Task Logs for running instance not visible in WebUI

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -831,6 +831,10 @@ class TaskInstance(Base, LoggingMixin):
     def try_number(self, value):
         self._try_number = value
 
+    @property
+    def next_try_number(self):
+        return self._try_number + 1
+
     def command(
             self,
             mark_success=False,

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -141,12 +141,14 @@ class FileTaskHandler(logging.Handler):
         # So the log for a particular task try will only show up when
         # try number gets incremented in DB, i.e logs produced the time
         # after cli run and before try_number + 1 in DB will not be displayed.
-        next_try = task_instance.try_number
 
         if try_number is None:
+            next_try = task_instance.next_try_number
             try_numbers = list(range(1, next_try))
         elif try_number < 1:
-            logs = ['Error fetching the logs. Try number {} is invalid.'.format(try_number)]
+            logs = [
+                'Error fetching the logs. Try number {} is invalid.'.format(try_number),
+            ]
             return logs
         else:
             try_numbers = [try_number]


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1897 Task Logs for running instance not visible in webui


### Description
- [x] Due to the change in AIRFLOW-1873 / #2832  I inadvertently changed the behaviour
such that task logs for a try wouldn't show up in the UI until after the
task run had completed.


### Tests
- [x] My PR adds the following unit tests: file_task_handler tests extendedc


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
