### PR TITLE
[AIRFLOW-2110] Enhance Http Hook to use a header in passed in the "extra" argument and add tenacity retry

### DIFF
--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -25,8 +25,6 @@ from __future__ import unicode_literals
 import os
 import random
 
-import tenacity
-
 from airflow.models import Connection
 from airflow.exceptions import AirflowException
 from airflow.utils.db import provide_session
@@ -44,7 +42,7 @@ class BaseHook(LoggingMixin):
     with them.
     """
     def __init__(self, source):
-        self._retry_obj = None
+        pass
 
     @classmethod
     @provide_session
@@ -101,18 +99,3 @@ class BaseHook(LoggingMixin):
 
     def run(self, sql):
         raise NotImplementedError()
-
-    def run_with_advanced_retry(self, _retry_args, *args, **kwargs):
-        """
-        Runs Hook.run() with a Tenacity decorator attached to it. This is useful for
-        connectors which might be disturbed by intermittent issues and should not
-        instantly fail.
-        :param _retry_args: Arguments which define the retry behaviour.
-            See Tenacity documentation at https://github.com/jd/tenacity
-        :type _retry_args: dict
-        """
-        self._retry_obj = tenacity.Retrying(
-            **_retry_args
-        )
-
-        self._retry_obj(self.run, *args, **kwargs)

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -25,7 +25,8 @@ from __future__ import unicode_literals
 import os
 import random
 
-from airflow import settings
+import tenacity
+
 from airflow.models import Connection
 from airflow.exceptions import AirflowException
 from airflow.utils.db import provide_session
@@ -43,8 +44,7 @@ class BaseHook(LoggingMixin):
     with them.
     """
     def __init__(self, source):
-        pass
-
+        self._retry_obj = None
 
     @classmethod
     @provide_session
@@ -101,3 +101,18 @@ class BaseHook(LoggingMixin):
 
     def run(self, sql):
         raise NotImplementedError()
+
+    def run_with_advanced_retry(self, _retry_args, *args, **kwargs):
+        """
+        Runs Hook.run() with a Tenacity decorator attached to it. This is useful for
+        connectors which might be disturbed by intermittent issues and should not
+        instantly fail.
+        :param _retry_args: Arguments which define the retry behaviour.
+            See Tenacity documentation at https://github.com/jd/tenacity
+        :type _retry_args: dict
+        """
+        self._retry_obj = tenacity.Retrying(
+            **_retry_args
+        )
+
+        self._retry_obj(self.run, *args, **kwargs)

--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -135,5 +135,5 @@ class HttpHook(BaseHook):
             return response
 
         except requests.exceptions.ConnectionError as ex:
-            logging.error(str(ex) + 'add retry logic here')
+            self.log.error(str(ex) + ' Tenacity will retry to execute the operation')
             raise ex

--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -20,7 +20,6 @@
 from builtins import str
 
 import requests
-import tenacity
 
 from airflow.hooks.base_hook import BaseHook
 from airflow.exceptions import AirflowException
@@ -67,11 +66,6 @@ class HttpHook(BaseHook):
 
         return session
 
