### PR TITLE
[AIRFLOW-1953] Add labels to dataflow operators

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -14,6 +14,11 @@ celery_result_backend -> result_backend
 ```
 This will result in the same config parameters as Celery 4 and will make it more transparent.
 
+### GCP Dataflow Operators
+Dataflow job labeling is now supported in Dataflow{Java,Python}Operator with a default
+"airflow-version" label, please upgrade your google-cloud-dataflow or apache-beam version
+to 2.2.0 or greater.
+
 ## Airflow 1.9
 
 ### SSH Hook updates, along with new SSH Operator & SFTP Operator

--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import select
 import subprocess
 import time
@@ -147,27 +148,40 @@ class DataFlowHook(GoogleCloudBaseHook):
         http_authorized = self._authorize()
         return build('dataflow', 'v1b3', http=http_authorized)
 
-    def _start_dataflow(self, task_id, variables, dataflow, name, command_prefix):
-        cmd = command_prefix + self._build_cmd(task_id, variables, dataflow)
+    def _start_dataflow(self, task_id, variables, dataflow,
+                        name, command_prefix, label_formatter):
+        cmd = command_prefix + self._build_cmd(task_id, variables,
+                                               dataflow, label_formatter)
         _Dataflow(cmd).wait_for_done()
-        _DataflowJob(
-            self.get_conn(), variables['project'], name, self.poll_sleep).wait_for_done()
+        _DataflowJob(self.get_conn(), variables['project'],
+                     name, self.poll_sleep).wait_for_done()
 
     def start_java_dataflow(self, task_id, variables, dataflow):
         name = task_id + "-" + str(uuid.uuid1())[:8]
         variables['jobName'] = name
-        self._start_dataflow(
-            task_id, variables, dataflow, name, ["java", "-jar"])
+
+        def label_formatter(labels_dict):
+            return ['--labels={}'.format(
+                    json.dumps(labels_dict).replace(' ', ''))]
+        self._start_dataflow(task_id, variables, dataflow, name,
+                             ["java", "-jar"], label_formatter)
 
     def start_python_dataflow(self, task_id, variables, dataflow, py_options):
         name = task_id + "-" + str(uuid.uuid1())[:8]
         variables["job_name"] = name
-        self._start_dataflow(
-            task_id, variables, dataflow, name, ["python"] + py_options)
 
-    def _build_cmd(self, task_id, variables, dataflow):
+        def label_formatter(labels_dict):
+            return ['--labels={}={}'.format(key, value)
+                    for key, value in labels_dict.items()]
+        self._start_dataflow(task_id, variables, dataflow, name,
+                             ["python"] + py_options, label_formatter)
+
+    def _build_cmd(self, task_id, variables, dataflow, label_formatter):
         command = [dataflow, "--runner=DataflowRunner"]
         if variables is not None:
-            for attr, value in variables.iteritems():
-                command.append("--" + attr + "=" + value)
+            for attr, value in variables.items():
+                if attr == 'labels':
+                    command += label_formatter(value)
+                else:
+                    command.append("--" + attr + "=" + value)
         return command

--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -19,6 +19,7 @@ import uuid
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.contrib.hooks.gcp_dataflow_hook import DataFlowHook
 from airflow.models import BaseOperator
+from airflow.version import version
 from airflow.utils.decorators import apply_defaults
 
 
@@ -52,7 +53,8 @@ class DataFlowJavaOperator(BaseOperator):
             'autoscalingAlgorithm': 'BASIC',
             'maxNumWorkers': '50',
             'start': '{{ds}}',
-            'partitionType': 'DAY'
+            'partitionType': 'DAY',
+            'labels': {'foo' : 'bar'}
         },
         dag=my-dag)
     ```
@@ -97,7 +99,7 @@ class DataFlowJavaOperator(BaseOperator):
             For this to work, the service account making the request must have
             domain-wide delegation enabled.
         :type delegate_to: string
-        :param poll_sleep: The time in seconds to sleep between polling Google 
+        :param poll_sleep: The time in seconds to sleep between polling Google
             Cloud Platform for the dataflow job status while the job is in the
             JOB_STATE_RUNNING state.
         :type poll_sleep: int
@@ -106,7 +108,8 @@ class DataFlowJavaOperator(BaseOperator):
 
         dataflow_default_options = dataflow_default_options or {}
         options = options or {}
-
+        options.setdefault('labels', {}).update(
+            {'airflow-version': 'v' + version.replace('.', '-').replace('+', '-')})
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.jar = jar
@@ -171,7 +174,7 @@ class DataFlowPythonOperator(BaseOperator):
             For this to work, the service account making the request must have
             domain-wide  delegation enabled.
         :type delegate_to: string
