### PR TITLE
[AIRFLOW-1960] Add support for attach secrets in kubernetes operator

### DIFF
--- a/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -84,7 +84,10 @@ class KubernetesRequestFactory:
 
     @staticmethod
     def attach_volumes(pod, req):
-        req['spec']['volumes'] = pod.volumes
+        req['spec']['volumes'] = (
+            req['spec'].get('volumes', []))
+        if len(pod.volumes) > 0:
+            req['spec']['volumes'].extend(pod.volumes)
 
     @staticmethod
     def attach_volume_mounts(pod, req):
@@ -101,8 +104,10 @@ class KubernetesRequestFactory:
     def extract_volume_secrets(pod, req):
         vol_secrets = [s for s in pod.secrets if s.deploy_type == 'volume']
         if any(vol_secrets):
-            req['spec']['containers'][0]['volumeMounts'] = []
-            req['spec']['volumes'] = []
+            req['spec']['containers'][0]['volumeMounts'] = (
+                req['spec']['containers'][0].get('volumeMounts', []))
+            req['spec']['volumes'] = (
+                req['spec'].get('volumes', []))
         for idx, vol in enumerate(vol_secrets):
             vol_id = 'secretvol' + str(idx)
             req['spec']['containers'][0]['volumeMounts'].append({

--- a/airflow/contrib/kubernetes/secret.py
+++ b/airflow/contrib/kubernetes/secret.py
@@ -25,7 +25,8 @@ class Secret:
         :param deploy_type: The type of secret deploy in Kubernetes, either `env` or
             `volume`
         :type deploy_type: ``str``
-        :param deploy_target: The environment variable to be created in the worker.
+        :param deploy_target: The environment variable when `deploy_type` `env` or
+            file path when `deploy_type` `volume` where expose secret
         :type deploy_target: ``str``
         :param secret: Name of the secrets object in Kubernetes
         :type secret: ``str``
@@ -34,5 +35,7 @@ class Secret:
         """
         self.deploy_type = deploy_type
         self.deploy_target = deploy_target.upper()
+        if deploy_type == 'volume':
+            self.deploy_target = deploy_target
         self.secret = secret
         self.key = key

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -27,6 +27,31 @@ ui_color = '#ffefeb'
 
 
 class KubernetesPodOperator(BaseOperator):
+    """
+    Execute a task in a Kubernetes Pod
+
+    :param image: Docker image name
+    :type image: str
+    :param: namespace: namespace name where run the Pod
+    :type: namespace: str
+    :param cmds: entrypoint of the container
+    :type cmds: list
+    :param arguments: arguments of to the entrypoint.
+        The docker image's CMD is used if this is not provided.
+    :type arguments: list
+    :param labels: labels to apply to the Pod
+    :type labels: dict
+    :param startup_timeout_seconds: timeout in seconds to startup the pod
+    :type startup_timeout_seconds: int
+    :param name: name for the pod
+    :type name: str
+    :param secrets: Secrets to attach to the container
+    :type secrets: list
+    :param in_cluster: run kubernetes client with in_cluster configuration
+    :type in_cluster: bool
+    :param get_logs: get the stdout of the container as logs of the tasks
+    """
+
     def execute(self, context):
         try:
 
@@ -41,6 +66,8 @@ class KubernetesPodOperator(BaseOperator):
                 arguments=self.arguments,
                 labels=self.labels
             )
+
+            pod.secrets = self.secrets
 
             launcher = pod_launcher.PodLauncher(client)
             final_state = launcher.run_pod(
@@ -59,15 +86,14 @@ class KubernetesPodOperator(BaseOperator):
                  cmds,
                  arguments,
                  name,
+                 secrets=None,
                  in_cluster=False,
                  labels=None,
                  startup_timeout_seconds=120,
-                 kube_executor_config=None,
                  get_logs=True,
                  *args,
                  **kwargs):
         super(KubernetesPodOperator, self).__init__(*args, **kwargs)
-        self.kube_executor_config = kube_executor_config or {}
         self.image = image
         self.namespace = namespace
         self.cmds = cmds
@@ -75,5 +101,6 @@ class KubernetesPodOperator(BaseOperator):
         self.labels = labels or {}
         self.startup_timeout_seconds = startup_timeout_seconds
         self.name = name
+        self.secrets = secrets or []
         self.in_cluster = in_cluster
         self.get_logs = get_logs


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] https://issues.apache.org/jira/browse/AIRFLOW-1960


### Description
- [x] This add the ability to attach secrets with kubernetes-operator:
```python
s = Secret('volume', '/test', 'airflow-secrets', 'key')

k = KubernetesPodOperator(namespace='default',
                          image="ubuntu:16.04",
                          cmds=["bash", "-cx"],
                          arguments=["echo", "10"],
                          labels={"foo": "bar"},
                          name="airflow-test-pod",
                          in_cluster=True,
                          task_id="task",
                          get_logs=True,
                          secrets=[s],
                          dag=dag
                          )
```

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
