### PR TITLE
[AIRFLOW-2029] Fix AttributeError in BigQueryPandasConnector

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -156,6 +156,7 @@ class BigQueryPandasConnector(GbqConnector):
                  reauth=False,
                  verbose=False,
                  dialect='legacy'):
+        super(BigQueryPandasConnector, self).__init__(project_id)
         gbq_check_google_client_version()
         gbq_test_google_api_imports()
         self.project_id = project_id


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2029


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
When BigQueryPandasConnector encounters a BQ job insertion error, the exception will be assigned to connector.http_error, which is defined in parent connector GbqConnector but uninitialized. Hence an AttributeError exception will be thrown and the exception handling routine is never exercised. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
