### PR TITLE
[AIRFLOW-2442] Airflow run command leaves database connections open

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -420,10 +420,6 @@ def _run(args, dag, ti):
 
 @cli_utils.action_logging
 def run(args, dag=None):
-    # Disable connection pooling to reduce the # of connections on the DB
-    # while it's waiting for the task to finish.
-    settings.configure_orm(disable_connection_pool=True)
-
     if dag:
         args.dag_id = dag.dag_id
 
@@ -437,11 +433,20 @@ def run(args, dag=None):
         if os.path.exists(args.cfg_path):
             os.remove(args.cfg_path)
 
+        # Do not log these properties since some may contain passwords.
+        # This may also set default values for database properties like
+        # core.sql_alchemy_pool_size
+        # core.sql_alchemy_pool_recycle
         for section, config in conf_dict.items():
             for option, value in config.items():
                 conf.set(section, option, value)
         settings.configure_vars()
-        settings.configure_orm()
+
+    # IMPORTANT, have to use the NullPool, otherwise, each "run" command may leave
+    # behind multiple open sleeping connections while heartbeating, which could
+    # easily exceed the database connection limit when
+    # processing hundreds of simultaneous tasks.
+    settings.configure_orm(disable_connection_pool=True)
 
     if not args.pickle and not dag:
         dag = get_dag(args)

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -89,8 +89,9 @@ sql_alchemy_pool_size = 5
 
 # The SqlAlchemy pool recycle is the number of seconds a connection
 # can be idle in the pool before it is invalidated. This config does
