### PR TITLE
[AIRFLOW-2331] Support init action timeout on dataproc cluster create

### DIFF
--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -62,6 +62,7 @@ MASTER_DISK_SIZE = 100
 WORKER_MACHINE_TYPE = 'n1-standard-2'
 WORKER_DISK_SIZE = 100
 NUM_PREEMPTIBLE_WORKERS = 2
+GET_INIT_ACTION_TIMEOUT = "600s"  # 10m
 LABEL1 = {}
 LABEL2 = {'application': 'test', 'year': 2017}
 SERVICE_ACCOUNT_SCOPES = [
@@ -130,9 +131,16 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
             self.assertEqual(dataproc_operator.master_disk_size, MASTER_DISK_SIZE)
             self.assertEqual(dataproc_operator.worker_machine_type, WORKER_MACHINE_TYPE)
             self.assertEqual(dataproc_operator.worker_disk_size, WORKER_DISK_SIZE)
-            self.assertEqual(dataproc_operator.num_preemptible_workers, NUM_PREEMPTIBLE_WORKERS)
+            self.assertEqual(dataproc_operator.num_preemptible_workers,
+                             NUM_PREEMPTIBLE_WORKERS)
             self.assertEqual(dataproc_operator.labels, self.labels[suffix])
-            self.assertEqual(dataproc_operator.service_account_scopes, SERVICE_ACCOUNT_SCOPES)
+            self.assertEqual(dataproc_operator.service_account_scopes,
+                             SERVICE_ACCOUNT_SCOPES)
+
+    def test_get_init_action_timeout(self):
+        for suffix, dataproc_operator in enumerate(self.dataproc_operators):
+            timeout = dataproc_operator._get_init_action_timeout()
+            self.assertEqual(timeout, "600s")
 
     def test_build_cluster_data(self):
         for suffix, dataproc_operator in enumerate(self.dataproc_operators):


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following:
 - [AIRFLOW-2331](https://issues.apache.org/jira/browse/AIRFLOW-2331) 


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
 - Add support to modify initialization action timeout on create cluster dataproc operator.


### Tests
- [x] My PR adds the following unit tests:
 - [test_get_init_action_timeout](https://github.com/apache/incubator-airflow/pull/3235/files#diff-f7804530ca88cb2e43e9492695ccde2cR140) in [tests/contrib/operators/test_dataproc_operator.py](https://github.com/apache/incubator-airflow/pull/3235/files#diff-f7804530ca88cb2e43e9492695ccde2c)


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`