### PR TITLE
[AIRFLOW-1920] Update CONTRIBUTING.md to reflect enforced linting rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ which you can setup on your fork as well to check before you submit your
 PR. We currently enforce most [PEP8](https://www.python.org/dev/peps/pep-0008/)
 and a few other linting rules. It is usually a good idea to lint locally
 as well using [flake8](https://flake8.readthedocs.org/en/latest/)
-using `flake8 airflow tests`
+using `flake8 airflow tests`. `git diff upstream/master -u -- "*.py" | flake8 --diff` will return any changed files in your branch that require linting.
 9. Please read this excellent [article](http://chris.beams.io/posts/git-commit/) on
 commit messages and adhere to them. It makes the lives of those who
 come after you a lot easier.
@@ -134,6 +134,10 @@ come after you a lot easier.
 Tests can then be run with (see also the [Running unit tests](#running-unit-tests) section below):
 
     ./run_unit_tests.sh
+
+Individual test files can be run with:
+
+    nosetests [path to file]
 
 #### Running unit tests
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1920


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- Updates Contributing guidelines to reflect enforced linting rules & adds
instructions for running single file unit tests.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
