### PR TITLE
[AIRFLOW-2397] Support affinity policies for Kubernetes executor/operator

### DIFF
--- a/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -70,6 +70,12 @@ class KubernetesRequestFactory:
             req['metadata']['annotations'][k] = v
 
     @staticmethod
+    def extract_affinity(pod, req):
+        req['spec']['affinity'] = req['spec'].get('affinity', {})
+        for k, v in six.iteritems(pod.affinity):
+            req['spec']['affinity'][k] = v
+
+    @staticmethod
     def extract_cmds(pod, req):
         req['spec']['containers'][0]['command'] = pod.cmds
 

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
@@ -58,4 +58,5 @@ spec:
         self.extract_init_containers(pod, req)
         self.extract_image_pull_secrets(pod, req)
         self.extract_annotations(pod, req)
+        self.extract_affinity(pod, req)
         return req

--- a/airflow/contrib/kubernetes/pod.py
+++ b/airflow/contrib/kubernetes/pod.py
@@ -54,6 +54,8 @@ class Pod:
     :type result: any
     :param image_pull_policy: Specify a policy to cache or always pull an image
     :type image_pull_policy: str
+    :param affinity: A dict containing a group of affinity scheduling rules
+    :type affinity: dict
     """
     def __init__(
             self,
@@ -74,7 +76,8 @@ class Pod:
             init_containers=None,
             service_account_name=None,
             resources=None,
-            annotations=None
+            annotations=None,
+            affinity=None
     ):
         self.image = image
         self.envs = envs or {}
@@ -94,3 +97,4 @@ class Pod:
         self.service_account_name = service_account_name
         self.resources = resources or Resources()
         self.annotations = annotations or {}
+        self.affinity = affinity or {}

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -64,6 +64,8 @@ class KubernetesPodOperator(BaseOperator):
     :type in_cluster: bool
     :param get_logs: get the stdout of the container as logs of the tasks
     :type get_logs: bool
+    :param affinity: A dict containing a group of affinity scheduling rules
+    :type affinity: dict
     """
     template_fields = ('cmds', 'arguments', 'env_vars')
 
@@ -91,6 +93,7 @@ class KubernetesPodOperator(BaseOperator):
             pod.image_pull_policy = self.image_pull_policy
             pod.annotations = self.annotations
             pod.resources = self.resources
+            pod.affinity = self.affinity
 
             launcher = pod_launcher.PodLauncher(client)
             final_state = launcher.run_pod(
@@ -122,6 +125,7 @@ class KubernetesPodOperator(BaseOperator):
                  image_pull_policy='IfNotPresent',
                  annotations=None,
                  resources=None,
+                 affinity=None,
                  *args,
                  **kwargs):
         super(KubernetesPodOperator, self).__init__(*args, **kwargs)
@@ -140,4 +144,5 @@ class KubernetesPodOperator(BaseOperator):
         self.get_logs = get_logs
         self.image_pull_policy = image_pull_policy
         self.annotations = annotations or {}
+        self.affinity = affinity or {}
         self.resources = resources or Resources()

--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -31,6 +31,56 @@ Kubernetes Operator
           }
         }
     volume = Volume(name='test-volume', configs=volume_config)
+
+    affinity = {
+        'nodeAffinity': {
+          'preferredDuringSchedulingIgnoredDuringExecution': [
+            {
+              "weight": 1,
+              "preference": {
+                "matchExpressions": [
+                  "key": "disktype",
+                  "operator": "In",
+                  "values": ["ssd"]
+                ]
+              }
+            }
+          ]
+        },
+        "podAffinity": {
+          "requiredDuringSchedulingIgnoredDuringExecution": [
+            {
+              "labelSelector": {
+                "matchExpressions": [
+                  {
+                    "key": "security",
+                    "operator": "In",
+                    "values": ["S1"]
+                  }
+                ]
+              },
+              "topologyKey": "failure-domain.beta.kubernetes.io/zone"
+            }
+          ]
+        },
+        "podAntiAffinity": {
+          "requiredDuringSchedulingIgnoredDuringExecution": [
+            {
+              "labelSelector": {
+                "matchExpressions": [
+                  {
+                    "key": "security",
+                    "operator": "In",
+                    "values": ["S2"]
+                  }
+                ]
+              },
+              "topologyKey": "kubernetes.io/hostname"
+            }
+          ]
+        }
+    }
+
     k = KubernetesPodOperator(namespace='default',
                               image="ubuntu:16.04",
                               cmds=["bash", "-cx"],
@@ -40,7 +90,8 @@ Kubernetes Operator
                               volume=[volume],
                               volume_mounts=[volume_mount]
                               name="test",
-                              task_id="task"
+                              task_id="task",
+                              affinity=affinity
                               )
 
 


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2397
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
KubernetesPodOperator now accept a dict type parameter called "affinity", which represents a group of affinity scheduling rules (nodeAffinity, podAffinity, podAntiAffinity). API reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#affinity-v1-core

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - the example code in docs/kubernetes.rst was updated


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`