### PR TITLE
[AIRFLOW-XXX] Fix failing PubSub tests on Python3

### DIFF
--- a/tests/contrib/operators/test_pubsub_operator.py
+++ b/tests/contrib/operators/test_pubsub_operator.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import unicode_literals
 
 from base64 import b64encode as b64e
 import unittest
@@ -35,10 +36,10 @@ TEST_TOPIC = 'test-topic'
 TEST_SUBSCRIPTION = 'test-subscription'
 TEST_MESSAGES = [
     {
-        'data': b64e('Hello, World!'),
+        'data': b64e(b'Hello, World!'),
         'attributes': {'type': 'greeting'}
     },
-    {'data': b64e('Knock, knock')},
+    {'data': b64e(b'Knock, knock')},
     {'attributes': {'foo': ''}}]
 
 


### PR DESCRIPTION
Correct failing tests due to not explicitly using b'' string when b64encoding.

Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
 - Correct failing tests due to not explicitly using b'' string when b64encoding. These were previously not being encountered because of the gcp_pubsub_hook test module being incorrectly named.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
