### PR TITLE
[AIRFLOW-2475] Reference triggered dag when using TriggerDagRunOperator

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2262,6 +2262,8 @@ class BaseOperator(LoggingMixin):
     # Defines the color in the UI
     ui_color = '#fff'
     ui_fgcolor = '#000'
+    # Defines attributes to be passed to the UI
+    ui_fields = []
 
     @apply_defaults
     def __init__(

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -53,6 +53,7 @@ class TriggerDagRunOperator(BaseOperator):
     template_fields = tuple()
     template_ext = tuple()
     ui_color = '#ffefeb'
+    ui_fields = ('trigger_dag_id',)
 
     @apply_defaults
     def __init__(

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -126,6 +126,12 @@
               </button>
               <hr/>
           </div>
+          <div id="div_btn_triggerdag">
+              <button id="btn_triggerdag" type="button" class="btn btn-primary">
+                Go to triggered DAG
+              </button>
+              <hr/>
+          </div>
           <button id="btn_task" type="button" class="btn btn-primary">
             Task Instance Details
           </button>
@@ -274,24 +280,33 @@ function updateQueryStringParameter(uri, key, value) {
     var task_id = '';
     var exection_date = '';
     var subdag_id = '';
-    function call_modal(t, d, sd) {
+    function call_modal(t, d, sd, td) {
       task_id = t;
       loc = String(window.location);
       $("#btn_filter").on("click", function(){
         window.location = updateQueryStringParameter(loc, "root", task_id);
       });
       subdag_id = sd;
+      triggered_dag = td;
       execution_date = d;
       $('#task_id').html(t);
       $('#execution_date').html(d);
       $('#myModal').modal({});
-      $("#myModal").css("margin-top","0px")
-        if (subdag_id===undefined)
-            $("#div_btn_subdag").hide();
-        else {
-            $("#div_btn_subdag").show();
-            subdag_id = "{{ dag.dag_id }}."+t;
-        }
+      $("#myModal").css("margin-top","0px");
+
+      if (subdag_id===undefined || subdag_id==false)
+          $("#div_btn_subdag").hide();
+      else {
+          $("#div_btn_subdag").show();
+          subdag_id = "{{ dag.dag_id }}."+t;
+      }
+
+      if (triggered_dag===undefined || triggered_dag==false)
+        $("#div_btn_triggerdag").hide();
+      else {
+        $("#div_btn_triggerdag").show();
+        triggerdag_id = triggered_dag;
+      }
     }
 
     function call_modal_dag(dag) {
@@ -313,6 +328,13 @@ function updateQueryStringParameter(uri, key, value) {
     $("#btn_subdag").click(function(){
       url = "{{ url_for('airflow.graph') }}" +
         "?dag_id=" + encodeURIComponent(subdag_id) +
+        "&execution_date=" + encodeURIComponent(execution_date);
+      window.location = url;
+    });
+
+    $("#btn_triggerdag").click(function(){
+      url = "{{ url_for('airflow.graph') }}" +
+        "?dag_id=" + encodeURIComponent(triggerdag_id) +
         "&execution_date=" + encodeURIComponent(execution_date);
       window.location = url;
     });

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -124,10 +124,9 @@
 
     d3.selectAll("g.node").on("click", function(d){
         task = tasks[d];
-        if (task.task_type == "SubDagOperator")
-            call_modal(d, execution_date, true);
-        else
-            call_modal(d, execution_date);
+        subdag = (task.task_type == "SubDagOperator")
+        triggerdag = ((task.task_type == "TriggerDagRunOperator") ? task.ui_fields.trigger_dag_id : false);
+        call_modal(d, execution_date, subdag, triggerdag);
     });
 
 

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -234,6 +234,8 @@ function update(source) {
             call_modal_dag(d);
         else if(nodeobj[d.task_id].operator=='SubDagOperator')
             call_modal(d.task_id, d.execution_date, true);
+        else if(nodeobj[d.task_id].operator=='TriggerDagRunOperator')
+            call_modal(d.task_id, d.execution_date, false, nodeobj[d.task_id].ui_fields.trigger_dag_id);
         else
             call_modal(d.task_id, d.execution_date);
       })

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1326,6 +1326,7 @@ class Airflow(BaseView):
                 'end_date': task.end_date,
                 'depends_on_past': task.depends_on_past,
                 'ui_color': task.ui_color,
+                'ui_fields': {attr: getattr(task, attr) for attr in task.ui_fields}
             }
 
         data = {
@@ -1436,6 +1437,7 @@ class Airflow(BaseView):
             t.task_id: {
                 'dag_id': t.dag_id,
                 'task_type': t.task_type,
+                'ui_fields': {attr: getattr(t, attr) for attr in t.ui_fields}
             }
             for t in dag.tasks}
         if not tasks:

--- a/airflow/www_rbac/templates/airflow/dag.html
+++ b/airflow/www_rbac/templates/airflow/dag.html
@@ -125,6 +125,12 @@
               </button>
               <hr/>
           </div>
+          <div id="div_btn_triggerdag">
+            <button id="btn_triggerdag" type="button" class="btn btn-primary">
+              Go to triggered DAG
+            </button>
+            <hr/>
+          </div>
           <button id="btn_task" type="button" class="btn btn-primary">
             Task Instance Details
           </button>
@@ -272,24 +278,33 @@ function updateQueryStringParameter(uri, key, value) {
     var task_id = '';
     var exection_date = '';
     var subdag_id = '';
-    function call_modal(t, d, sd) {
+    function call_modal(t, d, sd, td) {
       task_id = t;
       loc = String(window.location);
       $("#btn_filter").on("click", function(){
         window.location = updateQueryStringParameter(loc, "root", task_id);
       });
       subdag_id = sd;
+      triggered_dag = td;
       execution_date = d;
       $('#task_id').html(t);
       $('#execution_date').html(d);
       $('#myModal').modal({});
-      $("#myModal").css("margin-top","0px")
-        if (subdag_id===undefined)
-            $("#div_btn_subdag").hide();
-        else {
-            $("#div_btn_subdag").show();
-            subdag_id = "{{ dag.dag_id }}."+t;
-        }
+      $("#myModal").css("margin-top","0px");
+
+      if (subdag_id===undefined || subdag_id==false)
+          $("#div_btn_subdag").hide();
+      else {
+          $("#div_btn_subdag").show();
+          subdag_id = "{{ dag.dag_id }}."+t;
+      }
+
+      if (triggered_dag===undefined || triggered_dag==false)
+        $("#div_btn_triggerdag").hide();
+      else {
+        $("#div_btn_triggerdag").show();
+        triggerdag_id = triggered_dag;
+      }
     }
 
     function call_modal_dag(dag) {
@@ -311,6 +326,13 @@ function updateQueryStringParameter(uri, key, value) {
     $("#btn_subdag").click(function(){
       url = "{{ url_for('Airflow.graph') }}" +
         "?dag_id=" + encodeURIComponent(subdag_id) +
+        "&execution_date=" + encodeURIComponent(execution_date);
+      window.location = url;
+    });
+
+    $("#btn_triggerdag").click(function(){
+      url = "{{ url_for('airflow.graph') }}" +
+        "?dag_id=" + encodeURIComponent(triggerdag_id) +
         "&execution_date=" + encodeURIComponent(execution_date);
       window.location = url;
     });

--- a/airflow/www_rbac/templates/airflow/graph.html
+++ b/airflow/www_rbac/templates/airflow/graph.html
@@ -122,10 +122,9 @@
 
     d3.selectAll("g.node").on("click", function(d){
         task = tasks[d];
-        if (task.task_type == "SubDagOperator")
-            call_modal(d, execution_date, true);
-        else
-            call_modal(d, execution_date);
+        subdag = (task.task_type == "SubDagOperator")
+        triggerdag = ((task.task_type == "TriggerDagRunOperator") ? task.ui_fields.trigger_dag_id : false);
+        call_modal(d, execution_date, subdag, triggerdag);
     });
 
 

--- a/airflow/www_rbac/templates/airflow/tree.html
+++ b/airflow/www_rbac/templates/airflow/tree.html
@@ -234,6 +234,8 @@ function update(source) {
             call_modal_dag(d);
         else if(nodeobj[d.task_id].operator=='SubDagOperator')
             call_modal(d.task_id, d.execution_date, true);
+        else if(nodeobj[d.task_id].operator=='TriggerDagRunOperator')
+            call_modal(d.task_id, d.execution_date, false, nodeobj[d.task_id].ui_fields.trigger_dag_id);
         else
             call_modal(d.task_id, d.execution_date);
       })


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2475


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
A "Go to triggered DAG" button is added in the graph and tree view when opening a task instance and the TriggerDagRunOperator is used.
I've added a `ui_fields` attribute to the BaseOperator for attributes to pass through to the UI. This way we can pass the target DAG id to the UI.

![image](https://user-images.githubusercontent.com/6249654/40143208-205ded6e-595b-11e8-88eb-b76845731f49.png)


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No test added, verified by opening UI, checking if button only displays when using the TriggerDagRunOperator, and clicking on button to verify correct URL.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
N/A

### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
