### PR TITLE
[AIRFLOW-1912] airflow.processor should not propagate logging

### DIFF
--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -90,7 +90,7 @@ DEFAULT_LOGGING_CONFIG = {
         'airflow.processor': {
             'handlers': ['file.processor'],
             'level': LOG_LEVEL,
-            'propagate': True,
+            'propagate': False,
         },
         'airflow.task': {
             'handlers': ['file.task'],


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1912


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
The root logger will write to stdout. If redirection is used
which is the case for processors and task runs (not runners)
this can end up in an endless loop in case propagation is True.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Config dependent.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [=X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

@TrevorEdwards @jgao54 @Fokko 
