### PR TITLE
[AIRFLOW-2241] Set pool slot to 0 if the user specified pool doesn't …

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1105,7 +1105,10 @@ class SchedulerJob(BaseJob):
                     )
                     open_slots = 0
                 else:
-                    open_slots = pools[pool].open_slots(session=session)
+                    user_pool = pools.get(pool)
+                    # If user specified task_instance pool not exists in model.Pool,
+                    # In this case scheduler should skip the task.
+                    open_slots = user_pool.open_slots(session=session) if user_pool else 0
 
             num_queued = len(task_instances)
             self.log.info(


### PR DESCRIPTION
…exist

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2241


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
User could accidentally put a noon-exist pool name into the dag which will cause the scheduler to throw an exception.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
not sure if this needs a test.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
