### PR TITLE
[AIRFLOW-2281] Add support for Sendgrid categories

### DIFF
--- a/airflow/contrib/utils/sendgrid.py
+++ b/airflow/contrib/utils/sendgrid.py
@@ -20,12 +20,13 @@ from __future__ import unicode_literals
 import base64
 import mimetypes
 import os
+
 import sendgrid
+from sendgrid.helpers.mail import Attachment, Content, Email, Mail, \
+    Personalization, CustomArg, Category
 
 from airflow.utils.email import get_email_address_list
 from airflow.utils.log.logging_mixin import LoggingMixin
-from sendgrid.helpers.mail import Attachment, Content, Email, Mail, \
-    Personalization, CustomArg
 
 
 def send_email(to, subject, html_content, files=None,
@@ -61,14 +62,19 @@ def send_email(to, subject, html_content, files=None,
         bcc = get_email_address_list(bcc)
         for bcc_address in bcc:
             personalization.add_bcc(Email(bcc_address))
-    mail.add_personalization(personalization)
-    mail.add_content(Content('text/html', html_content))
 
     # Add custom_args to personalization if present
     pers_custom_args = kwargs.get('personalization_custom_args', None)
     if isinstance(pers_custom_args, dict):
         for key in pers_custom_args.keys():
             personalization.add_custom_arg(CustomArg(key, pers_custom_args[key]))
+
+    mail.add_personalization(personalization)
+    mail.add_content(Content('text/html', html_content))
+
+    categories = kwargs.get('categories', [])
+    for cat in categories:
+        mail.add_category(Category(cat))
 
     # Add email attachment.
     for fname in files or []:

--- a/tests/contrib/utils/test_sendgrid.py
+++ b/tests/contrib/utils/test_sendgrid.py
@@ -44,9 +44,11 @@ class SendEmailSendGridTest(unittest.TestCase):
             'from': {'email': u'foo@bar.com'},
             'subject': 'sendgrid-send-email unit test'}
         self.personalization_custom_args = {'arg1': 'val1', 'arg2': 'val2'}
-        self.expected_mail_data_custom_args = copy.deepcopy(self.expected_mail_data)
-        self.expected_mail_data_custom_args['personalizations'][0]['custom_args'] = \
+        self.categories = ['cat1', 'cat2']
+        self.expected_mail_data_extras = copy.deepcopy(self.expected_mail_data)
+        self.expected_mail_data_extras['personalizations'][0]['custom_args'] = \
             self.personalization_custom_args
+        self.expected_mail_data_extras['categories'] = self.categories
 
         # Test the right email is constructed.
 
@@ -60,8 +62,9 @@ class SendEmailSendGridTest(unittest.TestCase):
     # Test the right email is constructed.
     @mock.patch('os.environ.get')
     @mock.patch('airflow.contrib.utils.sendgrid._post_sendgrid_mail')
-    def test_send_email_sendgrid_correct_email_custom_args(self, mock_post, mock_get):
+    def test_send_email_sendgrid_correct_email_extras(self, mock_post, mock_get):
         mock_get.return_value = 'foo@bar.com'
         send_email(self.to, self.subject, self.html_content, cc=self.cc, bcc=self.bcc,
-                   personalization_custom_args=self.personalization_custom_args)
-        mock_post.assert_called_with(self.expected_mail_data_custom_args)
+                   personalization_custom_args=self.personalization_custom_args,
+                   categories=self.categories)
+        mock_post.assert_called_with(self.expected_mail_data_extras)


### PR DESCRIPTION
### JIRA
- [ ] My PR addresses the following [Airflow JIRA]
    - https://issues.apache.org/jira/browse/AIRFLOW-2281


### Description
- [X] Add support for Sendgrid categories passed via kwargs


### Tests
- [X] Unit tests expanded


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
