### PR TITLE
[AIRFLOW-2227] allow the ability to delete an airflow variable using the variable class 

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4285,6 +4285,7 @@ class Variable(Base, LoggingMixin):
         session.add(Variable(key=key, val=stored_value))
         session.flush()
 
+
     @classmethod
     @provide_session
     def delete(cls, key, session=None):
@@ -4295,6 +4296,7 @@ class Variable(Base, LoggingMixin):
             session.rollback()
             logging.warning("Failed to delete key {}".format(key))
             logging.exception(e)
+
 
     @classmethod
     @provide_session

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4285,24 +4285,22 @@ class Variable(Base, LoggingMixin):
         session.add(Variable(key=key, val=stored_value))
         session.flush()
 
-
     @classmethod
     @provide_session
     def delete(cls, key, session=None):
         try:
-            session.query(Variable).filter(Variable.key == key).delete()
+            session.query(cls).filter(cls.key == key).delete()
             session.commit()
         except Exception as e:
             session.rollback()
             logging.warning("Failed to delete key {}".format(key))
             logging.exception(e)
 
-
     @classmethod
     @provide_session
     def get_keys(cls, session=None):
         try:
-            keys = {obj.key for obj in session.query(Variable).all()}
+            keys = {obj.key for obj in session.query(cls).all()}
             return keys
         except Exception as e:
             logging.warning("Failed to retrieve variables keys")

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4286,6 +4286,29 @@ class Variable(Base, LoggingMixin):
         session.flush()
 
 
+    @classmethod
+    @provide_session
+    def delete(cls, key, session=None):
+        try:
+            session.query(Variable).filter(Variable.key == key).delete()
+            session.commit()
+        except Exception as e:
+            session.rollback()
+            logging.warning("Failed to delete key {}".format(key))
+            logging.exception(e)
+
+
+    @classmethod
+    @provide_session
+    def get_keys(cls, session=None):
+        try:
+            keys = {obj.key for obj in session.query(Variable).all()}
+            return keys
+        except Exception as e:
+            logging.warning("Failed to get keys")
+            logging.exception(e)
+
+
 class XCom(Base, LoggingMixin):
     """
     Base class for XCom objects.

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4285,7 +4285,6 @@ class Variable(Base, LoggingMixin):
         session.add(Variable(key=key, val=stored_value))
         session.flush()
 
-
     @classmethod
     @provide_session
     def delete(cls, key, session=None):
@@ -4297,7 +4296,6 @@ class Variable(Base, LoggingMixin):
             logging.warning("Failed to delete key {}".format(key))
             logging.exception(e)
 
-
     @classmethod
     @provide_session
     def get_keys(cls, session=None):
@@ -4305,7 +4303,7 @@ class Variable(Base, LoggingMixin):
             keys = {obj.key for obj in session.query(Variable).all()}
             return keys
         except Exception as e:
-            logging.warning("Failed to get keys")
+            logging.warning("Failed to retrieve variables keys")
             logging.exception(e)
 
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2227


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In order to allow using migration (via alembic or customized scripts) one need the ability to delete variables (delete function).Another utility function was added to allow retrieval of all the current variables keys.t. This PR allow these abilities.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 Variable methods in models.py has no tests [Link](https://github.com/apache/incubator-airflow/blob/master/tests/models.py)

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
