### PR TITLE
[AIRFLOW-2046] Fix kerberos error to work with python 3.x

### DIFF
--- a/airflow/security/kerberos.py
+++ b/airflow/security/kerberos.py
@@ -51,8 +51,8 @@ def renew_from_kt():
     if subp.returncode != 0:
         log.error("Couldn't reinit from keytab! `kinit' exited with %s.\n%s\n%s" % (
             subp.returncode,
-            "\n".join(subp.stdout.readlines()),
-            "\n".join(subp.stderr.readlines())))
+            b"\n".join(subp.stdout.readlines()),
+            b"\n".join(subp.stderr.readlines())))
         sys.exit(subp.returncode)
 
     global NEED_KRB181_WORKAROUND


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2046)

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Allows kerberos to run on python 3.x

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This change should not effect existing tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

Yes

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Yes