### PR TITLE
[AIRFLOW-2091] Fix incorrect docstring parameter in BigQuery Hook

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1256,9 +1256,9 @@ class BigQueryCursor(BigQueryBaseCursor):
 
         :param operation: The query to execute.
         :type operation: string
-        :param parameters: List of dictionary parameters to substitute into the
+        :param seq_of_parameters: List of dictionary parameters to substitute into the
             query.
-        :type parameters: list
+        :type seq_of_parameters: list
         """
         for parameters in seq_of_parameters:
             self.execute(operation, parameters)


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2091


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- Instead of `seq_of_parameters`, the docstring contains `parameters`. This has been fixed in this PR

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Docstring change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
