### PR TITLE
[AIRFLOW-2359] Add set failed for DagRun and task in tree view

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1017,7 +1017,8 @@ class SchedulerJob(BaseJob):
                     models.TaskInstance.dag_id == subq.c.dag_id,
                     models.TaskInstance.task_id == subq.c.task_id,
                     models.TaskInstance.execution_date ==
-                    subq.c.execution_date)) \
+                    subq.c.execution_date,
+                    models.TaskInstance.task_id == subq.c.task_id)) \
                 .update({models.TaskInstance.state: new_state},
                         synchronize_session=False)
             session.commit()

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1654,9 +1654,9 @@ class TaskInstance(Base, LoggingMixin):
             self.state = State.SKIPPED
         except AirflowException as e:
             self.refresh_from_db()
-            # for case when task is marked as success externally
+            # for case when task is marked as success/failed externally
             # current behavior doesn't hit the success callback
-            if self.state == State.SUCCESS:
+            if self.state in {State.SUCCESS, State.FAILED}:
                 return
             else:
                 self.handle_failure(e, test_mode, context)

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -197,6 +197,24 @@
             </button>
           </span>
           <hr/>
+          <button id="btn_failed" type="button" class="btn btn-primary">
+            Mark Failed
+          </button>
+          <span class="btn-group">
+            <button id="btn_failed_past"
+              type="button" class="btn" data-toggle="button">Past</button>
+            <button id="btn_failed_future"
+              type="button" class="btn" data-toggle="button">
+              Future
+            </button>
+            <button id="btn_failed_upstream"
+              type="button" class="btn" data-toggle="button">Upstream</button>
+            <button id="btn_failed_downstream"
+              type="button" class="btn" data-toggle="button">
+              Downstream
+            </button>
+          </span>
+          <hr/>
           <button id="btn_success" type="button" class="btn btn-primary">
             Mark Success
           </button>
@@ -240,6 +258,9 @@
           </button>
           <button id="btn_dagrun_clear" type="button" class="btn btn-primary">
             Clear
+          </button>
+          <button id="btn_dagrun_failed" type="button" class="btn btn-primary">
+            Mark Failed
           </button>
           <button id="btn_dagrun_success" type="button" class="btn btn-primary">
             Mark Success
@@ -389,6 +410,20 @@ function updateQueryStringParameter(uri, key, value) {
       window.location = url;
     });
 
+    $("#btn_failed").click(function(){
+      url = "{{ url_for('airflow.failed') }}" +
+        "?task_id=" + encodeURIComponent(task_id) +
+        "&dag_id=" + encodeURIComponent(dag_id) +
+        "&upstream=" + $('#btn_failed_upstream').hasClass('active') +
+        "&downstream=" + $('#btn_failed_downstream').hasClass('active') +
+        "&future=" + $('#btn_failed_future').hasClass('active') +
+        "&past=" + $('#btn_failed_past').hasClass('active') +
+        "&execution_date=" + encodeURIComponent(execution_date) +
+        "&origin=" + encodeURIComponent(window.location);
+
+      window.location = url;
+    });
+
     $("#btn_success").click(function(){
       url = "{{ url_for('airflow.success') }}" +
         "?task_id=" + encodeURIComponent(task_id) +
@@ -400,6 +435,14 @@ function updateQueryStringParameter(uri, key, value) {
         "&execution_date=" + encodeURIComponent(execution_date) +
         "&origin=" + encodeURIComponent(window.location);
 
+      window.location = url;
+    });
+
+    $('#btn_dagrun_failed').click(function(){
+      url = "{{ url_for('airflow.dagrun_failed') }}" +
+        "?dag_id=" + encodeURIComponent(dag_id) +
+        "&execution_date=" + encodeURIComponent(execution_date) +
+        "&origin=" + encodeURIComponent(window.location);
       window.location = url;
     });
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -18,77 +18,69 @@
 # under the License.
 #
 
-from past.builtins import basestring, unicode
-
 import ast
-import datetime as dt
-import logging
-import os
-import pkg_resources
-import socket
-from functools import wraps
-from datetime import timedelta
-import copy
-import math
-import json
-import bleach
-import pendulum
 import codecs
-from collections import defaultdict
-import itertools
-
+import copy
+import datetime as dt
 import inspect
-from textwrap import dedent
+import itertools
+import json
+import logging
+import math
+import os
 import traceback
+from collections import defaultdict
+from datetime import timedelta
+from functools import wraps
+from textwrap import dedent
 
+import bleach
+import markdown
+import nvd3
+import pendulum
+import pkg_resources
 import sqlalchemy as sqla
-from sqlalchemy import or_, desc, and_, union_all
-
 from flask import (
     abort, jsonify, redirect, url_for, request, Markup, Response,
     current_app, render_template, make_response)
-from flask_admin import BaseView, expose, AdminIndexView
-from flask_admin.contrib.sqla import ModelView
-from flask_admin.actions import action
-from flask_admin.babel import lazy_gettext
-from flask_admin.tools import iterdecode
 from flask import flash
 from flask._compat import PY2
-
-from jinja2.sandbox import ImmutableSandboxedEnvironment
+from flask_admin import BaseView, expose, AdminIndexView
+from flask_admin.actions import action
+from flask_admin.babel import lazy_gettext
+from flask_admin.contrib.sqla import ModelView
+from flask_admin.form.fields import DateTimeField
+from flask_admin.tools import iterdecode
 from jinja2 import escape
-
-import markdown
-import nvd3
-
+from jinja2.sandbox import ImmutableSandboxedEnvironment
+from past.builtins import basestring, unicode
+from pygments import highlight, lexers
+from pygments.formatters import HtmlFormatter
+from sqlalchemy import or_, desc, and_, union_all
 from wtforms import (
     Form, SelectField, TextAreaField, PasswordField,
     StringField, validators)
-from flask_admin.form.fields import DateTimeField
-
-from pygments import highlight, lexers
-from pygments.formatters import HtmlFormatter
 
 import airflow
 from airflow import configuration as conf
 from airflow import models
 from airflow import settings
-from airflow.api.common.experimental.mark_tasks import set_dag_run_state
+from airflow.api.common.experimental.mark_tasks import (set_dag_run_state_to_running,
+                                                        set_dag_run_state_to_success,
+                                                        set_dag_run_state_to_failed)
 from airflow.exceptions import AirflowException
-from airflow.models import XCom, DagRun
-from airflow.ti_deps.dep_context import DepContext, QUEUE_DEPS, SCHEDULER_DEPS
-
 from airflow.models import BaseOperator
+from airflow.models import XCom, DagRun
 from airflow.operators.subdag_operator import SubDagOperator
-
+from airflow.ti_deps.dep_context import DepContext, QUEUE_DEPS, SCHEDULER_DEPS
 from airflow.utils import timezone
-from airflow.utils.json import json_ser
-from airflow.utils.state import State
+from airflow.utils.dates import infer_time_unit, scale_time_units, parse_execution_date
 from airflow.utils.db import create_session, provide_session
 from airflow.utils.helpers import alchemy_to_dict
-from airflow.utils.dates import infer_time_unit, scale_time_units, parse_execution_date
-from airflow.utils.timezone import datetime
+from airflow.utils.json import json_ser
 from airflow.utils.net import get_hostname
+from airflow.utils.state import State
+from airflow.utils.timezone import datetime
 from airflow.www import utils as wwwutils
 from airflow.www.forms import (DateTimeForm, DateTimeWithNumRunsForm,
                                DateTimeWithNumRunsWithDagRunsForm)
@@ -1208,16 +1200,7 @@ class Airflow(BaseView):
             })
         return wwwutils.json_response(payload)
 
