### PR TITLE
[AIRFLOW-2127] Keep existing loggers during Alembic migrations

### DIFF
--- a/airflow/migrations/env.py
+++ b/airflow/migrations/env.py
@@ -25,7 +25,7 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)
+fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2127.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Python's `logging.config.fileConfig` function will, by default, disable all existing loggers when it is called. The `fileConfig` function is used with default arguments by Airflow during Alembic migrations and disables all loggers except those from alembic and sqlalchemy (this includes disabling Airflow's own loggers). This change sets the `disable_existing_loggers` flag of `fileConfig` to `False` so that it _does not_ disable any existing loggers, allowing them to continue working as normal.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This is an extremely limited change that I expect to be exercised by existing tests (if not explicitly tested).

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
