### PR TITLE
[AIRFLOW-2377] Improve Sendgrid sender support

### DIFF
--- a/airflow/contrib/utils/sendgrid.py
+++ b/airflow/contrib/utils/sendgrid.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -51,7 +51,9 @@ def send_email(to, subject, html_content, files=None,
     SENDGRID_API_KEY={your-sendgrid-api-key}.
     """
     mail = Mail()
-    mail.from_email = Email(os.environ.get('SENDGRID_MAIL_FROM'))
+    from_email = kwargs.get('from_email') or os.environ.get('SENDGRID_MAIL_FROM')
+    from_name = kwargs.get('from_name') or os.environ.get('SENDGRID_MAIL_SENDER')
+    mail.from_email = Email(from_email, from_name)
     mail.subject = subject
 
     # Add the recipient list of to emails.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [AIRFLOW-2377]


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
Support for passing sender email and name as parameters

### Tests
- [X] My PR adds the following unit tests:
Additional unit test and fix of existing tests 


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.

### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