-    @expose('/dagrun_success')
-    @login_required
-    @wwwutils.action_logging
-    @wwwutils.notify_owner
-    def dagrun_success(self):
-        dag_id = request.args.get('dag_id')
-        execution_date = request.args.get('execution_date')
-        confirmed = request.args.get('confirmed') == 'true'
-        origin = request.args.get('origin')
-
+    def _mark_dagrun_state_as_failed(self, dag_id, execution_date, confirmed, origin):
         if not execution_date:
             flash('Invalid execution date', 'error')
             return redirect(origin)
@@ -1229,8 +1212,36 @@ class Airflow(BaseView):
             flash('Cannot find DAG: {}'.format(dag_id), 'error')
             return redirect(origin)
 
-        new_dag_state = set_dag_run_state(dag, execution_date, state=State.SUCCESS,
-                                          commit=confirmed)
+        new_dag_state = set_dag_run_state_to_failed(dag, execution_date, commit=confirmed)
+
+        if confirmed:
+            flash('Marked failed on {} task instances'.format(len(new_dag_state)))
+            return redirect(origin)
+
+        else:
+            details = '\n'.join([str(t) for t in new_dag_state])
+
+            response = self.render('airflow/confirm.html',
+                                   message=("Here's the list of task instances you are "
+                                            "about to mark as failed"),
+                                   details=details)
+
+            return response
+
+    def _mark_dagrun_state_as_success(self, dag_id, execution_date, confirmed, origin):
+        if not execution_date:
+            flash('Invalid execution date', 'error')
+            return redirect(origin)
+
+        execution_date = pendulum.parse(execution_date)
+        dag = dagbag.get_dag(dag_id)
+
+        if not dag:
+            flash('Cannot find DAG: {}'.format(dag_id), 'error')
+            return redirect(origin)
+
+        new_dag_state = set_dag_run_state_to_success(dag, execution_date,
+                                                     commit=confirmed)
 
         if confirmed:
             flash('Marked success on {} task instances'.format(len(new_dag_state)))
@@ -1241,30 +1252,43 @@ class Airflow(BaseView):
 
             response = self.render('airflow/confirm.html',
                                    message=("Here's the list of task instances you are "
-                                            "about to mark as successful:"),
+                                            "about to mark as success"),
                                    details=details)
 
             return response
 
-    @expose('/success')
+    @expose('/dagrun_failed')
     @login_required
     @wwwutils.action_logging
     @wwwutils.notify_owner
-    def success(self):
+    def dagrun_failed(self):
         dag_id = request.args.get('dag_id')
-        task_id = request.args.get('task_id')
+        execution_date = request.args.get('execution_date')
+        confirmed = request.args.get('confirmed') == 'true'
         origin = request.args.get('origin')
