### PR TITLE
[AIRFLOW-2300] Add S3 Select functionarity to S3ToHiveTransfer

### DIFF
--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -194,9 +194,11 @@ class S3Hook(AwsHook):
         :param expression_type: S3 Select expression type
         :type expression_type: str
         :param input_serialization: S3 Select input data serialization format
-        :type input_serialization: str
+        :type input_serialization: dict
         :param output_serialization: S3 Select output data serialization format
-        :type output_serialization: str
+        :type output_serialization: dict
+        :return: retrieved subset of original data by S3 Select
+        :rtype: str
 
         .. seealso::
             For more details about S3 Select parameters:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2300
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

To improve efficiency and usability, this PR adds
S3 Select functionarity to S3ToHiveTransfer.
It also contains some minor fixes for documents
and comments.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added test_execute_with_select_expression to tests.operators.s3_to_hive_operator:S3ToHiveTransferTest


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
