### PR TITLE
[AIRFLOW-2238] Switch PR tool to push to Github

### DIFF
--- a/dev/airflow-pr
+++ b/dev/airflow-pr
@@ -65,8 +65,6 @@ AIRFLOW_GIT_LOCATION = os.environ.get(
 
 # Remote name which points to the Gihub site
 GITHUB_REMOTE_NAME = os.environ.get("GITHUB_REMOTE_NAME", "github")
-# Remote name which points to Apache git
-APACHE_REMOTE_NAME = os.environ.get("APACHE_REMOTE_NAME", "apache")
 # OAuth key used for issuing requests against the GitHub API. If this is not
 # defined, then requests will be unauthenticated. You should only need to
 # configure this if you find yourself regularly exceeding your IP's
@@ -175,7 +173,7 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc, local):
     pr_branch_name = "%s_MERGE_PR_%s" % (BRANCH_PREFIX, pr_num)
     target_branch_name = "%s_MERGE_PR_%s_%s" % (BRANCH_PREFIX, pr_num, target_ref.upper())
     run_cmd("git fetch %s pull/%s/head:%s" % (GITHUB_REMOTE_NAME, pr_num, pr_branch_name))
-    run_cmd("git fetch %s %s:%s" % (APACHE_REMOTE_NAME, target_ref, target_branch_name))
+    run_cmd("git fetch %s %s:%s" % (GITHUB_REMOTE_NAME, target_ref, target_branch_name))
     run_cmd("git checkout %s" % target_branch_name)
 
     had_conflicts = False
@@ -394,11 +392,11 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc, local):
             '\n\nThe local merge is complete ({}).\n'.format(
                 target_branch_name) +
             click.style(
-                'Push to Apache ({})?'.format(APACHE_REMOTE_NAME), 'red'))
+                'Push to Gitbox ({})?'.format(GITHUB_REMOTE_NAME), 'red'))
 
     try:
         run_cmd('git push %s %s:%s' % (
-            APACHE_REMOTE_NAME, target_branch_name, target_ref))
+            GITHUB_REMOTE_NAME, target_branch_name, target_ref))
     except Exception as e:
         clean_up()
         fail("Exception while pushing: %s" % e)
@@ -421,7 +419,7 @@ def cherry_pick(pr_num, merge_hash, default_branch):
         BRANCH_PREFIX, pr_num, pick_ref.upper())
 
     run_cmd("git fetch %s %s:%s" % (
-        APACHE_REMOTE_NAME, pick_ref, pick_branch_name))
+        GITHUB_REMOTE_NAME, pick_ref, pick_branch_name))
     run_cmd("git checkout %s" % pick_branch_name)
 
     try:
@@ -437,12 +435,12 @@ def cherry_pick(pr_num, merge_hash, default_branch):
         continue_maybe(msg)
 
     continue_maybe("Pick complete (local ref %s). Push to %s?" % (
-        pick_branch_name, APACHE_REMOTE_NAME))
+        pick_branch_name, GITHUB_REMOTE_NAME))
 
     try:
         run_cmd(
             'git push %s %s:%s' % (
-                APACHE_REMOTE_NAME, pick_branch_name, pick_ref))
+                GITHUB_REMOTE_NAME, pick_branch_name, pick_ref))
     except Exception as e:
         clean_up()
         fail("Exception while pushing: %s" % e)
@@ -809,9 +807,6 @@ def main(pr_num, local=False):
     - GITHUB_REMOTE_NAME
         GitHub remote name (defaults to "github")
 
-    - APACHE_REMOTE_NAME
-        Apache git remote name (defaults to "apache")
-
     - JIRA_USERNAME
         ASF JIRA username for automatically closing JIRA issues. Users will be
         prompted if it is not set.
@@ -936,11 +931,10 @@ def cli():
     This tool should be used by Airflow committers to test PRs, merge them
     into the master branch, and close related JIRA issues.
 
