### PR TITLE
[AIRFLOW-2205] Remove unsupported args from JdbcHook doc

### DIFF
--- a/airflow/hooks/jdbc_hook.py
+++ b/airflow/hooks/jdbc_hook.py
@@ -23,21 +23,9 @@ class JdbcHook(DbApiHook):
     """
     General hook for jdbc db access.
 
-    If a connection id is specified, host, port, schema, username and password will be taken from the predefined connection.
+    JDBC URL, username and password will be taken from the predefined connection.
+    Note that the whole JDBC URL must be specified in the "host" field in the DB.
     Raises an airflow error if the given connection id doesn't exist.
-    Otherwise host, port, schema, username and password can be specified on the fly.
-
-    :param jdbc_url: jdbc connection url
-    :type jdbc_url: string
-    :param jdbc_driver_name: jdbc driver name
-    :type jdbc_driver_name: string
-    :param jdbc_driver_loc: path to jdbc driver
-    :type jdbc_driver_loc: string
-    :param conn_id: reference to a predefined database
-    :type conn_id: string
-    :param sql: the sql code to be executed
-    :type sql: string or string pointing to a template file. File must have
-        a '.sql' extensions.
     """
 
     conn_name_attr = 'jdbc_conn_id'

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -311,6 +311,7 @@ interface when possible and acting as building blocks for operators.
       HiveServer2Hook
 .. autoclass:: airflow.hooks.http_hook.HttpHook
 .. autoclass:: airflow.hooks.druid_hook.DruidHook
+.. autoclass:: airflow.hooks.jdbc_hook.JdbcHook
 .. autoclass:: airflow.hooks.mssql_hook.MsSqlHook
 .. autoclass:: airflow.hooks.mysql_hook.MySqlHook
 .. autoclass:: airflow.hooks.postgres_hook.PostgresHook


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2205


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

JdbcHook's docstring has unsupported arguments,
a wrongly named argument and unimplemented feature description.
This PR fixes them and adds JdbcHook to the API reference.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR doesn't need testing since it's documentation fix. I ran docs/build.sh locally and confirmed that the API document was generated as expected.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
