### PR TITLE
[AIRFLOW-1958] Add **kwargs to send_email

### DIFF
--- a/airflow/contrib/utils/sendgrid.py
+++ b/airflow/contrib/utils/sendgrid.py
@@ -27,7 +27,9 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from sendgrid.helpers.mail import Attachment, Content, Email, Mail, Personalization
 
 
-def send_email(to, subject, html_content, files=None, dryrun=False, cc=None, bcc=None, mime_subtype='mixed'):
+def send_email(to, subject, html_content, files=None,
+               dryrun=False, cc=None, bcc=None,
+               mime_subtype='mixed', **kwargs):
     """
     Send an email with html content using sendgrid.
 

--- a/airflow/utils/email.py
+++ b/airflow/utils/email.py
@@ -34,17 +34,23 @@ from airflow.exceptions import AirflowConfigException
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 
-def send_email(to, subject, html_content, files=None, dryrun=False, cc=None, bcc=None, mime_subtype='mixed'):
+def send_email(to, subject, html_content, files=None,
+               dryrun=False, cc=None, bcc=None,
+               mime_subtype='mixed', **kwargs):
     """
     Send email using backend specified in EMAIL_BACKEND.
     """
     path, attr = configuration.get('email', 'EMAIL_BACKEND').rsplit('.', 1)
     module = importlib.import_module(path)
     backend = getattr(module, attr)
-    return backend(to, subject, html_content, files=files, dryrun=dryrun, cc=cc, bcc=bcc, mime_subtype=mime_subtype)
+    return backend(to, subject, html_content, files=files,
+                   dryrun=dryrun, cc=cc, bcc=bcc,
+                   mime_subtype=mime_subtype, **kwargs)
 
 
-def send_email_smtp(to, subject, html_content, files=None, dryrun=False, cc=None, bcc=None, mime_subtype='mixed'):
+def send_email_smtp(to, subject, html_content, files=None,
+                    dryrun=False, cc=None, bcc=None,
+                    mime_subtype='mixed', **kwargs):
     """
     Send an email with html content
 


### PR DESCRIPTION
### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1958


### Description
- [X] **kwargs added to email function definitions. This can be used with custom backends


### Tests
- [X] Covered by existing cases (at least should be)


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
