### PR TITLE
[AIRFLOW-1985] Impersonation fixes for using `run_as_user`

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -58,8 +58,14 @@ class BaseExecutor(LoggingMixin):
             ignore_depends_on_past=False,
             ignore_task_deps=False,
             ignore_ti_state=False,
-            pool=None):
+            pool=None,
+            cfg_path=None):
         pool = pool or task_instance.pool
+
+        # TODO (edgarRd): AIRFLOW-1985:
+        # cfg_path is needed to propagate the config values if using impersonation
+        # (run_as_user), given that there are different code paths running tasks.
+        # For a long term solution we need to address AIRFLOW-1986
         command = task_instance.command(
             local=True,
             mark_success=mark_success,
@@ -68,7 +74,8 @@ class BaseExecutor(LoggingMixin):
             ignore_task_deps=ignore_task_deps,
             ignore_ti_state=ignore_ti_state,
             pool=pool,
-            pickle_id=pickle_id)
+            pickle_id=pickle_id,
+            cfg_path=cfg_path)
         self.queue_command(
             task_instance,
             command,

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -58,6 +58,7 @@ from airflow.utils.db import create_session, provide_session
 from airflow.utils.email import send_email
 from airflow.utils.log.logging_mixin import LoggingMixin, set_context, StreamLogWriter
 from airflow.utils.state import State
+from airflow.utils.configuration import tmp_configuration_copy
 
 Base = models.Base
 ID_LEN = models.ID_LEN
@@ -2234,13 +2235,20 @@ class BackfillJob(BaseJob):
                                 # Skip scheduled state, we are executing immediately
                                 ti.state = State.QUEUED
                                 session.merge(ti)
+
+                                cfg_path = None
+                                if executor.__class__ in (executors.LocalExecutor,
+                                                          executors.SequentialExecutor):
+                                    cfg_path = tmp_configuration_copy()
+
                                 executor.queue_task_instance(
                                     ti,
                                     mark_success=self.mark_success,
                                     pickle_id=pickle_id,
                                     ignore_task_deps=self.ignore_task_deps,
                                     ignore_depends_on_past=ignore_depends_on_past,
-                                    pool=self.pool)
+                                    pool=self.pool,
+                                    cfg_path=cfg_path)
                                 ti_status.started[key] = ti
                                 ti_status.to_run.pop(key)
                         session.commit()

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -981,6 +981,8 @@ class TaskInstance(Base, LoggingMixin):
         :param job_id: job ID (needs more details)
         :param pool: the Airflow pool that the task should run in
         :type pool: unicode
+        :param cfg_path: the Path to the configuration file
+        :type cfg_path: basestring
         :return: shell command that can be used to run the task instance
         """
         iso = execution_date.isoformat()

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -19,10 +19,20 @@ import signal
 from subprocess import Popen, STDOUT, PIPE
 from tempfile import gettempdir, NamedTemporaryFile
 
+from airflow import configuration as conf
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory
+
+
+# These variables are required in cases when BashOperator tasks use airflow specific code,
+# e.g. they import packages in the airflow context and the possibility of impersonation
+# gives not guarantee that these variables are available in the impersonated environment.
+# Hence, we need to propagate them in the Bash script used as a wrapper of commands in
+# this BashOperator.
+PYTHONPATH_VAR = 'PYTHONPATH'
+AIRFLOW_HOME_VAR = 'AIRFLOW_HOME'
 
 
 class BashOperator(BaseOperator):
@@ -66,25 +76,34 @@ class BashOperator(BaseOperator):
         Execute the bash command in a temporary directory
         which will be cleaned afterwards
         """
-        bash_command = self.bash_command
         self.log.info("Tmp dir root location: \n %s", gettempdir())
+
+        airflow_home_value = conf.get('core', AIRFLOW_HOME_VAR)
+        pythonpath_value = os.environ.get(PYTHONPATH_VAR, '')
+
+        bash_command = ('export {}={}; '.format(AIRFLOW_HOME_VAR, airflow_home_value) +
+                        'export {}={}; '.format(PYTHONPATH_VAR, pythonpath_value) +
+                        self.bash_command)
+
         with TemporaryDirectory(prefix='airflowtmp') as tmp_dir:
             with NamedTemporaryFile(dir=tmp_dir, prefix=self.task_id) as f:
 
                 f.write(bytes(bash_command, 'utf_8'))
                 f.flush()
                 fname = f.name
