### PR TITLE
[AIRFLOW-2463] Make task instance context available for hive queries

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -40,6 +40,7 @@ There are five roles created for Airflow by default: Admin, User, Op, Viewer, an
 - Airflow dag home page is now `/home` (instead of `/admin`).
 - All ModelViews in Flask-AppBuilder follow a different pattern from Flask-Admin. The `/admin` part of the url path will no longer exist. For example: `/admin/connection` becomes `/connection/list`, `/admin/connection/new` becomes `/connection/add`, `/admin/connection/edit` becomes `/connection/edit`, etc.
 - Due to security concerns, the new webserver will no longer support the features in the `Data Profiling` menu of old UI, including `Ad Hoc Query`, `Charts`, and `Known Events`.
+- HiveServer2Hook.get_results() always returns a list of tuples, even when a single column is queried, as per Python API 2.
 
 ### airflow.contrib.sensors.hdfs_sensors renamed to airflow.contrib.sensors.hdfs_sensor
 
@@ -72,7 +73,7 @@ supported and will be removed entirely in Airflow 2.0
 With Airflow 1.9 or lower, Unload operation always included header row. In order to include header row,
 we need to turn off parallel unload. It is preferred to perform unload operation using all nodes so that it is
 faster for larger tables. So, parameter called `include_header` is added and default is set to False.
-Header row will be added only if this parameter is set True and also in that case parallel will be automatically turned off (`PARALLEL OFF`)  
+Header row will be added only if this parameter is set True and also in that case parallel will be automatically turned off (`PARALLEL OFF`)
 
 ### Google cloud connection string
 

--- a/airflow/operators/hive_to_mysql.py
+++ b/airflow/operators/hive_to_mysql.py
@@ -17,12 +17,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from tempfile import NamedTemporaryFile
+
 from airflow.hooks.hive_hooks import HiveServer2Hook
 from airflow.hooks.mysql_hook import MySqlHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
-
-from tempfile import NamedTemporaryFile
+from airflow.utils.operator_helpers import context_to_airflow_vars
 
 
 class HiveToMySqlTransfer(BaseOperator):
@@ -88,7 +89,8 @@ class HiveToMySqlTransfer(BaseOperator):
         if self.bulk_load:
             tmpfile = NamedTemporaryFile()
             hive.to_csv(self.sql, tmpfile.name, delimiter='\t',
-                        lineterminator='\n', output_header=False)
+                        lineterminator='\n', output_header=False,
+                        hive_conf=context_to_airflow_vars(context))
         else:
             results = hive.get_records(self.sql)
 

--- a/airflow/operators/hive_to_samba_operator.py
+++ b/airflow/operators/hive_to_samba_operator.py
@@ -23,6 +23,7 @@ from airflow.hooks.hive_hooks import HiveServer2Hook
 from airflow.hooks.samba_hook import SambaHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.operator_helpers import context_to_airflow_vars
 
 
 class Hive2SambaOperator(BaseOperator):
@@ -60,6 +61,7 @@ class Hive2SambaOperator(BaseOperator):
         hive = HiveServer2Hook(hiveserver2_conn_id=self.hiveserver2_conn_id)
         tmpfile = tempfile.NamedTemporaryFile()
         self.log.info("Fetching file from Hive")
-        hive.to_csv(hql=self.hql, csv_filepath=tmpfile.name)
+        hive.to_csv(hql=self.hql, csv_filepath=tmpfile.name,
+                    hive_conf=context_to_airflow_vars(context))
         self.log.info("Pushing to samba")
         samba.push_from_local(self.destination_filepath, tmpfile.name)

--- a/airflow/utils/operator_helpers.py
+++ b/airflow/utils/operator_helpers.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,32 +18,49 @@
 # under the License.
 #
 