+        return self._mark_dagrun_state_as_failed(dag_id, execution_date,
+                                                 confirmed, origin)
+
+    @expose('/dagrun_success')
+    @login_required
+    @wwwutils.action_logging
+    @wwwutils.notify_owner
+    def dagrun_success(self):
+        dag_id = request.args.get('dag_id')
+        execution_date = request.args.get('execution_date')
+        confirmed = request.args.get('confirmed') == 'true'
+        origin = request.args.get('origin')
+        return self._mark_dagrun_state_as_success(dag_id, execution_date,
+                                                  confirmed, origin)
+
+    def _mark_task_instance_state(self, dag_id, task_id, origin, execution_date,
+                                  confirmed, upstream, downstream,
+                                  future, past, state):
         dag = dagbag.get_dag(dag_id)
         task = dag.get_task(task_id)
         task.dag = dag
 
-        execution_date = request.args.get('execution_date')
         execution_date = pendulum.parse(execution_date)
-        confirmed = request.args.get('confirmed') == "true"
-        upstream = request.args.get('upstream') == "true"
-        downstream = request.args.get('downstream') == "true"
-        future = request.args.get('future') == "true"
-        past = request.args.get('past') == "true"
 
         if not dag:
             flash("Cannot find DAG: {}".format(dag_id))
@@ -1279,25 +1303,65 @@ class Airflow(BaseView):
         if confirmed:
             altered = set_state(task=task, execution_date=execution_date,
                                 upstream=upstream, downstream=downstream,
-                                future=future, past=past, state=State.SUCCESS,
+                                future=future, past=past, state=state,
                                 commit=True)
 
-            flash("Marked success on {} task instances".format(len(altered)))
+            flash("Marked {} on {} task instances".format(state, len(altered)))
             return redirect(origin)
 
         to_be_altered = set_state(task=task, execution_date=execution_date,
                                   upstream=upstream, downstream=downstream,
-                                  future=future, past=past, state=State.SUCCESS,
+                                  future=future, past=past, state=state,
                                   commit=False)
 
         details = "\n".join([str(t) for t in to_be_altered])
 
         response = self.render("airflow/confirm.html",
                                message=("Here's the list of task instances you are "
-                                        "about to mark as successful:"),
+                                        "about to mark as {}:".format(state)),
                                details=details)
 
         return response
+
+    @expose('/failed')
+    @login_required
+    @wwwutils.action_logging
+    @wwwutils.notify_owner
+    def failed(self):
+        dag_id = request.args.get('dag_id')
+        task_id = request.args.get('task_id')
+        origin = request.args.get('origin')
+        execution_date = request.args.get('execution_date')
+
+        confirmed = request.args.get('confirmed') == "true"
+        upstream = request.args.get('upstream') == "true"
+        downstream = request.args.get('downstream') == "true"
+        future = request.args.get('future') == "true"
+        past = request.args.get('past') == "true"
+
+        return self._mark_task_instance_state(dag_id, task_id, origin, execution_date,
+                                              confirmed, upstream, downstream,
+                                              future, past, State.FAILED)
+
+    @expose('/success')
+    @login_required
+    @wwwutils.action_logging
+    @wwwutils.notify_owner
+    def success(self):
+        dag_id = request.args.get('dag_id')
+        task_id = request.args.get('task_id')
+        origin = request.args.get('origin')
+        execution_date = request.args.get('execution_date')
+
+        confirmed = request.args.get('confirmed') == "true"
+        upstream = request.args.get('upstream') == "true"
+        downstream = request.args.get('downstream') == "true"
+        future = request.args.get('future') == "true"
+        past = request.args.get('past') == "true"
+
+        return self._mark_task_instance_state(dag_id, task_id, origin, execution_date,
+                                              confirmed, upstream, downstream,
+                                              future, past, State.SUCCESS)
 
     @expose('/tree')
     @login_required
@@ -2596,19 +2660,8 @@ class DagRunModelView(ModelViewOnly):
         models.DagStat.update(dirty_ids, dirty_only=False, session=session)
 
     @action('set_running', "Set state to 'running'", None)
-    def action_set_running(self, ids):
-        self.set_dagrun_state(ids, State.RUNNING)
-
-    @action('set_failed', "Set state to 'failed'", None)
-    def action_set_failed(self, ids):
-        self.set_dagrun_state(ids, State.FAILED)
-
-    @action('set_success', "Set state to 'success'", None)
-    def action_set_success(self, ids):
-        self.set_dagrun_state(ids, State.SUCCESS)
-
     @provide_session
-    def set_dagrun_state(self, ids, target_state, session=None):
+    def action_set_running(self, ids, session=None):
         try:
             DR = models.DagRun
             count = 0
@@ -2616,19 +2669,97 @@ class DagRunModelView(ModelViewOnly):
             for dr in session.query(DR).filter(DR.id.in_(ids)).all():
                 dirty_ids.append(dr.dag_id)
                 count += 1
-                dr.state = target_state
-                if target_state == State.RUNNING:
-                    dr.start_date = timezone.utcnow()
-                else:
-                    dr.end_date = timezone.utcnow()
-            session.commit()
+                dr.state = State.RUNNING
+                dr.start_date = timezone.utcnow()
             models.DagStat.update(dirty_ids, session=session)
             flash(
-                "{count} dag runs were set to '{target_state}'".format(**locals()))
+                "{count} dag runs were set to running".format(**locals()))
         except Exception as ex:
             if not self.handle_view_exception(ex):
                 raise Exception("Ooops")
             flash('Failed to set state', 'error')
