### PR TITLE
[AIRFLOW-2266] Resolve gcp_api installation for Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,6 @@ gcp_api = [
     'google-api-python-client>=1.5.0, <1.6.0',
     'oauth2client>=2.0.2, <2.1.0',
     'PyOpenSSL',
-    'google-cloud-dataflow>=2.2.0',
     'pandas-gbq'
 ]
 hdfs = ['snakebite>=2.7.8']
@@ -206,8 +205,7 @@ devel_all = (sendgrid + devel + all_dbs + doc + samba + s3 + slack + crypto + or
 # Snakebite & Google Cloud Dataflow are not Python 3 compatible :'(
 if PY3:
     devel_ci = [package for package in devel_all if package not in
-                ['snakebite>=2.7.8', 'snakebite[kerberos]>=2.7.8',
-                 'google-cloud-dataflow>=2.2.0']]
+                ['snakebite>=2.7.8', 'snakebite[kerberos]>=2.7.8']]
 else:
     devel_ci = devel_all
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
    - https://issues.apache.org/jira/browse/AIRFLOW-2266
    - https://issues.apache.org/jira/browse/AIRFLOW-2343

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
This is caused due to the fact that the latest release (2.4) for apache-beam[gcp] is not available for Python 3.x. Also as we are using Google's discovery-based API for all google cloud related commands we don't require to import google-cloud-dataflow package
- More information about the same issue over here: https://stackoverflow.com/questions/49047778/airflow-installation-failure-beamgcp


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
N/A

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
