### PR TITLE
[AIRFLOW-2042] Fix browser menu appearing over the autocomplete menu

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -278,8 +278,9 @@
 
       $input.change(function() {
         var current = $input.typeahead("getActive");
-
       });
+
+      $input.attr("autocomplete", "off");
 
       $('#dags').dataTable({
         "iDisplayLength": 500,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2042


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Fixes a small but annoying issue in Safari, in which typing in search bar makes both the browser default and bootstrap typeahead menus to appear. To prevent it, we set autocomplete to "off" on input elements.

##### Before:

![issue](https://user-images.githubusercontent.com/62379/35524278-0507249a-0519-11e8-92e5-d627d575a1a0.png)

##### After:

![after](https://user-images.githubusercontent.com/62379/35524282-091275a8-0519-11e8-8cb4-ea3206f3754f.png)


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This is a tiny UI change.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`