### PR TITLE
[AIRFLOW-1908] Fix celery broker options config load

### DIFF
--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -32,7 +32,7 @@ DEFAULT_CELERY_CONFIG = {
     'task_default_queue': configuration.get('celery', 'DEFAULT_QUEUE'),
     'task_default_exchange': configuration.get('celery', 'DEFAULT_QUEUE'),
     'broker_url': configuration.get('celery', 'BROKER_URL'),
-    'broker_transport_options': {'visibility_timeout': broker_transport_options},
+    'broker_transport_options': broker_transport_options,
     'result_backend': configuration.get('celery', 'RESULT_BACKEND'),
     'worker_concurrency': configuration.getint('celery', 'WORKER_CONCURRENCY'),
 }

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -28,6 +28,8 @@ import sys
 
 from future import standard_library
 
+from six import iteritems
+
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 standard_library.install_aliases()
@@ -237,8 +239,27 @@ class AirflowConfigParser(ConfigParser):
         self._validate()
 
     def getsection(self, section):
+        """
+        Returns the section as a dict. Values are converted to int, float, bool
+        as required.
+        :param section: section from the config
+        :return: dict
+        """
         if section in self._sections:
-            return self._sections[section]
+            _section = self._sections[section]
+            for key, val in iteritems(self._sections[section]):
+                try:
+                    val = int(val)
+                except ValueError:
+                    try:
+                        val = float(val)
+                    except ValueError:
+                        if val.lower() in ('t', 'true'):
+                            val = True
+                        elif val.lower() in ('f', 'false'):
+                            val = False
+                _section[key] = val
+            return _section
 
         return None
 

--- a/scripts/ci/airflow_travis.cfg
+++ b/scripts/ci/airflow_travis.cfg
@@ -50,6 +50,12 @@ result_backend = db+mysql://root@localhost/airflow
 flower_port = 5555
 default_queue = default
 
+[celery_broker_transport_options]
+visibility_timeout = 21600
+_test_only_bool = True
+_test_only_float = 12.0
+_test_only_string = this is a test
+
 [scheduler]
 job_heartbeat_sec = 1
 scheduler_heartbeat_sec = 5

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 from __future__ import print_function
-import os
 import unittest
+
+import six
 
 from airflow import configuration
 from airflow.configuration import conf
+
 
 class ConfTest(unittest.TestCase):
 
@@ -52,3 +54,13 @@ class ConfTest(unittest.TestCase):
         cfg_dict = conf.as_dict(display_sensitive=True, display_source=True)
         self.assertEqual(
             cfg_dict['testsection']['testkey'], ('testvalue', 'env var'))
+
+    def test_broker_transport_options(self):
+        section_dict = conf.getsection("celery_broker_transport_options")
+        self.assertTrue(isinstance(section_dict['visibility_timeout'], int))
+
+        self.assertTrue(isinstance(section_dict['_test_only_bool'], bool))
+
+        self.assertTrue(isinstance(section_dict['_test_only_float'], float))
+
+        self.assertTrue(isinstance(section_dict['_test_only_string'], six.string_types))


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1908


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

cc: @FrankNagel @Fokko 