### PR TITLE
[AIRFLOW-2461] Add support for cluster scaling on dataproc operator

### DIFF
--- a/docs/code.rst
+++ b/docs/code.rst
@@ -126,6 +126,7 @@ Operators
 .. autoclass:: airflow.contrib.operators.dataflow_operator.DataflowTemplateOperator
 .. autoclass:: airflow.contrib.operators.dataflow_operator.DataFlowPythonOperator
 .. autoclass:: airflow.contrib.operators.dataproc_operator.DataprocClusterCreateOperator
+.. autoclass:: airflow.contrib.operators.dataproc_operator.DataprocClusterScaleOperator
 .. autoclass:: airflow.contrib.operators.dataproc_operator.DataprocClusterDeleteOperator
 .. autoclass:: airflow.contrib.operators.dataproc_operator.DataProcPigOperator
 .. autoclass:: airflow.contrib.operators.dataproc_operator.DataProcHiveOperator

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -571,6 +571,7 @@ DataProc Operators
 
 - :ref:`DataprocClusterCreateOperator` : Create a new cluster on Google Cloud Dataproc.
 - :ref:`DataprocClusterDeleteOperator` : Delete a cluster on Google Cloud Dataproc.
+- :ref:`DataprocClusterScaleOperator` : Scale up or down a cluster on Google Cloud Dataproc.
 - :ref:`DataProcPigOperator` : Start a Pig query Job on a Cloud DataProc cluster.
 - :ref:`DataProcHiveOperator` : Start a Hive query Job on a Cloud DataProc cluster.
 - :ref:`DataProcSparkSqlOperator` : Start a Spark SQL query Job on a Cloud DataProc cluster.
@@ -586,6 +587,13 @@ DataprocClusterCreateOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: airflow.contrib.operators.dataproc_operator.DataprocClusterCreateOperator
+
+.. _DataprocClusterScaleOperator:
+
+DataprocClusterScaleOperator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: airflow.contrib.operators.dataproc_operator.DataprocClusterScaleOperator
 
 .. _DataprocClusterDeleteOperator:
 

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -24,14 +24,15 @@ import unittest
 
 from airflow import DAG
 from airflow.contrib.operators.dataproc_operator import \
-    DataprocClusterCreateOperator,\
-    DataprocClusterDeleteOperator,\
-    DataProcHadoopOperator,\
-    DataProcHiveOperator,\
-    DataProcPySparkOperator,\
-    DataProcSparkOperator,\
-    DataprocWorkflowTemplateInstantiateInlineOperator,\
-    DataprocWorkflowTemplateInstantiateOperator
+    DataprocClusterCreateOperator, \
+    DataprocClusterDeleteOperator, \
+    DataProcHadoopOperator, \
+    DataProcHiveOperator, \
+    DataProcPySparkOperator, \
+    DataProcSparkOperator, \
+    DataprocWorkflowTemplateInstantiateInlineOperator, \
+    DataprocWorkflowTemplateInstantiateOperator, \
+    DataprocClusterScaleOperator
 from airflow.version import version
 
 from copy import deepcopy
@@ -229,7 +230,8 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
                          "2017-06-07T00:00:00.000000Z")
 
     def test_cluster_name_log_no_sub(self):
