### PR TITLE
[AIRFLOW-2314] Remove only leading slash in GCS path

### DIFF
--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -457,5 +457,6 @@ def _parse_gcs_url(gsurl):
         raise AirflowException('Please provide a bucket name')
     else:
         bucket = parsed_url.netloc
-        blob = parsed_url.path.strip('/')
+        # Remove leading '/' but NOT trailing one
+        blob = parsed_url.path.lstrip('/')
         return bucket, blob

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -14,12 +14,11 @@
 
 import unittest
 
-from airflow.exceptions import AirflowException
 import airflow.contrib.hooks.gcs_hook as gcs_hook
+from airflow.exceptions import AirflowException
 
 
 class TestGCSHookHelperFunctions(unittest.TestCase):
-
     def test_parse_gcs_url(self):
         """
         Test GCS url parsing
@@ -30,17 +29,14 @@ class TestGCSHookHelperFunctions(unittest.TestCase):
             ('bucket', 'path/to/blob'))
 
         # invalid URI
-        self.assertRaises(
-            AirflowException,
-            gcs_hook._parse_gcs_url,
-            'gs:/bucket/path/to/blob')
+        self.assertRaises(AirflowException, gcs_hook._parse_gcs_url,
+                          'gs:/bucket/path/to/blob')
 
         # trailing slash
         self.assertEqual(
             gcs_hook._parse_gcs_url('gs://bucket/path/to/blob/'),
-            ('bucket', 'path/to/blob'))
+            ('bucket', 'path/to/blob/'))
 
         # bucket only
         self.assertEqual(
-            gcs_hook._parse_gcs_url('gs://bucket/'),
-            ('bucket', ''))
+            gcs_hook._parse_gcs_url('gs://bucket/'), ('bucket', ''))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-2314\] Remove only leading slash in GCS path"
    - https://issues.apache.org/jira/browse/AIRFLOW-2314


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
    - This PR resolves an unwanted behaviour of the `_parse_gcs_url` function in `airflow.contrib.hooks.gcs_hook` that strips both the leading and trailing slash characters in the blob part of the URI, to *only* keep the stripping leading character (if available).

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - `tests/contrib/hooks/test_gcs_hook.py`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`