### PR TITLE
[AIRFLOW-2167] cleanup nonexistent import errors on the first iteration in addition to periodically

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1598,7 +1598,7 @@ class SchedulerJob(BaseJob):
         # Last time that self.heartbeat() was called.
         last_self_heartbeat_time = timezone.utcnow()
         # Last time that the DAG dir was traversed to look for files
-        last_dag_dir_refresh_time = timezone.utcnow()
+        last_dag_dir_refresh_time = None
 
         # Use this value initially
         known_file_paths = processor_manager.file_paths
@@ -1610,16 +1610,17 @@ class SchedulerJob(BaseJob):
             loop_start_time = time.time()
 
             # Traverse the DAG directory for Python files containing DAGs
-            # periodically
-            elapsed_time_since_refresh = (timezone.utcnow() -
-                                          last_dag_dir_refresh_time).total_seconds()
-
-            if elapsed_time_since_refresh > self.dag_dir_list_interval:
+            # on first run and periodically
+            if last_dag_dir_refresh_time is None or \
+               (timezone.utcnow() - last_dag_dir_refresh_time).total_seconds() > \
+               self.dag_dir_list_interval:
                 # Build up a list of Python files that could contain DAGs
                 self.log.info("Searching for files in %s", self.subdir)
                 known_file_paths = list_py_file_paths(self.subdir)
                 last_dag_dir_refresh_time = timezone.utcnow()
-                self.log.info("There are %s files in %s", len(known_file_paths), self.subdir)
+                self.log.info("There are %s files in %s",
+                              len(known_file_paths),
+                              self.subdir)
                 processor_manager.set_file_paths(known_file_paths)
 
                 self.log.debug("Removing old import errors")


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [AIRFLOW-2167](https://issues.apache.org/jira/browse/AIRFLOW-2167) issues and references them in the PR title. For example, "[AIRFLOW-2167] cleanup nonexistent dags on the first iteration in addition to periodically"
    - https://issues.apache.org/jira/browse/AIRFLOW-2167


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
  - This PR tweaks `airflow/jobs.py` to cleanup nonexistent import errors on the first iteration of the scheuduler and periodically as defined by `dag_dir_list_interval`.  This way, a scheduler setup with a small number of runs will still have old errors cleaned up.
  - Previously, a scheduler would only run this cleanup after the number of seconds in `dag_dir_list_interval` had elapsed.  For schedulers defined with a small number of runs, this meant the cleanup never occurred.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - extremely good reason:  This is a very minor code tweak.  No new functionality is added, existing functionality is only triggered one additional time.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
