### PR TITLE
[AIRFLOW-713] EmrCreateJobFlowOperator and EmrAddStepsOperator attributes are not jinjafied

### DIFF
--- a/airflow/contrib/operators/emr_create_job_flow_operator.py
+++ b/airflow/contrib/operators/emr_create_job_flow_operator.py
@@ -29,7 +29,7 @@ class EmrCreateJobFlowOperator(BaseOperator):
     :param job_flow_overrides: boto3 style arguments to override emr_connection extra
     :type steps: dict
     """
-    template_fields = []
+    template_fields = ['job_flow_overrides']
     template_ext = ()
     ui_color = '#f9c915'
 

--- a/tests/contrib/operators/test_emr_create_job_flow_operator.py
+++ b/tests/contrib/operators/test_emr_create_job_flow_operator.py
@@ -14,10 +14,16 @@
 #
 
 import unittest
+from datetime import timedelta
+
 from mock import MagicMock, patch
 
-from airflow import configuration
+from airflow import DAG, configuration
 from airflow.contrib.operators.emr_create_job_flow_operator import EmrCreateJobFlowOperator
+from airflow.models import TaskInstance
+from airflow.utils import timezone
+
+DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 
 RUN_JOB_FLOW_SUCCESS_RETURN = {
     'ResponseMetadata': {
@@ -26,31 +32,81 @@ RUN_JOB_FLOW_SUCCESS_RETURN = {
     'JobFlowId': 'j-8989898989'
 }
 
+
 class TestEmrCreateJobFlowOperator(unittest.TestCase):
+    # When
+    _config = {
+        'Name': 'test_job_flow',
+        'ReleaseLabel': '5.11.0',
+        'Steps': [{
+            'Name': 'test_step',
+            'ActionOnFailure': 'CONTINUE',
+            'HadoopJarStep': {
+                'Jar': 'command-runner.jar',
+                'Args': [
+                    '/usr/lib/spark/bin/run-example',
+                    '{{ macros.ds_add(ds, -1) }}',
+                    '{{ ds }}'
+                ]
+            }
+        }]
+    }
+
     def setUp(self):
         configuration.load_test_config()
+        args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE
+        }
 
         # Mock out the emr_client (moto has incorrect response)
-        mock_emr_client = MagicMock()
-        mock_emr_client.run_job_flow.return_value = RUN_JOB_FLOW_SUCCESS_RETURN
+        self.emr_client_mock = MagicMock()
+        self.operator = EmrCreateJobFlowOperator(
+            task_id='test_task',
+            aws_conn_id='aws_default',
+            emr_conn_id='emr_default',
+            job_flow_overrides=self._config,
+            dag=DAG('test_dag_id', default_args=args)
+        )
 
-        mock_emr_session = MagicMock()
-        mock_emr_session.client.return_value = mock_emr_client
+    def test_init(self):
+        self.assertEqual(self.operator.aws_conn_id, 'aws_default')
+        self.assertEqual(self.operator.emr_conn_id, 'emr_default')
+
+    def test_render_template(self):
+        ti = TaskInstance(self.operator, DEFAULT_DATE)
+        ti.render_templates()
+
+        expected_args = {
+            'Name': 'test_job_flow',
+            'ReleaseLabel': '5.11.0',
+            'Steps': [{
+                'Name': 'test_step',
+                'ActionOnFailure': 'CONTINUE',
+                'HadoopJarStep': {
+                    'Jar': 'command-runner.jar',
+                    'Args': [
+                        '/usr/lib/spark/bin/run-example',
+                        (DEFAULT_DATE - timedelta(days=1)).strftime("%Y-%m-%d"),
+                        DEFAULT_DATE.strftime("%Y-%m-%d"),
+                    ]
+                }
+            }]
+        }
+
+        self.assertDictEqual(self.operator.job_flow_overrides, expected_args)
+
+    def test_execute_returns_job_id(self):
+        self.emr_client_mock.run_job_flow.return_value = RUN_JOB_FLOW_SUCCESS_RETURN
 
         # Mock out the emr_client creator
-        self.boto3_session_mock = MagicMock(return_value=mock_emr_session)
+        emr_session_mock = MagicMock()
+        emr_session_mock.client.return_value = self.emr_client_mock
+        self.boto3_session_mock = MagicMock(return_value=emr_session_mock)
 
-
-    def test_execute_uses_the_emr_config_to_create_a_cluster_and_returns_job_id(self):
         with patch('boto3.session.Session', self.boto3_session_mock):
+            self.assertEqual(self.operator.execute(None), 'j-8989898989')
 
-            operator = EmrCreateJobFlowOperator(
-                task_id='test_task',
-                aws_conn_id='aws_default',
-                emr_conn_id='emr_default'
-            )
-
-            self.assertEqual(operator.execute(None), 'j-8989898989')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-713


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
