### PR TITLE
[AIRFLOW-2477] Improve time units for task duration and landing times…

### DIFF
--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -1167,8 +1167,11 @@ class Airflow(AirflowBaseView):
         # update the y Axis on both charts to have the correct time units
         chart.create_y_axis('yAxis', format='.02f', custom_format=False,
                             label='Duration ({})'.format(y_unit))
+        chart.axislist['yAxis']['axisLabelDistance'] = '40'
         cum_chart.create_y_axis('yAxis', format='.02f', custom_format=False,
                                 label='Duration ({})'.format(cum_y_unit))
+        cum_chart.axislist['yAxis']['axisLabelDistance'] = '40'
+
         for task in dag.tasks:
             if x[task.task_id]:
                 chart.add_serie(name=task.task_id, x=x[task.task_id],
@@ -1317,6 +1320,7 @@ class Airflow(AirflowBaseView):
         # update the y Axis to have the correct time units
         chart.create_y_axis('yAxis', format='.02f', custom_format=False,
                             label='Landing Time ({})'.format(y_unit))
+        chart.axislist['yAxis']['axisLabelDistance'] = '40'
         for task in dag.tasks:
             if x[task.task_id]:
                 chart.add_serie(name=task.task_id, x=x[task.task_id],


### PR DESCRIPTION
… charts for RBAC UI

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2477
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
The original fix could be found at https://github.com/apache/incubator-airflow/pull/1914 which add unit for duration and landing_time for old UI. The unit doesn't show up in new UI. After the fix, the unit shows up correctly in the UI.
<img width="1178" alt="screen shot 2018-05-17 at 12 01 00 am" src="https://user-images.githubusercontent.com/3223098/40161518-df456c52-5965-11e8-81cf-5fa5583fa5c7.png">
<img width="1207" alt="screen shot 2018-05-17 at 12 01 40 am" src="https://user-images.githubusercontent.com/3223098/40161528-eb61d7dc-5965-11e8-8d78-b3bab4b2a2f3.png">
<img width="1255" alt="screen shot 2018-05-17 at 12 01 07 am" src="https://user-images.githubusercontent.com/3223098/40161534-eefe74ae-5965-11e8-9de8-be2e29ad7dd5.png">
<img width="1189" alt="screen shot 2018-05-17 at 12 01 47 am" src="https://user-images.githubusercontent.com/3223098/40161541-f289d6ae-5965-11e8-995d-1ab4cf9ca67b.png">


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
