### PR TITLE
Correct http_hook to use conn_type instead of schema

### DIFF
--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -41,8 +41,8 @@ class HttpHook(BaseHook):
             self.base_url = conn.host
         else:
             # schema defaults to HTTP
-            schema = conn.schema if conn.schema else "http"
-            self.base_url = schema + "://" + conn.host
+            conn_type = conn.conn_type if conn.conn_type else "http"
+            self.base_url = conn_type + "://" + conn.host
 
         if conn.port:
             self.base_url = self.base_url + ":" + str(conn.port) + "/"

--- a/tests/core.py
+++ b/tests/core.py
@@ -2360,7 +2360,7 @@ class HttpHookTest(unittest.TestCase):
 
     @mock.patch('airflow.hooks.http_hook.HttpHook.get_connection')
     def test_https_connection(self, mock_get_connection):
-        c = models.Connection(conn_id='http_default', conn_type='http',
+        c = models.Connection(conn_id='http_default', conn_type='https',
                               host='localhost', schema='https')
         mock_get_connection.return_value = c
         hook = HttpHook()
@@ -2378,7 +2378,7 @@ class HttpHookTest(unittest.TestCase):
 
     @mock.patch('airflow.hooks.http_hook.HttpHook.get_connection')
     def test_host_encoded_https_connection(self, mock_get_connection):
-        c = models.Connection(conn_id='http_default', conn_type='http',
+        c = models.Connection(conn_id='http_default', conn_type='https',
                               host='https://localhost')
         mock_get_connection.return_value = c
         hook = HttpHook()


### PR DESCRIPTION
The HttpHook class seems to be using a wrong property from Connection to
figure our the connection type (http, https, etc).
Property conn_type seems to be the right one to use.