### PR TITLE
[AIRFLOW-2467] Update import direct warn message to use the module name

### DIFF
--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -338,11 +338,11 @@ class AirflowImporter(object):
             # This functionality is deprecated, and AirflowImporter should be
             # removed in 2.0.
             warnings.warn(
-                "Importing {i} directly from {m} has been "
+                "Importing '{i}' directly from '{m}' has been "
                 "deprecated. Please import from "
                 "'{m}.[operator_module]' instead. Support for direct "
                 "imports will be dropped entirely in Airflow 2.0.".format(
-                    i=attribute, m=self._parent_module),
+                    i=attribute, m=self._parent_module.__name__),
                 DeprecationWarning)
 
         loaded_module = self._loaded_modules[module]


### PR DESCRIPTION
This commit updates the import direct warn message making it a little easier to understand.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2467

### Description
- [x] This change updates the direct import warn message to use the module's name instead of the module class str repr, ex:

Current message:

```[2018-05-14 02:43:19,205] {{logging_mixin.py:84}} WARNING - /usr/local/airflow/code/airflow/utils/helpers.py:351: DeprecationWarning: Importing DummyOperator directly from <module 'airflow.operators' from '/usr/local/airflow/code/airflow/operators/__init__.py'> has been deprecated. Please import from '<module 'airflow.operators' from '/usr/local/airflow/code/airflow/operators/__init__.py'>.[operator_module]' instead. Support for direct imports will be dropped entirely in Airflow 2.0.```

Updated message:

```[2018-05-15 04:37:30,434] {{logging_mixin.py:95}} WARNING - /usr/local/airflow/code/airflow/utils/helpers.py:346: DeprecationWarning: Importing 'DummyOperator' directly from 'airflow.operators' has been deprecated. Please import from 'airflow.operators.[operator_module]' instead. Support for direct imports will be dropped entirely in Airflow 2.0.```

### Tests
- [x] Build runs successfully

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"

### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
