### PR TITLE
[AIRFLOW-2003] Use flask-caching instead of flask-cache

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -17,7 +17,7 @@ import six
 
 from flask import Flask
 from flask_admin import Admin, base
-from flask_cache import Cache
+from flask_caching import Cache
 from flask_wtf.csrf import CSRFProtect
 csrf = CSRFProtect()
 

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,7 @@ def do_setup():
             'dill>=0.2.2, <0.3',
             'flask>=0.11, <0.12',
             'flask-admin==1.4.1',
-            'flask-cache>=0.13.1, <0.14',
+            'flask-caching>=1.3.3, <1.4.0',
             'flask-login==0.2.11',
             'flask-swagger==0.2.13',
             'flask-wtf>=0.14, <0.15',


### PR DESCRIPTION
Flask-cache has been unmaintained for over three years,
flask-caching is the community supported version.

Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2003


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

Bring dependency up to date.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

covered by existing.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
