### PR TITLE
[AIRFLOW-1971] Propagate hive config on impersonation

### DIFF
--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -64,6 +64,7 @@ class BaseTaskRunner(LoggingMixin):
                 'smtp': cfg_dict.get('smtp', {}),
                 'scheduler': cfg_dict.get('scheduler', {}),
                 'webserver': cfg_dict.get('webserver', {}),
+                'hive': cfg_dict.get('hive', {}),  # we should probably generalized this
             }
             temp_fd, cfg_path = mkstemp()
 

--- a/tests/dags/test_impersonation_custom.py
+++ b/tests/dags/test_impersonation_custom.py
@@ -41,7 +41,17 @@ def print_today():
     print('Today is {}'.format(dt.strftime('%Y-%m-%d')))
 
 
+def check_hive_conf():
+    from airflow import configuration as conf
+    assert conf.get('hive', 'default_hive_mapred_queue') == 'airflow'
+
+
 PythonOperator(
     python_callable=print_today,
     task_id='exec_python_fn',
+    dag=dag)
+
+PythonOperator(
+    python_callable=check_hive_conf,
+    task_id='exec_check_hive_conf_fn',
     dag=dag)


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1971

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently, if hive specific settings are defined in the configuration
file, they are not being propagated when using impersonation.
We need to propagate this configuration down to the impersonated
process.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added test in impersonation tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
