### PR TITLE
[AIRFLOW-1153] Allow HiveOperators to take hiveconfs

### DIFF
--- a/airflow/operators/hive_operator.py
+++ b/airflow/operators/hive_operator.py
@@ -30,6 +30,9 @@ class HiveOperator(BaseOperator):
     :type hql: string
     :param hive_cli_conn_id: reference to the Hive database
     :type hive_cli_conn_id: string
+    :param hiveconfs: if defined, these key value pairs will be passed
+        to hive as ``-hiveconf "key"="value"``
+    :type hiveconfs: dict
     :param hiveconf_jinja_translate: when True, hiveconf-type templating
         ${var} gets translated into jinja-type templating {{ var }} and
         ${hiveconf:var} gets translated into jinja-type templating {{ var }}.
@@ -51,7 +54,7 @@ class HiveOperator(BaseOperator):
     """
 
     template_fields = ('hql', 'schema', 'hive_cli_conn_id', 'mapred_queue',
-                       'mapred_job_name', 'mapred_queue_priority')
+                       'hiveconfs', 'mapred_job_name', 'mapred_queue_priority')
     template_ext = ('.hql', '.sql',)
     ui_color = '#f0e4ec'
 
@@ -60,6 +63,7 @@ class HiveOperator(BaseOperator):
             self, hql,
             hive_cli_conn_id='hive_cli_default',
             schema='default',
+            hiveconfs=None,
             hiveconf_jinja_translate=False,
             script_begin_tag=None,
             run_as_owner=False,
@@ -69,15 +73,15 @@ class HiveOperator(BaseOperator):
             *args, **kwargs):
 
         super(HiveOperator, self).__init__(*args, **kwargs)
-        self.hiveconf_jinja_translate = hiveconf_jinja_translate
         self.hql = hql
-        self.schema = schema
         self.hive_cli_conn_id = hive_cli_conn_id
+        self.schema = schema
+        self.hiveconfs = hiveconfs or {}
+        self.hiveconf_jinja_translate = hiveconf_jinja_translate
         self.script_begin_tag = script_begin_tag
         self.run_as = None
         if run_as_owner:
             self.run_as = self.dag.owner
-
         self.mapred_queue = mapred_queue
         self.mapred_queue_priority = mapred_queue_priority
         self.mapred_job_name = mapred_job_name
@@ -114,8 +118,13 @@ class HiveOperator(BaseOperator):
                 .format(ti.hostname.split('.')[0], ti.dag_id, ti.task_id,
                         ti.execution_date.isoformat())
 
-        self.hook.run_cli(hql=self.hql, schema=self.schema,
-                          hive_conf=context_to_airflow_vars(context))
+        if self.hiveconf_jinja_translate:
+            self.hiveconfs = context_to_airflow_vars(context)
+        else:
+            self.hiveconfs.update(context_to_airflow_vars(context))
+
+        self.log.info('Passing HiveConf: %s', self.hiveconfs)
+        self.hook.run_cli(hql=self.hql, schema=self.schema, hive_conf=self.hiveconfs)
 
     def dry_run(self):
         self.hook = self.get_hook()

--- a/tests/operators/hive_operator.py
+++ b/tests/operators/hive_operator.py
@@ -91,6 +91,16 @@ class HiveOperatorTest(HiveEnvironmentTest):
         t.prepare_template()
         self.assertEqual(t.hql, "SELECT {{ num_col }} FROM {{ table }};")
 
+    def test_hiveconf(self):
+        hql = "SELECT * FROM ${hiveconf:table} PARTITION (${hiveconf:day});"
+        t = operators.hive_operator.HiveOperator(
+            hiveconfs={'table': 'static_babynames', 'day': '{{ ds }}'},
+            task_id='dry_run_basic_hql', hql=hql, dag=self.dag)
+        t.prepare_template()
+        self.assertEqual(
+            t.hql,
+            "SELECT * FROM ${hiveconf:table} PARTITION (${hiveconf:day});")
+
 
 if 'AIRFLOW_RUNALL_TESTS' in os.environ:
 


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1153


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

HiveOperator can only replace variables via jinja and the replacements
are global to the dag through the context and user_defined_macros.
It would be much more flexible to open up hive_conf to the HiveOperator
level so hive scripts can be recycled at the task level, leveraging
HiveHook already existing hive_conf param and _prepare_hiveconf
function.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added test_hiveconf in tests/operators/hive_operator.py


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