+AIRFLOW_VAR_NAME_FORMAT_MAPPING = {
+    'AIRFLOW_CONTEXT_DAG_ID': {'default': 'airflow.ctx.dag_id',
+                               'env_var_format': 'AIRFLOW_CTX_DAG_ID'},
+    'AIRFLOW_CONTEXT_TASK_ID': {'default': 'airflow.ctx.task_id',
+                                'env_var_format': 'AIRFLOW_CTX_TASK_ID'},
+    'AIRFLOW_CONTEXT_EXECUTION_DATE': {'default': 'airflow.ctx.execution_date',
+                                       'env_var_format': 'AIRFLOW_CTX_EXECUTION_DATE'},
+    'AIRFLOW_CONTEXT_DAG_RUN_ID': {'default': 'airflow.ctx.dag_run_id',
+                                   'env_var_format': 'AIRFLOW_CTX_DAG_RUN_ID'}
+}
 
-def context_to_airflow_vars(context):
+
+def context_to_airflow_vars(context, in_env_var_format=False):
     """
     Given a context, this function provides a dictionary of values that can be used to
     externally reconstruct relations between dags, dag_runs, tasks and task_instances.
+    Default to abc.def.ghi format and can be made to ABC_DEF_GHI format if
+    in_env_var_format is set to True.
 
-    :param context: The context for the task_instance of interest
+    :param context: The context for the task_instance of interest.
     :type context: dict
+    :param in_env_var_format: If returned vars should be in ABC_DEF_GHI format.
+    :type in_env_var_format: bool
+    :return task_instance context as dict.
     """
-    params = {}
-    dag = context.get('dag')
-    if dag and dag.dag_id:
-        params['airflow.ctx.dag.dag_id'] = dag.dag_id
-
-    dag_run = context.get('dag_run')
-    if dag_run and dag_run.execution_date:
-        params['airflow.ctx.dag_run.execution_date'] = dag_run.execution_date.isoformat()
-
-    task = context.get('task')
-    if task and task.task_id:
-        params['airflow.ctx.task.task_id'] = task.task_id
-
+    params = dict()
+    if in_env_var_format:
+        name_format = 'env_var_format'
+    else:
+        name_format = 'default'
     task_instance = context.get('task_instance')
+    if task_instance and task_instance.dag_id:
+        params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_DAG_ID'][
+            name_format]] = task_instance.dag_id
+    if task_instance and task_instance.task_id:
+        params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_TASK_ID'][
+            name_format]] = task_instance.task_id
     if task_instance and task_instance.execution_date:
-        params['airflow.ctx.task_instance.execution_date'] = (
-            task_instance.execution_date.isoformat()
-        )
-
+        params[
+            AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_EXECUTION_DATE'][
+                name_format]] = task_instance.execution_date.isoformat()
+    dag_run = context.get('dag_run')
+    if dag_run and dag_run.run_id:
+        params[AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_DAG_RUN_ID'][
+            name_format]] = dag_run.run_id
     return params

--- a/tests/operators/bash_operator.py
+++ b/tests/operators/bash_operator.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import os
+import unittest
 from datetime import datetime, timedelta
 
 from airflow import DAG
@@ -59,7 +59,11 @@ class BashOperatorTestCase(unittest.TestCase):
                 task_id='echo_env_vars',
                 dag=self.dag,
                 bash_command='echo $AIRFLOW_HOME>> {0};'
