### PR TITLE
[AIRFLOW-2016] assign template_fields for Dataproc Workflow Template sub-classes

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -1031,8 +1031,6 @@ class DataProcPySparkOperator(BaseOperator):
 
 
 class DataprocWorkflowTemplateBaseOperator(BaseOperator):
-    template_fields = ['template_id', 'template']
-
     @apply_defaults
     def __init__(self,
                  project_id,
@@ -1083,6 +1081,8 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocWorkflowTemplateBaseOp
     :type delegate_to: string
     """
 
+    template_fields = ['template_id']
+
     @apply_defaults
     def __init__(self, template_id, *args, **kwargs):
         (super(DataprocWorkflowTemplateInstantiateOperator, self)
@@ -1124,6 +1124,8 @@ class DataprocWorkflowTemplateInstantiateInlineOperator(
         delegation enabled.
     :type delegate_to: string
     """
+
+    template_fields = ['template']
 
     @apply_defaults
     def __init__(self, template, *args, **kwargs):


### PR DESCRIPTION
### JIRA
- [X] My PR addresses a bug discussed in recent comments comments on the following JIRA:
    - https://issues.apache.org/jira/browse/AIRFLOW-2016

In those comments I confirmed with the original submitter for that ticket, @DanSedov , that the existing code has a problem and that it is correctly addressed by this commit.

### Description
- [X] This change moves the `template_fields` for the DataProc WorkflowTemplate operators out of the base operator and into the derived classes.  This is necessary because the derived classes only use subsets of the templated fields, and so when task instances are instantiated for them, errors are thrown for the fields that are missing.

### Tests
- [X] My PR is a small bug fix that will be difficult to test in unit tests, but I have tested it on our Airflow deployments and confirmed that it fixes the problem.  Prior to this commit, the WorkflowTemplate operators are not usable because of this bug.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] No new functionality is provided

### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
