### PR TITLE
[AIRFLOW-2460] Users can acces PersistentVolumeClaims and Configmaps using KubernetesPodOperator

### DIFF
--- a/airflow/contrib/kubernetes/pod_generator.py
+++ b/airflow/contrib/kubernetes/pod_generator.py
@@ -19,6 +19,8 @@ import os
 
 from airflow.contrib.kubernetes.pod import Pod
 import uuid
+from airflow.contrib.kubernetes.volume_mount import VolumeMount  # noqa
+from airflow.contrib.kubernetes.volume import Volume  # noqa
 
 
 class PodGenerator:
@@ -64,16 +66,30 @@ class PodGenerator:
     def _get_init_containers(self):
         return self.init_containers
 
-    def add_volume(self, name):
+    def add_volume(self, volume):
+        """
+        Args:
+            volume (Volume):
+        """
+
+        self._add_volume(name=volume.name, configs=volume.configs)
+
+    def _add_volume(self, name, configs):
         """
 
         Args:
             name (str):
+            configs (dict): Configurations for the volume.
+            Could be used to define PersistentVolumeClaim, ConfigMap, etc...
 
         Returns:
 
         """
-        self.volumes.append({'name': name})
+        volume_map = {'name': name}
+        for k, v in configs.items():
+            volume_map[k] = v
+
+        self.volumes.append(volume_map)
 
     def add_volume_with_configmap(self, name, config_map):
         self.volumes.append(
@@ -83,11 +99,11 @@ class PodGenerator:
             }
         )
 
