### PR TITLE
[AIRFLOW-2530] KubernetesOperator supports multiple clusters

### DIFF
--- a/airflow/contrib/kubernetes/kube_client.py
+++ b/airflow/contrib/kubernetes/kube_client.py
@@ -17,16 +17,20 @@
 from airflow.configuration import conf
 
 
-def _load_kube_config(in_cluster):
+def _load_kube_config(in_cluster, cluster_context):
     from kubernetes import config, client
     if in_cluster:
         config.load_incluster_config()
         return client.CoreV1Api()
     else:
-        config.load_kube_config()
-        return client.CoreV1Api()
+        if cluster_context is None:
+            config.load_kube_config()
+            return client.CoreV1Api()
+        else:
+            return client.CoreV1Api(
+                api_client=config.new_client_from_config(context=cluster_context))
 
 
-def get_kube_client(in_cluster=conf.getboolean('kubernetes', 'in_cluster')):
-    # TODO: This should also allow people to point to a cluster.
-    return _load_kube_config(in_cluster)
+def get_kube_client(in_cluster=conf.getboolean('kubernetes', 'in_cluster'),
+                    cluster_context=None):
+    return _load_kube_config(in_cluster, cluster_context)

--- a/airflow/contrib/kubernetes/pod_launcher.py
+++ b/airflow/contrib/kubernetes/pod_launcher.py
@@ -37,9 +37,10 @@ class PodStatus(object):
 
 
 class PodLauncher(LoggingMixin):
-    def __init__(self, kube_client=None, in_cluster=True):
+    def __init__(self, kube_client=None, in_cluster=True, cluster_context=None):
         super(PodLauncher, self).__init__()
-        self._client = kube_client or get_kube_client(in_cluster=in_cluster)
+        self._client = kube_client or get_kube_client(in_cluster=in_cluster,
+                                                      cluster_context=cluster_context)
         self._watch = watch.Watch()
         self.kube_req_factory = pod_fac.SimplePodRequestFactory()
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2530


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Now, kubernetesOperator supports only in-cluster or current context. It's useful to support multiple clusters with specifying the kubernetes context.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
It's hard to prepare multiple kubernetes clusters...

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
