### PR TITLE
[Airflow-2202] Add filter support in HiveMetastoreHook().max_partition()

### DIFF
--- a/airflow/macros/hive.py
+++ b/airflow/macros/hive.py
@@ -16,9 +16,9 @@ import datetime
 
 
 def max_partition(
-        table, schema="default", field=None, filter=None,
+        table, schema="default", field=None, filter_map=None,
         metastore_conn_id='metastore_default'):
-    '''
+    """
     Gets the max partition for a table.
 
     :param schema: The hive schema the table lives in
@@ -27,24 +27,27 @@ def max_partition(
         notation as in "my_database.my_table", if a dot is found,
         the schema param is disregarded
     :type table: string
-    :param hive_conn_id: The hive connection you are interested in.
+    :param metastore_conn_id: The hive connection you are interested in.
         If your default is set you don't need to use this parameter.
-    :type hive_conn_id: string
-    :param filter: filter on a subset of partition as in
-        `sub_part='specific_value'`
-    :type filter: string
+    :type metastore_conn_id: string
+    :param filter_map: partition_key:partition_value map used for partition filtering,
+                       e.g. {'key1': 'value1', 'key2': 'value2'}.
+                       Only partitions matching all partition_key:partition_value
+                       pairs will be considered as candidates of max partition.
+    :type filter_map: map
     :param field: the field to get the max value from. If there's only
         one partition field, this will be inferred
+    :type field: str
 
     >>> max_partition('airflow.static_babynames_partitioned')
     '2015-01-01'
-    '''
+    """
     from airflow.hooks.hive_hooks import HiveMetastoreHook
     if '.' in table:
         schema, table = table.split('.')
     hh = HiveMetastoreHook(metastore_conn_id=metastore_conn_id)
     return hh.max_partition(
-        schema=schema, table_name=table, field=field)
+        schema=schema, table_name=table, field=field, filter_map=filter_map)
 
 
 def _closest_date(target_dt, date_list, before_target=None):


### PR DESCRIPTION
**Some more manual tests pending, also need to make it python3 compatible to pass CI**

Adding back support for filter in max_partition().

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2202) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2202


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Adding back support for filter in max_partition() which could be used by some valid use cases. It will work for tables with multiple partitions, which is the behavior before (tho the doc stated it only works for single partitioned table). This change also kept the behavior when trying to get max partition on a sub-partitioned table without supplying filter--it will return the max partition value of the partition key even it is not unique.

Some extra checks are added to provide more meaningful exception messages.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added test_hive_hook.py to test _get_max_partition_from_part_names(). Also tested on our local branch.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
