### PR TITLE
[AIRFLOW-2446] Add S3ToRedshiftTransfer into the "Integration" doc

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -268,7 +268,8 @@ AWS RedShift
 
 - :ref:`AwsRedshiftClusterSensor` : Waits for a Redshift cluster to reach a specific status.
 - :ref:`RedshiftHook` : Interact with AWS Redshift, using the boto3 library.
-- :ref:`RedshiftToS3Transfer` : Executes an unload command to S3 as a CSV with headers.
+- :ref:`RedshiftToS3Transfer` : Executes an unload command to S3 as CSV with or without headers.
+- :ref:`S3ToRedshiftTransfer` : Executes an copy command from S3 as CSV with or without headers.
 
 .. _AwsRedshiftClusterSensor:
 
@@ -290,6 +291,13 @@ RedshiftToS3Transfer
 """"""""""""""""""""
 
 .. autoclass:: airflow.operators.redshift_to_s3_operator.RedshiftToS3Transfer
+
+.. _S3ToRedshiftTransfer:
+
+S3ToRedshiftTransfer
+""""""""""""""""""""
+
+.. autoclass:: airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer
 
 
 .. _Databricks:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2446
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds an undocumented AWS-related operator
into the "Integration" section and fixes some
obsolete description.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's just a documentation fix. I ran docs/build.sh locally and confirmed the document is rendered as expected.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