+
+    @action('set_failed', "Set state to 'failed'",
+            "All running task instances would also be marked as failed, are you sure?")
+    @provide_session
+    def action_set_failed(self, ids, session=None):
+        try:
+            DR = models.DagRun
+            count = 0
+            dirty_ids = []
+            altered_tis = []
+            for dr in session.query(DR).filter(DR.id.in_(ids)).all():
+                dirty_ids.append(dr.dag_id)
+                count += 1
+                altered_tis += \
+                    set_dag_run_state_to_failed(dagbag.get_dag(dr.dag_id),
+                                                dr.execution_date,
+                                                commit=True,
+                                                session=session)
+            models.DagStat.update(dirty_ids, session=session)
+            altered_ti_count = len(altered_tis)
+            flash(
+                "{count} dag runs and {altered_ti_count} task instances "
+                "were set to failed".format(**locals()))
+        except Exception as ex:
+            if not self.handle_view_exception(ex):
+                raise Exception("Ooops")
+            flash('Failed to set state', 'error')
+
+    @action('set_success', "Set state to 'success'",
+            "All task instances would also be marked as success, are you sure?")
+    @provide_session
+    def action_set_success(self, ids, session=None):
+        try:
+            DR = models.DagRun
+            count = 0
+            dirty_ids = []
+            altered_tis = []
+            for dr in session.query(DR).filter(DR.id.in_(ids)).all():
+                dirty_ids.append(dr.dag_id)
+                count += 1
+                altered_tis += \
+                    set_dag_run_state_to_success(dagbag.get_dag(dr.dag_id),
+                                                 dr.execution_date,
+                                                 commit=True,
+                                                 session=session)
+            models.DagStat.update(dirty_ids, session=session)
+            altered_ti_count = len(altered_tis)
+            flash(
+                "{count} dag runs and {altered_ti_count} task instances "
+                "were set to success".format(**locals()))
+        except Exception as ex:
+            if not self.handle_view_exception(ex):
+                raise Exception("Ooops")
+            flash('Failed to set state', 'error')
+
+    # Called after editing DagRun model in the UI.
+    @provide_session
+    def after_model_change(self, form, dagrun, is_created, session=None):
+        altered_tis = []
+        if dagrun.state == State.SUCCESS:
+            altered_tis = set_dag_run_state_to_success(
+                dagbag.get_dag(dagrun.dag_id),
+                dagrun.execution_date,
+                commit=True)
+        elif dagrun.state == State.FAILED:
+            altered_tis = set_dag_run_state_to_failed(
+                dagbag.get_dag(dagrun.dag_id),
+                dagrun.execution_date,
+                commit=True,
+                session=session)
+        elif dagrun.state == State.RUNNING:
+            altered_tis = set_dag_run_state_to_running(
+                dagbag.get_dag(dagrun.dag_id),
+                dagrun.execution_date,
+                commit=True,
+                session=session)
+
+        altered_ti_count = len(altered_tis)
+        models.DagStat.update([dagrun.dag_id], session=session)
+        flash(
+            "1 dag run and {altered_ti_count} task instances "
+            "were set to '{dagrun.state}'".format(**locals()))
 
 
 class LogModelView(ModelViewOnly):

--- a/airflow/www_rbac/templates/airflow/dag.html
+++ b/airflow/www_rbac/templates/airflow/dag.html
@@ -196,6 +196,24 @@
             </button>
           </span>
           <hr/>
+          <button id="btn_failed" type="button" class="btn btn-primary">
+            Mark Failed
+          </button>
+          <span class="btn-group">
+            <button id="btn_failed_past"
+              type="button" class="btn" data-toggle="button">Past</button>
+            <button id="btn_failed_future"
+              type="button" class="btn" data-toggle="button">
+              Future
+            </button>
+            <button id="btn_failed_upstream"
+              type="button" class="btn" data-toggle="button">Upstream</button>
+            <button id="btn_failed_downstream"
+              type="button" class="btn" data-toggle="button">
+              Downstream
+            </button>
+          </span>
+          <hr/>
           <button id="btn_success" type="button" class="btn btn-primary">
             Mark Success
           </button>
@@ -239,6 +257,9 @@
           </button>
           <button id="btn_dagrun_clear" type="button" class="btn btn-primary">
             Clear
+          </button>
+          <button id="btn_dagrun_failed" type="button" class="btn btn-primary">
+            Mark Failed
           </button>
           <button id="btn_dagrun_success" type="button" class="btn btn-primary">
             Mark Success
@@ -387,6 +408,20 @@ function updateQueryStringParameter(uri, key, value) {
       window.location = url;
     });
 
