### PR TITLE
[AIRFLOW-1267] [AIRFLOW-1874] Add dialect parameter to BigQueryHook

### DIFF
--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -98,6 +98,7 @@ class BigQueryOperator(BaseOperator):
             self.log.info('Executing: %s', self.bql)
             hook = BigQueryHook(
                 bigquery_conn_id=self.bigquery_conn_id,
+                use_legacy_sql=self.use_legacy_sql,
                 delegate_to=self.delegate_to)
             conn = hook.get_conn()
             self.bq_cursor = conn.cursor()
@@ -107,7 +108,6 @@ class BigQueryOperator(BaseOperator):
             write_disposition=self.write_disposition,
             allow_large_results=self.allow_large_results,
             udf_config=self.udf_config,
-            use_legacy_sql=self.use_legacy_sql,
             maximum_billing_tier=self.maximum_billing_tier,
             create_disposition=self.create_disposition,
             query_params=self.query_params,

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -308,6 +308,25 @@ class TestTimePartitioningInRunJob(unittest.TestCase):
             )
 
 
+class TestBigQueryHookLegacySql(unittest.TestCase):
+    """Ensure `use_legacy_sql` param in `BigQueryHook` propagates properly."""
+
+    @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')
+    def test_hook_uses_legacy_sql_by_default(self, run_with_config):
+        with mock.patch.object(hook.BigQueryHook, 'get_service'):
+            bq_hook = hook.BigQueryHook()
+            bq_hook.get_first('query')
+            args, kwargs = run_with_config.call_args
+            self.assertIs(args[0]['query']['useLegacySql'], True)
+
+    @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')
+    def test_legacy_sql_override_propagates_properly(self, run_with_config):
+        with mock.patch.object(hook.BigQueryHook, 'get_service'):
+            bq_hook = hook.BigQueryHook(use_legacy_sql=False)
+            bq_hook.get_first('query')
+            args, kwargs = run_with_config.call_args
+            self.assertIs(args[0]['query']['useLegacySql'], False)
+
+
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
Allows a default BigQuery dialect to be specified at the hook level, which is threaded through to the
underlying cursors.

This allows standard SQL dialect to be used, while maintaining compatibility with the
`DbApiHook` interface.

Addresses AIRFLOW-1267 and AIRFLOW-1874

### JIRA
- Addresses https://issues.apache.org/jira/browse/AIRFLOW-1267 and https://issues.apache.org/jira/browse/AIRFLOW-1874

### Description
- Adds a `use_legacy_sql` parameter to the BigQueryHook constructor. This parameter determines whether queries executed via this hook will be issued using `legacy` or `standard` dialect by default. To maintain compatibility, this can still be overridden at the cursor level, and in the `get_pandas_df` method.

### Tests
- Adds `TestBigQueryHookLegacySql`, which tests that this parameter is threaded through from hook instantiation down to the underlying cursor. No regressions on existing `BigQueryHook` tests
