### PR TITLE
[AIRFLOW-2407] Use feature detection for reload()

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -144,11 +144,7 @@ def create_app(config=None, testing=False):
         # required for testing purposes otherwise the module retains
         # a link to the default_auth
         if app.config['TESTING']:
-            try:
-                reload         # Python 2
-            except NameError:  # Python 3
-                from importlib import reload
-            reload(e)
+            six.moves.reload_module(e)
 
         app.register_blueprint(e.api_experimental, url_prefix='/api/experimental')
 

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -144,11 +144,11 @@ def create_app(config=None, testing=False):
         # required for testing purposes otherwise the module retains
         # a link to the default_auth
         if app.config['TESTING']:
-            if six.PY2:
-                reload(e)
-            else:
-                import importlib
-                importlib.reload(e)
+            try:
+                reload         # Python 2
+            except NameError:  # Python 3
+                from importlib import reload
+            reload(e)
 
         app.register_blueprint(e.api_experimental, url_prefix='/api/experimental')
 


### PR DESCRIPTION
[Use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection) is a Python porting best practice that avoids a flake8 undefined name error...

flake8 testing of https://github.com/apache/incubator-airflow on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./airflow/www/app.py:148:17: F821 undefined name 'reload'
                reload(e)
                ^
```

Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2407
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
See above.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This PR fixes flake8 tests that are currently failing.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
