### PR TITLE
[AIRFLOW-2112] Fix svg width for Recent Tasks on UI.

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -389,7 +389,7 @@
             states = json[dag_id];
             g = d3.select('svg#task-run-' + dag_id)
               .attr('height', diameter + (stroke_width_hover * 2))
-              .attr('width', '180px')
+              .attr('width', '240px')
               .selectAll("g")
               .data(states)
               .enter()


### PR DESCRIPTION
As we expect to have 8 elements with width between 25px and 30px, 30 px
were used.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2112


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Width was increased.

Before:
![before](https://user-images.githubusercontent.com/192702/36279591-b45a5d8c-127e-11e8-9075-62a719c44ddc.png)

After:
![after](https://user-images.githubusercontent.com/192702/36279590-b4303f2a-127e-11e8-9c42-6a4764b3f852.png)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
