### PR TITLE
[AIRFLOW-2376] Fix no hive section error

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -19,6 +19,7 @@
 # under the License.
 
 from __future__ import print_function
+from backports.configparser import NoSectionError
 import logging
 
 import os
@@ -439,7 +440,13 @@ def run(args, dag=None):
 
         for section, config in conf_dict.items():
             for option, value in config.items():
-                conf.set(section, option, value)
+                try:
+                    conf.set(section, option, value)
+                except NoSectionError:
+                    log.error('Section {section} Option {option} '
+                              'does not exist in the config!'.format(section=section,
+                                                                     option=option))
+
         settings.configure_vars()
         settings.configure_orm()
 

--- a/airflow/utils/configuration.py
+++ b/airflow/utils/configuration.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -26,11 +26,6 @@ from tempfile import mkstemp
 from airflow import configuration as conf
 
 
-COPY_SECTIONS = [
-    'core', 'smtp', 'scheduler', 'celery', 'webserver', 'hive'
-]
-
-
 def tmp_configuration_copy():
     """
     Returns a path for a temporary file including a full copy of the configuration
@@ -40,11 +35,7 @@ def tmp_configuration_copy():
     cfg_dict = conf.as_dict(display_sensitive=True)
     temp_fd, cfg_path = mkstemp()
 
-    cfg_subset = dict()
-    for section in COPY_SECTIONS:
-        cfg_subset[section] = cfg_dict.get(section, {})
-
     with os.fdopen(temp_fd, 'w') as temp_file:
-        json.dump(cfg_subset, temp_file)
+        json.dump(cfg_dict, temp_file)
 
     return cfg_path


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2376
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Fix the issue which airflow cli throws "backports.configparser.NoSectionError: No section: u'hive'" error.
The reason is because when user uses either run or backfill cli command, airflow tries to copy some of the confirguration(https://github.com/apache/incubator-airflow/blob/master/airflow/utils/configuration.py#L34). Currently hive is one of section for copy, but if user's airflow.cfg doesn't have configuration for this section. It will throw the error described in the jira ticket. Since hive section is not required for core, just remove that.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
