### PR TITLE
[AIRFLOW-2382] Fix wrong description for delimiter

### DIFF
--- a/airflow/contrib/operators/s3_list_operator.py
+++ b/airflow/contrib/operators/s3_list_operator.py
@@ -24,8 +24,7 @@ from airflow.utils.decorators import apply_defaults
 
 class S3ListOperator(BaseOperator):
     """
-    List all objects from the bucket with the given string prefix and delimiter
-    in name.
+    List all objects from the bucket with the given string prefix in name.
 
     This operator returns a python list with the name of objects which can be
     used by `xcom` in the downstream task.
@@ -35,22 +34,21 @@ class S3ListOperator(BaseOperator):
     :param prefix: Prefix string to filters the objects whose name begin with
         such prefix
     :type prefix: string
-    :param delimiter: The delimiter by which you want to filter the objects.
-        For e.g to lists the CSV files from in a directory in S3 you would use
-        delimiter='.csv'.
+    :param delimiter: the delimiter marks key hierarchy.
     :type delimiter: string
     :param aws_conn_id: The connection ID to use when connecting to S3 storage.
     :type aws_conn_id: string
 
     **Example**:
-        The following operator would list all the CSV files from the S3
+        The following operator would list all the files
+        (excluding subfolders) from the S3
         ``customers/2018/04/`` key in the ``data`` bucket. ::
 
             s3_file = S3ListOperator(
                 task_id='list_3s_files',
                 bucket='data',
                 prefix='customers/2018/04/',
-                delimiter='.csv',
+                delimiter='/',
                 aws_conn_id='aws_customers_conn'
             )
     """

--- a/airflow/contrib/operators/s3_to_gcs_operator.py
+++ b/airflow/contrib/operators/s3_to_gcs_operator.py
@@ -37,12 +37,10 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
     :param prefix: Prefix string which filters objects whose name begin with
         such prefix.
     :type prefix: string
-    :param delimiter: The delimiter by which you want to filter the objects on.
-        E.g. to list CSV files from a S3 key you would do the following,
-        `delimiter='.csv'`.
+    :param delimiter: the delimiter marks key hierarchy.
     :type delimiter: string
     :param aws_conn_id: The source S3 connection
-    :type aws_conn_id: str
+    :type aws_conn_id: string
     :param dest_gcs_conn_id: The destination connection ID to use
         when connecting to Google Cloud Storage.
     :type dest_gcs_conn_id: string


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2382
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Fix misleading descriptions for the 'delimiter'
parameter in S3ListOperator and
S3ToGoogleCloudStorageOperator's docstring.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's documentation fix.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
