### PR TITLE
[AIRFLOW-2207] Fix flaky test that uses app.cached_app()

### DIFF
--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -453,6 +453,8 @@ class TestMountPoint(unittest.TestCase):
         configuration.conf.set("webserver", "base_url", "http://localhost:8080/test")
         config = dict()
         config['WTF_CSRF_METHODS'] = []
+        # Clear cached app to remount base_url forcefully
+        application.app = None
         app = application.cached_app(config=config, testing=True)
         self.client = Client(app)
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2207


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

tests.www.test_views:TestMountPoint.test_mount changes base_url
then calls airflow.www.app.cached_app().
But if another test calls app.cached_app() first without changing
base_url, succeeding test_mount fails on Travis.
So test_mount should clear cached app for itself in its setup method
so as to remount base_url forcefully.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR does not need a new test, because it's a fix for existing test case. I ran `run_unit_tests.sh tests.www.test_views` with another test case that calls app.cached_app() and confirmed both of them succeed.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
