### PR TITLE
[AIRFLOW-2485] Fix Incorrect logging for Qubole Sensor

### DIFF
--- a/airflow/contrib/sensors/qubole_sensor.py
+++ b/airflow/contrib/sensors/qubole_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -56,20 +56,20 @@ class QuboleSensor(BaseSensorOperator):
         super(QuboleSensor, self).__init__(*args, **kwargs)
 
     def poke(self, context):
-        global this  # apache/incubator-airflow/pull/3297#issuecomment-385988083
+
         conn = BaseHook.get_connection(self.qubole_conn_id)
         Qubole.configure(api_token=conn.password, api_url=conn.host)
 
-        this.log.info('Poking: %s', self.data)
+        self.log.info('Poking: %s', self.data)
 
         status = False
         try:
             status = self.sensor_class.check(self.data)
         except Exception as e:
-            this.log.exception(e)
+            self.log.exception(e)
             status = False
 
-        this.log.info('Status of this Poke: %s', status)
+        self.log.info('Status of this Poke: %s', status)
 
         return status
 


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2485
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- Replace incorrect `this.log` keyword for logging of Qubole Sensor to `self.log`
I am sure https://github.com/apache/incubator-airflow/pull/3297#issuecomment-385988083 was supposed to mean `self.log.info` instead of `this.log.info`.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
