### PR TITLE
[AIRFLOW-2173] Don't check task IDs for concurrency reached check

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3331,7 +3331,6 @@ class DAG(BaseDag, LoggingMixin):
         TI = TaskInstance
         qry = session.query(func.count(TI.task_id)).filter(
             TI.dag_id == self.dag_id,
-            TI.task_id.in_(self.task_ids),
             TI.state == State.RUNNING,
         )
         return qry.scalar() >= self.concurrency


### PR DESCRIPTION
### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2173


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
Currently the concurrency reached check does a filter in the DB query to only include tasks that are currently in the parsed DAG. For sufficiently large DAGs with many tasks, this causes mysql to use an inefficient query plan and can put a lot of load on the database. Since there is no good reason to omit old running tasks in a DAG from concurrency, this filter should just be removed.

There are some instances of this pattern that can and should be removed, but this is the one that had a significant impact on DB performance.

### Tests
Running on Airbnb infrastructure for several days, with a significant decrease in DB load, all unit tests pass.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

@saguziel 