### PR TITLE
[AIRFLOW-1863] Add dag run selection widgets to gantt view

### DIFF
--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -29,7 +29,7 @@ from flask_wtf import FlaskForm
 
 
 class DateTimeForm(FlaskForm):
-    # Date filter form needed for gantt and graph view
+    # Date filter form for task views
     execution_date = DateTimeField(
         "Execution date", widget=DateTimePickerWidget())
 
@@ -47,3 +47,7 @@ class DateTimeWithNumRunsForm(FlaskForm):
         (365, "365"),
     ))
 
+
+class DateTimeWithNumRunsWithDagRunsForm(DateTimeWithNumRunsForm):
+    # Date time and number of runs and dag runs form for graph and gantt view
+    execution_date = SelectField("DAG run")

--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -28,6 +28,8 @@
 {{ super() }}
 <form method="get">
   <div class="form-inline">
+    Base date: {{ form.base_date(class_="form-control") }}
+    Number of runs: {{ form.num_runs(class_="form-control") }}
     Run:<input type="hidden" value="{{ dag.dag_id }}" name="dag_id">
     {{ form.execution_date(class_="form-control") | safe }}
     <input type="submit" value="Go" class="btn btn-default" action="" method="get">

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -89,7 +89,8 @@ from airflow.utils.dates import infer_time_unit, scale_time_units, parse_executi
 from airflow.utils.timezone import datetime
 from airflow.utils.net import get_hostname
 from airflow.www import utils as wwwutils
-from airflow.www.forms import DateTimeForm, DateTimeWithNumRunsForm
+from airflow.www.forms import (DateTimeForm, DateTimeWithNumRunsForm,
+                               DateTimeWithNumRunsWithDagRunsForm)
 from airflow.www.validators import GreaterEqualThan
 
 QUERY_LIMIT = 100000
