### PR TITLE
[AIRFLOW-1955] Do not reference unassigned variable

### DIFF
--- a/airflow/utils/log/gcs_task_handler.py
+++ b/airflow/utils/log/gcs_task_handler.py
@@ -138,10 +138,10 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
         if append:
             try:
                 old_log = self.gcs_read(remote_log_location)
+                log = '\n'.join([old_log, log]) if old_log else log
             except Exception as e:
                 if not hasattr(e, 'resp') or e.resp.get('status') != '404':
-                    old_log = '*** Previous log discarded: {}\n\n'.format(str(e))
-            log = '\n'.join([old_log, log]) if old_log else log
+                    log = '*** Previous log discarded: {}\n\n'.format(str(e)) + log
 
         try:
             bkt, blob = self.parse_gcs_url(remote_log_location)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1955


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Remove a code path which attempts to referenced an unassigned variable


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Current tests cover this


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
