### PR TITLE
[AIRFLOW-1909] Update docs with supported versions of MySQL server

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -66,7 +66,11 @@ Here's the list of the subpackages and what they enable:
 |               |                                              | support as an Airflow backend                   |
 +---------------+----------------------------------------------+-------------------------------------------------+
 |  mysql        | ``pip install apache-airflow[mysql]``        | MySQL operators and hook, support as            |
-|               |                                              | an Airflow backend                              |
+|               |                                              | an Airflow backend. The version of MySQL server |
+|               |                                              | that can be used depends on the version of      |
+|               |                                              | ``mysqlclient`` package installed. For example, |
+|               |                                              | ``mysqlclient`` 1.3.12 can only be used  with   |
+|               |                                              | MySQL server 5.5 through 5.7.                   |
 +---------------+----------------------------------------------+-------------------------------------------------+
 |  password     | ``pip install apache-airflow[password]``     | Password Authentication for users               |
 +---------------+----------------------------------------------+-------------------------------------------------+

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -67,10 +67,10 @@ Here's the list of the subpackages and what they enable:
 +---------------+----------------------------------------------+-------------------------------------------------+
 |  mysql        | ``pip install apache-airflow[mysql]``        | MySQL operators and hook, support as            |
 |               |                                              | an Airflow backend. The version of MySQL server |
-|               |                                              | that can be used depends on the version of      |
-|               |                                              | ``mysqlclient`` package installed. For example, |
-|               |                                              | ``mysqlclient`` 1.3.12 can only be used  with   |
-|               |                                              | MySQL server 5.5 through 5.7.                   |
+|               |                                              | has to be 5.6.4+. The exact version upper bound | 
+|               |                                              | depends on version of ``mysqlclient`` package.  |
+|               |                                              | For example, ``mysqlclient`` 1.3.12 can only be |
+|               |                                              | used with MySQL server 5.6.4 through 5.7.       |
 +---------------+----------------------------------------------+-------------------------------------------------+
 |  password     | ``pip install apache-airflow[password]``     | Password Authentication for users               |
 +---------------+----------------------------------------------+-------------------------------------------------+

--- a/docs/start_doc_server.sh
+++ b/docs/start_doc_server.sh
@@ -11,4 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-python -m SimpleHTTPServer 8000
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+(cd $THIS_DIR/_build/html;
+# The below command works on both Python 2 and Python 3
+python -m http.server 8000 && python -m SimpleHTTPServer 8000
+)


### PR DESCRIPTION
Also, updates a docs script to be compatible with both
Python 2 and Python 3.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1909


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
* Update docs with supported versions of MySQL server
* Update a docs script to be compatible with both Python 2 and Python 3.
* Update a docs script to always serve the docs from the right directory regardless
of which directory the script was called from.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
* Ran the docs build successfully.
* Manually reviewed the documentation to make sure it looks fine.
![mysql-doc](https://user-images.githubusercontent.com/1709451/33870055-eac72f90-dec0-11e7-8d7b-f07e94dbe89e.png)
* Ran the python script for starting the server from various different directories and with Python 3.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
