### PR TITLE
Update file_processor_handler.py

### DIFF
--- a/airflow/utils/log/file_processor_handler.py
+++ b/airflow/utils/log/file_processor_handler.py
@@ -44,8 +44,7 @@ class FileProcessorHandler(logging.Handler):
             self.filename_jinja_template = Template(self.filename_template)
 
         self._cur_date = datetime.today()
-        if not os.path.exists(self._get_log_directory()):
-            os.makedirs(self._get_log_directory())
+        os.makedirs(self._get_log_directory(), exist_ok=True)
 
         self._symlink_latest_log_directory()
 


### PR DESCRIPTION
### Description
This conditional can result in a race condition of
1) Process 1 checks for directory
2) Process 2 checks for directory
3) Process 1 successfully creates directory
4) Process 2 fails when trying to create directory

using `exist_ok` will avoid this and be equivalent otherwise.

### Tests
- [x] This is common python `os.makedirs` practice.

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`


### JIRA Issue
https://issues.apache.org/jira/browse/AIRFLOW-2051