### PR TITLE
[AIRFLOW-2487] Allow user to set conn type for druid ingestion hook

### DIFF
--- a/tests/hooks/test_druid_hook.py
+++ b/tests/hooks/test_druid_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,7 +18,7 @@
 # under the License.
 #
 
-import mock
+from mock import MagicMock, patch
 import requests
 import requests_mock
 import unittest
@@ -31,98 +31,116 @@ class TestDruidHook(unittest.TestCase):
 
     def setUp(self):
         super(TestDruidHook, self).setUp()
-
         session = requests.Session()
         adapter = requests_mock.Adapter()
         session.mount('mock', adapter)
 
+        class TestDRuidhook(DruidHook):
+            def get_conn_url(self):
+                return 'http://druid-overlord:8081/druid/indexer/v1/task'
+        self.db_hook = TestDRuidhook()
+
     @requests_mock.mock()
     def test_submit_gone_wrong(self, m):
-        hook = DruidHook()
         task_post = m.post(
             'http://druid-overlord:8081/druid/indexer/v1/task',
             text='{"task":"9f8a7359-77d4-4612-b0cd-cc2f6a3c28de"}'
         )
         status_check = m.get(
-            'http://druid-overlord:8081/druid/indexer/v1/task/9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/status',
+            'http://druid-overlord:8081/druid/indexer/v1/task/'
+            '9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/status',
             text='{"status":{"status": "FAILED"}}'
         )
 
         # The job failed for some reason
         with self.assertRaises(AirflowException):
-            hook.submit_indexing_job('Long json file')
+            self.db_hook.submit_indexing_job('Long json file')
 
         self.assertTrue(task_post.called_once)
         self.assertTrue(status_check.called_once)
 
     @requests_mock.mock()
     def test_submit_ok(self, m):
-        hook = DruidHook()
         task_post = m.post(
             'http://druid-overlord:8081/druid/indexer/v1/task',
             text='{"task":"9f8a7359-77d4-4612-b0cd-cc2f6a3c28de"}'
         )
         status_check = m.get(
-            'http://druid-overlord:8081/druid/indexer/v1/task/9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/status',
+            'http://druid-overlord:8081/druid/indexer/v1/task/'
+            '9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/status',
             text='{"status":{"status": "SUCCESS"}}'
         )
 
         # Exists just as it should
-        hook.submit_indexing_job('Long json file')
+        self.db_hook.submit_indexing_job('Long json file')
 
         self.assertTrue(task_post.called_once)
         self.assertTrue(status_check.called_once)
 
     @requests_mock.mock()
     def test_submit_unknown_response(self, m):
-        hook = DruidHook()
         task_post = m.post(
             'http://druid-overlord:8081/druid/indexer/v1/task',
             text='{"task":"9f8a7359-77d4-4612-b0cd-cc2f6a3c28de"}'
         )
         status_check = m.get(
-            'http://druid-overlord:8081/druid/indexer/v1/task/9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/status',
+            'http://druid-overlord:8081/druid/indexer/v1/task/'
+            '9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/status',
             text='{"status":{"status": "UNKNOWN"}}'
         )
 
         # An unknown error code
         with self.assertRaises(AirflowException):
-            hook.submit_indexing_job('Long json file')
+            self.db_hook.submit_indexing_job('Long json file')
 
         self.assertTrue(task_post.called_once)
         self.assertTrue(status_check.called_once)
 
     @requests_mock.mock()
     def test_submit_timeout(self, m):
-        hook = DruidHook(timeout=0, max_ingestion_time=5)
+        self.db_hook.timeout = 0
+        self.db_hook.max_ingestion_time = 5
         task_post = m.post(
             'http://druid-overlord:8081/druid/indexer/v1/task',
             text='{"task":"9f8a7359-77d4-4612-b0cd-cc2f6a3c28de"}'
         )
         status_check = m.get(
-            'http://druid-overlord:8081/druid/indexer/v1/task/9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/status',
+            'http://druid-overlord:8081/druid/indexer/v1/task/'
+            '9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/status',
             text='{"status":{"status": "RUNNING"}}'
         )
         shutdown_post = m.post(
-            'http://druid-overlord:8081/druid/indexer/v1/task/9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/shutdown',
+            'http://druid-overlord:8081/druid/indexer/v1/task/'
+            '9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/shutdown',
             text='{"task":"9f8a7359-77d4-4612-b0cd-cc2f6a3c28de"}'
         )
 
         # Because the jobs keeps running
         with self.assertRaises(AirflowException):
-            hook.submit_indexing_job('Long json file')
+            self.db_hook.submit_indexing_job('Long json file')
 
         self.assertTrue(task_post.called_once)
         self.assertTrue(status_check.called)
         self.assertTrue(shutdown_post.called_once)
+
+    @patch('airflow.hooks.druid_hook.DruidHook.get_connection')
+    def test_get_conn_url(self, mock_get_connection):
+        get_conn_value = MagicMock()
+        get_conn_value.host = 'test_host'
+        get_conn_value.conn_type = 'https'
+        get_conn_value.port = '1'
+        get_conn_value.extra_dejson = {'endpoint': 'ingest'}
+        mock_get_connection.return_value = get_conn_value
+        hook = DruidHook(timeout=0, max_ingestion_time=5)
+        self.assertEquals(hook.get_conn_url(), 'https://test_host:1/ingest')
 
 
 class TestDruidDbApiHook(unittest.TestCase):
 
     def setUp(self):
         super(TestDruidDbApiHook, self).setUp()
-        self.cur = mock.MagicMock()
-        self.conn = conn = mock.MagicMock()
+        self.cur = MagicMock()
+        self.conn = conn = MagicMock()
         self.conn.host = 'host'
         self.conn.port = '1000'
         self.conn.conn_type = 'druid'


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2487
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
   1. Allow user to configure the connection type for druid ingestion hook(http, https etc).
   2. Fix flake8 for druid_hook, and test_druid_hook.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   Add unit test

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
