### PR TITLE
[AIRFLOW-2473] Fix wrong skip condition for TransferTests

### DIFF
--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -31,7 +31,8 @@ from hmsclient import HMSClient
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.hive_hooks import HiveCliHook, HiveMetastoreHook
-from airflow import DAG, configuration, operators
+from airflow import DAG, configuration
+from airflow.operators.hive_operator import HiveOperator
 from airflow.utils import timezone
 from airflow.utils.tests import assertEqualIgnoreMultipleSpaces
 
@@ -70,7 +71,7 @@ class HiveEnvironmentTest(unittest.TestCase):
         ADD PARTITION({{ params.partition_by }}='{{ ds }}');
         """
         self.hook = HiveMetastoreHook()
-        t = operators.hive_operator.HiveOperator(
+        t = HiveOperator(
             task_id='HiveHook_' + str(random.randint(1, 10000)),
             params={
                 'database': self.database,

--- a/tests/operators/operators.py
+++ b/tests/operators/operators.py
@@ -256,11 +256,8 @@ class PostgresTest(unittest.TestCase):
             assert 'database "foobar" does not exist' in str(e)
 
 
-@skipUnlessImported('airflow.operators.hive_operator', 'HiveOperator')
-@skipUnlessImported('airflow.operators.postgres_operator', 'PostgresOperator')
+@skipUnlessImported('airflow.operators.mysql_to_hive', 'MySqlToHiveTransfer')
 class TransferTests(unittest.TestCase):
-    cluster = None
-
     def setUp(self):
         configuration.load_test_config()
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2473
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR fixes wrong @skipUnlessImported which decorates
TransferTests and does minor refactoring.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's a fix for test itself.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
