### PR TITLE
[AIRFLOW-2358] Make the Kubernetes example optional

### DIFF
--- a/airflow/example_dags/example_kubernetes_operator.py
+++ b/airflow/example_dags/example_kubernetes_operator.py
@@ -16,8 +16,17 @@
 # under the License.
 
 import airflow
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+import logging
 from airflow.models import DAG
+
+try:
+    # Kubernetes is optional, so not available in vanilla Airflow
+    # pip install airflow[gcp]
+    from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+except ImportError:
+    # Just import the BaseOperator as the KubernetesPodOperator
+    logging.warn("Could not import KubernetesPodOperator")
+    from airflow.models import BaseOperator as KubernetesPodOperator
 
 args = {
     'owner': 'airflow',
@@ -29,14 +38,14 @@ dag = DAG(
     default_args=args,
     schedule_interval=None)
 
-k = KubernetesPodOperator(namespace='default',
-                          image="ubuntu:16.04",
-                          cmds=["bash", "-cx"],
-                          arguments=["echo", "10"],
-                          labels={"foo": "bar"},
-                          name="airflow-test-pod",
-                          in_cluster=False,
-                          task_id="task",
-                          get_logs=True,
-                          dag=dag
-                          )
+k = KubernetesPodOperator(
+    namespace='default',
+    image="ubuntu:16.04",
+    cmds=["bash", "-cx"],
+    arguments=["echo", "10"],
+    labels={"foo": "bar"},
+    name="airflow-test-pod",
+    in_cluster=False,
+    task_id="task",
+    get_logs=True,
+    dag=dag)


### PR DESCRIPTION
If you havent installed Kubernetes the initdb operation will fail

```
2018-04-22 19:49:04,718 ERROR - Failed to import: /opt/airflow/airflow-20180420/src/apache-airflow/airflow/example_dags/example_kubernetes_operator.py
Traceback (most recent call last):
  File "/opt/airflow/airflow-20180420/src/apache-airflow/airflow/models.py", line 300, in process_file
    m = imp.load_source(mod_name, filepath)
  File "/opt/airflow/airflow-20180420/src/apache-airflow/airflow/example_dags/example_kubernetes_operator.py", line 19, in <module>
    from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
  File "/opt/airflow/airflow-20180420/src/apache-airflow/airflow/contrib/operators/kubernetes_pod_operator.py", line 21, in <module>
    from airflow.contrib.kubernetes import kube_client, pod_generator, pod_launcher
  File "/opt/airflow/airflow-20180420/src/apache-airflow/airflow/contrib/kubernetes/pod_launcher.py", line 25, in <module>
    from kubernetes import watch
```

Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-2358\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2358
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-2358\], code changes always need a JIRA issue.


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
