### PR TITLE
[AIRFLOW-2303] S3 List Operator

### DIFF
--- a/airflow/contrib/operators/s3_list_operator.py
+++ b/airflow/contrib/operators/s3_list_operator.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from airflow.hooks.S3_hook import S3Hook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class S3ListOperator(BaseOperator):
+    """
+    List all objects from the bucket with the given string prefix and delimiter
+    in name.
+
+    This operator returns a python list with the name of objects which can be
+    used by `xcom` in the downstream task.
+
+    :param bucket: The S3 bucket where to find the objects.
+    :type bucket: string
+    :param prefix: Prefix string to filters the objects whose name begin with
+        such prefix
+    :type prefix: string
+    :param delimiter: The delimiter by which you want to filter the objects.
+        For e.g to lists the CSV files from in a directory in S3 you would use
+        delimiter='.csv'.
+    :type delimiter: string
+    :param aws_conn_id: The connection ID to use when connecting to S3 storage.
+    :type aws_conn_id: string
+
+    **Example**:
+        The following operator would list all the CSV files from the S3
+        ``customers/2018/04/`` key in the ``data`` bucket. ::
+
+            s3_file = S3ListOperator(
+                task_id='list_3s_files',
+                bucket='data',
+                prefix='customers/2018/04/',
+                delimiter='.csv',
+                aws_conn_id='aws_customers_conn'
+            )
+    """
+    template_fields = ('bucket', 'prefix', 'delimiter')
+    ui_color = '#ffd700'
+
+    @apply_defaults
+    def __init__(self,
+                 bucket,
+                 prefix='',
+                 delimiter='',
+                 aws_conn_id='aws_default',
+                 *args,
+                 **kwargs):
+        super(S3ListOperator, self).__init__(*args, **kwargs)
+        self.bucket = bucket
+        self.prefix = prefix
+        self.delimiter = delimiter
+        self.aws_conn_id = aws_conn_id
+
+    def execute(self, context):
+        hook = S3Hook(aws_conn_id=self.aws_conn_id)
+
+        self.log.info(
+            'Getting the list of files from bucket: {0} in prefix: {1} (Delimiter {2})'.
+            format(self.bucket, self.prefix, self.delimiter))
+
+        return hook.list_keys(
+            bucket_name=self.bucket,
+            prefix=self.prefix,
+            delimiter=self.delimiter)

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -164,6 +164,7 @@ Operators
 .. autoclass:: airflow.contrib.operators.pubsub_operator.PubSubSubscriptionDeleteOperator
 .. autoclass:: airflow.contrib.operators.pubsub_operator.PubSubPublishOperator
 .. autoclass:: airflow.contrib.operators.qubole_operator.QuboleOperator
+.. autoclass:: airflow.contrib.operators.s3_list_operator.S3ListOperator
 .. autoclass:: airflow.contrib.operators.sftp_operator.SFTPOperator
 .. autoclass:: airflow.contrib.operators.spark_jdbc_operator.SparkJDBCOperator
 .. autoclass:: airflow.contrib.operators.spark_sql_operator.SparkSqlOperator

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -196,9 +196,17 @@ EmrHook
 AWS S3
 '''''''
 
+- :ref:`S3ListOperator` : Lists the files matching a key prefix from a S3 location.
 - :ref:`S3FileTransformOperator` : Copies data from a source S3 location to a temporary location on the local filesystem.
 - :ref:`S3ToHiveTransfer` : Moves data from S3 to Hive. The operator downloads a file from S3, stores the file locally before loading it into a Hive table.
 - :ref:`S3Hook` : Interact with AWS S3.
+
+.. _S3ListOperator:
+
+S3ListOperator
+""""""""""""""
+
+.. autoclass:: airflow.contrib.operators.s3_list_operator.S3ListOperator
 
 .. _S3FileTransformOperator:
 

--- a/tests/contrib/operators/test_s3_list_operator.py
+++ b/tests/contrib/operators/test_s3_list_operator.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from airflow.contrib.operators.s3_list_operator import S3ListOperator
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+TASK_ID = 'test-s3-list-operator'
+BUCKET = 'test-bucket'
+DELIMITER = '.csv'
+PREFIX = 'TEST'
+MOCK_FILES = ["TEST1.csv", "TEST2.csv", "TEST3.csv"]
+
+
+class S3ListOperatorTest(unittest.TestCase):
+    @mock.patch('airflow.contrib.operators.s3_list_operator.S3Hook')
+    def test_execute(self, mock_hook):
+
+        mock_hook.return_value.list_keys.return_value = MOCK_FILES
+
+        operator = S3ListOperator(
+            task_id=TASK_ID, bucket=BUCKET, prefix=PREFIX, delimiter=DELIMITER)
+
+        files = operator.execute(None)
+
+        mock_hook.return_value.list_keys.assert_called_once_with(
+            bucket_name=BUCKET, prefix=PREFIX, delimiter=DELIMITER)
+        self.assertEqual(sorted(files), sorted(MOCK_FILES))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title: "\[AIRFLOW-2303\] S3 List Operator"
    - https://issues.apache.org/jira/browse/AIRFLOW-2303


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- Lists the contents of an S3 bucket given a prefix and a delimiter (both optional) and returns the contents as a list.


### Tests
- [x] My PR adds the following unit tests:
- `tests/contrib/operators/test_s3_list_operator.py`
- Tested also in house (directly with an S3 bucket)


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
