### PR TITLE
AIRFLOW-2147: Plugin manager: added 'sensors' attribute

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -76,11 +76,13 @@ class AirflowMacroPlugin(object):
         self.namespace = namespace
 
 from airflow import operators
+from airflow import sensors
 from airflow import hooks
 from airflow import executors
 from airflow import macros
 
 operators._integrate_plugins()
+sensors._integrate_plugins()
 hooks._integrate_plugins()
 executors._integrate_plugins()
 macros._integrate_plugins()

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -76,13 +76,13 @@ class AirflowMacroPlugin(object):
         self.namespace = namespace
 
 from airflow import operators
-from airflow import sensors
+from airflow import sensors  # noqa: E402
 from airflow import hooks
 from airflow import executors
 from airflow import macros
 
 operators._integrate_plugins()
-sensors._integrate_plugins()
+sensors._integrate_plugins()  # noqa: E402
 hooks._integrate_plugins()
 executors._integrate_plugins()
 macros._integrate_plugins()

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -36,6 +36,7 @@ class AirflowPluginException(Exception):
 class AirflowPlugin(object):
     name = None
     operators = []
+    sensors = []
     hooks = []
     executors = []
     macros = []
@@ -115,9 +116,9 @@ menu_links = []
 
 for p in plugins:
     operators_modules.append(
-        make_module('airflow.operators.' + p.name, p.operators))
+        make_module('airflow.operators.' + p.name, p.operators + p.sensors))
     sensors_modules.append(
-        make_module('airflow.sensors.' + p.name, p.operators)
+        make_module('airflow.sensors.' + p.name, p.sensors)
     )
     hooks_modules.append(make_module('airflow.hooks.' + p.name, p.hooks))
     executors_modules.append(

--- a/airflow/sensors/__init__.py
+++ b/airflow/sensors/__init__.py
@@ -48,13 +48,13 @@ def _integrate_plugins():
 
         if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
             from zope.deprecation import deprecated as _deprecated
-            for _operator in sensors_module._objects:
-                operator_name = _operator.__name__
-                globals()[operator_name] = _operator
+            for _sensor in sensors_module._objects:
+                sensor_name = _sensor.__name__
+                globals()[sensor_name] = _sensor
                 _deprecated(
-                    operator_name,
+                    sensor_name,
                     "Importing plugin operator '{i}' directly from "
                     "'airflow.operators' has been deprecated. Please "
                     "import from 'airflow.operators.[plugin_module]' "
                     "instead. Support for direct imports will be dropped "
-                    "entirely in Airflow 2.0.".format(i=operator_name))
+                    "entirely in Airflow 2.0.".format(i=sensor_name))

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -6,7 +6,7 @@ features to its core by simply dropping files in your
 ``$AIRFLOW_HOME/plugins`` folder.
 
 The python modules in the ``plugins`` folder get imported,
-and **hooks**, **operators**, **macros**, **executors** and web **views**
+and **hooks**, **operators**, **sensors**, **macros**, **executors** and web **views**
 get integrated to Airflow's main collections and become available for use.
 
 What for?
@@ -61,6 +61,8 @@ looks like:
         name = None
         # A list of class(es) derived from BaseOperator
         operators = []
+        # A list of class(es) derived from BaseSensorOperator
+        sensors = []
         # A list of class(es) derived from BaseHook
         hooks = []
         # A list of class(es) derived from BaseExecutor
@@ -93,7 +95,8 @@ definitions in Airflow.
 
     # Importing base classes that we need to derive
     from airflow.hooks.base_hook import BaseHook
-    from airflow.models import  BaseOperator
+    from airflow.models import BaseOperator
+    from airflow.sensors.base_sensor_operator import BaseSensorOperator
     from airflow.executors.base_executor import BaseExecutor
 
     # Will show up under airflow.hooks.test_plugin.PluginHook
@@ -102,6 +105,10 @@ definitions in Airflow.
 
     # Will show up under airflow.operators.test_plugin.PluginOperator
     class PluginOperator(BaseOperator):
