### PR TITLE
[AIRFLOW-83] Add MongoHook for MongoDB

### DIFF
--- a/airflow/contrib/hooks/mongo_hook.py
+++ b/airflow/contrib/hooks/mongo_hook.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pymongo import MongoClient
+from pymongo.errors import ConnectionFailure
+
+from airflow.hooks.base_hook import BaseHook
+from airflow.utils.log.logging_mixin import LoggingMixin
+
+
+class MongoHook(BaseHook, LoggingMixin):
+    """
+    Hook for interacting with a MongoDB node or cluster using Pymongo.
+    The associated connection is rewritten as the following MongoDB URI,
+    where empty sections are omitted:
+
+    mongodb://{login}:{password}@{host}:{port}/{schema}?{extra}
+
+    The hook will not re-write the {extra} section, i.e. it must be
+    properly query-encoded.
+
+    Pymongo API documentation can be found at:
+    https://api.mongodb.com/python/current/api/index.html
+    """
+
+    def __init__(self,
+                 mongo_conn_id='mongo_default',
+                 reuse_connection=True):
+        self.mongo_conn_id = mongo_conn_id
+        self.reuse_connection = reuse_connection
+        self.mongo_client = None
+
+        conn = self.get_connection(self.mongo_conn_id)
+
+        self.mongo_uri = self.build_uri(conn)
+        self.shadow_mongo_uri = self.build_uri(conn, shadow=True)
+
+    @staticmethod
+    def build_uri(conn, shadow=False):
+        """
+        Given an Airflow connection, construct the MongoDB connection URI.
+
+        https://docs.mongodb.com/manual/reference/connection-string/
+        """
+
+        uri = 'mongodb://'
+
+        if conn.login:
+            uri += conn.login
+
+            if conn.password:
+                if shadow:
+                    uri += ':***'
+                else:
+                    uri += ':' + conn.password
+
+            uri += '@'
+
+        uri += conn.host or 'localhost'
+
+        if conn.port:
+            uri += ':' + str(int(conn.port))
+
+        if conn.schema:
+            uri += '/' + conn.schema
+
+        if conn.extra:
+            uri += '?' + conn.extra
+
+        return uri
+
+    def get_conn(self, check_connection=True):
+        """
+        Returns an initialised pymongo MongoClient.
+        """
+        if self.reuse_connection and self.mongo_client:
+            return self.mongo_client
+
+        client = MongoClient(self.mongo_uri)
+
+        self.log.debug(
+            'Opening Mongo connection for: {}'.format(
+                self.shadow_mongo_uri))
+
+        if check_connection:
+            try:
+                client.admin.command('ismaster')
+            except ConnectionFailure:
+                self.log.error(
+                    'Mongo connection {} failed: is the '
+                    'database reachable?'.format(
+                        self.shadow_mongo_uri))
+                raise
+
+        self.mongo_client = client
+        return client
+
+    def get_database(self, *args, **kwargs):
+        """
+        Return database `name`. If not provided, use the default database
+        provided in the connection string (or the "schema" field of the
+        Airflow connection).
+
+        The full set of supported arguments can be found at:
+
+        https://api.mongodb.com/python/current/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient.get_database
+        """
+        return self.get_conn().get_database(*args, **kwargs)

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -583,6 +583,7 @@ class Connection(Base, LoggingMixin):
         ('jenkins', 'Jenkins'),
         ('mysql', 'MySQL',),
         ('postgres', 'Postgres',),
+        ('mongo', 'MongoDB',),
         ('oracle', 'Oracle',),
         ('vertica', 'Vertica',),
         ('presto', 'Presto',),

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -140,6 +140,10 @@ def initdb(rbac=False):
             port=9083))
     merge_conn(
         models.Connection(
+            conn_id='mongo_default', conn_type='mongo',
+            host='localhost', port=27017))
+    merge_conn(
+        models.Connection(
             conn_id='mysql_default', conn_type='mysql',
             login='root',
             host='localhost'))

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -373,6 +373,7 @@ Community contributed hooks
 .. autoclass:: airflow.contrib.hooks.gcs_hook.GoogleCloudStorageHook
 .. autoclass:: airflow.contrib.hooks.jenkins_hook.JenkinsHook
 .. autoclass:: airflow.contrib.hooks.jira_hook.JiraHook
+.. autoclass:: airflow.contrib.hooks.mongo_hook.MongoHook
 .. autoclass:: airflow.contrib.hooks.pinot_hook.PinotDbApiHook
 .. autoclass:: airflow.contrib.hooks.qubole_hook.QuboleHook
 .. autoclass:: airflow.contrib.hooks.redis_hook.RedisHook

