### PR TITLE
[AIRFLOW-2099] Handle getsource() calls gracefully

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -21,7 +21,7 @@ import logging
 import os
 import pkg_resources
 import socket
-from functools import wraps
+from functools import wraps, partial
 from datetime import timedelta
 import copy
 import math
@@ -240,6 +240,31 @@ def wrapped_markdown(s):
     return '<div class="rich_doc">' + markdown.markdown(s) + "</div>"
 
 
+def get_python_source(x):
+    """ Helper function to get Python source, or not, without exceptions"""
+    source_code = None
+
+    if isinstance(x, partial):
+        source_code = inspect.getsource(x.func)
+
+    if source_code is None:
+        try:
+            source_code = inspect.getsource(x)
+        except TypeError:
+            pass
+
+    if source_code is None:
+        try:
+            source_code = inspect.getsource(x.__call__)
+        except TypeError:
+            pass
+
+    if source_code is None:
+        source_code = 'No source code available for {}'.format(type(x))
+
+    return source_code
+
+
 attr_renderer = {
     'bash_command': lambda x: render(x, lexers.BashLexer),
     'hql': lambda x: render(x, lexers.SqlLexer),
@@ -250,7 +275,9 @@ attr_renderer = {
     'doc_yaml': lambda x: render(x, lexers.YamlLexer),
     'doc_md': wrapped_markdown,
     'python_callable': lambda x: render(
-        inspect.getsource(x), lexers.PythonLexer),
+        get_python_source(x),
+        lexers.PythonLexer,
+    ),
 }
 
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -1800,6 +1800,20 @@ class WebUiTests(unittest.TestCase):
         response = self.app.get(url)
         self.assertIn("run_this_last", response.data.decode('utf-8'))
 
+    def test_dag_view_task_with_python_operator_using_partial(self):
+        response = self.app.get(
+            '/admin/airflow/task?'
+            'task_id=test_dagrun_functool_partial&dag_id=test_issue_2099_dag&'
+            'execution_date={}'.format(DEFAULT_DATE_DS))
+        self.assertIn("A function with two args", response.data.decode('utf-8'))
+
+    def test_dag_view_task_with_python_operator_using_instance(self):
+        response = self.app.get(
+            '/admin/airflow/task?'
+            'task_id=test_dagrun_instance&dag_id=test_issue_2099_dag&'
+            'execution_date={}'.format(DEFAULT_DATE_DS))
+        self.assertIn("A __call__ method", response.data.decode('utf-8'))
+
     def tearDown(self):
         configuration.conf.set("webserver", "expose_config", "False")
         self.dag_bash.clear(start_date=DEFAULT_DATE, end_date=timezone.utcnow())

--- a/tests/dags/test_issue_2099.py
+++ b/tests/dags/test_issue_2099.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+DAG designed to test a PythonOperator that calls a functool.partial
+"""
+import functools
+import logging
+
+from datetime import datetime
+
+from airflow.models import DAG
+from airflow.operators.python_operator import PythonOperator
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+default_args = dict(
+    start_date=DEFAULT_DATE,
+    owner='airflow')
+
+
+class CallableClass(object):
+    def __call__(self):
+        """ A __call__ method """
+        pass
+
+
+def a_function(arg_x, arg_y):
+    """ A function with two args """
+    pass
+
+
+partial_function = functools.partial(a_function, arg_x=1)
+class_instance = CallableClass()
+
+logging.info('class_instance type: {}'.format(type(class_instance)))
+
+dag = DAG(dag_id='test_issue_2099_dag', default_args=default_args)
+
+dag_task1 = PythonOperator(
+    task_id='test_dagrun_functool_partial',
+    dag=dag,
+    python_callable=partial_function,
+)
+
+dag_task2 = PythonOperator(
+    task_id='test_dagrun_instance',
+    dag=dag,
+    python_callable=class_instance,
+)


### PR DESCRIPTION
There are several scenarios where Task Instance view tries to render
Python callables where 'x' is not the correct artefact to target.

This commit adds a helper fuction to test for known scenarios, and
derives the source from the correc artefact or as a default returns
'No source available for <type>'. This means that even in unknown or
unfixable edge cases, the Task Instance view still renders instead of
displaying an exception.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
1. Adds a wrapper function for getting Python source code.
2. It tests for/catches known anomalies and implements a work around, finally returning 'source code not available for <type>' if no option works.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
1.  test_dag_view_task_with_python_operator_using_partial
2. test_dag_view_task_with_python_operator_using_instance

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
