### PR TITLE
[AIRFLOW-2462] Change PasswordUser pasword setter to correct syntax

### DIFF
--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -63,7 +63,7 @@ class PasswordUser(models.User):
         return self._password
 
     @password.setter
-    def _set_password(self, plaintext):
+    def password(self, plaintext):
         self._password = generate_password_hash(plaintext, 12)
         if PY3:
             self._password = str(self._password, 'utf-8')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2462


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Fixed incorrect sqlalchemy setter syntax in the PasswordUser password setter

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
