### PR TITLE
[AIRFLOW-2185] Use state instead of query param for redirect_uri

### DIFF
--- a/airflow/contrib/auth/backends/github_enterprise_auth.py
+++ b/airflow/contrib/auth/backends/github_enterprise_auth.py
@@ -122,8 +122,8 @@ class GHEAuthBackend(object):
         log.debug('Redirecting user to GHE login')
         return self.ghe_oauth.authorize(callback=url_for(
             'ghe_oauth_callback',
-            _external=True,
-            next=request.args.get('next') or request.referrer or None))
+            _external=True),
+            state=request.args.get('next') or request.referrer or None)
 
     def get_ghe_user_profile_info(self, ghe_token):
         resp = self.ghe_oauth.get(self.ghe_api_route('/user'),
@@ -188,7 +188,7 @@ class GHEAuthBackend(object):
     def oauth_callback(self, session=None):
         log.debug('GHE OAuth callback called')
 
-        next_url = request.args.get('next') or url_for('admin.index')
+        next_url = request.args.get('state') or url_for('admin.index')
 
         resp = self.ghe_oauth.authorized_response()
 

--- a/airflow/contrib/auth/backends/google_auth.py
+++ b/airflow/contrib/auth/backends/google_auth.py
@@ -109,8 +109,8 @@ class GoogleAuthBackend(object):
         return self.google_oauth.authorize(callback=url_for(
             'google_oauth_callback',
             _external=True,
-            _scheme='https',
-            next=request.args.get('next') or request.referrer or None))
+            _scheme='https'),
+            state=request.args.get('next') or request.referrer or None)
 
     def get_google_user_profile_info(self, google_token):
         resp = self.google_oauth.get('https://www.googleapis.com/oauth2/v1/userinfo',
@@ -143,7 +143,7 @@ class GoogleAuthBackend(object):
     def oauth_callback(self, session=None):
         log.debug('Google OAuth callback called')
 
-        next_url = request.args.get('next') or url_for('admin.index')
+        next_url = request.args.get('state') or url_for('admin.index')
 
         resp = self.google_oauth.authorized_response()
 


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2185


### Description
Both the Google OAuth2 and GHE authentication plugins include the `next_url` as a query parameter in redirect_uri. This breaks at least Google OAuth2, unless you include the query parameter in the authorized redirection URI. This isn't the most flexible solution, as you would have to do the same for every potential next URL, and seems to go against the OAuth2 spec.

Instead the next_url should be sent via the state parameter which MUST be maintained by all spec compliant OAuth2 implementations, and is not used when comparing redirection URIs.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 This is not easily unit testable, but I have tested it with Google OAuth2. Assuming GHE follows the OAuth2 spec, it should work there as well.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
