### PR TITLE
[AIRFLOW-2500] Fix MySqlToHiveTransfer to transfer unsigned type properly

### DIFF
--- a/airflow/operators/mysql_to_hive.py
+++ b/airflow/operators/mysql_to_hive.py
@@ -104,9 +104,10 @@ class MySqlToHiveTransfer(BaseOperator):
             t.DOUBLE: 'DOUBLE',
             t.FLOAT: 'DOUBLE',
             t.INT24: 'INT',
-            t.LONG: 'INT',
-            t.LONGLONG: 'BIGINT',
+            t.LONG: 'BIGINT',
+            t.LONGLONG: 'DECIMAL(38,0)',
             t.SHORT: 'INT',
+            t.TINY: 'SMALLINT',
             t.YEAR: 'INT',
         }
         return d[mysql_type] if mysql_type in d else 'STRING'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2500
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

MySQL supports unsigned data types, but Hive doesn't.
So if MySqlToHiveTransfer maps MySQL's data types to
Hive's corresponding ones directly (e.g. INT -> INT),
unsigned values over signed type's upper bound
transferred from MySQL are interpreted as invalid
by Hive, and users get NULL.
To avoid it, this PR fixes MySqlToHiveTransfer
to map MySQL data types to Hive's wider ones
(e.g. SMALLINT -> INT, INT -> BIGINT, etc.).


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- tests.operators.operators.TransferTests.test_mysql_to_hive_type_conversion
- tests.operators.operators.TransferTests.test_mysql_to_hive_verify_loaded_values


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
