### PR TITLE
[AIRFLOW-2102] Add custom_args to Sendgrid personalizations

### DIFF
--- a/airflow/contrib/utils/sendgrid.py
+++ b/airflow/contrib/utils/sendgrid.py
@@ -24,7 +24,8 @@ import sendgrid
 
 from airflow.utils.email import get_email_address_list
 from airflow.utils.log.logging_mixin import LoggingMixin
-from sendgrid.helpers.mail import Attachment, Content, Email, Mail, Personalization
+from sendgrid.helpers.mail import Attachment, Content, Email, Mail, \
+    Personalization, CustomArg
 
 
 def send_email(to, subject, html_content, files=None,
@@ -62,6 +63,12 @@ def send_email(to, subject, html_content, files=None,
             personalization.add_bcc(Email(bcc_address))
     mail.add_personalization(personalization)
     mail.add_content(Content('text/html', html_content))
+
+    # Add custom_args to personalization if present
+    pers_custom_args = kwargs.get('personalization_custom_args', None)
+    if isinstance(pers_custom_args, dict):
+        for key in pers_custom_args.keys():
+            personalization.add_custom_arg(CustomArg(key, pers_custom_args[key]))
 
     # Add email attachment.
     for fname in files or []:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2102


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
   See linked Jira issue

### Tests
- [X] My PR adds the following unit tests:
`test_send_email_sendgrid_correct_email_custom_args`


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
