### PR TITLE
add logic to google cloud base hook to make it able to create delegat…

### DIFF
--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -106,7 +106,8 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
                     .from_json_keyfile_dict(keyfile_dict, scopes)
             except json.decoder.JSONDecodeError:
                 raise AirflowException('Invalid key JSON.')
-        return credentials
+
+        return credentials.create_delegated(self.delegate_to) if self.delegate_to else credentials
 
     def _get_access_token(self):
         """

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -107,7 +107,8 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
             except json.decoder.JSONDecodeError:
                 raise AirflowException('Invalid key JSON.')
 
-        return credentials.create_delegated(self.delegate_to) if self.delegate_to else credentials
+        return credentials.create_delegated(self.delegate_to) \
+            if self.delegate_to else credentials
 
     def _get_access_token(self):
         """

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -65,10 +65,6 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
         keyfile_dict = self._get_field('keyfile_dict', False)
         scope = self._get_field('scope', False)
 
-        kwargs = {}
-        if self.delegate_to:
-            kwargs['sub'] = self.delegate_to
-
         if not key_path and not keyfile_dict:
             self.log.info('Getting connection using `gcloud auth` user, '
                           'since no key file is defined for hook.')


### PR DESCRIPTION
JIRA link to this PR: https://issues.apache.org/jira/browse/AIRFLOW-2171

Description: 
The GoogleCloudBaseHook has a variable named delegate_to to create delegated credentials but it never actually been used. Adding the logic back to make it able to create delegated credentials upon request.