### PR TITLE
[AIRFLOW-1949] Fix var upload, str() produces "b'...'" which is not json

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -28,6 +28,7 @@ import math
 import json
 import bleach
 import pendulum
+import codecs
 from collections import defaultdict
 
 import inspect
@@ -88,6 +89,8 @@ from airflow.www.validators import GreaterEqualThan
 
 QUERY_LIMIT = 100000
 CHART_LIMIT = 200000
+
+UTF8_READER = codecs.getreader('utf-8')
 
 dagbag = models.DagBag(settings.DAGS_FOLDER)
 
@@ -1790,10 +1793,9 @@ class Airflow(BaseView):
     @wwwutils.action_logging
     def varimport(self):
         try:
-            out = str(request.files['file'].read())
-            d = json.loads(out)
-        except Exception:
-            flash("Missing file or syntax error.")
+            d = json.load(UTF8_READER(request.files['file']))
+        except Exception as e:
+            flash("Missing file or syntax error: {}.".format(e))
         else:
             for k, v in d.items():
                 models.Variable.set(k, v, serialize_json=isinstance(v, dict))

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import copy
 import logging.config
 import os
@@ -376,6 +377,51 @@ class TestLogView(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('Log file isn',
                       response.data.decode('utf-8'))
+
+
+class TestVarImportView(unittest.TestCase):
+
+    IMPORT_ENDPOINT = '/admin/airflow/varimport'
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestVarImportView, cls).setUpClass()
+        session = Session()
+        session.query(models.User).delete()
+        session.commit()
+        user = models.User(username='airflow')
+        session.add(user)
+        session.commit()
+        session.close()
+
+    def setUp(self):
+        super(TestVarImportView, self).setUp()
+        configuration.load_test_config()
+        app = application.create_app(testing=True)
+        app.config['WTF_CSRF_METHODS'] = []
+        self.app = app.test_client()
+
+    def tearDown(self):
+        super(TestVarImportView, self).tearDown()
+
+    @classmethod
+    def tearDownClass(cls):
+        session = Session()
+        session.query(models.User).delete()
+        session.commit()
+        session.close()
+        super(TestVarImportView, cls).tearDownClass()
+
+    def test_import_variables(self):
+        response = self.app.post(
+            self.IMPORT_ENDPOINT,
+            data={'file': (io.BytesIO(b'{"KEY": "VALUE"}'), 'test.json')},
+            follow_redirects=True
+        )
+        self.assertEqual(response.status_code, 200)
+        body = response.data.decode('utf-8')
+        self.assertIn('KEY', body)
+        self.assertIn('VALUE', body)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1949


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Previously the varimport request handler was using str to coerce the buffer:

    out = str(request.files['file'].read())

This was producing:

    b'{...

Which is not valid JSON. Producing an Exception. Unfortunately the exception message is also not printed (flashed) so it's hard to discern what is going wrong.

I've added the exception to the flash message and removed the use of str. This works for me.



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Not sure how to add value with a unit test to this handler? Could use some guidance.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
