### PR TITLE
[AIRFLOW-2092] Fixed incorrect parameter in docstring for FTPHook

### DIFF
--- a/airflow/contrib/hooks/ftp_hook.py
+++ b/airflow/contrib/hooks/ftp_hook.py
@@ -154,7 +154,7 @@ class FTPHook(BaseHook, LoggingMixin):
         :type remote_full_path: str
         :param local_full_path_or_buffer: full path to the local file or a
             file-like buffer
-        :type local_full_path: str or file-like buffer
+        :type local_full_path_or_buffer: str or file-like buffer
         """
         conn = self.get_conn()
 


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2092


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- Fixed the datatype of parameter `local_full_path_or_buffer` in `retrieve_file` method for FTPHook


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
docstring change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
