### PR TITLE
[AIRFLOW-83] add mongo hooks and operators

### DIFF
--- a/airflow/contrib/hooks/mongo_hook.py
+++ b/airflow/contrib/hooks/mongo_hook.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ssl import CERT_NONE
+
+from airflow.hooks.base_hook import BaseHook
+from pymongo import MongoClient
+
+
+class MongoHook(BaseHook):
+    """
+    PyMongo Wrapper to Interact With Mongo Database
+    Mongo Connection Documentation
+    https://docs.mongodb.com/manual/reference/connection-string/index.html
+    You can specify connection string options in extra field of your connection
+    https://docs.mongodb.com/manual/reference/connection-string/index.html#connection-string-options
+    ex.
+        {replicaSet: test, ssl: True, connectTimeoutMS: 30000}
+    """
+    conn_type = 'MongoDb'
+
+    def __init__(self, conn_id='mongo_default', *args, **kwargs):
+        super(MongoHook, self).__init__(source='mongo')
+
+        self.mongo_conn_id = conn_id
+        self.connection = self.get_connection(conn_id)
+        self.extras = self.connection.extra_dejson
+
+    def get_conn(self):
+        """
+        Fetches PyMongo Client
+        """
+        conn = self.connection
+
+        uri = 'mongodb://{creds}{host}{port}/{database}'.format(
+            creds='{}:{}@'.format(
+                conn.login, conn.password
+            ) if conn.login is not None else '',
+
+            host=conn.host,
+            port='' if conn.port is None else ':{}'.format(conn.port),
+            database='' if conn.schema is None else conn.schema
+        )
+
+        # Mongo Connection Options dict that is unpacked when passed to MongoClient
+        options = self.extras
+
+        # If we are using SSL disable requiring certs from specific hostname
+        if options.get('ssl', False):
+            options.update({'ssl_cert_reqs': CERT_NONE})
+
+        return MongoClient(uri, **options)
+
+    def get_collection(self, mongo_collection, mongo_db=None):
+        """
+        Fetches a mongo collection object for querying.
+
+        Uses connection schema as DB unless specified
+        """
+        mongo_db = mongo_db if mongo_db is not None else self.connection.schema
+        mongo_conn = self.get_conn()
+
+        return mongo_conn.get_database(mongo_db).get_collection(mongo_collection)
+
+    def aggregate(self, mongo_collection, aggregate_query, mongo_db=None, **kwargs):
+        """
+        Runs and aggregation pipeline and returns the results
+        https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.aggregate
+        http://api.mongodb.com/python/current/examples/aggregation.html
+        """
+        collection = self.get_collection(mongo_collection, mongo_db=mongo_db)
+
+        return collection.aggregate(aggregate_query, **kwargs)
+
+    def find(self, mongo_collection, query, find_one=False, mongo_db=None, **kwargs):
+        """
+        Runs a mongo find query and returns the results
+        https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.find
+        """
+        collection = self.get_collection(mongo_collection, mongo_db=mongo_db)
+
+        if find_one:
+            return collection.find_one(query, **kwargs)
+        else:
+            return collection.find(query, **kwargs)
+
+    def insert_one(self, mongo_collection, doc, mongo_db=None, **kwargs):
+        """
+        Inserts a single document into a mongo collection
+        """
+        collection = self.get_collection(mongo_collection, mongo_db=mongo_db)
+
+        return collection.insert_one(doc, **kwargs)
+
+    def insert_many(self, mongo_collection, docs, mongo_db=None, **kwargs):
+        """
+        Inserts many docs into a mongo collection.
+        https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.insert_many
+        """
+        collection = self.get_collection(mongo_collection, mongo_db=mongo_db)
+
+        return collection.insert_many(docs, **kwargs)

