### PR TITLE
[AIRFLOW-2454] Support imagePullPolicy for k8s

### DIFF
--- a/airflow/contrib/kubernetes/pod.py
+++ b/airflow/contrib/kubernetes/pod.py
@@ -1,4 +1,3 @@
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -53,6 +52,8 @@ class Pod:
     :param result: The result that will be returned to the operator after
                    successful execution of the pod
     :type result: any
+    :param image_pull_policy: Specify a policy to cache or always pull an image
+    :type image_pull_policy: str
     """
     def __init__(
             self,

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -76,6 +76,7 @@ class KubernetesPodOperator(BaseOperator):
 
             pod.secrets = self.secrets
             pod.envs = self.env_vars
+            pod.image_pull_policy = self.image_pull_policy
 
             launcher = pod_launcher.PodLauncher(client)
             final_state = launcher.run_pod(
@@ -102,6 +103,7 @@ class KubernetesPodOperator(BaseOperator):
                  labels=None,
                  startup_timeout_seconds=120,
                  get_logs=True,
+                 image_pull_policy='IfNotPresent',
                  *args,
                  **kwargs):
         super(KubernetesPodOperator, self).__init__(*args, **kwargs)
@@ -116,3 +118,4 @@ class KubernetesPodOperator(BaseOperator):
         self.secrets = secrets or []
         self.in_cluster = in_cluster
         self.get_logs = get_logs
+        self.image_pull_policy = image_pull_policy


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow 2454](https://issues.apache.org/jira/browse/AIRFLOW-2454) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

We were running into an issue with old images being run in our Airflow Kubernetes cluster. This is because by default, the imagePullPolicy is set to 'IfNotPresent'. Developers should be able to control this.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Adds a single parameter

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
