### PR TITLE
[AIRFLOW-2086] Add a configuration variable to control numbers of dag run for display

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -5,6 +5,9 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Add a configuration variable(default_dag_run_display_number) to control numbers of dag run for display
+Add a configuration variable(default_dag_run_display_number) under webserver section to control num of dag run to show in UI.
+
 ### Default executor for SubDagOperator is changed to SequentialExecutor
 
 ### New Webserver UI with Role-Based Access Control

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -280,6 +280,9 @@ rbac = False
 # Define the color of navigation bar
 navbar_color = #007A87
 
+# Default dagrun to show in UI
+default_dag_run_display_number = 25
+
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -57,7 +57,7 @@
       <li><a href="{{ url_for("airflow.graph", dag_id=dag.dag_id, root=root, execution_date=execution_date) }}">
           <span class="glyphicon glyphicon-certificate" aria-hidden="true"></span>
         Graph View</a></li>
-      <li><a href="{{ url_for("airflow.tree", dag_id=dag.dag_id, num_runs=25, root=root) }}">
+      <li><a href="{{ url_for("airflow.tree", dag_id=dag.dag_id, num_runs=num_runs, root=root) }}">
           <span class="glyphicon glyphicon-tree-deciduous" aria-hidden="true"></span>
         Tree View
       </a></li>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -145,7 +145,7 @@
                 </a>
 
                 <!-- Tree -->
-                <a href="{{ url_for('airflow.tree', dag_id=dag.dag_id, num_runs=25) }}">
+                <a href="{{ url_for('airflow.tree', dag_id=dag.dag_id, num_runs=num_runs) }}">
                     <span class="glyphicon glyphicon-tree-deciduous" aria-hidden="true" data-original-title="Tree View"></span>
                 </a>
 

--- a/airflow/www/templates/airflow/list_dags.html
+++ b/airflow/www/templates/airflow/list_dags.html
@@ -147,7 +147,7 @@
                 <svg height="10" width="10" id='dag-{{ row.dag_id }}' style="display: block;"></svg>
             </td>
             <td>
-              <a href="{{ url_for("airflow.tree", dag_id=row.dag_id, num_runs=25) }}" title="Tree View">
+              <a href="{{ url_for("airflow.tree", dag_id=row.dag_id, num_runs=num_runs) }}" title="Tree View">
                   <span class="glyphicon glyphicon-tree-deciduous" aria-hidden="true"></span>
               </a>
               <a href="{{ url_for("airflow.graph", dag_id=row.dag_id) }}" title="Graph View">

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -1227,6 +1227,7 @@ class Airflow(BaseView):
     @wwwutils.action_logging
     @provide_session
     def tree(self, session=None):
+        default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
         blur = conf.getboolean('webserver', 'demo_mode')
         dag = dagbag.get_dag(dag_id)
@@ -1239,7 +1240,7 @@ class Airflow(BaseView):
 
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
-        num_runs = int(num_runs) if num_runs else 25
+        num_runs = int(num_runs) if num_runs else default_dag_run
 
         if base_date:
             base_date = timezone.parse(base_date)
@@ -1348,7 +1349,7 @@ class Airflow(BaseView):
             ),
             root=root,
             form=form,
-            dag=dag, data=data, blur=blur)
+            dag=dag, data=data, blur=blur, num_runs=num_runs)
 
     @expose('/graph')
     @login_required
@@ -1468,11 +1469,12 @@ class Airflow(BaseView):
     @wwwutils.action_logging
     @provide_session
     def duration(self, session=None):
+        default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
         dag = dagbag.get_dag(dag_id)
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
-        num_runs = int(num_runs) if num_runs else 25
+        num_runs = int(num_runs) if num_runs else default_dag_run
 
         if base_date:
             base_date = pendulum.parse(base_date)
@@ -1575,11 +1577,12 @@ class Airflow(BaseView):
     @wwwutils.action_logging
     @provide_session
     def tries(self, session=None):
+        default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
         dag = dagbag.get_dag(dag_id)
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
-        num_runs = int(num_runs) if num_runs else 25
+        num_runs = int(num_runs) if num_runs else default_dag_run
 
         if base_date:
             base_date = pendulum.parse(base_date)
@@ -1638,11 +1641,12 @@ class Airflow(BaseView):
     @wwwutils.action_logging
     @provide_session
     def landing_times(self, session=None):