+    $("#btn_failed").click(function(){
+      url = "{{ url_for('Airflow.failed') }}" +
+        "?task_id=" + encodeURIComponent(task_id) +
+        "&dag_id=" + encodeURIComponent(dag_id) +
+        "&upstream=" + $('#btn_failed_upstream').hasClass('active') +
+        "&downstream=" + $('#btn_failed_downstream').hasClass('active') +
+        "&future=" + $('#btn_failed_future').hasClass('active') +
+        "&past=" + $('#btn_failed_past').hasClass('active') +
+        "&execution_date=" + encodeURIComponent(execution_date) +
+        "&origin=" + encodeURIComponent(window.location);
+
+      window.location = url;
+    });
+
     $("#btn_success").click(function(){
       url = "{{ url_for('Airflow.success') }}" +
         "?task_id=" + encodeURIComponent(task_id) +
@@ -398,6 +433,14 @@ function updateQueryStringParameter(uri, key, value) {
         "&execution_date=" + encodeURIComponent(execution_date) +
         "&origin=" + encodeURIComponent(window.location);
 
+      window.location = url;
+    });
+
+    $('#btn_dagrun_failed').click(function(){
+      url = "{{ url_for('Airflow.dagrun_failed') }}" +
+        "?dag_id=" + encodeURIComponent(dag_id) +
+        "&execution_date=" + encodeURIComponent(execution_date) +
+        "&origin=" + encodeURIComponent(window.location);
       window.location = url;
     });
 

--- a/docs/scheduler.rst
+++ b/docs/scheduler.rst
@@ -158,6 +158,7 @@ Here are some of the ways you can **unblock tasks**:
   states (``failed``, or ``success``)
 * Clearing a task instance will no longer delete the task instance record. Instead it updates
   max_tries and set the current task instance state to be None.
+* Marking task instances as failed can be done through the UI. This can be used to stop running task instances.
 * Marking task instances as successful can be done through the UI. This is mostly to fix false negatives,
   or for instance when the fix has been applied outside of Airflow.
 * The ``airflow backfill`` CLI subcommand has a flag to ``--mark_success`` and allows selecting

--- a/tests/api/common/experimental/mark_tasks.py
+++ b/tests/api/common/experimental/mark_tasks.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,14 +18,16 @@
 # under the License.
 
 import unittest
+from datetime import datetime
 
 from airflow import models
 from airflow.api.common.experimental.mark_tasks import (
-    set_state, _create_dagruns, set_dag_run_state)
+    set_state, _create_dagruns, set_dag_run_state_to_success, set_dag_run_state_to_failed,
+    set_dag_run_state_to_running)
 from airflow.settings import Session
+from airflow.utils import timezone
 from airflow.utils.dates import days_ago
 from airflow.utils.state import State
-from datetime import datetime, timedelta
 
 DEV_NULL = "/dev/null"
 
@@ -223,77 +225,9 @@ class TestMarkDAGRun(unittest.TestCase):
 
         self.session = Session()
 
-    def verify_dag_run_states(self, dag, date, state=State.SUCCESS):
-        drs = models.DagRun.find(dag_id=dag.dag_id, execution_date=date)
-        dr = drs[0]
-        self.assertEqual(dr.get_state(), state)
-        tis = dr.get_task_instances(session=self.session)
-        for ti in tis:
-            self.assertEqual(ti.state, state)
-
-    def test_set_running_dag_run_state(self):
-        date = self.execution_dates[0]
-        dr = self.dag1.create_dagrun(
-            run_id='manual__' + datetime.now().isoformat(),
-            state=State.RUNNING,
-            execution_date=date,
-            session=self.session
-        )
-        for ti in dr.get_task_instances(session=self.session):
-            ti.set_state(State.RUNNING, self.session)
-
-        altered = set_dag_run_state(self.dag1, date, state=State.SUCCESS, commit=True)
-
-        # All of the task should be altered
-        self.assertEqual(len(altered), len(self.dag1.tasks))
-        self.verify_dag_run_states(self.dag1, date)
-
-    def test_set_success_dag_run_state(self):
-        date = self.execution_dates[0]
-
-        dr = self.dag1.create_dagrun(
-            run_id='manual__' + datetime.now().isoformat(),
-            state=State.SUCCESS,
-            execution_date=date,
-            session=self.session
-        )
-        for ti in dr.get_task_instances(session=self.session):
-            ti.set_state(State.SUCCESS, self.session)
-
-        altered = set_dag_run_state(self.dag1, date, state=State.SUCCESS, commit=True)
-
-        # None of the task should be altered
-        self.assertEqual(len(altered), 0)
-        self.verify_dag_run_states(self.dag1, date)
-
-    def test_set_failed_dag_run_state(self):
-        date = self.execution_dates[0]
-        dr = self.dag1.create_dagrun(
-            run_id='manual__' + datetime.now().isoformat(),
-            state=State.FAILED,
-            execution_date=date,
-            session=self.session
-        )
-        dr.get_task_instance('runme_0').set_state(State.FAILED, self.session)
-
-        altered = set_dag_run_state(self.dag1, date, state=State.SUCCESS, commit=True)
-
-        # All of the task should be altered
-        self.assertEqual(len(altered), len(self.dag1.tasks))
-        self.verify_dag_run_states(self.dag1, date)
-
-    def test_set_mixed_dag_run_state(self):
-        """
-        This test checks function set_dag_run_state with mixed task instance
-        state.
-        """
-        date = self.execution_dates[0]
-        dr = self.dag1.create_dagrun(
-            run_id='manual__' + datetime.now().isoformat(),
-            state=State.FAILED,
-            execution_date=date,
-            session=self.session
-        )
+    def _set_default_task_instance_states(self, dr):
+        if dr.dag_id != 'test_example_bash_operator':
+            return
         # success task
         dr.get_task_instance('runme_0').set_state(State.SUCCESS, self.session)
         # skipped task
