### PR TITLE
[AIRFLOW-1882] Add ignoreUnknownValues option to gcs_to_bq operator

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -733,6 +733,7 @@ class BigQueryBaseCursor(LoggingMixin):
                  field_delimiter=',',
                  max_bad_records=0,
                  quote_character=None,
+                 ignore_unknown_values=False,
                  allow_quoted_newlines=False,
                  allow_jagged_rows=False,
                  schema_update_options=(),
@@ -776,6 +777,12 @@ class BigQueryBaseCursor(LoggingMixin):
         :param quote_character: The value that is used to quote data sections in a CSV
             file.
         :type quote_character: string
+        :param ignore_unknown_values: [Optional] Indicates if BigQuery should allow
+            extra values that are not represented in the table schema.
+            If true, the extra values are ignored. If false, records with extra columns
+            are treated as bad records, and if there are too many bad records, an
+            invalid error is returned in the job result.
+        :type ignore_unknown_values: bool
         :param allow_quoted_newlines: Whether to allow quoted newlines (true) or not
             (false).
         :type allow_quoted_newlines: boolean
@@ -842,6 +849,7 @@ class BigQueryBaseCursor(LoggingMixin):
                 'sourceFormat': source_format,
                 'sourceUris': source_uris,
                 'writeDisposition': write_disposition,
+                'ignoreUnknownValues': ignore_unknown_values
             }
         }
 
@@ -885,6 +893,8 @@ class BigQueryBaseCursor(LoggingMixin):
             src_fmt_configs['skipLeadingRows'] = skip_leading_rows
         if 'fieldDelimiter' not in src_fmt_configs:
             src_fmt_configs['fieldDelimiter'] = field_delimiter
+        if 'ignoreUnknownValues' not in src_fmt_configs:
+            src_fmt_configs['ignoreUnknownValues'] = ignore_unknown_values
         if quote_character is not None:
             src_fmt_configs['quote'] = quote_character
         if allow_quoted_newlines:

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -66,6 +66,12 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
     :type max_bad_records: int
     :param quote_character: The value that is used to quote data sections in a CSV file.
     :type quote_character: string
+    :param ignore_unknown_values: [Optional] Indicates if BigQuery should allow
+        extra values that are not represented in the table schema.
+        If true, the extra values are ignored. If false, records with extra columns
+        are treated as bad records, and if there are too many bad records, an
+        invalid error is returned in the job result.
+    :type ignore_unknown_values: bool
     :param allow_quoted_newlines: Whether to allow quoted newlines (true) or not (false).
     :type allow_quoted_newlines: boolean
     :param allow_jagged_rows: Accept rows that are missing trailing optional columns.
@@ -124,6 +130,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                  field_delimiter=',',
                  max_bad_records=0,
                  quote_character=None,
+                 ignore_unknown_values=False,
                  allow_quoted_newlines=False,
                  allow_jagged_rows=False,
                  max_id_key=None,
@@ -154,6 +161,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         self.field_delimiter = field_delimiter
         self.max_bad_records = max_bad_records
         self.quote_character = quote_character
+        self.ignore_unknown_values = ignore_unknown_values
         self.allow_quoted_newlines = allow_quoted_newlines
         self.allow_jagged_rows = allow_jagged_rows
         self.external_table = external_table
@@ -198,6 +206,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                 field_delimiter=self.field_delimiter,
                 max_bad_records=self.max_bad_records,
                 quote_character=self.quote_character,
+                ignore_unknown_values=self.ignore_unknown_values,
                 allow_quoted_newlines=self.allow_quoted_newlines,
                 allow_jagged_rows=self.allow_jagged_rows,
                 src_fmt_configs=self.src_fmt_configs
@@ -214,6 +223,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                 field_delimiter=self.field_delimiter,
                 max_bad_records=self.max_bad_records,
                 quote_character=self.quote_character,
+                ignore_unknown_values=self.ignore_unknown_values,
                 allow_quoted_newlines=self.allow_quoted_newlines,
                 allow_jagged_rows=self.allow_jagged_rows,
                 schema_update_options=self.schema_update_options,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1882


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- Added `ignore_unknown_values` to
`run_load` method in `BigQuery Hook`
- Added `ignore_unknown_values` to `GoogleCloudStorageToBigQueryOperator`


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Minor change. Just added a parameter

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
