### PR TITLE
[AIRFLOW-2208] Link to same DagRun graph from TaskInstance view

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -54,7 +54,7 @@
               Back to {{ dag.parent_dag.dag_id }}</a>
           </li>
       {% endif %}
-      <li><a href="{{ url_for("airflow.graph", dag_id=dag.dag_id, root=root) }}">
+      <li><a href="{{ url_for("airflow.graph", dag_id=dag.dag_id, root=root, execution_date=execution_date) }}">
           <span class="glyphicon glyphicon-certificate" aria-hidden="true"></span>
         Graph View</a></li>
       <li><a href="{{ url_for("airflow.tree", dag_id=dag.dag_id, num_runs=25, root=root) }}">

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -254,7 +254,7 @@ def action_logging(f):
             task_id=request.args.get('task_id'),
             dag_id=request.args.get('dag_id'))
 
-        if 'execution_date' in request.args:
+        if request.args.get('execution_date'):
             log.execution_date = timezone.parse(request.args.get('execution_date'))
 
         with create_session() as session:

--- a/tests/core.py
+++ b/tests/core.py
@@ -1579,12 +1579,12 @@ class WebUiTests(unittest.TestCase):
 
         self.dagbag = models.DagBag(include_examples=True)
         self.dag_bash = self.dagbag.dags['example_bash_operator']
-        self.dag_bash2 = self.dagbag.dags['test_example_bash_operator']
+        self.dag_python = self.dagbag.dags['example_python_operator']
         self.sub_dag = self.dagbag.dags['example_subdag_operator']
         self.runme_0 = self.dag_bash.get_task('runme_0')
         self.example_xcom = self.dagbag.dags['example_xcom']
 
-        self.dagrun_bash2 = self.dag_bash2.create_dagrun(
+        self.dagrun_python = self.dag_python.create_dagrun(
             run_id="test_{}".format(models.DagRun.id_for_date(timezone.utcnow())),
             execution_date=DEFAULT_DATE,
             start_date=timezone.utcnow(),
@@ -1611,14 +1611,16 @@ class WebUiTests(unittest.TestCase):
         self.assertIn("DAGs", resp_html)
         self.assertIn("example_bash_operator", resp_html)
 
-        # The HTML should contain data for the last-run. A link to the specific run, and the text of
-        # the date.
+        # The HTML should contain data for the last-run. A link to the specific run,
+        #  and the text of the date.
         url = "/admin/airflow/graph?" + urlencode({
-            "dag_id": self.dag_bash2.dag_id,
-            "execution_date": self.dagrun_bash2.execution_date,
+            "dag_id": self.dag_python.dag_id,
+            "execution_date": self.dagrun_python.execution_date,
         }).replace("&", "&amp;")
         self.assertIn(url, resp_html)
-        self.assertIn(self.dagrun_bash2.execution_date.strftime("%Y-%m-%d %H:%M"), resp_html)
+        self.assertIn(
+            self.dagrun_python.execution_date.strftime("%Y-%m-%d %H:%M"),
+            resp_html)
 
     def test_query(self):
         response = self.app.get('/admin/queryview/')
@@ -1645,6 +1647,10 @@ class WebUiTests(unittest.TestCase):
         response = self.app.get(
             '/admin/airflow/graph?dag_id=example_bash_operator')
         self.assertIn("runme_0", response.data.decode('utf-8'))
+        # confirm that the graph page loads when execution_date is blank
+        response = self.app.get(
+            '/admin/airflow/graph?dag_id=example_bash_operator&execution_date=')
+        self.assertIn("runme_0", response.data.decode('utf-8'))
         response = self.app.get(
             '/admin/airflow/tree?num_runs=25&dag_id=example_bash_operator')
         self.assertIn("runme_0", response.data.decode('utf-8'))
@@ -1656,8 +1662,8 @@ class WebUiTests(unittest.TestCase):
         self.assertIn("example_bash_operator", response.data.decode('utf-8'))
         response = self.app.get(
             '/admin/airflow/landing_times?'
-            'days=30&dag_id=test_example_bash_operator')
-        self.assertIn("test_example_bash_operator", response.data.decode('utf-8'))
+            'days=30&dag_id=example_python_operator')
+        self.assertIn("example_python_operator", response.data.decode('utf-8'))
         response = self.app.get(
             '/admin/airflow/landing_times?'
             'days=30&dag_id=example_xcom')
@@ -1696,16 +1702,16 @@ class WebUiTests(unittest.TestCase):
             '/admin/airflow/task_stats')
         self.assertIn("example_bash_operator", response.data.decode('utf-8'))
         url = (
-            "/admin/airflow/success?task_id=run_this_last&"
-            "dag_id=test_example_bash_operator&upstream=false&downstream=false&"
+            "/admin/airflow/success?task_id=print_the_context&"
+            "dag_id=example_python_operator&upstream=false&downstream=false&"
             "future=false&past=false&execution_date={}&"
             "origin=/admin".format(DEFAULT_DATE_DS))
         response = self.app.get(url)
         self.assertIn("Wait a minute", response.data.decode('utf-8'))
         response = self.app.get(url + "&confirmed=true")
         response = self.app.get(
-            '/admin/airflow/clear?task_id=run_this_last&'
-            'dag_id=test_example_bash_operator&future=true&past=false&'
+            '/admin/airflow/clear?task_id=print_the_context&'
+            'dag_id=example_python_operator&future=true&past=false&'
             'upstream=true&downstream=false&'
             'execution_date={}&'
             'origin=/admin'.format(DEFAULT_DATE_DS))
@@ -1724,8 +1730,8 @@ class WebUiTests(unittest.TestCase):
         self.assertIn("section-1-task-5", response.data.decode('utf-8'))
         response = self.app.get(url + "&confirmed=true")
         url = (
-            "/admin/airflow/clear?task_id=runme_1&"
-            "dag_id=test_example_bash_operator&future=false&past=false&"
+            "/admin/airflow/clear?task_id=print_the_context&"
+            "dag_id=example_python_operator&future=false&past=false&"
             "upstream=false&downstream=true&"
             "execution_date={}&"
             "origin=/admin".format(DEFAULT_DATE_DS))
@@ -1770,10 +1776,10 @@ class WebUiTests(unittest.TestCase):
     def test_fetch_task_instance(self):
         url = (
             "/admin/airflow/object/task_instances?"
-            "dag_id=test_example_bash_operator&"
+            "dag_id=example_python_operator&"
             "execution_date={}".format(DEFAULT_DATE_DS))
         response = self.app.get(url)
-        self.assertIn("run_this_last", response.data.decode('utf-8'))
+        self.assertIn("print_the_context", response.data.decode('utf-8'))
 
     def tearDown(self):
         configuration.conf.set("webserver", "expose_config", "False")


### PR DESCRIPTION
Allow graph view to accept blank execution_date and pass it
through when it's available.

Make sure you have checked _all_ steps below.
### JIRA
- [x] My PR addresses the following [Airflow-22208](https://issues.apache.org/jira/browse/AIRFLOW-2208/) issues and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

No changes to the UI. I've just passed the execution_date to the graph view from the task_instance view. I've also had to change the check to allow for a blank execution_date. Without the change the UI fails on trying to parse the execution_date while logging. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I've added a check that the UI renders fine if a blank execution_date is passed into the graph UI under WebUI test method. This test is currently failing on master on setup since it's trying to instantiate a non-existsent example Dag. I've replaced the references to it to example_python_operator which does exist. Let me know if you would like me to handle this differently.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