-# not apply to sqlite.
-sql_alchemy_pool_recycle = 3600
+# not apply to sqlite. If the number of DB connections is ever exceeded,
+# a lower config value will allow the system to recover faster.
+sql_alchemy_pool_recycle = 1800
 
 # How many seconds to retry re-establishing a DB connection after
 # disconnects. Setting this to 0 disables retries.


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following Jira [AIRFLOW-2442](https://issues.apache.org/jira/browse/AIRFLOW-2442) and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

The "airflow run" command creates a connection to the database and leaves it open (until killed by SQLALchemy later). The number of these connections can skyrocket whenever hundreds/thousands of tasks are launched simultaneously, and potentially hit the database connection limit.

The problem is that in cli.py, the run() method first calls 
{code}settings.configure_orm(disable_connection_pool=True){code} correctly
to use a NullPool, but then parses any custom configs and again calls {code}settings.configure_orm(){code}, thereby overriding the desired behavior with a QueuePool.
The QueuePool uses the default configs for SQL_ALCHEMY_POOL_SIZE (5 connections) and SQL_ALCHEMY_POOL_RECYCLE (1 hour). This means that while the task is running and the executor is sending heartbeats, the sleeping connection is idle until it is killed by SQLAlchemy.

### Tests
- [x] Unit Tests. I ran unit tests on the head of master and there were 6 failures.
I then ran unit tests with my patch and encountered the same errors that are unrelated to my change.

```
960 tests run in 813.349 seconds.
6 FAILED, 129 errors, 24 skipped (801 tests passed)

[fail] 0.03% tests.contrib.hooks.test_ssh_hook.SSHHookTest.test_tunnel: 0.2227s [fail] 0.02% tests.transplant_class.<locals>.C.test_cli_webserver_background: 0.1979s
[fail] 0.02% tests.contrib.hooks.test_ssh_hook.SSHHookTest.test_ssh_connection: 0.1712s
[fail] 0.01% tests.transplant_class.<locals>.C.test_cli_webserver_foreground: 0.1157s [fail] 0.00% tests.transplant_class.<locals>.C.test_overwrite_schema: 0.0329s
[fail] 0.00% tests.utils.test_json.TestAirflowJsonEncoder.test_encode_raises: 0.0010s 
```

- [x] System Tests: I have a staging environment with an internal branch of Airflow that I used to verify the change in behavior. I ran a Stress Test DAG that launches about 10k tasks for several days and verified the behavior with and without my fix.
Notice that with my fix, the number of open DB connections sharply decreases from 20k to < 250.
![fixed_before_and_after](https://user-images.githubusercontent.com/225711/39836123-37b9bc38-5387-11e8-88c4-ef3b1fec672c.jpg)

Sample DAG Run log show success:
```
[2018-05-08 18:59:27,698] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 18:59:27,698] {settings.py:147} DEBUG - settings.configure_orm(): Traceback:
[2018-05-08 18:59:27,699] {base_task_runner.py:93} INFO - Subtask: ['  File "/usr/local/bin/airflow", line 28, in <module>\n    args.func(args)\n', '  File "/usr/local/lib/python2.7/dist-packages/airflow/bin/cli.py", line 351, in run\n    settings.configure_orm(disable_connection_pool=True)\n', '  File "/usr/local/lib/python2.7/dist-packages/airflow/settings.py", line 147, in configure_orm\n    logging.debug("settings.configure_orm(): Traceback:\\n{}".format(repr(traceback.format_stack())))\n']
[2018-05-08 18:59:27,699] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 18:59:27,698] {settings.py:151} INFO - settings.configure_orm(): Using NullPool
[2018-05-08 18:59:27,700] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 18:59:27,700] {models.py:192} INFO - Filling up the DagBag from /srv/data/airflow-bronze/stress_test/100/dag.py
[2018-05-08 18:59:27,700] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 18:59:27,700] {models.py:423} INFO - Processing dag_folder as file
[2018-05-08 18:59:27,701] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 18:59:27,700] {models.py:251} INFO - Processing filepath /srv/data/airflow-bronze/stress_test/100/dag.py
[2018-05-08 18:59:27,701] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 18:59:27,701] {models.py:271} INFO - Processed file is not a zip file
[2018-05-08 18:59:27,701] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 18:59:27,701] {models.py:279} DEBUG - Importing /srv/data/airflow-bronze/stress_test/100/dag.py
[2018-05-08 18:59:27,702] {base_task_runner.py:93} INFO - Subtask: /usr/local/lib/python2.7/dist-packages/airflow/utils/helpers.py:351: DeprecationWarning: Importing BashOperator directly from <module 'airflow.operators' from '/usr/local/lib/python2.7/dist-packages/airflow/operators/__init__.pyc'> has been deprecated. Please import from '<module 'airflow.operators' from '/usr/local/lib/python2.7/dist-packages/airflow/operators/__init__.pyc'>.[operator_module]' instead. Support for direct imports will be dropped entirely in Airflow 2.0.
[2018-05-08 18:59:27,702] {base_task_runner.py:93} INFO - Subtask:   DeprecationWarning)
[2018-05-08 18:59:27,856] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 18:59:27,856] {models.py:400} DEBUG - Loaded DAG <DAG: airflow_stress_test_dag_100_0000>
[2018-05-08 18:59:27,857] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 18:59:27,857] {models.py:400} DEBUG - Loaded DAG <DAG: airflow_stress_test_dag_100_0000>
[2018-05-08 18:59:27,888] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 18:59:27,888] {cli.py:420} INFO - Running on host i-0d21c6dac1f9809c3.inst.aws.us-east-1.prod.musta.ch
[2018-05-08 18:59:27,908] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 18:59:27,908] {bash_operator.py:86} INFO - tmp dir root location: 
[2018-05-08 18:59:27,908] {base_task_runner.py:93} INFO - Subtask: /tmp
[2018-05-08 18:59:27,909] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 18:59:27,909] {bash_operator.py:95} INFO - Temporary script location :/tmp/airflowtmpgmrKiW/airflow_stress_test_dag_100_0000_task_0084PWbSHF
[2018-05-08 18:59:27,909] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 18:59:27,909] {bash_operator.py:96} INFO - Running command: export AIRFLOW_HOME=/srv/airflow; export PYTHONPATH=/srv/data/airflow-bronze:/usr/local/lib/python2.7/dist-packages/airflow:/srv/airflow/pythonpath; sleep 480
[2018-05-08 18:59:27,916] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 18:59:27,916] {bash_operator.py:105} INFO - Output:
[2018-05-08 19:00:26,054] {jobs.py:186} DEBUG - [heartbeat]
[2018-05-08 19:01:26,136] {jobs.py:186} DEBUG - [heartbeat]
[2018-05-08 19:02:26,184] {jobs.py:186} DEBUG - [heartbeat]
[2018-05-08 19:03:26,243] {jobs.py:186} DEBUG - [heartbeat]
[2018-05-08 19:04:26,298] {jobs.py:186} DEBUG - [heartbeat]
[2018-05-08 19:05:26,340] {jobs.py:186} DEBUG - [heartbeat]
[2018-05-08 19:06:26,383] {jobs.py:186} DEBUG - [heartbeat]
[2018-05-08 19:07:26,391] {jobs.py:186} DEBUG - [heartbeat]
[2018-05-08 19:07:27,918] {base_task_runner.py:93} INFO - Subtask: [2018-05-08 19:07:27,918] {bash_operator.py:112} INFO - Command exited with return code 0
[2018-05-08 19:08:26,455] {jobs.py:186} DEBUG - [heartbeat]
[2018-05-08 19:08:26,455] {jobs.py:2520} INFO - Task exited with return code 0
```


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
