### PR TITLE
[AIRFLOW-2554] Enable convenience access to in/outlets in templates

### DIFF
--- a/docs/lineage.rst
+++ b/docs/lineage.rst
@@ -16,30 +16,30 @@ works.
     from airflow.lineage.datasets import File
     from airflow.models import DAG
     from datetime import timedelta
-    
+
     FILE_CATEGORIES = ["CAT1", "CAT2", "CAT3"]
-    
+
     args = {
         'owner': 'airflow',
         'start_date': airflow.utils.dates.days_ago(2)
     }
-    
+
     dag = DAG(
         dag_id='example_lineage', default_args=args,
         schedule_interval='0 0 * * *',
         dagrun_timeout=timedelta(minutes=60))
-    
+
     f_final = File("/tmp/final")
-    run_this_last = DummyOperator(task_id='run_this_last', dag=dag, 
+    run_this_last = DummyOperator(task_id='run_this_last', dag=dag,
         inlets={"auto": True},
         outlets={"datasets": [f_final,]})
-    
+
     f_in = File("/tmp/whole_directory/")
     outlets = []
     for file in FILE_CATEGORIES:
         f_out = File("/tmp/{}/{{{{ execution_date }}}}".format(file))
         outlets.append(f_out)
-    run_this = BashOperator(    
+    run_this = BashOperator(
         task_id='run_me_first', bash_command='echo 1', dag=dag,
         inlets={"datasets": [f_in,]},
         outlets={"datasets": outlets}
@@ -49,25 +49,39 @@ works.
 
 Tasks take the parameters `inlets` and `outlets`. Inlets can be manually defined by a list of dataset `{"datasets":
 [dataset1, dataset2]}` or can be configured to look for outlets from upstream tasks `{"task_ids": ["task_id1", "task_id2"]}`
-or can be configured to pick up outlets from direct upstream tasks `{"auto": True}` or a combination of them. Outlets 
-are defined as list of dataset `{"datasets": [dataset1, dataset2]}`. Any fields for the dataset are templated with 
-the context when the task is being executed. 
+or can be configured to pick up outlets from direct upstream tasks `{"auto": True}` or a combination of them. Outlets
+are defined as list of dataset `{"datasets": [dataset1, dataset2]}`. Any fields for the dataset are templated with
+the context when the task is being executed.
 
 .. note:: Operators can add inlets and outlets automatically if the operator supports it.
 
-In the example DAG task `run_me_first` is a BashOperator that takes 3 inlets: `CAT1`, `CAT2`, `CAT3`, that are 
+In the example DAG task `run_me_first` is a BashOperator that takes 3 inlets: `CAT1`, `CAT2`, `CAT3`, that are
 generated from a list. Note that `execution_date` is a templated field and will be rendered when the task is running.
 
 .. note:: Behind the scenes Airflow prepares the lineage metadata as part of the `pre_execute` method of a task. When the task
-          has finished execution `post_execute` is called and lineage metadata is pushed into XCOM. Thus if you are creating 
+          has finished execution `post_execute` is called and lineage metadata is pushed into XCOM. Thus if you are creating
           your own operators that override this method make sure to decorate your method with `prepare_lineage` and `apply_lineage`
           respectively.
 
+Templating
+----------
+
+Inlets and outlets are available in templated variables by referring to their (qualified) name. If their name collides
+with one of the built-in names (ie. 'dag') the built-in name takes precedence and the inlets or outlets will only be
+available by using `{{ inlet['name'] }}` in your template.
+
+.. code:: python
+
+    my_file = File(name="my_file", "my_file.{{ ds }}")
+    run_this = BashOperator(
+        task_id='run_me_first', bash_command="echo {{ my_file.name }}; echo {{ inlet['myfile'].name }}", dag=dag,
+        inlets={"datasets": [my_file,]}
+        )
 
 Apache Atlas
 ------------
 
-Airflow can send its lineage metadata to Apache Atlas. You need to enable the `atlas` backend and configure it 
+Airflow can send its lineage metadata to Apache Atlas. You need to enable the `atlas` backend and configure it
 properly, e.g. in your `airflow.cfg`:
 
 .. code:: python
@@ -80,6 +94,6 @@ properly, e.g. in your `airflow.cfg`:
     password = my_password
     host = host
     port = 21000
-    
+
 
 Please make sure to have the `atlasclient` package installed.


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2554
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:

This change allows easy access to inlets/outlets in templates e.g.
File(name="myfile") can be accessed by {{ myfile.XXXX }}. In case
it the name collides with dag level names (e.g. "dag") in can be
accessed by {{ inlet['dag'] }}.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Current tests cover this.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

Added.

### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
