### PR TITLE
[AIRFLOW-1963] Add config for HiveOperator mapred_queue

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -170,6 +170,9 @@ default_ram = 512
 default_disk = 512
 default_gpus = 0
 
+[hive]
+# Default mapreduce queue for HiveOperator tasks
+default_hive_mapred_queue =
 
 [webserver]
 # The base url of your website as airflow cannot guess what domain or
@@ -457,7 +460,6 @@ keytab = airflow.keytab
 
 [github_enterprise]
 api_rev = v3
-
 
 [admin]
 # UI to hide sensitive variable fields when set to True

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -51,6 +51,9 @@ auth_backend = airflow.api.auth.backend.default
 [operators]
 default_owner = airflow
 
+[hive]
+default_hive_mapred_queue = airflow
+
 [webserver]
 base_url = http://localhost:8080
 web_server_host = 0.0.0.0

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -25,6 +25,7 @@ import time
 from tempfile import NamedTemporaryFile
 import hive_metastore
 
+from airflow import configuration as conf
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 from airflow.utils.helpers import as_flattened_list
@@ -82,7 +83,8 @@ class HiveCliHook(BaseHook):
                     "Invalid Mapred Queue Priority.  Valid values are: "
                     "{}".format(', '.join(HIVE_QUEUE_PRIORITIES)))
 
-        self.mapred_queue = mapred_queue
+        self.mapred_queue = mapred_queue or conf.get('hive',
+                                                     'default_hive_mapred_queue')
         self.mapred_queue_priority = mapred_queue_priority
         self.mapred_job_name = mapred_job_name
 

--- a/airflow/operators/hive_operator.py
+++ b/airflow/operators/hive_operator.py
@@ -77,13 +77,19 @@ class HiveOperator(BaseOperator):
         self.mapred_queue_priority = mapred_queue_priority
         self.mapred_job_name = mapred_job_name
 
+        # assigned lazily - just for consistency we can create the attribute with a
+        # `None` initial value, later it will be populated by the execute method.
+        # This also makes `on_kill` implementation consistent since it assumes `self.hook`
+        # is defined.
+        self.hook = None
+
     def get_hook(self):
         return HiveCliHook(
-                        hive_cli_conn_id=self.hive_cli_conn_id,
-                        run_as=self.run_as,
-                        mapred_queue=self.mapred_queue,
-                        mapred_queue_priority=self.mapred_queue_priority,
-                        mapred_job_name=self.mapred_job_name)
+            hive_cli_conn_id=self.hive_cli_conn_id,
+            run_as=self.run_as,
+            mapred_queue=self.mapred_queue,
+            mapred_queue_priority=self.mapred_queue_priority,
+            mapred_job_name=self.mapred_job_name)
 
     def prepare_template(self):
         if self.hiveconf_jinja_translate:
@@ -103,4 +109,5 @@ class HiveOperator(BaseOperator):
         self.hook.test_hql(hql=self.hql)
 
     def on_kill(self):
-        self.hook.kill()
+        if self.hook:
+            self.hook.kill()

--- a/scripts/ci/airflow_travis.cfg
+++ b/scripts/ci/airflow_travis.cfg
@@ -31,6 +31,9 @@ base_url = http://localhost:8080
 web_server_host = 0.0.0.0
 web_server_port = 8080
 
+[hive]
+default_hive_mapred_queue = airflow
+
 [email]
 email_backend = airflow.utils.send_email_smtp
 


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1963


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Previously there's no way to define a default `mapred_queue` for HiveOperators, but there may be valid use cases where a default could be configured in airflow to make HiveOperator tasks more flexible.

Adding configuration setting for specifying a default mapred_queue for
hive jobs using the HiveOperator.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added tests that check for the default `mapred_queue` and the override via parameters.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

PTAL @aoen @saguziel