### PR TITLE
[AIRFLOW-1975] Make TriggerDagRunOperator callback optional

### DIFF
--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -28,7 +28,7 @@ class DagRunOrder(object):
 
 class TriggerDagRunOperator(BaseOperator):
     """
-    Triggers a DAG run for a specified ``dag_id`` if a criteria is met
+    Triggers a DAG run for a specified ``dag_id``
 
     :param trigger_dag_id: the dag_id to trigger
     :type trigger_dag_id: str
@@ -51,7 +51,7 @@ class TriggerDagRunOperator(BaseOperator):
     def __init__(
             self,
             trigger_dag_id,
-            python_callable,
+            python_callable=None,
             *args, **kwargs):
         super(TriggerDagRunOperator, self).__init__(*args, **kwargs)
         self.python_callable = python_callable
@@ -59,7 +59,8 @@ class TriggerDagRunOperator(BaseOperator):
 
     def execute(self, context):
         dro = DagRunOrder(run_id='trig__' + timezone.utcnow().isoformat())
-        dro = self.python_callable(context, dro)
+        if self.python_callable is not None:
+            dro = self.python_callable(context, dro)
         if dro:
             with create_session() as session:
                 dbag = DagBag(settings.DAGS_FOLDER)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1975


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

Removes the need to create and pass a callback when instantiating a TriggerDagRunOperator.

Simply trigger the dag by it's id.
```python
TriggerDagRunOperator('my-dag')
```

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No tests.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
