### PR TITLE
[AIRFLOW-2394] default cmds and arguments to docker image in k8sOperator

### DIFF
--- a/airflow/contrib/kubernetes/pod_generator.py
+++ b/airflow/contrib/kubernetes/pod_generator.py
@@ -26,11 +26,9 @@ class PodGenerator:
 
     def __init__(self, kube_config=None):
         self.kube_config = kube_config
-        self.env_vars = {}
         self.volumes = []
         self.volume_mounts = []
         self.init_containers = []
-        self.secrets = []
 
     def add_init_container(self,
                            name,
@@ -129,8 +127,8 @@ class PodGenerator:
             cmds=cmds,
             args=arguments,
             labels=labels,
-            envs=self.env_vars,
-            secrets={},
+            envs={},
+            secrets=[],
             # service_account_name=self.kube_config.worker_service_account_name,
             # image_pull_secrets=self.kube_config.image_pull_secrets,
             init_containers=worker_init_container_spec,

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -30,11 +30,13 @@ class KubernetesPodOperator(BaseOperator):
     """
     Execute a task in a Kubernetes Pod
 
-    :param image: Docker image name
+    :param image: Docker image you wish to launch. Defaults to dockerhub.io,
+        but fully qualified URLS will point to custom repositories
     :type image: str
-    :param: namespace: namespace name where run the Pod
+    :param: namespace: the namespace to run within kubernetes
     :type: namespace: str
-    :param cmds: entrypoint of the container
+    :param cmds: entrypoint of the container.
+        The docker images's entrypoint is used if this is not provide.
     :type cmds: list
     :param arguments: arguments of to the entrypoint.
         The docker image's CMD is used if this is not provided.
@@ -43,15 +45,18 @@ class KubernetesPodOperator(BaseOperator):
     :type labels: dict
     :param startup_timeout_seconds: timeout in seconds to startup the pod
     :type startup_timeout_seconds: int
-    :param name: name for the pod
+    :param name: name of the task you want to run,
+        will be used to generate a pod id
     :type name: str
     :param env_vars: Environment variables initialized in the container
     :type env_vars: dict
-    :param secrets: Secrets to attach to the container
+    :param secrets: Kubernetes secrets to inject in the container,
+        They can be exposed as environment vars or files in a volume.
     :type secrets: list
     :param in_cluster: run kubernetes client with in_cluster configuration
     :type in_cluster: bool
     :param get_logs: get the stdout of the container as logs of the tasks
+    :type get_logs: bool
     """
 
     def execute(self, context):
@@ -85,9 +90,9 @@ class KubernetesPodOperator(BaseOperator):
     def __init__(self,
                  namespace,
                  image,
-                 cmds,
-                 arguments,
                  name,
+                 cmds=None,
+                 arguments=None,
                  env_vars=None,
                  secrets=None,
                  in_cluster=False,
@@ -99,8 +104,8 @@ class KubernetesPodOperator(BaseOperator):
         super(KubernetesPodOperator, self).__init__(*args, **kwargs)
         self.image = image
         self.namespace = namespace
-        self.cmds = cmds
-        self.arguments = arguments
+        self.cmds = cmds or []
+        self.arguments = arguments or []
         self.labels = labels or {}
         self.startup_timeout_seconds = startup_timeout_seconds
         self.name = name

--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -1,5 +1,5 @@
 Kubernetes Executor
-===================
+^^^^^^^^^^^^^^^^^^^
 
 The kubernetes executor is introduced in Apache Airflow 1.10.0. The Kubernetes executor will create a new pod for every task instance.
 
@@ -9,31 +9,29 @@ Example helm charts are available at `scripts/ci/kubernetes/kube/{airflow,volume
 
 
 Kubernetes Operator
-===================
-
-
+^^^^^^^^^^^^^^^^^^^
 
 .. code:: python
 
-    from airflow.comtrib.operators import KubernetesOperator
+    from airflow.contrib.operators import KubernetesOperator
+    from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+    from airflow.contrib.kubernetes.secret import Secret
+
+    secret_file = Secret('volume', '/etc/sql_conn', 'airflow-secrets', 'sql_alchemy_conn')
+    secret_env  = Secret('env', 'SQL_CONN', 'airflow-secrets', 'sql_alchemy_conn')
+
     k = KubernetesPodOperator(namespace='default',
                               image="ubuntu:16.04",
                               cmds=["bash", "-cx"],
                               arguments=["echo", "10"],
                               labels={"foo": "bar"},
+                              secrets=[secret_file,secret_env]
                               name="test",
                               task_id="task"
                               )
 
 
+.. autoclass:: airflow.contrib.operators.kubernetes_pod_operator.KubernetesPodOperator
 
-=================================   ====================================
-Variable                            Description
-=================================   ====================================
-``@namespace``                      The namespace is your isolated work environment within kubernetes
-``@image``                          docker image you wish to launch. Defaults to dockerhub.io, but fully qualified URLS will point to custom repositories
-``@cmds``                           To start a task in a docker image, we need to tell it what to do. the cmds array is the space seperated bash command that will define the task completed by the container
-``arguments``                       arguments for your bash command
-``@labels``                         Labels are an important element of launching kubernetes pods, as it tells kubernetes what pods a service can route to. For example, if you launch 5 postgres pods with the label  {'postgres':'foo'} and create a postgres service with the same label, kubernetes will know that any time that service is queried, it can pick any of those 5 postgres instances as the endpoint for that service.
-``@name``                           name of the task you want to run, will be used to generate a pod id
-=================================   ====================================
+.. autoclass:: airflow.contrib.operators.secret.Secret
+


### PR DESCRIPTION
…es operator

Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
