### PR TITLE
[AIRFLOW-2203] Dag import speed

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -34,3 +34,7 @@ class AirflowTaskTimeout(AirflowException):
 
 class AirflowSkipException(AirflowException):
     pass
+
+
+class AirflowDagCycleException(AirflowException):
+    pass

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -22,7 +22,7 @@ from future.standard_library import install_aliases
 from builtins import str
 from builtins import object, bytes
 import copy
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 from datetime import timedelta
 
 import dill
@@ -63,7 +63,9 @@ import six
 from airflow import settings, utils
 from airflow.executors import GetDefaultExecutor, LocalExecutor
 from airflow import configuration
-from airflow.exceptions import AirflowException, AirflowSkipException, AirflowTaskTimeout
+from airflow.exceptions import (
+    AirflowDagCycleException, AirflowException, AirflowSkipException, AirflowTaskTimeout
+)
 from airflow.dag.base_dag import BaseDag, BaseDagBag
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
 from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
@@ -121,7 +123,6 @@ else:
 
 # Used by DAG context_managers
 _CONTEXT_MANAGER_DAG = None
-
 
 def clear_task_instances(tis, session, activate_dag_runs=True, dag=None):
     """
@@ -182,6 +183,11 @@ class DagBag(BaseDagBag, LoggingMixin):
         with airflow or not
     :type include_examples: bool
     """
