### PR TITLE
[AIRFLOW-2103] Fix Bug in webserver when using password_auth

### DIFF
--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -18,7 +18,7 @@ from sys import version_info
 
 import base64
 import flask_login
-from flask_login import current_user
+from flask_login import login_required, current_user, logout_user
 from flask import flash, Response
 from wtforms import Form, PasswordField, StringField
 from wtforms.validators import InputRequired


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2103


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- Added `login_required` & `logout_user` in import statement to resolve issue with failing Airflow Webserver when `airflow.contrib.auth.backends.password_auth` is used as `auth_backend`. More details in the [Jira issue](https://issues.apache.org/jira/browse/AIRFLOW-2103).

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 Minor change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
