### PR TITLE
[AIRFLOW-1994] Change background color of Scheduled state Task Instances

### DIFF
--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -49,6 +49,7 @@ class State(object):
         UP_FOR_RETRY,
         QUEUED,
         NONE,
+        SCHEDULED,
     )
 
     dag_states = (
@@ -67,7 +68,7 @@ class State(object):
         UPSTREAM_FAILED: 'orange',
         SKIPPED: 'pink',
         REMOVED: 'lightgrey',
-        SCHEDULED: 'white',
+        SCHEDULED: 'tan',
         NONE: 'lightblue',
     }
 


### PR DESCRIPTION
On Task Instances page 'Scheduled' state TIs are not-visible due to white
background. Changing background color to tan for better UX.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1994) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

A small change to spot TIs with Scheduled state easily
Then:
<img width="428" alt="screen shot 2018-01-11 at 2 43 46 pm" src="https://user-images.githubusercontent.com/5952735/34851218-e6b70fe4-f6dd-11e7-805a-75383c8961dd.png">

Now:
<img width="427" alt="screen shot 2018-01-11 at 2 24 14 pm" src="https://user-images.githubusercontent.com/5952735/34851165-b37aedc6-f6dd-11e7-9af4-707dcf4199bd.png">

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Manually tested

### Commits

- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
