### PR TITLE
Update the plugin docs for macros

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -146,6 +146,7 @@ definitions in Airflow.
         sensors = [PluginSensorOperator]
         hooks = [PluginHook]
         executors = [PluginExecutor]
+        # This can be accessed via {{ macros.test_plugin.plugin_macro }}
         macros = [plugin_macro]
         admin_views = [v]
         flask_blueprints = [bp]


### PR DESCRIPTION


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.
Documentation improvement

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

I was very confused how to use macros defined via plugins in my Jinja.
I couldn't find examples for it anywhere on the internet
So I added an example here

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Only a documentation change

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
