### PR TITLE
[AIRFLOW-2278] Add possibility to edit DAGs in webapp

### DIFF
--- a/airflow/www/static/main.css
+++ b/airflow/www/static/main.css
@@ -146,6 +146,24 @@ input, select {
 #sql_ace {
     visibility: hidden;
 }
+#dag_editor {
+    margin: 10px 0px;
+    width: 100%;
+    height: 100px;
+}
+#dag_edited {
+    visibility: hidden;
+    display: none;
+}
+.dag-header {
+    display: flex;
+}
+.dag-header h4{
+    flex-grow: 1;
+}
+.dag-header .btn{
+    float: right;
+}
 table.dataframe {
     font-size: 12px;
 }

--- a/airflow/www/static/mode-python.js
+++ b/airflow/www/static/mode-python.js
@@ -1,0 +1,291 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+define("ace/mode/python_highlight_rules",["require","exports","module","ace/lib/oop","ace/mode/text_highlight_rules"], function(require, exports, module) {
+"use strict";
+
+var oop = require("../lib/oop");
+var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+
+var PythonHighlightRules = function() {
+
+    var keywords = (
+        "and|as|assert|break|class|continue|def|del|elif|else|except|exec|" +
+        "finally|for|from|global|if|import|in|is|lambda|not|or|pass|print|" +
+        "raise|return|try|while|with|yield|async|await"
+    );
+
+    var builtinConstants = (
+        "True|False|None|NotImplemented|Ellipsis|__debug__"
+    );
+
+    var builtinFunctions = (
+        "abs|divmod|input|open|staticmethod|all|enumerate|int|ord|str|any|" +
+        "eval|isinstance|pow|sum|basestring|execfile|issubclass|print|super|" +
+        "binfile|iter|property|tuple|bool|filter|len|range|type|bytearray|" +
+        "float|list|raw_input|unichr|callable|format|locals|reduce|unicode|" +
+        "chr|frozenset|long|reload|vars|classmethod|getattr|map|repr|xrange|" +
+        "cmp|globals|max|reversed|zip|compile|hasattr|memoryview|round|" +
+        "__import__|complex|hash|min|set|apply|delattr|help|next|setattr|" +
+        "buffer|dict|hex|object|slice|coerce|dir|id|oct|sorted|intern"
+    );
+
+    //var futureReserved = "";
+    var keywordMapper = this.createKeywordMapper({
+        "invalid.deprecated": "debugger",
+        "support.function": builtinFunctions,
+        "variable.language": "self|cls",
+        "constant.language": builtinConstants,
+        "keyword": keywords
+    }, "identifier");
+
+    var strPre = "(?:r|u|ur|R|U|UR|Ur|uR)?";
+
+    var decimalInteger = "(?:(?:[1-9]\\d*)|(?:0))";
+    var octInteger = "(?:0[oO]?[0-7]+)";
+    var hexInteger = "(?:0[xX][\\dA-Fa-f]+)";
+    var binInteger = "(?:0[bB][01]+)";
+    var integer = "(?:" + decimalInteger + "|" + octInteger + "|" + hexInteger + "|" + binInteger + ")";
+
+    var exponent = "(?:[eE][+-]?\\d+)";
+    var fraction = "(?:\\.\\d+)";
+    var intPart = "(?:\\d+)";
+    var pointFloat = "(?:(?:" + intPart + "?" + fraction + ")|(?:" + intPart + "\\.))";
+    var exponentFloat = "(?:(?:" + pointFloat + "|" +  intPart + ")" + exponent + ")";
+    var floatNumber = "(?:" + exponentFloat + "|" + pointFloat + ")";
+
+    var stringEscape =  "\\\\(x[0-9A-Fa-f]{2}|[0-7]{3}|[\\\\abfnrtv'\"]|U[0-9A-Fa-f]{8}|u[0-9A-Fa-f]{4})";
+
+    this.$rules = {
+        "start" : [ {
+            token : "comment",
+            regex : "#.*$"
+        }, {
+            token : "string",           // multi line """ string start
+            regex : strPre + '"{3}',
+            next : "qqstring3"
+        }, {
+            token : "string",           // " string
+            regex : strPre + '"(?=.)',
+            next : "qqstring"
+        }, {
+            token : "string",           // multi line ''' string start
+            regex : strPre + "'{3}",
+            next : "qstring3"
+        }, {
+            token : "string",           // ' string
+            regex : strPre + "'(?=.)",
+            next : "qstring"
+        }, {
+            token : "constant.numeric", // imaginary
+            regex : "(?:" + floatNumber + "|\\d+)[jJ]\\b"
+        }, {
+            token : "constant.numeric", // float
+            regex : floatNumber
+        }, {
+            token : "constant.numeric", // long integer
+            regex : integer + "[lL]\\b"
+        }, {
+            token : "constant.numeric", // integer
+            regex : integer + "\\b"
+        }, {
+            token : keywordMapper,
+            regex : "[a-zA-Z_$][a-zA-Z0-9_$]*\\b"
+        }, {
+            token : "keyword.operator",
+            regex : "\\+|\\-|\\*|\\*\\*|\\/|\\/\\/|%|<<|>>|&|\\||\\^|~|<|>|<=|=>|==|!=|<>|="
+        }, {
+            token : "paren.lparen",
+            regex : "[\\[\\(\\{]"
+        }, {
+            token : "paren.rparen",
+            regex : "[\\]\\)\\}]"
+        }, {
+            token : "text",
+            regex : "\\s+"
+        } ],
+        "qqstring3" : [ {
+            token : "constant.language.escape",
+            regex : stringEscape
+        }, {
+            token : "string", // multi line """ string end
+            regex : '"{3}',
+            next : "start"
+        }, {
+            defaultToken : "string"
+        } ],
+        "qstring3" : [ {
+            token : "constant.language.escape",
+            regex : stringEscape
+        }, {
+            token : "string",  // multi line ''' string end
+            regex : "'{3}",
+            next : "start"
+        }, {
+            defaultToken : "string"
+        } ],
+        "qqstring" : [{
+            token : "constant.language.escape",
+            regex : stringEscape
+        }, {
+            token : "string",
+            regex : "\\\\$",
+            next  : "qqstring"
+        }, {
+            token : "string",
+            regex : '"|$',
+            next  : "start"
+        }, {
+            defaultToken: "string"
+        }],
+        "qstring" : [{
+            token : "constant.language.escape",
+            regex : stringEscape
+        }, {
+            token : "string",
+            regex : "\\\\$",
+            next  : "qstring"
+        }, {
+            token : "string",
+            regex : "'|$",
+            next  : "start"
+        }, {
+            defaultToken: "string"
+        }]
+    };
+};
+
+oop.inherits(PythonHighlightRules, TextHighlightRules);
+
+exports.PythonHighlightRules = PythonHighlightRules;
+});
+
+define("ace/mode/folding/pythonic",["require","exports","module","ace/lib/oop","ace/mode/text_highlight_rules"],function(require, exports, module) {
+"use strict";
+
+var oop = require("../../lib/oop");
+var BaseFoldMode = require("./fold_mode").FoldMode;
+
+var FoldMode = exports.FoldMode = function(markers) {
+    this.foldingStartMarker = new RegExp("([\\[{])(?:\\s*)$|(" + markers + ")(?:\\s*)(?:#.*)?$");
+};
+oop.inherits(FoldMode, BaseFoldMode);
+
+(function() {
+
+    this.getFoldWidgetRange = function(session, foldStyle, row) {
+        var line = session.getLine(row);
+        var match = line.match(this.foldingStartMarker);
+        if (match) {
+            if (match[1])
+                return this.openingBracketBlock(session, match[1], row, match.index);
+            if (match[2])
+                return this.indentationBlock(session, row, match.index + match[2].length);
+            return this.indentationBlock(session, row);
+        }
+    };
+
+}).call(FoldMode.prototype);
+
+});
+
+define("ace/mode/python",["require","exports","module","ace/lib/oop","ace/mode/text","ace/mode/python_highlight_rules","ace/range", "ace/mode/folding/pythonic"], function(require, exports, module) {
+"use strict";
+
+var oop = require("../lib/oop");
+var TextMode = require("./text").Mode;
+var PythonHighlightRules = require("./python_highlight_rules").PythonHighlightRules;
+var PythonFoldMode = require("./folding/pythonic").FoldMode;
+var Range = require("../range").Range;
+
+var Mode = function() {
+    this.HighlightRules = PythonHighlightRules;
+    this.foldingRules = new PythonFoldMode("\\:");
+    this.$behaviour = this.$defaultBehaviour;
+};
+oop.inherits(Mode, TextMode);
+
+(function() {
+
+    this.lineCommentStart = "#";
+
+    this.getNextLineIndent = function(state, line, tab) {
+        var indent = this.$getIndent(line);
+
+        var tokenizedLine = this.getTokenizer().getLineTokens(line, state);
+        var tokens = tokenizedLine.tokens;
+
+        if (tokens.length && tokens[tokens.length-1].type == "comment") {
+            return indent;
+        }
+
+        if (state == "start") {
+            var match = line.match(/^.*[\{\(\[:]\s*$/);
+            if (match) {
+                indent += tab;
+            }
+        }
+
+        return indent;
+    };
+
+    var outdents = {
+        "pass": 1,
+        "return": 1,
+        "raise": 1,
+        "break": 1,
+        "continue": 1
+    };
+    
+    this.checkOutdent = function(state, line, input) {
+        if (input !== "\r\n" && input !== "\r" && input !== "\n")
+            return false;
+
+        var tokens = this.getTokenizer().getLineTokens(line.trim(), state).tokens;
+        
+        if (!tokens)
+            return false;
+        
+        // ignore trailing comments
+        do {
+            var last = tokens.pop();
+        } while (last && (last.type == "comment" || (last.type == "text" && last.value.match(/^\s+$/))));
+        
+        if (!last)
+            return false;
+        
+        return (last.type == "keyword" && outdents[last.value]);
+    };
+
+    this.autoOutdent = function(state, doc, row) {
+        // outdenting in python is slightly different because it always applies
+        // to the next line and only of a new line is inserted
+        
+        row += 1;
+        var indent = this.$getIndent(doc.getLine(row));
+        var tab = doc.getTabString();
+        if (indent.slice(-tab.length) == tab)
+            doc.remove(new Range(row, indent.length-tab.length, row, indent.length));
+    };
+
+    this.$id = "ace/mode/python";
+}).call(Mode.prototype);
+
+exports.Mode = Mode;
+});

--- a/airflow/www/templates/airflow/dag_code.html
+++ b/airflow/www/templates/airflow/dag_code.html
@@ -20,39 +20,70 @@
 
 {% block body %}
     {{ super() }}
-    <h4>{{ title }}</h4>
-    {% if html_code %}
-        {{ html_code|safe }}
-    {% endif %}
-    {% if code %}
-        <pre>{{ code }}</pre>
-    {% endif %}
-
-    {% if code_dict %}
-        {% for k, v in code_dict.items() %}
-            <h5>{{ k }}</h5>
-            <pre>{{ v }}</pre>
-        {% endfor %}
-    {% endif %}
-    {% if html_dict %}
-        {% for k, v in html_dict.items() %}
-            <h5>{{ k }}</h5>
-            {{ v|safe }}
-        {% endfor %}
+    {% if (is_editable and code) %}
+      <form method="post" id="dag_form">
+        <div class="form-inline">
+          <div class="dag-header">
+            <h4>{{ title }}</h4>
+            <input name="_csrf_token" type="hidden" value="{{ csrf_token() }}">
+            <input type="submit" class="btn btn-primary" value="Save">
+          </div>
+          <span id="results"></span><br>
+          <div id='dag_editor' style="visibility: hidden;">{{ code|safe }}</div>
+          <textarea id="dag_edited" name="dag_edited">{{ code|safe }}</textarea>
+        </div>
+      </form>
+    {% else %}
+      <h4>{{ title }}</h4>
+      {% if html_code %}
+          {{ html_code|safe }}
+      {% endif %}
+      {% if code_dict %}
+          {% for k, v in code_dict.items() %}
+              <h5>{{ k }}</h5>
+              <pre>{{ v }}</pre>
+          {% endfor %}
+      {% endif %}
+      {% if html_dict %}
+          {% for k, v in html_dict.items() %}
+              <h5>{{ k }}</h5>
+              {{ v|safe }}
+          {% endfor %}
+      {% endif %}
     {% endif %}
 {% endblock %}
 
 {% block tail %}
-    {{ super() }}
-    <script>
-      // We blur task_ids in demo mode
+  {{ super() }}
+  <script src="{{ url_for('static', filename='ace.js') }}"></script>
+  <script src="{{ url_for('static', filename='mode-python.js') }}"></script>
+  <script>
     $( document ).ready(function() {
+      {% if (is_editable and code) %}
+        var editor = ace.edit("dag_editor");
+        var textarea = $('textarea[name="dag_edited"]').hide();
+        function sync() {
+            textarea.val(editor.getSession().getValue());
+        }
+        editor.setTheme("ace/theme/crimson_editor");
+        editor.setOptions({
+            minLines: 3,
+            maxLines: Infinity,
+        });
+        editor.getSession().setMode("ace/mode/python");
+        editor.getSession().on('change', sync);
+        // Prevents ugly code look before ace editor has rendered it
+        $('#dag_editor').css('visibility', 'visible');
+        editor.focus();
+      {% endif %}
+
+      // We blur task_ids in demo mode
       if ("{{ demo_mode }}" == "True") {
-          $("pre span.s").css({
-              'text-shadow': '0px 0px 10px red',
-              'color': 'transparent',
-          });
+        $("pre span.s").css({
+            'text-shadow': '0px 0px 10px red',
+            'color': 'transparent',
+        });
       }
     });
-    </script>
+  </script>
 {% endblock %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -652,7 +652,7 @@ class Airflow(BaseView):
             html_code=html_code,
             code=code,
             dag=dag,
-            title=title, 
+            title=title,
             is_editable=is_dag_editable(dag),
             root=request.args.get('root'),
             demo_mode=conf.getboolean('webserver', 'demo_mode'))


### PR DESCRIPTION
​
Make sure you have checked _all_ steps below.
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
- https://issues.apache.org/jira/browse/AIRFLOW-2278
### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
> When you need to make some minor changes in your DAG would be nice to have possibility to edit it from webapp.
> To protect DAG from editing by everyone should be set up arg inside DAG 'editable_by'. Where '*' means everyone, and ['user1', 'user2'] means specific users.
> Example when DAG can be editable in webapp by user1 and user2 only:
```
args = {
'owner': 'airflow',
'editable_by': ['user1', 'user2'],
'start_date': airflow.utils.dates.days_ago(2)
}
```
And with access you will get:
![airflow-dag-edit](https://user-images.githubusercontent.com/4667951/38294690-efbe761e-37eb-11e8-9541-26ef63bf790b.PNG)


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
> My change is simple and related most of all to front-end part
### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
1. Subject is separated from body by a blank line
2. Subject is limited to 50 characters
3. Subject does not end with a period
4. Subject uses the imperative mood ("add", not "adding")
5. Body wraps at 72 characters
6. Body explains "what" and "why", not "how"
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
> Passed