### PR TITLE
[AIRFLOW-2014]: Fix set_task_instance_state for Sub-DAGs

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2595,6 +2595,7 @@ class TaskInstanceModelView(ModelViewOnly):
             count = len(ids)
             for id in ids:
                 task_id, dag_id, execution_date = id.split(',')
+                dag_id = dag_id.replace('..', '.')
                 execution_date = parse_execution_date(execution_date)
 
                 ti = session.query(TI).filter(TI.task_id == task_id,


### PR DESCRIPTION
Sub-DAG ids are sent from the HTML form with pattern 'parent..child'
(with two periods instead of the expected one). This 'fix' addresses that
at the receiving end, by replacing the two dots with one. A more global
remedy may be called for. This change only addresses the set_task_instance_state
use case.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2014


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Here is a sample URL parameter that will cause the sqlalchemy row not found error:
`rowid=validate_something%2Cparent..my-sub-DAG%2C2018-01-18+03%3A00%3A00`. Other details above and in the JIRA issue.

### Tests
- [x] There are no existing unit tests of www/views.py `set_task_instance_state`. While desirable to have those tests, it seems beyond the scope of this bug fix to create them from scratch.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
