### PR TITLE
[AIRFLOW-1480] Render template attributes for ExternalTaskSensor fields

### DIFF
--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -202,6 +202,7 @@ class ExternalTaskSensor(BaseSensorOperator):
         or execution_date_fn can be passed to ExternalTaskSensor, but not both.
     :type execution_date_fn: callable
     """
+    template_fields = ['external_dag_id', 'external_task_id']
     ui_color = '#19647e'
 
     @apply_defaults

--- a/tests/operators/sensors.py
+++ b/tests/operators/sensors.py
@@ -272,6 +272,25 @@ class ExternalTaskSensorTests(unittest.TestCase):
             'start_date': DEFAULT_DATE,
             'depends_on_past': False}
 
+    def test_templated_sensor(self):
+        dag = DAG(TEST_DAG_ID, self.args)
+
+        with dag:
+            sensor = ExternalTaskSensor(
+                task_id='templated_task',
+                external_dag_id='dag_{{ ds }}',
+                external_task_id='task_{{ ds }}',
+                start_date=DEFAULT_DATE
+            )
+
+        instance = TaskInstance(sensor, DEFAULT_DATE)
+        instance.render_templates()
+
+        self.assertEqual(sensor.external_dag_id,
+                         "dag_{}".format(DEFAULT_DATE.date()))
+        self.assertEqual(sensor.external_task_id,
+                         "task_{}".format(DEFAULT_DATE.date()))
+
     def test_external_task_sensor_fn_multiple_execution_dates(self):
         bash_command_code = """
 {% set s=execution_date.time().second %}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1480) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