-    @tenacity.retry(
-        wait=tenacity.wait_exponential(),
-        stop=tenacity.stop_after_attempt(7),
-        retry=tenacity.retry_if_exception_type(requests.exceptions.ConnectionError)
-    )
     def run(self, endpoint, data=None, headers=None, extra_options=None):
         """
         Performs the request

--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -61,7 +61,7 @@ class HttpHook(BaseHook):
         if conn.login:
             session.auth = (conn.login, conn.password)
         if conn.extra:
-            session.headers.update(json.loads(conn.extra))
+            session.headers.update(conn.extra_dejson)
         if headers:
             session.headers.update(headers)
 

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -89,6 +89,7 @@ Sphinx-PyPI-upload
 sphinx_rtd_theme
 sqlalchemy>=1.1.15, <1.2.0
 statsd
+tenacity==4.8.0
 thrift
 thrift_sasl
 unicodecsv

--- a/setup.py
+++ b/setup.py
@@ -267,6 +267,7 @@ def do_setup():
             'sqlalchemy>=1.1.15, <1.2.0',
             'sqlalchemy-utc>=0.9.0',
             'tabulate>=0.7.5, <0.8.0',
+            'tenacity == 4.8.0',
             'thrift>=0.9.2',
             'tzlocal>=1.4',
             'werkzeug>=0.14.1, <0.15.0',

--- a/setup.py
+++ b/setup.py
@@ -267,7 +267,7 @@ def do_setup():
             'sqlalchemy>=1.1.15, <1.2.0',
             'sqlalchemy-utc>=0.9.0',
             'tabulate>=0.7.5, <0.8.0',
-            'tenacity == 4.8.0',
+            'tenacity==4.8.0',
             'thrift>=0.9.2',
             'tzlocal>=1.4',
             'werkzeug>=0.14.1, <0.15.0',

--- a/tests/core.py
+++ b/tests/core.py
@@ -2343,58 +2343,6 @@ class HDFSHookTest(unittest.TestCase):
         self.assertIsInstance(client, snakebite.client.HAClient)
 
 
-try:
-    from airflow.hooks.http_hook import HttpHook
-except ImportError:
-    HttpHook = None
-
-
-@unittest.skipIf(HttpHook is None,
-                 "Skipping test because HttpHook is not installed")
-class HttpHookTest(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-
-    @mock.patch('airflow.hooks.http_hook.HttpHook.get_connection')
-    def test_http_connection(self, mock_get_connection):
-        c = models.Connection(conn_id='http_default', conn_type='http',
-                              host='localhost', schema='http')
-        mock_get_connection.return_value = c
-        hook = HttpHook()
-        hook.get_conn({})
-        self.assertEqual(hook.base_url, 'http://localhost')
-
-    @mock.patch('airflow.hooks.http_hook.HttpHook.get_connection')
-    def test_https_connection(self, mock_get_connection):
-        c = models.Connection(conn_id='http_default', conn_type='http',
-                              host='localhost', schema='https')
-        mock_get_connection.return_value = c
-        hook = HttpHook()
-        hook.get_conn({})
-        self.assertEqual(hook.base_url, 'https://localhost')
-
-    @mock.patch('airflow.hooks.http_hook.HttpHook.get_connection')
-    def test_host_encoded_http_connection(self, mock_get_connection):
-        c = models.Connection(conn_id='http_default', conn_type='http',
-                              host='http://localhost')
-        mock_get_connection.return_value = c
-        hook = HttpHook()
-        hook.get_conn({})
-        self.assertEqual(hook.base_url, 'http://localhost')
-
-    @mock.patch('airflow.hooks.http_hook.HttpHook.get_connection')
-    def test_host_encoded_https_connection(self, mock_get_connection):
-        c = models.Connection(conn_id='http_default', conn_type='http',
-                              host='https://localhost')
-        mock_get_connection.return_value = c
-        hook = HttpHook()
-        hook.get_conn({})
-        self.assertEqual(hook.base_url, 'https://localhost')
-
-
-send_email_test = mock.Mock()
-
-
 class EmailTest(unittest.TestCase):
     def setUp(self):
         configuration.conf.remove_option('email', 'EMAIL_BACKEND')

--- a/tests/core.py
+++ b/tests/core.py
@@ -2342,6 +2342,8 @@ class HDFSHookTest(unittest.TestCase):
         client = HDFSHook().get_conn()
         self.assertIsInstance(client, snakebite.client.HAClient)
 
+send_email_test = mock.Mock()
+
 
 class EmailTest(unittest.TestCase):
     def setUp(self):

--- a/tests/hooks/test_http_hook.py
+++ b/tests/hooks/test_http_hook.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import json
+
+import requests
+import requests_mock
+
+import tenacity
+from tenacity import wait_none
+
+from airflow.exceptions import AirflowException
+from airflow.hooks.http_hook import HttpHook
+from airflow.hooks.base_hook import BaseHook
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+
+def get_airflow_connection(conn_id=None):
+    real = BaseHook('')
+    real.get_connection = mock.MagicMock()
+    conn = real.get_connection()
+    conn.host = 'http://test'
+    conn.port = 8080
+    conn.login = 'test'
+    conn.password = 'test'
+    conn.extra = '{"bareer": "test"}'
+    conn.schema = None
+    return conn
+
+
+def get_airflow_connection_noheaders(conn_id=None):
+    real = BaseHook('')
+    real.get_connection = mock.MagicMock()
+    conn = real.get_connection()
+    conn.host = 'http://test'
+    conn.port = 8080
+    conn.login = 'test'
+    conn.password = 'test'
+    conn.extra = None
+    conn.schema = None
+    return conn
+
+
+class TestHttpHook(unittest.TestCase):
+    """Test get, post and raise_for_status"""
+    def setUp(self):
+        session = requests.Session()
+        adapter = requests_mock.Adapter()
+        session.mount('mock', adapter)
+        self.get_hook = HttpHook(method='GET')
+        self.post_hook = HttpHook(method='POST')
+
+    @requests_mock.mock()
+    def test_raise_for_status_with_200(self, m):
+
+        m.get(
+            'http://test:8080/v1/test',
+            status_code=200,
+            text='{"status":{"status": 200}}',
+            reason='OK'
+        )
+        with mock.patch(
+            'airflow.hooks.base_hook.BaseHook.get_connection',
+            side_effect=get_airflow_connection
+        ):
+
+            resp = self.get_hook.run('v1/test')
+            self.assertEquals(resp.text, '{"status":{"status": 200}}')
+
+    @requests_mock.mock()
+    def test_get_request_do_not_raise_for_status_if_check_response_is_false(self, m):
+
+        m.get(
+            'http://test:8080/v1/test',
+            status_code=404,
+            text='{"status":{"status": 404}}',
+            reason='Bad request'
+        )
+
+        with mock.patch(
+            'airflow.hooks.base_hook.BaseHook.get_connection',
+            side_effect=get_airflow_connection
+        ):
+            resp = self.get_hook.run('v1/test', extra_options={'check_response': False})
+            self.assertEquals(resp.text, '{"status":{"status": 404}}')
+
+    @requests_mock.mock()
+    def test_hook_contains_header_from_extra_field(self, m):
+        with mock.patch(
+            'airflow.hooks.base_hook.BaseHook.get_connection',
+            side_effect=get_airflow_connection
+        ):
+            expected_conn = get_airflow_connection()
+            conn = self.get_hook.get_conn()
+            self.assertDictContainsSubset(json.loads(expected_conn.extra), conn.headers)
+            self.assertEquals(conn.headers.get('bareer'), 'test')
+
+    @requests_mock.mock()
+    def test_hook_uses_provided_header(self, m):
+        with mock.patch(
+            'airflow.hooks.base_hook.BaseHook.get_connection',
+            side_effect=get_airflow_connection_noheaders
+        ):
+            conn = self.get_hook.get_conn()
+            self.assertIsNone(conn.headers.get('bareer'))
+
+    @requests_mock.mock()
+    def test_hook_has_no_header_from_extra(self, m):
+        with mock.patch(
+            'airflow.hooks.base_hook.BaseHook.get_connection',
+            side_effect=get_airflow_connection_noheaders
+        ):
+            conn = self.get_hook.get_conn()
+            self.assertIsNone(conn.headers.get('bareer'))
+
+    @requests_mock.mock()
+    def test_hooks_header_from_extra_is_overridden(self, m):
+        with mock.patch(
+            'airflow.hooks.base_hook.BaseHook.get_connection',
+            side_effect=get_airflow_connection
+        ):
+            conn = self.get_hook.get_conn(headers={"bareer": "newT0k3n"})
+            self.assertEquals(conn.headers.get('bareer'), 'newT0k3n')
+
+    @requests_mock.mock()
+    def test_post_request(self, m):
+
+        m.post(
+            'http://test:8080/v1/test',
+            status_code=200,
+            text='{"status":{"status": 200}}',
+            reason='OK'
+        )
+
+        with mock.patch(
+            'airflow.hooks.base_hook.BaseHook.get_connection',
+            side_effect=get_airflow_connection
+        ):
+            resp = self.post_hook.run('v1/test')
+            self.assertEquals(resp.status_code, 200)
+
+    @requests_mock.mock()
+    def test_post_request_with_error_code(self, m):
+
+        m.post(
+            'http://test:8080/v1/test',
+            status_code=418,
+            text='{"status":{"status": 418}}',
+            reason='I\'m a teapot'
+        )
+
+        with mock.patch(
+            'airflow.hooks.base_hook.BaseHook.get_connection',
+            side_effect=get_airflow_connection
+        ):
+            with self.assertRaises(AirflowException):
+                self.post_hook.run('v1/test')
+
+    @requests_mock.mock()
+    def test_post_request_do_not_raise_for_status_if_check_response_is_false(self, m):
+
+        m.post(
+            'http://test:8080/v1/test',
+            status_code=418,
+            text='{"status":{"status": 418}}',
+            reason='I\'m a teapot'
+        )
+
+        with mock.patch(
+            'airflow.hooks.base_hook.BaseHook.get_connection',
+            side_effect=get_airflow_connection
+        ):
+            resp = self.post_hook.run('v1/test', extra_options={'check_response': False})
+            self.assertEquals(resp.status_code, 418)
+
+    @mock.patch('airflow.hooks.http_hook.requests.Session')
+    def test_retry_on_conn_error(self, mocked_session):
+
+        def send_and_raise(request, **kwargs):
+            raise requests.exceptions.ConnectionError
+
+        self.get_hook.run.retry.wait = wait_none()
+        mocked_session().send.side_effect = send_and_raise
+        # The job failed for some reason
+        with self.assertRaises(tenacity.RetryError):
+            self.get_hook.run('v1/test')
+        self.assertEquals(
+            self.get_hook.run.retry.stop.max_attempt_number + 1,
+            mocked_session.call_count
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/hooks/test_http_hook.py
+++ b/tests/hooks/test_http_hook.py
@@ -22,11 +22,7 @@ import tenacity
 
 from airflow import configuration, models
 from airflow.exceptions import AirflowException
-
-try:
-    from airflow.hooks.http_hook import HttpHook
-except ImportError:
-    HttpHook = None
+from airflow.hooks.http_hook import HttpHook
 
 try:
     from unittest import mock
@@ -46,8 +42,6 @@ def get_airflow_connection(conn_id=None):
     )
 
 
-@unittest.skipIf(HttpHook is None,
-                 "Skipping test because HttpHook is not installed")
 class TestHttpHook(unittest.TestCase):
     """Test get, post and raise_for_status"""
     def setUp(self):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

## JIRA

- [x]   My PR addresses the following Airflow JIRA issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
[AIRFLOW-2110] Enhance Http Hook to use a header in passed in the "extra" argument and add tenacity retry"
https://issues.apache.org/jira/browse/AIRFLOW-2122

## Description
- [x]  Add possibility to add a json header in the "extra" field in the connection:
{"Authorization": "Bearer Here1sMyT0k3N"}
Also add tenacity retry so the operator won't fall over in case of a connection issue.
Here are some details about my PR, including screenshots of any UI changes:
In the original hook we could not skip raise for status, pass headers from the "extra" field in the airflow UI and would immediately fail on connection error. Now in case of connection error the hook will retry 7 times with exponential backoff, the "raise for status" method can be skipped and can pass a JSON header in the extra field in the UI.

## Tests

- [x]  My PR adds the following unit tests OR does not need testing for this extremely good reason:
test_raise_for_status_with_200
test_get_request_do_not_raise_for_status_if_check_response_is_false
test_hook_contains_header_from_extra_field
test_hook_uses_provided_header
test_hook_has_no_header_from_extra
test_hooks_header_from_extra_is_overridden
test_post_request
test_post_request_with_error_code
test_post_request_do_not_raise_for_status_if_check_response_is_false
test_retry_on_conn_error
test_header_from_extra_and_run_method_are_merged

## Commits 

- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "How to write a good git commit message":

Subject is separated from body by a blank line
Subject is limited to 50 characters
Subject does not end with a period
Subject uses the imperative mood ("add", not "adding")
Body wraps at 72 characters
Body explains "what" and "why", not "how"

- [x]  Passes git diff upstream/master -u -- "*.py" | flake8 --diff