### PR TITLE
[AIRFLOW-1916] Don't upload logs to remote from `run --raw`

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -362,7 +362,8 @@ def run(args, dag=None):
     task = dag.get_task(task_id=args.task_id)
     ti = TaskInstance(task, args.execution_date)
     ti.refresh_from_db()
-    ti.init_run_context()
+
+    ti.init_run_context(raw=args.raw)
 
     hostname = socket.getfqdn()
     log.info("Running %s on host %s", ti, hostname)
@@ -418,10 +419,6 @@ def run(args, dag=None):
                 pool=args.pool)
             executor.heartbeat()
             executor.end()
-
-    # Child processes should not flush or upload to remote
-    if args.raw:
-        return
 
     logging.shutdown()
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -807,6 +807,9 @@ class TaskInstance(Base, LoggingMixin):
         self.hostname = ''
         self.init_on_load()
         self._log = logging.getLogger("airflow.task")
+        # Is this TaskInstance being currently running within `airflow run --raw`.
+        # Not persisted to the database so only valid for the current process
+        self.is_raw = False
 
     @reconstructor
     def init_on_load(self):
@@ -1879,11 +1882,12 @@ class TaskInstance(Base, LoggingMixin):
             TI.state == State.RUNNING
         ).count()
 
-    def init_run_context(self):
+    def init_run_context(self, raw=False):
         """
         Sets the log context.
         """
         self._set_context(self)
+        self.raw = raw
 
 
 class TaskFail(Base):

--- a/airflow/utils/log/gcs_task_handler.py
+++ b/airflow/utils/log/gcs_task_handler.py
@@ -32,6 +32,7 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
         self.log_relative_path = ''
         self._hook = None
         self.closed = False
+        self.upload_on_close = True
 
     def _build_hook(self):
         remote_conn_id = configuration.get('core', 'REMOTE_LOG_CONN_ID')
@@ -59,6 +60,7 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
         # log path to upload log files into GCS and read from the
         # remote location.
         self.log_relative_path = self._render_filename(ti, ti.try_number)
+        self.upload_on_close = not ti.is_raw
 
     def close(self):
         """
@@ -72,6 +74,9 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
             return
 
         super(GCSTaskHandler, self).close()
+
+        if not self.upload_on_close:
+            return
 
         local_loc = os.path.join(self.local_base, self.log_relative_path)
         remote_loc = os.path.join(self.remote_base, self.log_relative_path)

--- a/airflow/utils/log/s3_task_handler.py
+++ b/airflow/utils/log/s3_task_handler.py
@@ -30,6 +30,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         self.log_relative_path = ''
         self._hook = None
         self.closed = False
+        self.upload_on_close = True
 
     def _build_hook(self):
         remote_conn_id = configuration.get('core', 'REMOTE_LOG_CONN_ID')
@@ -54,6 +55,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         # Local location and remote location is needed to open and
         # upload local log file to S3 remote storage.
         self.log_relative_path = self._render_filename(ti, ti.try_number)
+        self.upload_on_close = not ti.is_raw
 
     def close(self):
         """
@@ -67,6 +69,9 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
             return
 
         super(S3TaskHandler, self).close()
+
+        if not self.upload_on_close:
+            return
 
         local_loc = os.path.join(self.local_base, self.log_relative_path)
         remote_loc = os.path.join(self.remote_base, self.log_relative_path)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1916

### Description
- [x] In a previous change we removed special config for airflow.task.raw handler (which
printed to stdout directly) and replaced it with one that wrote to the
log file itself. The problem comes that python automatically calls
`logging.shutdown()` itself on process clean exit. This ended up
uploading the log file twice: once from the end of `airflow run --raw`,
and then again from the explicit shutdown() call at the end of cli's
`run()`

  Since logging is automatically shutdown this change adds and explicit
flag to control if the GC and S3 handlers should upload the file or not,
and we tell them not to when running with `--raw`.

### Tests
- [x] My PR adds the following unit tests: expanded on tests to S3 and Base log handlers.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
