### PR TITLE
[AIRFLOW-2452] Document field_dict must be OrderedDict

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -27,6 +27,7 @@ import itertools
 import re
 import subprocess
 import time
+from collections import OrderedDict
 from tempfile import NamedTemporaryFile
 import hmsclient
 
@@ -303,8 +304,9 @@ class HiveCliHook(BaseHook):
         :param recreate: whether to drop and recreate the table at every
             execution
         :type recreate: bool
-        :param field_dict: mapping from column name to hive data type
-        :type field_dict: dict
+        :param field_dict: mapping from column name to hive data type.
+            Note that it must be OrderedDict so as to keep columns' order.
+        :type field_dict: OrderedDict
         :param encoding: string encoding to use when writing DataFrame to file
         :type encoding: str
         :param pandas_kwargs: passed to DataFrame.to_csv
@@ -325,7 +327,10 @@ class HiveCliHook(BaseHook):
                 'V': 'STRING'    # void
             }
 
-            return dict((col, DTYPE_KIND_HIVE_TYPE[dtype.kind]) for col, dtype in df.dtypes.iteritems())
+            d = OrderedDict()
+            for col, dtype in df.dtypes.iteritems():
+                d[col] = DTYPE_KIND_HIVE_TYPE[dtype.kind]
+            return d
 
         if pandas_kwargs is None:
             pandas_kwargs = {}
@@ -378,8 +383,9 @@ class HiveCliHook(BaseHook):
         :param delimiter: field delimiter in the file
         :type delimiter: str
         :param field_dict: A dictionary of the fields name in the file
-            as keys and their Hive types as values
-        :type field_dict: dict
+            as keys and their Hive types as values.
+            Note that it must be OrderedDict so as to keep columns' order.
+        :type field_dict: OrderedDict
         :param create: whether to create the table if it doesn't exist
         :type create: bool
         :param overwrite: whether to overwrite the data in table or partition

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -25,6 +25,7 @@ import random
 import mock
 import unittest
 
+from collections import OrderedDict
 from hmsclient import HMSClient
 
 from airflow.exceptions import AirflowException
@@ -130,6 +131,7 @@ class TestHiveCliHook(unittest.TestCase):
         kwargs = mock_load_file.call_args[1]
         self.assertEqual(kwargs["delimiter"], delimiter)
         self.assertEqual(kwargs["field_dict"], {"c": u"STRING"})
+        self.assertTrue(isinstance(kwargs["field_dict"], OrderedDict))
         self.assertEqual(kwargs["table"], table)
 
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2452
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

HiveCliHook.load_file has a parameter called
field_dict, which defines name-type pairs
for columns, must be OrderedDict so as to
keep columns' order, but it's undocumented.
This PR adds an note about that, and fixes
HiveCliHook.load_df function which calls
load_file internally.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added new assertion to TestHiveCliHook.test_load_df.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`