### PR TITLE
[AIRFLOW-2407] Declare as global virtualenv_string_args

### DIFF
--- a/tests/operators/test_virtualenv_operator.py
+++ b/tests/operators/test_virtualenv_operator.py
@@ -163,6 +163,7 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
 
     def test_string_args(self):
         def f():
+            global virtualenv_string_args
             print(virtualenv_string_args)
             if virtualenv_string_args[0] != virtualenv_string_args[2]:
                 raise Exception


### PR DESCRIPTION
Declare as global virtualenv_string_args defined elsewhere

Without this change __flake8__ will complain of undefined name __virtualenv_string_args__ which is discussed at:
* https://github.com/apache/incubator-airflow/blob/master/airflow/operators/python_operator.py#L174

flake8 testing of https://github.com/apache/incubator-airflow on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tests/operators/test_virtualenv_operator.py:166:19: F821 undefined name 'virtualenv_string_args'
            print(virtualenv_string_args)
                  ^
./tests/operators/test_virtualenv_operator.py:167:16: F821 undefined name 'virtualenv_string_args'
            if virtualenv_string_args[0] != virtualenv_string_args[2]:
               ^
./tests/operators/test_virtualenv_operator.py:167:45: F821 undefined name 'virtualenv_string_args'
            if virtualenv_string_args[0] != virtualenv_string_args[2]:
                                            ^
```

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
* See above.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
It fixes tests flake8 that currently fail.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | __python3 -m__ flake8 --diff`
