### PR TITLE
[AIRFLOW-2146] Resolve issues with BQ using DbApiHook methods

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -662,8 +662,8 @@ class Connection(Base, LoggingMixin):
                 from airflow.hooks.mysql_hook import MySqlHook
                 return MySqlHook(mysql_conn_id=self.conn_id)
             elif self.conn_type == 'google_cloud_platform':
-                from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
-                return GoogleCloudBaseHook(gcp_conn_id=self.conn_id)
+                from airflow.contrib.hooks.bigquery_hook import BigQueryHook
+                return BigQueryHook(bigquery_conn_id=self.conn_id)
             elif self.conn_type == 'postgres':
                 from airflow.hooks.postgres_hook import PostgresHook
                 return PostgresHook(postgres_conn_id=self.conn_id)

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -103,7 +103,8 @@ def initdb():
             schema='default'))
     merge_conn(
         models.Connection(
-            conn_id='bigquery_default', conn_type='bigquery'))
+            conn_id='bigquery_default', conn_type='google_cloud_platform',
+            schema='default'))
     merge_conn(
         models.Connection(
             conn_id='local_mysql', conn_type='mysql',

--- a/tests/core.py
+++ b/tests/core.py
@@ -1039,7 +1039,6 @@ class CliTests(unittest.TestCase):
         # expected:
         self.assertIn(['aws_default', 'aws'], conns)
         self.assertIn(['beeline_default', 'beeline'], conns)
-        self.assertIn(['bigquery_default', 'bigquery'], conns)
         self.assertIn(['emr_default', 'emr'], conns)
         self.assertIn(['mssql_default', 'mssql'], conns)
         self.assertIn(['mysql_default', 'mysql'], conns)


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2146


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- Resolves issues with using methods like `get_records()` from `BigQueryHook` which is extended from `DbApiHook`.
- Reverting one changed file from https://github.com/apache/incubator-airflow/pull/3031 to use BigQuery Hook again instead of `GoogleCloudBaseHook`
- Fix `conn_type` of `bigquery_default` connection

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No major change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
