### PR TITLE
[AIRFLOW-1466] fix to match domain and hostname

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -2555,7 +2555,8 @@ class LocalTaskJob(BaseJob):
         ti = self.task_instance
 
         fqdn = socket.getfqdn()
-        same_hostname = fqdn == ti.hostname
+        same_hostname = ((fqdn == ti.hostname) or
+                         ti.hostname.startswith("%s." % fqdn))
         same_process = ti.pid == os.getpid()
 
         if ti.state == State.RUNNING:


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR when possible.

JIRA
https://issues.apache.org/jira/browse/AIRFLOW-1466

Description
As on JIRA bug report

Also, a PR is available for this https://github.com/apache/incubator-airflow/pull/2484 which is no longer working in my case.

Tests
Should not change any test, it's only to resolve cases when domain and hostname does not match (on EMR specifically)