### PR TITLE
[AIRFLOW-2351] timezone fix for @once DAGs

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -3081,7 +3081,10 @@ class DAG(BaseDag, LoggingMixin):
                 self.default_args['start_date'] = (
                     timezone.parse(self.default_args['start_date'])
                 )
-            self.timezone = self.default_args['start_date'].tzinfo
+            if self.default_args['start_date']:
+                self.timezone = self.default_args['start_date'].tzinfo
+            else:
+                self.timezone = settings.TIMEZONE
         else:
             self.timezone = settings.TIMEZONE
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [AIRFLOW-2351](https://issues.apache.org/jira/browse/AIRFLOW-2351) issue and references them in the PR title. 


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

> Upgraded Airflow .. getting following error [1] when processing a DAG
> We have 'start_date': None set in default_args.. but this used to work im previous airflow versions.
> This is a '@once DAG.. so we don't need a start_date (no back fill).
> 
>  
> 
> [2018-01-16 16:05:25,283] {models.py:293} ERROR - Failed to import: /home/rdautkha/airflow/dags/discover/discover-ora-load-2.py
> Traceback (most recent call last):
>   File "/opt/airflow/airflow-20180116/src/apache-airflow/airflow/models.py", line 290, in process_file
>     m = imp.load_source(mod_name, filepath)
>   File "/home/rdautkha/airflow/dags/discover/discover-ora-load-2.py", line 66, in <module>
>     orientation                    = 'TB',                          # default graph view
>   File "/opt/airflow/airflow-20180116/src/apache-airflow/airflow/models.py", line 2951, in _init_
>     self.timezone = self.default_args['start_date'].tzinfo
> AttributeError: 'NoneType' object has no attribute 'tzinfo'
> 
> 

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Tested manually

