### PR TITLE
[AIRFLOW-2273] Add Discord webhook operator/hook

### DIFF
--- a/airflow/contrib/hooks/discord_webhook_hook.py
+++ b/airflow/contrib/hooks/discord_webhook_hook.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+import re
+
+from airflow.hooks.http_hook import HttpHook
+from airflow.exceptions import AirflowException
+
+
+class DiscordWebhookHook(HttpHook):
+    """
+    This hook allows you to post messages to Discord using incoming webhooks.
+    Takes a Discord connection ID with a default relative webhook endpoint. The
+    default endpoint can be overridden using the webhook_endpoint parameter
+    (https://discordapp.com/developers/docs/resources/webhook).
+
+    Each Discord webhook can be pre-configured to use a specific username and
+    avatar_url. You can override these defaults in this hook.
+
+    :param http_conn_id: Http connection ID with host as "https://discord.com/api/" and
+                         default webhook endpoint in the extra field in the form of
+                         {"webhook_endpoint": "webhooks/{webhook.id}/{webhook.token}"}
+    :type http_conn_id: str
+    :param webhook_endpoint: Discord webhook endpoint in the form of
+                             "webhooks/{webhook.id}/{webhook.token}"
+    :type webhook_endpoint: str
+    :param message: The message you want to send to your Discord channel
+                    (max 2000 characters)
+    :type message: str
+    :param username: Override the default username of the webhook
+    :type username: str
+    :param avatar_url: Override the default avatar of the webhook
+    :type avatar_url: str
+    :param tts: Is a text-to-speech message
+    :type tts: bool
+    :param proxy: Proxy to use to make the Discord webhook call
+    :type proxy: str
+    """
+
+    def __init__(self,
+                 http_conn_id=None,
+                 webhook_endpoint=None,
+                 message="",
+                 username=None,
+                 avatar_url=None,
+                 tts=False,
+                 proxy=None,
+                 *args,
+                 **kwargs):
+        super(DiscordWebhookHook, self).__init__(*args, **kwargs)
+        self.http_conn_id = http_conn_id
+        self.webhook_endpoint = self._get_webhook_endpoint(http_conn_id, webhook_endpoint)
+        self.message = message
+        self.username = username
+        self.avatar_url = avatar_url
+        self.tts = tts
+        self.proxy = proxy
+
+    def _get_webhook_endpoint(self, http_conn_id, webhook_endpoint):
+        """
+        Given a Discord http_conn_id, return the default webhook endpoint or override if a
+        webhook_endpoint is manually supplied.
+
+        :param http_conn_id: The provided connection ID
+        :param webhook_endpoint: The manually provided webhook endpoint
+        :return: Webhook endpoint (str) to use
+        """
+        if webhook_endpoint:
+            endpoint = webhook_endpoint
+        elif http_conn_id:
+            conn = self.get_connection(http_conn_id)
+            extra = conn.extra_dejson
+            endpoint = extra.get('webhook_endpoint', '')
+        else:
+            raise AirflowException('Cannot get webhook endpoint: No valid Discord '
+                                   'webhook endpoint or http_conn_id supplied.')
+
+        # make sure endpoint matches the expected Discord webhook format
+        if not re.match('^webhooks/[0-9]+/[a-zA-Z0-9_-]+$', endpoint):
+            raise AirflowException('Expected Discord webhook endpoint in the form '
+                                   'of "webhooks/{webhook.id}/{webhook.token}".')
+
+        return endpoint
+
+    def _build_discord_payload(self):
+        """
+        Construct the Discord JSON payload. All relevant parameters are combined here
+        to a valid Discord JSON payload.
+
+        :return: Discord payload (str) to send
+        """
+        payload = {}
+
+        if self.username:
+            payload['username'] = self.username
+        if self.avatar_url:
+            payload['avatar_url'] = self.avatar_url
+
+        payload['tts'] = self.tts
+
+        if len(self.message) <= 2000:
+            payload['content'] = self.message
+        else:
+            raise AirflowException('Discord message length must be 2000 or fewer '
+                                   'characters.')
+
+        return json.dumps(payload)
+
+    def execute(self):
+        """
+        Execute the Discord webhook call
+        """
+        proxies = {}
+        if self.proxy:
+            # we only need https proxy for Discord
+            proxies = {'https': self.proxy}
+
+        discord_payload = self._build_discord_payload()
+
+        self.run(endpoint=self.webhook_endpoint,
+                 data=discord_payload,
+                 headers={'Content-type': 'application/json'},
+                 extra_options={'proxies': proxies})

