### PR TITLE
[AIRFLOW-2088] Fix duplicate keys in MySQL to GCS Helper function

### DIFF
--- a/airflow/contrib/operators/mysql_to_gcs.py
+++ b/airflow/contrib/operators/mysql_to_gcs.py
@@ -214,7 +214,6 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
         when a schema_filename is set.
         """
         d = {
-            FIELD_TYPE.INT24: 'INTEGER',
             FIELD_TYPE.TINY: 'INTEGER',
             FIELD_TYPE.BIT: 'INTEGER',
             FIELD_TYPE.DATETIME: 'TIMESTAMP',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2088


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- Remove the duplicate key in `MySqlToGoogleCloudStorageOperator` in the `type_map` helper function that maps from MySQL fields to BigQuery fields.

![image](https://user-images.githubusercontent.com/8811558/36022964-de5267c4-0db0-11e8-9acf-74a6a76c2725.png)


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Minor change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
