### PR TITLE
[AIRFLOW-2471] Fix HiveCliHook.load_df to use unused parameters

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -285,8 +285,6 @@ class HiveCliHook(BaseHook):
             self,
             df,
             table,
-            create=True,
-            recreate=False,
             field_dict=None,
             delimiter=',',
             encoding='utf8',
@@ -297,17 +295,16 @@ class HiveCliHook(BaseHook):
         Hive data types will be inferred if not passed but column names will
         not be sanitized.
 
+        :param df: DataFrame to load into a Hive table
+        :type df: DataFrame
         :param table: target Hive table, use dot notation to target a
             specific database
         :type table: str
-        :param create: whether to create the table if it doesn't exist
-        :type create: bool
-        :param recreate: whether to drop and recreate the table at every
-            execution
-        :type recreate: bool
         :param field_dict: mapping from column name to hive data type.
             Note that it must be OrderedDict so as to keep columns' order.
         :type field_dict: OrderedDict
+        :param delimiter: field delimiter in the file
+        :type delimiter: str
         :param encoding: string encoding to use when writing DataFrame to file
         :type encoding: str
         :param pandas_kwargs: passed to DataFrame.to_csv
@@ -340,7 +337,7 @@ class HiveCliHook(BaseHook):
         with TemporaryDirectory(prefix='airflow_hiveop_') as tmp_dir:
             with NamedTemporaryFile(dir=tmp_dir, mode="w") as f:
 
-                if field_dict is None and (create or recreate):
+                if field_dict is None:
                     field_dict = _infer_field_types_from_df(df)
 
                 df.to_csv(path_or_buf=f,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2471
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR fixes HiveCliHook.load_df to pass
load_file the parameter called create and
recreate, which are currently ignored.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

tests.hooks.test_hive_hook:TestHiveCliHook.test_load_df_with_optional_parameters


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
