### PR TITLE
[AIRFLOW-1903] Use config.admin_endpoint instead of hardcoded

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -175,6 +175,10 @@ default_gpus = 0
 # airflow sends to point links to the right web server
 base_url = http://localhost:8080
 
+# The base endpoint.  This is primarily useful to transition from the base airflow
+# webserver to the flask based webserver which will use a different endpoint.
+admin_endpoint = /admin/airflow
+
 # The ip specified when starting the web server
 web_server_host = 0.0.0.0
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -986,7 +986,8 @@ class TaskInstance(Base, LoggingMixin):
         iso = self.execution_date.isoformat()
         BASE_URL = configuration.get('webserver', 'BASE_URL')
         return BASE_URL + (
-            "/admin/airflow/log"
+            configuration.get('webserver', 'admin_endpoint') +
+            "/log"
             "?dag_id={self.dag_id}"
             "&task_id={self.task_id}"
             "&execution_date={iso}"
@@ -997,7 +998,8 @@ class TaskInstance(Base, LoggingMixin):
         iso = self.execution_date.isoformat()
         BASE_URL = configuration.get('webserver', 'BASE_URL')
         return BASE_URL + (
-            "/admin/airflow/action"
+            configuration.get('webserver', 'admin_endpoint') +
+            "/action"
             "?action=success"
             "&task_id={self.task_id}"
             "&dag_id={self.dag_id}"

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -84,7 +84,6 @@ ___  ___ |  / _  /   _  __/ _  / / /_/ /_ |/ |/ /
  _/_/  |_/_/  /_/    /_/    /_/  \____/____/|__/
  """
 
-BASE_LOG_URL = '/admin/airflow/log'
 LOGGING_LEVEL = logging.INFO
 
 # the prefix to append to gunicorn worker processes after init

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -116,6 +116,7 @@ class TestVariableView(unittest.TestCase):
             'val': 'text_val',
             'is_encrypted': True
         }
+        self.admin_endpoint = configuration.get('webserver', 'admin_endpoint')
 
     def tearDown(self):
         self.session.query(models.Variable).delete()
@@ -150,7 +151,7 @@ class TestVariableView(unittest.TestCase):
                       response.data.decode('utf-8'))
 
     def test_xss_prevention(self):
-        xss = "/admin/airflow/variables/asdf<img%20src=''%20onerror='alert(1);'>"
+        xss = self.admin_endpoint + "/variables/asdf<img%20src=''%20onerror='alert(1);'>"
 
         response = self.app.get(
             xss,


### PR DESCRIPTION
Replace "/admin/airflow" with a config option, to make it easier
to change enpoints.  In the short term, this is primarily to enable
correct links to logs in email alerts

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1903


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
    Allow the /admin/airflow to be configured


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:  Current test coverage is adequate


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
