### PR TITLE
Add Quantopian to list of Airflow users

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Currently **officially** using Airflow:
 1. [Postmates](http://www.postmates.com) [[@syeoryn](https://github.com/syeoryn)]
 1. [Pronto Tools](http://www.prontotools.io/) [[@zkan](https://github.com/zkan) & [@mesodiar](https://github.com/mesodiar)]
 1. [Qplum](https://qplum.co) [[@manti](https://github.com/manti)]
+1. [Quantopian](https://www.quantopian.com/) [[@eronarn](http://github.com/eronarn)]
 1. [Qubole](https://qubole.com) [[@msumit](https://github.com/msumit)]
 1. [Quizlet](https://quizlet.com) [[@quizlet](https://github.com/quizlet)]
 1. [Quora](https://www.quora.com/)


### PR DESCRIPTION
We've been using it in production for a few months now, and we love it!

Presumably I don't need to file a JIRA issue for this one :)