### PR TITLE
[AIRFLOW-2449] Fix operators.py to run all test cases

### DIFF
--- a/tests/operators/operators.py
+++ b/tests/operators/operators.py
@@ -45,7 +45,7 @@ class MySqlTest(unittest.TestCase):
         dag = DAG(TEST_DAG_ID, default_args=args)
         self.dag = dag
 
-    def mysql_operator_test(self):
+    def test_mysql_operator_test(self):
         sql = """
         CREATE TABLE IF NOT EXISTS test_airflow (
             dummy VARCHAR(50)
@@ -59,7 +59,7 @@ class MySqlTest(unittest.TestCase):
             dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
-    def mysql_operator_test_multi(self):
+    def test_mysql_operator_test_multi(self):
         sql = [
             "TRUNCATE TABLE test_airflow",
             "INSERT INTO test_airflow VALUES ('X')",
@@ -71,7 +71,7 @@ class MySqlTest(unittest.TestCase):
             sql=sql, dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
-    def mysql_hook_test_bulk_load(self):
+    def test_mysql_hook_test_bulk_load(self):
         records = ("foo", "bar", "baz")
 
         import tempfile
@@ -140,7 +140,7 @@ class PostgresTest(unittest.TestCase):
         dag = DAG(TEST_DAG_ID, default_args=args)
         self.dag = dag
 
-    def postgres_operator_test(self):
+    def test_postgres_operator_test(self):
         sql = """
         CREATE TABLE IF NOT EXISTS test_airflow (
             dummy VARCHAR(50)
@@ -161,7 +161,7 @@ class PostgresTest(unittest.TestCase):
             end_date=DEFAULT_DATE,
             ignore_ti_state=True)
 
-    def postgres_operator_test_multi(self):
+    def test_postgres_operator_test_multi(self):
         sql = [
             "TRUNCATE TABLE test_airflow",
             "INSERT INTO test_airflow VALUES ('X')",


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2449
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

MySqlTest and PostgresTest in tests/operators/operators.py
have some unexecuted tests due to wrong naming convention.
This PR fixes it.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's a fix for test itself.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
