### PR TITLE
[AIRFLOW-2204] Fix webserver debug mode

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -16,6 +16,7 @@
 import unittest
 
 from mock import patch, Mock, MagicMock
+from time import sleep
 
 import psutil
 
@@ -57,3 +58,14 @@ class TestCLI(unittest.TestCase):
 
         with patch('psutil.Process', return_value=self.process):
             self.assertEqual(get_num_ready_workers_running(self.gunicorn_master_proc), 0)
+
+    def test_cli_webserver_debug(self):
+        p = psutil.Popen(["airflow", "webserver", "-d"])
+        sleep(3)  # wait for webserver to start
+        return_code = p.poll()
+        self.assertEqual(
+            None,
+            return_code,
+            "webserver terminated with return code {} in debug mode".format(return_code))
+        p.terminate()
+        p.wait()


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2204) issues and references them in the PR title. 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

The command `airflow webserver -d` crashes because it tries to call the method run from the `cached_app` (from `airflow.www.app`) returned value, i.e. a `DispatcherMiddleware` instance. To run the flask app in debug mode (without gunicorn) it has to be created directly via `create_app` (also from `airflow.www.app`), that returns the Flask instance.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Very small changes, just a variable assign pushed a few lines down the usual flow and a line added for the debug flow. 
(Some are to fix PEP8 compliance and pass `git diff upstream/master -u -- "*.py" | flake8 --diff`)

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
