### PR TITLE
[AIRFLOW-800] Initialize default GCP Connection with valid conn_type

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -49,7 +49,7 @@ class BigQueryHook(GoogleCloudBaseHook, DbApiHook, LoggingMixin):
                  delegate_to=None,
                  use_legacy_sql=True):
         super(BigQueryHook, self).__init__(
-            conn_id=bigquery_conn_id, delegate_to=delegate_to)
+            gcp_conn_id=bigquery_conn_id, delegate_to=delegate_to)
         self.use_legacy_sql = use_legacy_sql
 
     def get_conn(self):

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -43,18 +43,19 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
 
     Legacy P12 key files are not supported.
     """
-    def __init__(self, conn_id, delegate_to=None):
+
+    def __init__(self, gcp_conn_id='google_cloud_default', delegate_to=None):
         """
-        :param conn_id: The connection ID to use when fetching connection info.
-        :type conn_id: string
+        :param gcp_conn_id: The connection ID to use when fetching connection info.
+        :type gcp_conn_id: string
         :param delegate_to: The account to impersonate, if any.
             For this to work, the service account making the request must have
             domain-wide delegation enabled.
         :type delegate_to: string
         """
-        self.conn_id = conn_id
+        self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
-        self.extras = self.get_connection(conn_id).extra_dejson
+        self.extras = self.get_connection(self.gcp_conn_id).extra_dejson
 
     def _get_credentials(self):
         """
@@ -69,8 +70,8 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
             kwargs['sub'] = self.delegate_to
 
         if not key_path and not keyfile_dict:
-            self.log.info('Getting connection using `gcloud auth` user, since no key file '
-                         'is defined for hook.')
+            self.log.info('Getting connection using `gcloud auth` user, '
+                          'since no key file is defined for hook.')
             credentials = GoogleCredentials.get_application_default()
         elif key_path:
             if not scope:
@@ -80,7 +81,7 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
             # Get credentials from a JSON file.
             if key_path.endswith('.json'):
                 self.log.info('Getting connection using a JSON key file.')
-                credentials = ServiceAccountCredentials\
+                credentials = ServiceAccountCredentials \
                     .from_json_keyfile_name(key_path, scopes)
             elif key_path.endswith('.p12'):
                 raise AirflowException('Legacy P12 key file are not supported, '
@@ -101,7 +102,7 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
                 keyfile_dict['private_key'] = keyfile_dict['private_key'].replace(
                     '\\n', '\n')
 
-                credentials = ServiceAccountCredentials\
+                credentials = ServiceAccountCredentials \
                     .from_json_keyfile_dict(keyfile_dict, scopes)
             except json.decoder.JSONDecodeError:
                 raise AirflowException('Invalid key JSON.')

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -662,8 +662,8 @@ class Connection(Base, LoggingMixin):
                 from airflow.hooks.mysql_hook import MySqlHook
                 return MySqlHook(mysql_conn_id=self.conn_id)
             elif self.conn_type == 'google_cloud_platform':
-                from airflow.contrib.hooks.bigquery_hook import BigQueryHook
-                return BigQueryHook(bigquery_conn_id=self.conn_id)
+                from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+                return GoogleCloudBaseHook(gcp_conn_id=self.conn_id)
             elif self.conn_type == 'postgres':
                 from airflow.hooks.postgres_hook import PostgresHook
                 return PostgresHook(postgres_conn_id=self.conn_id)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-800


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- `airflow initdb` creates a connection with `conn_id='bigquery_default'` and `conn_type='bigquery'`. However, bigquery is not a valid `conn_type`, according to `models.Connection._types`, and BigQuery connections should use the google_cloud_platform conn_type.
    - Changed the connection to `GoogleCloudBaseHook` instead of `BigQueryHook` which was causing an invalid `conn_type` creation during `airflow initdb`
    - Modified `GoogleCloudBaseHook` to change the name of parameter `conn_id` to keep it consistent with other Hooks.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No new code added

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
