### PR TITLE
[AIRFLOW-2309] Fix duration calculation on TaskFail

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1981,7 +1981,10 @@ class TaskFail(Base):
         self.execution_date = execution_date
         self.start_date = start_date
         self.end_date = end_date
-        self.duration = (self.end_date - self.start_date).total_seconds()
+        if self.end_date and self.start_date:
+            self.duration = (self.end_date - self.start_date).total_seconds()
+        else:
+            self.duration = None
 
 
 class Log(Base):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2309
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Encountered a corner case where calculating duration can raise a TypeError if start_date or end_date are None.  I ran into this with Celery executor and I think it occurs if the task errors out before it is marked with a start_date.  Wrapping the duration calculation with a guard fixes the problem.  

This is consistent with  def set_duration(self):

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
The "normal" case is covered by existing tests.  The negative case, unfortunately I don't have a good repro of as I fixed the bug while troubleshooting a different issue and I don't have the traceback or exact steps anymore.  This is a pretty trivial safe change though.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
