### PR TITLE
[AIRFLOW-2546] Set logging level correctly to avoid no section error

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -459,7 +459,7 @@ def run(args, dag=None):
                 try:
                     conf.set(section, option, value)
                 except NoSectionError:
-                    log.error('Section {section} Option {option} '
+                    log.debug('Section {section} Option {option} '
                               'does not exist in the config!'.format(section=section,
                                                                      option=option))
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2546
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
The following log is flooded in the cli when running backfill:
```
[2018-05-31 00:37:22,376] {cli.py:454} ERROR - Section kubernetes Option git_sync_container_tag does not exist in the config!
[2018-05-31 00:37:22,376] {cli.py:454} ERROR - Section kubernetes Option git_sync_init_container_name does not exist in the config!
[2018-05-31 00:37:22,377] {cli.py:454} ERROR - Section kubernetes Option worker_service_account_name does not exist in the config!
[2018-05-31 00:37:22,377] {cli.py:454} ERROR - Section kubernetes Option image_pull_secrets does not exist in the config!
[2018-05-31 00:37:22,377] {cli.py:454} ERROR - Section kubernetes Option gcp_service_account_keys does not exist in the config!
[2018-05-31 00:37:22,377] {cli.py:454} ERROR - Section kubernetes Option in_cluster does not exist in the config!
```
Set the logging level correctly to avoid this error. To clarify, this error is fine and non-blocking for running backfill. It just indicates user airflow.cfg doesn't include those specific configs.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
