### PR TITLE
[AIRFLOW-2427] Add tests to named hive sensor

### DIFF
--- a/tests/sensors/test_named_hive_partition_sensor.py
+++ b/tests/sensors/test_named_hive_partition_sensor.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import random
+import unittest
+from datetime import timedelta
+
+from airflow import configuration, DAG, operators
+from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
+from airflow.utils.timezone import datetime
+from airflow.hooks.hive_hooks import HiveMetastoreHook
+
+configuration.load_test_config()
+
+DEFAULT_DATE = datetime(2015, 1, 1)
+DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
+DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
+
+
+class NamedHivePartitionSensorTests(unittest.TestCase):
+    def setUp(self):
+        configuration.load_test_config()
+        args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
+        self.dag = DAG('test_dag_id', default_args=args)
+        self.next_day = (DEFAULT_DATE +
+                         timedelta(days=1)).isoformat()[:10]
+        self.database = 'airflow'
+        self.partition_by = 'ds'
+        self.table = 'static_babynames_partitioned'
+        self.hql = """
+                CREATE DATABASE IF NOT EXISTS {{ params.database }};
+                USE {{ params.database }};
+                DROP TABLE IF EXISTS {{ params.table }};
+                CREATE TABLE IF NOT EXISTS {{ params.table }} (
+                    state string,
+                    year string,
+                    name string,
+                    gender string,
+                    num int)
+                PARTITIONED BY ({{ params.partition_by }} string);
+                ALTER TABLE {{ params.table }}
+                ADD PARTITION({{ params.partition_by }}='{{ ds }}');
+                """
+        self.hook = HiveMetastoreHook()
+        t = operators.hive_operator.HiveOperator(
+            task_id='HiveHook_' + str(random.randint(1, 10000)),
+            params={
+                'database': self.database,
+                'table': self.table,
+                'partition_by': self.partition_by
+            },
+            hive_cli_conn_id='beeline_default',
+            hql=self.hql, dag=self.dag)
+        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE,
+              ignore_ti_state=True)
+
+    def tearDown(self):
+        hook = HiveMetastoreHook()
+        with hook.get_conn() as metastore:
+            metastore.drop_table(self.database, self.table, deleteData=True)
+
+    def test_parse_partition_name_correct(self):
+        schema = 'default'
+        table = 'users'
+        partition = 'ds=2016-01-01/state=IT'
+        name = '{schema}.{table}/{partition}'.format(schema=schema,
+                                                     table=table,
+                                                     partition=partition)
+        parsed_schema, parsed_table, parsed_partition = (
+            NamedHivePartitionSensor.parse_partition_name(name)
+        )
+        self.assertEqual(schema, parsed_schema)
+        self.assertEqual(table, parsed_table)
+        self.assertEqual(partition, parsed_partition)
+
+    def test_parse_partition_name_incorrect(self):
+        name = 'incorrect.name'
+        with self.assertRaises(ValueError):
+            NamedHivePartitionSensor.parse_partition_name(name)
+
+    def test_parse_partition_name_default(self):
+        table = 'users'
+        partition = 'ds=2016-01-01/state=IT'
+        name = '{table}/{partition}'.format(table=table,
+                                            partition=partition)
+        parsed_schema, parsed_table, parsed_partition = (
+            NamedHivePartitionSensor.parse_partition_name(name)
+        )
+        self.assertEqual('default', parsed_schema)
+        self.assertEqual(table, parsed_table)
+        self.assertEqual(partition, parsed_partition)
+
+    def test_poke_existing(self):
+        partitions = ["{}.{}/{}={}".format(self.database,
+                                           self.table,
+                                           self.partition_by,
+                                           DEFAULT_DATE_DS)]
+        sensor = NamedHivePartitionSensor(partition_names=partitions,
+                                          task_id='test_poke_existing',
+                                          poke_interval=1,
+                                          hook=self.hook,
+                                          dag=self.dag)
+        self.assertTrue(sensor.poke(None))
+
+    def test_poke_non_existing(self):
+        partitions = ["{}.{}/{}={}".format(self.database,
+                                           self.table,
+                                           self.partition_by,
+                                           self.next_day)]
+        sensor = NamedHivePartitionSensor(partition_names=partitions,
+                                          task_id='test_poke_non_existing',
+                                          poke_interval=1,
+                                          hook=self.hook,
+                                          dag=self.dag)
+        self.assertFalse(sensor.poke(None))


### PR DESCRIPTION
Dear Airflow maintainers, please accept my PR (as soon as CI finishes successfully).


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2427) issues and references them in the PR title. For example, "\[AIRFLOW-2427\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2427
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
I've added tests to `NamedHivePartitionSensor`. I've also added the ability to pass an hook when creating the sensor and to avoid passing the database name when passing the partition name.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  + `test_parse_partition_name_correct`
  + `test_parse_partition_name_incorrect`
  + `test_parse_partition_name_default`
  + `test_poke_existing`
  + `test_poke_non_existing`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`