### PR TITLE
[AIRFLOW-2089] - Add on kill for SparkSubmit in Standalone Cluster

### DIFF
--- a/airflow/contrib/hooks/spark_submit_hook.py
+++ b/airflow/contrib/hooks/spark_submit_hook.py
@@ -409,7 +409,48 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                     .format(returncode)
                 )
 
+    def _build_spark_driver_kill_command(self):
+        """
+        Construct the spark-submit command to kill a driver.
+        :return: full command to kill a driver
+        """
+
+        # If the spark_home is passed then build the spark-submit executable path using
+        # the spark_home; otherwise assume that spark-submit is present in the path to
+        # the executing user
+        if self._connection['spark_home']:
+            connection_cmd = [os.path.join(self._connection['spark_home'],
+                                           'bin',
+                                           self._connection['spark_binary'])]
+        else:
+            connection_cmd = [self._connection['spark_binary']]
+
+        # The url ot the spark master
+        connection_cmd += ["--master", self._connection['master']]
+
+        # The actual kill command
+        connection_cmd += ["--kill", self._driver_id]
+
+        self.log.debug("Spark-Kill cmd: %s", connection_cmd)
+
+        return connection_cmd
+
     def on_kill(self):
+
+        self.log.debug("Kill Command is being called")
+
+        if self._should_track_driver_status:
+            if self._driver_id:
+                self.log.info('Killing driver {} on cluster'
+                              .format(self._driver_id))
+
+                kill_cmd = self._build_spark_driver_kill_command()
+                driver_kill = subprocess.Popen(kill_cmd,
+                                               stdout=subprocess.PIPE,
+                                               stderr=subprocess.PIPE)
+
+                self.log.info("Spark driver {} killed with return code: {}"
+                              .format(self._driver_id, driver_kill.wait()))
 
         if self._submit_sp and self._submit_sp.poll() is None:
             self.log.info('Sending kill signal to %s', self._connection['spark_binary'])

--- a/tests/contrib/hooks/test_spark_submit_hook.py
+++ b/tests/contrib/hooks/test_spark_submit_hook.py
@@ -456,6 +456,28 @@ class TestSparkSubmitHook(unittest.TestCase):
                            stderr=-1, stdout=-1),
                       mock_popen.mock_calls)
 
+    def test_standalone_cluster_process_on_kill(self):
+        # Given
+        log_lines = [
+            'Running Spark using the REST application submission protocol.',
+            '17/11/28 11:14:15 INFO RestSubmissionClient: Submitting a request ' +
+            'to launch an application in spark://spark-standalone-master:6066',
+            '17/11/28 11:14:15 INFO RestSubmissionClient: Submission successfully ' +
+            'created as driver-20171128111415-0001. Polling submission state...'
+        ]
+        hook = SparkSubmitHook(conn_id='spark_standalone_cluster')
+        hook._process_spark_submit_log(log_lines)
+
+        # When
+        kill_cmd = hook._build_spark_driver_kill_command()
+
+        # Then
+        self.assertEqual(kill_cmd[0], '/path/to/spark_home/bin/spark-submit')
+        self.assertEqual(kill_cmd[1], '--master')
+        self.assertEqual(kill_cmd[2], 'spark://spark-standalone-master:6066')
+        self.assertEqual(kill_cmd[3], '--kill')
+        self.assertEqual(kill_cmd[4], 'driver-20171128111415-0001')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2089) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2089


### Description
- [x] This PR adds a kill command in case of running a Standalone Cluster for Spark


### Tests
- [x] I added unit test to check if the correct kill command is created for the Spark Cluster


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. 

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`