### PR TITLE
[AIRFLOW-2348] Strip common prefix path, when copying files from GCS to GCS

### DIFF
--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -102,10 +102,10 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
                                                         source_object,
                                                         self.destination_bucket,
                                                         self.destination_object,
-                                                        source_object))
+                                                        source_object[wildcard_position:]))
                 hook.copy(self.source_bucket, source_object,
                           self.destination_bucket, "{}/{}".format(self.destination_object,
-                                                                  source_object))
+                                                                  source_object[wildcard_position:]))
                 if self.move_object:
                     hook.delete(self.source_bucket, source_object)
 


### PR DESCRIPTION
Small to fix that strips the  path prefix when using wild card in GoogleCloudStorageToGoogleCloudStorageOperator

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-2348\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2348



### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
