### PR TITLE
[AIRFLOW-2018] Make Sensors backward compatible

### DIFF
--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 #
 
-
 import sys
+import os
 from airflow.models import BaseOperator
-
 
 # ------------------------------------------------------------------------
 #
@@ -29,10 +28,8 @@ from airflow.models import BaseOperator
 #
 # ------------------------------------------------------------------------
 
-
 # Imports operators dynamically while keeping the package API clean,
 # abstracting the underlying modules
-
 
 _operators = {
     'bash_operator': ['BashOperator'],
@@ -52,6 +49,21 @@ _operators = {
         'PrestoCheckOperator',
         'PrestoValueCheckOperator',
         'PrestoIntervalCheckOperator',
+    ],
+    'sensors': [
+        'BaseSensorOperator',
+        'ExternalTaskSensor',
+        'HdfsSensor',
+        'HivePartitionSensor',
+        'HttpSensor',
+        'MetastorePartitionSensor',
+        'NamedHivePartitionSensor',
+        'S3KeySensor',
+        'S3PrefixSensor',
+        'SqlSensor',
+        'TimeDeltaSensor',
+        'TimeSensor',
+        'WebHdfsSensor',
     ],
     'dagrun_operator': ['TriggerDagRunOperator'],
     'dummy_operator': ['DummyOperator'],
@@ -78,8 +90,7 @@ _operators = {
     'oracle_operator': ['OracleOperator']
 }
 
-import os as _os
-if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
+if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
     from airflow.utils.helpers import AirflowImporter
     airflow_importer = AirflowImporter(sys.modules[__name__], _operators)
 
@@ -94,7 +105,7 @@ def _integrate_plugins():
         ##########################################################
         # TODO FIXME Remove in Airflow 2.0
 
-        if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
+        if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
             from zope.deprecation import deprecated as _deprecated
             for _operator in operators_module._objects:
                 operator_name = _operator.__name__

--- a/airflow/operators/sensors.py
+++ b/airflow/operators/sensors.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-c
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# ------------------------------------------------------------------------
+#
+# #TODO #FIXME Airflow 2.0
+#
+# In Airflow this will be moved to the airflow.sensors package.
+# Until then this class will provide backward compatibility
+#
+# ------------------------------------------------------------------------
+
+
+from airflow.sensors.base_sensor_operator import BaseSensorOperator as \
+    BaseSensorOperatorImp
+from airflow.sensors.external_task_sensor import ExternalTaskSensor as \
+    ExternalTaskSensorImp
+from airflow.sensors.hdfs_sensor import HdfsSensor as HdfsSensorImp
+from airflow.sensors.hive_partition_sensor import HivePartitionSensor as \
+    HivePartitionSensorImp
+from airflow.sensors.http_sensor import HttpSensor as HttpSensorImp
+from airflow.sensors.metastore_partition_sensor import MetastorePartitionSensor as \
+    MetastorePartitionSensorImp
+from airflow.sensors.s3_key_sensor import S3KeySensor as S3KeySensorImp
+from airflow.sensors.s3_prefix_sensor import S3PrefixSensor as S3PrefixSensorImp
+from airflow.sensors.sql_sensor import SqlSensor as SqlSensorImp
+from airflow.sensors.time_delta_sensor import TimeDeltaSensor as TimeDeltaSensorImp
+from airflow.sensors.time_sensor import TimeSensor as TimeSensorImp
+from airflow.sensors.web_hdfs_sensor import WebHdfsSensor as WebHdfsSensorImp
+
+
+class BaseSensorOperator(BaseSensorOperatorImp):
+    pass
+
+
+class ExternalTaskSensor(ExternalTaskSensorImp):
+    pass
+
+
+class HdfsSensor(HdfsSensorImp):
+    pass
+
+
+class HttpSensor(HttpSensorImp):
+    pass
+
+
+class MetastorePartitionSensor(MetastorePartitionSensorImp):
+    pass
+
+
+class HivePartitionSensor(HivePartitionSensorImp):
+    pass
+
+
+class S3KeySensor(S3KeySensorImp):
+    pass
+
+
+class S3PrefixSensor(S3PrefixSensorImp):
+    pass
+
+
+class SqlSensor(SqlSensorImp):
+    pass
+
+
+class TimeDeltaSensor(TimeDeltaSensorImp):
+    pass
+
+
+class TimeSensor(TimeSensorImp):
+    pass
+
+
+class WebHdfsSensor(WebHdfsSensorImp):
+    pass


### PR DESCRIPTION
To keep compatibility until Airflow 2.0, we want to keep the sensors api compatible.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
