### PR TITLE
[AIRFLOW-2172] Cast template_fields into a list if it is string

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -29,6 +29,7 @@ from builtins import object, bytes
 import copy
 from collections import namedtuple, defaultdict
 from datetime import timedelta
+from past.builtins import basestring
 
 import dill
 import functools
@@ -2661,6 +2662,9 @@ class BaseOperator(LoggingMixin):
         pass
 
     def resolve_template_files(self):
+        # Cast the template_fields to a list if it is defined as ('field')
+        if isinstance(self.template_fields, basestring):
+            self.template_fields = [self.template_fields, ]
         # Getting the content of files for template_field / template_ext
         for attr in self.template_fields:
             content = getattr(self, attr)
@@ -2794,6 +2798,8 @@ class BaseOperator(LoggingMixin):
 
     def dry_run(self):
         self.log.info('Dry run')
+        if isinstance(self.template_fields, basestring):
+            self.template_fields = [self.template_fields, ]
         for attr in self.template_fields:
             content = getattr(self, attr)
             if content and isinstance(content, six.string_types):

--- a/tests/core.py
+++ b/tests/core.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -582,6 +582,31 @@ class CoreTest(unittest.TestCase):
             some_templated_field=NonBoolObject(),
             dag=self.dag)
         t.resolve_template_files()
+
+    def test_template_field_is_str(self):
+        """
+        Test template when it is given as "template_fields = ('hql')"
+        """
+        class TestOperator(BaseOperator):
+            """
+            An operator to test template substitution
+            """
+            template_fields = ('some_templated_field')
+
+            def __init__(self, *args, **kwargs):
+                super(TestOperator, self).__init__(*args, **kwargs)
+
+            def execute(*args, **kwargs):
+                pass
+
+        op = TestOperator(
+            task_id='test_template_is_str',
+            dag=self.dag
+        )
+        op.resolve_template_files()
+
+        self.assertEqual(type(op.template_fields), list)
+        self.assertEqual(op.template_fields[0], 'some_templated_field')
 
     def test_import_examples(self):
         self.assertEqual(len(self.dagbag.dags), NUM_EXAMPLE_DAGS)


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2172
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
Cast template_fields into a list if the type of operator's template_fields is string

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
