### PR TITLE
[AIRFLOW-2023] Add debug logging around number of queued files

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -476,6 +476,12 @@ class DagFileProcessorManager(LoggingMixin):
                 running_processors[file_path] = processor
         self._processors = running_processors
 
+        self.log.debug("%s/%s scheduler processes running",
+                       len(self._processors), self._parallelism)
+
+        self.log.debug("%s file paths queued for processing",
+                       len(self._file_path_queue))
+
         # Collect all the DAGs that were found in the processed files
         simple_dags = []
         for file_path, processor in finished_processors.items():


### PR DESCRIPTION
### JIRA
https://issues.apache.org/jira/browse/AIRFLOW-2023

### Description
Add debug logging around number of queued files to process in the
scheduler. This makes it easy to see when there are bottlenecks due to parallelism and how long it takes for all files to be processed.

### Tests
N/A

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

@saguziel
