### PR TITLE
[AIRFLOW-2313] Add optional TTL parameters for Dataproc operator

### DIFF
--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -197,7 +197,7 @@ class DataProcHook(GoogleCloudBaseHook):
     def __init__(self,
                  gcp_conn_id='google_cloud_default',
                  delegate_to=None,
-                 api_version='v1'):
+                 api_version='v1beta2'):
         super(DataProcHook, self).__init__(gcp_conn_id, delegate_to)
         self.api_version = api_version
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2313


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds three extra optional parameters to the `DataprocClusterCreateOperator` and relevant unit tests as well.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

New tests:
* `test_build_cluster_data_with_autoDeleteTime` check if autoDeleteTime is added to config
* `test_build_cluster_data_with_autoDeleteTtl` check if autoDeleteTtl is added to config
* `test_build_cluster_data_with_autoDeleteTime_and_autoDeleteTtl` check if autoDeleteTime overrides autoDeleteTtl if both set

Updated tests:
* `test_build_cluster_data` additional checks for new parameters
* `test_init` additional checks for new paramteres


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
   - There are some errors unrelated to this PR