### PR TITLE
[AIRFLOW-2074] Fix log var name in GHE auth

### DIFF
--- a/airflow/contrib/auth/backends/github_enterprise_auth.py
+++ b/airflow/contrib/auth/backends/github_enterprise_auth.py
@@ -119,7 +119,7 @@ class GHEAuthBackend(object):
                                     self.oauth_callback)
 
     def login(self, request):
-        _log.debug('Redirecting user to GHE login')
+        log.debug('Redirecting user to GHE login')
         return self.ghe_oauth.authorize(callback=url_for(
             'ghe_oauth_callback',
             _external=True,
@@ -169,7 +169,7 @@ class GHEAuthBackend(object):
             if team['id'] in allowed_teams:
                 return True
 
-        _log.debug('Denying access for user "%s", not a member of "%s"',
+        log.debug('Denying access for user "%s", not a member of "%s"',
                    username,
                    str(allowed_teams))
 
@@ -186,7 +186,7 @@ class GHEAuthBackend(object):
 
     @provide_session
     def oauth_callback(self, session=None):
-        _log.debug('GHE OAuth callback called')
+        log.debug('GHE OAuth callback called')
 
         next_url = request.args.get('next') or url_for('admin.index')
 
@@ -206,7 +206,7 @@ class GHEAuthBackend(object):
                 return redirect(url_for('airflow.noaccess'))
 
         except AuthenticationError:
-            _log.exception('')
+            log.exception('')
             return redirect(url_for('airflow.noaccess'))
 
         user = session.query(models.User).filter(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2074

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

The refactor in https://github.com/apache/incubator-airflow/commit/a7a518902dcf1e7fd4bf477cf57cee691f181b29#diff-a1e98b59fef0a4c044aa9b1def8eee90R32 changed the logger name from `_log` to `log`, but didn't update callers. This makes the GHE auth backend unusable due to:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python2.7/site-packages/flask_admin/base.py", line 69, in inner
    return self._run_view(f, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/flask_admin/base.py", line 368, in _run_view
    return fn(self, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/airflow/www/views.py", line 674, in login
    return airflow.login.login(self, request)
  File "/usr/local/lib/python2.7/site-packages/airflow/contrib/auth/backends/github_enterprise_auth.py", line 232, in login
    return login_manager.login(request)
  File "/usr/local/lib/python2.7/site-packages/airflow/contrib/auth/backends/github_enterprise_auth.py", line 122, in login
    _log.debug('Redirecting user to GHE login')
NameError: global name '_log' is not defined
```

This PR changes callers from `_log` to `log` so that GHE auth backend works again.

### Tests
- [*] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No need for tests as this relates to logs.

### Commits
- [*] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [*] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
