### PR TITLE
[AIRFLOW-2400] Add Ability to set Environment Variables for K8s

### DIFF
--- a/airflow/contrib/kubernetes/pod.py
+++ b/airflow/contrib/kubernetes/pod.py
@@ -45,7 +45,7 @@ class Pod:
     :param image: The docker image
     :type image: str
     :param envs: A dict containing the environment variables
-    :type envs:s dict
+    :type envs: dict
     :param cmds: The command to be run on the pod
     :type cmds: list str
     :param secrets: Secrets to be launched to the pod

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -69,7 +69,7 @@ class KubernetesPodOperator(BaseOperator):
             )
 
             pod.secrets = self.secrets
-            pod.env_vars = self.env_vars
+            pod.envs = self.env_vars
 
             launcher = pod_launcher.PodLauncher(client)
             final_state = launcher.run_pod(

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -46,7 +46,7 @@ class KubernetesPodOperator(BaseOperator):
     :param name: name for the pod
     :type name: str
     :param env_vars: Environment variables initialized in the container
-    :type env_vars: list
+    :type env_vars: dict
     :param secrets: Secrets to attach to the container
     :type secrets: list
     :param in_cluster: run kubernetes client with in_cluster configuration

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -45,6 +45,8 @@ class KubernetesPodOperator(BaseOperator):
     :type startup_timeout_seconds: int
     :param name: name for the pod
     :type name: str
+    :param env_vars: Environment variables initialized in the container
+    :type env_vars: list
     :param secrets: Secrets to attach to the container
     :type secrets: list
     :param in_cluster: run kubernetes client with in_cluster configuration
@@ -54,7 +56,6 @@ class KubernetesPodOperator(BaseOperator):
 
     def execute(self, context):
         try:
-
             client = kube_client.get_kube_client(in_cluster=self.in_cluster)
             gen = pod_generator.PodGenerator()
 
@@ -68,6 +69,7 @@ class KubernetesPodOperator(BaseOperator):
             )
 
             pod.secrets = self.secrets
+            pod.env_vars = self.env_vars
 
             launcher = pod_launcher.PodLauncher(client)
             final_state = launcher.run_pod(
@@ -86,6 +88,7 @@ class KubernetesPodOperator(BaseOperator):
                  cmds,
                  arguments,
                  name,
+                 env_vars=None,
                  secrets=None,
                  in_cluster=False,
                  labels=None,
@@ -101,6 +104,7 @@ class KubernetesPodOperator(BaseOperator):
         self.labels = labels or {}
         self.startup_timeout_seconds = startup_timeout_seconds
         self.name = name
+        self.env_vars = env_vars or {}
         self.secrets = secrets or []
         self.in_cluster = in_cluster
         self.get_logs = get_logs


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-2400\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2400
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
This allows a user to add environmnent variables to the Pod from the invoker of the KubernetesPodOperator.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This adds an additional parameter, similar to https://github.com/apache/incubator-airflow/commit/72f15a108e5556970229cb68d3b0968ee18db46e.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
