### PR TITLE
[WIP][Airflow 2006] kubernetes pod logs to airflow scheduler

### DIFF
--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -43,11 +43,15 @@ class KubernetesPodOperator(BaseOperator):
                                )
 
             launcher = pod_launcher.PodLauncher(client)
-            final_state = launcher.run_pod(pod, self.startup_timeout_seconds)
+            final_state = launcher.run_pod(
+                pod,
+                startup_timeout=self.startup_timeout_seconds,
+                get_logs=self.get_logs)
             if final_state != State.SUCCESS:
                 raise AirflowException("Pod returned a failure")
         except AirflowException as ex:
             raise AirflowException("Pod Launching failed: {error}".format(error=ex))
+
 
     @apply_defaults
     def __init__(self,
@@ -60,6 +64,7 @@ class KubernetesPodOperator(BaseOperator):
                  labels=None,
                  startup_timeout_seconds=120,
                  kube_executor_config=None,
+                 get_logs=True,
                  *args,
                  **kwargs):
         super(KubernetesPodOperator, self).__init__(*args, **kwargs)
@@ -72,3 +77,4 @@ class KubernetesPodOperator(BaseOperator):
         self.startup_timeout_seconds = startup_timeout_seconds
         self.name = name
         self.in_cluster = in_cluster
+        self.get_logs = get_logs

--- a/airflow/example_dags/example_kubernetes_operator.py
+++ b/airflow/example_dags/example_kubernetes_operator.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import airflow
+from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.models import DAG
+
+args = {
+    'owner': 'airflow',
+    'start_date': airflow.utils.dates.days_ago(2)
+}
+
+dag = DAG(
+    dag_id='example_kubernetes_operator',
+    default_args=args,
+    schedule_interval=None)
+
+k = KubernetesPodOperator(namespace='default',
+                          image="ubuntu:16.04",
+                          cmds=["bash", "-cx"],
+                          arguments=["echo", "10"],
+                          labels={"foo": "bar"},
+                          name="airflow-test-pod",
+                          in_cluster=False,
+                          task_id="task",
+                          get_logs=True,
+                          dag=dag
+                          )

--- a/tests/core.py
+++ b/tests/core.py
@@ -68,7 +68,7 @@ from jinja2 import UndefinedError
 
 import six
 
-NUM_EXAMPLE_DAGS = 18
+NUM_EXAMPLE_DAGS = 19
 DEV_NULL = '/dev/null'
 TEST_DAG_FOLDER = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), 'dags')

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -156,6 +156,7 @@ class BackfillJobTest(unittest.TestCase):
             'example_trigger_target_dag',
             'example_trigger_controller_dag',  # tested above
             'test_utils',  # sleeps forever
+            'example_kubernetes_operator',  # only works with k8s cluster
         ]
 
         logger = logging.getLogger('BackfillJobTest.test_backfill_examples')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2006


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:

Users who launch pods on kubernetes will want to see the logs of their pods as the job is running. This PR uses the k8s logging API to track logs live and report them as log.info into the airflow scheduler for future analysis.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