+        default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
         dag = dagbag.get_dag(dag_id)
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
-        num_runs = int(num_runs) if num_runs else 25
+        num_runs = int(num_runs) if num_runs else default_dag_run
 
         if base_date:
             base_date = pendulum.parse(base_date)
@@ -1759,6 +1763,7 @@ class Airflow(BaseView):
     @wwwutils.action_logging
     @provide_session
     def gantt(self, session=None):
+
         dag_id = request.args.get('dag_id')
         dag = dagbag.get_dag(dag_id)
         demo_mode = conf.getboolean('webserver', 'demo_mode')

--- a/airflow/www_rbac/templates/airflow/dag.html
+++ b/airflow/www_rbac/templates/airflow/dag.html
@@ -56,7 +56,7 @@
       <li><a href="{{ url_for("Airflow.graph", dag_id=dag.dag_id, root=root) }}">
           <span class="glyphicon glyphicon-certificate" aria-hidden="true"></span>
         Graph View</a></li>
-      <li><a href="{{ url_for("Airflow.tree", dag_id=dag.dag_id, num_runs=25, root=root) }}">
+      <li><a href="{{ url_for("Airflow.tree", dag_id=dag.dag_id, num_runs=num_runs, root=root) }}">
           <span class="glyphicon glyphicon-tree-deciduous" aria-hidden="true"></span>
         Tree View
       </a></li>

--- a/airflow/www_rbac/templates/airflow/dags.html
+++ b/airflow/www_rbac/templates/airflow/dags.html
@@ -146,7 +146,7 @@
                 </a>
 
                 <!-- Tree -->
-                <a href="{{ url_for('Airflow.tree', dag_id=dag.dag_id, num_runs=25) }}">
+                <a href="{{ url_for('Airflow.tree', dag_id=dag.dag_id, num_runs=num_runs) }}">
                     <span class="glyphicon glyphicon-tree-deciduous" aria-hidden="true" data-original-title="Tree View"></span>
                 </a>
 

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -860,6 +860,7 @@ class Airflow(AirflowBaseView):
     @action_logging
     @provide_session
     def tree(self, session=None):
+        default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
         blur = conf.getboolean('webserver', 'demo_mode')
         dag = dagbag.get_dag(dag_id)
@@ -872,7 +873,7 @@ class Airflow(AirflowBaseView):
 
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
-        num_runs = int(num_runs) if num_runs else 25
+        num_runs = int(num_runs) if num_runs else default_dag_run
 
         if base_date:
             base_date = timezone.parse(base_date)
@@ -980,7 +981,7 @@ class Airflow(AirflowBaseView):
             ),
             root=root,
             form=form,
-            dag=dag, data=data, blur=blur)
+            dag=dag, data=data, blur=blur, num_runs=num_runs)
 
     @expose('/graph')
     @has_access
@@ -1101,11 +1102,12 @@ class Airflow(AirflowBaseView):
     @action_logging
     @provide_session
     def duration(self, session=None):
+        default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
         dag = dagbag.get_dag(dag_id)
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
-        num_runs = int(num_runs) if num_runs else 25
+        num_runs = int(num_runs) if num_runs else default_dag_run
 
         if base_date:
             base_date = pendulum.parse(base_date)
@@ -1204,11 +1206,12 @@ class Airflow(AirflowBaseView):
     @action_logging
     @provide_session
     def tries(self, session=None):
+        default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
         dag = dagbag.get_dag(dag_id)
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
-        num_runs = int(num_runs) if num_runs else 25
+        num_runs = int(num_runs) if num_runs else default_dag_run
 
         if base_date:
             base_date = pendulum.parse(base_date)
@@ -1267,11 +1270,12 @@ class Airflow(AirflowBaseView):
     @action_logging
     @provide_session
     def landing_times(self, session=None):
+        default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
         dag = dagbag.get_dag(dag_id)
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs')
-        num_runs = int(num_runs) if num_runs else 25
+        num_runs = int(num_runs) if num_runs else default_dag_run
 
         if base_date:
             base_date = pendulum.parse(base_date)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2086
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Similar to what airflow-2393, airflow-2086 describes, airflow tree view is very slow to run which often triggers guicorn timeout if the dag has many tasks and dependencies. We limit the default tree view to most recent 5 dagruns which help to alleviate the issue.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
