### PR TITLE
[AIRFLOW-2065] Fix race-conditions when creating loggers

### DIFF
--- a/airflow/utils/log/file_processor_handler.py
+++ b/airflow/utils/log/file_processor_handler.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import errno
 import logging
 import os
 
@@ -45,7 +46,14 @@ class FileProcessorHandler(logging.Handler):
 
         self._cur_date = datetime.today()
         if not os.path.exists(self._get_log_directory()):
-            os.makedirs(self._get_log_directory())
+            try:
+                os.makedirs(self._get_log_directory())
+            except OSError as e:
+                # only ignore case where the directory already exist
+                if e.errno != errno.EEXIST:
+                    raise
+
+                logging.warning("%s already exists", self._get_log_directory())
 
         self._symlink_latest_log_directory()
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2065) issues and references them in the PR title


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

If two or more workers start at the same time, they will execute
the same operations to create output directories for storing the log
files. It can lead to race-conditions when, for example,  worker A
create the directory right after the non-existance check done by
worker B; worker B will also try to create the directory while it does
already exist.

Some of these race-conditions have already been fixed by #2564. This PR fixes the remaining issue when *creating* the log directory

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Not easily testable

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
