### PR TITLE
[AIRFLOW-2260] SSHOperator add command template .sh files

### DIFF
--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -41,6 +41,7 @@ class SSHOperator(BaseOperator):
     """
 
     template_fields = ('command',)
+    template_ext = ('.sh',)
 
     @apply_defaults
     def __init__(self,


### PR DESCRIPTION
[AIRFLOW-2260] SSHOperator add command template .sh files

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2260


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
    Template files are not currently possible with SSHOperator. This PR adds files with the .sh extension as a template to the command parameter. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    Trivial change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
