### PR TITLE
[DoNOTMerge][AIRFLOW-2537] prevent 'clear' to set backfill DAGRuns as running

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3671,12 +3671,15 @@ class DAG(BaseDag, LoggingMixin):
 
     @provide_session
     def set_dag_runs_state(
-            self, state=State.RUNNING, session=None):
+            self, state=State.RUNNING, session=None,
+            include_backfill_dagruns=False,
+    ):
         drs = session.query(DagModel).filter_by(dag_id=self.dag_id).all()
         dirty_ids = []
         for dr in drs:
-            dr.state = state
-            dirty_ids.append(dr.dag_id)
+            if include_backfill_dagruns or dr.is_backfill:
+                dr.state = state
+                dirty_ids.append(dr.dag_id)
         DagStat.update(dirty_ids, session=session)
 
     @provide_session


### PR DESCRIPTION
When issuing a 'clear' CLI command or through the UI, it should not
affect the state of backfill-related DAG runs

https://issues.apache.org/jira/browse/AIRFLOW-2537