### PR TITLE
[AIRFLOW-2000] Support non-main dataflow job class

### DIFF
--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -73,6 +73,7 @@ class DataFlowJavaOperator(BaseOperator):
             gcp_conn_id='google_cloud_default',
             delegate_to=None,
             poll_sleep=10,
+            job_class=None,
             *args,
             **kwargs):
         """
@@ -103,6 +104,9 @@ class DataFlowJavaOperator(BaseOperator):
             Cloud Platform for the dataflow job status while the job is in the
             JOB_STATE_RUNNING state.
         :type poll_sleep: int
+        :param job_class: The name of the dataflow job class to be executued, it
+        is often not the main class configured in the dataflow jar file.
+        :type job_class: string
         """
         super(DataFlowJavaOperator, self).__init__(*args, **kwargs)
 
@@ -116,6 +120,7 @@ class DataFlowJavaOperator(BaseOperator):
         self.dataflow_default_options = dataflow_default_options
         self.options = options
         self.poll_sleep = poll_sleep
+        self.job_class = job_class
 
     def execute(self, context):
         bucket_helper = GoogleCloudBucketHelper(
@@ -128,7 +133,8 @@ class DataFlowJavaOperator(BaseOperator):
         dataflow_options = copy.copy(self.dataflow_default_options)
         dataflow_options.update(self.options)
 
-        hook.start_java_dataflow(self.task_id, dataflow_options, self.jar)
+        hook.start_java_dataflow(self.task_id, dataflow_options,
+                                 self.jar, self.job_class)
 
 
 class DataflowTemplateOperator(BaseOperator):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2000


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
Allow one to launch a non-main runnable dataflow job class in dataflow jar files.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
