### PR TITLE
[AIRFLOW-2059] taskinstance query is awful, un-indexed

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -780,7 +780,7 @@ class TaskInstance(Base, LoggingMixin):
     max_tries = Column(Integer)
     hostname = Column(String(1000))
     unixname = Column(String(1000))
-    job_id = Column(Integer)
+    job_id = Column(Integer, index=True)
     pool = Column(String(50))
     queue = Column(String(50))
     priority_weight = Column(Integer)


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### JIRA
- [x ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2059


### Description
- [x ] Here are some details about my PR, including screenshots of any UI changes:
index job_id column(integer type, suitable for indexing) in task_instance model to speed up query time.

### Tests
- [x ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: db model improvement


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
