### PR TITLE
AIRFLOW-2179: Make parametrable the IP on which the worker log server binds to

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -860,7 +860,7 @@ def serve_logs(args):
             as_attachment=False)
 
     WORKER_LOG_SERVER_BIND_IP = \
-        int(conf.get('celery', 'WORKER_LOG_SERVER_BIND_IP'))
+        conf.get('celery', 'WORKER_LOG_SERVER_BIND_IP')
     WORKER_LOG_SERVER_PORT = \
         int(conf.get('celery', 'WORKER_LOG_SERVER_PORT'))
     flask_app.run(

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -859,10 +859,12 @@ def serve_logs(args):
             mimetype="application/json",
             as_attachment=False)
 
+    WORKER_LOG_SERVER_BIND_IP = \
+        int(conf.get('celery', 'WORKER_LOG_SERVER_BIND_IP'))
     WORKER_LOG_SERVER_PORT = \
         int(conf.get('celery', 'WORKER_LOG_SERVER_PORT'))
     flask_app.run(
-        host='0.0.0.0', port=WORKER_LOG_SERVER_PORT)
+        host=WORKER_LOG_SERVER_BIND_IP, port=WORKER_LOG_SERVER_PORT)
 
 
 def worker(args):

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -298,8 +298,9 @@ worker_concurrency = 16
 # When you start an airflow worker, airflow starts a tiny web server
 # subprocess to serve the workers local log files to the airflow main
 # web server, who then builds pages and sends them to users. This defines
-# the port on which the logs are served. It needs to be unused, and open
+# the ip and the port on which the logs are served. It needs to be unused, and open
 # visible from the main web server to connect into the workers.
+worker_log_server_bind_ip = 0.0.0.0
 worker_log_server_port = 8793
 
 # The Celery broker URL. Celery supports RabbitMQ, Redis and experimentally

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -77,6 +77,7 @@ smtp_mail_from = airflow@example.com
 [celery]
 celery_app_name = airflow.executors.celery_executor
 worker_concurrency = 16
+worker_log_server_bind_ip = 0.0.0.0
 worker_log_server_port = 8793
 broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
 result_backend = db+mysql://airflow:airflow@localhost:3306/airflow

--- a/scripts/ci/airflow_travis.cfg
+++ b/scripts/ci/airflow_travis.cfg
@@ -47,6 +47,7 @@ smtp_mail_from = airflow@example.com
 [celery]
 celery_app_name = airflow.executors.celery_executor
 worker_concurrency = 16
+worker_log_server_bind_ip = 0.0.0.0
 worker_log_server_port = 8793
 broker_url = amqp://guest:guest@localhost:5672/
 result_backend = db+mysql://root@localhost/airflow


### PR DESCRIPTION
Hello

I'd be glad if the tiny web server subprocess to serve the workers local log files could be set to bind to localhost only as could be done for Gunicorn or Flower. See [cli.py#L865](https://github.com/apache/incubator-airflow/blob/master/airflow/bin/cli.py#L865).

### JIRA
This PR is associated with [AIRFLOW-2179](https://issues.apache.org/jira/browse/AIRFLOW-2179/) 


### Description
The idea is to be able to choose where tp bind the subprocess local webserver log files, for example on local host and not on 0.0.0.0.


### Tests
As it's only a configuration change and the default is present, a new unit test is not mandatory.


### Review
I'm not sure if the lines needs to be changed: [file_task_handler.py#L109](https://github.com/apache/incubator-airflow/blob/976fd1245a981b37957e4e35367b0e504d8e3d67/airflow/utils/log/file_task_handler.py#L109)