### PR TITLE
AIRFLOW[2137] AIRFLOW[2138] Add wildcard expansion for GoogleCloudStorage Operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Currently **officially** using Airflow:
 1. [Zenly](https://zen.ly) [[@cerisier](https://github.com/cerisier) & [@jbdalido](https://github.com/jbdalido)]
 1. [Zymergen](https://www.zymergen.com/)
 1. [99](https://99taxis.com) [[@fbenevides](https://github.com/fbenevides), [@gustavoamigo](https://github.com/gustavoamigo) & [@mmmaia](https://github.com/mmmaia)]
+1. [dotmodus](http://dotmodus.com) [@dannylee12](https://github.com/dannylee12)
 
 ## Links
 

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -33,6 +33,11 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
     :type bucket: string
     :param source_objects: List of Google cloud storage URIs to load from.
         If source_format is 'DATASTORE_BACKUP', the list must only contain a single URI.
+        If wildcards are used in this argument:
+            You can use only one wildcard for objects (filenames) within your
+            bucket. The wildcard can appear inside the object name or at the
+            end of the object name. Appending a wildcard to the bucket name is
+            unsupported.
     :type object: list
     :param destination_project_dataset_table: The dotted (<project>.)<dataset>.<table>
         BigQuery table to load data into. If <project> is not included, project will
@@ -190,8 +195,12 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         else:
             schema_fields = self.schema_fields
 
-        source_uris = ['gs://{}/{}'.format(self.bucket, source_object)
-                       for source_object in self.source_objects]
+        if '*' in self.source_objects:
+            source_uris = ['gs://{}/{}'.format(self.bucket,
+                                               self.source_objects)]
+        else:
+            source_uris = ['gs://{}/{}'.format(self.bucket, source_object)
+                           for source_object in self.source_objects]
         conn = bq_hook.get_conn()
         cursor = conn.cursor()
 

--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -94,12 +94,6 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
                                     suffix=self.source_bucket[wildcard_position:])
 
             for source_object in objects:
-                print('Executing copy of gs://{0}/{1} to '
-                              'gs://{2}/{3}/{1}'.format(self.source_bucket,
-                                                        source_object,
-                                                        self.destination_bucket,
-                                                        self.destination_object,
-                                                        source_object))
                 self.log.info('Executing copy of gs://{0}/{1} to '
                               'gs://{2}/{3}/{1}'.format(self.source_bucket,
                                                         source_object,

--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -25,12 +25,22 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
     :type source_bucket: string
     :param source_object: The source name of the object to copy in the Google cloud
         storage bucket.
+        If wildcards are used in this argument:
+            You can use only one wildcard for objects (filenames) within your
+            bucket. The wildcard can appear inside the object name or at the
+            end of the object name. Appending a wildcard to the bucket name is
+            unsupported.
     :type source_object: string
     :param destination_bucket: The destination Google cloud storage bucket where the object should be.
     :type destination_bucket: string
     :param destination_object: The destination name of the object in the destination Google cloud
         storage bucket.
+        If a wildcard is supplied in the source_object argument, this is the folder that the files will be
+        copied to in the destination bucket.
     :type destination_object: string
+    :param move_object: When move object is True, the object is moved instead of copied to the new location.
+                        This is the equivalent of a mv command as opposed to a cp command.
+    :type move_object: bool
     :param google_cloud_storage_conn_id: The connection ID to use when
         connecting to Google cloud storage.
     :type google_cloud_storage_conn_id: string
@@ -38,7 +48,8 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
         For this to work, the service account making the request must have domain-wide delegation enabled.
     :type delegate_to: string
     """
-    template_fields = ('source_bucket', 'source_object', 'destination_bucket', 'destination_object',)
+    template_fields = ('source_bucket', 'source_object', 'destination_bucket',
+                       'destination_object',)
     ui_color = '#f0eee4'
 
     @apply_defaults
@@ -47,22 +58,67 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
                  source_object,
                  destination_bucket=None,
                  destination_object=None,
+                 move_object=False,
                  google_cloud_storage_conn_id='google_cloud_storage_default',
                  delegate_to=None,
                  *args,
                  **kwargs):
-        super(GoogleCloudStorageToGoogleCloudStorageOperator, self).__init__(*args, **kwargs)
+        super(GoogleCloudStorageToGoogleCloudStorageOperator, self).__init__(
+            *args, **kwargs)
         self.source_bucket = source_bucket
         self.source_object = source_object
         self.destination_bucket = destination_bucket
         self.destination_object = destination_object
+        self.move_object = move_object
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
         self.delegate_to = delegate_to
 
     def execute(self, context):
-        self.log.info('Executing copy: %s, %s, %s, %s', self.source_bucket, self.source_object,
-                      self.destination_bucket or self.source_bucket,
-                      self.destination_object or self.source_object)
-        hook = GoogleCloudStorageHook(google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
-                                      delegate_to=self.delegate_to)
-        hook.copy(self.source_bucket, self.source_object, self.destination_bucket, self.destination_object)
+
+        hook = GoogleCloudStorageHook(
+            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+            delegate_to=self.delegate_to)
+
+        if '*' in self.source_object:
+            self.log.debug("Wildcard provided, expanding objects to copy")
+            if self.source_object[-1] == '*':  # Asterix in last position
+                objects = hook.list(self.source_bucket,
+                                    prefix=self.source_object[:-1])
+            elif self.source_object[0] == '*':  # Asterix in first position
+                objects = hook.list(self.source_bucket,
+                                    suffix=self.source_object[1:])
+            else:  # Asterix in the string
+                wildcard_position = self.source_object.index('*')
+                objects = hook.list(self.source_bucket,
+                                    prefix=self.source_bucket[:wildcard_position],
+                                    suffix=self.source_bucket[wildcard_position:])
+
+            for source_object in objects:
+                print('Executing copy of gs://{0}/{1} to '
+                              'gs://{2}/{3}/{1}'.format(self.source_bucket,
+                                                        source_object,
+                                                        self.destination_bucket,
+                                                        self.destination_object,
+                                                        source_object))
+                self.log.info('Executing copy of gs://{0}/{1} to '
+                              'gs://{2}/{3}/{1}'.format(self.source_bucket,
+                                                        source_object,
+                                                        self.destination_bucket,
+                                                        self.destination_object,
+                                                        source_object))
+                hook.copy(self.source_bucket, source_object,
+                          self.destination_bucket, "{}/{}".format(self.destination_object,
+                                                                  source_object))
+                if self.move_object:
+                    hook.delete(self.source_bucket, source_object)
+
+        else:
+            self.log.info('Executing copy: %s, %s, %s, %s', self.source_bucket,
+                          self.source_object,
+                          self.destination_bucket or self.source_bucket,
+                          self.destination_object or self.source_object)
+            hook.copy(self.source_bucket, self.source_object,
+                      self.destination_bucket, self.destination_object)
+
+            if self.move_object:
+                hook.delete(self.source_bucket, self.source_object)

--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -31,21 +31,27 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
             end of the object name. Appending a wildcard to the bucket name is
             unsupported.
     :type source_object: string
-    :param destination_bucket: The destination Google cloud storage bucket where the object should be.
+    :param destination_bucket: The destination Google cloud storage bucket
+    where the object should be.
     :type destination_bucket: string
-    :param destination_object: The destination name of the object in the destination Google cloud
+    :param destination_object: The destination name of the object in the
+    destination Google cloud
         storage bucket.
-        If a wildcard is supplied in the source_object argument, this is the folder that the files will be
+        If a wildcard is supplied in the source_object argument, this is the
+        folder that the files will be
         copied to in the destination bucket.
     :type destination_object: string
-    :param move_object: When move object is True, the object is moved instead of copied to the new location.
-                        This is the equivalent of a mv command as opposed to a cp command.
+    :param move_object: When move object is True, the object is moved instead
+    of copied to the new location.
+                        This is the equivalent of a mv command as opposed to a
+                        cp command.
     :type move_object: bool
     :param google_cloud_storage_conn_id: The connection ID to use when
         connecting to Google cloud storage.
     :type google_cloud_storage_conn_id: string
     :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide delegation enabled.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: string
     """
     template_fields = ('source_bucket', 'source_object', 'destination_bucket',

--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -25,20 +25,37 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
     :type source_bucket: string
     :param source_object: The source name of the object to copy in the Google cloud
         storage bucket.
+        If wildcards are used in this argument:
+            You can use only one wildcard for objects (filenames) within your
+            bucket. The wildcard can appear inside the object name or at the
+            end of the object name. Appending a wildcard to the bucket name is
+            unsupported.
     :type source_object: string
-    :param destination_bucket: The destination Google cloud storage bucket where the object should be.
+    :param destination_bucket: The destination Google cloud storage bucket
+    where the object should be.
     :type destination_bucket: string
-    :param destination_object: The destination name of the object in the destination Google cloud
+    :param destination_object: The destination name of the object in the
+    destination Google cloud
         storage bucket.
+        If a wildcard is supplied in the source_object argument, this is the
+        folder that the files will be
+        copied to in the destination bucket.
     :type destination_object: string
+    :param move_object: When move object is True, the object is moved instead
+    of copied to the new location.
+                        This is the equivalent of a mv command as opposed to a
+                        cp command.
+    :type move_object: bool
     :param google_cloud_storage_conn_id: The connection ID to use when
         connecting to Google cloud storage.
     :type google_cloud_storage_conn_id: string
     :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide delegation enabled.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: string
     """
-    template_fields = ('source_bucket', 'source_object', 'destination_bucket', 'destination_object',)
+    template_fields = ('source_bucket', 'source_object', 'destination_bucket',
+                       'destination_object',)
     ui_color = '#f0eee4'
 
     @apply_defaults
@@ -47,22 +64,61 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
                  source_object,
                  destination_bucket=None,
                  destination_object=None,
+                 move_object=False,
                  google_cloud_storage_conn_id='google_cloud_storage_default',
                  delegate_to=None,
                  *args,
                  **kwargs):
-        super(GoogleCloudStorageToGoogleCloudStorageOperator, self).__init__(*args, **kwargs)
+        super(GoogleCloudStorageToGoogleCloudStorageOperator, self).__init__(
+            *args, **kwargs)
         self.source_bucket = source_bucket
         self.source_object = source_object
         self.destination_bucket = destination_bucket
         self.destination_object = destination_object
+        self.move_object = move_object
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
         self.delegate_to = delegate_to
 
     def execute(self, context):
-        self.log.info('Executing copy: %s, %s, %s, %s', self.source_bucket, self.source_object,
-                      self.destination_bucket or self.source_bucket,
-                      self.destination_object or self.source_object)
-        hook = GoogleCloudStorageHook(google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
-                                      delegate_to=self.delegate_to)
-        hook.copy(self.source_bucket, self.source_object, self.destination_bucket, self.destination_object)
+
+        hook = GoogleCloudStorageHook(
+            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+            delegate_to=self.delegate_to)
+
+        if '*' in self.source_object:
+            self.log.debug("Wildcard provided, expanding objects to copy")
+            if self.source_object[-1] == '*':  # Asterix in last position
+                objects = hook.list(self.source_bucket,
+                                    prefix=self.source_object[:-1])
+            elif self.source_object[0] == '*':  # Asterix in first position
+                objects = hook.list(self.source_bucket,
+                                    suffix=self.source_object[1:])
+            else:  # Asterix in the string
+                wildcard_position = self.source_object.index('*')
+                objects = hook.list(self.source_bucket,
+                                    prefix=self.source_bucket[:wildcard_position],
+                                    suffix=self.source_bucket[wildcard_position:])
+
+            for source_object in objects:
+                self.log.info('Executing copy of gs://{0}/{1} to '
+                              'gs://{2}/{3}/{1}'.format(self.source_bucket,
+                                                        source_object,
+                                                        self.destination_bucket,
+                                                        self.destination_object,
+                                                        source_object))
+                hook.copy(self.source_bucket, source_object,
+                          self.destination_bucket, "{}/{}".format(self.destination_object,
+                                                                  source_object))
+                if self.move_object:
+                    hook.delete(self.source_bucket, source_object)
+
+        else:
+            self.log.info('Executing copy: %s, %s, %s, %s', self.source_bucket,
+                          self.source_object,
+                          self.destination_bucket or self.source_bucket,
+                          self.destination_object or self.source_object)
+            hook.copy(self.source_bucket, self.source_object,
+                      self.destination_bucket, self.destination_object)
+
+            if self.move_object:
+                hook.delete(self.source_bucket, self.source_object)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2137
    - https://issues.apache.org/jira/browse/AIRFLOW-2138


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
    - https://issues.apache.org/jira/browse/AIRFLOW-2137
    - Allows a wildcard to be provided in the source_objects field. 
   - https://issues.apache.org/jira/browse/AIRFLOW-2138
   - Add support wildcards to be provided in the GoogleCloudStorageToGoogleCloudStorage operator.
    - Add a new argument move_object that, when set deletes the file, allowing this operator to work more as a mv command than a cp command if required.

    - As this wildcard expansion allows multiple files to be copied/moved, the destination argument becomes the name of the folder to which the files are copied into.
Therefore, these files are not renamed once copied/moved, but rather retain their original names.


### Tests
- [x] My PR does not need testing for this extremely good reason:
   All items of this pr are tested previously. This PR does not change any functionality of the underlying   hooks, but rather extends how they can be used. Therefore, writing new tests is deemed unnecessary.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. 
Not sure how to squash commits? 
In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
