### PR TITLE
[AIRFLOW-2549] Fix DataProcOperation error-check

### DIFF
--- a/tests/contrib/hooks/test_gcp_dataproc_hook.py
+++ b/tests/contrib/hooks/test_gcp_dataproc_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,7 +19,7 @@
 #
 
 import unittest
-from airflow.contrib.hooks.gcp_dataproc_hook import DataProcHook
+from airflow.contrib.hooks.gcp_dataproc_hook import DataProcHook, _DataProcOperation
 
 try:
     from unittest import mock
@@ -48,6 +48,98 @@ class DataProcHookTest(unittest.TestCase):
 
     @mock.patch(DATAPROC_STRING.format('_DataProcJob'))
     def test_submit(self, job_mock):
-      with mock.patch(DATAPROC_STRING.format('DataProcHook.get_conn', return_value=None)):
-        self.dataproc_hook.submit(PROJECT_ID, JOB)
-        job_mock.assert_called_once_with(mock.ANY, PROJECT_ID, JOB, REGION)
+        with mock.patch(DATAPROC_STRING.format('DataProcHook.get_conn',
+                                               return_value=None)):
+            self.dataproc_hook.submit(PROJECT_ID, JOB)
+            job_mock.assert_called_once_with(mock.ANY, PROJECT_ID, JOB, REGION)
+
+    def test_successful_operation_detector(self):
+        operation_api_response = \
+            {
+                "done": True,
+                "metadata": {
+                    "@type": "type.googleapis.com/google.cloud.dataproc.v1beta2."
+                             "WorkflowMetadata",
+                    "clusterName": "fake-dataproc-cluster",
+                    "createCluster": {
+                        "done": True,
+                        "operationId": "projects/my-project/regions/us-central1/"
+                                       "operations/1111111-0000-aaaa-bbbb-ffffffffffff"
+                    },
+                    "deleteCluster": {
+                        "done": True,
+                        "operationId": "projects/my-project/regions/us-central1/"
+                                       "operations/1111111-1111-aaaa-bbbb-ffffffffffff"
+                    },
+                    "graph": {
+                        "nodes": [
+                            {
+                                "jobId": "my-job-abcdefghijklm",
+                                "state": "COMPLETED",
+                                "stepId": "my-job"
+                            }
+                        ]
+                    },
+                    "state": "DONE"
+                },
+                "name": "projects/my-project/regions/us-central1/operations/"
+                        "dddddddd-dddd-dddd-dddd-dddddddddddd",
+                "response": {
+                    "@type": "type.googleapis.com/google.protobuf.Empty"
+                }
+            }
+
+        operation = _DataProcOperation(None, operation_api_response)
+
+        self.assertTrue(operation._check_done())
+
+    def test_failed_operation_detector(self):
+        failure_response = \
+            {
+                "done": True,
+                "metadata": {
+                    "@type": "type.googleapis.com/google.cloud.dataproc."
+                             "v1beta2.WorkflowMetadata",
+                    "clusterName": "fake-dataproc-cluster",
+                    "createCluster": {
+                        "done": True,
+                        "operationId": "projects/my-project/regions/us-central1/"
+                                       "operations/1111111-0000-aaaa-bbbb-ffffffffffff"
+                    },
+                    "deleteCluster": {
+                        "done": True,
+                        "operationId": "projects/my-project/regions/us-central1/"
+                                       "operations/1111111-1111-aaaa-bbbb-ffffffffffff"
+                    },
+                    "graph": {
+                        "nodes": [
+                            {
+                                "error": "Google Cloud Dataproc Agent reports job"
+                                         "failure. If logs are available, they can"
+                                         " be found in 'gs://dataproc-00000000-0000-"
+                                         "0000-0000-000000000000-us-central1/"
+                                         "google-cloud-dataproc-metainfo/cccccccc-cccc-"
+                                         "cccc-cccc-cccccccccccc/jobs/"
+                                         "my-job-abcdefghijklm/driveroutput'.",
+                                "jobId": "my-job-abcdefghijklm",
+                                "state": "FAILED",
+                                "stepId": "my-job"
+                            }
+                        ]
+                    },
+                    "state": "DONE"
+                },
+                "name": "projects/my-project/regions/us-central1/operations/"
+                        "dddddddd-dddd-dddd-dddd-dddddddddddd",
+                "response": {
+                    "@type": "type.googleapis.com/google.protobuf.Empty"
+                }
+            }
+
+        operation = _DataProcOperation(None, failure_response)
+
+        with self.assertRaises(Exception) as context:
+            operation._check_done()
+
+        self.assertTrue(context.exception.message.startswith(
+            'Google Dataproc Operation'))

--- a/tests/contrib/hooks/test_gcp_dataproc_hook.py
+++ b/tests/contrib/hooks/test_gcp_dataproc_hook.py
@@ -141,5 +141,5 @@ class DataProcHookTest(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             operation._check_done()
 
-        self.assertTrue(context.exception.message.startswith(
+        self.assertTrue(str(context.exception).startswith(
             'Google Dataproc Operation'))


### PR DESCRIPTION
GCP DataProc Workflow Template operators should report errors when jobs
fail, even though the errors are not propagated up to the 'error'
field of the DataProcOperation API response object.

This commit checks the outcomes of the individual jobs for errors, and
raises an Exception if any are detected.

This behavior is consistent in spirit with the documentation for
DataProc Workflow templates, which states "A failure in any node in a
workflow will cause the workflow to fail."  See:
https://cloud.google.com/dataproc/docs/concepts/workflows/overview

Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2549) issues and references them in the PR title. 


### Description
- [ X ] Here are some details about my PR, including screenshots of any UI changes:
There are no UI changes.  The only change is that DataProcWorkflowTemplate-based operators will report failures when any of their component jobs/nodes fail, whereas previously those operators would report successes.


### Tests
- [X] My PR adds unit tests to make sure that the _DataProcOperator class responds properly to both successful and failed workflow template operations.


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    N/A

### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
