### PR TITLE
[AIRFLOW-2328] Fix empty GCS blob in S3ToGoogleCloudStorageOperator

### DIFF
--- a/airflow/contrib/operators/s3_to_gcs_operator.py
+++ b/airflow/contrib/operators/s3_to_gcs_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -102,11 +102,12 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
         self.replace = replace
 
         if dest_gcs and not self._gcs_object_is_directory(self.dest_gcs):
-            self.log.info('Destination Google Cloud Storage path is not a '
-                          'valid "directory", define one and end the path '
-                          'with a slash: "/".')
+            self.log.info(
+                'Destination Google Cloud Storage path is not a valid '
+                '"directory", define a path that ends with a slash "/" or '
+                'leave it empty for the root of the bucket.')
             raise AirflowException('The destination Google Cloud Storage path '
-                                   'must end with a slash "/".')
+                                   'must end with a slash "/" or be empty.')
 
     def execute(self, context):
         # use the super method to list all the files in an S3 bucket/key
@@ -188,4 +189,4 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
     def _gcs_object_is_directory(self, object):
         bucket, blob = _parse_gcs_url(object)
 
-        return blob.endswith('/')
+        return len(blob) == 0 or blob.endswith('/')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-2328\] Fix empty GCS blob in S3ToGoogleCloudStorageOperator"
    - https://issues.apache.org/jira/browse/AIRFLOW-2328

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
    - Fixes a non-covered case when the destination GCS path for syncing with S3 only consists of the GCS bucket, that is, the GCS blob path is empty.

### Tests
- [x] My PR does not need testing for this extremely good reason:
    - Prior tests still apply: `tests/contrib/operators/test_s3_to_gcs_operator.py`


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
