### PR TITLE
[AIRFLOW-2264] Improve create_user cli help message

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1568,23 +1568,24 @@ class CLIFactory(object):
         # create_user
         'role': Arg(
             ('-r', '--role',),
-            help='Role of the user',
+            help='Role of the user. Existing roles include Admin, '
+                 'User, Op, Viewer, and Public',
             type=str),
         'firstname': Arg(
             ('-f', '--firstname',),
-            help='First name of the admin user',
+            help='First name of the user',
             type=str),
         'lastname': Arg(
             ('-l', '--lastname',),
-            help='Last name of the admin user',
+            help='Last name of the user',
             type=str),
         'email': Arg(
             ('-e', '--email',),
-            help='Email of the admin user',
+            help='Email of the user',
             type=str),
         'username': Arg(
             ('-u', '--username',),
-            help='Username of the admin user',
+            help='Username of the user',
             type=str),
     }
     subparsers = (


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2264


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
 improve the new create_user cli command help message.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
