### PR TITLE
[AIRFLOW-2261] Check config/env for remote base log folder

### DIFF
--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -41,7 +41,7 @@ PROCESSOR_FILENAME_TEMPLATE = '{{ filename }}.log'
 # s3 buckets should start with "s3://"
 # gcs buckets should start with "gs://"
 # wasb buckets should start with "wasb" just to help Airflow select correct handler
-REMOTE_BASE_LOG_FOLDER = ''
+REMOTE_BASE_LOG_FOLDER = conf.get('core', 'REMOTE_BASE_LOG_FOLDER')
 
 DEFAULT_LOGGING_CONFIG = {
     'version': 1,

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -41,6 +41,7 @@ base_log_folder = {AIRFLOW_HOME}/logs
 # configuration requirements.
 remote_logging = False
 remote_log_conn_id =
+remote_base_log_folder =
 encrypt_s3_logs = False
 
 # Logging level


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2261


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
With this change, one should be able to enable remote log storage via `REMOTE_BASE_LOG_FOLDER`, `REMOTE_LOGGING`, and `REMOTE_LOG_CONN_ID` in either the config file or environment variables.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
The change is fairly minor.  Plus, I'm not sure how automated testing is set up for this (e.g. mock remote destinations)--update me and I'll add one.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
