### PR TITLE
[AIRFLOW-2115] Fix doc links to PythonHosted

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ If you are proposing a feature:
 
 ## Documentation
 
-The latest API documentation is usually available [here](http://pythonhosted.org/airflow).
+The latest API documentation is usually available [here](https://airflow.incubator.apache.org/).
 To generate a local version, you need to have installed airflow with
 the `doc` extra. In that case you can generate the doc by running:
 

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -224,7 +224,7 @@ error_logfile = -
 expose_config = False
 
 # Set to true to turn on authentication:
-# http://pythonhosted.org/airflow/security.html#web-authentication
+# https://airflow.incubator.apache.org/security.html#web-authentication
 authenticate = False
 
 # Filter the list of dags by owner name (requires authentication to be enabled)

--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -15,7 +15,7 @@
 """
 ### Tutorial Documentation
 Documentation that goes along with the Airflow tutorial located
-[here](http://pythonhosted.org/airflow/tutorial.html)
+[here](https://airflow.incubator.apache.org/tutorial.html)
 """
 import airflow
 from airflow import DAG

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -103,10 +103,11 @@ def create_app(config=None, testing=False):
 
         admin.add_link(base.MenuLink(
             category='Docs', name='Documentation',
-            url='http://pythonhosted.org/airflow/'))
+            url='https://airflow.incubator.apache.org/'))
         admin.add_link(
             base.MenuLink(category='Docs',
-                name='Github',url='https://github.com/apache/incubator-airflow'))
+                          name='Github',
+                          url='https://github.com/apache/incubator-airflow'))
 
         av(vs.VersionView(name='Version', category="About"))
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -130,7 +130,7 @@ definitions in Airflow.
     ml = MenuLink(
         category='Test Plugin',
         name='Test Menu Link',
-        url='http://pythonhosted.org/airflow/')
+        url='https://airflow.incubator.apache.org/')
 
     # Defining the plugin class
     class AirflowTestPlugin(AirflowPlugin):

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -58,7 +58,8 @@ bp = Blueprint(
 ml = MenuLink(
     category='Test Plugin',
     name='Test Menu Link',
-    url='http://pythonhosted.org/airflow/')
+    url='https://airflow.incubator.apache.org/')
+
 
 # Defining the plugin class
 class AirflowTestPlugin(AirflowPlugin):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2115


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Replaced `http://pythonhosted.org/airflow/` links to `https://airflow.incubator.apache.org/` in:
- Airflow Web UI
- `default_airflow.cfg` file
- Tutorial
- `CONTRIBUTING.md`

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Changes are just replaced links

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
