### PR TITLE
[AIRFLOW-2034] Fix mixup between %s and {} when using str.format

### DIFF
--- a/airflow/hooks/slack_hook.py
+++ b/airflow/hooks/slack_hook.py
@@ -52,5 +52,5 @@ class SlackHook(BaseHook):
         rc = sc.api_call(method, **api_params)
 
         if not rc['ok']:
-            msg = "Slack API call failed (%s)".format(rc['error'])
+            msg = "Slack API call failed ({})".format(rc['error'])
             raise AirflowException(msg)

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -96,9 +96,9 @@ class BaseTaskRunner(LoggingMixin):
                 line = line.decode('utf-8')
             if len(line) == 0:
                 break
-            self.log.info(u'Job {}: Subtask {} %s'.format(
-                self._task_instance.job_id, self._task_instance.task_id),
-                line.rstrip('\n'))
+            self.log.info('Job %s: Subtask %s %s',
+                          self._task_instance.job_id, self._task_instance.task_id,
+                          line.rstrip('\n'))
 
     def run_command(self, run_with, join_args=False):
         """


### PR DESCRIPTION
Fix mixup between %s and {} when using str.format

### Description
- [X] Here are some details about my PR

Convention is to use .format for string formating outside logging, else use lazy formation
See comment in related issue
#https://github.com/apache/incubator-airflow/pull/2823/files
Identified problematic case using following command line
`grep -r '%s'./* | grep '\.format('`

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2034/)

### Tests
Testing content of log or message make test too brittle