### PR TITLE
[AIRFLOW-1157] Fix missing pools crashing the scheduler

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1096,7 +1096,14 @@ class SchedulerJob(BaseJob):
                 # non_pooled_task_slot_count per run
                 open_slots = conf.getint('core', 'non_pooled_task_slot_count')
             else:
-                open_slots = pools[pool].open_slots(session=session)
+                if pool not in pools:
+                    self.log.warning(
+                        "Tasks using non-existent pool '%s' will not be scheduled",
+                        pool
+                    )
+                    open_slots = 0
+                else:
+                    open_slots = pools[pool].open_slots(session=session)
 
             num_queued = len(task_instances)
             self.log.info(

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -1145,6 +1145,30 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertIn(tis[1].key, res_keys)
         self.assertIn(tis[3].key, res_keys)
 
+    def test_nonexistent_pool(self):
+        dag_id = 'SchedulerJobTest.test_nonexistent_pool'
+        task_id = 'dummy_wrong_pool'
+        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, concurrency=16)
+        task = DummyOperator(dag=dag, task_id=task_id, pool="this_pool_doesnt_exist")
+        dagbag = self._make_simple_dag_bag([dag])
+
+        scheduler = SchedulerJob(**self.default_scheduler_args)
+        session = settings.Session()
+
+        dr = scheduler.create_dag_run(dag)
+
+        ti = TI(task, dr.execution_date)
+        ti.state = State.SCHEDULED
+        session.merge(ti)
+        session.commit()
+
+        res = scheduler._find_executable_task_instances(
+            dagbag,
+            states=[State.SCHEDULED],
+            session=session)
+        session.commit()
+        self.assertEqual(0, len(res))
+
     def test_find_executable_task_instances_none(self):
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_none'
         task_id_1 = 'dummy'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1157


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Prior to patch if a task instance with non-existent pool was getting scheduled it would fail with this:

```
[2017-04-27 19:31:25,980] {dag_processing.py:627} INFO - Started a process (PID: 129) to generate tasks for /opt/airflow/dags/test-4.py - logging into /tmp/airflow/scheduler/logs/2017-04-27/test-4.py.log
[2017-04-27 19:31:26,004] {jobs.py:1007} INFO - Tasks up for execution:
        <TaskInstance: crash_scheduler.crash 2017-04-27 19:30:51.948542 [scheduled]>
[2017-04-27 19:31:26,006] {jobs.py:1311} INFO - Exited execute loop
[2017-04-27 19:31:26,008] {jobs.py:1325} INFO - Terminating child PID: 128
[2017-04-27 19:31:26,008] {jobs.py:1325} INFO - Terminating child PID: 129
[2017-04-27 19:31:26,008] {jobs.py:1329} INFO - Waiting up to 5s for processes to exit...
Traceback (most recent call last):
  File "/usr/bin/airflow", line 28, in <module>
    args.func(args)
  File "/usr/lib/python2.7/site-packages/airflow/bin/cli.py", line 839, in scheduler
    job.run()
  File "/usr/lib/python2.7/site-packages/airflow/jobs.py", line 200, in run
    self._execute()
  File "/usr/lib/python2.7/site-packages/airflow/jobs.py", line 1309, in _execute
    self._execute_helper(processor_manager)
  File "/usr/lib/python2.7/site-packages/airflow/jobs.py", line 1437, in _execute_helper
    (State.SCHEDULED,))
  File "/usr/lib/python2.7/site-packages/airflow/utils/db.py", line 53, in wrapper
    result = func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/airflow/jobs.py", line 1025, in _execute_task_instances
    open_slots = pools[pool].open_slots(session=session)
KeyError: u'a_non_existant_pool'
```

After the patch a warning is thrown instead and the task isn't scheduled until the pool is added

```
[2018-02-02 15:49:35,397] {jobs.py:1079} INFO - Tasks up for execution:
        <TaskInstance: crash_scheduler.crash 2018-02-02 15:46:34+00:00 [scheduled]>
[2018-02-02 15:49:35,399] {jobs.py:1102} WARNING - Tasks using non-existent pool 'a_non_existent_pool' will not be scheduled
[2018-02-02 15:49:35,399] {jobs.py:1112} INFO - Figuring out tasks to run in Pool(name=a_non_existent_pool) with 0 open slots and 1 task instances in queue
[2018-02-02 15:49:35,400] {jobs.py:1126} INFO - Not scheduling since there are 0 open slots in pool a_non_existent_pool
[2018-02-02 15:49:35,400] {jobs.py:1181} INFO - Setting the follow tasks to queued state:
```



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added test `SchedulerJobTest.test_nonexistent_pool`. It asserts that the number of pool slots is 9 and fails on `master` with:

```
======================================================================
ERROR: test_nonexistent_pool (tests.jobs.SchedulerJobTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/iansuvak/code/incubator-airflow/tests/jobs.py", line 1193, in test_nonexistent_pool
    session=session)
  File "/Users/iansuvak/code/incubator-airflow/airflow/utils/db.py", line 65, in wrapper
    return func(*args, **kwargs)
  File "/Users/iansuvak/code/incubator-airflow/airflow/jobs.py", line 1100, in _find_executable_task_instances
    open_slots = pools[pool].open_slots(session=session)
KeyError: 'this_pool_doesnt_exist'
```

on this branch it passes:

```
nosetests tests/jobs.py:SchedulerJobTest.test_nonexistent_pool
.
----------------------------------------------------------------------
Ran 1 test in 0.067s

OK
[2018-02-08 22:45:04,882] {settings.py:165} DEBUG - Disposing DB connection pool (PID 26497)
```


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/ by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
