### PR TITLE
[AIRFLOW-1433] Set default rbac to initdb

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -85,7 +85,7 @@ def merge_conn(conn, session=None):
         session.commit()
 
 
-def initdb(rbac):
+def initdb(rbac=False):
     session = settings.Session()
 
     from airflow import models


### PR DESCRIPTION
05e1861e24de42f9a2c649cd93041c5c744504e1 breaks the api for
any program directly importing airflow.utils.  This sets
a reasonable default.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1433
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Sets a default value to allow old code to continue calling airflow.utils.initdb with no arguments

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
