### PR TITLE
[AIRFLOW-2212] Fix ungenerated sensor API reference

### DIFF
--- a/airflow/contrib/sensors/hdfs_sensor.py
+++ b/airflow/contrib/sensors/hdfs_sensor.py
@@ -25,6 +25,7 @@ class HdfsSensorRegex(HdfsSensor):
     def poke(self, context):
         """
         poke matching files in a directory with self.regex
+
         :return: Bool depending on the search criteria
         """
         sb = self.hook(self.hdfs_conn_id).get_conn()
@@ -53,6 +54,7 @@ class HdfsSensorFolder(HdfsSensor):
     def poke(self, context):
         """
         poke for a non empty directory
+
         :return: Bool depending on the search criteria
         """
         sb = self.hook(self.hdfs_conn_id).get_conn()

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -184,9 +184,13 @@ Sensors
 .. autoclass:: airflow.contrib.sensors.emr_job_flow_sensor.EmrJobFlowSensor
 .. autoclass:: airflow.contrib.sensors.emr_step_sensor.EmrStepSensor
 .. autoclass:: airflow.contrib.sensors.file_sensor.FileSensor
-.. autoclass:: airflow.contrib.sensors.ftp_sensor.FtpSensor
-.. autoclass:: airflow.contrib.sensors.gcs_sensor.GcsSensor
-.. autoclass:: airflow.contrib.sensors.hdfs_sensor.HdfsSensor
+.. autoclass:: airflow.contrib.sensors.ftp_sensor.FTPSensor
+.. autoclass:: airflow.contrib.sensors.ftp_sensor.FTPSSensor
+.. autoclass:: airflow.contrib.sensors.gcs_sensor.GoogleCloudStorageObjectSensor
+.. autoclass:: airflow.contrib.sensors.gcs_sensor.GoogleCloudStorageObjectUpdatedSensor
+.. autoclass:: airflow.contrib.sensors.gcs_sensor.GoogleCloudStoragePrefixSensor
+.. autoclass:: airflow.contrib.sensors.hdfs_sensor.HdfsSensorFolder
+.. autoclass:: airflow.contrib.sensors.hdfs_sensor.HdfsSensorRegex
 .. autoclass:: airflow.contrib.sensors.jira_sensor.JiraSensor
 .. autoclass:: airflow.contrib.sensors.pubsub_sensor.PubSubPullSensor
 .. autoclass:: airflow.contrib.sensors.qubole_sensor.QuboleSensor


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2212


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Some community-contributed sensors are missing from API reference.
This PR fixes docs/code.rst to refer to collect sensor classes.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR does not need a new test since it's documentation fix. I ran docs/build.sh and confirmed that the API reference was generated as expected.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
