### PR TITLE
[AIRFLOW-1930] Convert func.now() to timezone.utcnow()

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -735,7 +735,7 @@ class DagPickle(Base):
     """
     id = Column(Integer, primary_key=True)
     pickle = Column(PickleType(pickler=dill))
-    created_dttm = Column(UtcDateTime, default=func.now())
+    created_dttm = Column(UtcDateTime, default=timezone.utcnow())
     pickle_hash = Column(Text)
 
     __tablename__ = "dag_pickle"
@@ -3969,7 +3969,7 @@ class Chart(Base):
         "User", cascade=False, cascade_backrefs=False, backref='charts')
     x_is_date = Column(Boolean, default=True)
     iteration_no = Column(Integer, default=0)
-    last_modified = Column(UtcDateTime, default=func.now())
+    last_modified = Column(UtcDateTime, default=timezone.utcnow())
 
     def __repr__(self):
         return self.label
@@ -4118,7 +4118,7 @@ class XCom(Base, LoggingMixin):
     key = Column(String(512))
     value = Column(LargeBinary)
     timestamp = Column(
-        DateTime, default=func.now(), nullable=False)
+        DateTime, default=timezone.utcnow(), nullable=False)
     execution_date = Column(UtcDateTime, nullable=False)
 
     # source information
@@ -4437,8 +4437,8 @@ class DagRun(Base, LoggingMixin):
 
     id = Column(Integer, primary_key=True)
     dag_id = Column(String(ID_LEN))
-    execution_date = Column(UtcDateTime, default=func.now())
-    start_date = Column(UtcDateTime, default=func.now())
+    execution_date = Column(UtcDateTime, default=timezone.utcnow())
+    start_date = Column(UtcDateTime, default=timezone.utcnow())
     end_date = Column(UtcDateTime)
     _state = Column('state', String(50), default=State.RUNNING)
     run_id = Column(String(ID_LEN))


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1930

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

func.now() defaults to the timezone of the database,
we assume that everything is in UTC which might not be
the case if func.now() is used.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

* Current tests 

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
