### PR TITLE
[AIRFLOW-1969] Always generate HTTPS URIs for Google OAuth2

### DIFF
--- a/airflow/contrib/auth/backends/google_auth.py
+++ b/airflow/contrib/auth/backends/google_auth.py
@@ -109,6 +109,7 @@ class GoogleAuthBackend(object):
         return self.google_oauth.authorize(callback=url_for(
             'google_oauth_callback',
             _external=True,
+            _scheme=get_config_param('scheme'),
             next=request.args.get('next') or request.referrer or None))
 
     def get_google_user_profile_info(self, google_token):
@@ -125,7 +126,7 @@ class GoogleAuthBackend(object):
     def domain_check(self, email):
         domain = email.split('@')[1]
         domains = get_config_param('domain').split(',')
-        if domain in domains:	
+        if domain in domains:
             return True
         return False
 
@@ -183,4 +184,3 @@ login_manager = GoogleAuthBackend()
 
 def login(self, request):
     return login_manager.login(request)
-

--- a/airflow/contrib/auth/backends/google_auth.py
+++ b/airflow/contrib/auth/backends/google_auth.py
@@ -109,7 +109,7 @@ class GoogleAuthBackend(object):
         return self.google_oauth.authorize(callback=url_for(
             'google_oauth_callback',
             _external=True,
-            _scheme=get_config_param('scheme'),
+            _scheme='https',
             next=request.args.get('next') or request.referrer or None))
 
     def get_google_user_profile_info(self, google_token):


### PR DESCRIPTION
In cases where the Airflow server is behind a proxy, and the proxy
serves https requests but reads http from airflow, the request
scheme is not a sufficient hint for which scheme to use for the
redirect uri generated for google auth. This patch updates the Google OAuth2 plugin to always force the scheme to be HTTPS.