### PR TITLE
[AIRFLOW-2333] Add Segment Hook with unit tests

### DIFF
--- a/airflow/contrib/hooks/segment_hook.py
+++ b/airflow/contrib/hooks/segment_hook.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+"""
+This module contains a Segment Hook
+which allows you to connect to your Segment account,
+retrieve data from it or write to that file.
+
+NOTE:   this hook also relies on the Segment analytics package:
+        https://github.com/segmentio/analytics-python
+"""
+import analytics
+from airflow.hooks.base_hook import BaseHook
+from airflow.exceptions import AirflowException
+
+from airflow.utils.log.logging_mixin import LoggingMixin
+
+
+class SegmentHook(BaseHook, LoggingMixin):
+    def __init__(
+            self,
+            segment_conn_id,
+            segment_debug_mode=False,
+            *args,
+            **kwargs
+    ):
+        """
+        Create new connection to Segment
+        and allows you to pull data out of Segment or write to it.
+
+        You can then use that file with other
+        Airflow operators to move the data around or interact with segment.
+
+        :param segment_conn_id: the name of the connection that has the parameters
+                            we need to connect to Segment.
+                            The connection should be type `json` and include a
+                            write_key security token in the `Extras` field.
+        :type segment_conn_id: str
+        :param segment_debug_mode: Determines whether Segment should run in debug mode.
+        Defaults to False
+        :type segment_debug_mode: False
+        .. note::
+            You must include a JSON structure in the `Extras` field.
+            We need a user's security token to connect to Segment.
+            So we define it in the `Extras` field as:
+                `{"write_key":"YOUR_SECURITY_TOKEN"}`
+        """
+        self.segment_conn_id = segment_conn_id
+        self.segment_debug_mode = segment_debug_mode
+        self._args = args
+        self._kwargs = kwargs
+
+        # get the connection parameters
+        self.connection = self.get_connection(self.segment_conn_id)
+        self.extras = self.connection.extra_dejson
+        self.write_key = self.extras.get('write_key')
+        if self.write_key is None:
+            raise AirflowException('No Segment write key provided')
+
+    def get_conn(self):
+        self.log.info('Setting write key for Segment analytics connection')
+        analytics.debug = self.segment_debug_mode
+        if self.segment_debug_mode:
+            self.log.debug('Setting Segment analytics connection to debug mode')
+        analytics.on_error = self.on_error
+        analytics.write_key = self.write_key
+        return analytics
+
+    def on_error(self, error, items):
+        """
+        Handles error callbacks when using Segment with segment_debug_mode set to True
+        """
+        self.log.error('Encountered Segment error: {segment_error} with '
+                       'items: {with_items}'.format(segment_error=error,
+                                                    with_items=items))
+        raise AirflowException('Segment error: {}'.format(error))

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -599,6 +599,7 @@ class Connection(Base, LoggingMixin):
         ('aws', 'Amazon Web Services',),
         ('emr', 'Elastic MapReduce',),
         ('snowflake', 'Snowflake',),
+        ('segment', 'Segment',),
     ]
 
     def __init__(

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -370,6 +370,7 @@ Community contributed hooks
 .. autoclass:: airflow.contrib.hooks.redis_hook.RedisHook
 .. autoclass:: airflow.contrib.hooks.redshift_hook.RedshiftHook
 .. autoclass:: airflow.contrib.hooks.salesfore_hook.SalesforceHook
+.. autoclass:: airflow.contrib.hooks.segment_hook.SegmentHook
 .. autoclass:: airflow.contrib.hooks.sftp_hook.SFTPHook
 .. autoclass:: airflow.contrib.hooks.slack_webhook_hook.SlackWebhookHook
 .. autoclass:: airflow.contrib.hooks.snowflake_hook.SnowflakeHook

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -177,6 +177,7 @@ kubernetes = ['kubernetes>=3.0.0',
               'cryptography>=2.0.0']
 snowflake = ['snowflake-connector-python>=1.5.2',
              'snowflake-sqlalchemy>=1.1.0']
+segment = ['analytics-python>=1.2.9']
 zendesk = ['zdesk']
 
 all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant + druid
@@ -202,7 +203,7 @@ devel_hadoop = devel_minreq + hive + hdfs + webhdfs + kerberos
 devel_all = (sendgrid + devel + all_dbs + doc + samba + s3 + slack + crypto + oracle +
              docker + ssh + kubernetes + celery + azure + redis + gcp_api + datadog +
              zendesk + jdbc + ldap + kerberos + password + webhdfs + jenkins +
-             druid + snowflake + elasticsearch)
+             druid + snowflake + segment + elasticsearch)
 
 # Snakebite & Google Cloud Dataflow are not Python 3 compatible :'(
 if PY3:
@@ -311,7 +312,8 @@ def do_setup():
             'jira': jira,
             'redis': redis,
             'kubernetes': kubernetes,
-            'snowflake': snowflake
+            'snowflake': snowflake,
+            'segment': segment
         },
         classifiers=[
             'Development Status :: 5 - Production/Stable',

--- a/tests/contrib/hooks/test_segment_hook.py
+++ b/tests/contrib/hooks/test_segment_hook.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import mock
+import unittest
+
+from airflow import configuration, AirflowException
+
+from airflow.contrib.hooks.segment_hook import SegmentHook
+
+
+class TestSegmentHook(unittest.TestCase):
+
+    def setUp(self):
+        super(TestSegmentHook, self).setUp()
+        configuration.load_test_config()
+
+        self.conn = conn = mock.MagicMock()
+        self.expected_write_key = 'foo'
+        self.conn.extra_dejson = {'write_key': self.expected_write_key}
+
+        class UnitTestSegmentHook(SegmentHook):
+            conn_name_attr = 'segment_conn_id'
+
+            def get_conn(self):
+                return conn
+
+            def get_connection(self, connection_id):
+                return conn
+
+        self.test_hook = UnitTestSegmentHook()
+
+    def test_get_conn(self):
+        expected_connection = self.test_hook.get_conn()
+        self.assertEqual(expected_connection, self.conn)
+        self.assertIsNotNone(self.expected_connection.write_key)
+        self.assertEqual(self.expected_connection.write_key, self.expected_write_key)
+
+    def test_on_error(self):
+        with self.assertRaises(AirflowException):
+            self.test_hook.on_error('error', ['items'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2333
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
Add Segment Hook to store Segment Analytics access
token with encryption in metadata database.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Unit test added.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
