### PR TITLE
[AIRFLOW-2016] Add support for Dataproc Workflow Templates

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -14,8 +14,11 @@
 #
 
 import time
+import uuid
+
 
 from airflow.contrib.hooks.gcp_dataproc_hook import DataProcHook
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.version import version
@@ -92,7 +95,7 @@ class DataprocClusterCreateOperator(BaseOperator):
     :type service_account_scopes: list[string]
     """
 
-    template_fields = ['cluster_name', ]
+    template_fields = ['cluster_name']
 
     @apply_defaults
     def __init__(self,
@@ -928,3 +931,113 @@ class DataProcPySparkOperator(BaseOperator):
         job.set_job_name(self.job_name)
 
         hook.submit(hook.project_id, job.build(), self.region)
+
+
+class DataprocWorkflowTemplateBaseOperator(BaseOperator):
+    template_fields = ['template_id', 'template']
+
+    @apply_defaults
+    def __init__(self,
+                 project_id,
+                 region='global',
+                 gcp_conn_id='google_cloud_default',
+                 delegate_to=None,
+                 *args,
+                 **kwargs):
+        super(DataprocWorkflowTemplateBaseOperator, self).__init__(*args, **kwargs)
+        self.gcp_conn_id = gcp_conn_id
+        self.delegate_to = delegate_to
+        self.project_id = project_id
+        self.region = region
+        self.hook = DataProcHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            api_version='v1beta2'
+        )
+
+    def execute(self, context):
+        self.hook.await(self.start())
+
+    def start(self, context):
+        raise AirflowException('plese start a workflow operation')
+
+
+class DataprocWorkflowTemplateInstantiateOperator(DataprocWorkflowTemplateBaseOperator):
+    """
+    Instantiate a WorkflowTemplate on Google Cloud Dataproc. The operator will wait
+    until the WorkflowTemplate is finished executing.
+
+    Please refer to:
+    https://cloud.google.com/dataproc/docs/reference/rest/v1beta2/projects.regions.workflowTemplates/instantiate
+
+    :param template_id: The id of the template.
+    :type template_id: string
+    :param project_id: The ID of the google cloud project in which
+        the template runs
+    :type project_id: string
+    :param region: leave as 'global', might become relevant in the future
+    :type region: string
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
+    :type gcp_conn_id: string
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have domain-wide
+        delegation enabled.
+        :type delegate_to: string
+    """
+
+    @apply_defaults
+    def __init__(self, template_id, *args, **kwargs):
+        (super(DataprocWorkflowTemplateInstantiateOperator, self)
+            .__init__(*args, **kwargs))
+        self.template_id = template_id
+
+    def start(self):
+        self.log.info('Instantiating Template: %s', self.template_id)
+        return (
+            self.hook.get_conn().projects().regions().workflowTemplates()
+            .instantiate(
+                name=('projects/%s/regions/%s/workflowTemplates/%s' %
+                      (self.project_id, self.region, self.template_id)),
+                body={'instanceId': str(uuid.uuid1())})
+            .execute())
+
+
+class DataprocWorkflowTemplateInstantiateInlineOperator(
+        DataprocWorkflowTemplateBaseOperator):
+    """
+    Instantiate a WorkflowTemplate Inline on Google Cloud Dataproc. The operator will
+    wait until the WorkflowTemplate is finished executing.
+
+    Please refer to:
+    https://cloud.google.com/dataproc/docs/reference/rest/v1beta2/projects.regions.workflowTemplates/instantiateInline
+
+    :param template: The template contents.
+    :type template: map
+    :param project_id: The ID of the google cloud project in which
+        the template runs
+    :type project_id: string
+    :param region: leave as 'global', might become relevant in the future
+    :type region: string
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
+    :type gcp_conn_id: string
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have domain-wide
+        delegation enabled.
+    :type delegate_to: string
+    """
+
+    @apply_defaults
+    def __init__(self, template, *args, **kwargs):
+        (super(DataprocWorkflowTemplateInstantiateInlineOperator, self)
+            .__init__(*args, **kwargs))
+        self.template = template
+
+    def start(self):
+        self.log.info('Instantiating Inline Template')
+        return (
+            self.hook.get_conn().projects().regions().workflowTemplates()
+            .instantiateInline(
+                parent='projects/%s/regions/%s' % (self.project_id, self.region),
+                instanceId=str(uuid.uuid1()),
+                body=self.template)
+            .execute())


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2016


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
Add new operators to support instantiation of Google Cloud Dataproc Workflow Templates.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
2 new tests in tests/contrib/hooks/test_gcp_dataproc_hook.py

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
