### PR TITLE
[AIRFLOW-2108] Fix log indentation in BashOperator

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -116,7 +116,7 @@ class BashOperator(BaseOperator):
                 self.log.info("Output:")
                 line = ''
                 for line in iter(sp.stdout.readline, b''):
-                    line = line.decode(self.output_encoding).strip()
+                    line = line.decode(self.output_encoding).rstrip()
                     self.log.info(line)
                 sp.wait()
                 self.log.info(


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2108


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- Changed from `strip` to `rstrip` to retain leading whitespaces. Check the [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW-2108) for more details.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Minor Change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
