### PR TITLE
[AIRFLOW-2248] Fix wrong param name in RedshiftToS3Transfer doc

### DIFF
--- a/airflow/operators/redshift_to_s3_operator.py
+++ b/airflow/operators/redshift_to_s3_operator.py
@@ -33,8 +33,8 @@ class RedshiftToS3Transfer(BaseOperator):
     :type redshift_conn_id: string
     :param aws_conn_id: reference to a specific S3 connection
     :type aws_conn_id: string
-    :param options: reference to a list of UNLOAD options
-    :type options: list
+    :param unload_options: reference to a list of UNLOAD options
+    :type unload_options: list
     """
 
     template_fields = ()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2248


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

The parameter 'unload_options' is wrongly referred to as 'options'
in the RedshiftToS3Transfer docstring. This PR fixes it.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR does not need testing since it's documentation fix. I ran docs/build.sh locally and confirmed the document is generated as expected.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
