### PR TITLE
[AIRFLOW-1853] Show only the desired number of runs in tree view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1254,6 +1254,10 @@ class Airflow(BaseView):
             dr.execution_date: alchemy_to_dict(dr) for dr in dag_runs}
 
         dates = sorted(list(dag_runs.keys()))
+        # Only show the desired number of runs regardless of the trigger method
+        if len(dates) > num_runs:
+            dates = dates[-num_runs:]
+
         max_date = max(dates) if dates else None
 
         tis = dag.get_task_instances(

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -894,6 +894,10 @@ class Airflow(AirflowBaseView):
             dr.execution_date: alchemy_to_dict(dr) for dr in dag_runs}
 
         dates = sorted(list(dag_runs.keys()))
+        # Only show the desired number of runs regardless of the trigger method
+        if len(dates) > num_runs:
+            dates = dates[-num_runs:]
+
         max_date = max(dates) if dates else None
 
         tis = dag.get_task_instances(


### PR DESCRIPTION
Previously, the "Number of runs" option was not being respected for DAGs that were externally triggered. Now, only the set number of runs is shown regardless of DAG trigger type.

Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1853


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
    - (See above for details)
    - **Before** ![airflow-numruns-5-bad](https://user-images.githubusercontent.com/10214785/39489796-93299b6c-4d3b-11e8-9d13-a45f2e61640a.png)
    - **After** ![airflow-numruns-5-good](https://user-images.githubusercontent.com/10214785/39489808-9a0b3c24-4d3b-11e8-9e10-f39d45c3121a.png)

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - This set of views does not have unit tests associated with it

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - No new functionality added, webserver now behaves as expected


### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
