### PR TITLE
[AIRFLOW-1988] Change BG color of None state TIs

### DIFF
--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -48,6 +48,7 @@ class State(object):
         UPSTREAM_FAILED,
         UP_FOR_RETRY,
         QUEUED,
+        NONE,
     )
 
     dag_states = (
@@ -67,6 +68,7 @@ class State(object):
         SKIPPED: 'pink',
         REMOVED: 'lightgrey',
         SCHEDULED: 'white',
+        NONE: 'lightblue',
     }
 
     @classmethod


### PR DESCRIPTION
On Task Instances page `None` state TIs are not-visible due to white
background. Changing background color for better UX.

Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1988


### Description
- [ ] A small change to spot TIs with None state easily

Current
<img width="411" alt="screen shot 2018-01-09 at 6 21 15 pm" src="https://user-images.githubusercontent.com/2018407/34830481-fe8023d2-f709-11e7-84ca-33a68c17796b.png">

After change
<img width="408" alt="screen shot 2018-01-09 at 6 21 24 pm" src="https://user-images.githubusercontent.com/2018407/34830492-07f89548-f70a-11e7-980b-1f4e47bb6254.png">



### Tests
- [ ] Manually tested

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
