### PR TITLE
[AIRFLOW-2429] Fix contrib folder's flake8 errors

### DIFF
--- a/airflow/contrib/__init__.py
+++ b/airflow/contrib/__init__.py
@@ -7,13 +7,12 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-

--- a/airflow/contrib/auth/__init__.py
+++ b/airflow/contrib/auth/__init__.py
@@ -7,13 +7,12 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-

--- a/airflow/contrib/auth/backends/__init__.py
+++ b/airflow/contrib/auth/backends/__init__.py
@@ -7,13 +7,12 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-

--- a/airflow/contrib/auth/backends/github_enterprise_auth.py
+++ b/airflow/contrib/auth/backends/github_enterprise_auth.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -150,8 +150,9 @@ class GHEAuthBackend(object):
                                  get_config_param('allowed_teams').split(',')]
             except ValueError:
                 # this is to deprecate using the string name for a team
-                raise ValueError('it appears that you are using the string name for a team, '
-                                 'please use the id number instead')
+                raise ValueError(
+                    'it appears that you are using the string name for a team, '
+                    'please use the id number instead')
 
         except AirflowConfigException:
             # No allowed teams defined, let anyone in GHE in.
@@ -175,8 +176,8 @@ class GHEAuthBackend(object):
                 return True
 
         log.debug('Denying access for user "%s", not a member of "%s"',
-                   username,
-                   str(allowed_teams))
+                  username,
+                  str(allowed_teams))
 
         return False
 
@@ -229,6 +230,7 @@ class GHEAuthBackend(object):
         session.commit()
 
         return redirect(next_url)
+
 
 login_manager = GHEAuthBackend()
 

--- a/airflow/contrib/auth/backends/google_auth.py
+++ b/airflow/contrib/auth/backends/google_auth.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -118,8 +118,9 @@ class GoogleAuthBackend(object):
             state=request.args.get('next') or request.referrer or None)
 
     def get_google_user_profile_info(self, google_token):
