### PR TITLE
[AIRFLOW-102] Fix test_complex_template always succeeds

### DIFF
--- a/tests/core.py
+++ b/tests/core.py
@@ -488,7 +488,8 @@ class CoreTest(unittest.TestCase):
 
     def test_complex_template(self):
         def verify_templated_field(context):
-            self.assertEqual(context['ti'].task.some_templated_field['bar'][1], context['ds'])
+            self.assertEqual(context['ti'].task.some_templated_field['bar'][1],
+                             context['ds'])
 
         t = OperatorSubclass(
             task_id='test_complex_template',
@@ -496,8 +497,8 @@ class CoreTest(unittest.TestCase):
                 'foo': '123',
                 'bar': ['baz', '{{ ds }}']
             },
-            on_success_callback=verify_templated_field,
             dag=self.dag)
+        t.execute = verify_templated_field
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     def test_template_with_variable(self):
@@ -505,7 +506,6 @@ class CoreTest(unittest.TestCase):
         Test the availability of variables in templates
         """
         val = {
-            'success': False,
             'test_value': 'a test value'
         }
         Variable.set("a_variable", val['test_value'])
@@ -513,22 +513,19 @@ class CoreTest(unittest.TestCase):
         def verify_templated_field(context):
             self.assertEqual(context['ti'].task.some_templated_field,
                              val['test_value'])
-            val['success'] = True
 
         t = OperatorSubclass(
             task_id='test_complex_template',
             some_templated_field='{{ var.value.a_variable }}',
-            on_success_callback=verify_templated_field,
             dag=self.dag)
+        t.execute = verify_templated_field
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-        self.assertTrue(val['success'])
 
     def test_template_with_json_variable(self):
         """
         Test the availability of variables (serialized as JSON) in templates
         """
         val = {
-            'success': False,
             'test_value': {'foo': 'bar', 'obj': {'v1': 'yes', 'v2': 'no'}}
         }
         Variable.set("a_variable", val['test_value'], serialize_json=True)
@@ -536,15 +533,13 @@ class CoreTest(unittest.TestCase):
         def verify_templated_field(context):
             self.assertEqual(context['ti'].task.some_templated_field,
                              val['test_value']['obj']['v2'])
-            val['success'] = True
 
         t = OperatorSubclass(
             task_id='test_complex_template',
             some_templated_field='{{ var.json.a_variable.obj.v2 }}',
-            on_success_callback=verify_templated_field,
             dag=self.dag)
+        t.execute = verify_templated_field
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-        self.assertTrue(val['success'])
 
     def test_template_with_json_variable_as_value(self):
         """
@@ -552,7 +547,6 @@ class CoreTest(unittest.TestCase):
         accessed as a value
         """
         val = {
-            'success': False,
             'test_value': {'foo': 'bar'}
         }
         Variable.set("a_variable", val['test_value'], serialize_json=True)
@@ -560,15 +554,13 @@ class CoreTest(unittest.TestCase):
         def verify_templated_field(context):
             self.assertEqual(context['ti'].task.some_templated_field,
                              u'{"foo": "bar"}')
-            val['success'] = True
 
         t = OperatorSubclass(
             task_id='test_complex_template',
             some_templated_field='{{ var.value.a_variable }}',
-            on_success_callback=verify_templated_field,
             dag=self.dag)
+        t.execute = verify_templated_field
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-        self.assertTrue(val['success'])
 
     def test_template_non_bool(self):
         """


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-102

### Description
Exceptions from on_success_callback are stomped on, meaning
test_complex_template would never fail.

Rather than follow the "success = True" pattern (which results in the
lovely-to-track-down error message of `AssertionError: False is not
true` I instead changed all these to have the verify method be execute
-- meaning exceptions are propagated unchanged.

Thanks to @sekikn in https://github.com/apache/incubator-airflow/pull/2375 for the info to track down what was going on. Sorry for not merging that as is -- I think this is a less fragile solution.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Can't write tests for tests. I did manually change the test cases to see that they all fail with sensible error messages, and they do:

    ```
      File "/Users/ash/code/python/incubator-airflow/tests/core.py", line 492, in verify_templated_field
        context['ds'])
    AssertionError: 'a2015-01-01' != '2015-01-01'
    - a2015-01-01
    ? -
    + 2015-01-01
    ```


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