@@ -307,31 +241,167 @@ class TestMarkDAGRun(unittest.TestCase):
         # failed task
         dr.get_task_instance('run_this_last').set_state(State.FAILED, self.session)
 
-        altered = set_dag_run_state(self.dag1, date, state=State.SUCCESS, commit=True)
+    def _verify_task_instance_states_remain_default(self, dr):
+        self.assertEqual(dr.get_task_instance('runme_0').state, State.SUCCESS)
+        self.assertEqual(dr.get_task_instance('runme_1').state, State.SKIPPED)
+        self.assertEqual(dr.get_task_instance('runme_2').state, State.UP_FOR_RETRY)
+        self.assertEqual(dr.get_task_instance('also_run_this').state, State.QUEUED, )
+        self.assertEqual(dr.get_task_instance('run_after_loop').state, State.RUNNING)
+        self.assertEqual(dr.get_task_instance('run_this_last').state, State.FAILED)
 
-        self.assertEqual(len(altered), len(self.dag1.tasks) - 1) # only 1 task succeeded
-        self.verify_dag_run_states(self.dag1, date)
+    def _verify_task_instance_states(self, dag, date, state):
+        TI = models.TaskInstance
+        tis = self.session.query(TI).filter(TI.dag_id == dag.dag_id,
+                                            TI.execution_date == date)
+        for ti in tis:
+            self.assertEqual(ti.state, state)
 
