### PR TITLE
[AIRFLOW-1966] fix PasswordUser.password setter

### DIFF
--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -58,7 +58,7 @@ class PasswordUser(models.User):
         return self._password
 
     @password.setter
-    def _set_password(self, plaintext):
+    def password(self, plaintext):
         self._password = generate_password_hash(plaintext, 12)
         if PY3:
             self._password = str(self._password, 'utf-8')

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -87,7 +87,7 @@ sphinx
 sphinx-argparse
 Sphinx-PyPI-upload
 sphinx_rtd_theme
-sqlalchemy>=1.1.15, <1.2.0
+sqlalchemy>=1.1.15, <=1.2.1
 statsd
 thrift
 thrift_sasl

--- a/setup.py
+++ b/setup.py
@@ -229,7 +229,7 @@ def do_setup():
             'python-nvd3==0.14.2',
             'requests>=2.5.1, <3',
             'setproctitle>=1.1.8, <2',
-            'sqlalchemy>=1.1.15, <1.2.0',
+            'sqlalchemy>=1.1.15, <=1.2.1',
             'sqlalchemy-utc>=0.9.0',
             'tabulate>=0.7.5, <0.8.0',
             'thrift>=0.9.2',


### PR DESCRIPTION
SQLAlchemy 1.2 broke the PasswordUser.password setter method for the
simple reason that the method wasn't named properly, which makes it
impossible to set passwords without requiring the use of a pre-1.2
version of SQLAlchemy.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes: see description above


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: a test already exists, but wouldn't pass with SQLAlchemy versions >= 1.2


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
