### PR TITLE
[AIRFLOW-2131] Remove confusing AirflowImport doc imports from API ref

### DIFF
--- a/docs/code.rst
+++ b/docs/code.rst
@@ -43,11 +43,6 @@ attributes.
 Operator API
 ''''''''''''
 
-.. automodule:: airflow.operators
-    :no-members:
-.. deprecated:: 1.8
- Use :code:`from airflow.operators.bash_operator import BashOperator` instead.
-
 .. autoclass:: airflow.operators.bash_operator.BashOperator
 .. autoclass:: airflow.operators.python_operator.BranchPythonOperator
 .. autoclass:: airflow.operators.dagrun_operator.TriggerDagRunOperator
@@ -88,11 +83,6 @@ Operator API
 
 Community-contributed Operators
 '''''''''''''''''''''''''''''''
-
-.. automodule:: airflow.contrib.operators
-    :no-members:
-.. deprecated:: 1.8
- Use :code:`from airflow.operators.bash_operator import BashOperator` instead.
 
 .. autoclass:: airflow.contrib.operators.bigquery_check_operator.BigQueryCheckOperator
 .. autoclass:: airflow.contrib.operators.bigquery_check_operator.BigQueryValueCheckOperator
@@ -263,10 +253,9 @@ persisted in the database.
 
 Hooks
 -----
-.. automodule:: airflow.hooks
-    :no-members:
-.. deprecated:: 1.8
- Use :code:`from airflow.operators.bash_operator import BashOperator` instead.
+
+Hooks are interfaces to external platforms and databases, implementing a common
+interface when possible and acting as building blocks for operators.
 
 .. autoclass:: airflow.hooks.dbapi_hook.DbApiHook
 .. autoclass:: airflow.hooks.docker_hook.DockerHook
@@ -287,11 +276,6 @@ Hooks
 
 Community contributed hooks
 '''''''''''''''''''''''''''
-
-.. automodule:: airflow.contrib.hooks
-    :no-members:
-.. deprecated:: 1.8
- Use :code:`from airflow.operators.bash_operator import BashOperator` instead.
 
 .. autoclass:: airflow.contrib.hooks.redshift_hook.RedshiftHook
 .. autoclass:: airflow.contrib.hooks.bigquery_hook.BigQueryHook


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
    - https://issues.apache.org/jira/browse/AIRFLOW-2131


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

The generated API documentation includes `automodule` declarations for several modules (hooks and operators) that end up pulling in docs from `airflow.utils.helpers.AirflowImporter`.

This leads to the confusing situation for new users who think they're reading docs about what Hooks are, but are instead reading unlabeled docs about the seemingly-deprecated AirflowImporter. (See Jira issue for screenshot)

This PR removes these `automodule` imports and adds a sentence paraphrased from the Concepts docs about what Hooks are.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

All docs, all the time.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