--- a/airflow/contrib/operators/mongo_to_s3.py
+++ b/airflow/contrib/operators/mongo_to_s3.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+from airflow.contrib.hooks.mongo_hook import MongoHook
+from airflow.hooks.S3_hook import S3Hook
+from airflow.models import BaseOperator
+from bson import json_util
+
+
+class MongoToS3Operator(BaseOperator):
+    """
+    Mongo -> S3
+        A more specific baseOperator meant to move data
+        from mongo via pymongo to s3 via boto
+
+        things to note
+                .execute() is written to depend on .transform()
+                .transform() is meant to be extended by child classes
+                to perform transformations unique to those operators needs
+    """
+
+    template_fields = ['s3_key', 'mongo_query']
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(self,
+                 mongo_conn_id,
+                 s3_conn_id,
+                 mongo_collection,
+                 mongo_query,
+                 s3_bucket,
+                 s3_key,
+                 mongo_db=None,
+                 *args, **kwargs):
+        super(MongoToS3Operator, self).__init__(*args, **kwargs)
+        # Conn Ids
+        self.mongo_conn_id = mongo_conn_id
+        self.s3_conn_id = s3_conn_id
+        # Mongo Query Settings
+        self.mongo_db = mongo_db
+        self.mongo_collection = mongo_collection
+        # Grab query and determine if we need to run an aggregate pipeline
+        self.mongo_query = mongo_query
+        self.is_pipeline = True if isinstance(
+            self.mongo_query, list) else False
+
+        # S3 Settings
+        self.s3_bucket = s3_bucket
+        self.s3_key = s3_key
+
+        # KWARGS
+        self.replace = kwargs.pop('replace', False)
+
+    def execute(self, context):
+        """
+        Executed by task_instance at runtime
+        """
+        s3_conn = S3Hook(self.s3_conn_id)
+
+        # Grab collection and execute query according to whether or not it is a pipeline
+        if self.is_pipeline:
+            results = MongoHook(self.mongo_conn_id).aggregate(
+                mongo_collection=self.mongo_collection,
+                aggregate_query=self.mongo_query,
+                mongo_db=self.mongo_db
+            )
+
+        else:
+            results = MongoHook(self.mongo_conn_id).find(
+                mongo_collection=self.mongo_collection,
+                query=self.mongo_query,
+                mongo_db=self.mongo_db
+            )
+
+        # Performs transform then stringifies the docs results into json format
+        docs_str = self._stringify(self.transform(results))
+
+        # Load Into S3
+        s3_conn.load_string(
+            string_data=docs_str,
+            key=self.s3_key,
+            bucket_name=self.s3_bucket,
+            replace=self.replace
+        )
+
+        return True
+
+    def _stringify(self, iterable, joinable='\n'):
+        """
+        Takes an interable (pymongo Cursor or Array) containing dictionaries and
+        returns a stringified version using python join
+        """
+        return joinable.join(
+            [json.dumps(doc, default=json_util.default) for doc in iterable]
+        )
+
+    def transform(self, docs):
+        """
+        Processes pyMongo cursor and returns single array with each element being
+                a JSON serializable dictionary
+
+        Base transform() assumes no processing is needed
+        ie. docs is a pyMongo cursor of documents and cursor just needs to be
+            converted into an array.
+        """
+        return [doc for doc in docs]

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -70,6 +70,7 @@ psycopg2
 pygments
 pyhive
 pykerberos
+pymongo
 PyOpenSSL
 PySmbClient
 python-daemon

--- a/setup.py
+++ b/setup.py
@@ -164,14 +164,16 @@ cloudant = ['cloudant>=0.5.9,<2.0'] # major update coming soon, clamp to 0.x
 redis = ['redis>=2.10.5']
 kubernetes = ['kubernetes>=3.0.0',
               'cryptography>=2.0.0']
+mongo = ['pymongo>=3.6.0']
 
