### PR TITLE
[AIRFLOW-2129] Presto hook calls _parse_exception_message but defines…

### DIFF
--- a/airflow/hooks/presto_hook.py
+++ b/airflow/hooks/presto_hook.py
@@ -71,7 +71,7 @@ class PrestoHook(DbApiHook):
             return super(PrestoHook, self).get_records(
                 self._strip_sql(hql), parameters)
         except DatabaseError as e:
-            raise PrestoException(self._parse_exception_message(e))
+            raise PrestoException(self._get_pretty_exception_message(e))
 
     def get_first(self, hql, parameters=None):
         """
@@ -82,7 +82,7 @@ class PrestoHook(DbApiHook):
             return super(PrestoHook, self).get_first(
                 self._strip_sql(hql), parameters)
         except DatabaseError as e:
-            raise PrestoException(self._parse_exception_message(e))
+            raise PrestoException(self._get_pretty_exception_message(e))
 
     def get_pandas_df(self, hql, parameters=None):
         """
@@ -94,7 +94,7 @@ class PrestoHook(DbApiHook):
             cursor.execute(self._strip_sql(hql), parameters)
             data = cursor.fetchall()
         except DatabaseError as e:
-            raise PrestoException(self._parse_exception_message(e))
+            raise PrestoException(self._get_pretty_exception_message(e))
         column_descriptions = cursor.description
         if data:
             df = pandas.DataFrame(data)


### PR DESCRIPTION
… _get_pretty_exception_message

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2129


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
   _parse_exception_message does not exist in presto_hook file. Based on the git blame history(https://github.com/apache/incubator-airflow/pull/2128), I blame it is a typo when the patch original committed. Just rename to the correct functions.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: just fix the typo.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