--- a/airflow/contrib/operators/discord_webhook_operator.py
+++ b/airflow/contrib/operators/discord_webhook_operator.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from airflow.contrib.hooks.discord_webhook_hook import DiscordWebhookHook
+from airflow.exceptions import AirflowException
+from airflow.operators.http_operator import SimpleHttpOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class DiscordWebhookOperator(SimpleHttpOperator):
+    """
+    This operator allows you to post messages to Discord using incoming webhooks.
+    Takes a Discord connection ID with a default relative webhook endpoint. The
+    default endpoint can be overridden using the webhook_endpoint parameter
+    (https://discordapp.com/developers/docs/resources/webhook).
+
+    Each Discord webhook can be pre-configured to use a specific username and
+    avatar_url. You can override these defaults in this operator.
+
+    :param http_conn_id: Http connection ID with host as "https://discord.com/api/" and
+                         default webhook endpoint in the extra field in the form of
+                         {"webhook_endpoint": "webhooks/{webhook.id}/{webhook.token}"}
+    :type http_conn_id: str
+    :param webhook_endpoint: Discord webhook endpoint in the form of
+                             "webhooks/{webhook.id}/{webhook.token}"
+    :type webhook_endpoint: str
+    :param message: The message you want to send to your Discord channel
+                    (max 2000 characters)
+    :type message: str
+    :param username: Override the default username of the webhook
+    :type username: str
+    :param avatar_url: Override the default avatar of the webhook
+    :type avatar_url: str
+    :param tts: Is a text-to-speech message
+    :type tts: bool
+    :param proxy: Proxy to use to make the Discord webhook call
+    :type proxy: str
+    """
+
+    template_fields = ('username', 'message')
+
+    @apply_defaults
+    def __init__(self,
+                 http_conn_id=None,
+                 webhook_endpoint=None,
+                 message="",
+                 username=None,
+                 avatar_url=None,
+                 tts=False,
+                 proxy=None,
+                 *args,
+                 **kwargs):
+        super(DiscordWebhookOperator, self).__init__(endpoint=webhook_endpoint,
+                                                     *args,
+                                                     **kwargs)
+
+        if not http_conn_id:
+            raise AirflowException('No valid Discord http_conn_id supplied.')
+
+        self.http_conn_id = http_conn_id
+        self.webhook_endpoint = webhook_endpoint
+        self.message = message
+        self.username = username
+        self.avatar_url = avatar_url
+        self.tts = tts
+        self.proxy = proxy
+        self.hook = None
+
+    def execute(self, context):
+        """
+        Call the DiscordWebhookHook to post message
+        """
+        self.hook = DiscordWebhookHook(
+            self.http_conn_id,
+            self.webhook_endpoint,
+            self.message,
+            self.username,
+            self.avatar_url,
+            self.tts,
+            self.proxy
+        )
+        self.hook.execute()

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -133,6 +133,7 @@ Operators
 .. autoclass:: airflow.contrib.operators.dataproc_operator.DataprocWorkflowTemplateInstantiateInlineOperator
 .. autoclass:: airflow.contrib.operators.datastore_export_operator.DatastoreExportOperator
 .. autoclass:: airflow.contrib.operators.datastore_import_operator.DatastoreImportOperator
+.. autoclass:: airflow.contrib.operators.discord_webhook_operator.DiscordWebhookOperator
 .. autoclass:: airflow.contrib.operators.druid_operator.DruidOperator
 .. autoclass:: airflow.contrib.operators.ecs_operator.ECSOperator
 .. autoclass:: airflow.contrib.operators.emr_add_steps_operator.EmrAddStepsOperator
@@ -337,6 +338,7 @@ Community contributed hooks
 .. autoclass:: airflow.contrib.hooks.cloudant_hook.CloudantHook
 .. autoclass:: airflow.contrib.hooks.gcs_hook.GoogleCloudStorageHook
 .. autoclass:: airflow.contrib.hooks.gcp_pubsub_hook.PubSubHook
+.. autoclass:: airflow.contrib.hooks.discord_webhook_hook.DiscordWebhookHook
 
 Executors
 ---------

