### PR TITLE
[AIRFLOW-2055] Elaborate on slightly ambiguous documentation

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1700,7 +1700,7 @@ class TaskInstance(Base, LoggingMixin):
         class VariableAccessor:
             """
             Wrapper around Variable. This way you can get variables in templates by using
-            {var.variable_name}.
+            {var.value.your_variable_name}.
             """
             def __init__(self):
                 self.var = None
@@ -1713,6 +1713,10 @@ class TaskInstance(Base, LoggingMixin):
                 return str(self.var)
 
         class VariableJsonAccessor:
+            """
+            Wrapper around deserialized Variables. This way you can get variables
+            in templates by using {var.json.your_variable_name}.
+            """
             def __init__(self):
                 self.var = None
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
    - https://issues.apache.org/jira/browse/AIRFLOW-2055


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
When I was writing a plugin that was trying to access the built-in Variable store, the documentation here led me to believe I could access it with `var.name_of_my_variable`. I've added some further documentation here that informs developers of the more specific calls which are referenced here: https://airflow.apache.org/code.html#default-variables


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