-        with patch('airflow.contrib.operators.dataproc_operator.DataProcHook') as mock_hook:
+        with patch('airflow.contrib.operators.dataproc_operator.DataProcHook') \
+                as mock_hook:
             mock_hook.return_value.get_conn = self.mock_conn
             dataproc_task = DataprocClusterCreateOperator(
                 task_id=TASK_ID,
@@ -245,7 +247,8 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
                 mock_info.assert_called_with('Creating cluster: %s', CLUSTER_NAME)
 
     def test_cluster_name_log_sub(self):
-        with patch('airflow.contrib.operators.dataproc_operator.DataProcHook') as mock_hook:
+        with patch('airflow.contrib.operators.dataproc_operator.DataProcHook') \
+                as mock_hook:
             mock_hook.return_value.get_conn = self.mock_conn
             dataproc_task = DataprocClusterCreateOperator(
                 task_id=TASK_ID,
@@ -256,13 +259,83 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
                 dag=self.dag
             )
             with patch.object(dataproc_task.log, 'info') as mock_info:
-                context = { 'ts_nodash' : 'testnodash'}
+                context = {'ts_nodash': 'testnodash'}
 
-                rendered = dataproc_task.render_template('cluster_name', getattr(dataproc_task,'cluster_name'), context)
+                rendered = dataproc_task.render_template(
+                    'cluster_name',
+                    getattr(dataproc_task, 'cluster_name'), context)
                 setattr(dataproc_task, 'cluster_name', rendered)
-                with self.assertRaises(TypeError) as _:
+                with self.assertRaises(TypeError):
                     dataproc_task.execute(None)
-                mock_info.assert_called_with('Creating cluster: %s', u'smoke-cluster-testnodash')
+                mock_info.assert_called_with('Creating cluster: %s',
+                                             u'smoke-cluster-testnodash')
+
+
+class DataprocClusterScaleOperatorTest(unittest.TestCase):
+    # Unit test for the DataprocClusterScaleOperator
+    def setUp(self):
+        self.mock_execute = Mock()
+        self.mock_execute.execute = Mock(return_value={'done': True})
+        self.mock_get = Mock()
+        self.mock_get.get = Mock(return_value=self.mock_execute)
+        self.mock_operations = Mock()
+        self.mock_operations.get = Mock(return_value=self.mock_get)
+        self.mock_regions = Mock()
+        self.mock_regions.operations = Mock(return_value=self.mock_operations)
+        self.mock_projects = Mock()
+        self.mock_projects.regions = Mock(return_value=self.mock_regions)
+        self.mock_conn = Mock()
+        self.mock_conn.projects = Mock(return_value=self.mock_projects)
+        self.dag = DAG(
+            'test_dag',
+            default_args={
+                'owner': 'airflow',
+                'start_date': DEFAULT_DATE,
+                'end_date': DEFAULT_DATE,
+            },
+            schedule_interval='@daily')
+
+    def test_cluster_name_log_no_sub(self):
+        with patch('airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook') as mock_hook:
+            mock_hook.return_value.get_conn = self.mock_conn
+            dataproc_task = DataprocClusterScaleOperator(
+                task_id=TASK_ID,
+                cluster_name=CLUSTER_NAME,
+                project_id=PROJECT_ID,
+                num_workers=NUM_WORKERS,
+                num_preemptible_workers=NUM_PREEMPTIBLE_WORKERS,
+                dag=self.dag
+            )
+            with patch.object(dataproc_task.log, 'info') as mock_info:
+                with self.assertRaises(TypeError):
+                    dataproc_task.execute(None)
+                mock_info.assert_called_with('Scaling cluster: %s', CLUSTER_NAME)
+
+    def test_cluster_name_log_sub(self):
+        with patch('airflow.contrib.operators.dataproc_operator.DataProcHook') \
+                as mock_hook:
+            mock_hook.return_value.get_conn = self.mock_conn
+            dataproc_task = DataprocClusterScaleOperator(
+                task_id=TASK_ID,
+                cluster_name='smoke-cluster-{{ ts_nodash }}',
+                project_id=PROJECT_ID,
+                num_workers=NUM_WORKERS,
+                num_preemptible_workers=NUM_PREEMPTIBLE_WORKERS,
+                dag=self.dag
+            )
+
+            with patch.object(dataproc_task.log, 'info') as mock_info:
+                context = {'ts_nodash': 'testnodash'}
+
+                rendered = dataproc_task.render_template(
+                    'cluster_name',
+                    getattr(dataproc_task, 'cluster_name'), context)
+                setattr(dataproc_task, 'cluster_name', rendered)
+                with self.assertRaises(TypeError):
+                    dataproc_task.execute(None)
+                mock_info.assert_called_with('Scaling cluster: %s',
+                                             u'smoke-cluster-testnodash')
+
 
 class DataprocClusterDeleteOperatorTest(unittest.TestCase):
     # Unit test for the DataprocClusterDeleteOperator
@@ -313,13 +386,17 @@ class DataprocClusterDeleteOperatorTest(unittest.TestCase):
             )
 
             with patch.object(dataproc_task.log, 'info') as mock_info:
-                context = { 'ts_nodash' : 'testnodash'}
+                context = {'ts_nodash': 'testnodash'}
 
-                rendered = dataproc_task.render_template('cluster_name', getattr(dataproc_task,'cluster_name'), context)
+                rendered = dataproc_task.render_template(
+                    'cluster_name',
+                    getattr(dataproc_task, 'cluster_name'), context)
                 setattr(dataproc_task, 'cluster_name', rendered)
-                with self.assertRaises(TypeError) as _:
+                with self.assertRaises(TypeError):
                     dataproc_task.execute(None)
-                mock_info.assert_called_with('Deleting cluster: %s', u'smoke-cluster-testnodash')
+                mock_info.assert_called_with('Deleting cluster: %s',
+                                             u'smoke-cluster-testnodash')
+
 
 class DataProcHadoopOperatorTest(unittest.TestCase):
     # Unit test for the DataProcHadoopOperator


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x]  [AIRFLOW-2461](https://issues.apache.org/jira/browse/AIRFLOW-2461)


### Description
- [x] Add support for scale dataproc clusters:


### Tests
- [x] Implementation of tests:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`