+        pass
+
+    # Will show up under airflow.sensors.test_plugin.PluginSensorOperator
+    class PluginSensorOperator(BaseSensorOperator):
         pass
 
     # Will show up under airflow.executors.test_plugin.PluginExecutor
@@ -136,6 +143,7 @@ definitions in Airflow.
     class AirflowTestPlugin(AirflowPlugin):
         name = "test_plugin"
         operators = [PluginOperator]
+        sensors = [PluginSensorOperator]
         hooks = [PluginHook]
         executors = [PluginExecutor]
         macros = [plugin_macro]

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -21,7 +21,8 @@ from flask_admin.base import MenuLink
 
 # Importing base classes that we need to derive
 from airflow.hooks.base_hook import BaseHook
-from airflow.models import  BaseOperator
+from airflow.models import BaseOperator
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.executors.base_executor import BaseExecutor
 
 # Will show up under airflow.hooks.test_plugin.PluginHook
@@ -31,6 +32,12 @@ class PluginHook(BaseHook):
 # Will show up under airflow.operators.test_plugin.PluginOperator
 class PluginOperator(BaseOperator):
     pass
+
+
+# Will show up under airflow.sensors.test_plugin.PluginSensorOperator
+class PluginSensorOperator(BaseSensorOperator):
+    pass
+
 
 # Will show up under airflow.executors.test_plugin.PluginExecutor
 class PluginExecutor(BaseExecutor):
@@ -65,6 +72,7 @@ ml = MenuLink(
 class AirflowTestPlugin(AirflowPlugin):
     name = "test_plugin"
     operators = [PluginOperator]
+    sensors = [PluginSensorOperator]
     hooks = [PluginHook]
     executors = [PluginExecutor]
     macros = [plugin_macro]

--- a/tests/plugins_manager.py
+++ b/tests/plugins_manager.py
@@ -27,6 +27,7 @@ from flask_admin.menu import MenuLink, MenuView
 
 from airflow.hooks.base_hook import BaseHook
 from airflow.models import  BaseOperator
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.executors.base_executor import BaseExecutor
 from airflow.www.app import cached_app
 
@@ -36,6 +37,10 @@ class PluginsTest(unittest.TestCase):
     def test_operators(self):
         from airflow.operators.test_plugin import PluginOperator
         self.assertTrue(issubclass(PluginOperator, BaseOperator))
+
+    def test_sensors(self):
+        from airflow.sensors.test_plugin import PluginSensorOperator
+        self.assertTrue(issubclass(PluginSensorOperator, BaseSensorOperator))
 
     def test_hooks(self):
         from airflow.hooks.test_plugin import PluginHook


### PR DESCRIPTION
AirflowPlugin required both BaseOperator and BaseSensorOperator
to be included in its `operators` attribute. I added a `sensors`
attribute and updated import logic so that anything added to
the new attribute can be imported from
`airflow.sensors.{plugin_name}`

The integration/`make_module` calls in `airflow.plugins_manager`
for operators is also updated to maintain the ability to import
sensors from `operators` to avoid breaking existing plugins

Updated unit tests and documentation to reflect this

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2147


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
  - Adds attribute `AirflowPlugin.sensors` so they can be imported like `from airflow.sensors.test_plugin 
    import PluginSensorOperator` instead of having to put both operators and sensors under `AirflowPlugin.operators`
  - Updates `plugins.rst` to reflect this
  - Doesn't break existing plugins- sensors can still be imported as usual


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - `tests/plugins/test_plugin.py`: Adds `PluginSensorOperator` to the examples
  - `tests/plugins_manager.py`: Adds import test for `PluginSensorOperator`


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
  - Doesn't pass `airflow/__init__.py` because it required adding an import which triggers _module level import not at top of file_ messages, which isn't actually a new warning if you run it without the diff (I'm guessing it was ignored before so the diff triggers it again). This also causes the Travis CI build to fail on this flake8 step. Not sure how to get around it, but you can see in the diff that the two added lines follow the surrounding style exactly.
