### PR TITLE
[AIRFLOW-2525] Fix a bug introduced by commit dabf1b9

### DIFF
--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import os
 import psycopg2
 import psycopg2.extensions
 from contextlib import closing
@@ -61,13 +62,24 @@ class PostgresHook(DbApiHook):
 
     def copy_expert(self, sql, filename, open=open):
         """
-        Executes SQL using psycopg2 copy_expert method
-        Necessary to execute COPY command without access to a superuser
+        Executes SQL using psycopg2 copy_expert method.
+        Necessary to execute COPY command without access to a superuser.
+
+        Note: if this method is called with a "COPY FROM" statement and
+        the specified input file does not exist, it creates an empty
+        file and no data is loaded, but the operation succeeds.
+        So if users want to be aware when the input file does not exist,
+        they have to check its existence by themselves.
         """
-        with open(filename, 'w+') as f:
+        if not os.path.isfile(filename):
+            with open(filename, 'w'):
+                pass
+
+        with open(filename, 'r+') as f:
             with closing(self.get_conn()) as conn:
                 with closing(conn.cursor()) as cur:
                     cur.copy_expert(sql, f)
+                    f.truncate(f.tell())
                     conn.commit()
 
     @staticmethod

--- a/tests/hooks/test_postgres_hook.py
+++ b/tests/hooks/test_postgres_hook.py
@@ -55,4 +55,4 @@ class TestPostgresHook(unittest.TestCase):
             self.cur.close.assert_called_once()
             self.conn.commit.assert_called_once()
             self.cur.copy_expert.assert_called_once_with(statement, m.return_value)
-            m.assert_called_once_with(filename, "w+")
+            self.assertEqual(m.call_args[0], (filename, "r+"))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2525
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

The previous commit on this issue (#3421)
introduced a new bug on COPY FROM operation.
This PR fixes it by adding a new parameter
to PostgresHook.copy_expert for specifying
file opening mode, instead of using
read and write file opening mode.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- Fixed tests.hooks.test_postgres_hook:TestPostgresHook.test_copy_expert in accordance with PostgresHook.copy_expert's change.
- Tested with PostgreSQL 9.5.12 as follows:


Initial state:

```
airflow=# SELECT * FROM t;
  c  
-----
 foo
 bar
 baz
(3 rows)
```

run COPY TO:

```
In [1]: from airflow.hooks.postgres_hook import PostgresHook
/home/sekikn/a3/lib/python3.5/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)

In [2]: h = PostgresHook()

In [3]: h.copy_expert("COPY t TO STDOUT", "/tmp/t")
[2018-05-26 10:14:54,078] {base_hook.py:83} INFO - Using connection to: localhost
```

dumped correctly:

```
$ cat /tmp/t
foo
bar
baz
```

the opposite operation:

```
In [4]: h.copy_expert("COPY t FROM STDIN", "/tmp/t", mode="r")
[2018-05-26 10:15:23,329] {base_hook.py:83} INFO - Using connection to: localhost
```

loaded successfully:

```
airflow=# SELECT * FROM t;
  c  
-----
 foo
 bar
 baz
 foo
 bar
 baz
(6 rows)
```

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
