### PR TITLE
[AIRFLOW-2031] Add missing param in the eg in DataFlow docstrings

### DIFF
--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -56,6 +56,7 @@ class DataFlowJavaOperator(BaseOperator):
             'partitionType': 'DAY',
             'labels': {'foo' : 'bar'}
         },
+        gcp_conn_id='gcp-airflow-service-account',
         dag=my-dag)
     ```
 
@@ -166,6 +167,7 @@ class DataflowTemplateOperator(BaseOperator):
             'inputFile': "gs://bucket/input/my_input.txt",
             'outputFile': "gs://bucket/output/my_output.txt"
         },
+        gcp_conn_id='gcp-airflow-service-account',
         dag=my-dag)
     ```
     ``template`` ``dataflow_default_options`` and ``parameters`` are templated so you can


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2031


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Added `gcp_conn_id` parameter in the examples provided in docstrings for DataFlow operators.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Just addition to docstrings, hence no tests required

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
