### PR TITLE
[AIRFLOW-2498] Fix Unexpected argument in SFTP Sensor

### DIFF
--- a/airflow/contrib/sensors/sftp_sensor.py
+++ b/airflow/contrib/sensors/sftp_sensor.py
@@ -38,7 +38,7 @@ class SFTPSensor(BaseSensorOperator):
     def __init__(self, path, sftp_conn_id='sftp_default', *args, **kwargs):
         super(SFTPSensor, self).__init__(*args, **kwargs)
         self.path = path
-        self.hook = SFTPHook(sftp_conn_id=sftp_conn_id)
+        self.hook = SFTPHook(sftp_conn_id)
 
     def poke(self, context):
         logging.info('Poking for %s', self.path)


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2498
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- The SFTP sensor is using SFTP hook and passing `sftp_conn_id` to `sftp_conn_id` parameter which doesn't exist. The solution would be to remove the parameter name, hence defaulting to first parameter which in this case would be `ftp_conn_id`

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
