### PR TITLE
[AIRFLOW-2090] Fix typo in DataStore Hook

### DIFF
--- a/airflow/contrib/hooks/datastore_hook.py
+++ b/airflow/contrib/hooks/datastore_hook.py
@@ -25,7 +25,7 @@ class DatastoreHook(GoogleCloudBaseHook):
     connection.
 
     This object is not threads safe. If you want to make multiple requests
-    simultaniously, you will need to create a hook per thread.
+    simultaneously, you will need to create a hook per thread.
     """
 
     def __init__(self,


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2090


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Spelling mistake in the word `simultaneously` in DataStore docs

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Just spelling change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
