### PR TITLE
[AIRFLOW-2184] Add druid_checker_operator

### DIFF
--- a/airflow/hooks/druid_hook.py
+++ b/airflow/hooks/druid_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -127,7 +127,8 @@ class DruidDbApiHook(DbApiHook):
             path=conn.extra_dejson.get('endpoint', '/druid/v2/sql'),
             scheme=conn.extra_dejson.get('schema', 'http')
         )
-        self.log('Get the connection to druid broker on {host}'.format(host=conn.host))
+        self.log.info('Get the connection to druid '
+                      'broker on {host}'.format(host=conn.host))
         return druid_broker_conn
 
     def get_uri(self):

--- a/airflow/operators/druid_check_operator.py
+++ b/airflow/operators/druid_check_operator.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.exceptions import AirflowException
+from airflow.hooks.druid_hook import DruidDbApiHook
+from airflow.operators.check_operator import CheckOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class DruidCheckOperator(CheckOperator):
+    """
+    Performs checks against Druid. The ``DruidCheckOperator`` expects
+    a sql query that will return a single row. Each value on that
+    first row is evaluated using python ``bool`` casting. If any of the
+    values return ``False`` the check is failed and errors out.
+
+    Note that Python bool casting evals the following as ``False``:
+
+    * ``False``
+    * ``0``
+    * Empty string (``""``)
+    * Empty list (``[]``)
+    * Empty dictionary or set (``{}``)
+
+    Given a query like ``SELECT COUNT(*) FROM foo``, it will fail only if
+    the count ``== 0``. You can craft much more complex query that could,
+    for instance, check that the table has the same number of rows as
+    the source table upstream, or that the count of today's partition is
+    greater than yesterday's partition, or that a set of metrics are less
+    than 3 standard deviation for the 7 day average.
+    This operator can be used as a data quality check in your pipeline, and
+    depending on where you put it in your DAG, you have the choice to
+    stop the critical path, preventing from
+    publishing dubious data, or on the side and receive email alterts
+    without stopping the progress of the DAG.
+
+    :param sql: the sql to be executed
+    :type sql: string
+    :param druid_broker_conn_id: reference to the druid broker
+    :type druid_broker_conn_id: string
+    """
+
+    @apply_defaults
+    def __init__(
+            self, sql,
+            druid_broker_conn_id='druid_broker_default',
+            *args, **kwargs):
+        super(DruidCheckOperator, self).__init__(sql=sql, *args, **kwargs)
+        self.druid_broker_conn_id = druid_broker_conn_id
+        self.sql = sql
+
+    def get_db_hook(self):
+        """
+        Return the druid db api hook.
+        """
+        return DruidDbApiHook(druid_broker_conn_id=self.druid_broker_conn_id)
+
+    def get_first(self, sql):
+        """
+        Executes the druid sql to druid broker and returns the first resulting row.
+
+        :param sql: the sql statement to be executed (str)
+        :type sql: str
+        """
+        with self.get_db_hook().get_conn() as cur:
+            cur.execute(sql)
+            return cur.fetchone()
+
+    def execute(self, context=None):
+        self.log.info('Executing SQL check: {}'.format(self.sql))
+        record = self.get_first(self.sql)
+        self.log.info("Record: {}".format(str(record)))
+        if not record:
+            raise AirflowException("The query returned None")
+        self.log.info("Success.")

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -51,6 +51,7 @@ Operators
 .. autoclass:: airflow.operators.check_operator.CheckOperator
 .. autoclass:: airflow.operators.docker_operator.DockerOperator
 .. autoclass:: airflow.operators.dummy_operator.DummyOperator
+.. autoclass:: airflow.operators.druid_check_operator.DruidCheckOperator
 .. autoclass:: airflow.operators.email_operator.EmailOperator
 .. autoclass:: airflow.operators.generic_transfer.GenericTransfer
 .. autoclass:: airflow.operators.hive_to_druid.HiveToDruidTransfer

--- a/tests/operators/test_druid_check_operator.py
+++ b/tests/operators/test_druid_check_operator.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+from datetime import datetime
+import unittest
+
+from airflow.models import DAG
+from airflow.exceptions import AirflowException
+from airflow.operators.druid_check_operator import DruidCheckOperator
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+
+class DruidCheckOperatorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.task_id = 'test_task'
+        self.druid_broker_conn_id = 'default_conn'
+
+    def __construct_operator(self, sql):
+
+        dag = DAG('test_dag', start_date=datetime(2017, 1, 1))
+
+        return DruidCheckOperator(
+            dag=dag,
+            task_id=self.task_id,
+            druid_broker_conn_id=self.druid_broker_conn_id,
+            sql=sql)
+
+    @mock.patch.object(DruidCheckOperator, 'get_first')
+    def test_execute_pass(self, mock_get_first):
+        mock_get_first.return_value = [10]
+
+        sql = 'select count(*) from tab1 limit 1;'
+
+        operator = self.__construct_operator(sql)
+
+        try:
+            operator.execute(None)
+        except AirflowException:
+            self.fail('Exception should not thrown!')
+
+    @mock.patch.object(DruidCheckOperator, 'get_first')
+    def test_execute_fail(self, mock_get_first):
+        mock_get_first.return_value = []
+        sql = 'select count(*) from tab1 limit 1;'
+
+        operator = self.__construct_operator(sql)
+
+        with self.assertRaises(AirflowException):
+            operator.execute()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2184
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Add a druid checker operator. Since no context manager is implemented in pydruid, override the execute and get_first methods.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit test added.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