+
+    # static class variables to detetct dag cycle
+    CYCLE_NEW = 0
+    CYCLE_IN_PROGRESS = 1
+    CYCLE_DONE = 2
 
     def __init__(
             self,
@@ -335,10 +341,17 @@ class DagBag(BaseDagBag, LoggingMixin):
                         dag.full_filepath = filepath
                         if dag.fileloc != filepath:
                             dag.fileloc = filepath
-                    dag.is_subdag = False
-                    self.bag_dag(dag, parent_dag=dag, root_dag=dag)
-                    found_dags.append(dag)
-                    found_dags += dag.subdags
+                    try:
+                        dag.is_subdag = False
+                        self.bag_dag(dag, parent_dag=dag, root_dag=dag)
+                        found_dags.append(dag)
+                        found_dags += dag.subdags
+                    except AirflowDagCycleException as cycle_exception:
+                        self.log.exception("Failed to bag_dag: %s", dag.full_filepath)
+                        self.import_errors[dag.full_filepath] = str(cycle_exception)
+                        self.file_last_changed[dag.full_filepath] = \
+                            file_last_changed_on_disk
+
 
         self.file_last_changed[filepath] = file_last_changed_on_disk
         return found_dags
@@ -381,20 +394,39 @@ class DagBag(BaseDagBag, LoggingMixin):
     def bag_dag(self, dag, parent_dag, root_dag):
         """
         Adds the DAG into the bag, recurses into sub dags.
+        Throws AirflowDagCycleException if a cycle is detected in this dag or its subdags
         """
-        self.dags[dag.dag_id] = dag
+
+        dag.test_cycle()  # throws if a task cycle is found
+
         dag.resolve_template_files()
         dag.last_loaded = timezone.utcnow()
 
         for task in dag.tasks:
             settings.policy(task)
 
-        for subdag in dag.subdags:
-            subdag.full_filepath = dag.full_filepath
-            subdag.parent_dag = dag
-            subdag.is_subdag = True
-            self.bag_dag(subdag, parent_dag=dag, root_dag=root_dag)
-        self.log.debug('Loaded DAG {dag}'.format(**locals()))
+        subdags = dag.subdags
+
+        try:
+            for subdag in subdags:
+                subdag.full_filepath = dag.full_filepath
+                subdag.parent_dag = dag
+                subdag.is_subdag = True
+                self.bag_dag(subdag, parent_dag=dag, root_dag=root_dag)
+
+            self.dags[dag.dag_id] = dag
+            self.log.debug('Loaded DAG {dag}'.format(**locals()))
+        except AirflowDagCycleException as cycle_exception:
+            # There was an error in bagging the dag. Remove it from the list of dags
+            self.log.exception('Exception bagging dag: {dag.dag_id}'.format(**locals()))
+            # Only necessary at the root level since DAG.subdags automatically
+            # performs DFS to search through all subdags
+            if dag == root_dag:
+                for subdag in subdags:
+                    if subdag.dag_id in self.dags:
+                        del self.dags[subdag.dag_id]
+            raise cycle_exception
+
 
     def collect_dags(
             self,
@@ -2699,21 +2731,6 @@ class BaseOperator(LoggingMixin):
         return list(map(lambda task_id: self._dag.task_dict[task_id],
                         self.get_flat_relative_ids(upstream)))
 
-    def detect_downstream_cycle(self, task=None):
-        """
-        When invoked, this routine will raise an exception if a cycle is
-        detected downstream from self. It is invoked when tasks are added to
-        the DAG to detect cycles.
-        """
-        if not task:
-            task = self
-        for t in self.get_direct_relatives():
-            if task is t:
-                msg = "Cycle detected in DAG. Faulty task: {0}".format(task)
-                raise AirflowException(msg)
-            else:
-                t.detect_downstream_cycle(task=task)
-        return False
 
     def run(
             self,
@@ -4077,6 +4094,42 @@ class DAG(BaseDag, LoggingMixin):
             else:
                 qry = qry.filter(TaskInstance.state.in_(states))
         return qry.scalar()
+
+    def test_cycle(self):
+        '''
+        Check to see if there are any cycles in the DAG. Returns False if no cycle found,
+        otherwise raises exception.
+        '''
+
+        # default of int is 0 which corresponds to CYCLE_NEW
+        visit_map = defaultdict(int)
+        for task_id in self.task_dict.keys():
+            # print('starting %s' % task_id)
+            if visit_map[task_id] == DagBag.CYCLE_NEW:
+                self._test_cycle_helper(visit_map, task_id)
+        return False
+
+    def _test_cycle_helper(self, visit_map, task_id):
+        '''
+        Checks if a cycle exists from the input task using DFS traversal
+        '''
+
+        # print('Inspecting %s' % task_id)
+        if visit_map[task_id] == DagBag.CYCLE_DONE:
+            return False
+
+        visit_map[task_id] = DagBag.CYCLE_IN_PROGRESS
+
+        task = self.task_dict[task_id]
+        for descendant_id in task.get_direct_relative_ids():
+            if visit_map[descendant_id] == DagBag.CYCLE_IN_PROGRESS:
+                msg = "Cycle detected in DAG. Faulty task: {0} to {1}".format(
+                    task_id, descendant_id)
+                raise AirflowDagCycleException(msg)
+            else:
+                self._test_cycle_helper(visit_map, descendant_id)
+
+        visit_map[task_id] = DagBag.CYCLE_DONE
 
 
 class Chart(Base):

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3843,11 +3843,10 @@ class DAG(BaseDag, LoggingMixin):
                 'exception.'.format(task.task_id),
                 category=PendingDeprecationWarning)
         else:
-            self.tasks.append(task)
             self.task_dict[task.task_id] = task
             task.dag = self
 
-        self.task_count = len(self.tasks)
+        self.task_count = len(self.task_dict)
 
     def add_tasks(self, tasks):
         """

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2318,8 +2318,8 @@ class BaseOperator(LoggingMixin):
         self.task_concurrency = task_concurrency
 
         # Private attributes
-        self._upstream_task_ids = []
-        self._downstream_task_ids = []
+        self._upstream_task_ids = set()
+        self._downstream_task_ids = set()
 
         if not dag and _CONTEXT_MANAGER_DAG:
             dag = _CONTEXT_MANAGER_DAG
@@ -2788,13 +2788,13 @@ class BaseOperator(LoggingMixin):
     def task_type(self):
         return self.__class__.__name__
 
-    def append_only_new(self, l, item):
-        if any([item is t for t in l]):
+    def add_only_new(self, item_set, item):
+        if item in item_set:
             raise AirflowException(
                 'Dependency {self}, {item} already registered'
                 ''.format(**locals()))
         else:
-            l.append(item)
+            item_set.add(item)
 
     def _set_relatives(self, task_or_task_list, upstream=False):
         try:
@@ -2810,7 +2810,7 @@ class BaseOperator(LoggingMixin):
 
         # relationships can only be set if the tasks share a single DAG. Tasks
         # without a DAG are assigned to that DAG.
-        dags = {t._dag.dag_id: t.dag for t in [self] + task_list if t.has_dag()}
+        dags = {t._dag.dag_id: t._dag for t in [self] + task_list if t.has_dag()}
 
         if len(dags) > 1:
             raise AirflowException(
@@ -2831,13 +2831,11 @@ class BaseOperator(LoggingMixin):
             if dag and not task.has_dag():
                 task.dag = dag
             if upstream:
-                task.append_only_new(task._downstream_task_ids, self.task_id)
-                self.append_only_new(self._upstream_task_ids, task.task_id)
+                task.add_only_new(task._downstream_task_ids, self.task_id)
+                self.add_only_new(self._upstream_task_ids, task.task_id)
             else:
-                self.append_only_new(self._downstream_task_ids, task.task_id)
-                task.append_only_new(task._upstream_task_ids, self.task_id)
-
-        self.detect_downstream_cycle()
+                self.add_only_new(self._downstream_task_ids, task.task_id)
+                task.add_only_new(task._upstream_task_ids, self.task_id)
 
     def set_downstream(self, task_or_task_list):
         """
@@ -3746,10 +3744,9 @@ class DAG(BaseDag, LoggingMixin):
         for t in dag.tasks:
             # Removing upstream/downstream references to tasks that did not
             # made the cut
-            t._upstream_task_ids = [
-                tid for tid in t._upstream_task_ids if tid in dag.task_ids]
-            t._downstream_task_ids = [
-                tid for tid in t._downstream_task_ids if tid in dag.task_ids]
+            t._upstream_task_ids = t._upstream_task_ids.intersection(dag.task_dict.keys())
+            t._downstream_task_ids = t._downstream_task_ids.intersection(
+                dag.task_dict.keys())
 
         if len(dag.tasks) < len(self.tasks):
             dag.partial = True

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -39,6 +39,19 @@ def apply_defaults(func):
     inheritance and argument defaults, this decorator also alerts with
     specific information about the missing arguments.
     """
+
+    import airflow.models
+    # Cache inspect.signature for the wrapper closure to avoid calling it
+    # at every decorated invocation. This is separate sig_cache created
+    # per decoration, i.e. each function decorated using apply_defaults will
+    # have a different sig_cache.
+    sig_cache = signature(func)
+    non_optional_args = {
+        name for (name, param) in sig_cache.parameters.items()
+        if param.default == param.empty and
+        param.name != 'self' and
+        param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD)}
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         if len(args) > 1:
@@ -46,9 +59,9 @@ def apply_defaults(func):
                 "Use keyword arguments when initializing operators")
         dag_args = {}
         dag_params = {}
-        import airflow.models
-        if kwargs.get('dag', None) or airflow.models._CONTEXT_MANAGER_DAG:
-            dag = kwargs.get('dag', None) or airflow.models._CONTEXT_MANAGER_DAG
+
+        dag = kwargs.get('dag', None) or airflow.models._CONTEXT_MANAGER_DAG
+        if dag:
             dag_args = copy(dag.default_args) or {}
             dag_params = copy(dag.params) or {}
 
@@ -67,16 +80,10 @@ def apply_defaults(func):
         dag_args.update(default_args)
         default_args = dag_args
 
-        sig = signature(func)
-        non_optional_args = [
-            name for (name, param) in sig.parameters.items()
-            if param.default == param.empty and
-            param.name != 'self' and
-            param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD)]
-        for arg in sig.parameters:
-            if arg in default_args and arg not in kwargs:
+        for arg in sig_cache.parameters:
+            if arg not in kwargs and arg in default_args:
                 kwargs[arg] = default_args[arg]
-        missing_args = list(set(non_optional_args) - set(kwargs))
+        missing_args = list(non_optional_args - set(kwargs))
         if missing_args:
             msg = "Argument {0} is required".format(missing_args)
             raise AirflowException(msg)

--- a/airflow/utils/operator_resources.py
+++ b/airflow/utils/operator_resources.py
@@ -99,16 +99,12 @@ class Resources(object):
     :param gpus: The number of gpu units that are required
     :type gpus: long
     """
-    def __init__(self, cpus=None, ram=None, disk=None, gpus=None):
-        if cpus is None:
-            cpus = configuration.getint('operators', 'default_cpus')
-        if ram is None:
-            ram = configuration.getint('operators', 'default_ram')
-        if disk is None:
-            disk = configuration.getint('operators', 'default_disk')
-        if gpus is None:
-            gpus = configuration.getint('operators', 'default_gpus')
-
+    def __init__(self,
+                 cpus=configuration.getint('operators', 'default_cpus'),
+                 ram=configuration.getint('operators', 'default_ram'),
+                 disk=configuration.getint('operators', 'default_disk'),
+                 gpus=configuration.getint('operators', 'default_gpus')
+                 ):
         self.cpus = CpuResource(cpus)
         self.ram = RamResource(ram)
         self.disk = DiskResource(disk)

--- a/airflow/utils/trigger_rule.py
+++ b/airflow/utils/trigger_rule.py
@@ -25,12 +25,17 @@ class TriggerRule(object):
     ONE_FAILED = 'one_failed'
     DUMMY = 'dummy'
 
+    _ALL_TRIGGER_RULES = {}
     @classmethod
     def is_valid(cls, trigger_rule):
         return trigger_rule in cls.all_triggers()
 
     @classmethod
     def all_triggers(cls):
-        return [getattr(cls, attr)
+        if not cls._ALL_TRIGGER_RULES:
+            cls._ALL_TRIGGER_RULES = {
+                getattr(cls, attr)
                 for attr in dir(cls)
-                if not attr.startswith("__") and not callable(getattr(cls, attr))]
+                if not attr.startswith("_") and not callable(getattr(cls, attr))
+            }
+        return cls._ALL_TRIGGER_RULES

--- a/airflow/utils/weight_rule.py
+++ b/airflow/utils/weight_rule.py
@@ -22,12 +22,17 @@ class WeightRule(object):
     UPSTREAM = 'upstream'
     ABSOLUTE = 'absolute'
 
+    _ALL_WEIGHT_RULES = {}
     @classmethod
     def is_valid(cls, weight_rule):
         return weight_rule in cls.all_weight_rules()
 
     @classmethod
     def all_weight_rules(cls):
-        return [getattr(cls, attr)
+        if not cls._ALL_WEIGHT_RULES:
+            cls._ALL_WEIGHT_RULES = {
+                getattr(cls, attr)
                 for attr in dir(cls)
-                if not attr.startswith("__") and not callable(getattr(cls, attr))]
+                if not attr.startswith("_") and not callable(getattr(cls, attr))
+            }
+        return cls._ALL_WEIGHT_RULES

--- a/tests/core.py
+++ b/tests/core.py
@@ -789,22 +789,6 @@ class CoreTest(unittest.TestCase):
         with self.assertRaisesRegexp(AirflowException, regexp):
             self.run_after_loop.set_upstream(self.runme_0)
 
-    def test_cyclic_dependencies_1(self):
-
-        regexp = "Cycle detected in DAG. (.*)runme_0(.*)"
-        with self.assertRaisesRegexp(AirflowException, regexp):
-            self.runme_0.set_upstream(self.run_after_loop)
-
-    def test_cyclic_dependencies_2(self):
-        regexp = "Cycle detected in DAG. (.*)run_after_loop(.*)"
-        with self.assertRaisesRegexp(AirflowException, regexp):
-            self.run_after_loop.set_downstream(self.runme_0)
-
-    def test_cyclic_dependencies_3(self):
-        regexp = "Cycle detected in DAG. (.*)run_this_last(.*)"
-        with self.assertRaisesRegexp(AirflowException, regexp):
-            self.run_this_last.set_downstream(self.runme_0)
-
     def test_bad_trigger_rule(self):
         with self.assertRaises(AirflowException):
             DummyOperator(

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -28,7 +28,7 @@ class TriggerRuleDepTest(unittest.TestCase):
         task = BaseOperator(task_id='test_task', trigger_rule=trigger_rule,
                             start_date=datetime(2015, 1, 1))
         if upstream_task_ids:
-            task._upstream_task_ids.extend(upstream_task_ids)
+            task._upstream_task_ids.update(upstream_task_ids)
         return TaskInstance(task=task, state=state, execution_date=None)
 
     def test_no_upstream_tasks(self):

--- a/tests/utils/test_decorators.py
+++ b/tests/utils/test_decorators.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from airflow.utils.decorators import apply_defaults
+from airflow.exceptions import AirflowException
+
+
+# Essentially similar to airflow.models.BaseOperator
+class DummyClass(object):
+    @apply_defaults
+    def __init__(self, test_param, params=None, default_args=None):
+        self.test_param = test_param
+
+
+class DummySubClass(DummyClass):
+    @apply_defaults
+    def __init__(self, test_sub_param, *args, **kwargs):
+        super(DummySubClass, self).__init__(*args, **kwargs)
+        self.test_sub_param = test_sub_param
+
+
+class ApplyDefaultTest(unittest.TestCase):
+
+    def test_apply(self):
+        dc = DummyClass(test_param=True)
+        self.assertTrue(dc.test_param)
+
+        with self.assertRaisesRegexp(AirflowException, 'Argument.*test_param.*required'):
+            DummySubClass(test_sub_param=True)
+
+    def test_default_args(self):
+        default_args = {'test_param': True}
+        dc = DummyClass(default_args=default_args)
+        self.assertTrue(dc.test_param)
+
+        default_args = {'test_param': True, 'test_sub_param': True}
+        dsc = DummySubClass(default_args=default_args)
+        self.assertTrue(dc.test_param)
+        self.assertTrue(dsc.test_sub_param)
+
+        default_args = {'test_param': True}
+        dsc = DummySubClass(default_args=default_args, test_sub_param=True)
+        self.assertTrue(dc.test_param)
+        self.assertTrue(dsc.test_sub_param)
+
+        with self.assertRaisesRegexp(AirflowException,
+                                     'Argument.*test_sub_param.*required'):
+            DummySubClass(default_args=default_args)
+
+    def test_incorrect_default_args(self):
+        default_args = {'test_param': True, 'extra_param': True}
+        dc = DummyClass(default_args=default_args)
+        self.assertTrue(dc.test_param)
+
+        default_args = {'random_params': True}
+        with self.assertRaisesRegexp(AirflowException, 'Argument.*test_param.*required'):
+            DummyClass(default_args=default_args)

--- a/tests/utils/test_trigger_rule.py
+++ b/tests/utils/test_trigger_rule.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from airflow.utils.trigger_rule import TriggerRule
+
+
+class TestTriggerRule(unittest.TestCase):
+
+    def test_valid_trigger_rules(self):
+        self.assertTrue(TriggerRule.is_valid(TriggerRule.ALL_SUCCESS))
+        self.assertTrue(TriggerRule.is_valid(TriggerRule.ALL_FAILED))
+        self.assertTrue(TriggerRule.is_valid(TriggerRule.ALL_DONE))
+        self.assertTrue(TriggerRule.is_valid(TriggerRule.ONE_SUCCESS))
+        self.assertTrue(TriggerRule.is_valid(TriggerRule.ONE_FAILED))
+        self.assertTrue(TriggerRule.is_valid(TriggerRule.DUMMY))
+        self.assertEqual(len(TriggerRule.all_triggers()), 6)

--- a/tests/utils/test_weight_rule.py
+++ b/tests/utils/test_weight_rule.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from airflow.utils.weight_rule import WeightRule
+
+
+class TestWeightRule(unittest.TestCase):
+
+    def test_valid_weight_rules(self):
+        self.assertTrue(WeightRule.is_valid(WeightRule.DOWNSTREAM))
+        self.assertTrue(WeightRule.is_valid(WeightRule.UPSTREAM))
+        self.assertTrue(WeightRule.is_valid(WeightRule.ABSOLUTE))
+        self.assertEqual(len(WeightRule.all_weight_rules()), 3)


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
   - https://issues.apache.org/jira/browse/AIRFLOW-2203


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Importing DAGS are terribly slow and operates at polynomial time (or worse). These changes bring huge performance boost for users who need have deep and wide dags. In the new toy example of a very basic Fan-In/Fan-Out x4 DAG found in `tests/dags/test_performance.py`, fails to compile in any reasonable timeframe using the original code. The following optimizations are employed:

1. Defer detecting cycles of DAGs. Currently `detect_downstream_cycle` traverses the entire graph every time a task is added. Updated to call cycle detection only once when the DAG is collected by the `DagBag`. This is crucial because it reduces runtime from polynomial to near linear. Commit `8e8e735`
2. Remove useless calls to `dag.tasks` in add_task command which iterates through every task needlessly for *every* task added. ~~Commit `013a7d2`~~
3. Cache expensive `inspect.signature` call. Currently being called at every `BaseOperator/Operator` construction. We should be able to cache this because the function signature of the constructor isn't really expected to change. ~~Commit `a7b230e`~~
4. ~~Use default `Resources` object for `BaseOperator` constructor. Currently every time an operator is constructed without specifying the `resources` parameter, a brand new `Resources` object is created that calls `configuration.getint()` 4x (to create `cpu/ram/disk/gpuResource`). A default declared `Resources` object can be shared for most tasks that don't need this functionality. Commit `6da941e`~~ Set default values for `Resources` object to be pulled from configuration. This changes from needing 4x configuration loads for every operator created to only 4x configuration loads to set the default values once.
   * ~~*WARNING* potential breaking change! Because the default Resource object is shared among all operators (when none is specified). `Resources`'s internal `Resource` objects are assumed to be immutable (hence the change to getter access only). If a task needs to have its `resources` modified, the user must create a new one manually.~~
5. Stop trigger/weight rules from recalculating the classes' static variables. ~~Commit `5d68744`~~
6. Maintain tasks' `_upstream_task_ids` and `_downstream_task_ids` as sets instead of lists. Currently everytime a task is added, it iterates through the entire list to see if the task has already been added. There shouldn't be a need to do this.
    * *WARNING* potential breaking change. The order in which a task is `set_downstream`/`set_upstream` is no longer preserved when retrieving the task list anymore. Order shouldn't have been an expected behavior to begin with, but just in case some people relied on that for some reason, they should be made aware.

An idea of the performance on my very old Haswell Laptop (in seconds):
1. Deferred Cycle Detection- Compared with no cycle detection. Only adds a little more time and at least the DAG can now be loaded (compared to original)


Width | Tasks | Original | No Cycle Detection | Deferred Cycle Detection | All changes
-- | -- | -- | -- | -- | --
25 | 105 | 6.67 | 0.312 | 0.373 | 0.234
50 | 205 | 199 | 0.352 | 0.436 | 0.329
100 | 405 | > 300 | 0.416 | 0.485 | 0.323
200 | 805 | >300 | 0.65 | 0.648 | 0.367
400 | 1605 | > 300 | 0.87 | 0.996 | 0.45
800 | 3205 | > 300 | 1.53 | 1.77 | 0.534
1600 | 6405 | > 300 | 3.24 | 3.86 | 0.773
3200 | 12805 | > 300 | 9.47 | 11.25 | 1.12
6400 | 25605 | > 300 | 36 | 42.43 | 2.18
12800 | 51205 | > 300 | 151 | 163 | 3.77
51200 | 204805 | > 300 |  >151 | > 163 | 14.75
102300 | 409605 | > 300| > 151  | > 163 | 28.8

Full benchmarks as each feature added can be found here:
https://docs.google.com/spreadsheets/d/1_39JRdPpXlWbWVM9jRVn7kBaIK7TshJllr5COC30Xeo/edit?usp=sharing


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- tests/utils/test_trigger_rule.py:TestTriggerRule
- tests/utils/test_weight_rule.py:TestWeightRule
- tests/utils/test_decorators.py:ApplyDefaultTest
- test/utils.py:OperatorResourcesTest.test_unable_to_change_resource
- tests/dags/test_performance.py
- tests/models.py:DagTest.test_cycle
- tests/models.py:DagBagTest.test_load_subdags
- tests/models.py:DagBagTest.test_skip_cycle_dags
- tests/models.py:DagBagTest.test_load_large_dag

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
   1. Subject is separated from body by a blank line
   2. Subject is limited to 50 characters
   3. Subject does not end with a period
   4. Subject uses the imperative mood ("add", not "adding")
   5. Body wraps at 72 characters
   6. Body explains "what" and "why", not "how"

~~Not yet, but I will. There are 6 different improvements that can be applied separately. I wasn't sure if they should each be individual PR's but they each contribute significantly to the performance boost. I kept them separate in case I needed to pull an individual change out of this PR. If everything checks out, I will squash them into one single commit.~~

As discussed on the PR below, I kept each of these features separate in a different commit (all prepended with [AIRFLOW-2203])

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`