### PR TITLE
[AIRFLOW-2291] Add optional params to ML Engine Training operator

### DIFF
--- a/airflow/contrib/operators/mlengine_operator.py
+++ b/airflow/contrib/operators/mlengine_operator.py
@@ -474,6 +474,16 @@ class MLEngineTrainingOperator(BaseOperator):
     :param scale_tier: Resource tier for MLEngine training job.
     :type scale_tier: string
 
+    :param runtime_version: The Google Cloud ML runtime version to use for training.
+    :type runtime_version: string
+
+    :param python_version: The version of Python used in training.
+    :type python_version: string
+
+    :param job_dir: A Google Cloud Storage path in which to store training
+        outputs and other data needed for training.
+    :type job_dir: string
+
     :param gcp_conn_id: The connection ID to use when fetching connection info.
     :type gcp_conn_id: string
 
@@ -497,6 +507,9 @@ class MLEngineTrainingOperator(BaseOperator):
         '_training_args',
         '_region',
         '_scale_tier',
+        '_runtime_version',
+        '_python_version',
+        '_job_dir'
     ]
 
     @apply_defaults
@@ -508,6 +521,9 @@ class MLEngineTrainingOperator(BaseOperator):
                  training_args,
                  region,
                  scale_tier=None,
+                 runtime_version=None,
+                 python_version=None,
+                 job_dir=None,
                  gcp_conn_id='google_cloud_default',
                  delegate_to=None,
                  mode='PRODUCTION',
@@ -521,6 +537,9 @@ class MLEngineTrainingOperator(BaseOperator):
         self._training_args = training_args
         self._region = region
         self._scale_tier = scale_tier
+        self._runtime_version = runtime_version
+        self._python_version = python_version
+        self._job_dir = job_dir
         self._gcp_conn_id = gcp_conn_id
         self._delegate_to = delegate_to
         self._mode = mode
@@ -554,6 +573,15 @@ class MLEngineTrainingOperator(BaseOperator):
                 'args': self._training_args,
             }
         }
+
+        if self._runtime_version:
+            training_request['trainingInput']['runtimeVersion'] = self._runtime_version
+
+        if self._python_version:
+            training_request['trainingInput']['pythonVersion'] = self._python_version
+
+        if self._job_dir:
+            training_request['trainingInput']['jobDir'] = self._job_dir
 
         if self._mode == 'DRY_RUN':
             self.log.info('In dry_run mode.')

--- a/tests/contrib/operators/test_mlengine_operator.py
+++ b/tests/contrib/operators/test_mlengine_operator.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import copy
 import datetime
 import unittest
 
@@ -26,7 +27,8 @@ from mock import ANY, patch
 
 from airflow import DAG, configuration
 from airflow.contrib.operators.mlengine_operator import (MLEngineBatchPredictionOperator,
-                                                         MLEngineTrainingOperator)
+                                                         MLEngineTrainingOperator,
+                                                         MLEngineVersionOperator)
 from airflow.exceptions import AirflowException
 
 DEFAULT_DATE = datetime.datetime(2017, 6, 6)
@@ -322,6 +324,33 @@ class MLEngineTrainingOperatorTest(unittest.TestCase):
             hook_instance.create_job.assert_called_with(
                 'test-project', self.TRAINING_INPUT, ANY)
 
+    def testSuccessCreateTrainingJobWithOptionalArgs(self):
+        training_input = copy.deepcopy(self.TRAINING_INPUT)
+        training_input['trainingInput']['runtimeVersion'] = '1.6'
+        training_input['trainingInput']['pythonVersion'] = '3.5'
+        training_input['trainingInput']['jobDir'] = 'gs://some-bucket/jobs/test_training'
+
+        with patch('airflow.contrib.operators.mlengine_operator.MLEngineHook') \
+                as mock_hook:
+            success_response = self.TRAINING_INPUT.copy()
+            success_response['state'] = 'SUCCEEDED'
+            hook_instance = mock_hook.return_value
+            hook_instance.create_job.return_value = success_response
+
+            training_op = MLEngineTrainingOperator(
+                runtime_version='1.6',
+                python_version='3.5',
+                job_dir='gs://some-bucket/jobs/test_training',
+                **self.TRAINING_DEFAULT_ARGS)
+            training_op.execute(None)
+
+            mock_hook.assert_called_with(gcp_conn_id='google_cloud_default',
+                                         delegate_to=None)
+            # Make sure only 'create_job' is invoked on hook instance
+            self.assertEquals(len(hook_instance.mock_calls), 1)
+            hook_instance.create_job.assert_called_with(
+                'test-project', training_input, ANY)
+
     def testHttpError(self):
         http_error_code = 403
         with patch('airflow.contrib.operators.mlengine_operator.MLEngineHook') \
@@ -367,6 +396,38 @@ class MLEngineTrainingOperatorTest(unittest.TestCase):
             hook_instance.create_job.assert_called_with(
                 'test-project', self.TRAINING_INPUT, ANY)
             self.assertEquals('A failure message', str(context.exception))
+
+
+class MLEngineVersionOperatorTest(unittest.TestCase):
+    VERSION_DEFAULT_ARGS = {
+        'project_id': 'test-project',
+        'model_name': 'test-model',
+        'task_id': 'test-version'
+    }
+    VERSION_INPUT = {
+        'name': 'v1',
+        'deploymentUri': 'gs://some-bucket/jobs/test_training/model.pb',
+        'runtimeVersion': '1.6'
+    }
+
+    def testSuccessCreateVersion(self):
+        with patch('airflow.contrib.operators.mlengine_operator.MLEngineHook') \
+                as mock_hook:
+            success_response = {'name': 'some-name', 'done': True}
+            hook_instance = mock_hook.return_value
+            hook_instance.create_version.return_value = success_response
+
+            training_op = MLEngineVersionOperator(
+                version=self.VERSION_INPUT,
+                **self.VERSION_DEFAULT_ARGS)
+            training_op.execute(None)
+
+            mock_hook.assert_called_with(gcp_conn_id='google_cloud_default',
+                                         delegate_to=None)
+            # Make sure only 'create_version' is invoked on hook instance
+            self.assertEquals(len(hook_instance.mock_calls), 1)
+            hook_instance.create_version.assert_called_with(
+                'test-project', 'test-model', self.VERSION_INPUT)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2291

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR adds three extra optional parameters to the `MLEngineTrainingOperator` as well as a new unit tes for the `MLEngineVersionOperator`

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- `testSuccessCreateTrainingJobWithOptionalArgs` for the extra parameters
- `testSuccessCreateVersion` for creating a new ML Model Version (no tests existed at all for this operator before)

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

There are a bunch of other errors *unrelated to this PR*