### PR TITLE
[AIRFLOW-2106] Cannot pass sandbox argument to sales_force hook preve…

### DIFF
--- a/airflow/contrib/hooks/salesforce_hook.py
+++ b/airflow/contrib/hooks/salesforce_hook.py
@@ -79,7 +79,8 @@ class SalesforceHook(BaseHook, LoggingMixin):
             username=self.connection.login,
             password=self.connection.password,
             security_token=self.extras['security_token'],
-            instance_url=self.connection.host
+            instance_url=self.connection.host,
+            sandbox=self.extras.get('sandbox', False)
         )
         self.sf = sf
         return sf


### PR DESCRIPTION
…nting sandbox connection

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2106

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Allow user to put 'sandbox' as input argument. User could set it in connection extra field.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  trivial fix

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
