### PR TITLE
[AIRFLOW-1588] Cast variables values to string.

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4226,7 +4226,7 @@ class Variable(Base, LoggingMixin):
         if serialize_json:
             stored_value = json.dumps(value)
         else:
-            stored_value = value
+            stored_value = str(value)
 
         session.query(cls).filter(cls.key == key).delete()
         session.add(Variable(key=key, val=stored_value))


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1588


### Description
- [x] Airflow `variables exporter` exports a valid JSON, which means that values that are just numeric, are exported as numbers instead of strings. While trying to import them back to another airflow instance, airflow tries to cast them into bytes (for fernet encryption) and it fails (bytes expect a string).
So, my solution was to just cast the variable into a string before casting it into bytes.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Does not affect the project logic anywhere.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
My changes passes this item.