### PR TITLE
[AIRFLOW-1904] Correct DAG fileloc to the right filepath

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -329,6 +329,8 @@ class DagBag(BaseDagBag, LoggingMixin):
                 if isinstance(dag, DAG):
                     if not dag.full_filepath:
                         dag.full_filepath = filepath
+                        if dag.fileloc != filepath:
+                            dag.fileloc = filepath
                     dag.is_subdag = False
                     self.bag_dag(dag, parent_dag=dag, root_dag=dag)
                     found_dags.append(dag)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1904



### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Currently dag file location `dag.fileloc` is determined by getting the second stack frame from the top, i.e. self.fileloc = sys._getframe().f_back.f_code.co_filename
However this fails if the DAG is constructed from an imported module. For example, if I import a DagBuilder in my dagfile, the dagbuilder's filepath would ended up becoming the fileloc, rather than the dag itself.
This causes a bug whenever the DAG is refreshed, because it tries to reload from the fileloc.



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested locally via UI to ensure that refresh works with the corrected fileloc.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
