### PR TITLE
[AIRFLOW-952] fix save empty extra field in UI

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -680,6 +680,9 @@ class Connection(Base, LoggingMixin):
                                     "using non-encrypted value.")
                 self._extra = value
                 self.is_extra_encrypted = False
+        else:
+            self._extra = value
+            self.is_extra_encrypted = False
 
     @declared_attr
     def extra(cls):


### PR DESCRIPTION
### JIRA
- [X] My PR addresses the following [AIRFLOW-952](https://issues.apache.org/jira/browse/AIRFLOW-952)

### Description
Addresses the issue where wiping out existing entries in the extra field does not delete the entry upon clicking the Save button.