--- a/setup.py
+++ b/setup.py
@@ -168,6 +168,7 @@ kerberos = ['pykerberos>=1.1.13',
 kubernetes = ['kubernetes>=3.0.0',
               'cryptography>=2.0.0']
 ldap = ['ldap3>=0.9.9.1']
+mongo = ['pymongo>=3.6.1']
 mssql = ['pymssql>=2.1.1', 'unicodecsv>=0.14.1']
 mysql = ['mysqlclient>=1.3.6']
 oracle = ['cx_Oracle>=5.1.2']
@@ -196,7 +197,7 @@ winrm = ['pywinrm==0.2.2']
 zendesk = ['zdesk']
 
 all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant + druid + pinot \
-    + cassandra
+    + cassandra + mongo
 devel = [
     'click',
     'freezegun',
@@ -316,6 +317,7 @@ def do_setup():
             'kerberos': kerberos,
             'kubernetes': kubernetes,
             'ldap': ldap,
+            'mongo': mongo,
             'mssql': mssql,
             'mysql': mysql,
             'oracle': oracle,

--- a/tests/contrib/hooks/test_mongo_hook.py
+++ b/tests/contrib/hooks/test_mongo_hook.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pymongo import MongoClient
+from pymongo.errors import ConnectionFailure
+import unittest
+
+from airflow import configuration
+from airflow.contrib.hooks.mongo_hook import MongoHook
+from airflow.models import Connection as Conn
+
+
+class TestMongoHook(unittest.TestCase):
+    def setUp(self):
+        configuration.load_test_config()
+
+    def test_uri_empty(self):
+        conn = Conn()
+        uri = MongoHook.build_uri(conn)
+        self.assertEqual(uri, 'mongodb://localhost')
+
+    def test_uri_simple(self):
+        conn = Conn(
+            host='1.2.3.4,1.2.3.5',
+            login='admin',
+            password='password',
+            schema='mydatabase',
+            extra='authSource=admin&replicaSet=replset')
+
+        uri = MongoHook.build_uri(conn)
+        self.assertEqual(
+            uri,
+            'mongodb://admin:password@1.2.3.4,1.2.3.5/mydatabase?'
+            'authSource=admin&replicaSet=replset')
+
+        uri = MongoHook.build_uri(conn, shadow=True)
+        self.assertEqual(
+            uri,
+            'mongodb://admin:***@1.2.3.4,1.2.3.5/mydatabase?'
+            'authSource=admin&replicaSet=replset')
+
+    def test_get_conn(self):
+        hook = MongoHook()
+
+        self.assertEqual(hook.mongo_conn_id, 'mongo_default')
+        self.assertEqual(hook.reuse_connection, True)
+        self.assertEqual(hook.mongo_client, None)
+
+        client = hook.get_conn(check_connection=False)
+
+        self.assertIsInstance(client, MongoClient)
+
+    def test_get_conn_failure(self):
+        hook = MongoHook()
+
+        with self.assertRaises(ConnectionFailure):
+            hook.get_conn()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### JIRA
This PR partially addresses [AIRFLOW-83](https://issues.apache.org/jira/browse/AIRFLOW-83).

A related PR (https://github.com/apache/incubator-airflow/pull/2962) exists with the MongoHook as well as an operator, but the status appears unclear given its complexity.

### Description
Introduces the `airflow.contrib.hooks.mongo_hook.MongoHook`, which is a thin wrapper on top of [PyMongo's MongoClient](https://api.mongodb.com/python/current/api/index.html).

By default, the `get_conn()` of this hook will check that the database connection is live, and the hook also proxies the MongoClient's `get_database()`. The liveness check can be disabled by passing the appropriate parameter to `get_conn(check_connection=False)`. By default the MongoClient is shared by all users of the hook, as PyMongo has its own connection pooling mechanism.

When initialising MongoClient, the hook will use the connection settings to construct a [Mongo connection URI](https://docs.mongodb.com/manual/reference/connection-string/). Connection strings logged by the hook mask the password.

### Tests
- [x] My PR adds the following unit tests: `tests.contrib.hooks.test_mongo_hook.TestMongoHook`, which tests URI construction as well as liveness check in `get_conn()`. Successful MongoClient connectivity isn't tested: given a valid URI construction, this is assumed to be PyMongo's responsibility.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