-    def test_set_state_without_commit(self):
-        date = self.execution_dates[0]
-
-        # Running dag run and task instances
-        dr = self.dag1.create_dagrun(
+    def _create_test_dag_run(self, state, date):
+        return self.dag1.create_dagrun(
             run_id='manual__' + datetime.now().isoformat(),
-            state=State.RUNNING,
+            state=state,
             execution_date=date,
             session=self.session
         )
-        for ti in dr.get_task_instances(session=self.session):
-            ti.set_state(State.RUNNING, self.session)
 
-        altered = set_dag_run_state(self.dag1, date, state=State.SUCCESS, commit=False)
+    def _verify_dag_run_state(self, dag, date, state):
+        drs = models.DagRun.find(dag_id=dag.dag_id, execution_date=date)
+        dr = drs[0]
+        self.assertEqual(dr.get_state(), state)
 
-        # All of the task should be altered
-        self.assertEqual(len(altered), len(self.dag1.tasks))
+    def test_set_running_dag_run_to_success(self):
+        date = self.execution_dates[0]
+        dr = self._create_test_dag_run(State.RUNNING, date)
+        self._set_default_task_instance_states(dr)
 
-        # Both dag run and task instances' states should remain the same
-        self.verify_dag_run_states(self.dag1, date, State.RUNNING)
+        altered = set_dag_run_state_to_success(self.dag1, date, commit=True)
+
+        # All except the SUCCESS task should be altered.
+        self.assertEqual(len(altered), 5)
+        self._verify_dag_run_state(self.dag1, date, State.SUCCESS)
+        self._verify_task_instance_states(self.dag1, date, State.SUCCESS)
+
+    def test_set_running_dag_run_to_failed(self):
+        date = self.execution_dates[0]
+        dr = self._create_test_dag_run(State.RUNNING, date)
+        self._set_default_task_instance_states(dr)
+
+        altered = set_dag_run_state_to_failed(self.dag1, date, commit=True)
+
+        # Only running task should be altered.
+        self.assertEqual(len(altered), 1)
+        self._verify_dag_run_state(self.dag1, date, State.FAILED)
+        self.assertEqual(dr.get_task_instance('run_after_loop').state, State.FAILED)
+
+    def test_set_running_dag_run_to_running(self):
+        date = self.execution_dates[0]
+        dr = self._create_test_dag_run(State.RUNNING, date)
+        self._set_default_task_instance_states(dr)
+
+        altered = set_dag_run_state_to_running(self.dag1, date, commit=True)
+
+        # None of the tasks should be altered.
+        self.assertEqual(len(altered), 0)
+        self._verify_dag_run_state(self.dag1, date, State.RUNNING)
+        self._verify_task_instance_states_remain_default(dr)
+
+    def test_set_success_dag_run_to_success(self):
+        date = self.execution_dates[0]
+        dr = self._create_test_dag_run(State.SUCCESS, date)
+        self._set_default_task_instance_states(dr)
+
+        altered = set_dag_run_state_to_success(self.dag1, date, commit=True)
+
+        # All except the SUCCESS task should be altered.
+        self.assertEqual(len(altered), 5)
+        self._verify_dag_run_state(self.dag1, date, State.SUCCESS)
+        self._verify_task_instance_states(self.dag1, date, State.SUCCESS)
+
+    def test_set_success_dag_run_to_failed(self):
+        date = self.execution_dates[0]
+        dr = self._create_test_dag_run(State.SUCCESS, date)
+        self._set_default_task_instance_states(dr)
+
+        altered = set_dag_run_state_to_failed(self.dag1, date, commit=True)
+
+        # Only running task should be altered.
+        self.assertEqual(len(altered), 1)
+        self._verify_dag_run_state(self.dag1, date, State.FAILED)
+        self.assertEqual(dr.get_task_instance('run_after_loop').state, State.FAILED)
+
+    def test_set_success_dag_run_to_running(self):
+        date = self.execution_dates[0]
+        dr = self._create_test_dag_run(State.SUCCESS, date)
+        self._set_default_task_instance_states(dr)
+
+        altered = set_dag_run_state_to_running(self.dag1, date, commit=True)
+
+        # None of the tasks should be altered.
+        self.assertEqual(len(altered), 0)
+        self._verify_dag_run_state(self.dag1, date, State.RUNNING)
+        self._verify_task_instance_states_remain_default(dr)
+
+    def test_set_failed_dag_run_to_success(self):
+        date = self.execution_dates[0]
+        dr = self._create_test_dag_run(State.SUCCESS, date)
+        self._set_default_task_instance_states(dr)
+
+        altered = set_dag_run_state_to_success(self.dag1, date, commit=True)
+
+        # All except the SUCCESS task should be altered.
+        self.assertEqual(len(altered), 5)
+        self._verify_dag_run_state(self.dag1, date, State.SUCCESS)
+        self._verify_task_instance_states(self.dag1, date, State.SUCCESS)
+
+    def test_set_failed_dag_run_to_failed(self):
+        date = self.execution_dates[0]
+        dr = self._create_test_dag_run(State.SUCCESS, date)
+        self._set_default_task_instance_states(dr)
+
+        altered = set_dag_run_state_to_failed(self.dag1, date, commit=True)
+
+        # Only running task should be altered.
+        self.assertEqual(len(altered), 1)
+        self._verify_dag_run_state(self.dag1, date, State.FAILED)
+        self.assertEqual(dr.get_task_instance('run_after_loop').state, State.FAILED)
+
+    def test_set_failed_dag_run_to_running(self):
+        date = self.execution_dates[0]
+        dr = self._create_test_dag_run(State.SUCCESS, date)
+        self._set_default_task_instance_states(dr)
+
+        altered = set_dag_run_state_to_running(self.dag1, date, commit=True)
+
+        # None of the tasks should be altered.
+        self.assertEqual(len(altered), 0)
+        self._verify_dag_run_state(self.dag1, date, State.RUNNING)
+        self._verify_task_instance_states_remain_default(dr)
+
+    def test_set_state_without_commit(self):
+        date = self.execution_dates[0]
+        dr = self._create_test_dag_run(State.RUNNING, date)
+        self._set_default_task_instance_states(dr)
+
+        will_be_altered = set_dag_run_state_to_running(self.dag1, date, commit=False)
+
+        # None of the tasks will be altered.
+        self.assertEqual(len(will_be_altered), 0)
+        self._verify_dag_run_state(self.dag1, date, State.RUNNING)
+        self._verify_task_instance_states_remain_default(dr)
+
+        will_be_altered = set_dag_run_state_to_failed(self.dag1, date, commit=False)
+
+        # Only the running task will be altered.
+        self.assertEqual(len(will_be_altered), 1)
+        self._verify_dag_run_state(self.dag1, date, State.RUNNING)
+        self._verify_task_instance_states_remain_default(dr)
+
+        will_be_altered = set_dag_run_state_to_success(self.dag1, date, commit=False)
+
+        # All except the SUCCESS task should be altered.
+        self.assertEqual(len(will_be_altered), 5)
+        self._verify_dag_run_state(self.dag1, date, State.RUNNING)
+        self._verify_task_instance_states_remain_default(dr)
 
     def test_set_state_with_multiple_dagruns(self):
         dr1 = self.dag2.create_dagrun(
@@ -353,8 +423,8 @@ class TestMarkDAGRun(unittest.TestCase):
             session=self.session
         )
 
-        altered = set_dag_run_state(self.dag2, self.execution_dates[1],
-                                state=State.SUCCESS, commit=True)
+        altered = set_dag_run_state_to_success(self.dag2, self.execution_dates[1],
+                                               commit=True)
 
         # Recursively count number of tasks in the dag
         def count_dag_tasks(dag):
@@ -364,29 +434,45 @@ class TestMarkDAGRun(unittest.TestCase):
             return count
 
         self.assertEqual(len(altered), count_dag_tasks(self.dag2))
-        self.verify_dag_run_states(self.dag2, self.execution_dates[1])
+        self._verify_dag_run_state(self.dag2, self.execution_dates[1], State.SUCCESS)
 
         # Make sure other dag status are not changed
-        dr1 = models.DagRun.find(dag_id=self.dag2.dag_id, execution_date=self.execution_dates[0])
+        dr1 = models.DagRun.find(dag_id=self.dag2.dag_id,
+                                 execution_date=self.execution_dates[0])
         dr1 = dr1[0]
-        self.assertEqual(dr1.get_state(), State.FAILED)
-        dr3 = models.DagRun.find(dag_id=self.dag2.dag_id, execution_date=self.execution_dates[2])
+        self._verify_dag_run_state(self.dag2, self.execution_dates[0], State.FAILED)
+        dr3 = models.DagRun.find(dag_id=self.dag2.dag_id,
+                                 execution_date=self.execution_dates[2])
         dr3 = dr3[0]
-        self.assertEqual(dr3.get_state(), State.RUNNING)
+        self._verify_dag_run_state(self.dag2, self.execution_dates[2], State.RUNNING)
 
     def test_set_dag_run_state_edge_cases(self):
         # Dag does not exist
-        altered = set_dag_run_state(None, self.execution_dates[0])
+        altered = set_dag_run_state_to_success(None, self.execution_dates[0])
+        self.assertEqual(len(altered), 0)
+        altered = set_dag_run_state_to_failed(None, self.execution_dates[0])
+        self.assertEqual(len(altered), 0)
+        altered = set_dag_run_state_to_running(None, self.execution_dates[0])
         self.assertEqual(len(altered), 0)
 
         # Invalid execution date
-        altered = set_dag_run_state(self.dag1, None)
+        altered = set_dag_run_state_to_success(self.dag1, None)
         self.assertEqual(len(altered), 0)
-        self.assertRaises(AssertionError, set_dag_run_state, self.dag1, timedelta(microseconds=-1))
+        altered = set_dag_run_state_to_failed(self.dag1, None)
+        self.assertEqual(len(altered), 0)
+        altered = set_dag_run_state_to_running(self.dag1, None)
+        self.assertEqual(len(altered), 0)
 
+        # This will throw AssertionError since dag.latest_execution_date
+        # need to be 0 does not exist.
+        self.assertRaises(AssertionError, set_dag_run_state_to_success, self.dag1,
+                          timezone.make_naive(self.execution_dates[0]))
+
+        # altered = set_dag_run_state_to_success(self.dag1, self.execution_dates[0])
         # DagRun does not exist
         # This will throw AssertionError since dag.latest_execution_date does not exist
-        self.assertRaises(AssertionError, set_dag_run_state, self.dag1, self.execution_dates[0])
+        self.assertRaises(AssertionError, set_dag_run_state_to_success,
+                          self.dag1, self.execution_dates[0])
 
     def tearDown(self):
         self.dag1.clear()
@@ -396,6 +482,7 @@ class TestMarkDAGRun(unittest.TestCase):
         self.session.query(models.TaskInstance).delete()
         self.session.query(models.DagStat).delete()
         self.session.commit()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/dags/test_example_bash_operator.py
+++ b/tests/dags/test_example_bash_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -27,6 +27,7 @@ from datetime import timedelta
 
 args = {
     'owner': 'airflow',
+    'retries': 3,
     'start_date': airflow.utils.dates.days_ago(2)
 }
 

--- a/tests/www_rbac/test_views.py
+++ b/tests/www_rbac/test_views.py
@@ -380,8 +380,14 @@ class TestAirflowBaseViews(TestBase):
         resp = self.client.post(url, follow_redirects=True)
         self.check_content_in_response('OK', resp)
 
-    def test_success(self):
+    def test_failed(self):
+        url = ('failed?task_id=run_this_last&dag_id=example_bash_operator&'
+               'execution_date={}&upstream=false&downstream=false&future=false&past=false'
+               .format(self.percent_encode(self.default_date)))
+        resp = self.client.get(url)
+        self.check_content_in_response('Wait a minute', resp)
 
+    def test_success(self):
         url = ('success?task_id=run_this_last&dag_id=example_bash_operator&'
                'execution_date={}&upstream=false&downstream=false&future=false&past=false'
                .format(self.percent_encode(self.default_date)))


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2359) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2359
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Adding set failed for DagRun and TaskInstance in tree view. Setting DagRun state to failed will mark all running task instances to failed and thus kill the task instance in the next heartbeat. Setting DagRun state to success will mark all task instances to success. Above logics are also added to DagRunModelView, so that the bahavior of setting DagRun state will be consistent over the platform.

