### PR TITLE
[AIRFLOW-1956] Add parameter whether the navbar clock time is UTC

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -182,6 +182,7 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
         def jinja_globals():
             return {
                 'hostname': socket.getfqdn(),
+                'timezone': settings.TIMEZONE.name,
                 'navbar_color': conf.get('webserver', 'NAVBAR_COLOR'),
             }
 

--- a/airflow/www/static/js/base.js
+++ b/airflow/www/static/js/base.js
@@ -20,12 +20,13 @@
 import {defaultFormatWithTZ, moment} from './datetime-utils';
 
 function displayTime() {
-  let utcTime = moment().utc().format(defaultFormatWithTZ);
+  let time = moment().tz(timezone).format(defaultFormatWithTZ);
+
   $('#clock')
     .attr("data-original-title", function() {
       return hostName
     })
-    .html(utcTime);
+    .html(time);
 
   setTimeout(displayTime, 1000);
 }

--- a/airflow/www/templates/appbuilder/baselayout.html
+++ b/airflow/www/templates/appbuilder/baselayout.html
@@ -69,6 +69,7 @@
 <script type="text/javascript">
   // below variables are used in base.js
   var hostName = '{{ hostname }}';
+  var timezone = '{{ timezone }}';
   var csrfToken = '{{ csrf_token() }}';
 </script>
 <script src="{{ url_for_asset('base.js') }}" type="text/javascript"></script>


### PR DESCRIPTION
For non-global service operators, the UTC in navbar is useless.
This enables us to switch the navbar clock time as the local time.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1956


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
We can select the UTC or the client local time on the navbar clock.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This is only UI change.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
