### PR TITLE
[AIRFLOW-1846] Hide Ad Hoc Query behind secure_mode config

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -128,8 +128,8 @@ default_impersonation =
 # What security module to use (for example kerberos):
 security =
 
-# If set to False enables some unsecure features like Charts. In 2.0 will
-# default to True.
+# If set to False enables some unsecure features like Charts and Ad Hoc Queries.
+# In 2.0 will default to True.
 secure_mode = False
 
 # Turn unit test mode on (overwrites many configuration options with test

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -39,6 +39,7 @@ fernet_key = {FERNET_KEY}
 non_pooled_task_slot_count = 128
 enable_xcom_pickling = False
 killed_task_cleanup_time = 5
+secure_mode = False
 
 [cli]
 api_client = airflow.api.client.local_client

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -69,9 +69,8 @@ def create_app(config=None, testing=False):
         vs = views
         av(vs.Airflow(name='DAGs', category='DAGs'))
 
-        av(vs.QueryView(name='Ad Hoc Query', category="Data Profiling"))
-
         if not conf.getboolean('core', 'secure_mode'):
+            av(vs.QueryView(name='Ad Hoc Query', category="Data Profiling"))
             av(vs.ChartModelView(
                 models.Chart, Session, name="Charts", category="Data Profiling"))
         av(vs.KnownEventView(

--- a/tests/core.py
+++ b/tests/core.py
@@ -1857,6 +1857,27 @@ class WebUiTests(unittest.TestCase):
         session.close()
 
 
+class SecureModeWebUiTests(unittest.TestCase):
+    def setUp(self):
+        configuration.load_test_config()
+        configuration.conf.set("webserver", "authenticate", "False")
+        configuration.conf.set("core", "secure_mode", "True")
+        app = application.create_app()
+        app.config['TESTING'] = True
+        self.app = app.test_client()
+
+    def test_query(self):
+        response = self.app.get('/admin/queryview/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_charts(self):
+        response = self.app.get('/admin/chart/')
+        self.assertEqual(response.status_code, 404)
+
+    def tearDown(self):
+        configuration.remove_option("core", "SECURE_MODE")
+
+
 class WebPasswordAuthTest(unittest.TestCase):
     def setUp(self):
         configuration.conf.set("webserver", "authenticate", "True")


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1846



### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
    - This hides the Ad Hoc Query section behind the secure_mode config that also hides Charts (which was added [here](https://issues.apache.org/jira/browse/AIRFLOW-1697)).
    ![image](https://user-images.githubusercontent.com/674003/34215526-8e28d1ee-e573-11e7-8c19-e7ae00e15c2e.png)


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    ```
    tests.core:SecureModeWebUiTests.test_query
    tests.core:SecureModeWebUiTests.test_charts
    ```

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