-        :param poll_sleep: The time in seconds to sleep between polling Google 
+        :param poll_sleep: The time in seconds to sleep between polling Google
             Cloud Platform for the dataflow job status while the job is in the
             JOB_STATE_RUNNING state.
         :type poll_sleep: int
@@ -182,6 +185,8 @@ class DataFlowPythonOperator(BaseOperator):
         self.py_options = py_options or []
         self.dataflow_default_options = dataflow_default_options or {}
         self.options = options or {}
+        self.options.setdefault('labels', {}).update(
+            {'airflow-version': 'v' + version.replace('.', '-').replace('+', '-')})
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.poll_sleep = poll_sleep

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ gcp_api = [
     'google-api-python-client>=1.5.0, <1.6.0',
     'oauth2client>=2.0.2, <2.1.0',
     'PyOpenSSL',
-    'google-cloud-dataflow',
+    'google-cloud-dataflow>=2.2.0',
     'pandas-gbq'
 ]
 hdfs = ['snakebite>=2.7.8']

--- a/tests/contrib/operators/test_dataflow_operator.py
+++ b/tests/contrib/operators/test_dataflow_operator.py
@@ -16,6 +16,7 @@
 import unittest
 
 from airflow.contrib.operators.dataflow_operator import DataFlowPythonOperator
+from airflow.version import version
 
 try:
     from unittest import mock
@@ -34,7 +35,13 @@ DEFAULT_OPTIONS = {
     'stagingLocation': 'gs://test/staging'
 }
 ADDITIONAL_OPTIONS = {
-    'output': 'gs://test/output'
+    'output': 'gs://test/output',
+    'labels': {'foo': 'bar'}
+}
+TEST_VERSION = 'v{}'.format(version.replace('.', '-').replace('+', '-'))
+EXPECTED_ADDITIONAL_OPTIONS = {
+    'output': 'gs://test/output',
+    'labels': {'foo': 'bar', 'airflow-version': TEST_VERSION}
 }
 POLL_SLEEP = 30
 GCS_HOOK_STRING = 'airflow.contrib.operators.dataflow_operator.{}'
@@ -60,7 +67,7 @@ class DataFlowPythonOperatorTest(unittest.TestCase):
         self.assertEqual(self.dataflow.dataflow_default_options,
                          DEFAULT_OPTIONS)
         self.assertEqual(self.dataflow.options,
-                         ADDITIONAL_OPTIONS)
+                         EXPECTED_ADDITIONAL_OPTIONS)
 
     @mock.patch('airflow.contrib.operators.dataflow_operator.DataFlowHook')
     @mock.patch(GCS_HOOK_STRING.format('GoogleCloudBucketHelper'))
@@ -76,7 +83,8 @@ class DataFlowPythonOperatorTest(unittest.TestCase):
         expected_options = {
             'project': 'test',
             'staging_location': 'gs://test/staging',
-            'output': 'gs://test/output'
+            'output': 'gs://test/output',
+            'labels': {'foo': 'bar', 'airflow-version': TEST_VERSION}
         }
         gcs_download_hook.assert_called_once_with(PY_FILE)
         start_python_hook.assert_called_once_with(TASK_ID, expected_options,

--- a/tests/contrib/operators/test_mlengine_operator_utils.py
+++ b/tests/contrib/operators/test_mlengine_operator_utils.py
@@ -26,11 +26,13 @@ from airflow import configuration, DAG
 from airflow.contrib.operators import mlengine_operator_utils
 from airflow.contrib.operators.mlengine_operator_utils import create_evaluate_ops
 from airflow.exceptions import AirflowException
+from airflow.version import version
 
 from mock import ANY
 from mock import patch
 
 DEFAULT_DATE = datetime.datetime(2017, 6, 6)
+TEST_VERSION = 'v{}'.format(version.replace('.', '-').replace('+', '-'))
 
 
 class CreateEvaluateOpsTest(unittest.TestCase):
@@ -115,6 +117,7 @@ class CreateEvaluateOpsTest(unittest.TestCase):
                 'eval-test-summary',
                 {
                     'prediction_path': 'gs://legal-bucket/fake-output-path',
+                    'labels': {'airflow-version': TEST_VERSION},
                     'metric_keys': 'err',
                     'metric_fn_encoded': self.metric_fn_encoded,
                 },


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1953


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
Add dataflow job labeling support in Dataflow{Java,Python}Operator.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Both  tests.contrib.operators.test_dataflow_operator and tests.contrib.hooks.test_gcp_dataflow_hook tests are passed without any issue. 

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

  