### PR TITLE
[AIRFLOW-2525] Fix PostgresHook.copy_expert to work with "COPY FROM"

### DIFF
--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -64,10 +64,11 @@ class PostgresHook(DbApiHook):
         Executes SQL using psycopg2 copy_expert method
         Necessary to execute COPY command without access to a superuser
         """
-        f = open(filename, 'w')
-        with closing(self.get_conn()) as conn:
-            with closing(conn.cursor()) as cur:
-                cur.copy_expert(sql, f)
+        with open(filename, 'w+') as f:
+            with closing(self.get_conn()) as conn:
+                with closing(conn.cursor()) as cur:
+                    cur.copy_expert(sql, f)
+                    conn.commit()
 
     @staticmethod
     def _serialize_cell(cell, conn):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2525
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

For now PostgresHook.copy_expert supports
"COPY TO" but not "COPY FROM", because it
opens a file with write mode and doesn't
commit operations. This PR fixes it by
opening a file with read and write mode
and committing operations at last.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Fixed tests.hooks.test_postgres_hook:TestPostgresHook.test_copy_expert to confirm that the open() function is called with read and write mode and operations are committed at last.
In addition, I confirmed that the fixed version worked with both COPY FROM and COPY TO with PostgreSQL 9.5.12.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
