### PR TITLE
[AIRFLOW-2114] Add AIRFLOW_HOME to PythonVirtualenvOperator

### DIFF
--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -21,12 +21,16 @@ import subprocess
 import sys
 import types
 
+from airflow import configuration as conf
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, SkipMixin
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory
 
 from textwrap import dedent
+
+
+AIRFLOW_HOME_VAR = 'AIRFLOW_HOME'
 
 
 class PythonOperator(BaseOperator):
@@ -275,9 +279,11 @@ class PythonVirtualenvOperator(PythonOperator):
     def _execute_in_subprocess(self, cmd):
         try:
             self.log.info("Executing cmd\n{}".format(cmd))
-            output = subprocess.check_output(cmd,
-                                             stderr=subprocess.STDOUT,
-                                             close_fds=True)
+            output = subprocess.check_output(
+                cmd,
+                stderr=subprocess.STDOUT,
+                close_fds=True,
+                env={AIRFLOW_HOME_VAR: conf.get('core', AIRFLOW_HOME_VAR)})
             if output:
                 self.log.info("Got output\n{}".format(output))
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2114

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR passes the `AIRFLOW_HOME` environment variable to the subprocess which is required in order for the connection information to be available within the subprocess. The logic is derived from the [BashOperator](https://github.com/apache/incubator-airflow/blob/master/airflow/operators/bash_operator.py#L81).

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Existing unit test converage.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`