### PR TITLE
[AIRFLOW-2532] Support logs_volume_subpath for KubernetesExecutor

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -550,6 +550,9 @@ dags_volume_subpath =
 # For DAGs mounted via a volume claim (mutually exclusive with volume claim)
 dags_volume_claim =
 
+# For volume mounted logs, the worker will look in this subpath for logs
+logs_volume_subpath =
+
 # A shared volume claim for the logs
 logs_volume_claim =
 

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -133,6 +133,11 @@ class KubeConfig:
         self.dags_volume_subpath = conf.get(
             self.kubernetes_section, 'dags_volume_subpath')
 
+        # This prop may optionally be set for PV Claims and is used to locate logs
+        # on a SubPath
+        self.logs_volume_subpath = conf.get(
+            self.kubernetes_section, 'logs_volume_subpath')
+
         # This prop may optionally be set for PV Claims and is used to write logs
         self.base_log_folder = configuration.get(self.core_section, 'base_log_folder')
 

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -128,7 +128,8 @@ class WorkerConfiguration(LoggingMixin):
             ),
             _construct_volume(
                 logs_volume_name,
-                self.kube_config.logs_volume_claim
+                self.kube_config.logs_volume_claim,
+                self.kube_config.logs_volume_subpath
             )
         ]
         volume_mounts = [{

--- a/scripts/ci/kubernetes/kube/configmaps.yaml
+++ b/scripts/ci/kubernetes/kube/configmaps.yaml
@@ -185,7 +185,9 @@ data:
     git_user =
     git_password =
     dags_volume_claim = airflow-dags
+    dags_volume_subpath =
     logs_volume_claim = airflow-logs
+    logs_volume_subpath =
     in_cluster = True
     namespace = default
     gcp_service_account_keys =


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
    - https://issues.apache.org/jira/browse/AIRFLOW-2532


### Description
- [x] Here are some details about my PR:
The kubernetes section in the configuration file supports
logs_volume_subpath for KubernetesExecutor.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Just add a parameter, no need for tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