-                             'echo $PYTHONPATH>> {0};'.format(fname)
+                             'echo $PYTHONPATH>> {0};'
+                             'echo $AIRFLOW_CTX_DAG_ID >> {0};'
+                             'echo $AIRFLOW_CTX_TASK_ID>> {0};'
+                             'echo $AIRFLOW_CTX_EXECUTION_DATE>> {0};'
+                             'echo $AIRFLOW_CTX_DAG_RUN_ID>> {0};'.format(fname)
             )
             os.environ['AIRFLOW_HOME'] = 'MY_PATH_TO_AIRFLOW_HOME'
             t.run(DEFAULT_DATE, DEFAULT_DATE,
@@ -70,3 +74,7 @@ class BashOperatorTestCase(unittest.TestCase):
                 self.assertIn('MY_PATH_TO_AIRFLOW_HOME', output)
                 # exported in run_unit_tests.sh as part of PYTHONPATH
                 self.assertIn('tests/test_utils', output)
+                self.assertIn('bash_op_test', output)
+                self.assertIn('echo_env_vars', output)
+                self.assertIn(DEFAULT_DATE.isoformat(), output)
+                self.assertIn('manual__' + DEFAULT_DATE.isoformat(), output)

--- a/tests/utils/test_operator_helpers.py
+++ b/tests/utils/test_operator_helpers.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,9 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from datetime import datetime
-import mock
 import unittest
+from datetime import datetime
+
+import mock
 
 from airflow.utils import operator_helpers
 
@@ -31,16 +32,18 @@ class TestOperatorHelpers(unittest.TestCase):
         self.dag_id = 'dag_id'
         self.task_id = 'task_id'
         self.execution_date = '2017-05-21T00:00:00'
+        self.dag_run_id = 'dag_run_id'
         self.context = {
-            'dag': mock.MagicMock(name='dag', dag_id=self.dag_id),
             'dag_run': mock.MagicMock(
                 name='dag_run',
+                run_id=self.dag_run_id,
                 execution_date=datetime.strptime(self.execution_date,
                                                  '%Y-%m-%dT%H:%M:%S'),
             ),
-            'task': mock.MagicMock(name='task', task_id=self.task_id),
             'task_instance': mock.MagicMock(
                 name='task_instance',
+                task_id=self.task_id,
+                dag_id=self.dag_id,
                 execution_date=datetime.strptime(self.execution_date,
                                                  '%Y-%m-%dT%H:%M:%S'),
             ),
@@ -53,10 +56,21 @@ class TestOperatorHelpers(unittest.TestCase):
         self.assertDictEqual(
             operator_helpers.context_to_airflow_vars(self.context),
             {
-                'airflow.ctx.dag.dag_id': self.dag_id,
-                'airflow.ctx.dag_run.execution_date': self.execution_date,
-                'airflow.ctx.task.task_id': self.task_id,
-                'airflow.ctx.task_instance.execution_date': self.execution_date,
+                'airflow.ctx.dag_id': self.dag_id,
+                'airflow.ctx.execution_date': self.execution_date,
+                'airflow.ctx.task_id': self.task_id,
+                'airflow.ctx.dag_run_id': self.dag_run_id,
+            }
+        )
+
+        self.assertDictEqual(
+            operator_helpers.context_to_airflow_vars(self.context,
+                                                     in_env_var_format=True),
+            {
+                'AIRFLOW_CTX_DAG_ID': self.dag_id,
+                'AIRFLOW_CTX_EXECUTION_DATE': self.execution_date,
+                'AIRFLOW_CTX_TASK_ID': self.task_id,
+                'AIRFLOW_CTX_DAG_RUN_ID': self.dag_run_id,
             }
         )
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2463) issues and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR is mainly to enable hive (e.g. through hive audit hook) to log task instance context( dag_id, task_id, dag_run_id and task instance execution_date) for hive queries. This would give users more audit and research power. For example:

- When data in one table was polluted, people can find out what tasks using the table need to rerun.
- Grouping hive queries by dag_id and task_id.
- Figure out whether the DAG run of the task instance is a manual run, scheduled run or backfill run.

This change will make task instance context available in the following cases:

- HiveServer2Hook() calls in Airflow official operators: as hive_conf
- HiveCliHook() and HiveServer2Hook() calls in PythonOperator: as hive_conf
- hive cli calls in BashOperator: as environment variable

The following cases are already covered without this change (with updated names):
- HiveCliHook() calls in HiveOperator(): as hive_conf

The following cases are not cover even with this change:
- beeline calls in BashOperator.

NOTE: 
If as environment variable, context would be available as `AIRFLOW_CTX_DAG_ID`, `AIRFLOW_CTX_TASK_ID`, `AIRFLOW_CTX_EXECUTION_DATE`, `AIRFLOW_CTX_DAG_RUN_ID`.
If as hvie_conf, as `airflow.ctx.dag_id`, `airflow.ctx.task_id`,  `airflow.ctx.execution_date`, `airflow.ctx.dag_run_id`. This is to follow the environment variable and hive conf naming convention.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
-- tests/operators/bash_operator.py
-- tests/operators/python_operator.py:PythonOperatorTest.test_echo_env_variables
-- tests/hooks/test_hive_hook.py: TestHiveCliHook.test_run_cli_with_hive_conf
-- tests/hooks/test_hive_hook.py: TestHiveServer2Hook. test_get_results_with_hive_conf

HiveServer2Hook uses impyla, which is compatible with at most thrift==0.9.3, but we are using thrift==0.11.0 in our CI. However we cannot just downgrade thrift because our new client package used in HiveCliHook, hmsclient, cannot work with thrift<=0.9.3. Thus the unit tests for HiveSever2Hook are removed and tested manually instead.

This logic has been running in Airbnb production for a week.

- Manually tested with test DAG file: https://gist.github.com/yrqls21/a89e37b82b5fc58a2e189d8ee23e61e4

`airflow test` output:
hive_cli task:
```
[2018-05-17 02:22:19,103] {hive_hooks.py:243} INFO - airflow.ctx.dag_id=kevin_hive_s2_test
[2018-05-17 02:22:19,105] {hive_hooks.py:243} INFO - airflow.ctx.dag_run_id=
[2018-05-17 02:22:19,106] {hive_hooks.py:243} INFO - airflow.ctx.task_id=hive_cli
[2018-05-17 02:22:19,106] {hive_hooks.py:243} INFO - airflow.ctx.execution_date=2018-05-10T00:00:00
```

beeline task:
```
[2018-05-17 02:22:50,442] {hive_hooks.py:243} INFO - 0: jdbc:hive2://i-0e2d3cb2c448a2300:10000/def> set airflow.ctx.dag_id;
[2018-05-17 02:22:50,512] {hive_hooks.py:243} INFO - +----------------------------------------+--+
[2018-05-17 02:22:50,512] {hive_hooks.py:243} INFO - |                  set                   |
[2018-05-17 02:22:50,513] {hive_hooks.py:243} INFO - +----------------------------------------+--+
[2018-05-17 02:22:50,513] {hive_hooks.py:243} INFO - | airflow.ctx.dag_id=kevin_hive_s2_test  |
[2018-05-17 02:22:50,513] {hive_hooks.py:243} INFO - +----------------------------------------+--+
[2018-05-17 02:22:50,513] {hive_hooks.py:243} INFO - 1 row selected (0.07 seconds)
[2018-05-17 02:22:50,514] {hive_hooks.py:243} INFO - 0: jdbc:hive2://i-0e2d3cb2c448a2300:10000/def> set airflow.ctx.dag_run_id;
[2018-05-17 02:22:50,516] {hive_hooks.py:243} INFO - +--------------------------+--+
[2018-05-17 02:22:50,516] {hive_hooks.py:243} INFO - |           set            |
[2018-05-17 02:22:50,517] {hive_hooks.py:243} INFO - +--------------------------+--+
[2018-05-17 02:22:50,517] {hive_hooks.py:243} INFO - | airflow.ctx.dag_run_id=  |
[2018-05-17 02:22:50,517] {hive_hooks.py:243} INFO - +--------------------------+--+
[2018-05-17 02:22:50,517] {hive_hooks.py:243} INFO - 1 row selected (0.002 seconds)
[2018-05-17 02:22:50,517] {hive_hooks.py:243} INFO - 0: jdbc:hive2://i-0e2d3cb2c448a2300:10000/def> set airflow.ctx.task_id;
[2018-05-17 02:22:50,520] {hive_hooks.py:243} INFO - +------------------------------+--+
[2018-05-17 02:22:50,520] {hive_hooks.py:243} INFO - |             set              |
[2018-05-17 02:22:50,521] {hive_hooks.py:243} INFO - +------------------------------+--+
[2018-05-17 02:22:50,521] {hive_hooks.py:243} INFO - | airflow.ctx.task_id=beeline  |
[2018-05-17 02:22:50,521] {hive_hooks.py:243} INFO - +------------------------------+--+
[2018-05-17 02:22:50,526] {hive_hooks.py:243} INFO - 1 row selected (0.009 seconds)
[2018-05-17 02:22:50,527] {hive_hooks.py:243} INFO - 0: jdbc:hive2://i-0e2d3cb2c448a2300:10000/def> set airflow.ctx.execution_date;
[2018-05-17 02:22:50,530] {hive_hooks.py:243} INFO - +-------------------------------------------------+--+
[2018-05-17 02:22:50,530] {hive_hooks.py:243} INFO - |                       set                       |
[2018-05-17 02:22:50,530] {hive_hooks.py:243} INFO - +-------------------------------------------------+--+
[2018-05-17 02:22:50,531] {hive_hooks.py:243} INFO - | airflow.ctx.execution_date=2018-05-10T00:00:00  |
[2018-05-17 02:22:50,531] {hive_hooks.py:243} INFO - +-------------------------------------------------+--+
[2018-05-17 02:22:50,531] {hive_hooks.py:243} INFO - 1 row selected (0.003 seconds)
```

hive_in_python_op task:
```
[2018-05-17 02:23:26,762] {python_operator.py:92} INFO - Exporting the following env vars:                                                                                     AIRFLOW_CTX_TASK_ID=hive_in_python_op
AIRFLOW_CTX_DAG_ID=kevin_hive_s2_test
AIRFLOW_CTX_EXECUTION_DATE=2018-05-10T00:00:00
[2018-05-15 08:17:28,011] {hive_hooks.py:246} INFO - AIRFLOW_CTX_DAG_ID=kevin_hive_s2_test
[2018-05-15 08:17:32,560] {hive_hooks.py:246} INFO - AIRFLOW_CTX_DAG_RUN_ID=
[2018-05-15 08:17:37,111] {hive_hooks.py:246} INFO - AIRFLOW_CTX_TASK_ID=hive_in_python_opp
[2018-05-15 08:17:41,725] {hive_hooks.py:246} INFO - AIRFLOW_CTX_EXECUTION_DATE=2018-05-10T00:00:00
OK
Time taken: 0.917 seconds
airflow.ctx.dag_id=kevin_hive_s2_test
OK
Time taken: 0.892 seconds
airflow.ctx.dag_run_id=
OK
Time taken: 0.869 seconds
airflow.ctx.task_id=hive_in_python_op
OK
Time taken: 0.895 seconds
airflow.ctx.execution_date=2018-05-10T00:00:00
```

echo_env_vars task:
```
[2018-05-17 02:25:53,249] {bash_operator.py:79} INFO - Exporting the following env vars:
AIRFLOW_CTX_TASK_ID=echo_env_vars
AIRFLOW_CTX_DAG_ID=kevin_hive_s2_test
AIRFLOW_CTX_EXECUTION_DATE=2018-05-10T00:00:00
[2018-05-17 02:25:53,259] {bash_operator.py:101} INFO - Output:
[2018-05-17 02:25:53,261] {bash_operator.py:105} INFO - kevin_hive_s2_test
[2018-05-17 02:25:53,261] {bash_operator.py:105} INFO - 2018-05-10T00:00:00
[2018-05-17 02:25:53,261] {bash_operator.py:105} INFO - echo_env_vars
[2018-05-17 02:25:53,261] {bash_operator.py:105} INFO -
[2018-05-17 02:25:53,261] {bash_operator.py:105} INFO - /home/kevin_yang/airflow
[2018-05-17 02:25:53,262] {bash_operator.py:108} INFO - Command exited with return code 0
```

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