-        resp = self.google_oauth.get('https://www.googleapis.com/oauth2/v1/userinfo',
-                                    token=(google_token, ''))
+        resp = self.google_oauth.get(
+            'https://www.googleapis.com/oauth2/v1/userinfo',
+            token=(google_token, ''))
 
         if not resp or resp.status != 200:
             raise AuthenticationError(
@@ -183,6 +184,7 @@ class GoogleAuthBackend(object):
         session.commit()
 
         return redirect(next_url)
+
 
 login_manager = GoogleAuthBackend()
 

--- a/airflow/contrib/auth/backends/kerberos_auth.py
+++ b/airflow/contrib/auth/backends/kerberos_auth.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -62,10 +62,13 @@ class KerberosUser(models.User, LoggingMixin):
 
         try:
             # this is pykerberos specific, verify = True is needed to prevent KDC spoofing
-            if not kerberos.checkPassword(user_principal, password, service_principal, realm, True):
+            if not kerberos.checkPassword(user_principal,
+                                          password,
+                                          service_principal, realm, True):
                 raise AuthenticationError()
         except kerberos.KrbError as e:
-            logging.error('Password validation for principal %s failed %s', user_principal, e)
+            logging.error(
+                'Password validation for principal %s failed %s', user_principal, e)
             raise AuthenticationError(e)
 
         return

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -83,7 +83,8 @@ def group_contains_user(conn, search_base, group_filter, user_name_attr, usernam
         log.warning("Unable to find group for %s %s", search_base, search_filter)
     else:
         for entry in conn.entries:
-            if username.lower() in map(lambda attr: attr.lower(), getattr(entry, user_name_attr).values):
+            if username.lower() in map(lambda attr: attr.lower(),
+                                       getattr(entry, user_name_attr).values):
                 return True
 
     return False
@@ -191,12 +192,6 @@ class LdapUser(models.User):
             username
         )
 
-        search_scopes = {
-            "LEVEL": LEVEL,
-            "SUBTREE": SUBTREE,
-            "BASE": BASE
-        }
-
         search_scope = LEVEL
         if configuration.conf.has_option("ldap", "search_scope"):
             if configuration.conf.get("ldap", "search_scope") == "SUBTREE":
@@ -226,12 +221,16 @@ class LdapUser(models.User):
 
         try:
             conn = get_ldap_connection(entry['dn'], password)
-        except KeyError as e:
+        except KeyError:
             log.error("""
-            Unable to parse LDAP structure. If you're using Active Directory and not specifying an OU, you must set search_scope=SUBTREE in airflow.cfg.
+            Unable to parse LDAP structure. If you're using Active Directory
+            and not specifying an OU, you must set search_scope=SUBTREE in airflow.cfg.
             %s
             """ % traceback.format_exc())
-            raise LdapException("Could not parse LDAP structure. Try setting search_scope in airflow.cfg, or check logs")
+            raise LdapException(
+                "Could not parse LDAP structure. "
+                "Try setting search_scope in airflow.cfg, or check logs"
+            )
 
         if not conn:
             log.info("Password incorrect for user %s", username)
@@ -271,6 +270,7 @@ def load_user(userid, session=None):
 
     user = session.query(models.User).filter(models.User.id == int(userid)).first()
     return LdapUser(user)
+
 
 @provide_session
 def login(self, request, session=None):

--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/example_dags/example_databricks_operator.py
+++ b/airflow/contrib/example_dags/example_databricks_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/example_dags/example_emr_job_flow_automatic_steps.py
+++ b/airflow/contrib/example_dags/example_emr_job_flow_automatic_steps.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -20,7 +20,8 @@
 from datetime import timedelta
 import airflow
 from airflow import DAG
-from airflow.contrib.operators.emr_create_job_flow_operator import EmrCreateJobFlowOperator
+from airflow.contrib.operators.emr_create_job_flow_operator \
+    import EmrCreateJobFlowOperator
 from airflow.contrib.sensors.emr_job_flow_sensor import EmrJobFlowSensor
 
 DEFAULT_ARGS = {

--- a/airflow/contrib/example_dags/example_emr_job_flow_manual_steps.py
+++ b/airflow/contrib/example_dags/example_emr_job_flow_manual_steps.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,10 +21,13 @@ from datetime import timedelta
 
 import airflow
 from airflow import DAG
-from airflow.contrib.operators.emr_create_job_flow_operator import EmrCreateJobFlowOperator
-from airflow.contrib.operators.emr_add_steps_operator import EmrAddStepsOperator
+from airflow.contrib.operators.emr_create_job_flow_operator \
+    import EmrCreateJobFlowOperator
+from airflow.contrib.operators.emr_add_steps_operator \
+    import EmrAddStepsOperator
 from airflow.contrib.sensors.emr_step_sensor import EmrStepSensor
-from airflow.contrib.operators.emr_terminate_job_flow_operator import EmrTerminateJobFlowOperator
+from airflow.contrib.operators.emr_terminate_job_flow_operator \
+    import EmrTerminateJobFlowOperator
 
 DEFAULT_ARGS = {
     'owner': 'airflow',

--- a/airflow/contrib/example_dags/example_pubsub_flow.py
+++ b/airflow/contrib/example_dags/example_pubsub_flow.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/example_dags/example_qubole_operator.py
+++ b/airflow/contrib/example_dags/example_qubole_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -49,20 +49,26 @@ dag = DAG('example_qubole_operator', default_args=default_args, schedule_interva
 
 dag.doc_md = __doc__
 
+
 def compare_result(ds, **kwargs):
     ti = kwargs['ti']
     r1 = t1.get_results(ti)
     r2 = t2.get_results(ti)
     return filecmp.cmp(r1, r2)
 
+
 t1 = QuboleOperator(
     task_id='hive_show_table',
     command_type='hivecmd',
     query='show tables',
     cluster_label='default',
-    fetch_logs=True, # If true, will fetch qubole command logs and concatenate them into corresponding airflow task logs
-    tags='aiflow_example_run',  # To attach tags to qubole command, auto attach 3 tags - dag_id, task_id, run_id
-    qubole_conn_id='qubole_default',  # Connection id to submit commands inside QDS, if not set "qubole_default" is used
+    fetch_logs=True,
+    # If `fetch_logs`=true, will fetch qubole command logs and concatenate
+    # them into corresponding airflow task logs
+    tags='aiflow_example_run',
+    # To attach tags to qubole command, auto attach 3 tags - dag_id, task_id, run_id
+    qubole_conn_id='qubole_default',
+    # Connection id to submit commands inside QDS, if not set "qubole_default" is used
     dag=dag)
 
 t2 = QuboleOperator(
@@ -103,7 +109,12 @@ join = DummyOperator(
 t4 = QuboleOperator(
     task_id='hadoop_jar_cmd',
     command_type='hadoopcmd',
-    sub_command='jar s3://paid-qubole/HadoopAPIExamples/jars/hadoop-0.20.1-dev-streaming.jar -mapper wc -numReduceTasks 0 -input s3://paid-qubole/HadoopAPITests/data/3.tsv -output s3://paid-qubole/HadoopAPITests/data/3_wc',
+    sub_command='jar s3://paid-qubole/HadoopAPIExamples/'
+                'jars/hadoop-0.20.1-dev-streaming.jar '
+                '-mapper wc '
+                '-numReduceTasks 0 -input s3://paid-qubole/HadoopAPITests/'
+                'data/3.tsv -output '
+                's3://paid-qubole/HadoopAPITests/data/3_wc',
     cluster_label='default',
     fetch_logs=True,
     dag=dag)

--- a/airflow/contrib/example_dags/example_qubole_sensor.py
+++ b/airflow/contrib/example_dags/example_qubole_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -50,11 +50,13 @@ t1 = QuboleFileSensor(
     qubole_conn_id='qubole_default',
     poke_interval=60,
     timeout=600,
-    data={"files":
-              ["s3://paid-qubole/HadoopAPIExamples/jars/hadoop-0.20.1-dev-streaming.jar",
-               "s3://paid-qubole/HadoopAPITests/data/{{ ds.split('-')[2] }}.tsv"
-               ] # will check for availability of all the files in array
-          },
+    data={
+        "files":
+            [
+                "s3://paid-qubole/HadoopAPIExamples/jars/hadoop-0.20.1-dev-streaming.jar",
+                "s3://paid-qubole/HadoopAPITests/data/{{ ds.split('-')[2] }}.tsv"
+            ]  # will check for availability of all the files in array
+    },
     dag=dag
 )
 
@@ -62,12 +64,14 @@ t2 = QubolePartitionSensor(
     task_id='check_hive_partition',
     poke_interval=10,
     timeout=60,
-    data={"schema":"default",
-          "table":"my_partitioned_table",
-          "columns":[
-              {"column" : "month", "values" : ["{{ ds.split('-')[1] }}"]},
-              {"column" : "day", "values" : ["{{ ds.split('-')[2] }}" , "{{ yesterday_ds.split('-')[2] }}"]}
-          ]# will check for partitions like [month=12/day=12,month=12/day=13]
+    data={"schema": "default",
+          "table": "my_partitioned_table",
+          "columns": [
+              {"column": "month", "values":
+                  ["{{ ds.split('-')[1] }}"]},
+              {"column": "day", "values":
+                  ["{{ ds.split('-')[2] }}", "{{ yesterday_ds.split('-')[2] }}"]}
+          ]  # will check for partitions like [month=12/day=12,month=12/day=13]
           },
     dag=dag
 )

--- a/airflow/contrib/example_dags/example_twitter_dag.py
+++ b/airflow/contrib/example_dags/example_twitter_dag.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -581,7 +581,7 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
             try:
                 self.log.info('Deleted pod: %s', str(key))
                 self.running.pop(key)
-            except KeyError as _:
+            except KeyError:
                 self.log.debug('Could not find key: %s', str(key))
                 pass
         self.event_buffer[key] = state

--- a/airflow/contrib/executors/mesos_executor.py
+++ b/airflow/contrib/executors/mesos_executor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,7 +22,7 @@ from future import standard_library
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.www.utils import LoginMixin
 
-standard_library.install_aliases()
+
 from builtins import str
 from queue import Queue
 
@@ -36,7 +36,7 @@ from airflow.settings import Session
 from airflow.utils.state import State
 from airflow.exceptions import AirflowException
 
-
+standard_library.install_aliases()
 DEFAULT_FRAMEWORK_NAME = 'Airflow'
 FRAMEWORK_CONNID_PREFIX = 'mesos_framework_'
 
@@ -74,7 +74,8 @@ class AirflowMesosScheduler(mesos.interface.Scheduler, LoggingMixin):
             )
 
     def registered(self, driver, frameworkId, masterInfo):
-        self.log.info("AirflowScheduler registered to Mesos with framework ID %s", frameworkId.value)
+        self.log.info("AirflowScheduler registered to Mesos with framework ID %s",
+                      frameworkId.value)
 
         if configuration.conf.getboolean('mesos', 'CHECKPOINT') and \
                 configuration.conf.get('mesos', 'FAILOVER_TIMEOUT'):
@@ -128,14 +129,15 @@ class AirflowMesosScheduler(mesos.interface.Scheduler, LoggingMixin):
                 elif resource.name == "mem":
                     offerMem += resource.scalar.value
 
-            self.log.info("Received offer %s with cpus: %s and mem: %s", offer.id.value, offerCpus, offerMem)
+            self.log.info("Received offer %s with cpus: %s and mem: %s",
+                          offer.id.value, offerCpus, offerMem)
 
             remainingCpus = offerCpus
             remainingMem = offerMem
 
             while (not self.task_queue.empty()) and \
-                  remainingCpus >= self.task_cpu and \
-                  remainingMem >= self.task_mem:
+                    remainingCpus >= self.task_cpu and \
+                    remainingMem >= self.task_mem:
                 key, cmd = self.task_queue.get()
                 tid = self.task_counter
                 self.task_counter += 1
@@ -194,7 +196,8 @@ class AirflowMesosScheduler(mesos.interface.Scheduler, LoggingMixin):
         try:
             key = self.task_key_map[update.task_id.value]
         except KeyError:
-            # The map may not contain an item if the framework re-registered after a failover.
+            # The map may not contain an item if the framework re-registered
+            # after a failover.
             # Discard these tasks.
             self.log.warning("Unrecognised task key %s", update.task_id.value)
             return
@@ -257,7 +260,8 @@ class MesosExecutor(BaseExecutor, LoginMixin):
                 session = Session()
                 connection = session.query(Connection).filter_by(conn_id=conn_id).first()
                 if connection is not None:
-                    # Set the Framework ID to let the scheduler reconnect with running tasks.
+                    # Set the Framework ID to let the scheduler reconnect
+                    # with running tasks.
                     framework.id.value = connection.extra
 
                 framework.failover_timeout = configuration.conf.getint(
@@ -268,7 +272,8 @@ class MesosExecutor(BaseExecutor, LoginMixin):
 
         self.log.info(
             'MesosFramework master : %s, name : %s, cpu : %s, mem : %s, checkpoint : %s',
-            master, framework.name, str(task_cpu), str(task_memory), str(framework.checkpoint)
+            master, framework.name,
+            str(task_cpu), str(task_memory), str(framework.checkpoint)
         )
 
         implicit_acknowledgements = 1
@@ -276,10 +281,12 @@ class MesosExecutor(BaseExecutor, LoginMixin):
         if configuration.conf.getboolean('mesos', 'AUTHENTICATE'):
             if not configuration.conf.get('mesos', 'DEFAULT_PRINCIPAL'):
                 self.log.error("Expecting authentication principal in the environment")
-                raise AirflowException("mesos.default_principal not provided in authenticated mode")
+                raise AirflowException(
+                    "mesos.default_principal not provided in authenticated mode")
             if not configuration.conf.get('mesos', 'DEFAULT_SECRET'):
                 self.log.error("Expecting authentication secret in the environment")
-                raise AirflowException("mesos.default_secret not provided in authenticated mode")
+                raise AirflowException(
+                    "mesos.default_secret not provided in authenticated mode")
 
             credential = mesos_pb2.Credential()
             credential.principal = configuration.conf.get('mesos', 'DEFAULT_PRINCIPAL')
@@ -288,7 +295,10 @@ class MesosExecutor(BaseExecutor, LoginMixin):
             framework.principal = credential.principal
 
             driver = mesos.native.MesosSchedulerDriver(
-                AirflowMesosScheduler(self.task_queue, self.result_queue, task_cpu, task_memory),
+                AirflowMesosScheduler(self.task_queue,
+                                      self.result_queue,
+                                      task_cpu,
+                                      task_memory),
                 framework,
                 master,
                 implicit_acknowledgements,
@@ -296,7 +306,10 @@ class MesosExecutor(BaseExecutor, LoginMixin):
         else:
             framework.principal = 'Airflow'
             driver = mesos.native.MesosSchedulerDriver(
-                AirflowMesosScheduler(self.task_queue, self.result_queue, task_cpu, task_memory),
+                AirflowMesosScheduler(self.task_queue,
+                                      self.result_queue,
+                                      task_cpu,
+                                      task_memory),
                 framework,
                 master,
                 implicit_acknowledgements)

--- a/airflow/contrib/hooks/__init__.py
+++ b/airflow/contrib/hooks/__init__.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,7 +24,7 @@
 
 
 import sys
-
+import os as _os
 
 # ------------------------------------------------------------------------
 #
@@ -62,7 +62,8 @@ _hooks = {
     'azure_data_lake_hook': ['AzureDataLakeHook'],
 }
 
-import os as _os
+
 if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
     from airflow.utils.helpers import AirflowImporter
+
     airflow_importer = AirflowImporter(sys.modules[__name__], _hooks)

--- a/airflow/contrib/hooks/aws_dynamodb_hook.py
+++ b/airflow/contrib/hooks/aws_dynamodb_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -33,7 +33,11 @@ class AwsDynamoDBHook(AwsHook):
     :type region_name: str
     """
 
-    def __init__(self, table_keys=None, table_name=None, region_name=None, *args, **kwargs):
+    def __init__(self,
+                 table_keys=None,
+                 table_name=None,
+                 region_name=None,
+                 *args, **kwargs):
         self.table_keys = table_keys
         self.table_name = table_name
         self.region_name = region_name

--- a/airflow/contrib/hooks/aws_hook.py
+++ b/airflow/contrib/hooks/aws_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -101,13 +101,16 @@ class AwsHook(BaseHook):
                     aws_secret_access_key = connection_object.password
 
                 elif 'aws_secret_access_key' in connection_object.extra_dejson:
-                    aws_access_key_id = connection_object.extra_dejson['aws_access_key_id']
-                    aws_secret_access_key = connection_object.extra_dejson['aws_secret_access_key']
+                    aws_access_key_id = connection_object.extra_dejson[
+                        'aws_access_key_id']
+                    aws_secret_access_key = connection_object.extra_dejson[
+                        'aws_secret_access_key']
 
                 elif 's3_config_file' in connection_object.extra_dejson:
                     aws_access_key_id, aws_secret_access_key = \
-                        _parse_s3_config(connection_object.extra_dejson['s3_config_file'],
-                                         connection_object.extra_dejson.get('s3_config_format'))
+                        _parse_s3_config(
+                            connection_object.extra_dejson['s3_config_file'],
+                            connection_object.extra_dejson.get('s3_config_format'))
 
                 if region_name is None:
                     region_name = connection_object.extra_dejson.get('region_name')
@@ -118,7 +121,6 @@ class AwsHook(BaseHook):
 
                 if role_arn is None and aws_account_id is not None and \
                         aws_iam_role is not None:
-
                     role_arn = "arn:aws:iam::" + aws_account_id + ":role/" + aws_iam_role
 
                 if role_arn is not None:

--- a/airflow/contrib/hooks/aws_lambda_hook.py
+++ b/airflow/contrib/hooks/aws_lambda_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -36,7 +36,8 @@ class AwsLambdaHook(AwsHook):
     :type invocation_type: str
     """
 
-    def __init__(self, function_name, region_name=None, log_type='None', qualifier='$LATEST',
+    def __init__(self, function_name, region_name=None,
+                 log_type='None', qualifier='$LATEST',
                  invocation_type='RequestResponse', *args, **kwargs):
         self.function_name = function_name
         self.region_name = region_name

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/cloudant_hook.py
+++ b/airflow/contrib/hooks/cloudant_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -42,8 +42,8 @@ class CloudantHook(BaseHook):
             if isinstance(s, unicode):
                 log = LoggingMixin().log
                 log.debug(
-                    'cloudant-python does not support unicode. Encoding %s as ascii using "ignore".',
-                    s
+                    'cloudant-python does not support unicode. Encoding %s as '
+                    'ascii using "ignore".', s
                 )
                 return s.encode('ascii', 'ignore')
 

--- a/airflow/contrib/hooks/databricks_hook.py
+++ b/airflow/contrib/hooks/databricks_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -117,7 +117,7 @@ class DatabricksHook(BaseHook, LoggingMixin):
         else:
             raise AirflowException('Unexpected HTTP Method: ' + method)
 
-        for attempt_num in range(1, self.retry_limit+1):
+        for attempt_num in range(1, self.retry_limit + 1):
             try:
                 response = request_func(
                     url,
@@ -195,10 +195,11 @@ class RunState:
     @property
     def is_terminal(self):
         if self.life_cycle_state not in RUN_LIFE_CYCLE_STATES:
-            raise AirflowException(('Unexpected life cycle state: {}: If the state has '
-                            'been introduced recently, please check the Databricks user '
-                            'guide for troubleshooting information').format(
-                                self.life_cycle_state))
+            raise AirflowException(
+                ('Unexpected life cycle state: {}: If the state has '
+                 'been introduced recently, please check the Databricks user '
+                 'guide for troubleshooting information').format(
+                    self.life_cycle_state))
         return self.life_cycle_state in ('TERMINATED', 'SKIPPED', 'INTERNAL_ERROR')
 
     @property

--- a/airflow/contrib/hooks/datadog_hook.py
+++ b/airflow/contrib/hooks/datadog_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -48,9 +48,11 @@ class DatadogHook(BaseHook, LoggingMixin):
         self.host = conn.host
 
         if self.api_key is None:
-            raise AirflowException("api_key must be specified in the Datadog connection details")
+            raise AirflowException("api_key must be specified in the "
+                                   "Datadog connection details")
         if self.app_key is None:
-            raise AirflowException("app_key must be specified in the Datadog connection details")
+            raise AirflowException("app_key must be specified in the "
+                                   "Datadog connection details")
 
         self.log.info("Setting up api keys for Datadog")
         options = {
@@ -89,8 +91,8 @@ class DatadogHook(BaseHook, LoggingMixin):
                      from_seconds_ago,
                      to_seconds_ago):
         """
-        Queries datadog for a specific metric, potentially with some function applied to it
-        and returns the results.
+        Queries datadog for a specific metric, potentially with some
+        function applied to it and returns the results.
 
         :param query: The datadog query to execute (see datadog docs)
         :type query: string
@@ -112,8 +114,8 @@ class DatadogHook(BaseHook, LoggingMixin):
     def post_event(self, title, text, tags=None, alert_type=None, aggregation_key=None):
         """
         Posts an event to datadog (processing finished, potentially alerts, other issues)
-        Think about this as a means to maintain persistence of alerts, rather than alerting
-        itself.
+        Think about this as a means to maintain persistence of alerts, rather than
+        alerting itself.
 
         :param title: The title of the event
         :type title: string

--- a/airflow/contrib/hooks/datastore_hook.py
+++ b/airflow/contrib/hooks/datastore_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,7 +18,6 @@
 # under the License.
 #
 
-import json
 import time
 from apiclient.discovery import build
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
@@ -55,17 +54,22 @@ class DatastoreHook(GoogleCloudBaseHook):
         :param partialKeys: a list of partial keys
         :return: a list of full keys.
         """
-        resp = self.connection.projects().allocateIds(projectId=self.project_id, body={'keys': partialKeys}).execute()
+        resp = self.connection.projects().allocateIds(
+            projectId=self.project_id, body={'keys': partialKeys}
+        ).execute()
         return resp['keys']
 
     def begin_transaction(self):
         """
         Get a new transaction handle
-        see https://cloud.google.com/datastore/docs/reference/rest/v1/projects/beginTransaction
+
+            .. seealso::
+                https://cloud.google.com/datastore/docs/reference/rest/v1/projects/beginTransaction
 
         :return: a transaction handle
         """
-        resp = self.connection.projects().beginTransaction(projectId=self.project_id, body={}).execute()
+        resp = self.connection.projects().beginTransaction(
+            projectId=self.project_id, body={}).execute()
         return resp['transaction']
 
     def commit(self, body):
@@ -78,7 +82,8 @@ class DatastoreHook(GoogleCloudBaseHook):
         :param body: the body of the commit request
         :return: the response body of the commit request
         """
-        resp = self.connection.projects().commit(projectId=self.project_id, body=body).execute()
+        resp = self.connection.projects().commit(
+            projectId=self.project_id, body=body).execute()
         return resp
 
     def lookup(self, keys, read_consistency=None, transaction=None):
@@ -99,7 +104,8 @@ class DatastoreHook(GoogleCloudBaseHook):
             body['readConsistency'] = read_consistency
         if transaction:
             body['transaction'] = transaction
-        return self.connection.projects().lookup(projectId=self.project_id, body=body).execute()
+        return self.connection.projects().lookup(
+            projectId=self.project_id, body=body).execute()
 
     def rollback(self, transaction):
         """
@@ -110,7 +116,8 @@ class DatastoreHook(GoogleCloudBaseHook):
 
         :param transaction: the transaction to roll back
         """
-        self.connection.projects().rollback(projectId=self.project_id, body={'transaction': transaction})\
+        self.connection.projects().rollback(
+            projectId=self.project_id, body={'transaction': transaction})\
             .execute()
 
     def run_query(self, body):
@@ -123,7 +130,8 @@ class DatastoreHook(GoogleCloudBaseHook):
         :param body: the body of the query request
         :return: the batch of query results.
         """
-        resp = self.connection.projects().runQuery(projectId=self.project_id, body=body).execute()
+        resp = self.connection.projects().runQuery(
+            projectId=self.project_id, body=body).execute()
         return resp['batch']
 
     def get_operation(self, name):
@@ -158,7 +166,8 @@ class DatastoreHook(GoogleCloudBaseHook):
             else:
                 return result
 
-    def export_to_storage_bucket(self, bucket, namespace=None, entity_filter=None, labels=None):
+    def export_to_storage_bucket(self, bucket, namespace=None,
+                                 entity_filter=None, labels=None):
         """
         Export entities from Cloud Datastore to Cloud Storage for backup
         """
@@ -172,10 +181,12 @@ class DatastoreHook(GoogleCloudBaseHook):
             'entityFilter': entity_filter,
             'labels': labels,
         }
-        resp = self.admin_connection.projects().export(projectId=self.project_id, body=body).execute()
+        resp = self.admin_connection.projects().export(
+            projectId=self.project_id, body=body).execute()
         return resp
 
-    def import_from_storage_bucket(self, bucket, file, namespace=None, entity_filter=None, labels=None):
+    def import_from_storage_bucket(self, bucket, file,
+                                   namespace=None, entity_filter=None, labels=None):
         """
         Import a backup from Cloud Storage to Cloud Datastore
         """
@@ -189,5 +200,6 @@ class DatastoreHook(GoogleCloudBaseHook):
             'entityFilter': entity_filter,
             'labels': labels,
         }
-        resp = self.admin_connection.projects().import_(projectId=self.project_id, body=body).execute()
+        resp = self.admin_connection.projects().import_(
+            projectId=self.project_id, body=body).execute()
         return resp

--- a/airflow/contrib/hooks/discord_webhook_hook.py
+++ b/airflow/contrib/hooks/discord_webhook_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/emr_hook.py
+++ b/airflow/contrib/hooks/emr_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -23,7 +23,8 @@ from airflow.contrib.hooks.aws_hook import AwsHook
 
 class EmrHook(AwsHook):
     """
-    Interact with AWS EMR. emr_conn_id is only neccessary for using the create_job_flow method.
+    Interact with AWS EMR. emr_conn_id is only neccessary for using the
+    create_job_flow method.
     """
 
     def __init__(self, emr_conn_id=None, *args, **kwargs):
@@ -37,7 +38,8 @@ class EmrHook(AwsHook):
     def create_job_flow(self, job_flow_overrides):
         """
         Creates a job flow using the config from the EMR connection.
-        Keys of the json extra hash may have the arguments of the boto3 run_job_flow method.
+        Keys of the json extra hash may have the arguments of the boto3
+        run_job_flow method.
         Overrides for this config may be passed as the job_flow_overrides.
         """
 

--- a/airflow/contrib/hooks/fs_hook.py
+++ b/airflow/contrib/hooks/fs_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/ftp_hook.py
+++ b/airflow/contrib/hooks/ftp_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -250,7 +250,7 @@ class FTPSHook(FTPHook):
             params = self.get_connection(self.ftp_conn_id)
 
             if params.port:
-               ftplib.FTP_TLS.port=params.port
+                ftplib.FTP_TLS.port = params.port
 
             self.conn = ftplib.FTP_TLS(
                 params.host, params.login, params.password

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/gcp_pubsub_hook.py
+++ b/airflow/contrib/hooks/gcp_pubsub_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/jenkins_hook.py
+++ b/airflow/contrib/hooks/jenkins_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/jira_hook.py
+++ b/airflow/contrib/hooks/jira_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/qubole_hook.py
+++ b/airflow/contrib/hooks/qubole_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -94,7 +94,7 @@ class QuboleHook(BaseHook, LoggingMixin):
                 log = LoggingMixin().log
                 if cmd.status == 'done':
                     log.info('Command ID: %s has been succeeded, hence marking this '
-                                'TI as Success.', cmd_id)
+                             'TI as Success.', cmd_id)
                     ti.state = State.SUCCESS
                 elif cmd.status == 'running':
                     log.info('Cancelling the Qubole Command Id: %s', cmd_id)
@@ -188,10 +188,10 @@ class QuboleHook(BaseHook, LoggingMixin):
         inplace_args = None
         tags = set([self.dag_id, self.task_id, context['run_id']])
 
-        for k,v in self.kwargs.items():
+        for k, v in self.kwargs.items():
             if k in COMMAND_ARGS[cmd_type]:
                 if k in HYPHEN_ARGS:
-                    args.append("--{0}={1}".format(k.replace('_', '-'),v))
+                    args.append("--{0}={1}".format(k.replace('_', '-'), v))
                 elif k in POSITIONAL_ARGS:
                     inplace_args = v
                 elif k == 'tags':
@@ -201,12 +201,12 @@ class QuboleHook(BaseHook, LoggingMixin):
                         for val in v:
                             tags.add(val)
                 else:
-                    args.append("--{0}={1}".format(k,v))
+                    args.append("--{0}={1}".format(k, v))
 
             if k == 'notify' and v is True:
                 args.append("--notify")
 
-        args.append("--tags={0}".format(','.join(filter(None,tags))))
+        args.append("--tags={0}".format(','.join(filter(None, tags))))
 
         if inplace_args is not None:
             args += inplace_args.split(' ')

--- a/airflow/contrib/hooks/redis_hook.py
+++ b/airflow/contrib/hooks/redis_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/redshift_hook.py
+++ b/airflow/contrib/hooks/redshift_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/salesforce_hook.py
+++ b/airflow/contrib/hooks/salesforce_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/sftp_hook.py
+++ b/airflow/contrib/hooks/sftp_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/slack_webhook_hook.py
+++ b/airflow/contrib/hooks/slack_webhook_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/snowflake_hook.py
+++ b/airflow/contrib/hooks/snowflake_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/spark_jdbc_hook.py
+++ b/airflow/contrib/hooks/spark_jdbc_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/spark_jdbc_script.py
+++ b/airflow/contrib/hooks/spark_jdbc_script.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/spark_sql_hook.py
+++ b/airflow/contrib/hooks/spark_sql_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,6 @@ import subprocess
 
 from airflow.hooks.base_hook import BaseHook
 from airflow.exceptions import AirflowException
-from airflow.utils.log.logging_mixin import LoggingMixin
 
 
 class SparkSqlHook(BaseHook):
@@ -34,9 +33,11 @@ class SparkSqlHook(BaseHook):
     :type conf: str (format: PROP=VALUE)
     :param conn_id: connection_id string
     :type conn_id: str
-    :param total_executor_cores: (Standalone & Mesos only) Total cores for all executors (Default: all the available cores on the worker)
+    :param total_executor_cores: (Standalone & Mesos only) Total cores for all executors
+        (Default: all the available cores on the worker)
     :type total_executor_cores: int
-    :param executor_cores: (Standalone & YARN only) Number of cores per executor (Default: 2)
+    :param executor_cores: (Standalone & YARN only) Number of cores per
+        executor (Default: 2)
     :type executor_cores: int
     :param executor_memory: Memory per executor (e.g. 1000M, 2G) (Default: 1G)
     :type executor_memory: str

--- a/airflow/contrib/hooks/sqoop_hook.py
+++ b/airflow/contrib/hooks/sqoop_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -71,7 +71,11 @@ class SqoopHook(BaseHook, LoggingMixin):
         self.verbose = verbose
         self.num_mappers = num_mappers
         self.properties = properties or {}
-        self.log.info("Using connection to: {}:{}/{}".format(self.conn.host, self.conn.port, self.conn.schema))
+        self.log.info(
+            "Using connection to: {}:{}/{}".format(
+                self.conn.host, self.conn.port, self.conn.schema
+            )
+        )
 
     def get_conn(self):
         return self.conn
@@ -95,10 +99,11 @@ class SqoopHook(BaseHook, LoggingMixin):
         """
         masked_cmd = ' '.join(self.cmd_mask_password(cmd))
         self.log.info("Executing command: {}".format(masked_cmd))
-        self.sp = subprocess.Popen(cmd,
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.STDOUT,
-                              **kwargs)
+        self.sp = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            **kwargs)
 
         for line in iter(self.sp.stdout):
             self.log.info(line.strip())
@@ -189,7 +194,8 @@ class SqoopHook(BaseHook, LoggingMixin):
         if extra_import_options:
             for key, value in extra_import_options.items():
                 cmd += ['--{}'.format(key)]
-                if value: cmd += [value]
+                if value:
+                    cmd += [value]
 
         return cmd
 
@@ -295,7 +301,8 @@ class SqoopHook(BaseHook, LoggingMixin):
         if extra_export_options:
             for key, value in extra_export_options.items():
                 cmd += ['--{}'.format(key)]
-                if value: cmd += [value]
+                if value:
+                    cmd += [value]
 
         # The required option
         cmd += ["--table", table]

--- a/airflow/contrib/hooks/ssh_hook.py
+++ b/airflow/contrib/hooks/ssh_hook.py
@@ -10,9 +10,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -54,7 +54,8 @@ class SSHHook(BaseHook, LoggingMixin):
     :type port: int
     :param timeout: timeout for the attempt to connect to the remote_host.
     :type timeout: int
-    :param keepalive_interval: send a keepalive packet to remote host every keepalive_interval seconds
+    :param keepalive_interval: send a keepalive packet to remote host every
+        keepalive_interval seconds
     :type keepalive_interval: int
     """
 

--- a/airflow/contrib/hooks/vertica_hook.py
+++ b/airflow/contrib/hooks/vertica_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/hooks/wasb_hook.py
+++ b/airflow/contrib/hooks/wasb_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/kubernetes/kube_client.py
+++ b/airflow/contrib/kubernetes/kube_client.py
@@ -16,6 +16,7 @@
 # under the License.
 from airflow.configuration import conf
 
+
 def _load_kube_config(in_cluster):
     from kubernetes import config, client
     if in_cluster:

--- a/airflow/contrib/kubernetes/pod_generator.py
+++ b/airflow/contrib/kubernetes/pod_generator.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import os
-
 from airflow.contrib.kubernetes.pod import Pod
 import uuid
 from airflow.contrib.kubernetes.volume_mount import VolumeMount  # noqa

--- a/airflow/contrib/operators/__init__.py
+++ b/airflow/contrib/operators/__init__.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,7 +24,7 @@
 
 
 import sys
-
+import os as _os
 
 # ------------------------------------------------------------------------
 #
@@ -48,7 +48,6 @@ _operators = {
     'hive_to_dynamodb': ['HiveToDynamoDBTransferOperator']
 }
 
-import os as _os
 if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
     from airflow.utils.helpers import AirflowImporter
     airflow_importer = AirflowImporter(sys.modules[__name__], _operators)

--- a/airflow/contrib/operators/awsbatch_operator.py
+++ b/airflow/contrib/operators/awsbatch_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -46,9 +46,11 @@ class AWSBatchOperator(BaseOperator):
     :param max_retries: exponential backoff retries while waiter is not merged
     :type max_retries: int
     :param aws_conn_id: connection id of AWS credentials / region name. If None,
-            credential boto3 strategy will be used (http://boto3.readthedocs.io/en/latest/guide/configuration.html).
+            credential boto3 strategy will be used
+            (http://boto3.readthedocs.io/en/latest/guide/configuration.html).
     :type aws_conn_id: str
-    :param region_name: region name to use in AWS Hook. Override the region_name in connection (if provided)
+    :param region_name: region name to use in AWS Hook.
+        Override the region_name in connection (if provided)
     """
 
     ui_color = '#c3dae0'
@@ -152,9 +154,12 @@ class AWSBatchOperator(BaseOperator):
                     if (job['status'] == 'FAILED' or
                             container['container']['exitCode'] != 0):
                         print("@@@@")
-                        raise AirflowException('This containers encounter an error during execution {}'.format(job))
+                        raise AirflowException(
+                            'This containers encounter an error during '
+                            'execution {}'.format(job))
             elif job['status'] is not 'SUCCEEDED':
-                raise AirflowException('This task is still pending {}'.format(job['status']))
+                raise AirflowException(
+                    'This task is still pending {}'.format(job['status']))
 
     def get_hook(self):
         return AwsHook(

--- a/airflow/contrib/operators/bigquery_check_operator.py
+++ b/airflow/contrib/operators/bigquery_check_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,7 +18,8 @@
 # under the License.
 
 from airflow.contrib.hooks.bigquery_hook import BigQueryHook
-from airflow.operators.check_operator import CheckOperator, ValueCheckOperator, IntervalCheckOperator
+from airflow.operators.check_operator import \
+    CheckOperator, ValueCheckOperator, IntervalCheckOperator
 from airflow.utils.decorators import apply_defaults
 
 

--- a/airflow/contrib/operators/bigquery_get_data.py
+++ b/airflow/contrib/operators/bigquery_get_data.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/bigquery_table_delete_operator.py
+++ b/airflow/contrib/operators/bigquery_table_delete_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/bigquery_to_bigquery.py
+++ b/airflow/contrib/operators/bigquery_to_bigquery.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/bigquery_to_gcs.py
+++ b/airflow/contrib/operators/bigquery_to_gcs.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -205,13 +205,14 @@ class DatabricksSubmitRunOperator(BaseOperator):
         Coerces content or all values of content if it is a dict to a string. The
         function will throw if content contains non-string or non-numeric types.
 
-        The reason why we have this function is because the ``self.json`` field must be a dict
-        with only string values. This is because ``render_template`` will fail for numerical values.
+        The reason why we have this function is because the ``self.json`` field must be a
+         dict with only string values. This is because ``render_template`` will fail
+        for numerical values.
         """
         c = self._deep_string_coerce
         if isinstance(content, six.string_types):
             return content
-        elif isinstance(content, six.integer_types+(float,)):
+        elif isinstance(content, six.integer_types + (float,)):
             # Databricks can tolerate either numeric or string types in the API backend.
             return str(content)
         elif isinstance(content, (list, tuple)):
@@ -221,8 +222,8 @@ class DatabricksSubmitRunOperator(BaseOperator):
                     for k, v in list(content.items())}
         else:
             param_type = type(content)
-            msg = 'Type {0} used for parameter {1} is not a number or a string' \
-                    .format(param_type, json_path)
+            msg = 'Type {0} used for parameter {1} is not a number or a string'\
+                .format(param_type, json_path)
             raise AirflowException(msg)
 
     def _log_run_page_url(self, url):

--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -249,13 +249,12 @@ class DataprocClusterCreateOperator(BaseOperator):
                 self.project_id, self.zone
             )
         master_type_uri = \
-            "https://www.googleapis.com/compute/v1/projects/{}/zones/{}/machineTypes/{}".format(
-                self.project_id, self.zone, self.master_machine_type
-            )
+            "https://www.googleapis.com/compute/v1/projects/{}/zones/{}/machineTypes/{}"\
+            .format(self.project_id, self.zone, self.master_machine_type)
         worker_type_uri = \
-            "https://www.googleapis.com/compute/v1/projects/{}/zones/{}/machineTypes/{}".format(
-                self.project_id, self.zone, self.worker_machine_type
-            )
+            "https://www.googleapis.com/compute/v1/projects/{}/zones/{}/machineTypes/{}"\
+            .format(self.project_id, self.zone, self.worker_machine_type)
+
         cluster_data = {
             'projectId': self.project_id,
             'clusterName': self.cluster_name,
@@ -297,7 +296,7 @@ class DataprocClusterCreateOperator(BaseOperator):
         # [a-z]([-a-z0-9]*[a-z0-9])? (current airflow version string follows
         # semantic versioning spec: x.y.z).
         cluster_data['labels'].update({'airflow-version':
-                                       'v' + version.replace('.', '-').replace('+','-')})
+                                       'v' + version.replace('.', '-').replace('+', '-')})
         if self.storage_bucket:
             cluster_data['config']['configBucket'] = self.storage_bucket
         if self.metadata:
@@ -305,7 +304,8 @@ class DataprocClusterCreateOperator(BaseOperator):
         if self.network_uri:
             cluster_data['config']['gceClusterConfig']['networkUri'] = self.network_uri
         if self.subnetwork_uri:
-            cluster_data['config']['gceClusterConfig']['subnetworkUri'] = self.subnetwork_uri
+            cluster_data['config']['gceClusterConfig']['subnetworkUri'] = \
+                self.subnetwork_uri
         if self.tags:
             cluster_data['config']['gceClusterConfig']['tags'] = self.tags
         if self.image_version:
@@ -332,10 +332,10 @@ class DataprocClusterCreateOperator(BaseOperator):
             cluster_data['config']['initializationActions'] = init_actions_dict
         if self.service_account:
             cluster_data['config']['gceClusterConfig']['serviceAccount'] =\
-                    self.service_account
+                self.service_account
         if self.service_account_scopes:
             cluster_data['config']['gceClusterConfig']['serviceAccountScopes'] =\
-                    self.service_account_scopes
+                self.service_account_scopes
         return cluster_data
 
     def execute(self, context):
@@ -368,7 +368,7 @@ class DataprocClusterCreateOperator(BaseOperator):
                 self.log.info(
                     'Cluster {} already exists... Checking status...',
                     self.cluster_name
-                 )
+                )
                 self._wait_for_done(service)
                 return True
             else:

--- a/airflow/contrib/operators/datastore_export_operator.py
+++ b/airflow/contrib/operators/datastore_export_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -35,15 +35,16 @@ class DatastoreExportOperator(BaseOperator):
     :type namespace: str
     :param datastore_conn_id: the name of the Datastore connection id to use
     :type datastore_conn_id: string
-    :param cloud_storage_conn_id: the name of the cloud storage connection id to force-write
-        backup
+    :param cloud_storage_conn_id: the name of the cloud storage connection id to
+        force-write backup
     :type cloud_storage_conn_id: string
     :param delegate_to: The account to impersonate, if any.
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
     :type delegate_to: string
-    :param entity_filter: description of what data from the project is included in the export,
-        refer to https://cloud.google.com/datastore/docs/reference/rest/Shared.Types/EntityFilter
+    :param entity_filter: description of what data from the project is included in the
+        export, refer to
+        https://cloud.google.com/datastore/docs/reference/rest/Shared.Types/EntityFilter
     :type entity_filter: dict
     :param labels: client-assigned labels for cloud storage
     :type labels: dict
@@ -92,7 +93,7 @@ class DatastoreExportOperator(BaseOperator):
             for o in objects:
                 gcs_hook.delete(self.bucket, o)
 
-        ds_hook = DatastoreHook(self.datastore_conn_id,self.delegate_to)
+        ds_hook = DatastoreHook(self.datastore_conn_id, self.delegate_to)
         result = ds_hook.export_to_storage_bucket(bucket=self.bucket,
                                                   namespace=self.namespace,
                                                   entity_filter=self.entity_filter,

--- a/airflow/contrib/operators/datastore_import_operator.py
+++ b/airflow/contrib/operators/datastore_import_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -35,8 +35,9 @@ class DatastoreImportOperator(BaseOperator):
     :param namespace: optional namespace of the backup metadata file in
         the specified Cloud Storage bucket.
     :type namespace: str
-    :param entity_filter: description of what data from the project is included in the export,
-        refer to https://cloud.google.com/datastore/docs/reference/rest/Shared.Types/EntityFilter
+    :param entity_filter: description of what data from the project is included in
+        the export, refer to
+        https://cloud.google.com/datastore/docs/reference/rest/Shared.Types/EntityFilter
     :type entity_filter: dict
     :param labels: client-assigned labels for cloud storage
     :type labels: dict

--- a/airflow/contrib/operators/discord_webhook_operator.py
+++ b/airflow/contrib/operators/discord_webhook_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/druid_operator.py
+++ b/airflow/contrib/operators/druid_operator.py
@@ -29,18 +29,17 @@ class DruidOperator(BaseOperator):
 
     :param json_index_file: The filepath to the druid index specification
     :type json_index_file: str
-    :param druid_ingest_conn_id: The connection id of the Druid overlord which accepts index jobs
+    :param druid_ingest_conn_id: The connection id of the Druid overlord which
+        accepts index jobs
     :type druid_ingest_conn_id: str
     """
     template_fields = ('index_spec_str',)
     template_ext = ('.json',)
 
-    def __init__(
-        self,
-        json_index_file,
-        druid_ingest_conn_id='druid_ingest_default',
-        max_ingestion_time=None,
-        *args, **kwargs):
+    def __init__(self, json_index_file,
+                 druid_ingest_conn_id='druid_ingest_default',
+                 max_ingestion_time=None,
+                 *args, **kwargs):
         super(DruidOperator, self).__init__(*args, **kwargs)
         self.conn_id = druid_ingest_conn_id
         self.max_ingestion_time = max_ingestion_time

--- a/airflow/contrib/operators/ecs_operator.py
+++ b/airflow/contrib/operators/ecs_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -37,9 +37,11 @@ class ECSOperator(BaseOperator):
             http://boto3.readthedocs.org/en/latest/reference/services/ecs.html#ECS.Client.run_task
     :type: overrides: dict
     :param aws_conn_id: connection id of AWS credentials / region name. If None,
-            credential boto3 strategy will be used (http://boto3.readthedocs.io/en/latest/guide/configuration.html).
+            credential boto3 strategy will be used
+            (http://boto3.readthedocs.io/en/latest/guide/configuration.html).
     :type aws_conn_id: str
-    :param region_name: region name to use in AWS Hook. Override the region_name in connection (if provided)
+    :param region_name: region name to use in AWS Hook.
+        Override the region_name in connection (if provided)
     :param launch_type: the launch type on which to run your task ('EC2' or 'FARGATE')
     :type: launch_type: str
     """
@@ -66,7 +68,7 @@ class ECSOperator(BaseOperator):
     def execute(self, context):
         self.log.info(
             'Running ECS Task - Task definition: %s - on cluster %s',
-            self.task_definition,self.cluster
+            self.task_definition, self.cluster
         )
         self.log.info('ECSOperator overrides: %s', self.overrides)
 
@@ -115,13 +117,16 @@ class ECSOperator(BaseOperator):
         for task in response['tasks']:
             containers = task['containers']
             for container in containers:
-                if container.get('lastStatus') == 'STOPPED' and container['exitCode'] != 0:
-                    raise AirflowException('This task is not in success state {}'.format(task))
+                if container.get('lastStatus') == 'STOPPED' and \
+                        container['exitCode'] != 0:
+                    raise AirflowException(
+                        'This task is not in success state {}'.format(task))
                 elif container.get('lastStatus') == 'PENDING':
                     raise AirflowException('This task is still pending {}'.format(task))
                 elif 'error' in container.get('reason', '').lower():
-                    raise AirflowException('This containers encounter an error during launching : {}'.
-                                           format(container.get('reason', '').lower()))
+                    raise AirflowException(
+                        'This containers encounter an error during launching : {}'.
+                        format(container.get('reason', '').lower()))
 
     def get_hook(self):
         return AwsHook(

--- a/airflow/contrib/operators/emr_add_steps_operator.py
+++ b/airflow/contrib/operators/emr_add_steps_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/emr_create_job_flow_operator.py
+++ b/airflow/contrib/operators/emr_create_job_flow_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,7 +25,8 @@ from airflow.exceptions import AirflowException
 class EmrCreateJobFlowOperator(BaseOperator):
     """
     Creates an EMR JobFlow, reading the config from the EMR connection.
-    A dictionary of JobFlow overrides can be passed that override the config from the connection.
+    A dictionary of JobFlow overrides can be passed that override
+    the config from the connection.
 
     :param aws_conn_id: aws connection to uses
     :type aws_conn_id: str

--- a/airflow/contrib/operators/emr_terminate_job_flow_operator.py
+++ b/airflow/contrib/operators/emr_terminate_job_flow_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/file_to_gcs.py
+++ b/airflow/contrib/operators/file_to_gcs.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -65,8 +65,8 @@ class FileToGoogleCloudStorageOperator(BaseOperator):
         Uploads the file to Google cloud storage
         """
         hook = GoogleCloudStorageHook(
-                google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
-                delegate_to=self.delegate_to)
+            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+            delegate_to=self.delegate_to)
 
         hook.upload(
             bucket=self.bucket,

--- a/airflow/contrib/operators/file_to_wasb.py
+++ b/airflow/contrib/operators/file_to_wasb.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -57,6 +57,8 @@ class FileToWasbOperator(BaseOperator):
         """Upload a file to Azure Blob Storage."""
         hook = WasbHook(wasb_conn_id=self.wasb_conn_id)
         self.log.info(
-            'Uploading {self.file_path} to wasb://{self.container_name} as {self.blob_name}'.format(**locals())
+            'Uploading {self.file_path} to wasb://{self.container_name} '
+            'as {self.blob_name}'.format(**locals())
         )
-        hook.load_file(self.file_path, self.container_name, self.blob_name, **self.load_options)
+        hook.load_file(self.file_path, self.container_name,
+                       self.blob_name, **self.load_options)

--- a/airflow/contrib/operators/gcs_download_operator.py
+++ b/airflow/contrib/operators/gcs_download_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -46,7 +46,8 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
         connecting to Google cloud storage.
     :type google_cloud_storage_conn_id: string
     :param delegate_to: The account to impersonate, if any.
-        For this to work, the service account making the request must have domain-wide delegation enabled.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
     :type delegate_to: string
     """
     template_fields = ('bucket', 'object', 'filename', 'store_to_xcom_key',)
@@ -84,5 +85,7 @@ class GoogleCloudStorageDownloadOperator(BaseOperator):
             if sys.getsizeof(file_bytes) < 48000:
                 context['ti'].xcom_push(key=self.store_to_xcom_key, value=file_bytes)
             else:
-                raise RuntimeError('The size of the downloaded file is too large to push to XCom!')
+                raise RuntimeError(
+                    'The size of the downloaded file is too large to push to XCom!'
+                )
         self.log.debug(file_bytes)

--- a/airflow/contrib/operators/gcs_list_operator.py
+++ b/airflow/contrib/operators/gcs_list_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/gcs_operator.py
+++ b/airflow/contrib/operators/gcs_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -184,8 +184,9 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         bq_hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
                                delegate_to=self.delegate_to)
 
-        if not self.schema_fields and self.schema_object \
-                                  and self.source_format != 'DATASTORE_BACKUP':
+        if not self.schema_fields and \
+                self.schema_object and \
+                self.source_format != 'DATASTORE_BACKUP':
             gcs_hook = GoogleCloudStorageHook(
                 google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
                 delegate_to=self.delegate_to)

--- a/airflow/contrib/operators/gcs_to_s3.py
+++ b/airflow/contrib/operators/gcs_to_s3.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/hipchat_operator.py
+++ b/airflow/contrib/operators/hipchat_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/hive_to_dynamodb.py
+++ b/airflow/contrib/operators/hive_to_dynamodb.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/jenkins_job_trigger_operator.py
+++ b/airflow/contrib/operators/jenkins_job_trigger_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/jira_operator.py
+++ b/airflow/contrib/operators/jira_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -29,6 +29,7 @@ template_fields = ('templates_dict',)
 template_ext = tuple()
 ui_color = '#ffefeb'
 
+
 class KubernetesPodOperator(BaseOperator):
     """
     Execute a task in a Kubernetes Pod

--- a/airflow/contrib/operators/mlengine_operator_utils.py
+++ b/airflow/contrib/operators/mlengine_operator_utils.py
@@ -28,6 +28,7 @@ from airflow.exceptions import AirflowException
 from airflow.operators.python_operator import PythonOperator
 from six.moves.urllib.parse import urlsplit
 
+
 def create_evaluate_ops(task_prefix,
                         data_format,
                         input_paths,

--- a/airflow/contrib/operators/postgres_to_gcs_operator.py
+++ b/airflow/contrib/operators/postgres_to_gcs_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/pubsub_operator.py
+++ b/airflow/contrib/operators/pubsub_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/qubole_operator.py
+++ b/airflow/contrib/operators/qubole_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/s3_list_operator.py
+++ b/airflow/contrib/operators/s3_list_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/sftp_operator.py
+++ b/airflow/contrib/operators/sftp_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -65,7 +65,8 @@ class SFTPOperator(BaseOperator):
         self.local_filepath = local_filepath
         self.remote_filepath = remote_filepath
         self.operation = operation
-        if not (self.operation.lower() == SFTPOperation.GET or self.operation.lower() == SFTPOperation.PUT):
+        if not (self.operation.lower() == SFTPOperation.GET or
+                self.operation.lower() == SFTPOperation.PUT):
             raise TypeError("unsupported operation value {0}, expected {1} or {2}"
                             .format(self.operation, SFTPOperation.GET, SFTPOperation.PUT))
 

--- a/airflow/contrib/operators/slack_webhook_operator.py
+++ b/airflow/contrib/operators/slack_webhook_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/snowflake_operator.py
+++ b/airflow/contrib/operators/snowflake_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/spark_jdbc_operator.py
+++ b/airflow/contrib/operators/spark_jdbc_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/spark_sql_operator.py
+++ b/airflow/contrib/operators/spark_sql_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -32,9 +32,11 @@ class SparkSqlOperator(BaseOperator):
     :type conf: str (format: PROP=VALUE)
     :param conn_id: connection_id string
     :type conn_id: str
-    :param total_executor_cores: (Standalone & Mesos only) Total cores for all executors (Default: all the available cores on the worker)
+    :param total_executor_cores: (Standalone & Mesos only) Total cores for all
+        executors (Default: all the available cores on the worker)
     :type total_executor_cores: int
-    :param executor_cores: (Standalone & YARN only) Number of cores per executor (Default: 2)
+    :param executor_cores: (Standalone & YARN only) Number of cores per
+        executor (Default: 2)
     :type executor_cores: int
     :param executor_memory: Memory per executor (e.g. 1000M, 2G) (Default: 1G)
     :type executor_memory: str

--- a/airflow/contrib/operators/sqoop_operator.py
+++ b/airflow/contrib/operators/sqoop_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -33,12 +33,16 @@ from airflow.utils.decorators import apply_defaults
 class SqoopOperator(BaseOperator):
     """
     Execute a Sqoop job.
-    Documentation for Apache Sqoop can be found here: https://sqoop.apache.org/docs/1.4.2/SqoopUserGuide.html.
+    Documentation for Apache Sqoop can be found here:
+        https://sqoop.apache.org/docs/1.4.2/SqoopUserGuide.html.
     """
-    template_fields = ('conn_id', 'cmd_type', 'table', 'query', 'target_dir', 'file_type', 'columns', 'split_by',
-                       'where', 'export_dir', 'input_null_string', 'input_null_non_string', 'staging_table',
-                       'enclosed_by', 'escaped_by', 'input_fields_terminated_by', 'input_lines_terminated_by',
-                       'input_optionally_enclosed_by', 'properties', 'extra_import_options', 'driver',
+    template_fields = ('conn_id', 'cmd_type', 'table', 'query', 'target_dir',
+                       'file_type', 'columns', 'split_by',
+                       'where', 'export_dir', 'input_null_string',
+                       'input_null_non_string', 'staging_table',
+                       'enclosed_by', 'escaped_by', 'input_fields_terminated_by',
+                       'input_lines_terminated_by', 'input_optionally_enclosed_by',
+                       'properties', 'extra_import_options', 'driver',
                        'extra_export_options', 'hcatalog_database', 'hcatalog_table',)
     ui_color = '#7D8CA4'
 
@@ -115,7 +119,8 @@ class SqoopOperator(BaseOperator):
         :param relaxed_isolation: use read uncommitted isolation level
         :param hcatalog_database: Specifies the database name for the HCatalog table
         :param hcatalog_table: The argument value for this option is the HCatalog table
-        :param create_hcatalog_table: Have sqoop create the hcatalog table passed in or not
+        :param create_hcatalog_table: Have sqoop create the hcatalog table passed
+            in or not
         :param properties: additional JVM properties passed to sqoop
         :param extra_import_options: Extra import options to pass as dict.
             If a key doesn't have a value, just pass an empty string to it.
@@ -189,7 +194,8 @@ class SqoopOperator(BaseOperator):
                 extra_export_options=self.extra_export_options)
         elif self.cmd_type == 'import':
             # add create hcatalog table to extra import options if option passed
-            # if new params are added to constructor can pass them in here so don't modify sqoop_hook for each param
+            # if new params are added to constructor can pass them in here
+            # so don't modify sqoop_hook for each param
             if self.create_hcatalog_table:
                 self.extra_import_options['create-hcatalog-table'] = ''
 

--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -109,7 +109,9 @@ class SSHOperator(BaseOperator):
                 agg_stdout += stdout.channel.recv(stdout_buffer_length)
 
             # read from both stdout and stderr
-            while not channel.closed or channel.recv_ready() or channel.recv_stderr_ready():
+            while not channel.closed or \
+                    channel.recv_ready() or \
+                    channel.recv_stderr_ready():
                 readq, _, _ = select([channel], [], [], self.timeout)
                 for c in readq:
                     if c.recv_ready():

--- a/airflow/contrib/operators/vertica_operator.py
+++ b/airflow/contrib/operators/vertica_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/operators/vertica_to_hive.py
+++ b/airflow/contrib/operators/vertica_to_hive.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -94,7 +94,9 @@ class VerticaToHiveTransfer(BaseOperator):
     @classmethod
     def type_map(cls, vertica_type):
         # vertica-python datatype.py donot provied the full type mapping access.
-        # Manual hack. Reference: https://github.com/uber/vertica-python/blob/master/vertica_python/vertica/column.py
+        # Manual hack.
+        # Reference:
+        # https://github.com/uber/vertica-python/blob/master/vertica_python/vertica/column.py
         d = {
             5: 'BOOLEAN',
             6: 'INT',
@@ -120,7 +122,8 @@ class VerticaToHiveTransfer(BaseOperator):
             for field in cursor.description:
                 col_count += 1
                 col_position = "Column{position}".format(position=col_count)
-                field_dict[col_position if field[0] == '' else field[0]] = self.type_map(field[1])
+                field_dict[col_position if field[0] == '' else field[0]] = \
+                    self.type_map(field[1])
             csv_writer.writerows(cursor.iterate())
             f.flush()
             cursor.close()

--- a/airflow/contrib/operators/vertica_to_mysql.py
+++ b/airflow/contrib/operators/vertica_to_mysql.py
@@ -18,6 +18,7 @@
 # under the License.
 
 import logging
+import MySQLdb
 
 from airflow.contrib.hooks.vertica_hook import VerticaHook
 from airflow.hooks.mysql_hook import MySqlHook
@@ -60,7 +61,7 @@ class VerticaToMySqlTransfer(BaseOperator):
     """
 
     template_fields = ('sql', 'mysql_table', 'mysql_preoperator',
-        'mysql_postoperator')
+                       'mysql_postoperator')
     template_ext = ('.sql',)
     ui_color = '#a0e08c'
 
@@ -102,7 +103,9 @@ class VerticaToMySqlTransfer(BaseOperator):
                 if self.bulk_load:
                     tmpfile = NamedTemporaryFile("w")
 
-                    logging.info("Selecting rows from Vertica to local file " + str(tmpfile.name) + "...")
+                    logging.info(
+                        "Selecting rows from Vertica to local file " + str(
+                            tmpfile.name) + "...")
                     logging.info(self.sql)
 
                     csv_writer = csv.writer(tmpfile, delimiter='\t', encoding='utf-8')
@@ -129,14 +132,20 @@ class VerticaToMySqlTransfer(BaseOperator):
                 logging.info("Bulk inserting rows into MySQL...")
                 with closing(mysql.get_conn()) as conn:
                     with closing(conn.cursor()) as cursor:
-                        cursor.execute("LOAD DATA LOCAL INFILE '%s' INTO TABLE %s LINES TERMINATED BY '\r\n' (%s)" % (tmpfile.name, self.mysql_table, ", ".join(selected_columns)))
+                        cursor.execute("LOAD DATA LOCAL INFILE '%s' INTO "
+                                       "TABLE %s LINES TERMINATED BY '\r\n' (%s)" %
+                                       (tmpfile.name,
+                                        self.mysql_table,
+                                        ", ".join(selected_columns)))
                         conn.commit()
                 tmpfile.close()
             else:
                 logging.info("Inserting rows into MySQL...")
-                mysql.insert_rows(table=self.mysql_table, rows=result, target_fields=selected_columns)
+                mysql.insert_rows(table=self.mysql_table,
+                                  rows=result,
+                                  target_fields=selected_columns)
             logging.info("Inserted rows into MySQL " + str(count))
-        except:
+        except (MySQLdb.Error, MySQLdb.Warning):
             logging.error("Inserted rows into MySQL 0")
             raise
 

--- a/airflow/contrib/plugins/metastore_browser/main.py
+++ b/airflow/contrib/plugins/metastore_browser/main.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -138,7 +138,7 @@ class MetastoreBrowserView(BaseView, wwwutils.DataProfilingMixin):
         """.format(where_clause=where_clause, LIMIT=TABLE_SELECTOR_LIMIT)
         h = MySqlHook(METASTORE_MYSQL_CONN_ID)
         d = [
-                {'id': row[0], 'text': row[0]}
+            {'id': row[0], 'text': row[0]}
             for row in h.get_records(sql)]
         return json.dumps(d)
 
@@ -160,6 +160,7 @@ class MetastoreBrowserView(BaseView, wwwutils.DataProfilingMixin):
         sql = "SHOW CREATE TABLE {table};".format(table=table)
         h = HiveCliHook(HIVE_CLI_CONN_ID)
         return h.run_cli(sql)
+
 
 v = MetastoreBrowserView(category="Plugins", name="Hive Metadata Browser")
 

--- a/airflow/contrib/sensors/__init__.py
+++ b/airflow/contrib/sensors/__init__.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/sensors/aws_redshift_cluster_sensor.py
+++ b/airflow/contrib/sensors/aws_redshift_cluster_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/sensors/bash_sensor.py
+++ b/airflow/contrib/sensors/bash_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -66,7 +66,6 @@ class BashSensor(BaseSensorOperator):
         self.log.info("Tmp dir root location: \n %s", gettempdir())
         with TemporaryDirectory(prefix='airflowtmp') as tmp_dir:
             with NamedTemporaryFile(dir=tmp_dir, prefix=self.task_id) as f:
-
                 f.write(bytes(bash_command, 'utf_8'))
                 f.flush()
                 fname = f.name

--- a/airflow/contrib/sensors/bigquery_sensor.py
+++ b/airflow/contrib/sensors/bigquery_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,37 +24,36 @@ from airflow.utils.decorators import apply_defaults
 class BigQueryTableSensor(BaseSensorOperator):
     """
     Checks for the existence of a table in Google Bigquery.
-    """
-    template_fields = ('project_id', 'dataset_id', 'table_id',)
-    ui_color = '#f0eee4'
 
-    @apply_defaults
-    def __init__(
-            self,
-            project_id,
-            dataset_id,
-            table_id,
-            bigquery_conn_id='bigquery_default_conn',
-            delegate_to=None,
-            *args,
-            **kwargs):
-        """
-        Create a new BigQueryTableSensor.
-
-        :param project_id: The Google cloud project in which to look for the table. The connection supplied to the hook
-        must provide access to the specified project.
+        :param project_id: The Google cloud project in which to look for the table.
+            The connection supplied to the hook must provide
+            access to the specified project.
         :type project_id: string
         :param dataset_id: The name of the dataset in which to look for the table.
             storage bucket.
         :type dataset_id: string
         :param table_id: The name of the table to check the existence of.
         :type table_id: string
-        :param bigquery_conn_id: The connection ID to use when connecting to Google BigQuery.
+        :param bigquery_conn_id: The connection ID to use when connecting to
+            Google BigQuery.
         :type bigquery_conn_id: string
         :param delegate_to: The account to impersonate, if any.
-            For this to work, the service account making the request must have domain-wide delegation enabled.
+            For this to work, the service account making the request must
+            have domain-wide delegation enabled.
         :type delegate_to: string
-        """
+    """
+    template_fields = ('project_id', 'dataset_id', 'table_id',)
+    ui_color = '#f0eee4'
+
+    @apply_defaults
+    def __init__(self,
+                 project_id,
+                 dataset_id,
+                 table_id,
+                 bigquery_conn_id='bigquery_default_conn',
+                 delegate_to=None,
+                 *args, **kwargs):
+
         super(BigQueryTableSensor, self).__init__(*args, **kwargs)
         self.project_id = project_id
         self.dataset_id = dataset_id

--- a/airflow/contrib/sensors/datadog_sensor.py
+++ b/airflow/contrib/sensors/datadog_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/sensors/emr_base_sensor.py
+++ b/airflow/contrib/sensors/emr_base_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/sensors/emr_job_flow_sensor.py
+++ b/airflow/contrib/sensors/emr_job_flow_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -30,7 +30,8 @@ class EmrJobFlowSensor(EmrBaseSensor):
     :type job_flow_id: string
     """
 
-    NON_TERMINAL_STATES = ['STARTING', 'BOOTSTRAPPING', 'RUNNING', 'WAITING', 'TERMINATING']
+    NON_TERMINAL_STATES = ['STARTING', 'BOOTSTRAPPING', 'RUNNING',
+                           'WAITING', 'TERMINATING']
     FAILED_STATE = ['TERMINATED_WITH_ERRORS']
     template_fields = ['job_flow_id']
     template_ext = ()

--- a/airflow/contrib/sensors/emr_step_sensor.py
+++ b/airflow/contrib/sensors/emr_step_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/sensors/file_sensor.py
+++ b/airflow/contrib/sensors/file_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/sensors/ftp_sensor.py
+++ b/airflow/contrib/sensors/ftp_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/sensors/gcs_sensor.py
+++ b/airflow/contrib/sensors/gcs_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,21 +24,7 @@ from airflow.utils.decorators import apply_defaults
 class GoogleCloudStorageObjectSensor(BaseSensorOperator):
     """
     Checks for the existence of a file in Google Cloud Storage.
-    """
-    template_fields = ('bucket', 'object')
-    ui_color = '#f0eee4'
-
-    @apply_defaults
-    def __init__(
-            self,
-            bucket,
-            object,  # pylint:disable=redefined-builtin
-            google_cloud_conn_id='google_cloud_default',
-            delegate_to=None,
-            *args,
-            **kwargs):
-        """
-        Create a new GoogleCloudStorageObjectSensor.
+    Create a new GoogleCloudStorageObjectSensor.
 
         :param bucket: The Google cloud storage bucket where the object is.
         :type bucket: string
@@ -49,9 +35,21 @@ class GoogleCloudStorageObjectSensor(BaseSensorOperator):
             connecting to Google cloud storage.
         :type google_cloud_storage_conn_id: string
         :param delegate_to: The account to impersonate, if any.
-            For this to work, the service account making the request must have domain-wide delegation enabled.
+            For this to work, the service account making the request must have
+            domain-wide delegation enabled.
         :type delegate_to: string
-        """
+    """
+    template_fields = ('bucket', 'object')
+    ui_color = '#f0eee4'
+
+    @apply_defaults
+    def __init__(self,
+                 bucket,
+                 object,  # pylint:disable=redefined-builtin
+                 google_cloud_conn_id='google_cloud_default',
+                 delegate_to=None,
+                 *args, **kwargs):
+
         super(GoogleCloudStorageObjectSensor, self).__init__(*args, **kwargs)
         self.bucket = bucket
         self.object = object
@@ -78,23 +76,7 @@ def ts_function(context):
 class GoogleCloudStorageObjectUpdatedSensor(BaseSensorOperator):
     """
     Checks if an object is updated in Google Cloud Storage.
-    """
-    template_fields = ('bucket', 'object')
-    template_ext = ('.sql',)
-    ui_color = '#f0eee4'
-
-    @apply_defaults
-    def __init__(
-            self,
-            bucket,
-            object,  # pylint:disable=redefined-builtin
-            ts_func=ts_function,
-            google_cloud_conn_id='google_cloud_default',
-            delegate_to=None,
-            *args,
-            **kwargs):
-        """
-        Create a new GoogleCloudStorageObjectUpdatedSensor.
+    Create a new GoogleCloudStorageObjectUpdatedSensor.
 
         :param bucket: The Google cloud storage bucket where the object is.
         :type bucket: string
@@ -112,7 +94,20 @@ class GoogleCloudStorageObjectUpdatedSensor(BaseSensorOperator):
             For this to work, the service account making the request must have domain-wide
             delegation enabled.
         :type delegate_to: string
-        """
+    """
+    template_fields = ('bucket', 'object')
+    template_ext = ('.sql',)
+    ui_color = '#f0eee4'
+
+    @apply_defaults
+    def __init__(self,
+                 bucket,
+                 object,  # pylint:disable=redefined-builtin
+                 ts_func=ts_function,
+                 google_cloud_conn_id='google_cloud_default',
+                 delegate_to=None,
+                 *args, **kwargs):
+
         super(GoogleCloudStorageObjectUpdatedSensor, self).__init__(*args, **kwargs)
         self.bucket = bucket
         self.object = object
@@ -131,21 +126,7 @@ class GoogleCloudStorageObjectUpdatedSensor(BaseSensorOperator):
 class GoogleCloudStoragePrefixSensor(BaseSensorOperator):
     """
     Checks for the existence of a files at prefix in Google Cloud Storage bucket.
-    """
-    template_fields = ('bucket', 'prefix')
-    ui_color = '#f0eee4'
-
-    @apply_defaults
-    def __init__(
-        self,
-        bucket,
-        prefix,
-        google_cloud_conn_id='google_cloud_default',
-        delegate_to=None,
-        *args,
-        **kwargs):
-        """
-        Create a new GoogleCloudStorageObjectSensor.
+    Create a new GoogleCloudStorageObjectSensor.
 
         :param bucket: The Google cloud storage bucket where the object is.
         :type bucket: string
@@ -156,9 +137,20 @@ class GoogleCloudStoragePrefixSensor(BaseSensorOperator):
             connecting to Google cloud storage.
         :type google_cloud_storage_conn_id: string
         :param delegate_to: The account to impersonate, if any.
-            For this to work, the service account making the request must have domain-wide delegation enabled.
+            For this to work, the service account making the request must have
+            domain-wide delegation enabled.
         :type delegate_to: string
-        """
+    """
+    template_fields = ('bucket', 'prefix')
+    ui_color = '#f0eee4'
+
+    @apply_defaults
+    def __init__(self,
+                 bucket,
+                 prefix,
+                 google_cloud_conn_id='google_cloud_default',
+                 delegate_to=None,
+                 *args, **kwargs):
         super(GoogleCloudStoragePrefixSensor, self).__init__(*args, **kwargs)
         self.bucket = bucket
         self.prefix = prefix
@@ -166,7 +158,8 @@ class GoogleCloudStoragePrefixSensor(BaseSensorOperator):
         self.delegate_to = delegate_to
 
     def poke(self, context):
-        self.log.info('Sensor checks existence of objects: %s, %s', self.bucket, self.prefix)
+        self.log.info('Sensor checks existence of objects: %s, %s',
+                      self.bucket, self.prefix)
         hook = GoogleCloudStorageHook(
             google_cloud_storage_conn_id=self.google_cloud_conn_id,
             delegate_to=self.delegate_to)

--- a/airflow/contrib/sensors/hdfs_sensor.py
+++ b/airflow/contrib/sensors/hdfs_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/sensors/jira_sensor.py
+++ b/airflow/contrib/sensors/jira_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -136,12 +136,16 @@ class JiraTicketSensor(JiraSensor):
                         )
 
         except JIRAError as jira_error:
-            self.log.error("Jira error while checking with expected value: %s", jira_error)
+            self.log.error("Jira error while checking with expected value: %s",
+                           jira_error)
         except Exception as e:
-            self.log.error("Error while checking with expected value %s:", self.expected_value)
+            self.log.error("Error while checking with expected value %s:",
+                           self.expected_value)
             self.log.exception(e)
         if result is True:
-            self.log.info("Issue field %s has expected value %s, returning success", self.field, self.expected_value)
+            self.log.info("Issue field %s has expected value %s, returning success",
+                          self.field, self.expected_value)
         else:
-            self.log.info("Issue field %s don't have expected value %s yet.", self.field, self.expected_value)
+            self.log.info("Issue field %s don't have expected value %s yet.",
+                          self.field, self.expected_value)
         return result

--- a/airflow/contrib/sensors/pubsub_sensor.py
+++ b/airflow/contrib/sensors/pubsub_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/sensors/redis_key_sensor.py
+++ b/airflow/contrib/sensors/redis_key_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/sensors/sftp_sensor.py
+++ b/airflow/contrib/sensors/sftp_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/sensors/wasb_sensor.py
+++ b/airflow/contrib/sensors/wasb_sensor.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/task_runner/__init__.py
+++ b/airflow/contrib/task_runner/__init__.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/airflow/contrib/task_runner/cgroup_task_runner.py
+++ b/airflow/contrib/task_runner/cgroup_task_runner.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -113,7 +113,8 @@ class CgroupTaskRunner(BaseTaskRunner):
         cgroups = self._get_cgroup_names()
         if cgroups["cpu"] != "/" or cgroups["memory"] != "/":
             self.log.debug(
-                "Already running in a cgroup (cpu: %s memory: %s) so not creating another one",
+                "Already running in a cgroup (cpu: %s memory: %s) so not "
+                "creating another one",
                 cgroups.get("cpu"), cgroups.get("memory")
             )
             self.process = self.run_command(['bash', '-c'], join_args=True)
@@ -174,9 +175,9 @@ class CgroupTaskRunner(BaseTaskRunner):
         # we might want to revisit that approach at some other point.
         if return_code == 137:
             self.log.warning("Task failed with return code of 137. This may indicate "
-                              "that it was killed due to excessive memory usage. "
-                              "Please consider optimizing your task or using the "
-                              "resources argument to reserve more memory for your task")
+                             "that it was killed due to excessive memory usage. "
+                             "Please consider optimizing your task or using the "
+                             "resources argument to reserve more memory for your task")
         return return_code
 
     def terminate(self):

--- a/airflow/contrib/utils/__init__.py
+++ b/airflow/contrib/utils/__init__.py
@@ -7,13 +7,12 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2429
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
