### PR TITLE
[AIRFLOW-2033] Add Google Cloud Storage List Operator

### DIFF
--- a/airflow/contrib/operators/gcs_list_operator.py
+++ b/airflow/contrib/operators/gcs_list_operator.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class GoogleCloudStorageListOperator(BaseOperator):
+    """
+    List all objects from the bucket with the give string prefix and delimiter in name.
+
+    This operator returns a python list with the name of objects which can be used by
+     `xcom` in the downstream task.
+
+    :param bucket: The Google cloud storage bucket to find the objects.
+    :type bucket: string
+    :param prefix: Prefix string which filters objects whose name begin with this prefix
+    :type prefix: string
+    :param delimiter: The delimiter by which you want to filter the objects.
+        For e.g to lists the CSV files from in a directory in GCS you would use
+        delimiter='.csv'.
+    :type delimiter: string
+    :param google_cloud_storage_conn_id: The connection ID to use when
+        connecting to Google cloud storage.
+    :type google_cloud_storage_conn_id: string
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: string
+
+    Example: The following Operator would list all the Avro files from `sales/sales-2017`
+        folder in `data` bucket.
+
+    GCS_Files = GoogleCloudStorageListOperator(
+        task_id='GCS_Files',
+        bucket='data',
+        prefix='sales/sales-2017/',
+        delimiter='.avro',
+        google_cloud_storage_conn_id=google_cloud_conn_id
+    )
+    """
+    template_fields = ('bucket', 'prefix', 'delimiter')
+    ui_color = '#f0eee4'
+
+    @apply_defaults
+    def __init__(self,
+                 bucket,
+                 prefix=None,
+                 delimiter=None,
+                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 delegate_to=None,
+                 *args,
+                 **kwargs):
+        super(GoogleCloudStorageListOperator, self).__init__(*args, **kwargs)
+        self.bucket = bucket
+        self.prefix = prefix
+        self.delimiter = delimiter
+        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.delegate_to = delegate_to
+
+    def execute(self, context):
+
+        hook = GoogleCloudStorageHook(
+            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+            delegate_to=self.delegate_to
+        )
+
+        self.log.info('Getting list of the files. Bucket: %s; Delimiter: %s; Prefix: %s',
+                      self.bucket, self.delimiter, self.prefix)
+
+        return hook.list(bucket=self.bucket,
+                         prefix=self.prefix,
+                         delimiter=self.delimiter)

--- a/tests/contrib/operators/test_gcs_list_operator.py
+++ b/tests/contrib/operators/test_gcs_list_operator.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from airflow.contrib.operators.gcs_list_operator import GoogleCloudStorageListOperator
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+TASK_ID = 'test-gcs-list-operator'
+TEST_BUCKET = 'test-bucket'
+DELIMITER = '.csv'
+PREFIX = 'TEST'
+
+
+class GoogleCloudStorageListOperatorTest(unittest.TestCase):
+
+    @mock.patch('airflow.contrib.operators.gcs_list_operator.GoogleCloudStorageHook')
+    def test_execute(self, mock_hook):
+        operator = GoogleCloudStorageListOperator(task_id=TASK_ID,
+                                                  bucket=TEST_BUCKET,
+                                                  prefix=PREFIX,
+                                                  delimiter=DELIMITER)
+
+        operator.execute(None)
+        mock_hook.return_value.list.assert_called_once_with(
+            bucket=TEST_BUCKET, prefix=PREFIX, delimiter=DELIMITER
+        )


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2033


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Added an operator to get object names in a GCS bucket filtered by prefix and delimiter with an example.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`tests.contrib.operators.test_gcs_list_operator.GoogleCloudStorageListOperatorTest`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