--- a/tests/contrib/hooks/test_discord_webhook_hook.py
+++ b/tests/contrib/hooks/test_discord_webhook_hook.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+import unittest
+
+from airflow import configuration, models, AirflowException
+from airflow.utils import db
+
+from airflow.contrib.hooks.discord_webhook_hook import DiscordWebhookHook
+
+
+class TestDiscordWebhookHook(unittest.TestCase):
+
+    _config = {
+        'http_conn_id': 'default-discord-webhook',
+        'webhook_endpoint': 'webhooks/11111/some-discord-token_111',
+        'message': 'your message here',
+        'username': 'Airflow Webhook',
+        'avatar_url': 'https://static-cdn.avatars.com/my-avatar-path',
+        'tts': False,
+        'proxy': 'https://proxy.proxy.com:8888'
+    }
+
+    expected_payload_dict = {
+        'username': _config['username'],
+        'avatar_url': _config['avatar_url'],
+        'tts': _config['tts'],
+        'content': _config['message']
+    }
+
+    expected_payload = json.dumps(expected_payload_dict)
+
+    def setUp(self):
+        configuration.load_test_config()
+        db.merge_conn(
+            models.Connection(
+                conn_id='default-discord-webhook',
+                host='https://discordapp.com/api/',
+                extra='{"webhook_endpoint": "webhooks/00000/some-discord-token_000"}')
+        )
+
+    def test_get_webhook_endpoint_manual_token(self):
+        # Given
+        provided_endpoint = 'webhooks/11111/some-discord-token_111'
+        hook = DiscordWebhookHook(webhook_endpoint=provided_endpoint)
+
+        # When
+        webhook_endpoint = hook._get_webhook_endpoint(None, provided_endpoint)
+
+        # Then
+        self.assertEqual(webhook_endpoint, provided_endpoint)
+
+    def test_get_webhook_endpoint_invalid_url(self):
+        # Given
+        provided_endpoint = 'https://discordapp.com/some-invalid-webhook-url'
+
+        # When/Then
+        expected_message = 'Expected Discord webhook endpoint in the form of'
+        with self.assertRaisesRegexp(AirflowException, expected_message):
+            DiscordWebhookHook(webhook_endpoint=provided_endpoint)
+
+    def test_get_webhook_endpoint_conn_id(self):
+        # Given
+        conn_id = 'default-discord-webhook'
+        hook = DiscordWebhookHook(http_conn_id=conn_id)
+        expected_webhook_endpoint = 'webhooks/00000/some-discord-token_000'
+
+        # When
+        webhook_endpoint = hook._get_webhook_endpoint(conn_id, None)
+
+        # Then
+        self.assertEqual(webhook_endpoint, expected_webhook_endpoint)
+
+    def test_build_discord_payload(self):
+        # Given
+        hook = DiscordWebhookHook(**self._config)
+
+        # When
+        payload = hook._build_discord_payload()
+
+        # Then
+        self.assertEqual(self.expected_payload, payload)
+
+    def test_build_discord_payload_message_length(self):
+        # Given
+        config = self._config.copy()
+        # create message over the character limit
+        config["message"] = 'c' * 2001
+        hook = DiscordWebhookHook(**config)
+
+        # When/Then
+        expected_message = 'Discord message length must be 2000 or fewer characters'
+        with self.assertRaisesRegexp(AirflowException, expected_message):
+            hook._build_discord_payload()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/contrib/operators/test_discord_webhook_operator.py
+++ b/tests/contrib/operators/test_discord_webhook_operator.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+from airflow import DAG, configuration
+
+from airflow.contrib.operators.discord_webhook_operator import DiscordWebhookOperator
+from airflow.utils import timezone
+
+DEFAULT_DATE = timezone.datetime(2018, 1, 1)
+
+
+class TestDiscordWebhookOperator(unittest.TestCase):
+    _config = {
+        'http_conn_id': 'discord-webhook-default',
+        'webhook_endpoint': 'webhooks/11111/some-discord-token_111',
+        'message': 'your message here',
+        'username': 'Airflow Webhook',
+        'avatar_url': 'https://static-cdn.avatars.com/my-avatar-path',
+        'tts': False,
+        'proxy': 'https://proxy.proxy.com:8888'
+    }
+
+    def setUp(self):
+        configuration.load_test_config()
+        args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE
+        }
+        self.dag = DAG('test_dag_id', default_args=args)
+
+    def test_execute(self):
+        operator = DiscordWebhookOperator(
+            task_id='discord_webhook_task',
+            dag=self.dag,
+            **self._config
+        )
+
+        self.assertEqual(self._config['http_conn_id'], operator.http_conn_id)
+        self.assertEqual(self._config['webhook_endpoint'], operator.webhook_endpoint)
+        self.assertEqual(self._config['message'], operator.message)
+        self.assertEqual(self._config['username'], operator.username)
+        self.assertEqual(self._config['avatar_url'], operator.avatar_url)
+        self.assertEqual(self._config['tts'], operator.tts)
+        self.assertEqual(self._config['proxy'], operator.proxy)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2273) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2273


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Add the Discord webhook operator and hook pair. This allows for the posting of messages to a Discord channel using incoming webhooks.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- tests/contrib/operators/test_discord_webhook_operator.py
- tests/contrib/hooks/test_discord_webhook_hook.py


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
