### PR TITLE
[AIRFLOW-2206] Remove unsupported args from JdbcOperator doc

### DIFF
--- a/airflow/operators/jdbc_operator.py
+++ b/airflow/operators/jdbc_operator.py
@@ -22,16 +22,8 @@ class JdbcOperator(BaseOperator):
 
     Requires jaydebeapi.
 
-    :param jdbc_url: driver specific connection url with string variables, e.g. for exasol jdbc:exa:{0}:{1};schema={2}
-    Template vars are defined like this: {0} = hostname, {1} = port, {2} = dbschema, {3} = extra
-    :type jdbc_url: string
-    :param jdbc_driver_name: classname of the specific jdbc driver, for exasol com.exasol.jdbc.EXADriver
-    :type jdbc_driver_name: string
-    :param jdbc_driver_loc: absolute path to jdbc driver location, for example /var/exasol/exajdbc.jar
-    :type jdbc_driver_loc: string
-
-    :param conn_id: reference to a predefined database
-    :type conn_id: string
+    :param jdbc_conn_id: reference to a predefined database
+    :type jdbc_conn_id: string
     :param sql: the sql code to be executed
     :type sql: Can receive a str representing a sql statement,
         a list of str (sql statements), or reference to a template file.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2206


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

JdbcOperator's docstring has unsupported arguments and
a wrongly named argument. This PR fixes them.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR doesn't need testing since it's documentation fix. I ran docs/build.sh locally and confirmed that the API reference is generated as expected.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
