### PR TITLE
[AIRFLOW-1840] and [AIRFLOW-2495] increment celery to >4.1.0 (current release is 4.1.1)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ async = [
 azure = ['azure-storage>=0.34.0']
 sendgrid = ['sendgrid>=5.2.0']
 celery = [
-    'celery>=4.0.2',
+    'celery>4.1.0, <4.2',
     'flower>=0.7.3'
 ]
 cgroups = [


### PR DESCRIPTION
…tay under 4.2.0 until that and/or 5.0 is tested.

[AIRFLOW-1840]
https://github.com/apache/incubator-airflow/pull/2806
also related to https://github.com/apache/incubator-airflow/pull/3388
[AIRFLOW-2495]

Make sure you have checked _all_ steps below.

### JIRA
- [ X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
incrementing celery to >4.1.0 (current release is 4.1.1) but making it stay under 4.2.0 until that and/or 5.0 is tested.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