Following are the screenshot of the new UI:
In tree view:
![screen shot 2018-04-30 at 12 22 49 pm](https://user-images.githubusercontent.com/7818710/39445909-72b277e8-4c71-11e8-88a7-663d3ade9471.png)
![screen shot 2018-04-30 at 12 22 58 pm](https://user-images.githubusercontent.com/7818710/39445913-7490e93c-4c71-11e8-90e8-a89407d8311e.png)

Set DagRun status in DagRunModelView:
![screen shot 2018-04-30 at 12 23 34 pm](https://user-images.githubusercontent.com/7818710/39445923-7ff43a7c-4c71-11e8-99ca-ce819b3c553d.png)
after the operation:
![screen shot 2018-04-30 at 12 23 51 pm](https://user-images.githubusercontent.com/7818710/39445928-86a295bc-4c71-11e8-8c9f-303b18aaeadb.png)

Edit DagRun status in model edit view:
After operation:
![screen shot 2018-04-30 at 12 24 17 pm](https://user-images.githubusercontent.com/7818710/39445945-9d0440e4-4c71-11e8-9a4c-5b9f33ff5f31.png)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests/api/common/experimental/mark_tasks.py:TestMarkDAGRun
tests/www_rbac/test_views.py: TestAirflowBaseViews:test_failed

Manual tested in both legacy UI and RBAC UI.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
