### PR TITLE
[AIRFLOW-2354] Change task instance run validation to not exclude das…

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -944,14 +944,16 @@ class Airflow(BaseView):
 
         try:
             from airflow.executors import GetDefaultExecutor
-            from airflow.executors.celery_executor import CeleryExecutor
+            from airflow.executors.local_executor import LocalExecutor
+            from airflow.executors.sequential_executor import SequentialExecutor
             executor = GetDefaultExecutor()
-            if not isinstance(executor, CeleryExecutor):
-                flash("Only works with the CeleryExecutor, sorry", "error")
+            if isinstance(executor, LocalExecutor) or \
+                    isinstance(executor, SequentialExecutor):
+                flash("Doesn't work with the LocalExecutor or SequentialExecutor, sorry",
+                      "error")
                 return redirect(origin)
         except ImportError:
-            # in case CeleryExecutor cannot be imported it is not active either
-            flash("Only works with the CeleryExecutor, sorry", "error")
+            flash("Error when attempting to validate the executor", "error")
             return redirect(origin)
 
         ti = models.TaskInstance(task=task, execution_date=execution_date)

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -591,14 +591,16 @@ class Airflow(AirflowBaseView):
 
         try:
             from airflow.executors import GetDefaultExecutor
-            from airflow.executors.celery_executor import CeleryExecutor
+            from airflow.executors.local_executor import LocalExecutor
+            from airflow.executors.sequential_executor import SequentialExecutor
             executor = GetDefaultExecutor()
-            if not isinstance(executor, CeleryExecutor):
-                flash("Only works with the CeleryExecutor, sorry", "error")
+            if isinstance(executor, LocalExecutor) or \
+                    isinstance(executor, SequentialExecutor):
+                flash("Doesn't work with the LocalExecutor or SequentialExecutor, sorry",
+                      "error")
                 return redirect(origin)
         except ImportError:
-            # in case CeleryExecutor cannot be imported it is not active either
-            flash("Only works with the CeleryExecutor, sorry", "error")
+            flash("Error when attempting to validate the executor", "error")
             return redirect(origin)
 
         ti = models.TaskInstance(task=task, execution_date=execution_date)


### PR DESCRIPTION
…k and plugin executors

Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.

https://issues.apache.org/jira/browse/AIRFLOW-2354

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

When running a single task instance from the UI there is a check that limits the functionality to the CeleryExecutor.

This seems outdated since the addition of the DaskExecutor which presumably supports this operation.

Also other airflow users (such as myself) may be using plugin executors that support running tasks this way.

Changed the check to block the operation when using either the LocalExecutor or SequentialExecutor, rather than permitting only for the CeleryExecutor.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added www.test_views.TestRunTaskInstanceView which includes two test cases for this

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

Not needed

### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Yup