### PR TITLE
[AIRFLOW-2172] Cast template_fields into a list if the type of templa…

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -24,6 +24,7 @@ from builtins import object, bytes
 import copy
 from collections import namedtuple
 from datetime import timedelta
+from past.builtins import basestring
 
 import dill
 import functools
@@ -2587,6 +2588,9 @@ class BaseOperator(LoggingMixin):
         pass
 
     def resolve_template_files(self):
+        # Cast the template_fields to a list if it is defined as ('field')
+        if isinstance(self.template_fields, basestring):
+            self.template_fields = list(self.template_fields)
         # Getting the content of files for template_field / template_ext
         for attr in self.template_fields:
             content = getattr(self, attr)
@@ -2735,6 +2739,8 @@ class BaseOperator(LoggingMixin):
 
     def dry_run(self):
         self.log.info('Dry run')
+        if isinstance(self.template_fields, basestring):
+            self.template_fields = list(self.template_fields)
         for attr in self.template_fields:
             content = getattr(self, attr)
             if content and isinstance(content, six.string_types):


### PR DESCRIPTION
…plate_fields has only one element

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2172


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Cast template_fields into a list if the type of operator's template_fields is string

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   minor change.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