-all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant
+all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant + mongo
 devel = [
     'click',
     'freezegun',
     'jira',
     'lxml>=3.3.4',
     'mock',
+    'mongomock',
     'moto==1.1.19',
     'nose',
     'nose-ignore-docstring==0.2',

--- a/tests/contrib/hooks/test_mongo_hook.py
+++ b/tests/contrib/hooks/test_mongo_hook.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+import pymongo
+try:
+    import mongomock
+except ImportError:
+    mongomock = None
+
+from airflow import configuration
+from airflow.contrib.hooks.mongo_hook import MongoHook
+
+
+class MongoHookTest(MongoHook):
+    '''
+    Extending hook so that a mockmongo collection object can be passed in
+    to get_collection()
+    '''
+    def __init__(self, conn_id='mongo_default', *args, **kwargs):
+        super(MongoHookTest, self).__init__(conn_id=conn_id, *args, **kwargs)
+
+    def get_collection(self, mock_collection, mongo_db):
+        return mock_collection
+
+
+class TestMongoHook(unittest.TestCase):
+    def setUp(self):
+        configuration.load_test_config()
+        self.hook = MongoHookTest(conn_id='mongo_default')
+        self.conn = self.hook.get_conn()
+
+    @unittest.skipIf(mongomock is None, 'mongomock package not present')
+    def test_get_conn(self):
+        print(self.hook.connection.port)
+        self.assertEqual(self.hook.connection.port, 27017)
+        self.assertIsInstance(self.conn, pymongo.MongoClient)
+
+    @unittest.skipIf(mongomock is None, 'mongomock package not present')
+    def test_insert_one(self):
+        collection = mongomock.MongoClient().db.collection
+        obj = {'test_insert_one': 'test_value'}
+        self.hook.insert_one(collection, obj)
+
+        result_obj = collection.find_one(filter=obj)
+
+        self.assertEqual(obj, result_obj)
+
+    @unittest.skipIf(mongomock is None, 'mongomock package not present')
+    def test_insert_many(self):
+        collection = mongomock.MongoClient().db.collection
+        objs = [
+            {'test_insert_many_1': 'test_value'},
+            {'test_insert_many_2': 'test_value'}
+        ]
+
+        self.hook.insert_many(collection, objs)
+
+        result_objs = collection.find()
+        result_objs = [result for result in result_objs]
+        self.assertEqual(len(result_objs), 2)
+
+    @unittest.skipIf(mongomock is None, 'mongomock package not present')
+    def test_find_one(self):
+        collection = mongomock.MongoClient().db.collection
+        obj = {'test_find_one': 'test_value'}
+        collection.insert(obj)
+
+        result_obj = self.hook.find(collection, {}, find_one=True)
+        result_obj = {result: result_obj[result] for result in result_obj}
+        self.assertEqual(obj, result_obj)
+
+    @unittest.skipIf(mongomock is None, 'mongomock package not present')
+    def test_find_many(self):
+        collection = mongomock.MongoClient().db.collection
+        objs = [{'test_find_many_1': 'test_value'}, {'test_find_many_2': 'test_value'}]
+        collection.insert(objs)
+
+        result_objs = self.hook.find(collection, {}, find_one=False)
+        result_objs = [result for result in result_objs]
+
+        self.assertGreater(len(result_objs), 1)
+
+    @unittest.skipIf(mongomock is None, 'mongomock package not present')
+    def test_aggregate(self):
+        collection = mongomock.MongoClient().db.collection
+        objs = [
+            {
+                'test_id': '1',
+                'test_status': 'success'
+            },
+            {
+                'test_id': '2',
+                'test_status': 'failure'
+            },
+            {
+                'test_id': '3',
+                'test_status': 'success'
+            }
+        ]
+
+        collection.insert(objs)
+
+        aggregate_query = [
+            {"$match": {'test_status': 'success'}}
+        ]
+
+        results = self.hook.aggregate(collection, aggregate_query)
+        results = [result for result in results]
+        self.assertEqual(len(results), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/contrib/operators/test_mongo_to_s3_operator.py
+++ b/tests/contrib/operators/test_mongo_to_s3_operator.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from airflow import DAG
+from airflow.contrib.operators.mongo_to_s3 import MongoToS3Operator
+from airflow.models import TaskInstance
+from airflow.utils import timezone
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+TASK_ID = 'test_mongo_to_s3_operator'
+MONGO_CONN_ID = 'default_mongo'
+S3_CONN_ID = 'default_s3'
+MONGO_COLLECTION = 'example_collection'
+MONGO_QUERY = {"$lt": "{{ ts + 'Z' }}"}
+S3_BUCKET = 'example_bucket'
+S3_KEY = 'example_key'
+
+DEFAULT_DATE = timezone.datetime(2017, 1, 1)
+MOCK_MONGO_RETURN = [
+    {'example_return_key_1': 'example_return_value_1'},
+    {'example_return_key_2': 'example_return_value_2'}
+]
+
+
+class MongoToS3OperatorTest(unittest.TestCase):
+
+    def setUp(self):
+        args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE
+        }
+
+        self.dag = DAG('test_dag_id', default_args=args)
+
+        self.mock_operator = MongoToS3Operator(
+            task_id=TASK_ID,
+            mongo_conn_id=MONGO_CONN_ID,
+            s3_conn_id=S3_CONN_ID,
+            mongo_collection=MONGO_COLLECTION,
+            mongo_query=MONGO_QUERY,
+            s3_bucket=S3_BUCKET,
+            s3_key=S3_KEY,
+            dag=self.dag
+        )
+
+    def test_init(self):
+        self.assertEqual(self.mock_operator.task_id, TASK_ID)
+        self.assertEqual(self.mock_operator.mongo_conn_id, MONGO_CONN_ID)
+        self.assertEqual(self.mock_operator.s3_conn_id, S3_CONN_ID)
+        self.assertEqual(self.mock_operator.mongo_collection, MONGO_COLLECTION)
+        self.assertEqual(self.mock_operator.mongo_query, MONGO_QUERY)
+        self.assertEqual(self.mock_operator.s3_bucket, S3_BUCKET)
+        self.assertEqual(self.mock_operator.s3_key, S3_KEY)
+
+    def test_template_field_overrides(self):
+        self.assertEqual(self.mock_operator.template_fields, ['s3_key', 'mongo_query'])
+
+    def test_render_template(self):
+        ti = TaskInstance(self.mock_operator, DEFAULT_DATE)
+        ti.render_templates()
+
+        expected_rendered_template = {'$lt': u'2017-01-01T00:00:00+00:00Z'}
+
+        self.assertDictEqual(
+            expected_rendered_template,
+            getattr(self.mock_operator, 'mongo_query')
+        )
+
+    @mock.patch('airflow.contrib.operators.mongo_to_s3.MongoHook')
+    @mock.patch('airflow.contrib.operators.mongo_to_s3.S3Hook')
+    def test_execute(self, mock_s3_hook, mock_mongo_hook):
+        operator = self.mock_operator
+
+        mock_mongo_hook.return_value.find.return_value = iter(MOCK_MONGO_RETURN)
+        mock_s3_hook.return_value.load_string.return_value = True
+
+        operator.execute(None)
+
+        mock_mongo_hook.return_value.find.assert_called_once_with(
+            mongo_collection=MONGO_COLLECTION,
+            query=MONGO_QUERY,
+            mongo_db=None
+        )
+
+        op_stringify = self.mock_operator._stringify
+        op_transform = self.mock_operator.transform
+
+        s3_doc_str = op_stringify(op_transform(MOCK_MONGO_RETURN))
+
+        mock_s3_hook.return_value.load_string.assert_called_once_with(
+            string_data=s3_doc_str,
+            key=S3_KEY,
+            bucket_name=S3_BUCKET,
+            replace=False
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Thanks for reviewing. I would appreciate any/all feedback as this is my first serious apache incubator-airflow PR.


Make sure you have checked _all_ steps below.

### JIRA
- [ x ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [ x ] Here are some details about my PR, including screenshots of any UI changes:

AIRFLOW-83 requests a mongo hook and operator contribution. We had one laying around that I expanded to be more in line with Airflow practices. 


### Tests
- [ x ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Adds 6 unit tests for the hook
Would love more insight on proper Operator testing if having no tests for it is unacceptable


### Commits
- [ x ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ x ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
added small fix in setup.py as well for code not touched by this PR 