-    Before you begin, make sure you have created the 'apache' and 'github' git
-    remotes. You can use the "setup_git_remotes" command to do this
-    automatically. If you do not want to use these remote names, you can tell
-    the PR tool by setting the appropriate environment variables. For more
-    information, run:
+    Before you begin, make sure you have created the 'github' git remote. You
+    can use the "setup_git_remotes" command to do this automatically. If you do
+    not want to use these remote names, you can tell the PR tool by setting the
+    appropriate environment variable. For more information, run:
 
         airflow-pr merge --help
     """
@@ -961,11 +955,10 @@ def cli():
 def merge(pr_num):
     """
     Utility for creating well-formed pull request merges and pushing them
-    to Apache, as well as closing JIRA issues.
+    to Gitbox (a.k.a. GitHub), as well as closing JIRA issues.
 
     This tool assumes you already have a local Airflow git folder and that you
-    have added remotes corresponding to both (i) the github apache Airflow
-    mirror and (ii) the apache git repo.
+    have added remote corresponding to the github apache Airflow repo.
 
     To configure the tool, set the following env vars:
     - AIRFLOW_GIT
@@ -974,9 +967,6 @@ def merge(pr_num):
 
     - GITHUB_REMOTE_NAME
         GitHub remote name (defaults to "github")
-
-    - APACHE_REMOTE_NAME
-        Apache git remote name (defaults to "apache")
 
     - JIRA_USERNAME
         ASF JIRA username for automatically closing JIRA issues. Users will be
