### PR TITLE
[AIRFLOW-2216] Use profile for AWS hook if S3 config file provided in aws_default connection extra parameters

### DIFF
--- a/airflow/contrib/hooks/aws_hook.py
+++ b/airflow/contrib/hooks/aws_hook.py
@@ -100,8 +100,11 @@ class AwsHook(BaseHook):
 
                 elif 's3_config_file' in connection_object.extra_dejson:
                     aws_access_key_id, aws_secret_access_key = \
-                        _parse_s3_config(connection_object.extra_dejson['s3_config_file'],
-                                         connection_object.extra_dejson.get('s3_config_format'))
+                        _parse_s3_config(
+                            connection_object.extra_dejson['s3_config_file'],
+                            connection_object.extra_dejson['s3_config_format'],
+                            connection_object.extra_dejson['profile']
+                        )
 
                 if region_name is None:
                     region_name = connection_object.extra_dejson.get('region_name')

--- a/tests/contrib/hooks/test_aws_hook.py
+++ b/tests/contrib/hooks/test_aws_hook.py
@@ -14,6 +14,7 @@
 #
 
 import unittest
+
 import boto3
 
 from airflow import configuration
@@ -140,6 +141,26 @@ class TestAwsHook(unittest.TestCase):
         self.assertEqual(credentials_from_hook.access_key, 'aws_access_key_id')
         self.assertEqual(credentials_from_hook.secret_key, 'aws_secret_access_key')
         self.assertIsNone(credentials_from_hook.token)
+
+    @mock.patch('airflow.contrib.hooks.aws_hook._parse_s3_config',
+                return_value=('aws_access_key_id', 'aws_secret_access_key'))
+    @mock.patch.object(AwsHook, 'get_connection')
+    def test_get_credentials_from_extra_with_s3_config_and_profile(
+        self, mock_get_connection, mock_parse_s3_config
+    ):
+        mock_connection = Connection(
+            extra='{"s3_config_format": "aws", '
+                  '"profile": "test", '
+                  '"s3_config_file": "aws-credentials", '
+                  '"region_name": "us-east-1"}')
+        mock_get_connection.return_value = mock_connection
+        hook = AwsHook()
+        hook._get_credentials(region_name=None)
+        mock_parse_s3_config.assert_called_with(
+            'aws-credentials',
+            'aws',
+            'test'
+        )
 
     @unittest.skipIf(mock_sts is None, 'mock_sts package not present')
     @mock.patch.object(AwsHook, 'get_connection')


### PR DESCRIPTION
[AIRFLOW-2216] Use profile for AWS hook if S3 config file provided in aws_default connection extra parameters; add test to validate profile set

Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. MY ISSUE ADDED:  https://issues.apache.org/jira/browse/AIRFLOW-2216


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

NO UI CHANGES MADE

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

UNIT TEST ADDED

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
