### PR TITLE
[AIRFLOW-2053] Fix quote character bug in BQ hook

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -799,7 +799,7 @@ class BigQueryBaseCursor(LoggingMixin):
             src_fmt_configs['skipLeadingRows'] = skip_leading_rows
         if 'fieldDelimiter' not in src_fmt_configs:
             src_fmt_configs['fieldDelimiter'] = field_delimiter
-        if quote_character:
+        if quote_character is not None:
             src_fmt_configs['quote'] = quote_character
         if allow_quoted_newlines:
             src_fmt_configs['allowQuotedNewlines'] = allow_quoted_newlines


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2053


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Modified the condition to check if the quote_character is set. This will allow setting `quote_character` as an empty string when the data doesn't contain quoted sections.

The BigQuery API states [here](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.quote) that :

> The value that is used to quote data sections in a CSV file. BigQuery converts the string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data in its raw, binary state. The default value is a double-quote ('"'). If your data does not contain quoted sections, set the property value to an empty string.

But the current implementation `run_load ` in BigQuery hook has incorrect check to include `quote_character`.

The code currently is:

```python
        if 'fieldDelimiter' not in src_fmt_configs:
            src_fmt_configs['fieldDelimiter'] = field_delimiter
        if quote_character:
            src_fmt_configs['quote'] = quote_character
        if allow_quoted_newlines:
            src_fmt_configs['allowQuotedNewlines'] = allow_quoted_newlines
```

If my data doesn't have quote characters as per BQ API docs I need to put `quote=''` i.e empty string. The above condition `if quote_character:` will return false for an empty string. Hence, I get the following error:

```
{'message': 'Error detected while parsing row starting at position: 0. Error: Data between close double quote (") and field separator.', 'reason': 'invalid'}
```


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Single line modification

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
