### PR TITLE
[AIRFLOW-2270] Handle removed tasks in backfill

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -2098,7 +2098,8 @@ class BackfillJob(BaseJob):
             # all tasks part of the backfill are scheduled to run
             if ti.state == State.NONE:
                 ti.set_state(State.SCHEDULED, session=session)
-            tasks_to_run[ti.key] = ti
+            if ti.state != State.REMOVED:
+                tasks_to_run[ti.key] = ti
 
         return tasks_to_run
 

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -709,6 +709,50 @@ class BackfillJobTest(unittest.TestCase):
         subdag.clear()
         dag.clear()
 
+
+    def test_backfill_execute_subdag_with_removed_task(self):
+        """
+        Ensure that subdag operators execute properly in the case where
+        an associated task of the subdag has been removed from the dag
+        definition, but has instances in the database from previous runs.
+        """
+        dag = self.dagbag.get_dag('example_subdag_operator')
+        subdag = dag.get_task('section-1').subdag
+
+        executor = TestExecutor(do_update=True)
+        job = BackfillJob(dag=subdag,
+                          start_date=DEFAULT_DATE,
+                          end_date=DEFAULT_DATE,
+                          executor=executor,
+                          donot_pickle=True)
+
+        removed_task_ti = TI(
+            task=DummyOperator(task_id='removed_task'),
+            execution_date=DEFAULT_DATE,
+            state=State.REMOVED)
+        removed_task_ti.dag_id = subdag.dag_id
+
+        session = settings.Session()
+        session.merge(removed_task_ti)
+
+        with timeout(seconds=30):
+            job.run()
+
+        for task in subdag.tasks:
+            instance = session.query(TI).filter(
+                TI.dag_id == subdag.dag_id,
+                TI.task_id == task.task_id,
+                TI.execution_date == DEFAULT_DATE).first()
+
+            self.assertIsNotNone(instance)
+            self.assertEqual(instance.state, State.SUCCESS)
+
+        removed_task_ti.refresh_from_db()
+        self.assertEqual(removed_task_ti.state, State.REMOVED)
+
+        subdag.clear()
+        dag.clear()
+
     def test_update_counters(self):
         dag = DAG(
             dag_id='test_manage_executor_state',


### PR DESCRIPTION
### JIRA
https://issues.apache.org/jira/browse/AIRFLOW-2270


### Description
Fixes issue with backfill jobs of dags, where tasks in the removed state are not run but still considered to be pending, causing an indefinite loop.

### Tests
Adds a regression test for this behavior under `test_backfill_execute_subdag_with_removed_task`
### Commits
