### PR TITLE
add dataproc_jars to templated fields in relevant dataproc operators

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -481,7 +481,7 @@ class DataProcPigOperator(BaseOperator):
     :param region: The specified region where the dataproc cluster is created.
     :type region: string
     """
-    template_fields = ['query', 'variables', 'job_name', 'cluster_name']
+    template_fields = ['query', 'variables', 'job_name', 'cluster_name', 'dataproc_jars']
     template_ext = ('.pg', '.pig',)
     ui_color = '#0273d4'
 
@@ -561,7 +561,7 @@ class DataProcHiveOperator(BaseOperator):
     :param region: The specified region where the dataproc cluster is created.
     :type region: string
     """
-    template_fields = ['query', 'variables', 'job_name', 'cluster_name']
+    template_fields = ['query', 'variables', 'job_name', 'cluster_name', 'dataproc_jars']
     template_ext = ('.q',)
     ui_color = '#0273d4'
 
@@ -642,7 +642,7 @@ class DataProcSparkSqlOperator(BaseOperator):
     :param region: The specified region where the dataproc cluster is created.
     :type region: string
     """
-    template_fields = ['query', 'variables', 'job_name', 'cluster_name']
+    template_fields = ['query', 'variables', 'job_name', 'cluster_name', 'dataproc_jars']
     template_ext = ('.q',)
     ui_color = '#0273d4'
 
@@ -731,7 +731,7 @@ class DataProcSparkOperator(BaseOperator):
     :type region: string
     """
 
-    template_fields = ['arguments', 'job_name', 'cluster_name']
+    template_fields = ['arguments', 'job_name', 'cluster_name', 'dataproc_jars']
     ui_color = '#0273d4'
 
     @apply_defaults
@@ -821,7 +821,7 @@ class DataProcHadoopOperator(BaseOperator):
     :type region: string
     """
 
-    template_fields = ['arguments', 'job_name', 'cluster_name']
+    template_fields = ['arguments', 'job_name', 'cluster_name', 'dataproc_jars']
     ui_color = '#0273d4'
 
     @apply_defaults
@@ -911,7 +911,7 @@ class DataProcPySparkOperator(BaseOperator):
     :type region: string
     """
 
-    template_fields = ['arguments', 'job_name', 'cluster_name']
+    template_fields = ['arguments', 'job_name', 'cluster_name', 'dataproc_jars']
     ui_color = '#0273d4'
 
     @staticmethod


### PR DESCRIPTION
### JIRA
- [X] My PR addresses the JIRA issue https://issues.apache.org/jira/browse/AIRFLOW-2411.  It allows jar files to be specified via templates, so that we can programmatically decide which jars to use.  I ran this proposed change by @fenglu-g and he agreed it was worthwhile.

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

This is a very minor change, adding only one field (`dataproc_jars`) to the list of templated fields for the various DataProc operators that submit jobs requiring jar files.  Note that this field is always called `dataproc_jars` in the operators, even though each operator's constructor has a different name for this field.  So the change may look a slight bit confusing, because it might appear that the templated field should vary by operator, but this is not the case.

### Tests
- [ ] My PR does not add tests because this is such a small change, and there are no tests currently in-place to test the templated fields.  However we have been running Airflow at Etsy with a subset of these changes (only the change for the `DataProcHadoopOperator`) successfully for about a month.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

### Documentation
- [ ] No documentation added because none exists which specifies the templated field list for dataproc operators.

### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
