### PR TITLE
[AIRFLOW-1656] Tree view dags query changed

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3622,7 +3622,8 @@ class DAG(BaseDag, LoggingMixin):
         TI = TaskInstance
         if not start_date:
             start_date = (timezone.utcnow() - timedelta(30)).date()
-            start_date = datetime.combine(start_date, datetime.min.time())
+            start_date = timezone.make_aware(
+                datetime.combine(start_date, datetime.min.time()))
         end_date = end_date or timezone.utcnow()
         tis = session.query(TI).filter(
             TI.dag_id == self.dag_id,

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -976,26 +976,22 @@ class Airflow(AirflowBaseView):
         else:
             base_date = dag.latest_execution_date or timezone.utcnow()
 
-        dates = dag.date_range(base_date, num=-abs(num_runs))
-        min_date = dates[0] if dates else timezone.utc_epoch()
-
         DR = models.DagRun
         dag_runs = (
             session.query(DR)
-                   .filter(DR.dag_id == dag.dag_id, # noqa
-                           DR.execution_date <= base_date,
-                           DR.execution_date >= min_date)
-                   .all() # noqa
+            .filter(
+                DR.dag_id == dag.dag_id,
+                DR.execution_date <= base_date)
+            .order_by(DR.execution_date.desc())
+            .limit(num_runs)
+            .all()
         )
         dag_runs = {
             dr.execution_date: alchemy_to_dict(dr) for dr in dag_runs}
 
         dates = sorted(list(dag_runs.keys()))
-        # Only show the desired number of runs regardless of the trigger method
-        if len(dates) > num_runs:
-            dates = dates[-num_runs:]
-
         max_date = max(dates) if dates else None
+        min_date = min(dates) if dates else None
 
         tis = dag.get_task_instances(
             session, start_date=min_date, end_date=base_date)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1656


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Base date and number of runs could not be set, tree view was unusable for None schedule dags (externally triggered). Loading of that page lasted too long when there are many dag runs. This is fixed in this PR.

before:
![tree_view_old](https://user-images.githubusercontent.com/16780459/40621628-e9eab4e6-629d-11e8-8887-4a05c6e8872e.png)
after:
![tree_view_new](https://user-images.githubusercontent.com/16780459/40621636-ef74f408-629d-11e8-9832-f3c1dc4bbb7b.png)


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No unit tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