@@ -317,6 +318,57 @@ def get_chart_height(dag):
     """
     return 600 + len(dag.tasks) * 10
 
+
+def get_date_time_num_runs_dag_runs_form_data(request, session, dag):
+    dttm = request.args.get('execution_date')
+    if dttm:
+        dttm = pendulum.parse(dttm)
+    else:
+        dttm = dag.latest_execution_date or timezone.utcnow()
+
+    base_date = request.args.get('base_date')
+    if base_date:
+        base_date = timezone.parse(base_date)
+    else:
+        # The DateTimeField widget truncates milliseconds and would loose
+        # the first dag run. Round to next second.
+        base_date = (dttm + timedelta(seconds=1)).replace(microsecond=0)
+
+    default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
+    num_runs = request.args.get('num_runs')
+    num_runs = int(num_runs) if num_runs else default_dag_run
+
+    DR = models.DagRun
+    drs = (
+        session.query(DR)
+        .filter(
+            DR.dag_id == dag.dag_id,
+            DR.execution_date <= base_date)
+        .order_by(desc(DR.execution_date))
+        .limit(num_runs)
+        .all()
+    )
+    dr_choices = []
+    dr_state = None
+    for dr in drs:
+        dr_choices.append((dr.execution_date.isoformat(), dr.run_id))
+        if dttm == dr.execution_date:
+            dr_state = dr.state
+
+    # Happens if base_date was changed and the selected dag run is not in result
+    if not dr_state and drs:
+        dr = drs[0]
+        dttm = dr.execution_date
+        dr_state = dr.state
+
+    return {
+        'dttm': dttm,
+        'base_date': base_date,
+        'num_runs': num_runs,
+        'execution_date': dttm.isoformat(),
+        'dr_choices': dr_choices,
+        'dr_state': dr_state,
+    }
 
 class Airflow(BaseView):
     def is_visible(self):
@@ -1356,7 +1408,6 @@ class Airflow(BaseView):
     @wwwutils.action_logging
     @provide_session
     def graph(self, session=None):
-        default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
         blur = conf.getboolean('webserver', 'demo_mode')
         dag = dagbag.get_dag(dag_id)
@@ -1398,48 +1449,11 @@ class Airflow(BaseView):
         for t in dag.roots:
             get_upstream(t)
 
-        dttm = request.args.get('execution_date')
-        if dttm:
-            dttm = pendulum.parse(dttm)
-        else:
-            dttm = dag.latest_execution_date or timezone.utcnow()
+        dt_nr_dr_data = get_date_time_num_runs_dag_runs_form_data(request, session, dag)
+        dt_nr_dr_data['arrange'] = arrange
+        dttm = dt_nr_dr_data['dttm']
 
-        base_date = request.args.get('base_date')
-        if base_date:
-            base_date = timezone.parse(base_date)
-        else:
-            # The DateTimeField widget truncates milliseconds and would loose
-            # the first dag run. Round to next second.
-            base_date = (dttm + timedelta(seconds=1)).replace(microsecond=0)
-
-        num_runs = request.args.get('num_runs')
-        num_runs = int(num_runs) if num_runs else default_dag_run
-
-        DR = models.DagRun
-        drs = (
-            session.query(DR)
-            .filter(
-                DR.dag_id == dag.dag_id,
-                DR.execution_date <= base_date)
-            .order_by(desc(DR.execution_date))
-            .limit(num_runs)
-            .all()
-        )
-        dr_choices = []
-        dr_state = None
-        for dr in drs:
-            dr_choices.append((dr.execution_date.isoformat(), dr.run_id))
-            if dttm == dr.execution_date:
-                dr_state = dr.state
-
-        # Happens if base_date was changed and the selected dag run is not in result
-        if not dr_state and drs:
-            dr = drs[0]
-            dttm = dr.execution_date
-            dr_state = dr.state
-
-        class GraphForm(DateTimeWithNumRunsForm):
-            execution_date = SelectField("DAG run", choices=dr_choices)
+        class GraphForm(DateTimeWithNumRunsWithDagRunsForm):
             arrange = SelectField("Layout", choices=(
                 ('LR', "Left->Right"),
                 ('RL', "Right->Left"),
@@ -1447,11 +1461,8 @@ class Airflow(BaseView):
                 ('BT', "Bottom->Top"),
             ))
 
-        form = GraphForm(
-            data={'execution_date': dttm.isoformat(),
-                  'arrange': arrange,
-                  'base_date': base_date,
-                  'num_runs': num_runs})
+        form = GraphForm(data=dt_nr_dr_data)
+        form.execution_date.choices = dt_nr_dr_data['dr_choices']
 
         task_instances = {
             ti.task_id: alchemy_to_dict(ti)
@@ -1474,7 +1485,7 @@ class Airflow(BaseView):
             width=request.args.get('width', "100%"),
             height=request.args.get('height', "800"),
             execution_date=dttm.isoformat(),
-            state_token=state_token(dr_state),
+            state_token=state_token(dt_nr_dr_data['dr_state']),
             doc_md=doc_md,
             arrange=arrange,
             operators=sorted(
@@ -1789,7 +1800,6 @@ class Airflow(BaseView):
     @wwwutils.action_logging
     @provide_session
     def gantt(self, session=None):
-
         dag_id = request.args.get('dag_id')
         dag = dagbag.get_dag(dag_id)
         demo_mode = conf.getboolean('webserver', 'demo_mode')
@@ -1801,13 +1811,11 @@ class Airflow(BaseView):
                 include_upstream=True,
                 include_downstream=False)
 
-        dttm = request.args.get('execution_date')
-        if dttm:
-            dttm = pendulum.parse(dttm)
-        else:
-            dttm = dag.latest_execution_date or timezone.utcnow()
+        dt_nr_dr_data = get_date_time_num_runs_dag_runs_form_data(request, session, dag)
+        dttm = dt_nr_dr_data['dttm']
 
-        form = DateTimeForm(data={'execution_date': dttm})
+        form = DateTimeWithNumRunsWithDagRunsForm(data=dt_nr_dr_data)
+        form.execution_date.choices = dt_nr_dr_data['dr_choices']
 
         tis = [
             ti for ti in dag.get_task_instances(session, dttm, dttm)

--- a/airflow/www_rbac/forms.py
+++ b/airflow/www_rbac/forms.py
@@ -38,7 +38,7 @@ from wtforms.fields import (IntegerField, SelectField, TextAreaField, PasswordFi
 
 
 class DateTimeForm(FlaskForm):
-    # Date filter form needed for gantt and graph view
+    # Date filter form needed for task views
     execution_date = DateTimeField(
         "Execution date", widget=DateTimePickerWidget())
 
@@ -55,6 +55,11 @@ class DateTimeWithNumRunsForm(FlaskForm):
         (100, "100"),
         (365, "365"),
     ))
+
+
+class DateTimeWithNumRunsWithDagRunsForm(DateTimeWithNumRunsForm):
+    # Date time and number of runs and dag runs form for graph and gantt view
+    execution_date = SelectField("DAG run")
 
 
 class DagRunForm(DynamicForm):

--- a/airflow/www_rbac/templates/airflow/gantt.html
+++ b/airflow/www_rbac/templates/airflow/gantt.html
@@ -29,6 +29,8 @@
 {{ super() }}
 <form method="get">
   <div class="form-inline">
+    Base date: {{ form.base_date(class_="form-control") }}
+    Number of runs: {{ form.num_runs(class_="form-control") }}
     Run:<input type="hidden" value="{{ dag.dag_id }}" name="dag_id">
     {{ form.execution_date(class_="form-control") | safe }}
     <input type="submit" value="Go" class="btn btn-default" action="" method="get">

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -72,12 +72,66 @@ from airflow.www_rbac import utils as wwwutils
 from airflow.www_rbac.app import app
 from airflow.www_rbac.decorators import action_logging, gzipped
 from airflow.www_rbac.forms import (DateTimeForm, DateTimeWithNumRunsForm,
+                                    DateTimeWithNumRunsWithDagRunsForm,
                                     DagRunForm, ConnectionForm)
 from airflow.www_rbac.security import is_view_only
 from airflow.www_rbac.widgets import AirflowModelListWidget
 
 PAGE_SIZE = conf.getint('webserver', 'page_size')
 dagbag = models.DagBag(settings.DAGS_FOLDER)
+
+
+def get_date_time_num_runs_dag_runs_form_data(request, session, dag):
+    dttm = request.args.get('execution_date')
+    if dttm:
+        dttm = pendulum.parse(dttm)
+    else:
+        dttm = dag.latest_execution_date or timezone.utcnow()
+
+    base_date = request.args.get('base_date')
+    if base_date:
+        base_date = timezone.parse(base_date)
+    else:
+        # The DateTimeField widget truncates milliseconds and would loose
+        # the first dag run. Round to next second.
+        base_date = (dttm + timedelta(seconds=1)).replace(microsecond=0)
+
+    default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
+    num_runs = request.args.get('num_runs')
+    num_runs = int(num_runs) if num_runs else default_dag_run
+
+    DR = models.DagRun
+    drs = (
+        session.query(DR)
+        .filter(
+            DR.dag_id == dag.dag_id,
+            DR.execution_date <= base_date)
+        .order_by(desc(DR.execution_date))
+        .limit(num_runs)
+        .all()
+    )
+    dr_choices = []
+    dr_state = None
+    for dr in drs:
+        dr_choices.append((dr.execution_date.isoformat(), dr.run_id))
+        if dttm == dr.execution_date:
+            dr_state = dr.state
+
+    # Happens if base_date was changed and the selected dag run is not in result
+    if not dr_state and drs:
+        dr = drs[0]
+        dttm = dr.execution_date
+        dr_state = dr.state
+
+    return {
+        'dttm': dttm,
+        'base_date': base_date,
+        'num_runs': num_runs,
+        'execution_date': dttm.isoformat(),
+        'dr_choices': dr_choices,
+        'dr_state': dr_state,
+    }
+
 
 ######################################################################################
 #                                    BaseViews
@@ -1031,7 +1085,6 @@ class Airflow(AirflowBaseView):
     @action_logging
     @provide_session
     def graph(self, session=None):
-        default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
         blur = conf.getboolean('webserver', 'demo_mode')
         dag = dagbag.get_dag(dag_id)
@@ -1073,48 +1126,11 @@ class Airflow(AirflowBaseView):
         for t in dag.roots:
             get_upstream(t)
 
-        dttm = request.args.get('execution_date')
-        if dttm:
-            dttm = pendulum.parse(dttm)
-        else:
-            dttm = dag.latest_execution_date or timezone.utcnow()
+        dt_nr_dr_data = get_date_time_num_runs_dag_runs_form_data(request, session, dag)
+        dt_nr_dr_data['arrange'] = arrange
+        dttm = dt_nr_dr_data['dttm']
 
-        base_date = request.args.get('base_date')
-        if base_date:
-            base_date = timezone.parse(base_date)
-        else:
-            # The DateTimeField widget truncates milliseconds and would loose
-            # the first dag run. Round to next second.
-            base_date = (dttm + timedelta(seconds=1)).replace(microsecond=0)
-
-        num_runs = request.args.get('num_runs')
-        num_runs = int(num_runs) if num_runs else default_dag_run
-
-        DR = models.DagRun
-        drs = (
-            session.query(DR)
-            .filter(
-                DR.dag_id == dag.dag_id,
-                DR.execution_date <= base_date)
-            .order_by(desc(DR.execution_date))
-            .limit(num_runs)
-            .all()
-        )
-        dr_choices = []
-        dr_state = None
-        for dr in drs:
-            dr_choices.append((dr.execution_date.isoformat(), dr.run_id))
-            if dttm == dr.execution_date:
-                dr_state = dr.state
-
-        # Happens if base_date was changed and the selected dag run is not in result
-        if not dr_state and drs:
-            dr = drs[0]
-            dttm = dr.execution_date
-            dr_state = dr.state
-
-        class GraphForm(DateTimeWithNumRunsForm):
-            execution_date = SelectField("DAG run", choices=dr_choices)
+        class GraphForm(DateTimeWithNumRunsWithDagRunsForm):
             arrange = SelectField("Layout", choices=(
                 ('LR', "Left->Right"),
                 ('RL', "Right->Left"),
@@ -1122,11 +1138,8 @@ class Airflow(AirflowBaseView):
                 ('BT', "Bottom->Top"),
             ))
 
-        form = GraphForm(
-            data={'execution_date': dttm.isoformat(),
-                  'arrange': arrange,
-                  'base_date': base_date,
-                  'num_runs': num_runs})
+        form = GraphForm(data=dt_nr_dr_data)
+        form.execution_date.choices = dt_nr_dr_data['dr_choices']
 
         task_instances = {
             ti.task_id: alchemy_to_dict(ti)
@@ -1150,7 +1163,7 @@ class Airflow(AirflowBaseView):
             width=request.args.get('width', "100%"),
             height=request.args.get('height', "800"),
             execution_date=dttm.isoformat(),
-            state_token=wwwutils.state_token(dr_state),
+            state_token=wwwutils.state_token(dt_nr_dr_data['dr_state']),
             doc_md=doc_md,
             arrange=arrange,
             operators=sorted(
@@ -1477,13 +1490,11 @@ class Airflow(AirflowBaseView):
                 include_upstream=True,
                 include_downstream=False)
 
-        dttm = request.args.get('execution_date')
-        if dttm:
-            dttm = pendulum.parse(dttm)
-        else:
-            dttm = dag.latest_execution_date or timezone.utcnow()
+        dt_nr_dr_data = get_date_time_num_runs_dag_runs_form_data(request, session, dag)
+        dttm = dt_nr_dr_data['dttm']
 
-        form = DateTimeForm(data={'execution_date': dttm})
+        form = DateTimeWithNumRunsWithDagRunsForm(data=dt_nr_dr_data)
+        form.execution_date.choices = dt_nr_dr_data['dr_choices']
 
         tis = [
             ti for ti in dag.get_task_instances(session, dttm, dttm)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-1863


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
    - Add same widgets to filter and select dag run known from graph view to the gantt chart view.
    - Extract common code to handle request parameters and DB query.
    - See screenshot attached to the Jira


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - tests.www_rbac.test_views.TestGanttView and tests.www.test_views.TestGanttView
    - Refactored existing TestGraphView tests (added in AIRFLOW-2529) to avoid duplication


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.


### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
