### PR TITLE
[AIRFLOW-1976] Fix for missing log/logger attribute FileProcessHandler

### DIFF
--- a/airflow/utils/log/file_processor_handler.py
+++ b/airflow/utils/log/file_processor_handler.py
@@ -108,15 +108,15 @@ class FileProcessorHandler(logging.Handler):
                         os.symlink(log_directory, latest_log_directory_path)
                 elif (os.path.isdir(latest_log_directory_path) or
                           os.path.isfile(latest_log_directory_path)):
-                    self.log.warning(
+                    logging.warning(
                         "%s already exists as a dir/file. Skip creating symlink.",
                         latest_log_directory_path
                     )
                 else:
                     os.symlink(log_directory, latest_log_directory_path)
             except OSError:
-                self.logger.warning("OSError while attempting to symlink "
-                                    "the latest log directory")
+                logging.warning("OSError while attempting to symlink "
+                                "the latest log directory")
 
     def _init_file(self, filename):
         """

--- a/tests/utils/log/test_file_processor_handler.py
+++ b/tests/utils/log/test_file_processor_handler.py
@@ -86,5 +86,24 @@ class TestFileProcessorHandler(unittest.TestCase):
             self.assertEqual(os.path.basename(os.readlink(link)), date2)
             self.assertTrue(os.path.exists(os.path.join(link, "log2")))
 
+    def test_symlink_latest_log_directory_exists(self):
+        handler = FileProcessorHandler(base_log_folder=self.base_log_folder,
+                                       filename_template=self.filename)
+        handler.dag_dir = self.dag_dir
+
+        date1 = (timezone.utcnow() + timedelta(days=1)).strftime("%Y-%m-%d")
+
+        p1 = os.path.join(self.base_log_folder, date1, "log1")
+        if os.path.exists(p1):
+            os.remove(p1)
+
+        link = os.path.join(self.base_log_folder, "latest")
+        if os.path.exists(link):
+            os.remove(link)
+        os.makedirs(link)
+
+        with freeze_time(date1):
+            handler.set_context(filename=os.path.join(self.dag_dir, "log1"))
+
     def tearDown(self):
         shutil.rmtree(self.base_log_folder, ignore_errors=True)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1976


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
Fixup for log/logger attributes missing in FileProcessHandler

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

  