### PR TITLE
[AIRFLOW-2544] Guard against next major release of Celery, Flower

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,8 +116,8 @@ azure_data_lake = [
 ]
 cassandra = ['cassandra-driver>=3.13.0']
 celery = [
-    'celery>=4.1.1',
-    'flower>=0.7.3'
+    'celery>=4.1.1, <4.2.0',
+    'flower>=0.7.3, <1.0'
 ]
 cgroups = [
     'cgroupspy>=0.1.4',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2544


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR proactively guards against the next major version of Celery (4.2) from being installed automatically until it's been tested.  It is currently in RC but not yet officially released.  I've also added an upper bound on Flower 1.0 similarly.

Related to https://issues.apache.org/jira/browse/AIRFLOW-1967, and created from discussion in https://github.com/apache/incubator-airflow/pull/2806.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

n/a - just a dependency version guard

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

n/a

### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
