### PR TITLE
[AIRFLOW-2501] Refer to devel instructions in docs contrib guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,11 +63,19 @@ If you are proposing a feature:
 
 ## Documentation
 
-The latest API documentation is usually available [here](https://airflow.incubator.apache.org/).
-To generate a local version, you need to have installed airflow with
-the `doc` extra. In that case you can generate the doc by running:
+The latest API documentation is usually available
+[here](https://airflow.incubator.apache.org/). To generate a local version,
+you need to have set up an Airflow development environemnt (see below). Also
+install the `doc` extra.
+
+    pip install -e .[doc]
+
+Generate the documentation by running:
 
     cd docs && ./build.sh
+
+Only a subset of the API reference documentation builds. Install additional
+extras to build the full API reference.
 
 ## Development and Testing
 


### PR DESCRIPTION
Without the devel extra, the docs do not build. The build fails due to
missing the mock package.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2501


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Updates the CONTRIBUTING.md guide with instructions on how to install `doc` extra and refers to `devel` instructions.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: No tests, just docs.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
