### PR TITLE
[AIRFLOW-878] Use absolute gunicorn executable location

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -739,8 +739,7 @@ def webserver(args):
                 os.path.dirname(sys.executable), "gunicorn")
             if os.path.isfile(location) and os.access(location, os.X_OK):
                 return location
-            else:
-                raise AirflowException("gunicorn could not be found")
+            raise AirflowException("gunicorn could not be found")
 
         gunicorn_exec = get_gunicorn_location()
 

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -734,8 +734,18 @@ def webserver(args):
                 =================================================================\
             '''.format(**locals())))
 
+        def get_gunicorn_location():
+            location = os.path.join(
+                os.path.dirname(sys.executable), "gunicorn")
+            if os.path.isfile(location) and os.access(location, os.X_OK):
+                return location
+            else:
+                raise AirflowException("gunicorn could not be found")
+
+        gunicorn_exec = get_gunicorn_location()
+
         run_args = [
-            'gunicorn',
+            gunicorn_exec,
             '-w', str(num_workers),
             '-k', str(args.workerclass),
             '-t', str(worker_timeout),


### PR DESCRIPTION
### JIRA
- [x ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-878] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-878

### Description
- [x ] Use absolute path for gunicorn

### Tests
- [x ] Unable to run test locally even my attempted to build a Docker container failed (Kerberos). It would be nice to have a minimal test setup without all the dependencies aka core.

### Commits
- [x ] My commits all reference JIRA issues in their subject lines.
- [x ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
