### PR TITLE
[AIRFLOW-2407] import logging for line 68 of kerberos_auth.py

### DIFF
--- a/airflow/contrib/auth/backends/kerberos_auth.py
+++ b/airflow/contrib/auth/backends/kerberos_auth.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import logging
 import flask_login
 from flask_login import login_required, current_user, logout_user
 from flask import flash


### PR DESCRIPTION
flake8 testing of https://github.com/apache/incubator-airflow on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./airflow/contrib/auth/backends/kerberos_auth.py:67:13: F821 undefined name 'logging'
            logging.error('Password validation for principal %s failed %s', user_principal, e)
            ^
```

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2407
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
See above.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This PR fixes flake8 tests which are currently failing.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [X] Passes git diff upstream/master -u -- "*.py" | __python3 -m__ flake8 --diff