@@ -1020,11 +1010,9 @@ def setup_git_remotes():
     click.echo(reflow("""
         This command will create git remotes to mirror the following
         structure. If you do not want to use these names, you must set the
-        GITHUB_REMOTE_NAME and APACHE_REMOTE_NAME environment variables:
+        GITHUB_REMOTE_NAME environment variable:
 
           git remote -v
-          apache https://git-wip-us.apache.org/repos/asf/incubator-airflow.git (fetch)
-          apache https://git-wip-us.apache.org/repos/asf/incubator-airflow.git (push)
           github https://github.com/apache/incubator-airflow.git (fetch)
           github https://github.com/apache/incubator-airflow.git (push)
 
@@ -1033,14 +1021,6 @@ def setup_git_remotes():
     continue_maybe('Do you want to continue?')
 
     error = False
-    try:
-        run_cmd('git remote add apache '
-                'https://git-wip-us.apache.org/repos/asf/incubator-airflow.git')
-    except:
-        click.echo(click.style(reflow(
-            '>>ERROR: Could not create apache remote. If it already exists, '
-            'run `git remote remove apache` to delete it.', fg='red')))
-        error = True
     try:
         run_cmd('git remote add github https://github.com/apache/incubator-airflow.git')
     except:

--- a/dev/airflow-pr
+++ b/dev/airflow-pr
@@ -54,7 +54,8 @@ except ImportError:
 try:
     import keyring
 except ImportError:
-    print("Could not find the keyring library. Run 'sudo pip install keyring' to install.")
+    print("Could not find the keyring library. "
+          "Run 'sudo pip install keyring' to install.")
     sys.exit(-1)
 
 # Location of your Airflow git development area
@@ -66,10 +67,12 @@ AIRFLOW_GIT_LOCATION = os.environ.get(
 GITHUB_REMOTE_NAME = os.environ.get("GITHUB_REMOTE_NAME", "github")
 # Remote name which points to Apache git
 APACHE_REMOTE_NAME = os.environ.get("APACHE_REMOTE_NAME", "apache")
-# OAuth key used for issuing requests against the GitHub API. If this is not defined, then requests
-# will be unauthenticated. You should only need to configure this if you find yourself regularly
-# exceeding your IP's unauthenticated request rate limit. You can create an OAuth key at
-# https://github.com/settings/tokens. This tool only requires the "public_repo" scope.
+# OAuth key used for issuing requests against the GitHub API. If this is not
+# defined, then requests will be unauthenticated. You should only need to
+# configure this if you find yourself regularly exceeding your IP's
+# unauthenticated request rate limit. You can create an OAuth key at
+# https://github.com/settings/tokens. This tool only requires the "public_repo"
+# scope.
 GITHUB_OAUTH_KEY = os.environ.get("GITHUB_OAUTH_KEY")
 
 GITHUB_BASE = "https://github.com/apache/incubator-airflow/pull"
@@ -205,7 +208,8 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc, local):
     except Exception as e:
         msg = "Error merging: %s\nWould you like to manually fix-up this merge?" % e
         continue_maybe(msg)
-        msg = "Okay, please fix any conflicts and 'git add' conflicting files... Finished?"
+        msg = ("Okay, please fix any conflicts and 'git add' conflicting files... " +
+               "Finished?")
         continue_maybe(msg)
         had_conflicts = True
 
@@ -216,7 +220,6 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc, local):
     if pr_commits:
         all_text += ' '.join(c['commit']['message'] for c in pr_commits)
     all_jira_refs = standardize_jira_ref(all_text, only_jira=True)
-    all_jira_issues = re.findall("AIRFLOW-[0-9]{1,6}", all_jira_refs)
 
     merge_message_flags = []
 
@@ -315,7 +318,6 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc, local):
         if primary_author == "":
             primary_author = distinct_authors[0]
 
-        authors = "\n".join(["Author: %s" % a for a in distinct_authors])
         merge_message_flags.append(u'--author="{}"'.format(primary_author))
 
     else:
@@ -327,7 +329,7 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc, local):
     # reflow commit message
     seen_first_line = False
     for i in range(1, len(merge_message_flags)):
-        if merge_message_flags[i-1] == '-m':
+        if merge_message_flags[i - 1] == '-m':
             # let the first line be as long as the user wants
             if not seen_first_line:
                 if '\n\n' in merge_message_flags[i]:
@@ -376,7 +378,7 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc, local):
             run_cmd(['git', 'commit'] + commit_flags, echo_cmd=False)
 
     if local:
-        msg ='\n' + reflow("""
+        msg = '\n' + reflow("""
             The PR has been merged locally in branch {}.
             You may leave this program running while you work on it. When
             you are finished, press any key to delete the PR branch and
@@ -390,8 +392,8 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc, local):
     else:
         continue_maybe(
             '\n\nThe local merge is complete ({}).\n'.format(
-                target_branch_name)
-            + click.style(
+                target_branch_name) +
+            click.style(
                 'Push to Apache ({})?'.format(APACHE_REMOTE_NAME), 'red'))
 
     try:
@@ -459,7 +461,7 @@ def fix_version_from_branch(branch, versions):
     if branch == "master":
         return versions[0]
     else:
-        #TODO adopt a release scheme with branches. Spark uses branch-XX.
+        # TODO adopt a release scheme with branches. Spark uses branch-XX.
         branch_ver = branch.replace("branch-", "")
         versions = list(filter(
             lambda x: x.name.startswith(branch_ver), versions))
@@ -692,18 +694,19 @@ def resolve_jira_issue(comment=None, jira_id=None, merge_branches=None):
         action["id"],
         fixVersions=jira_fix_versions,
         comment=comment or None,
-        resolution = {'id': resolution.raw['id']})
+        resolution={'id': resolution.raw['id']})
 
     click.echo("Successfully resolved {id}{fv}!".format(
         id=jira_id,
         fv=' with fix versions={}'.format(fix_versions) if fix_versions else ''
-        ))
+    ))
 
 
 def standardize_jira_ref(text, only_jira=False):
     """
     Standardize the [AIRFLOW-XXXXX] [MODULE] prefix
-    Converts "[AIRFLOW-XXX][mllib] Issue", "[MLLib] AIRFLOW-XXX. Issue" or "AIRFLOW XXX [MLLIB]: Issue" to "[AIRFLOW-XXX][MLLIB] Issue"
+    Converts "[AIRFLOW-XXX][mllib] Issue", "[MLLib] AIRFLOW-XXX. Issue" or
+    "AIRFLOW XXX [MLLIB]: Issue" to "[AIRFLOW-XXX][MLLIB] Issue"
 
     >>> standardize_jira_ref("[AIRFLOW-5821] [SQL] ParquetRelation2 CTAS should check if delete is successful")
     '[AIRFLOW-5821][SQL] ParquetRelation2 CTAS should check if delete is successful'
@@ -725,7 +728,7 @@ def standardize_jira_ref(text, only_jira=False):
     'Additional information for users building from source code'
     >>> standardize_jira_ref('AIRFLOW 35 AIRFLOW--36 AIRFLOW  37 test', only_jira=True)
     '[AIRFLOW-35][AIRFLOW-36][AIRFLOW-37]'
-    """
+    """  # noqa
     jira_refs = []
     components = []
 
@@ -770,8 +773,8 @@ def standardize_jira_ref(text, only_jira=False):
     # Assemble full text (JIRA ref(s), module(s), remaining text)
     clean_text = ''.join(unique(jira_refs)).strip()
     if not only_jira:
-         clean_text += (
-             ''.join(unique(components)).strip() + " " + text.strip())
+        clean_text += (
+            ''.join(unique(components)).strip() + " " + text.strip())
 
     # Replace multiple spaces with a single space, e.g. if no jira refs
     # and/or components were included
@@ -847,7 +850,6 @@ def main(pr_num, local=False):
         click.echo('Working with pull request {}'.format(pr_num))
 
     pr = get_json("{}/pulls/{}".format(GITHUB_API_BASE, pr_num))
-    pr_events = get_json("{}/issues/{}/events".format(GITHUB_API_BASE, pr_num))
 
     url = pr["url"]
 
@@ -874,33 +876,6 @@ def main(pr_num, local=False):
     user_login = pr["user"]["login"]
     base_ref = pr["head"]["ref"]
     pr_repo_desc = "%s/%s" % (user_login, base_ref)
-
-    # Merged pull requests are either closed or merged by asfgit
-    merge_commits = [
-        e for e in pr_events
-        if e["actor"]["login"] == GITHUB_USER and
-        (e["event"] == "closed" or e["event"] == "merged")]
-
-    if merge_commits and False:
-        merge_hash = merge_commits[0]["commit_id"]
-        message = get_json(
-            "%s/commits/%s" % (GITHUB_API_BASE, merge_hash)
-            )["commit"]["message"]
-
-        continue_maybe(
-            "Pull request %s has already been merged. "
-            "Do you want to backport?" % pr_num)
-        commit_is_downloaded = run_cmd(
-            ['git', 'rev-parse', '--quiet', '--verify',
-             "%s^{commit}" % merge_hash]) != ""
-        if not commit_is_downloaded:
-            fail(
-                "Couldn't find any merge commit for #%s, "
-                "you may need to update HEAD." % pr_num)
-
-        click.echo("Found commit %s:\n%s" % (merge_hash, message))
-        cherry_pick(pr_num, merge_hash, latest_branch)
-        sys.exit(0)
 
     if not bool(pr["mergeable"]):
         msg = ('Pull request {} is not mergeable in its current form.\n'
@@ -1059,7 +1034,8 @@ def setup_git_remotes():
 
     error = False
     try:
-        run_cmd('git remote add apache https://git-wip-us.apache.org/repos/asf/incubator-airflow.git')
+        run_cmd('git remote add apache '
+                'https://git-wip-us.apache.org/repos/asf/incubator-airflow.git')
     except:
         click.echo(click.style(reflow(
             '>>ERROR: Could not create apache remote. If it already exists, '
@@ -1072,7 +1048,8 @@ def setup_git_remotes():
             '>>ERROR: Could not create github remote. If it already exists, '
             'run `git remote remove github` to delete it.', fg='red')))
         error = True
-    click.echo('Done setting up git remotes. Run git remote -v to see them.')
+    if not error:
+        click.echo('Done setting up git remotes. Run git remote -v to see them.')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
    - https://issues.apache.org/jira/browse/AIRFLOW-2238

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

    Prepare for the migration to commit directly to github - the PR tool only needs to know about github now. Tested in squash mode https://github.com/ashb/incubator-airflow/commit/437f95112060c6f23f8f8520a9e2341390407e11 here and non-squash https://github.com/ashb/incubator-airflow/commit/437f95112060c6f23f8f8520a9e2341390407e11

    I also removed dead code and fixed the file to not have any PEP8 warnings.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

    No unit tests, but did test as well as possible against my own fork.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