-                script_location = tmp_dir + "/" + fname
+                script_location = os.path.abspath(fname)
                 self.log.info(
                     "Temporary script location: %s",
                     script_location
                 )
+
                 def pre_exec():
                     # Restore default signal disposition and invoke setsid
                     for sig in ('SIGPIPE', 'SIGXFZ', 'SIGXFSZ'):
                         if hasattr(signal, sig):
                             signal.signal(getattr(signal, sig), signal.SIG_DFL)
                     os.setsid()
+
                 self.log.info("Running command: %s", bash_command)
                 sp = Popen(
                     ['bash', fname],
@@ -114,4 +133,3 @@ class BashOperator(BaseOperator):
     def on_kill(self):
         self.log.info('Sending SIGTERM signal to bash process group')
         os.killpg(os.getpgid(self.sp.pid), signal.SIGTERM)
-

--- a/airflow/utils/configuration.py
+++ b/airflow/utils/configuration.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+import os
+import json
+from tempfile import mkstemp
+
+from airflow import configuration as conf
+
+
+COPY_SECTIONS = [
+    'core', 'smtp', 'scheduler', 'celery', 'webserver', 'hive'
+]
+
+
+def tmp_configuration_copy():
+    """
+    Returns a path for a temporary file including a full copy of the configuration
+    settings.
+    :return: a path to a temporary file
+    """
+    cfg_dict = conf.as_dict(display_sensitive=True)
+    temp_fd, cfg_path = mkstemp()
+
+    cfg_subset = dict()
+    for section in COPY_SECTIONS:
+        cfg_subset[section] = cfg_dict.get(section, {})
+
+    with os.fdopen(temp_fd, 'w') as temp_file:
+        json.dump(cfg_subset, temp_file)
+
+    return cfg_path

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -189,7 +189,7 @@ class FileTaskHandler(logging.Handler):
         if not os.path.exists(directory):
             # Create the directory as globally writable using custom mkdirs
             # as os.makedirs doesn't set mode properly.
-            mkdirs(directory, 0o775)
+            mkdirs(directory, 0o777)
 
         if not os.path.exists(full_path):
             open(full_path, "a").close()

--- a/tests/dags/test_impersonation_subdag.py
+++ b/tests/dags/test_impersonation_subdag.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+
+from airflow.models import DAG
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.subdag_operator import SubDagOperator
+from airflow.operators.bash_operator import BashOperator
+from airflow.executors import SequentialExecutor
+
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+
+default_args = {
+    'owner': 'airflow',
+    'start_date': DEFAULT_DATE,
+    'run_as_user': 'airflow_test_user'
+}
+
+dag = DAG(dag_id='impersonation_subdag', default_args=default_args)
+
+
+def print_today():
+    print('Today is {}'.format(datetime.utcnow()))
+
+
+subdag = DAG('impersonation_subdag.test_subdag_operation',
+             default_args=default_args)
+
+
+PythonOperator(
+    python_callable=print_today,
+    task_id='exec_python_fn',
+    dag=subdag)
+
+
+BashOperator(
+    task_id='exec_bash_operator',
+    bash_command='echo "Running within SubDag"',
+    dag=subdag
+)
+
+
+subdag_operator = SubDagOperator(task_id='test_subdag_operation',
+                                 subdag=subdag,
+                                 executor=SequentialExecutor(),
+                                 dag=dag)

--- a/tests/impersonation.py
+++ b/tests/impersonation.py
@@ -129,3 +129,13 @@ class ImpersonationTest(unittest.TestCase):
             'impersonation_with_custom_pkg',
             'exec_python_fn'
         )
+
+    def test_impersonation_subdag(self):
+        """
+        Tests that impersonation using a subdag correctly passes the right configuration
+        :return:
+        """
+        self.run_backfill(
+            'impersonation_subdag',
+            'test_subdag_operation'
+        )


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1985

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

* [AIRFLOW-1985] Changes to propagate config in subdags

* [AIRFLOW-1985] Make sure tasks running have the config

Making sure all tasks have the proper configuration by copying it into a
temporary file.

* [AIRFLOW-1985] Airflow home and python path to BashOperator

BashOperators should have the context of the AIRFLOW_HOME and PYTHONPATH
as other tasks have.

Make sure you have checked _all_ steps below.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Impersonation unit tests included. Integration tests were also done in a staging environment.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
