### PR TITLE
 [AIRFLOW-1954] Add new DataFlowTemplateOperator which runs Dataflow pipeline based on a template

### DIFF
--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -159,6 +159,11 @@ class DataFlowHook(GoogleCloudBaseHook):
         self._start_dataflow(
             task_id, variables, dataflow, name, ["java", "-jar"])
 
+    def start_template_dataflow(self, task_id, variables, parameters, dataflow_template):
+        name = task_id + "-" + str(uuid.uuid1())[:8]
+        self._start_template_dataflow(
+            name, variables, parameters, dataflow_template)
+
     def start_python_dataflow(self, task_id, variables, dataflow, py_options):
         name = task_id + "-" + str(uuid.uuid1())[:8]
         variables["job_name"] = name
@@ -171,3 +176,26 @@ class DataFlowHook(GoogleCloudBaseHook):
             for attr, value in variables.iteritems():
                 command.append("--" + attr + "=" + value)
         return command
+
+    def _start_template_dataflow(self, name, variables, parameters, dataflow_template):
+        # Builds RuntimeEnvironment from variables dictionary
+        # https://cloud.google.com/dataflow/docs/reference/rest/v1b3/RuntimeEnvironment
+        environment = {}
+        for key in ['maxWorkers', 'zone', 'serviceAccountEmail', 'tempLocation',
+                    'bypassTempDirValidation', 'machineType']:
+            if key in variables:
+                environment.update({key: variables[key]})
+        body = {"jobName": name,
+                "parameters": parameters,
+                "environment": environment}
+        service = self.get_conn()
+        if variables['project'] is None:
+            raise Exception(
+                'Project not specified')
+        request = service.projects().templates().launch(projectId=variables['project'],
+                                                        gcsPath=dataflow_template,
+                                                        body=body)
+        response = request.execute()
+        _DataflowJob(
+            self.get_conn(), variables['project'], name, self.poll_sleep).wait_for_done()
+        return response

--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import re
 import uuid
+import copy
 
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.contrib.hooks.gcp_dataflow_hook import DataFlowHook
@@ -126,6 +126,102 @@ class DataFlowJavaOperator(BaseOperator):
         dataflow_options.update(self.options)
 
         hook.start_java_dataflow(self.task_id, dataflow_options, self.jar)
+
+
+class DataflowTemplateOperator(BaseOperator):
+    """
+    Start a Templated Cloud DataFlow batch job. The parameters of the operation
+    will be passed to the job.
+    It's a good practice to define dataflow_* parameters in the default_args of the dag
+    like the project, zone and staging location.
+    https://cloud.google.com/dataflow/docs/reference/rest/v1b3/LaunchTemplateParameters
+    https://cloud.google.com/dataflow/docs/reference/rest/v1b3/RuntimeEnvironment
+    ```
+    default_args = {
+        'dataflow_default_options': {
+            'project': 'my-gcp-project'
+            'zone': 'europe-west1-d',
+            'tempLocation': 'gs://my-staging-bucket/staging/'
+            }
+        }
+    }
+    ```
+    You need to pass the path to your dataflow template as a file reference with the
+    ``template`` parameter. Use ``parameters`` to pass on parameters to your job.
+    Use ``environment`` to pass on runtime environment variables to your job.
+    ```
+    t1 = DataflowTemplateOperator(
+        task_id='datapflow_example',
+        template='{{var.value.gcp_dataflow_base}}',
+        parameters={
+            'inputFile': "gs://bucket/input/my_input.txt",
+            'outputFile': "gs://bucket/output/my_output.txt"
+        },
+        dag=my-dag)
+    ```
+    ``template`` ``dataflow_default_options`` and ``parameters`` are templated so you can
+    use variables in them.
+    """
+    template_fields = ['parameters', 'dataflow_default_options', 'template']
+    ui_color = '#0273d4'
+
+    @apply_defaults
+    def __init__(
+            self,
+            template,
+            dataflow_default_options=None,
+            parameters=None,
+            gcp_conn_id='google_cloud_default',
+            delegate_to=None,
+            poll_sleep=10,
+            *args,
+            **kwargs):
+        """
+        Create a new DataflowTemplateOperator. Note that
+        dataflow_default_options is expected to save high-level options
+        for project information, which apply to all dataflow operators in the DAG.
+        https://cloud.google.com/dataflow/docs/reference/rest/v1b3
+        /LaunchTemplateParameters
+        https://cloud.google.com/dataflow/docs/reference/rest/v1b3/RuntimeEnvironment
+        For more detail on job template execution have a look at the reference:
+        https://cloud.google.com/dataflow/docs/templates/executing-templates
+        :param template: The reference to the DataFlow template.
+        :type template: string
+        :param dataflow_default_options: Map of default job environment options.
+        :type dataflow_default_options: dict
+        :param parameters: Map of job specific parameters for the template.
+        :type parameters: dict
+        :param gcp_conn_id: The connection ID to use connecting to Google Cloud
+        Platform.
+        :type gcp_conn_id: string
+        :param delegate_to: The account to impersonate, if any.
+            For this to work, the service account making the request must have
+            domain-wide delegation enabled.
+        :type delegate_to: string
+        :param poll_sleep: The time in seconds to sleep between polling Google
+            Cloud Platform for the dataflow job status while the job is in the
+            JOB_STATE_RUNNING state.
+        :type poll_sleep: int
+        """
+        super(DataflowTemplateOperator, self).__init__(*args, **kwargs)
+
+        dataflow_default_options = dataflow_default_options or {}
+        parameters = parameters or {}
+
+        self.gcp_conn_id = gcp_conn_id
+        self.delegate_to = delegate_to
+        self.dataflow_default_options = dataflow_default_options
+        self.poll_sleep = poll_sleep
+        self.template = template
+        self.parameters = parameters
+
+    def execute(self, context):
+        hook = DataFlowHook(gcp_conn_id=self.gcp_conn_id,
+                            delegate_to=self.delegate_to,
+                            poll_sleep=self.poll_sleep)
+
+        hook.start_template_dataflow(self.task_id, self.dataflow_default_options,
+                                     self.parameters, self.template)
 
 
 class DataFlowPythonOperator(BaseOperator):

