### PR TITLE
[AIRFLOW-2160] Fix bad rowid deserialization

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2570,7 +2570,7 @@ class TaskInstanceModelView(ModelViewOnly):
 
             # Collect dags upfront as dagbag.get_dag() will reset the session
             for id_str in ids:
-                task_id, dag_id, execution_date = id_str.split(',')
+                task_id, dag_id, execution_date = iterdecode(id_str)
                 dag = dagbag.get_dag(dag_id)
                 task_details = dag_to_task_details.setdefault(dag, [])
                 task_details.append((task_id, execution_date))
@@ -2604,7 +2604,7 @@ class TaskInstanceModelView(ModelViewOnly):
             TI = models.TaskInstance
             count = len(ids)
             for id in ids:
-                task_id, dag_id, execution_date = id.split(',')
+                task_id, dag_id, execution_date = iterdecode(id)
                 execution_date = parse_execution_date(execution_date)
 
                 ti = session.query(TI).filter(TI.task_id == task_id,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2160


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

When there is a dot in a task's ID or in its execution date, changing its state from the UI fails.

The reason for this is that Flask-Admin's iterencode function encodes composite primary keys using dot as the escape symbol. If there is already a dot in any of the values, it is doubled.

On decoding however, Airflow is currently just splitting the string on a comma.

This PR switches to using Flask-Admin's iterdecode to correctly decode task instance rowids when they contain a dot.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No new functionality


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
