### PR TITLE
[AIRFLOW-1907] Pass max_ingestion_time to Druid hook

### DIFF
--- a/airflow/contrib/operators/druid_operator.py
+++ b/airflow/contrib/operators/druid_operator.py
@@ -34,10 +34,11 @@ class DruidOperator(BaseOperator):
         self,
         json_index_file,
         druid_ingest_conn_id='druid_ingest_default',
+        max_ingestion_time=None,
         *args, **kwargs):
-
         super(DruidOperator, self).__init__(*args, **kwargs)
         self.conn_id = druid_ingest_conn_id
+        self.max_ingestion_time = max_ingestion_time
 
         with open(json_index_file) as data_file:
             index_spec = json.load(data_file)
@@ -49,6 +50,9 @@ class DruidOperator(BaseOperator):
         )
 
     def execute(self, context):
-        hook = DruidHook(druid_ingest_conn_id=self.conn_id)
+        hook = DruidHook(
+            druid_ingest_conn_id=self.conn_id,
+            max_ingestion_time=self.max_ingestion_time
+        )
         self.log.info("Sumitting %s", self.index_spec_str)
         hook.submit_indexing_job(self.index_spec_str)

--- a/airflow/hooks/druid_hook.py
+++ b/airflow/hooks/druid_hook.py
@@ -36,7 +36,7 @@ class DruidHook(BaseHook):
             self,
             druid_ingest_conn_id='druid_ingest_default',
             timeout=1,
-            max_ingestion_time=18000):
+            max_ingestion_time=None):
 
         self.druid_ingest_conn_id = druid_ingest_conn_id
         self.timeout = timeout
@@ -72,7 +72,7 @@ class DruidHook(BaseHook):
 
             sec = sec + 1
 
-            if sec > self.max_ingestion_time:
+            if self.max_ingestion_time and sec > self.max_ingestion_time:
                 # ensure that the job gets killed if the max ingestion time is exceeded
                 requests.post("{0}/{1}/shutdown".format(url, druid_task_id))
                 raise AirflowException('Druid ingestion took more than %s seconds', self.max_ingestion_time)


### PR DESCRIPTION
From the Druid operator we want to pass the max_ingestion_time to the hook since some jobs might take considerably more time than the others

Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
