### PR TITLE
[AIRFLOW-2258] Allow import of Parquet-format files into BigQuery

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -351,7 +351,7 @@ class BigQueryBaseCursor(LoggingMixin):
         source_format = source_format.upper()
         allowed_formats = [
             "CSV", "NEWLINE_DELIMITED_JSON", "AVRO", "GOOGLE_SHEETS",
-            "DATASTORE_BACKUP"
+            "DATASTORE_BACKUP", "PARQUET"
         ]
         if source_format not in allowed_formats:
             raise ValueError("{0} is not a valid source format. "
@@ -807,7 +807,7 @@ class BigQueryBaseCursor(LoggingMixin):
         source_format = source_format.upper()
         allowed_formats = [
             "CSV", "NEWLINE_DELIMITED_JSON", "AVRO", "GOOGLE_SHEETS",
-            "DATASTORE_BACKUP"
+            "DATASTORE_BACKUP", "PARQUET"
         ]
         if source_format not in allowed_formats:
             raise ValueError("{0} is not a valid source format. "
@@ -903,6 +903,7 @@ class BigQueryBaseCursor(LoggingMixin):
             ],
             'DATASTORE_BACKUP': ['projectionFields'],
             'NEWLINE_DELIMITED_JSON': ['autodetect', 'ignoreUnknownValues'],
+            'PARQUET': ['autodetect', 'ignoreUnknownValues'],
             'AVRO': [],
         }
         valid_configs = src_fmt_to_configs_mapping[source_format]


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
> - [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2258) issues and references them in the PR title.

### Description
> - [X] Here are some details about my PR, including screenshots of any UI changes:

Update the "allowed_formats" in bigquery_operator.py to allow files of format PARQUET.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

> I followed the instructions in the contributor guidelines and was prepared to add tests, however my change is a very simple set of additions to whitelists restricting what file types may be imported into BigQuery. It would seem that according to these testing guidelines, there ought to be tests for this, however there are none, and so I'm assuming there are good reasons for this that are not immediately obvious to me. I'm submitting this PR on the basis of this reasoning, however I am happy to take feedback and reconsider this.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
 X   1. Subject is separated from body by a blank line
 X   2. Subject is limited to 50 characters
 X   3. Subject does not end with a period
 X   4. Subject uses the imperative mood ("add", not "adding")
 X   5. Body wraps at 72 characters
 X   6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

> This runs and exits-zero.

Additional Note: I have run several Parquet-to-BQ jobs using this code, which have succeeded.