### PR TITLE
[AIRFLOW-2169] Encode binary data with base64 before importing to BigQuery

### DIFF
--- a/tests/contrib/operators/test_mysql_to_gcs_operator.py
+++ b/tests/contrib/operators/test_mysql_to_gcs_operator.py
@@ -18,6 +18,7 @@
 # under the License.
 
 import unittest
+import json
 from mock import MagicMock
 
 from airflow.contrib.operators.mysql_to_gcs import \
@@ -33,19 +34,28 @@ class MySqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
         sql = "some_sql"
         bucket = "some_bucket"
         filename = "some_filename"
-        schema = "some_schema"
-        description_list = [['col_integer'], ['col_byte']]
         row_iter = [[1, b'byte_str_1'], [2, b'byte_str_2']]
+        schema = []
+        schema.append({
+            'name': 'location',
+            'type': 'STRING',
+            'mode': 'nullable',
+        })
+        schema.append({
+            'name': 'uuid',
+            'type': 'BYTES',
+            'mode': 'nullable',
+        })
+        schema_str = json.dumps(schema)
 
         op = MySqlToGoogleCloudStorageOperator(
             task_id=task_id,
             sql=sql,
             bucket=bucket,
             filename=filename,
-            schema=schema)
+            schema=schema_str)
 
         cursor_mock = MagicMock()
-        cursor_mock.description = description_list
         cursor_mock.__iter__.return_value = row_iter
 
         # Run


### PR DESCRIPTION
1. According to BigQuery SQL Data Type, imported BYTES data must be base64-encoded. Therefore, I added a helper function(support both PY2 & PY3) to encode binary type field in row with base64. Documentation could be seen: https://cloud.google.com/bigquery/data-types
2. Also updated related unit test