### PR TITLE
[AIRFLOW-2466] consider task_id in _change_state_for_tis_without_dagrun

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1014,6 +1014,7 @@ class SchedulerJob(BaseJob):
                 .query(models.TaskInstance) \
                 .filter(and_(
                     models.TaskInstance.dag_id == subq.c.dag_id,
+                    models.TaskInstance.task_id == subq.c.task_id,
                     models.TaskInstance.execution_date ==
                     subq.c.execution_date)) \
                 .update({models.TaskInstance.state: new_state},

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -1611,13 +1611,17 @@ class SchedulerJobTest(unittest.TestCase):
             self.assertEqual(State.QUEUED, ti.state)
 
     def test_change_state_for_tis_without_dagrun(self):
-        dag = DAG(
+        dag1 = DAG(
             dag_id='test_change_state_for_tis_without_dagrun',
             start_date=DEFAULT_DATE)
 
         DummyOperator(
             task_id='dummy',
-            dag=dag,
+            dag=dag1,
+            owner='airflow')
+        DummyOperator(
+            task_id='dummy_b',
+            dag=dag1,
             owner='airflow')
 
         dag2 = DAG(
@@ -1639,7 +1643,7 @@ class SchedulerJobTest(unittest.TestCase):
             owner='airflow')
 
         session = settings.Session()
-        dr = dag.create_dagrun(run_id=DagRun.ID_PREFIX,
+        dr1 = dag1.create_dagrun(run_id=DagRun.ID_PREFIX,
                                state=State.RUNNING,
                                execution_date=DEFAULT_DATE,
                                start_date=DEFAULT_DATE,
@@ -1651,8 +1655,10 @@ class SchedulerJobTest(unittest.TestCase):
                                  start_date=DEFAULT_DATE,
                                  session=session)
 
-        ti = dr.get_task_instance(task_id='dummy', session=session)
-        ti.state = State.SCHEDULED
+        ti1a = dr1.get_task_instance(task_id='dummy', session=session)
+        ti1a.state = State.SCHEDULED
+        ti1b = dr1.get_task_instance(task_id='dummy_b', session=session)
+        ti1b.state = State.SUCCESS
         session.commit()
 
         ti2 = dr2.get_task_instance(task_id='dummy', session=session)
@@ -1664,7 +1670,7 @@ class SchedulerJobTest(unittest.TestCase):
         session.merge(ti3)
         session.commit()
 
-        dagbag = self._make_simple_dag_bag([dag, dag2, dag3])
+        dagbag = self._make_simple_dag_bag([dag1, dag2, dag3])
         scheduler = SchedulerJob(num_runs=0, run_duration=0)
         scheduler._change_state_for_tis_without_dagrun(
             simple_dag_bag=dagbag,
@@ -1672,9 +1678,13 @@ class SchedulerJobTest(unittest.TestCase):
             new_state=State.NONE,
             session=session)
 
-        ti = dr.get_task_instance(task_id='dummy', session=session)
-        ti.refresh_from_db(session=session)
-        self.assertEqual(ti.state, State.SCHEDULED)
+        ti1a = dr1.get_task_instance(task_id='dummy', session=session)
+        ti1a.refresh_from_db(session=session)
+        self.assertEqual(ti1a.state, State.SCHEDULED)
+
+        ti1b = dr1.get_task_instance(task_id='dummy_b', session=session)
+        ti1b.refresh_from_db(session=session)
+        self.assertEqual(ti1b.state, State.SUCCESS)
 
         ti2 = dr2.get_task_instance(task_id='dummy', session=session)
         ti2.refresh_from_db(session=session)
@@ -1683,11 +1693,11 @@ class SchedulerJobTest(unittest.TestCase):
         ti3.refresh_from_db(session=session)
         self.assertEquals(ti3.state, State.NONE)
 
-        dr.refresh_from_db(session=session)
-        dr.state = State.FAILED
+        dr1.refresh_from_db(session=session)
+        dr1.state = State.FAILED
 
         # why o why
-        session.merge(dr)
+        session.merge(dr1)
         session.commit()
 
         scheduler._change_state_for_tis_without_dagrun(
@@ -1695,8 +1705,12 @@ class SchedulerJobTest(unittest.TestCase):
             old_states=[State.SCHEDULED, State.QUEUED],
             new_state=State.NONE,
             session=session)
-        ti.refresh_from_db(session=session)
-        self.assertEqual(ti.state, State.NONE)
+        ti1a.refresh_from_db(session=session)
+        self.assertEqual(ti1a.state, State.NONE)
+
+        # don't touch ti1b
+        ti1b.refresh_from_db(session=session)
+        self.assertEqual(ti1b.state, State.SUCCESS)
 
         # don't touch ti2
         ti2.refresh_from_db(session=session)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following:
    - https://issues.apache.org/jira/browse/AIRFLOW-2466


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

    There is a bug in _change_state_for_tis_without_dagrun where the update is not filtered by task_id, this means that if any tasks in a dagrun match, all will be updated. The existing tests do not cover the case of multiple task instances in a single dag/dagrun.

    I have updated the code to properly filter by task_id and I have updated the tests to consider the possibility of multiple task instances on a single dag/dagrun.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

    - fix to catch the missed case in tests/jobs.py:SchedulerJobTest.test_change_state_for_tis_without_dagrun


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
