### PR TITLE
[AIRFLOW-1893] Propagate PYTHONPATH when using impersonation

### DIFF
--- a/airflow/task_runner/base_task_runner.py
+++ b/airflow/task_runner/base_task_runner.py
@@ -25,6 +25,9 @@ from airflow import configuration as conf
 from tempfile import mkstemp
 
 
+PYTHONPATH_VAR = 'PYTHONPATH'
+
+
 class BaseTaskRunner(LoggingMixin):
     """
     Runs Airflow task instances by invoking the `airflow run` command with raw
@@ -77,7 +80,12 @@ class BaseTaskRunner(LoggingMixin):
             with os.fdopen(temp_fd, 'w') as temp_file:
                 json.dump(cfg_subset, temp_file)
 
+            # propagate PYTHONPATH environment variable
+            pythonpath_value = os.environ.get(PYTHONPATH_VAR, '')
             popen_prepend = ['sudo', '-H', '-u', self.run_as_user]
+
+            if pythonpath_value:
+                popen_prepend.append('{}={}'.format(PYTHONPATH_VAR, pythonpath_value))
 
         self._cfg_path = cfg_path
         self._command = popen_prepend + self._task_instance.command_as_list(

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -25,6 +25,10 @@ export AIRFLOW__TESTSECTION__TESTKEY=testvalue
 # use Airflow 2.0-style imports
 export AIRFLOW_USE_NEW_IMPORTS=1
 
+# add test/contrib to PYTHONPATH
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export PYTHONPATH=$PYTHONPATH:${DIR}/tests/test_utils
+
 # any argument received is overriding the default nose execution arguments:
 
 nose_args=$@

--- a/tests/dags/test_impersonation_custom.py
+++ b/tests/dags/test_impersonation_custom.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.models import DAG
+from airflow.operators.python_operator import PythonOperator
+from datetime import datetime
+
+# AIRFLOW-1893 - Originally, impersonation tests were incomplete missing the use case when
+# DAGs access custom packages usually made available through the PYTHONPATH environment
+# variable. This file includes a DAG that imports a custom package made available and if
+# run via the previous implementation of impersonation, will fail by not being able to
+# import the custom package.
+# This DAG is used to test that impersonation propagates the PYTHONPATH environment
+# variable correctly.
+from tests.test_utils.fake_datetime import FakeDatetime
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+
+args = {
+    'owner': 'airflow',
+    'start_date': DEFAULT_DATE,
+    'run_as_user': 'airflow_test_user'
+}
+
+dag = DAG(dag_id='impersonation_with_custom_pkg', default_args=args)
+
+
+def print_today():
+    dt = FakeDatetime.utcnow()
+    print('Today is {}'.format(dt.strftime('%Y-%m-%d')))
+
+
+PythonOperator(
+    python_callable=print_today,
+    task_id='exec_python_fn',
+    dag=dag)

--- a/tests/test_utils/fake_datetime.py
+++ b/tests/test_utils/fake_datetime.py
@@ -21,4 +21,4 @@ class FakeDatetime(datetime):
     """
 
     def __new__(cls, *args, **kwargs):
-        return date.__new__(datetime, *args, **kwargs)
+        return datetime.__new__(datetime, *args, **kwargs)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1893


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

When using impersonation via `run_as_user`, the PYTHONPATH environment
variable is not propagated hence there may be issues when depending on
specific custom packages used in DAGs.
This PR propagates only the PYTHONPATH in the process creating the
sub-process with impersonation, if any.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added test in `tests/impersonation.py`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

PTAL @aoen 