-    def add_mount(self,
-                  name,
-                  mount_path,
-                  sub_path,
-                  read_only):
+    def _add_mount(self,
+                   name,
+                   mount_path,
+                   sub_path,
+                   read_only):
         """
 
         Args:
@@ -106,6 +122,19 @@ class PodGenerator:
             'subPath': sub_path,
             'readOnly': read_only
         })
+
+    def add_mount(self,
+                  volume_mount):
+        """
+        Args:
+            volume_mount (VolumeMount):
+        """
+        self._add_mount(
+            name=volume_mount.name,
+            mount_path=volume_mount.mount_path,
+            sub_path=volume_mount.sub_path,
+            read_only=volume_mount.read_only
+        )
 
     def _get_volumes_and_mounts(self):
         return self.volumes, self.volume_mounts

--- a/airflow/contrib/kubernetes/volume.py
+++ b/airflow/contrib/kubernetes/volume.py
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+class Volume:
+    """Defines Kubernetes Volume"""
+
+    def __init__(self, name, configs):
+        """ Adds Kubernetes Volume to pod. allows pod to access features like ConfigMaps
+        and Persistent Volumes
+        :param name: the name of the volume mount
+        :type: name: str
+        :param configs: dictionary of any features needed for volume.
+        We purposely keep this vague since there are multiple volume types with changing
+        configs.
+        :type: configs: dict
+        """
+        self.name = name
+        self.configs = configs

--- a/airflow/contrib/kubernetes/volume_mount.py
+++ b/airflow/contrib/kubernetes/volume_mount.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+class VolumeMount:
+    """Defines Kubernetes Volume Mount"""
+
+    def __init__(self, name, mount_path, sub_path, read_only):
+        """Initialize a Kubernetes Volume Mount. Used to mount pod level volumes to
+        running container.
+        :param name: the name of the volume mount
+        :type name: str
+        :param mount_path:
+        :type mount_path: str
+        :param sub_path: subpath within the volume mount
+        :type sub_path: str
+        :param read_only: whether to access pod with read-only mode
+        :type read_only: bool
+        """
+        self.name = name
+        self.mount_path = mount_path
+        self.sub_path = sub_path
+        self.read_only = read_only

--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -19,13 +19,26 @@ Kubernetes Operator
 
     secret_file = Secret('volume', '/etc/sql_conn', 'airflow-secrets', 'sql_alchemy_conn')
     secret_env  = Secret('env', 'SQL_CONN', 'airflow-secrets', 'sql_alchemy_conn')
+    volume_mount = VolumeMount('test-volume',
+                                mount_path='/root/mount_file',
+                                sub_path=None,
+                                read_only=True)
 
+    volume_config= {
+        'persistentVolumeClaim':
+          {
+            'claimName': 'test-volume'
+          }
+        }
+    volume = Volume(name='test-volume', configs=volume_config)
     k = KubernetesPodOperator(namespace='default',
                               image="ubuntu:16.04",
                               cmds=["bash", "-cx"],
                               arguments=["echo", "10"],
                               labels={"foo": "bar"},
                               secrets=[secret_file,secret_env]
+                              volume=[volume],
+                              volume_mounts=[volume_mount]
                               name="test",
                               task_id="task"
                               )

--- a/scripts/ci/kubernetes/docker/Dockerfile
+++ b/scripts/ci/kubernetes/docker/Dockerfile
@@ -46,7 +46,7 @@ RUN pip install -U setuptools && \
 COPY airflow.tar.gz /tmp/airflow.tar.gz
 RUN pip install /tmp/airflow.tar.gz
 
-COPY airflow-init.sh /tmp/airflow-init.sh
+COPY airflow-test-env-init.sh /tmp/airflow-test-env-init.sh
 
 COPY bootstrap.sh /bootstrap.sh
 RUN chmod +x /bootstrap.sh

--- a/scripts/ci/kubernetes/docker/airflow-test-env-init.sh
+++ b/scripts/ci/kubernetes/docker/airflow-test-env-init.sh
@@ -21,4 +21,5 @@ cd /usr/local/lib/python2.7/dist-packages/airflow && \
 cp -R example_dags/* /root/airflow/dags/ && \
 airflow initdb && \
 alembic upgrade heads && \
-(airflow create_user -u airflow -l airflow -f jon -e airflow@apache.org -r Admin -p airflow || true)
+(airflow create_user -u airflow -l airflow -f jon -e airflow@apache.org -r Admin -p airflow || true) && \
+echo "retrieved from mount" > /root/test_volume/test.txt

--- a/scripts/ci/kubernetes/kube/airflow.yaml
+++ b/scripts/ci/kubernetes/kube/airflow.yaml
@@ -51,6 +51,8 @@ spec:
           subPath: airflow.cfg
         - name: airflow-dags
           mountPath: /root/airflow/dags
+        - name: test-volume
+          mountPath: /root/test_volume
         env:
         - name: SQL_ALCHEMY_CONN
           valueFrom:
@@ -61,7 +63,7 @@ spec:
           - "bash"
         args:
           - "-cx"
-          - "./tmp/airflow-init.sh"
+          - "./tmp/airflow-test-env-init.sh"
       containers:
       - name: webserver
         image: airflow
@@ -128,6 +130,9 @@ spec:
       - name: airflow-dags
         persistentVolumeClaim:
           claimName: airflow-dags
+      - name: test-volume
+        persistentVolumeClaim:
+          claimName: test-volume
       - name: airflow-logs
         persistentVolumeClaim:
           claimName: airflow-logs

--- a/scripts/ci/kubernetes/kube/volumes.yaml
+++ b/scripts/ci/kubernetes/kube/volumes.yaml
@@ -62,4 +62,26 @@ spec:
   resources:
     requests:
       storage: 2Gi
-
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: test-volume
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 2Gi
+  hostPath:
+    path: /airflow-dags/
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: test-volume
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 2Gi


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2460
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:

In order to run tasks using the KubernetesPodOperator in a production setting, users need to be able to access pre-existing data through PersistentVolumes or ConfigMaps. This PR creates and tests Volume and VolumeMount objects that will allow this functionality.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

https://github.com/apache/incubator-airflow/compare/master...bloomberg:k8s-mounts?expand=1#diff-63cf36e64e6d9d0139231078d856b245R64

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
