### PR TITLE
[AIRFLOW-2520] CLI - make backfill less verbose

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -198,7 +198,9 @@ def backfill(args, dag=None):
             ignore_first_depends_on_past=args.ignore_first_depends_on_past,
             ignore_task_deps=args.ignore_dependencies,
             pool=args.pool,
-            delay_on_limit_secs=args.delay_on_limit)
+            delay_on_limit_secs=args.delay_on_limit,
+            verbose=args.verbose,
+        )
 
 
 @cli_utils.action_logging
@@ -1322,6 +1324,9 @@ class CLIFactory(object):
         'mark_success': Arg(
             ("-m", "--mark_success"),
             "Mark jobs as succeeded without running them", "store_true"),
+        'verbose': Arg(
+            ("-v", "--verbose"),
+            "Make logging output more verbose", "store_true"),
         'local': Arg(
             ("-l", "--local"),
             "Run the task using the LocalExecutor", "store_true"),
@@ -1673,7 +1678,8 @@ class CLIFactory(object):
                 'dag_id', 'task_regex', 'start_date', 'end_date',
                 'mark_success', 'local', 'donot_pickle',
                 'bf_ignore_dependencies', 'bf_ignore_first_depends_on_past',
-                'subdir', 'pool', 'delay_on_limit', 'dry_run')
+                'subdir', 'pool', 'delay_on_limit', 'dry_run', 'verbose',
+            )
         }, {
             'func': list_tasks,
             'help': "List the tasks within a DAG",

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1952,6 +1952,7 @@ class BackfillJob(BaseJob):
             ignore_task_deps=False,
             pool=None,
             delay_on_limit_secs=1.0,
+            verbose=False,
             *args, **kwargs):
         self.dag = dag
         self.dag_id = dag.dag_id
@@ -1963,6 +1964,7 @@ class BackfillJob(BaseJob):
         self.ignore_task_deps = ignore_task_deps
         self.pool = pool
         self.delay_on_limit_secs = delay_on_limit_secs
+        self.verbose = verbose
         super(BackfillJob, self).__init__(*args, **kwargs)
 
     def _update_counters(self, ti_status):
@@ -2257,7 +2259,7 @@ class BackfillJob(BaseJob):
                     if ti.are_dependencies_met(
                             dep_context=backfill_context,
                             session=session,
-                            verbose=True):
+                            verbose=self.verbose):
                         ti.refresh_from_db(lock_for_update=True, session=session)
                         if ti.state == State.SCHEDULED or ti.state == State.UP_FOR_RETRY:
                             if executor.has_task(ti):
@@ -2364,11 +2366,11 @@ class BackfillJob(BaseJob):
                 t.are_dependencies_met(
                     dep_context=DepContext(ignore_depends_on_past=False),
                     session=session,
-                    verbose=True) !=
+                    verbose=self.verbose) !=
                 t.are_dependencies_met(
                     dep_context=DepContext(ignore_depends_on_past=True),
                     session=session,
-                    verbose=True)
+                    verbose=self.verbose)
                 for t in ti_status.deadlocked)
             if deadlocked_depends_on_past:
                 err += (


### PR DESCRIPTION
### JIRA
[AIRFLOW-2520]

### Description
Used backfill recently and it would log a shit ton of logging messages
telling me all the tasks that were not ready to run at every tick.

These messages are not useful and should be muted by default.

I understand that this may be helpful in the context of `airflow run`
in the context where dependencies aren't met, so decided to manage
a flag instead of simply going `logging.debug` on it.

Make sure you have checked _all_ steps below.


### Documentation
- should be autogenerated for CLI


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
