### PR TITLE
Add qplum to Airflow users

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Currently **officially** using Airflow:
 1. [PMC](https://pmc.com/) [[@andrewm4894](https://github.com/andrewm4894)]
 1. [Postmates](http://www.postmates.com) [[@syeoryn](https://github.com/syeoryn)]
 1. [Pronto Tools](http://www.prontotools.io/) [[@zkan](https://github.com/zkan) & [@mesodiar](https://github.com/mesodiar)]
+1. [Qplum](https://qplum.co) [[@manti](https://github.com/manti)]
 1. [Qubole](https://qubole.com) [[@msumit](https://github.com/msumit)]
 1. [Quizlet](https://quizlet.com) [[@quizlet](https://github.com/quizlet)]
 1. [Quora](https://www.quora.com/)


### PR DESCRIPTION
What ? - this PR adds qplum to the users list.
Testing -  Not required
