### PR TITLE
[AIRFLOW-2174] Fix typos and wrongly rendered documents

### DIFF
--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -33,32 +33,33 @@ class DataFlowJavaOperator(BaseOperator):
 
     .. code-block:: python
 
-        default_args = {
-            'dataflow_default_options': {
-                'project': 'my-gcp-project',
-                'zone': 'europe-west1-d',
-                'stagingLocation': 'gs://my-staging-bucket/staging/'
-            }
-        }
+       default_args = {
+           'dataflow_default_options': {
+               'project': 'my-gcp-project',
+               'zone': 'europe-west1-d',
+               'stagingLocation': 'gs://my-staging-bucket/staging/'
+           }
+       }
 
     You need to pass the path to your dataflow as a file reference with the ``jar``
-    parameter, the jar needs to be a self executing jar (see documentation here: 
-    https://beam.apache.org/documentation/runners/dataflow/#self-executing-jar). 
+    parameter, the jar needs to be a self executing jar (see documentation here:
+    https://beam.apache.org/documentation/runners/dataflow/#self-executing-jar).
     Use ``options`` to pass on options to your job.
 
     .. code-block:: python
-        t1 = DataFlowOperation(
-            task_id='datapflow_example',
-            jar='{{var.value.gcp_dataflow_base}}pipeline/build/libs/pipeline-example-1.0.jar',
-            options={
-                'autoscalingAlgorithm': 'BASIC',
-                'maxNumWorkers': '50',
-                'start': '{{ds}}',
-                'partitionType': 'DAY',
-                'labels': {'foo' : 'bar'}
-            },
-            gcp_conn_id='gcp-airflow-service-account',
-            dag=my-dag)
+
+       t1 = DataFlowOperation(
+           task_id='datapflow_example',
+           jar='{{var.value.gcp_dataflow_base}}pipeline/build/libs/pipeline-example-1.0.jar',
+           options={
+               'autoscalingAlgorithm': 'BASIC',
+               'maxNumWorkers': '50',
+               'start': '{{ds}}',
+               'partitionType': 'DAY',
+               'labels': {'foo' : 'bar'}
+           },
+           gcp_conn_id='gcp-airflow-service-account',
+           dag=my-dag)
 
     Both ``jar`` and ``options`` are templated so you can use variables in them.
     """
@@ -151,29 +152,31 @@ class DataflowTemplateOperator(BaseOperator):
         https://cloud.google.com/dataflow/docs/reference/rest/v1b3/RuntimeEnvironment
 
     .. code-block:: python
-        default_args = {
-            'dataflow_default_options': {
-                'project': 'my-gcp-project'
-                'zone': 'europe-west1-d',
-                'tempLocation': 'gs://my-staging-bucket/staging/'
-                }
-            }
-        }
+
+       default_args = {
+           'dataflow_default_options': {
+               'project': 'my-gcp-project'
+               'zone': 'europe-west1-d',
+               'tempLocation': 'gs://my-staging-bucket/staging/'
+               }
+           }
+       }
 
     You need to pass the path to your dataflow template as a file reference with the
     ``template`` parameter. Use ``parameters`` to pass on parameters to your job.
     Use ``environment`` to pass on runtime environment variables to your job.
 
     .. code-block:: python
-        t1 = DataflowTemplateOperator(
-            task_id='datapflow_example',
-            template='{{var.value.gcp_dataflow_base}}',
-            parameters={
-                'inputFile': "gs://bucket/input/my_input.txt",
-                'outputFile': "gs://bucket/output/my_output.txt"
-            },
-            gcp_conn_id='gcp-airflow-service-account',
-            dag=my-dag)
+
+       t1 = DataflowTemplateOperator(
+           task_id='datapflow_example',
+           template='{{var.value.gcp_dataflow_base}}',
+           parameters={
+               'inputFile': "gs://bucket/input/my_input.txt",
+               'outputFile': "gs://bucket/output/my_output.txt"
+           },
+           gcp_conn_id='gcp-airflow-service-account',
+           dag=my-dag)
 
     ``template``, ``dataflow_default_options`` and ``parameters`` are templated so you can
     use variables in them.

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -983,7 +983,7 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocWorkflowTemplateBaseOp
     :param delegate_to: The account to impersonate, if any.
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
-        :type delegate_to: string
+    :type delegate_to: string
     """
 
     @apply_defaults

--- a/airflow/contrib/operators/mlengine_operator.py
+++ b/airflow/contrib/operators/mlengine_operator.py
@@ -280,8 +280,9 @@ class MLEngineModelOperator(BaseOperator):
     :type model: dict
 
     :param operation: The operation to perform. Available operations are:
-        'create': Creates a new model as provided by the `model` parameter.
-        'get': Gets a particular model where the name is specified in `model`.
+
+        * ``create``: Creates a new model as provided by the `model` parameter.
+        * ``get``: Gets a particular model where the name is specified in `model`.
 
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: string
@@ -350,10 +351,12 @@ class MLEngineVersionOperator(BaseOperator):
     :type version: dict
 
     :param operation: The operation to perform. Available operations are:
+
         *   ``create``: Creates a new version in the model specified by `model_name`,
             in which case the `version` parameter should contain all the
             information to create that version
             (e.g. `name`, `deploymentUrl`).
+
         *   ``get``: Gets full information of a particular version in the model
             specified by `model_name`.
             The name of the version should be specified in the `version`

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3151,6 +3151,7 @@ class DAG(BaseDag, LoggingMixin):
     def following_schedule(self, dttm):
         """
         Calculates the following schedule for this dag in local time
+
         :param dttm: utc datetime
         :return: utc datetime
         """
@@ -3165,6 +3166,7 @@ class DAG(BaseDag, LoggingMixin):
     def previous_schedule(self, dttm):
         """
         Calculates the previous schedule for this dag in local time
+
         :param dttm: utc datetime
         :return: utc datetime
         """

--- a/airflow/operators/hive_stats_operator.py
+++ b/airflow/operators/hive_stats_operator.py
@@ -28,16 +28,14 @@ class HiveStatsCollectionOperator(BaseOperator):
     """
     Gathers partition statistics using a dynamically generated Presto
     query, inserts the stats into a MySql table with this format. Stats
-    overwrite themselves if you rerun the same date/partition.
+    overwrite themselves if you rerun the same date/partition. ::
 
-    ``
-    CREATE TABLE hive_stats (
-        ds VARCHAR(16),
-        table_name VARCHAR(500),
-        metric VARCHAR(200),
-        value BIGINT
-    );
-    ``
+        CREATE TABLE hive_stats (
+            ds VARCHAR(16),
+            table_name VARCHAR(500),
+            metric VARCHAR(200),
+            value BIGINT
+        );
 
     :param table: the source table, in the format ``database.table_name``
     :type table: str

--- a/airflow/operators/redshift_to_s3_operator.py
+++ b/airflow/operators/redshift_to_s3_operator.py
@@ -20,6 +20,7 @@ from airflow.utils.decorators import apply_defaults
 class RedshiftToS3Transfer(BaseOperator):
     """
     Executes an UNLOAD command to s3 as a CSV with headers
+
     :param schema: reference to a specific schema in redshift database
     :type schema: string
     :param table: reference to a specific table in redshift database

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -101,7 +101,7 @@ connections by following steps below:
 
 3. Replace ``airflow.cfg`` fernet_key value with the one from step 2.
 Alternatively, you can store your fernet_key in OS environment variable. You
-do not need to change ``airflow.cfg`` in this case as AirFlow will use environment
+do not need to change ``airflow.cfg`` in this case as Airflow will use environment
 variable over the value in ``airflow.cfg``:
 
 .. code-block:: bash
@@ -109,7 +109,7 @@ variable over the value in ``airflow.cfg``:
   # Note the double underscores
   EXPORT AIRFLOW__CORE__FERNET_KEY = your_fernet_key
 
-4. Restart AirFlow webserver.
+4. Restart Airflow webserver.
 5. For existing connections (the ones that you had defined before installing ``airflow[crypto]`` and creating a Fernet key), you need to open each connection in the connection admin UI, re-type the password, and save it.
 
 Connections in Airflow pipelines can be created using environment variables.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -129,7 +129,7 @@ of default parameters that we can use when creating tasks.
     }
 
 For more information about the BaseOperator's parameters and what they do,
-refer to the :py:class:``airflow.models.BaseOperator`` documentation.
+refer to the :py:class:`airflow.models.BaseOperator` documentation.
 
 Also, note that you could easily define different sets of arguments that
 would serve different purposes. An example of that would be to have


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2174


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Fix typos and wrongly rendered documents in the following pages:

- tutorial.html#default-arguments
- configuration.html#connections
- code.html#airflow.operators.hive_stats_operator.HiveStatsCollectionOperator
- code.html#airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer
- code.html#airflow.contrib.operators.dataflow_operator.DataFlowJavaOperator
- code.html#airflow.contrib.operators.dataflow_operator.DataflowTemplateOperator
- code.html#airflow.contrib.operators.dataproc_operator.DataprocWorkflowTemplateInstantiateOperator
- code.html#airflow.contrib.operators.mlengine_operator.MLEngineModelOperator
- code.html#airflow.contrib.operators.mlengine_operator.MLEngineVersionOperator
- code.html#airflow.models.DAG.following_schedule
- code.html#airflow.models.DAG.previous_schedule


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR does not need testing since it's documentation fix. I ran docs/build.sh locally and confirmed that all modifications were properly rendered.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
