### PR TITLE
[AIRFLOW-2083] Docs: Use "its" instead of "it's" where appropriate

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1572,7 +1572,7 @@ class CLIFactory(object):
             'func': test,
             'help': (
                 "Test a task instance. This will run a task without checking for "
-                "dependencies or recording it's state in the database."),
+                "dependencies or recording its state in the database."),
             'args': (
                 'dag_id', 'task_id', 'execution_date', 'subdir', 'dry_run',
                 'task_params'),

--- a/airflow/contrib/hooks/redshift_hook.py
+++ b/airflow/contrib/hooks/redshift_hook.py
@@ -79,7 +79,7 @@ class RedshiftHook(AwsHook):
 
     def restore_from_cluster_snapshot(self, cluster_identifier, snapshot_identifier):
         """
-        Restores a cluster from it's snapshot
+        Restores a cluster from its snapshot
 
         :param cluster_identifier: unique identifier of a cluster
         :type cluster_identifier: str

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -68,7 +68,7 @@ class BaseJob(Base, LoggingMixin):
     """
     Abstract class to be derived for jobs. Jobs are processing items with state
     and duration that aren't task instances. For instance a BackfillJob is
-    a collection of task instance runs, but should have it's own state, start
+    a collection of task instance runs, but should have its own state, start
     and end time.
     """
 
@@ -1796,8 +1796,8 @@ class SchedulerJob(BaseJob):
             dep_context = DepContext(deps=QUEUE_DEPS, ignore_task_deps=True)
 
             # Only schedule tasks that have their dependencies met, e.g. to avoid
-            # a task that recently got it's state changed to RUNNING from somewhere
-            # other than the scheduler from getting it's state overwritten.
+            # a task that recently got its state changed to RUNNING from somewhere
+            # other than the scheduler from getting its state overwritten.
             # TODO(aoen): It's not great that we have to check all the task instance
             # dependencies twice; once to get the task scheduled, and again to actually
             # run the task. We should try to come up with a way to only check them once.

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -127,7 +127,7 @@ class TriggerRuleDep(BaseTIDep):
             "total": upstream, "successes": successes, "skipped": skipped,
             "failed": failed, "upstream_failed": upstream_failed, "done": done
         }
-        # TODO(aoen): Ideally each individual trigger rules would be it's own class, but
+        # TODO(aoen): Ideally each individual trigger rules would be its own class, but
         # this isn't very feasible at the moment since the database queries need to be
         # bundled together for efficiency.
         # handling instant state assignment based on trigger rules

--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -146,7 +146,7 @@ def round_time(dt, delta, start_date=timezone.make_aware(datetime.min)):
 
     # We are looking for a datetime in the form start_date + i * delta
     # which is as close as possible to dt. Since delta could be a relative
-    # delta we don't know it's exact length in seconds so we cannot rely on
+    # delta we don't know its exact length in seconds so we cannot rely on
     # division to find i. Instead we employ a binary search algorithm, first
     # finding an upper and lower limit and then disecting the interval until
     # we have found the closest match.

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -811,10 +811,12 @@ class Airflow(BaseView):
             - The scheduler is down or under heavy load<br/>
             {}
             <br/>
-            If this task instance does not start soon please contact your Airflow administrator for assistance."""
-                .format(
-                "- This task instance already ran and had it's state changed manually (e.g. cleared in the UI)<br/>"
-                if ti.state == State.NONE else "")))]
+            If this task instance does not start soon please contact your Airflow """
+                   """administrator for assistance."""
+                   .format(
+                       "- This task instance already ran and had its state changed "
+                       "manually (e.g. cleared in the UI)<br/>"
+                       if ti.state == State.NONE else "")))]
 
         # Use the scheduler's context to figure out which dependencies are not met
         dep_context = DepContext(SCHEDULER_DEPS)

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -41,7 +41,7 @@ Airflow has many components that can be reused when building an application:
 * A metadata database to store your models
 * Access to your databases, and knowledge of how to connect to them
 * An array of workers that your application can push workload to
-* Airflow is deployed, you can just piggy back on it's deployment logistics
+* Airflow is deployed, you can just piggy back on its deployment logistics
 * Basic charting capabilities, underlying libraries and abstractions
 
 

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -2548,7 +2548,7 @@ class SchedulerJobTest(unittest.TestCase):
 
     def test_dag_get_active_runs(self):
         """
-        Test to check that a DAG returns it's active runs
+        Test to check that a DAG returns its active runs
         """
 
         now = timezone.utcnow()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2083


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Fix trivial spelling/grammar errors

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: trivial changes to documentation.  No testing appropriate


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
