### PR TITLE
[AIRFLOW-1633] docker_operator needs a way to set shm_size

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -140,6 +140,7 @@ class DockerOperator(BaseOperator):
         self.xcom_push_flag = xcom_push
         self.xcom_all = xcom_all
         self.docker_conn_id = docker_conn_id
+        self.shm_size = kwargs.get('shm_size')
 
         self.cli = None
         self.container = None
@@ -184,15 +185,17 @@ class DockerOperator(BaseOperator):
             self.volumes.append('{0}:{1}'.format(host_tmp_dir, self.tmp_dir))
 
             self.container = self.cli.create_container(
-                    command=self.get_command(),
-                    cpu_shares=cpu_shares,
-                    environment=self.environment,
-                    host_config=self.cli.create_host_config(binds=self.volumes,
-                                                            network_mode=self.network_mode),
-                    image=image,
-                    mem_limit=self.mem_limit,
-                    user=self.user,
-                    working_dir=self.working_dir
+                command=self.get_command(),
+                cpu_shares=cpu_shares,
+                environment=self.environment,
+                host_config=self.cli.create_host_config(
+                    binds=self.volumes,
+                    network_mode=self.network_mode,
+                    shm_size=self.shm_size),
+                image=image,
+                mem_limit=self.mem_limit,
+                user=self.user,
+                working_dir=self.working_dir
             )
             self.cli.start(self.container['Id'])
 

--- a/dev/airflow-pr
+++ b/dev/airflow-pr
@@ -107,12 +107,14 @@ def reflow(text, width=80):
 
 def get_json(url):
     try:
+        print('GOT HERE 11')
         request = urllib.Request(url)
         if GITHUB_OAUTH_KEY:
             request.add_header('Authorization', 'token %s' % GITHUB_OAUTH_KEY)
-
+        print('GOT HERE 12')
         # decode response for Py3 compatibility
         response = urllib.urlopen(request).read().decode('utf-8')
+        print('GOT HERE 13')
         return json.loads(response)
     except urllib.HTTPError as e:
         if (

--- a/dev/airflow-pr
+++ b/dev/airflow-pr
@@ -825,12 +825,15 @@ def main(pr_num, local=False):
 
     os.chdir(AIRFLOW_GIT_LOCATION)
     original_head = get_current_ref()
-
+    
+    print('GOT HERE 1')
     branches = get_json("%s/branches" % GITHUB_API_BASE)
+    print('GOT HERE 2')
     branch_names = filter(
         lambda x: x.startswith("branch-"), [x['name'] for x in branches])
     # Assumes branch names can be sorted lexicographically
     latest_branch = sorted(branch_names, reverse=True)
+    print('GOT HERE 3')
     if latest_branch:
         latest_branch = latest_branch[0]
     else:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1633


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
   add shm_size config option to docker_operator

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 trivial change

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
