### PR TITLE
[AIRFLOW-2481] Fix flaky Kubernetes test

### DIFF
--- a/airflow/example_dags/example_python_operator.py
+++ b/airflow/example_dags/example_python_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -51,8 +51,8 @@ run_this = PythonOperator(
     python_callable=print_context,
     dag=dag)
 
-# Generate 10 sleeping tasks, sleeping from 0 to 9 seconds respectively
-for i in range(10):
+# Generate 10 sleeping tasks, sleeping from 0 to 4 seconds respectively
+for i in range(5):
     task = PythonOperator(
         task_id='sleep_for_' + str(i),
         python_callable=my_sleeping_function,

--- a/tests/contrib/minikube/test_kubernetes_executor.py
+++ b/tests/contrib/minikube/test_kubernetes_executor.py
@@ -188,7 +188,7 @@ class KubernetesExecutorTest(unittest.TestCase):
                           execution_date=execution_date,
                           dag_id='example_python_operator',
                           task_id='print_the_context',
-                          expected_final_state='success', timeout=100)
+                          expected_final_state='success', timeout=120)
 
         self.ensure_dag_expected_state(host=host,
                                        execution_date=execution_date,


### PR DESCRIPTION
The test does not have enough time to finish. Therefore simplify the dag a bit to let the test execute more quickly, and give it a bit more time.

```
======================================================================
1) FAIL: test_integration_run_dag_with_scheduler_failure (tests.contrib.minikube.test_kubernetes_executor.KubernetesExecutorTest)
----------------------------------------------------------------------
   Traceback (most recent call last):
    tests/contrib/minikube/test_kubernetes_executor.py line 196 in test_integration_run_dag_with_scheduler_failure
      expected_final_state='success', timeout=100)
    tests/contrib/minikube/test_kubernetes_executor.py line 118 in ensure_dag_expected_state
      self.assertEqual(state, expected_final_state)
   AssertionError: 'running' != 'success'
   - running
   + success
```

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-2481\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2481
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-2481\], code changes always need a JIRA issue.