### PR TITLE
[AIRFLOW-2094] Jinjafied parameters in DataProc{*} Operators

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -64,7 +64,7 @@ class DataprocClusterCreateOperator(BaseOperator):
     :type master_machine_type: string
     :param master_disk_size: Disk size for the master node
     :type master_disk_size: int
-    :param worker_machine_type:Compute engine machine type to use for the worker nodes
+    :param worker_machine_type: Compute engine machine type to use for the worker nodes
     :type worker_machine_type: string
     :param worker_disk_size: Disk size for the worker nodes
     :type worker_disk_size: int
@@ -95,7 +95,7 @@ class DataprocClusterCreateOperator(BaseOperator):
     :type service_account_scopes: list[string]
     """
 
-    template_fields = ['cluster_name']
+    template_fields = ['cluster_name', 'project_id', 'zone', 'region']
 
     @apply_defaults
     def __init__(self,
@@ -339,7 +339,7 @@ class DataprocClusterDeleteOperator(BaseOperator):
     :type delegate_to: string
     """
 
-    template_fields = ['cluster_name']
+    template_fields = ['cluster_name', 'project_id', 'region']
 
     @apply_defaults
     def __init__(self,


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2094


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- Minor docstring change
- Jinjafied project_id, region & zone in DataProc{*} Operators to allow using Airflow variables


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Minor changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
