### PR TITLE
[AIRFLOW-2307] Add uuid attribute to TaskInstance, return uuid in Executor

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -133,10 +133,12 @@ class BaseExecutor(LoggingMixin):
             ti.refresh_from_db()
             if ti.state != State.RUNNING:
                 self.running[key] = command
-                self.execute_async(key=key,
+                uuid = self.execute_async(key=key,
                                    command=command,
                                    queue=queue,
                                    executor_config=ti.executor_config)
+                if uuid:
+                    ti.set_uuid(uuid)
             else:
                 self.logger.info(
                     'Task is already running, not sending to '

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -87,6 +87,8 @@ class CeleryExecutor(BaseExecutor):
             args=[command], queue=queue)
         self.last_state[key] = celery_states.PENDING
 
+        return self.tasks[key].id
+
     def sync(self):
         self.log.debug("Inquiring about %s celery task(s)", len(self.tasks))
         for key, async in list(self.tasks.items()):

--- a/airflow/executors/dask_executor.py
+++ b/airflow/executors/dask_executor.py
@@ -68,6 +68,8 @@ class DaskExecutor(BaseExecutor):
         future = self.client.submit(airflow_run, pure=False)
         self.futures[future] = key
 
+        return future.key
+
     def _process_future(self, future):
         if future.done():
             key = self.futures[future]

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -47,6 +47,7 @@ locally, into just one `LocalExecutor` with multiple modes.
 import multiprocessing
 import subprocess
 import time
+import uuid
 
 from builtins import range
 
@@ -223,6 +224,8 @@ class LocalExecutor(BaseExecutor):
 
     def execute_async(self, key, command, queue=None, executor_config=None):
         self.impl.execute_async(key=key, command=command)
+
+        return str(uuid.uuid4())
 
     def sync(self):
         self.impl.sync()

--- a/airflow/executors/sequential_executor.py
+++ b/airflow/executors/sequential_executor.py
@@ -19,6 +19,7 @@
 
 from builtins import str
 import subprocess
+import uuid
 
 from airflow.executors.base_executor import BaseExecutor
 from airflow.utils.state import State
@@ -39,6 +40,8 @@ class SequentialExecutor(BaseExecutor):
 
     def execute_async(self, key, command, queue=None, executor_config=None):
         self.commands_to_run.append((key, command,))
+
+        return str(uuid.uuid4())
 
     def sync(self):
         for key, command in self.commands_to_run:

--- a/airflow/migrations/versions/d02246ccf39b_add_uuid_field_to_task_instance.py
+++ b/airflow/migrations/versions/d02246ccf39b_add_uuid_field_to_task_instance.py
@@ -1,0 +1,39 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""add uuid field to task instance
+
+Revision ID: d02246ccf39b
+Revises: 0e2a74e0fc9f
+Create Date: 2018-04-09 23:12:29.317366
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd02246ccf39b'
+down_revision = '0e2a74e0fc9f'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('task_instance', sa.Column('uuid', sa.String(length=250), nullable=True))
+    op.create_index('ti_uuid', 'task_instance', ['uuid'], unique=False)
+
+
+def downgrade():
+    op.drop_column('task_instance', 'uuid')
+    op.drop_index('ti_uuid', table_name='task_instance')

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2571,7 +2571,7 @@ class TaskInstanceModelView(ModelViewOnly):
     verbose_name = "task instance"
     column_filters = (
         'state', 'dag_id', 'task_id', 'execution_date', 'hostname',
-        'queue', 'pool', 'operator', 'start_date', 'end_date')
+        'queue', 'pool', 'operator', 'start_date', 'end_date', 'uuid')
     filter_converter = wwwutils.UtcFilterConverter()
     named_filter_urls = True
     column_formatters = dict(
@@ -2586,7 +2586,7 @@ class TaskInstanceModelView(ModelViewOnly):
         dag_id=dag_link,
         run_id=dag_run_link,
         duration=duration_f)
-    column_searchable_list = ('dag_id', 'task_id', 'state')
+    column_searchable_list = ('dag_id', 'task_id', 'state', 'uuid')
     column_default_sort = ('job_id', True)
     form_choices = {
         'state': [
@@ -2597,7 +2597,7 @@ class TaskInstanceModelView(ModelViewOnly):
     }
     column_list = (
         'state', 'dag_id', 'task_id', 'execution_date', 'operator',
-        'start_date', 'end_date', 'duration', 'job_id', 'hostname',
+        'start_date', 'end_date', 'duration', 'job_id', 'uuid', 'hostname',
         'unixname', 'priority_weight', 'queue', 'queued_dttm', 'try_number',
         'pool', 'log_url')
     page_size = PAGE_SIZE

--- a/tests/executors/dask_executor.py
+++ b/tests/executors/dask_executor.py
@@ -122,6 +122,14 @@ class DaskExecutorTest(BaseDaskTest):
                     cluster_address=self.cluster.scheduler_address))
             job.run()
 
+    @unittest.skipIf(SKIP_DASK, 'Dask unsupported by this configuration')
+    def test_executer_uuid(self):
+        executor = DaskExecutor(cluster_address=self.cluster.scheduler_address)
+        executor.start()
+        uuid = executor.execute_async(key='fail', command='exit 1')
+        self.assertTrue(uuid)
+        self.assertIsInstance(uuid, str)
+
     def tearDown(self):
         self.cluster.close(timeout=5)
 

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -53,6 +53,13 @@ class CeleryExecutorTest(unittest.TestCase):
         self.assertNotIn('success', executor.tasks)
         self.assertNotIn('fail', executor.tasks)
 
+    def test_executer_uuid(self):
+        executor = CeleryExecutor(parallelism=0)
+        executor.start()
+        uuid = executor.execute_async(key='fail', command='exit 1')
+        self.assertTrue(uuid)
+        self.assertIsInstance(uuid, str)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/executors/test_local_executor.py
+++ b/tests/executors/test_local_executor.py
@@ -74,6 +74,13 @@ class LocalExecutorTest(unittest.TestCase):
         test_parallelism = 2
         self.execution_parallelism(parallelism=test_parallelism)
 
+    def test_executer_uuid(self):
+        executor = LocalExecutor(parallelism=0)
+        executor.start()
+        uuid = executor.execute_async(key='fail', command='exit 1')
+        self.assertTrue(uuid)
+        self.assertIsInstance(uuid, str)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
…k id

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2307
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Closes AIRFLOW-2307.  Adds uid to task instance, opportunistically set uid if an id is returned from execute_async.  Returns task id from CeleryExecutor.   This should be generally applicable to other executors with a little work.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Covered by existing tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
