### PR TITLE
[AIRFLOW-1905] Make start_doc_sever script python3 compatible

### DIFF
--- a/docs/start_doc_server.sh
+++ b/docs/start_doc_server.sh
@@ -11,4 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-python -m SimpleHTTPServer 8000
+python -c "import SimpleHTTPServer" 2> /dev/null 
+
+if [ $? -eq 0 ]
+then
+	python -m SimpleHTTPServer 8000
+else
+	python -m http.server 8000
+fi


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1905

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

start_doc_server script used *SimpleHttpServer* module which has been changed to *http.server*.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
