### PR TITLE
[AIRFLOW-1995] add on_kill method to SqoopOperator

### DIFF
--- a/airflow/contrib/hooks/sqoop_hook.py
+++ b/airflow/contrib/hooks/sqoop_hook.py
@@ -88,21 +88,22 @@ class SqoopHook(BaseHook, LoggingMixin):
         :param kwargs: extra arguments to Popen (see subprocess.Popen)
         :return: handle to subprocess
         """
-        self.log.info("Executing command: {}".format(' '.join(self.cmd_mask_password(cmd))))
-        sp = subprocess.Popen(cmd,
+        masked_cmd = ' '.join(self.cmd_mask_password(cmd))
+        self.log.info("Executing command: {}".format(masked_cmd))
+        self.sp = subprocess.Popen(cmd,
                               stdout=subprocess.PIPE,
                               stderr=subprocess.STDOUT,
                               **kwargs)
 
-        for line in iter(sp.stdout):
+        for line in iter(self.sp.stdout):
             self.log.info(line.strip())
 
-        sp.wait()
+        self.sp.wait()
 
-        self.log.info("Command exited with return code %s", sp.returncode)
+        self.log.info("Command exited with return code %s", self.sp.returncode)
 
-        if sp.returncode:
-            raise AirflowException("Sqoop command failed: {}".format(' '.join(self.cmd_mask_password(cmd))))
+        if self.sp.returncode:
+            raise AirflowException("Sqoop command failed: {}".format(masked_cmd))
 
     def _prepare_command(self, export=False):
         sqoop_cmd_type = "export" if export else "import"

--- a/airflow/contrib/operators/sqoop_operator.py
+++ b/airflow/contrib/operators/sqoop_operator.py
@@ -16,6 +16,8 @@
 """
 This module contains a sqoop 1 operator
 """
+import os
+import signal
 
 from airflow.contrib.hooks.sqoop_hook import SqoopHook
 from airflow.exceptions import AirflowException
@@ -148,22 +150,24 @@ class SqoopOperator(BaseOperator):
         self.hcatalog_table = hcatalog_table
         self.create_hcatalog_table = create_hcatalog_table
         self.properties = properties
-        self.extra_import_options = extra_import_options
-        self.extra_export_options = extra_export_options
+        self.extra_import_options = extra_import_options or {}
+        self.extra_export_options = extra_export_options or {}
 
     def execute(self, context):
         """
         Execute sqoop job
         """
-        hook = SqoopHook(conn_id=self.conn_id,
-                         verbose=self.verbose,
-                         num_mappers=self.num_mappers,
-                         hcatalog_database=self.hcatalog_database,
-                         hcatalog_table=self.hcatalog_table,
-                         properties=self.properties)
+        self.hook = SqoopHook(
+            conn_id=self.conn_id,
+            verbose=self.verbose,
+            num_mappers=self.num_mappers,
+            hcatalog_database=self.hcatalog_database,
+            hcatalog_table=self.hcatalog_table,
+            properties=self.properties
+        )
 
         if self.cmd_type == 'export':
-            hook.export_table(
+            self.hook.export_table(
                 table=self.table,
                 export_dir=self.export_dir,
                 input_null_string=self.input_null_string,
@@ -185,10 +189,12 @@ class SqoopOperator(BaseOperator):
                 self.extra_import_options['create-hcatalog-table'] = ''
 
             if self.table and self.query:
-                raise AirflowException('Cannot specify query and table together. Need to specify either or.')
+                raise AirflowException(
+                    'Cannot specify query and table together. Need to specify either or.'
+                )
 
             if self.table:
-                hook.import_table(
+                self.hook.import_table(
                     table=self.table,
                     target_dir=self.target_dir,
                     append=self.append,
@@ -200,7 +206,7 @@ class SqoopOperator(BaseOperator):
                     driver=self.driver,
                     extra_import_options=self.extra_import_options)
             elif self.query:
-                hook.import_query(
+                self.hook.import_query(
                     query=self.query,
                     target_dir=self.target_dir,
                     append=self.append,
@@ -215,3 +221,7 @@ class SqoopOperator(BaseOperator):
                 )
         else:
             raise AirflowException("cmd_type should be 'import' or 'export'")
+
+    def on_kill(self):
+        self.log.info('Sending SIGTERM signal to bash process group')
+        os.killpg(os.getpgid(self.hook.sp.pid), signal.SIGTERM)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow 1995](https://issues.apache.org/jira/browse/AIRFLOW-1995/) issues and references them in the PR title. For example, "[AIRFLOW-1995] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1995


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
The sqoop operator behind the scenes sets off a bash command, but one bug arises due to the fact that the on kill method is not implemented. It needs to be implemented in order to kill the process for a sqoop task, otherwise weird things happen trying to end the task.

CC @Fokko 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Difficult to get a test for. Tested locally by making sure the pid is killed as soon as method is called locally but without binary it fails. I use same on kill method as bash operator

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
