### PR TITLE
[AIRFLOW-1927] Convert naive datetimes for TaskInstances

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -27,7 +27,7 @@ from importlib import import_module
 import argparse
 from builtins import input
 from collections import namedtuple
-from dateutil.parser import parse as parsedate
+from airflow.utils.timezone import parse as parsedate
 import json
 from tabulate import tabulate
 

--- a/docs/timezone.rst
+++ b/docs/timezone.rst
@@ -2,9 +2,9 @@ Time zones
 ==========
 
 Support for time zones is enabled by default. Airflow stores datetime information in UTC internally and in the database.
- It allows you to run your DAGs with time zone dependent schedules. At the moment Airflow does not them to the end 
- user’s time zone in the user interface. Also templates used in Operators are not translated. Time zone information 
- is exposed and it is left up to the writer of DAG what do with it.
+It allows you to run your DAGs with time zone dependent schedules. At the moment Airflow does not convert them to the 
+end user’s time zone in the user interface. There it will always be displayed in UTC. Also templates used in Operators 
+are not converted. Time zone information is exposed and it is up to the writer of DAG what do with it.
 
 This is handy if your users live in more than one time zone and you want to display datetime information according to 
 each user’s wall clock.

--- a/setup.py
+++ b/setup.py
@@ -221,7 +221,7 @@ def do_setup():
             'lxml>=3.6.0, <4.0',
             'markdown>=2.5.2, <3.0',
             'pandas>=0.17.1, <1.0.0',
-            'pendulum==1.3.2',
+            'pendulum==1.4.0',
             'psutil>=4.2.0, <5.0.0',
             'pygments>=2.0.1, <3.0',
             'python-daemon>=2.1.1, <2.2',

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -333,6 +333,31 @@ class BackfillJobTest(unittest.TestCase):
         ti_dependent.refresh_from_db()
         self.assertEquals(ti_dependent.state, State.SUCCESS)
 
+    def test_run_naive_taskinstance(self):
+        """
+        Test that we can run naive (non-localized) task instances
+        """
+        NAIVE_DATE = datetime.datetime(2016, 1, 1)
+        dag_id = 'test_run_ignores_all_dependencies'
+
+        dag = self.dagbag.get_dag('test_run_ignores_all_dependencies')
+        dag.clear()
+
+        task0_id = 'test_run_dependent_task'
+        args0 = ['run',
+                 '-A',
+                 dag_id,
+                 task0_id,
+                 NAIVE_DATE.isoformat()]
+
+        cli.run(self.parser.parse_args(args0))
+        ti_dependent0 = TI(
+            task=dag.get_task(task0_id),
+            execution_date=NAIVE_DATE)
+
+        ti_dependent0.refresh_from_db()
+        self.assertEquals(ti_dependent0.state, State.FAILED)
+
     def test_cli_backfill_depends_on_past(self):
         """
         Test that CLI respects -I argument

--- a/tests/models.py
+++ b/tests/models.py
@@ -897,6 +897,29 @@ class TaskInstanceTest(unittest.TestCase):
         self.assertTrue(
             op3.end_date == DEFAULT_DATE + datetime.timedelta(days=9))
 
+    def test_timezone_awareness(self):
+        NAIVE_DATETIME = DEFAULT_DATE.replace(tzinfo=None)
+
+        # check ti without dag (just for bw compat)
+        op_no_dag = DummyOperator(task_id='op_no_dag')
+        ti = TI(task=op_no_dag, execution_date=NAIVE_DATETIME)
+
+        self.assertEquals(ti.execution_date, DEFAULT_DATE)
+
+        # check with dag without localized execution_date
+        dag = DAG('dag', start_date=DEFAULT_DATE)
+        op1 = DummyOperator(task_id='op_1')
+        dag.add_task(op1)
+        ti = TI(task=op1, execution_date=NAIVE_DATETIME)
+
+        self.assertEquals(ti.execution_date, DEFAULT_DATE)
+
+        # with dag and localized execution_date
+        tz = pendulum.timezone("Europe/Amsterdam")
+        execution_date = timezone.datetime(2016, 1, 1, 1, 0, 0, tzinfo=tz)
+        utc_date = timezone.convert_to_utc(execution_date)
+        ti = TI(task=op1, execution_date=execution_date)
+        self.assertEquals(ti.execution_date, utc_date)
 
     def test_set_dag(self):
         """


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1927


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

TaskInstances are sometimes instantiated outside core
Airflow with naive datetimes. In case this happens we
now default to using the time zone of the DAG if that
is available or the default system time zone.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

tests added

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
