### PR TITLE
[AIRFLOW-1921] Added support for presto https and user auth

### DIFF
--- a/airflow/hooks/presto_hook.py
+++ b/airflow/hooks/presto_hook.py
@@ -21,6 +21,7 @@ from builtins import str
 
 from pyhive import presto
 from pyhive.exc import DatabaseError
+from requests.auth import HTTPBasicAuth
 
 from airflow.hooks.dbapi_hook import DbApiHook
 
@@ -45,11 +46,17 @@ class PrestoHook(DbApiHook):
     def get_conn(self):
         """Returns a connection object"""
         db = self.get_connection(self.presto_conn_id)
+        reqkwargs = None
+        if db.password is not None:
+            reqkwargs = {'auth': HTTPBasicAuth(db.login, db.password)}
         return presto.connect(
             host=db.host,
             port=db.port,
             username=db.login,
+            source=db.extra_dejson.get('source', 'airflow'),
+            protocol=db.extra_dejson.get('protocol', 'http'),
             catalog=db.extra_dejson.get('catalog', 'hive'),
+            requests_kwargs=reqkwargs,
             schema=db.schema)
 
     @staticmethod


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow-1921]
    - https://issues.apache.org/jira/browse/AIRFLOW-1921


### Description
- [ ] This PR adds support for connecting to presto via https, using HTTP BasicAuth authentication, as recommended in the PyHive source.

To use this functionality, set the password in the connections UI. Set {"protocol": "https"} in the Extra args. 

### Tests
- [ ] My PR does not add any tests for the PrestoHook. There are currently no tests for this hook.


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
