### PR TITLE
[AIRFLOW-2417] Wait until pod end running after run it

### DIFF
--- a/airflow/contrib/kubernetes/pod_launcher.py
+++ b/airflow/contrib/kubernetes/pod_launcher.py
@@ -88,10 +88,9 @@ class PodLauncher(LoggingMixin):
                 _preload_content=False)
             for line in logs:
                 self.log.info(line)
-        else:
-            while self.pod_is_running(pod):
-                self.log.info('Pod %s has state %s', pod.name, State.RUNNING)
-                time.sleep(2)
+        while self.pod_is_running(pod):
+            self.log.info('Pod %s has state %s', pod.name, State.RUNNING)
+            time.sleep(2)
         return self._task_status(self.read_pod(pod))
 
     def _task_status(self, event):

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -82,7 +82,9 @@ class KubernetesPodOperator(BaseOperator):
                 startup_timeout=self.startup_timeout_seconds,
                 get_logs=self.get_logs)
             if final_state != State.SUCCESS:
-                raise AirflowException('Pod returned a failure')
+                raise AirflowException(
+                    'Pod returned a failure: {state}'.format(state=final_state)
+                )
         except AirflowException as ex:
             raise AirflowException('Pod Launching failed: {error}'.format(error=ex))
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] If the pod_running check is after else airflow is not gonna run it never
```
[2018-05-03 23:19:04,546] {logging_mixin.py:95} INFO - [2018-05-03 23:19:04,546] {pod_launcher.py:101} INFO - Event: etl-kubernetes-operator-v2-pod-bi-listing-with-booking-info-39a7a676 had an event of type Running

[2018-05-03 23:19:04,552] {models.py:1680} ERROR - Pod Launching failed: Pod returned a failure: running
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/airflow/models.py", line 1577, in _run_raw_task
    result = task_copy.execute(context=context)
  File "/usr/local/lib/python2.7/dist-packages/airflow/contrib/operators/kubernetes_pod_operator.py", line 87, in execute
    raise AirflowException('Pod Launching failed: {error}'.format(error=ex))
AirflowException: Pod Launching failed: Pod returned a failure: running
[2018-05-03 23:19:04,553] {models.py:1708} INFO - Marking task as FAILED.
[2018-05-03 23:19:04,565] {models.py:1728} ERROR - Pod Launching failed: Pod returned a failure: running
[2018-05-03 23:19:04,566] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info Traceback (most recent call last):
[2018-05-03 23:19:04,566] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info   File "/usr/local/bin/airflow", line 32, in <module>
[2018-05-03 23:19:04,566] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info     args.func(args)
[2018-05-03 23:19:04,566] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info   File "/usr/local/lib/python2.7/dist-packages/airflow/utils/cli.py", line 74, in wrapper
[2018-05-03 23:19:04,566] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info     return f(*args, **kwargs)
[2018-05-03 23:19:04,566] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info   File "/usr/local/lib/python2.7/dist-packages/airflow/bin/cli.py", line 470, in run
[2018-05-03 23:19:04,567] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info     _run(args, dag, ti)
[2018-05-03 23:19:04,567] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info   File "/usr/local/lib/python2.7/dist-packages/airflow/bin/cli.py", line 385, in _run
[2018-05-03 23:19:04,567] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info     pool=args.pool,
[2018-05-03 23:19:04,567] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info   File "/usr/local/lib/python2.7/dist-packages/airflow/utils/db.py", line 74, in wrapper
[2018-05-03 23:19:04,567] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info     return func(*args, **kwargs)
[2018-05-03 23:19:04,567] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info   File "/usr/local/lib/python2.7/dist-packages/airflow/models.py", line 1577, in _run_raw_task
[2018-05-03 23:19:04,567] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info     result = task_copy.execute(context=context)
[2018-05-03 23:19:04,567] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info   File "/usr/local/lib/python2.7/dist-packages/airflow/contrib/operators/kubernetes_pod_operator.py", line 87, in execute
[2018-05-03 23:19:04,567] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info     raise AirflowException('Pod Launching failed: {error}'.format(error=ex))
[2018-05-03 23:19:04,568] {base_task_runner.py:106} INFO - Job 110: Subtask bi-listing-with-booking-info airflow.exceptions.AirflowException: Pod Launching failed: Pod returned a failure: running
[2018-05-03 23:19:05,558] {logging_mixin.py:95} INFO - [2018-05-03 23:19:05,558] {jobs.py:2552} INFO - Task exited with return code 1
```
### Test
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
