### PR TITLE
[AIRFLOW-2502] Change Single triple quotes to double for docstrings

### DIFF
--- a/airflow/contrib/auth/backends/github_enterprise_auth.py
+++ b/airflow/contrib/auth/backends/github_enterprise_auth.py
@@ -48,27 +48,27 @@ class GHEUser(models.User):
         self.user = user
 
     def is_active(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return True
 
     def is_authenticated(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return True
 
     def is_anonymous(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return False
 
     def get_id(self):
-        '''Returns the current user id as required by flask_login'''
+        """Returns the current user id as required by flask_login"""
         return self.user.get_id()
 
     def data_profiling(self):
-        '''Provides access to data profiling tools'''
+        """Provides access to data profiling tools"""
         return True
 
     def is_superuser(self):
-        '''Access all the things'''
+        """Access all the things"""
         return True
 
 

--- a/airflow/contrib/auth/backends/google_auth.py
+++ b/airflow/contrib/auth/backends/google_auth.py
@@ -47,27 +47,27 @@ class GoogleUser(models.User):
         self.user = user
 
     def is_active(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return True
 
     def is_authenticated(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return True
 
     def is_anonymous(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return False
 
     def get_id(self):
-        '''Returns the current user id as required by flask_login'''
+        """Returns the current user id as required by flask_login"""
         return self.user.get_id()
 
     def data_profiling(self):
-        '''Provides access to data profiling tools'''
+        """Provides access to data profiling tools"""
         return True
 
     def is_superuser(self):
-        '''Access all the things'''
+        """Access all the things"""
         return True
 
 

--- a/airflow/contrib/auth/backends/kerberos_auth.py
+++ b/airflow/contrib/auth/backends/kerberos_auth.py
@@ -74,27 +74,27 @@ class KerberosUser(models.User, LoggingMixin):
         return
 
     def is_active(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return True
 
     def is_authenticated(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return True
 
     def is_anonymous(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return False
 
     def get_id(self):
-        '''Returns the current user id as required by flask_login'''
+        """Returns the current user id as required by flask_login"""
         return self.user.get_id()
 
     def data_profiling(self):
-        '''Provides access to data profiling tools'''
+        """Provides access to data profiling tools"""
         return True
 
     def is_superuser(self):
-        '''Access all the things'''
+        """Access all the things"""
         return True
 
 

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -237,27 +237,27 @@ class LdapUser(models.User):
             raise AuthenticationError("Invalid username or password")
 
     def is_active(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return True
 
     def is_authenticated(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return True
 
     def is_anonymous(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return False
 
     def get_id(self):
-        '''Returns the current user id as required by flask_login'''
+        """Returns the current user id as required by flask_login"""
         return self.user.get_id()
 
     def data_profiling(self):
-        '''Provides access to data profiling tools'''
+        """Provides access to data profiling tools"""
         return self.data_profiler
 
     def is_superuser(self):
-        '''Access all the things'''
+        """Access all the things"""
         return self.superuser
 
 

--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -72,27 +72,27 @@ class PasswordUser(models.User):
         return check_password_hash(self._password, plaintext)
 
     def is_active(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return True
 
     def is_authenticated(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return True
 
     def is_anonymous(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return False
 
     def get_id(self):
-        '''Returns the current user id as required by flask_login'''
+        """Returns the current user id as required by flask_login"""
         return str(self.id)
 
     def data_profiling(self):
-        '''Provides access to data profiling tools'''
+        """Provides access to data profiling tools"""
         return True
 
     def is_superuser(self):
-        '''Access all the things'''
+        """Access all the things"""
         return True
 
 

--- a/airflow/contrib/hooks/fs_hook.py
+++ b/airflow/contrib/hooks/fs_hook.py
@@ -22,7 +22,7 @@ from airflow.hooks.base_hook import BaseHook
 
 
 class FSHook(BaseHook):
-    '''
+    """
     Allows for interaction with an file server.
 
     Connection should have a name and a path specified under extra:
@@ -32,7 +32,7 @@ class FSHook(BaseHook):
     Conn Type: File (path)
     Host, Shchema, Login, Password, Port: empty
     Extra: {"path": "/tmp"}
-    '''
+    """
 
     def __init__(self, conn_id='fs_default'):
         conn = self.get_connection(conn_id)

--- a/airflow/contrib/hooks/snowflake_hook.py
+++ b/airflow/contrib/hooks/snowflake_hook.py
@@ -41,10 +41,10 @@ class SnowflakeHook(DbApiHook):
         self.database = kwargs.pop("database", None)
 
     def _get_conn_params(self):
-        '''
+        """
         one method to fetch connection params as a dict
         used in get_uri() and get_connection()
-        '''
+        """
         conn = self.get_connection(self.snowflake_conn_id)
         account = conn.extra_dejson.get('account', None)
         warehouse = conn.extra_dejson.get('warehouse', None)
@@ -61,9 +61,9 @@ class SnowflakeHook(DbApiHook):
         return conn_config
 
     def get_uri(self):
-        '''
+        """
         override DbApiHook get_uri method for get_sqlalchemy_engine()
-        '''
+        """
         conn_config = self._get_conn_params()
         uri = 'snowflake://{user}:{password}@{account}/{database}/'
         uri += '{schema}?warehouse={warehouse}'
@@ -79,12 +79,12 @@ class SnowflakeHook(DbApiHook):
         return conn
 
     def _get_aws_credentials(self):
-        '''
+        """
         returns aws_access_key_id, aws_secret_access_key
         from extra
 
         intended to be used by external import and export statements
-        '''
+        """
         if self.snowflake_conn_id:
             connection_object = self.get_connection(self.snowflake_conn_id)
             if 'aws_secret_access_key' in connection_object.extra_dejson:

--- a/airflow/contrib/hooks/vertica_hook.py
+++ b/airflow/contrib/hooks/vertica_hook.py
@@ -24,9 +24,9 @@ from airflow.hooks.dbapi_hook import DbApiHook
 
 
 class VerticaHook(DbApiHook):
-    '''
+    """
     Interact with Vertica.
-    '''
+    """
 
     conn_name_attr = 'vertica_conn_id'
     default_conn_name = 'vertica_default'

--- a/airflow/default_login.py
+++ b/airflow/default_login.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,12 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-'''
+"""
 Override this file to handle your authenticating / login.
 
 Copy and alter this file and put in your PYTHONPATH as airflow_login.py,
 the new module will override this one.
-'''
+"""
 
 import flask_login
 from flask_login import login_required, current_user, logout_user
@@ -45,27 +45,27 @@ class DefaultUser(object):
         self.user = user
 
     def is_active(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return True
 
     def is_authenticated(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return True
 
     def is_anonymous(self):
-        '''Required by flask_login'''
+        """Required by flask_login"""
         return False
 
     def data_profiling(self):
-        '''Provides access to data profiling tools'''
+        """Provides access to data profiling tools"""
         return True
 
     def is_superuser(self):
-        '''Access all the things'''
+        """Access all the things"""
         return True
 
-#models.User = User  # hack!
-#del User
+# models.User = User  # hack!
+# del User
 
 
 @login_manager.user_loader

--- a/airflow/example_dags/docker_copy_data.py
+++ b/airflow/example_dags/docker_copy_data.py
@@ -7,20 +7,22 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-'''
-This sample "listen to directory". move the new file and print it, using docker-containers.
-The following operators are being used: DockerOperator, BashOperator & ShortCircuitOperator.
+"""
+This sample "listen to directory". move the new file and print it,
+using docker-containers.
+The following operators are being used: DockerOperator, BashOperator &
+ShortCircuitOperator.
 TODO: Review the workflow, change it accordingly to to your environment & enable the code.
-'''
+"""
 
 # from __future__ import print_function
 #

--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -60,10 +60,10 @@ class PostgresHook(DbApiHook):
         return self.conn
 
     def copy_expert(self, sql, filename, open=open):
-        '''
+        """
         Executes SQL using psycopg2 copy_expert method
         Necessary to execute COPY command without access to a superuser
-        '''
+        """
         f = open(filename, 'w')
         with closing(self.get_conn()) as conn:
             with closing(conn.cursor()) as cur:

--- a/airflow/hooks/samba_hook.py
+++ b/airflow/hooks/samba_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,9 +24,9 @@ from airflow.hooks.base_hook import BaseHook
 
 
 class SambaHook(BaseHook):
-    '''
+    """
     Allows for interaction with an samba server.
-    '''
+    """
 
     def __init__(self, samba_conn_id):
         self.conn = self.get_connection(samba_conn_id)

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -132,16 +132,16 @@ class BaseJob(Base, LoggingMixin):
         raise AirflowException("Job shut down externally.")
 
     def on_kill(self):
-        '''
+        """
         Will be called when an external kill command is received
-        '''
+        """
         pass
 
     def heartbeat_callback(self, session=None):
         pass
 
     def heartbeat(self):
-        '''
+        """
         Heartbeats update the job's entry in the database with a timestamp
         for the latest_heartbeat and allows for the job to be killed
         externally. This allows at the system level to monitor what is
@@ -158,7 +158,7 @@ class BaseJob(Base, LoggingMixin):
         will sleep 50 seconds to complete the 60 seconds and keep a steady
         heart rate. If you go over 60 seconds before calling it, it won't
         sleep at all.
-        '''
+        """
         with create_session() as session:
             job = session.query(BaseJob).filter_by(id=self.id).one()
             make_transient(job)

--- a/airflow/macros/hive.py
+++ b/airflow/macros/hive.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -56,7 +56,7 @@ def max_partition(
 
 
 def _closest_date(target_dt, date_list, before_target=None):
-    '''
+    """
     This function finds the date in a list closest to the target date.
     An optional parameter can be given to get the closest before or after.
 
@@ -68,7 +68,7 @@ def _closest_date(target_dt, date_list, before_target=None):
     :type before_target: bool or None
     :returns: The closest date
     :rtype: datetime.date or None
-    '''
+    """
     fb = lambda d: target_dt - d if d <= target_dt else datetime.timedelta.max
     fa = lambda d: d - target_dt if d >= target_dt else datetime.timedelta.max
     fnone = lambda d: target_dt - d if d < target_dt else d - target_dt
@@ -83,7 +83,7 @@ def _closest_date(target_dt, date_list, before_target=None):
 def closest_ds_partition(
         table, ds, before=True, schema="default",
         metastore_conn_id='metastore_default'):
-    '''
+    """
     This function finds the date in a list closest to the target date.
     An optional parameter can be given to get the closest before or after.
 
@@ -99,7 +99,7 @@ def closest_ds_partition(
     >>> tbl = 'airflow.static_babynames_partitioned'
     >>> closest_ds_partition(tbl, '2015-01-02')
     '2015-01-01'
-    '''
+    """
     from airflow.hooks.hive_hooks import HiveMetastoreHook
     if '.' in table:
         schema, table = table.split('.')

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4170,10 +4170,10 @@ class DAG(BaseDag, LoggingMixin):
         return qry.scalar()
 
     def test_cycle(self):
-        '''
+        """
         Check to see if there are any cycles in the DAG. Returns False if no cycle found,
         otherwise raises exception.
-        '''
+        """
 
         # default of int is 0 which corresponds to CYCLE_NEW
         visit_map = defaultdict(int)
@@ -4184,9 +4184,9 @@ class DAG(BaseDag, LoggingMixin):
         return False
 
     def _test_cycle_helper(self, visit_map, task_id):
-        '''
+        """
         Checks if a cycle exists from the input task using DFS traversal
-        '''
+        """
 
         # print('Inspecting %s' % task_id)
         if visit_map[task_id] == DagBag.CYCLE_DONE:

--- a/airflow/operators/check_operator.py
+++ b/airflow/operators/check_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -91,13 +91,13 @@ class CheckOperator(BaseOperator):
 
 
 def _convert_to_float_if_possible(s):
-    '''
+    """
     A small helper function to convert a string to a numeric value
     if appropriate
 
     :param s: the string to be converted
     :type s: str
-    '''
+    """
     try:
         ret = float(s)
     except (ValueError, TypeError):

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -343,9 +343,9 @@ def upgradedb():
 
 
 def resetdb(rbac):
-    '''
+    """
     Clear out the database
-    '''
+    """
     from airflow import models
 
     # alembic adds significant import time, so we import it lazily

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -241,9 +241,9 @@ def epoch(dttm):
 
 
 def action_logging(f):
-    '''
+    """
     Decorator to log user actions
-    '''
+    """
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         if current_user and hasattr(current_user, 'username'):
@@ -272,9 +272,9 @@ def action_logging(f):
 
 
 def notify_owner(f):
-    '''
+    """
     Decorator to notify owner of actions taken on their DAGs by others
-    '''
+    """
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         """
@@ -329,9 +329,9 @@ def json_response(obj):
 
 
 def gzipped(f):
-    '''
+    """
     Decorator to make a view compressed
-    '''
+    """
     @functools.wraps(f)
     def view_func(*args, **kwargs):
         @after_this_request
@@ -366,9 +366,9 @@ def gzipped(f):
 
 
 def make_cache_key(*args, **kwargs):
-    '''
+    """
     Used by cache to get a unique key per URL
-    '''
+    """
     path = request.path
     args = str(hash(frozenset(request.args.items())))
     return (path + args).encode('ascii', 'ignore')

--- a/airflow/www_rbac/decorators.py
+++ b/airflow/www_rbac/decorators.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -26,9 +26,9 @@ from airflow import models, settings
 
 
 def action_logging(f):
-    '''
+    """
     Decorator to log user actions
-    '''
+    """
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         session = settings.Session()
@@ -58,9 +58,9 @@ def action_logging(f):
 
 
 def gzipped(f):
-    '''
+    """
     Decorator to make a view compressed
-    '''
+    """
     @functools.wraps(f)
     def view_func(*args, **kwargs):
         @after_this_request

--- a/airflow/www_rbac/utils.py
+++ b/airflow/www_rbac/utils.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -198,9 +198,9 @@ def json_response(obj):
 
 
 def make_cache_key(*args, **kwargs):
-    '''
+    """
     Used by cache to get a unique key per URL
-    '''
+    """
     path = request.path
     args = str(hash(frozenset(request.args.items())))
     return (path + args).encode('ascii', 'ignore')

--- a/tests/contrib/hooks/test_spark_sql_hook.py
+++ b/tests/contrib/hooks/test_spark_sql_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -32,7 +32,7 @@ from airflow.contrib.hooks.spark_sql_hook import SparkSqlHook
 
 
 def get_after(sentinel, iterable):
-    "Get the value after `sentinel` in an `iterable`"
+    """Get the value after `sentinel` in an `iterable`"""
     truncated = dropwhile(lambda el: el != sentinel, iterable)
     next(truncated)
     return next(truncated)


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2502
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- Changed single triple quotes to double quote characters to be consistent with the docstring convention in [PEP 257](https://www.python.org/dev/peps/pep-0257/)

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
