### PR TITLE
[AIRFLOW-2380] Add support for environment variables in Spark submit operator.

### DIFF
--- a/airflow/contrib/operators/spark_submit_operator.py
+++ b/airflow/contrib/operators/spark_submit_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -77,6 +77,9 @@ class SparkSubmitOperator(BaseOperator):
     :type num_executors: int
     :param application_args: Arguments for the application being submitted
     :type application_args: list
+    :param env_vars: Environment variables for spark-submit. It
+                     supports yarn and k8s mode too.
+    :type env_vars: dict
     :param verbose: Whether to pass the verbose flag to spark-submit process for debugging
     :type verbose: bool
     """
@@ -105,6 +108,7 @@ class SparkSubmitOperator(BaseOperator):
                  name='airflow-spark',
                  num_executors=None,
                  application_args=None,
+                 env_vars=None,
                  verbose=False,
                  *args,
                  **kwargs):
@@ -128,6 +132,7 @@ class SparkSubmitOperator(BaseOperator):
         self._name = name
         self._num_executors = num_executors
         self._application_args = application_args
+        self._env_vars = env_vars
         self._verbose = verbose
         self._hook = None
         self._conn_id = conn_id
@@ -156,6 +161,7 @@ class SparkSubmitOperator(BaseOperator):
             name=self._name,
             num_executors=self._num_executors,
             application_args=self._application_args,
+            env_vars=self._env_vars,
             verbose=self._verbose
         )
         self._hook.submit(self._application)


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [AIRFLOW-2380](https://issues.apache.org/jira/browse/AIRFLOW/-2380)

### Description
- [x] Add support to define environment variables on spark-submit. It is done in all sopported modes

### Tests
- [x] My PR adds the following unit tests [tests/contrib/hooks/test_spark_submit_hook.py](https://github.com/apache/incubator-airflow/pull/3268/files#diff-21bd32cb32899d6d06ce4885f5d30e63)
 - test_resolve_spark_submit_env_vars_standalone_client_mode
 - test_resolve_spark_submit_env_vars_standalone_cluster_mode
 - test_resolve_spark_submit_env_vars_yarn
 - test_resolve_spark_submit_env_vars_k8s


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
