### PR TITLE
[AIRFLOW-192] New BaseOperator param weight_rule for priority_weight …

### DIFF
--- a/airflow/utils/weight_rule.py
+++ b/airflow/utils/weight_rule.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import unicode_literals
+
+from builtins import object
+
+
+class WeightRule(object):
+    DOWNSTREAM = 'downstream'
+    UPSTREAM = 'upstream'
+    ABSOLUTE = 'absolute'
+
+    @classmethod
+    def is_valid(cls, weight_rule):
+        return weight_rule in cls.all_weight_rules()
+
+    @classmethod
+    def all_weight_rules(cls):
+        return [getattr(cls, attr)
+                for attr in dir(cls)
+                if not attr.startswith("__") and not callable(getattr(cls, attr))]


### PR DESCRIPTION
…aggregation

Improved task generation performance significantly by using sets of
task_ids and dag_ids instead of lists when calculating total priority
weight.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-192


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
        weighting method used for the effective total           
        priority weight of the task. Options are:                               
        ``{ downstream | upstream | absolute }`` default is ``downstream``      
        When set to ``downstream`` the effective weight of the task is the      
        aggregate sum of all downstream descendants. As a result, upstream      
        tasks will have higher weight and will be scheduled more aggressively   
        when using positive weight values. This is useful when you have         
        multiple dag run instances and desire to have all upstream tasks to     
        complete for all runs before each dag can continue processing           
        downstream tasks. When set to ``upstream`` the effective weight is the  
        aggregate sum of all upstream ancestors. This is the opposite where     
        downtream tasks have higher weight and will be scheduled more           
        aggressively when using positive weight values. This is useful when you 
        have multiple dag run instances and prefer to have each dag complete    
        before starting upstream tasks of other dags.  When set to              
        ``absolute``, the effective weight is the exact ``priority_weight``     
        specified without additional weighting. You may want to do this when    
        you know exactly what priority weight each task should have.            
        Additionally, when set to ``absolute``, there is bonus effect of        
        significantly speeding up the task creation process as for very large   
        DAGS. Options can be set as string or using the constants defined in    
        the static class ``airflow.utils.WeightRule``
 
Additionally, the performance of the priority weight is significantly improved by switching over to a set instead of iterating through a list to test for membership.

For this dag on my computer:
[2.5k parallel operators] -> [join operator] -> [2.5k parallel operators] -> [join operator] -> [2.5k parallel operators] 

| Implementation | Time to "Examine DAG run" |
| - | - |
| Original | 10 minutes |
| New | 60 seconds |
| `absolute` weight | 1 second |

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
test_dag_task_priority_weight_total

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`