### PR TITLE
[AIRFLOW-2080] Use a log-out icon instead of a power button

### DIFF
--- a/airflow/www/templates/admin/master.html
+++ b/airflow/www/templates/admin/master.html
@@ -85,7 +85,7 @@
         <ul class="nav navbar-nav navbar-right">
             <li><a id="clock"></a></li>
             {% if current_user.is_authenticated %}
-              <li><a href="{{ url_for('airflow.logout') }}"><span data-toggle="tooltip" data-placement="left" title="Logout" class="glyphicon glyphicon-off"></span></a></li>
+              <li><a href="{{ url_for('airflow.logout') }}"><span data-toggle="tooltip" data-placement="left" title="Logout" class="glyphicon glyphicon-log-out"></span></a></li>
             {% endif %}
         </ul>
           <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
Some users think the existing log out icon will restart Airflow itself. Using the log out icon should avoid confusion.

<img width="205" alt="glyphicon-log-out" src="https://user-images.githubusercontent.com/616164/35861596-4e344404-0b40-11e8-940b-67c6f573a671.png">

The JIRA for this is AIRFLOW-2080