### PR TITLE
[AIRFLOW-2381] Fix flaky APIPassword test

### DIFF
--- a/tests/www/api/experimental/test_password_endpoints.py
+++ b/tests/www/api/experimental/test_password_endpoints.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -56,24 +56,15 @@ class ApiPasswordTests(unittest.TestCase):
 
     def test_authorized(self):
         with self.app.test_client() as c:
-            url_template = '/api/experimental/dags/{}/dag_runs'
-            response = c.post(
-                url_template.format('example_bash_operator'),
-                data=json.dumps(dict(run_id='my_run' + datetime.now().isoformat())),
-                content_type="application/json",
+            response = c.get(
+                '/api/experimental/pools',
                 headers={'Authorization': 'Basic aGVsbG86d29ybGQ='}  # hello:world
             )
             self.assertEqual(200, response.status_code)
 
     def test_unauthorized(self):
         with self.app.test_client() as c:
-            url_template = '/api/experimental/dags/{}/dag_runs'
-            response = c.post(
-                url_template.format('example_bash_operator'),
-                data=json.dumps(dict(run_id='my_run' + datetime.now().isoformat())),
-                content_type="application/json"
-            )
-
+            response = c.get('/api/experimental/pools')
             self.assertEqual(401, response.status_code)
 
     def tearDown(self):


### PR DESCRIPTION
This test is in conflict with different tests running in parallel. By calling a simple overview page, the behaviour of checking the password is still checked, but isn't dependent on a specific dag being present in the database.

cc @bolkedebruin 

Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
