### PR TITLE
[AIRFLOW-2142] Include system error message on mkdir failure

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -337,7 +337,8 @@ def mkdir_p(path):
         if exc.errno == errno.EEXIST and os.path.isdir(path):
             pass
         else:
-            raise AirflowConfigException('Had trouble creating a directory')
+            raise AirflowConfigException(
+                'Error creating {}: {}'.format(path, exc.strerror))
 
 
 # Setting AIRFLOW_HOME and AIRFLOW_CONFIG from environment variables, using


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2142

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Changes error message from:
$ AIRFLOW_HOME=/baddir airflow scheduler 2>&1 | sed -n \$p
airflow.exceptions.AirflowConfigException: Had trouble creating a directory

to 

$ AIRFLOW_HOME=/baddir airflow scheduler  2>&1 | sed -n '$p'
airflow.exceptions.AirflowConfigException: Error creating /baddir: Permission denied

IMO, we should remove the stack trace as well (making the above sed unnecessary), but that's a discussion for a different day.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
