### PR TITLE
[AIRFLOW-1472] Fix SLA misses triggering on skipped tasks.

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -617,7 +617,9 @@ class SchedulerJob(BaseJob):
                 func.max(TI.execution_date).label('max_ti'))
             .with_hint(TI, 'USE INDEX (PRIMARY)', dialect_name='mysql')
             .filter(TI.dag_id == dag.dag_id)
-            .filter(TI.state == State.SUCCESS)
+            .filter(or_(
+                TI.state == State.SUCCESS,
+                TI.state == State.SKIPPED))
             .filter(TI.task_id.in_(dag.task_ids))
             .group_by(TI.task_id).subquery('sq')
         )


### PR DESCRIPTION
### JIRA
This PR addresses https://issues.apache.org/jira/browse/AIRFLOW-1472

### Description
Airflow currently will only consider SUCCESS tasks when computing SLA misses (specifically, when searching for the most recent task instance). This patch adds SKIPPED to the query under the assumption that SKIPPED is a success state. This is relevant to branching operators, for example, as they rely on skipping downstream tasks: where such tasks have a SLA, they are prone to emitting false positive SLA miss e-mails.

### Tests
We have tested this internally as a branch of v1.9.0, but not as part of master. No unit tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
To the extent that the output is unchanged.