### PR TITLE
[Airflow-2423] syncing DAGs without scheduler/web-server restart

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -38,6 +38,12 @@ airflow_home = {AIRFLOW_HOME}
 # This path must be absolute
 dags_folder = {AIRFLOW_HOME}/dags
 
+# These 2 fields are optional, specifying S3 location to sync DAGs with
+s3_dags_folder = s3://<s3 dags location>
+# The conn id below has to be configured, by first adding through the web-server UI using
+# these steps: https://airflow.apache.org/configuration.html#connections
+s3_dags_folder_conn_id = <conn id>
+
 # The folder where airflow should store its log files
 # This path must be absolute
 base_log_folder = {AIRFLOW_HOME}/logs

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1549,6 +1549,12 @@ class SchedulerJob(BaseJob):
         # Build up a list of Python files that could contain DAGs
         self.log.info("Searching for files in %s", self.subdir)
         known_file_paths = list_py_file_paths(self.subdir)
+
+        # Sync DAGs from S3 in the scheduler and metadata backend, if S3 DAGs
+        # location is defined in config
+        self.dagbag = models.DagBag()
+        self.dagbag.get_dags_from_s3(force=False)
+
         self.log.info("There are %s files in %s", len(known_file_paths), self.subdir)
 
         def processor_factory(file_path):

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -29,6 +29,7 @@ from builtins import object, bytes
 import copy
 from collections import namedtuple, defaultdict
 from datetime import timedelta
+import botocore
 
 import dill
 import functools
@@ -93,6 +94,7 @@ from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.weight_rule import WeightRule
 from airflow.utils.net import get_hostname
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.configuration import conf, mkdir_p
 
 install_aliases()
 
@@ -207,6 +209,7 @@ class DagBag(BaseDagBag, LoggingMixin):
         self.file_last_changed = {}
         self.executor = executor
         self.import_errors = {}
+        self.s3_dag_counter = 0
 
         if include_examples:
             example_dag_folder = os.path.join(
@@ -220,6 +223,74 @@ class DagBag(BaseDagBag, LoggingMixin):
         :return: the amount of dags contained in this dagbag
         """
         return len(self.dags)
+
+    def get_dags_from_s3(self, force=False, fileloc=None, refresh_every=5):
+        """
+
+        Syncing DAGs from a common remote location is useful while running Airflow on
+        a distributed setup (like mesos), where the hosts running the scheduler and
+        the web-server can vary with time. Also, where scheduler and
+        web-server restart is to be avoided for every DAG update/addition.
+        
+        If [CORE]/s3_dags_folder property is defined in the airflow config,
+        this function will recursively download any '.py' files found
+        there to {dags_folder}/s3_dags/. This folder is scanned to sync all
+        the newly added DAGs in S3 location with the web-server, scheduler
+        and backend metastore.
+        While syncing, the corresponding DAG file from S3 is downloaded only if its
+        new or its last update timestamp is later than the local DAG file's last
+        update timestamp.
+
+        If force is set to True, the S3 DAGs will be refreshed, otherwise they are
+        refreshed every 'refresh_every' time this function is called.
+        If fileloc is provided, only the DAGs at that specific location will be
+        checked. Fileloc should be relative to{DAGS_FOLDER}/s3_dags/{FILELOC};
+        It corresponds to the part of the directory structured mirrored from S3
+
+        """
+
+        if not force and self._s3_dag_counter % refresh_every != 0:
+            return
+
+        self.s3_dag_counter += 1
+
+        # get S3 location of DAGs and create the necessary directories
+        s3_dag_folder = os.path.join(
+            conf.get('core', 'dags_folder'), 's3_dags')
+
+        mkdir_p(s3_dag_folder)
+
+        # use airflow S3Hook and Connection
+        from airflow.hooks.S3_hook import S3Hook
+        s3_hook = S3Hook(conf.get('core', 's3_dags_folder_conn_id'))
+        bucket, prefix = s3_hook.parse_s3_url(
+            conf.get('core', 's3_dags_folder'))
+        if fileloc:
+            prefix = fileloc
+
+        logging.info('Retrieving DAGs from S3...')
+        # download keys if they are new or modified later than local version
+        keys = s3_hook.list_keys(bucket, prefix)
+        for key in keys:
+            filename = os.path.join(s3_dag_folder, key)
+            key_obj = s3_hook.get_key(key, bucket)
+            with open(filename, 'wb') as data:
+                key_obj.download_fileobj(data)
+            logging.info("file download done for" + str(key))
+        if fileloc:
+            return
+
+        # remove any files that aren't in the key list
+        key_names = [os.path.join(s3_dag_folder, key) for key in keys]
+        for root, dirs, files in os.walk(s3_dag_folder):
+            for f in files:
+                full_f = os.path.join(root, f)
+                if full_f not in key_names:
+                    os.remove(full_f)
+                    try:
+                        os.removedirs(root)
+                    except:
+                        pass
 
     def get_dag(self, dag_id):
         """
@@ -264,6 +335,9 @@ class DagBag(BaseDagBag, LoggingMixin):
         # todo: raise exception?
         if filepath is None or not os.path.isfile(filepath):
             return found_dags
+        if 's3_dags' in filepath:
+            fileloc = filepath.split('s3_dags/')[-1]
+            self.get_dags_from_s3(force=True, fileloc=fileloc)
 
         try:
             # This failed before in what may have been a git sync
@@ -449,6 +523,8 @@ class DagBag(BaseDagBag, LoggingMixin):
         stats = []
         FileLoadStat = namedtuple(
             'FileLoadStat', "file duration dag_num task_num dags")
+        if conf.has_option('core', 's3_dags_folder') and conf.get('core', 's3_dags_folder'):
+            self.get_dags_from_s3()
         if os.path.isfile(dag_folder):
             self.process_file(dag_folder, only_if_updated=only_if_updated)
         elif os.path.isdir(dag_folder):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following:
    - https://issues.apache.org/jira/browse/AIRFLOW-2423

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR enables syncing DAGs from a common remote location in S3 without scheduler or web-server restart.  Syncing DAGs is useful while running Airflow on a distributed setup (like in mesos), where the hosts/containers running the scheduler and the web-server can change with time. Also, where scheduler and web-server restart is to be avoided for every DAG update/addition. This PR syncs DAGs periodically from S3 location with the local DAGs in scheduler and web-server. The newly added/updated DAG in S3 is reflected in the web-server and scheduler local directories, and added to the meta-store backend on every call of `collect_dags` 
If `s3_dags_folder` property is defined in the airflow config, the '.py' files from S3 location are recursively scanned. The corresponding DAG file from S3 is downloaded only if its new or its last update timestamp is later than the local DAG file's last update timestamp.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested it locally, and using it with airflow deployment on mesos. Currently, there is no test for s3_hook which is required in this PR, due to which a test for S3 DAG sync is not added

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
