### PR TITLE
[AIRFLOW-1729] DagBag Improve time taken in collect_dags

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -446,13 +446,12 @@ class DagBag(BaseDagBag, LoggingMixin):
         if os.path.isfile(dag_folder):
             self.process_file(dag_folder, only_if_updated=only_if_updated)
         elif os.path.isdir(dag_folder):
-            patterns = []
             for root, dirs, files in os.walk(dag_folder, followlinks=True):
-                ignore_file = [f for f in files if f == '.airflowignore']
-                if ignore_file:
-                    f = open(os.path.join(root, ignore_file[0]), 'r')
-                    patterns += [p for p in f.read().split('\n') if p]
-                    f.close()
+                patterns = []
+                ignore_file = os.path.join(root, '.airflowignore')
+                if os.path.isfile(ignore_file):
+                    with open(ignore_file, 'r') as f:
+                        patterns += [p for p in f.read().split('\n') if p]
                 for f in files:
                     try:
                         filepath = os.path.join(root, f)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1729

### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
The change will remove unnecessary accumulation of .airflowignore file entries. 


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Trivial change

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`