### PR TITLE
[AIRFLOW-2542] Renaming Renaming AWS Batch Operator property, queue to job_queue

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -35,6 +35,7 @@ Run `airflow webserver` to start the new UI. This will bring up a log in page, e
 There are five roles created for Airflow by default: Admin, User, Op, Viewer, and Public. To configure roles/permissions, go to the `Security` tab and click `List Roles` in the new UI.
 
 #### Breaking changes
+- AWS Batch Operator renamed property queue to job_queue to prevent conflict with the internal queue from CeleryExecutor - AIRFLOW-2542
 - Users created and stored in the old users table will not be migrated automatically. FAB's built-in authentication support must be reconfigured.
 - Airflow dag home page is now `/home` (instead of `/admin`).
 - All ModelViews in Flask-AppBuilder follow a different pattern from Flask-Admin. The `/admin` part of the url path will no longer exist. For example: `/admin/connection` becomes `/connection/list`, `/admin/connection/new` becomes `/connection/add`, `/admin/connection/edit` becomes `/connection/edit`, etc.

--- a/tests/contrib/operators/test_awsbatch_operator.py
+++ b/tests/contrib/operators/test_awsbatch_operator.py
@@ -50,7 +50,7 @@ class TestAWSBatchOperator(unittest.TestCase):
         self.batch = AWSBatchOperator(
             task_id='task',
             job_name='51455483-c62c-48ac-9b88-53a6a725baa3',
-            queue='queue',
+            job_queue='queue',
             job_definition='hello-world',
             max_retries=5,
             overrides={},
@@ -60,7 +60,7 @@ class TestAWSBatchOperator(unittest.TestCase):
     def test_init(self):
 
         self.assertEqual(self.batch.job_name, '51455483-c62c-48ac-9b88-53a6a725baa3')
-        self.assertEqual(self.batch.queue, 'queue')
+        self.assertEqual(self.batch.job_queue, 'queue')
         self.assertEqual(self.batch.job_definition, 'hello-world')
         self.assertEqual(self.batch.max_retries, 5)
         self.assertEqual(self.batch.overrides, {})


### PR DESCRIPTION
### JIRA
- [] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2542) issues and references them in the PR title.
    - When using the AWS Batch operator property "queue" today it's forcing the CeleryExecutor queue to also be named as the same.
    - Solution changing the parameters to allow default queue on CeleryExecutor and give flexibility.

### Description
- Renaming AWS Batch Operator property, queue to job_queue to remove CeleryExecutor conflict
- Fixed the infinite loop waiter
- Reduced the waiter exponential backoff to milliseconds
### Tests
- [x] Same as from [AIRFLOW-1790], with renamed properties

### Commits
- Renaming AWS Batch Operator property, queue to job_queue to remove CeleryExecutor conflict
- Fixed the infinite loop waiter
- Reduced the waiter exponential backoff to milliseconds

### Release Note
- Changed property queue to job_queue to remove CeleryExecutor queue conflict
- Fixed infinite loop on waiter
- Reduced the waiter exponential backoff to milliseconds

### Documentation
- Added warning for users about the change property from queue to job_queue.

### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
