### PR TITLE
[AIRFLOW-2220] Remove duplicate numeric list entry in security.rst

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -294,7 +294,6 @@ backend. In order to setup an application:
 
 1. Navigate to https://console.developers.google.com/apis/
 2. Select 'Credentials' from the left hand nav
-2. Select 'Credentials' from the left hand nav
 3. Click 'Create credentials' and choose 'OAuth client ID'
 4. Choose 'Web application'
 5. Fill in the required information (the 'Authorized redirect URIs' must be fully qualifed e.g. http://airflow.example.com/oauth2callback)


### PR DESCRIPTION
This duplicate entry was causing rst formatting issues in the security
section of the documentation.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2220)

### Description
- In the security section of the documentation under Google Authentication there was a miss formatted numeric list. This change fixes that.

### Tests
- I have verified the fix and attached screen shots to the ticket

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
