### PR TITLE
[AIRFLOW-2226] Rename google_cloud_storage_default to google_cloud_default

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,10 @@ Dataflow job labeling is now supported in Dataflow{Java,Python}Operator with a d
 "airflow-version" label, please upgrade your google-cloud-dataflow or apache-beam version
 to 2.2.0 or greater.
 
+### Google cloud connection string
+
+With Airflow 1.9 or lower there where two connection strings for the Google Cloud operators, both `google_cloud_storage_default` and `google_cloud_default`. This can be confusing and therefore the `google_cloud_storage_default` connection id has been replaced with `google_cloud_default` to make the connection id consistent across Airflow.
+
 ## Airflow 1.9
 
 ### SSH Hook updates, along with new SSH Operator & SFTP Operator

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -27,7 +27,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
     """
 
     def __init__(self,
-                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None):
         super(GoogleCloudStorageHook, self).__init__(google_cloud_storage_conn_id,
                                                      delegate_to)

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -242,7 +242,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
                  gcs_schema_object=None,
                  time_partitioning={},
                  bigquery_conn_id='bigquery_default',
-                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
                  *args, **kwargs):
 
@@ -376,7 +376,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
                  allow_quoted_newlines=False,
                  allow_jagged_rows=False,
                  bigquery_conn_id='bigquery_default',
-                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
                  src_fmt_configs={},
                  *args, **kwargs):

--- a/airflow/contrib/operators/file_to_gcs.py
+++ b/airflow/contrib/operators/file_to_gcs.py
@@ -36,13 +36,13 @@ class FileToGoogleCloudStorageOperator(BaseOperator):
     :type delegate_to: string
     """
     template_fields = ('src', 'dst', 'bucket')
-    
+
     @apply_defaults
     def __init__(self,
                  src,
                  dst,
                  bucket,
-                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 google_cloud_storage_conn_id='google_cloud_default',
                  mime_type='application/octet-stream',
                  delegate_to=None,
                  *args,

--- a/airflow/contrib/operators/gcs_copy_operator.py
+++ b/airflow/contrib/operators/gcs_copy_operator.py
@@ -67,7 +67,7 @@ class GoogleCloudStorageCopyOperator(BaseOperator):
                  source_files_delimiter=None,
                  destination_bucket=None,
                  destination_directory='',
-                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
                  *args,
                  **kwargs):

--- a/airflow/contrib/operators/gcs_download_operator.py
+++ b/airflow/contrib/operators/gcs_download_operator.py
@@ -53,7 +53,7 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
                  object,
                  filename=None,
                  store_to_xcom_key=None,
-                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
                  *args,
                  **kwargs):

--- a/airflow/contrib/operators/gcs_list_operator.py
+++ b/airflow/contrib/operators/gcs_list_operator.py
@@ -60,7 +60,7 @@ class GoogleCloudStorageListOperator(BaseOperator):
                  bucket,
                  prefix=None,
                  delimiter=None,
-                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
                  *args,
                  **kwargs):

--- a/airflow/contrib/operators/gcs_operator.py
+++ b/airflow/contrib/operators/gcs_operator.py
@@ -85,7 +85,7 @@ class GoogleCloudStorageCreateBucketOperator(BaseOperator):
                  location='US',
                  project_id=None,
                  labels=None,
-                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
                  *args,
                  **kwargs):

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -135,7 +135,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                  allow_jagged_rows=False,
                  max_id_key=None,
                  bigquery_conn_id='bigquery_default',
-                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
                  schema_update_options=(),
                  src_fmt_configs={},

--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -65,7 +65,7 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
                  destination_bucket=None,
                  destination_object=None,
                  move_object=False,
-                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
                  *args,
                  **kwargs):

--- a/airflow/contrib/operators/mysql_to_gcs.py
+++ b/airflow/contrib/operators/mysql_to_gcs.py
@@ -45,7 +45,7 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
                  schema_filename=None,
                  approx_max_file_size_bytes=1900000000,
                  mysql_conn_id='mysql_default',
-                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 google_cloud_storage_conn_id='google_cloud_default',
                  schema=None,
                  delegate_to=None,
                  *args,

--- a/airflow/contrib/operators/postgres_to_gcs_operator.py
+++ b/airflow/contrib/operators/postgres_to_gcs_operator.py
@@ -44,7 +44,7 @@ class PostgresToGoogleCloudStorageOperator(BaseOperator):
                  schema_filename=None,
                  approx_max_file_size_bytes=1900000000,
                  postgres_conn_id='postgres_default',
-                 google_cloud_storage_conn_id='google_cloud_storage_default',
+                 google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
                  parameters=None,
                  *args,

--- a/airflow/contrib/sensors/gcs_sensor.py
+++ b/airflow/contrib/sensors/gcs_sensor.py
@@ -28,7 +28,7 @@ class GoogleCloudStorageObjectSensor(BaseSensorOperator):
             self,
             bucket,
             object,  # pylint:disable=redefined-builtin
-            google_cloud_conn_id='google_cloud_storage_default',
+            google_cloud_conn_id='google_cloud_default',
             delegate_to=None,
             *args,
             **kwargs):
@@ -84,7 +84,7 @@ class GoogleCloudStorageObjectUpdatedSensor(BaseSensorOperator):
             bucket,
             object,  # pylint:disable=redefined-builtin
             ts_func=ts_function,
-            google_cloud_conn_id='google_cloud_storage_default',
+            google_cloud_conn_id='google_cloud_default',
             delegate_to=None,
             *args,
             **kwargs):
@@ -135,7 +135,7 @@ class GoogleCloudStoragePrefixSensor(BaseSensorOperator):
         self,
         bucket,
         prefix,
-        google_cloud_conn_id='google_cloud_storage_default',
+        google_cloud_conn_id='google_cloud_default',
         delegate_to=None,
         *args,
         **kwargs):


### PR DESCRIPTION
The Google cloud operators uses both google_cloud_storage_default and google_cloud_default as a default conn_id. This is confusing and the google_cloud_storage_default conn_id isnt initialized by default in db.py. Therefore we rename the google_cloud_storage_default to google_cloud_default for simplicity and convenience.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2226


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
