### PR TITLE
[AIRFLOW-2495] Bump up celery to >= 4.1.1 to get dependency on kombu >= 4.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ azure_data_lake = [
 ]
 cassandra = ['cassandra-driver>=3.13.0']
 celery = [
-    'celery>=4.0.2',
+    'celery>=4.1.1',
     'flower>=0.7.3'
 ]
 cgroups = [


### PR DESCRIPTION
### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2495

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Bump up celery to >= 4.1.1 to get dependency on kombu >= 4.2.0

This allows broker_url with sqla to work.  kombu 4.0.2 does not support sqla urls.

Make sure you have checked _all_ steps below.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
