### PR TITLE
[AIRFLOW-2234] Enable insert_rows for PrestoHook

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -208,8 +208,8 @@ class DbApiHook(BaseHook):
                     for cell in row:
                         l.append(self._serialize_cell(cell, conn))
                     values = tuple(l)
-                    placeholders = ["%s",]*len(values)
-                    sql = "INSERT INTO {0} {1} VALUES ({2});".format(
+                    placeholders = ["%s", ] * len(values)
+                    sql = "INSERT INTO {0} {1} VALUES ({2})".format(
                         table,
                         target_fields,
                         ",".join(placeholders))

--- a/airflow/hooks/presto_hook.py
+++ b/airflow/hooks/presto_hook.py
@@ -109,5 +109,18 @@ class PrestoHook(DbApiHook):
         """
         return super(PrestoHook, self).run(self._strip_sql(hql), parameters)
 
-    def insert_rows(self):
-        raise NotImplementedError()
+    # TODO Enable commit_every once PyHive supports transaction.
+    # Unfortunately, PyHive 0.5.1 doesn't support transaction for now,
+    # whereas Presto 0.132+ does.
+    def insert_rows(self, table, rows, target_fields=None):
+        """
+        A generic way to insert a set of tuples into a table.
+
+        :param table: Name of the target table
+        :type table: str
+        :param rows: The rows to insert into the table
+        :type rows: iterable of tuples
+        :param target_fields: The names of the columns to fill in the table
+        :type target_fields: iterable of strings
+        """
+        super(PrestoHook, self).insert_rows(table, rows, target_fields, 0)

--- a/tests/hooks/test_dbapi_hook.py
+++ b/tests/hooks/test_dbapi_hook.py
@@ -23,17 +23,18 @@ class TestDbApiHook(unittest.TestCase):
 
     def setUp(self):
         super(TestDbApiHook, self).setUp()
-        
+
         self.cur = mock.MagicMock()
-        self.conn = conn = mock.MagicMock()
+        self.conn = mock.MagicMock()
         self.conn.cursor.return_value = self.cur
-        
+        conn = self.conn
+
         class TestDBApiHook(DbApiHook):
             conn_name_attr = 'test_conn_id'
-            
+
             def get_conn(self):
                 return conn
-        
+
         self.db_hook = TestDBApiHook()
 
     def test_get_records(self):
@@ -73,3 +74,56 @@ class TestDbApiHook(unittest.TestCase):
         self.conn.close.assert_called_once()
         self.cur.close.assert_called_once()
         self.cur.execute.assert_called_once_with(statement)
+
+    def test_insert_rows(self):
+        table = "table"
+        rows = [("hello",),
+                ("world",)]
+
+        self.db_hook.insert_rows(table, rows)
+
+        self.conn.close.assert_called_once()
+        self.cur.close.assert_called_once()
+
+        commit_count = 2  # The first and last commit
+        self.assertEqual(commit_count, self.conn.commit.call_count)
+
+        sql = "INSERT INTO {}  VALUES (%s)".format(table)
+        for row in rows:
+            self.cur.execute.assert_any_call(sql, row)
+
+    def test_insert_rows_target_fields(self):
+        table = "table"
+        rows = [("hello",),
+                ("world",)]
+        target_fields = ["field"]
+
+        self.db_hook.insert_rows(table, rows, target_fields)
+
+        self.conn.close.assert_called_once()
+        self.cur.close.assert_called_once()
+
+        commit_count = 2  # The first and last commit
+        self.assertEqual(commit_count, self.conn.commit.call_count)
+
+        sql = "INSERT INTO {} ({}) VALUES (%s)".format(table, target_fields[0])
+        for row in rows:
+            self.cur.execute.assert_any_call(sql, row)
+
+    def test_insert_rows_commit_every(self):
+        table = "table"
+        rows = [("hello",),
+                ("world",)]
+        commit_every = 1
+
+        self.db_hook.insert_rows(table, rows, commit_every=commit_every)
+
+        self.conn.close.assert_called_once()
+        self.cur.close.assert_called_once()
+
+        commit_count = 2 + divmod(len(rows), commit_every)[0]
+        self.assertEqual(commit_count, self.conn.commit.call_count)
+
+        sql = "INSERT INTO {}  VALUES (%s)".format(table)
+        for row in rows:
+            self.cur.execute.assert_any_call(sql, row)

--- a/tests/hooks/test_presto_hook.py
+++ b/tests/hooks/test_presto_hook.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import unittest
+
+from mock import patch
+
+from airflow.hooks.presto_hook import PrestoHook
+
+
+class TestPrestoHook(unittest.TestCase):
+
+    def setUp(self):
+        super(TestPrestoHook, self).setUp()
+
+        self.cur = mock.MagicMock()
+        self.conn = mock.MagicMock()
+        self.conn.cursor.return_value = self.cur
+        conn = self.conn
+
+        class UnitTestPrestoHook(PrestoHook):
+            conn_name_attr = 'test_conn_id'
+
+            def get_conn(self):
+                return conn
+
+        self.db_hook = UnitTestPrestoHook()
+
+    @patch('airflow.hooks.dbapi_hook.DbApiHook.insert_rows')
+    def test_insert_rows(self, mock_insert_rows):
+        table = "table"
+        rows = [("hello",),
+                ("world",)]
+        target_fields = None
+        self.db_hook.insert_rows(table, rows, target_fields)
+        mock_insert_rows.assert_called_once_with(table, rows, None, 0)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2234


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

PrestoHook.insert_rows() raises NotImplementedError for now.
But Presto 0.126+ allows specifying column names in INSERT queries,
so we can leverage DbApiHook.insert_rows() almost as is.
This PR implements this function, and includes some flake8 fixes.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added some tests to TestDbApiHook and newly added TestPrestoHook.
In addition, I manually called PrestoHook.insert_rows() and confirmed that it worked as expected.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
