### PR TITLE
Set initial user password

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -40,10 +40,12 @@ attack. Creating a new user has to be done via a Python REPL on the same machine
     >>> import airflow
     >>> from airflow import models, settings
     >>> from airflow.contrib.auth.backends.password_auth import PasswordUser
+    >>> from flask_bcrypt import generate_password_hash
     >>> user = PasswordUser(models.User())
     >>> user.username = 'new_user_name'
     >>> user.email = 'new_user_email@example.com'
-    >>> user.password = 'set_the_password'
+    >>> user._password = generate_password_hash('set_the_password', 12)
+    >>> user._password = str(user._password, 'utf-8')
     >>> session = settings.Session()
     >>> session.add(user)
     >>> session.commit()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Following line fails with `AttributeError: can't set attribute`
```
user.password = 'set_the_password'
```
It's fixed by directly updating `user._password`

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Only updating docs

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
