### PR TITLE
[AIRFLOW-2209] restore flask_login imports

### DIFF
--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -18,7 +18,7 @@ from sys import version_info
 
 import base64
 import flask_login
-from flask_login import current_user
+from flask_login import login_required, current_user, logout_user  # noqa: F401
 from flask import flash, Response
 from wtforms import Form, PasswordField, StringField
 from wtforms.validators import InputRequired


### PR DESCRIPTION
### JIRA
- My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-2209] AttributeError: module 'airflow.contrib.auth.backends.password_auth' has no attribute 'login_required'"
    - https://issues.apache.org/jira/browse/AIRFLOW-2209


### Description
- The solution restores missing imports in line with the other `auth.backends` modules.