--- a/tests/contrib/operators/test_dataflow_operator.py
+++ b/tests/contrib/operators/test_dataflow_operator.py
@@ -15,6 +15,8 @@
 
 import unittest
 
+from airflow.contrib.operators.dataflow_operator import DataFlowPythonOperator, \
+    DataflowTemplateOperator
 from airflow.contrib.operators.dataflow_operator import DataFlowPythonOperator
 
 try:
@@ -26,12 +28,23 @@ except ImportError:
         mock = None
 
 
-TASK_ID = 'test-python-dataflow'
+TASK_ID = 'test-dataflow-operator'
+TEMPLATE = 'gs://dataflow-templates/wordcount/template_file'
+PARAMETERS = {
+    'inputFile': 'gs://dataflow-samples/shakespeare/kinglear.txt',
+    'output': 'gs://test/output/my_output'
+}
 PY_FILE = 'gs://my-bucket/my-object.py'
 PY_OPTIONS = ['-m']
-DEFAULT_OPTIONS = {
+DEFAULT_OPTIONS_PYTHON = {
     'project': 'test',
-    'stagingLocation': 'gs://test/staging'
+    'stagingLocation': 'gs://test/staging',
+}
+DEFAULT_OPTIONS_TEMPLATE = {
+    'project': 'test',
+    'stagingLocation': 'gs://test/staging',
+    'tempLocation': 'gs://test/temp',
+    'zone': 'us-central1-f'
 }
 ADDITIONAL_OPTIONS = {
     'output': 'gs://test/output'
@@ -47,7 +60,7 @@ class DataFlowPythonOperatorTest(unittest.TestCase):
             task_id=TASK_ID,
             py_file=PY_FILE,
             py_options=PY_OPTIONS,
-            dataflow_default_options=DEFAULT_OPTIONS,
+            dataflow_default_options=DEFAULT_OPTIONS_PYTHON,
             options=ADDITIONAL_OPTIONS,
             poll_sleep=POLL_SLEEP)
 
@@ -58,7 +71,7 @@ class DataFlowPythonOperatorTest(unittest.TestCase):
         self.assertEqual(self.dataflow.py_options, PY_OPTIONS)
         self.assertEqual(self.dataflow.poll_sleep, POLL_SLEEP)
         self.assertEqual(self.dataflow.dataflow_default_options,
-                         DEFAULT_OPTIONS)
+                         DEFAULT_OPTIONS_PYTHON)
         self.assertEqual(self.dataflow.options,
                          ADDITIONAL_OPTIONS)
 
@@ -82,3 +95,41 @@ class DataFlowPythonOperatorTest(unittest.TestCase):
         start_python_hook.assert_called_once_with(TASK_ID, expected_options,
                                                   mock.ANY, PY_OPTIONS)
         self.assertTrue(self.dataflow.py_file.startswith('/tmp/dataflow'))
+
+
+class DataFlowTemplateOperatorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.dataflow = DataflowTemplateOperator(
+            task_id=TASK_ID,
+            template=TEMPLATE,
+            parameters=PARAMETERS,
+            dataflow_default_options=DEFAULT_OPTIONS_TEMPLATE,
+            poll_sleep=POLL_SLEEP)
+
+    def test_init(self):
+        """Test DataflowTemplateOperator instance is properly initialized."""
+        self.assertEqual(self.dataflow.task_id, TASK_ID)
+        self.assertEqual(self.dataflow.template, TEMPLATE)
+        self.assertEqual(self.dataflow.parameters, PARAMETERS)
+        self.assertEqual(self.dataflow.poll_sleep, POLL_SLEEP)
+        self.assertEqual(self.dataflow.dataflow_default_options,
+                         DEFAULT_OPTIONS_TEMPLATE)
+
+    @mock.patch('airflow.contrib.operators.dataflow_operator.DataFlowHook')
+    def test_exec(self, dataflow_mock):
+        """Test DataFlowHook is created and the right args are passed to
+        start_template_workflow.
+
+        """
+        start_template_hook = dataflow_mock.return_value.start_template_dataflow
+        self.dataflow.execute(None)
+        self.assertTrue(dataflow_mock.called)
+        expected_options = {
+            'project': 'test',
+            'stagingLocation': 'gs://test/staging',
+            'tempLocation': 'gs://test/temp',
+            'zone': 'us-central1-f'
+        }
+        start_template_hook.assert_called_once_with(TASK_ID, expected_options,
+                                                    PARAMETERS, TEMPLATE)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [AIRFLOW-1954] (https://issues.apache.org/jira/browse/AIRFLOW-1954) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
This operator should start a Dataflow pipeline based on a template.
https://cloud.google.com/dataflow/docs/templates/overview

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`