### PR TITLE
[AIRFLOW-2515] Add dependency on thrift_sasl to hive extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,7 @@ hive = [
     'hmsclient>=0.1.0',
     'pyhive>=0.1.3',
     'impyla>=0.13.3',
+    'thrift_sasl==0.2.1',
     'unicodecsv>=0.14.1'
 ]
 jdbc = ['jaydebeapi>=1.1.1']

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -30,7 +30,7 @@ from collections import OrderedDict
 from hmsclient import HMSClient
 
 from airflow.exceptions import AirflowException
-from airflow.hooks.hive_hooks import HiveCliHook, HiveMetastoreHook
+from airflow.hooks.hive_hooks import HiveCliHook, HiveMetastoreHook, HiveServer2Hook
 from airflow import DAG, configuration
 from airflow.operators.hive_operator import HiveOperator
 from airflow.utils import timezone
@@ -317,3 +317,9 @@ class TestHiveMetastoreHook(HiveEnvironmentTest):
         self.assertFalse(
             self.hook.table_exists(str(random.randint(1, 10000)))
         )
+
+
+class TestHiveServer2Hook(unittest.TestCase):
+    def test_get_conn(self):
+        hook = HiveServer2Hook()
+        hook.get_conn()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2515
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds a dependency on thrift_sasl to hive extra
so that HiveServer2Hook.get_conn() works.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

tests.hooks.test_hive_hook:TestHiveServer2Hook.test_get_conn

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
