### PR TITLE
[AIRFLOW-2132] Add step to initialize database to Installation doc

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -94,3 +94,17 @@ Here's the list of the subpackages and what they enable:
 +---------------+----------------------------------------------+-------------------------------------------------+
 |  redis        | ``pip install apache-airflow[redis]``        | Redis hooks and sensors                         |
 +---------------+----------------------------------------------+-------------------------------------------------+
+
+Initiating Airflow Database
+'''''''''''''''''''''''''''
+
+Airflow requires a database to be initiated before you can run tasks. If you're just
+experimenting and learning Airflow, you can stick with the default SQLite option. If
+you don't want to use SQLite, then take a look at :doc:`configuration` to setup a
+different database.
+
+After configuration, you'll need to initialize the database before you can run tasks:
+
+.. code-block:: bash
+
+    airflow initdb


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ X ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2132


### Description
- [ X ] Here are some details about my PR, including screenshots of any UI changes:
Added an additional step in the installation doc about initializing the database because not all new users will start with the Quickstart document where this crucial step is included.


### Tests
- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
N/A

### Commits
- [ X ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ X ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
