### PR TITLE
[AIRFLOW-2244] bugfix: remove legacy LongText code from models.py

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -116,11 +116,6 @@ def get_fernet():
         raise AirflowException("Could not create Fernet object: {}".format(ve))
 
 
-if 'mysql' in settings.SQL_ALCHEMY_CONN:
-    LongText = LONGTEXT
-else:
-    LongText = Text
-
 # Used by DAG context_managers
 _CONTEXT_MANAGER_DAG = None
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2244


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Trivial change to remove code that is iterating an empty variable and getting a TypeError.  This specifically started popping up after configuring remote logging to Azure Storage.  I think logging may be getting initialized before the rest of the config, resulting in the None value in settings.SQL_ALCHEMY_CONN

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Removing non-referenced code, normal test cases should cover.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
