### PR TITLE
[AIRFLOW-2435] Change ecs_operator.py to be able to pass launch_type

### DIFF
--- a/airflow/contrib/operators/ecs_operator.py
+++ b/airflow/contrib/operators/ecs_operator.py
@@ -40,6 +40,8 @@ class ECSOperator(BaseOperator):
             credential boto3 strategy will be used (http://boto3.readthedocs.io/en/latest/guide/configuration.html).
     :type aws_conn_id: str
     :param region_name: region name to use in AWS Hook. Override the region_name in connection (if provided)
+    :param launch_type: the launch type on which to run your task ('EC2' or 'FARGATE')
+    :type: launch_type: str
     """
 
     ui_color = '#f0ede4'
@@ -49,7 +51,7 @@ class ECSOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self, task_definition, cluster, overrides,
-                 aws_conn_id=None, region_name=None, **kwargs):
+                 aws_conn_id=None, region_name=None, launch_type='EC2', **kwargs):
         super(ECSOperator, self).__init__(**kwargs)
 
         self.aws_conn_id = aws_conn_id
@@ -57,6 +59,7 @@ class ECSOperator(BaseOperator):
         self.task_definition = task_definition
         self.cluster = cluster
         self.overrides = overrides
+        self.launch_type = launch_type
 
         self.hook = self.get_hook()
 
@@ -76,7 +79,8 @@ class ECSOperator(BaseOperator):
             cluster=self.cluster,
             taskDefinition=self.task_definition,
             overrides=self.overrides,
-            startedBy=self.owner
+            startedBy=self.owner,
+            launchType=self.launch_type
         )
 
         failures = response['failures']

--- a/tests/contrib/operators/test_ecs_operator.py
+++ b/tests/contrib/operators/test_ecs_operator.py
@@ -97,6 +97,7 @@ class TestECSOperator(unittest.TestCase):
         self.aws_hook_mock.return_value.get_client_type.assert_called_once_with('ecs', region_name='eu-west-1')
         client_mock.run_task.assert_called_once_with(
             cluster='c',
+            launchType='EC2',
             overrides={},
             startedBy=mock.ANY,  # Can by 'airflow' or 'Airflow'
             taskDefinition='t'
@@ -119,6 +120,7 @@ class TestECSOperator(unittest.TestCase):
         self.aws_hook_mock.return_value.get_client_type.assert_called_once_with('ecs', region_name='eu-west-1')
         client_mock.run_task.assert_called_once_with(
             cluster='c',
+            launchType='EC2',
             overrides={},
             startedBy=mock.ANY,  # Can by 'airflow' or 'Airflow'
             taskDefinition='t'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/AIRFLOW-2435) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2435
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Added launch_type to ECSOperator. Default value remains EC2

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
If someone can point me in the right direction for this, gladly.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
