### PR TITLE
[AIRFLOW-2557] Remove paged test for s3

### DIFF
--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -77,7 +77,8 @@ class S3Hook(AwsHook):
         plist = self.list_prefixes(bucket_name, previous_level, delimiter)
         return False if plist is None else prefix in plist
 
-    def list_prefixes(self, bucket_name, prefix='', delimiter=''):
+    def list_prefixes(self, bucket_name, prefix='', delimiter='',
+                      page_size=None, max_items=None):
         """
         Lists prefixes in a bucket under prefix
 
@@ -87,11 +88,21 @@ class S3Hook(AwsHook):
         :type prefix: str
         :param delimiter: the delimiter marks key hierarchy.
         :type delimiter: str
+        :param page_size: pagination size
+        :type page_size: int
+        :param max_items: maximum items to return
+        :type max_items: int
         """
+        config = {
+            'PageSize': page_size,
+            'MaxItems': max_items,
+        }
+
         paginator = self.get_conn().get_paginator('list_objects_v2')
         response = paginator.paginate(Bucket=bucket_name,
                                       Prefix=prefix,
-                                      Delimiter=delimiter)
+                                      Delimiter=delimiter,
+                                      PaginationConfig=config)
 
         has_results = False
         prefixes = []
@@ -104,7 +115,8 @@ class S3Hook(AwsHook):
         if has_results:
             return prefixes
 
-    def list_keys(self, bucket_name, prefix='', delimiter=''):
+    def list_keys(self, bucket_name, prefix='', delimiter='',
+                  page_size=None, max_items=None):
         """
         Lists keys in a bucket under prefix and not containing delimiter
 
@@ -114,11 +126,21 @@ class S3Hook(AwsHook):
         :type prefix: str
         :param delimiter: the delimiter marks key hierarchy.
         :type delimiter: str
+        :param page_size: pagination size
+        :type page_size: int
+        :param max_items: maximum items to return
+        :type max_items: int
         """
+        config = {
+            'PageSize': page_size,
+            'MaxItems': max_items,
+        }
+
         paginator = self.get_conn().get_paginator('list_objects_v2')
         response = paginator.paginate(Bucket=bucket_name,
                                       Prefix=prefix,
-                                      Delimiter=delimiter)
+                                      Delimiter=delimiter,
+                                      PaginationConfig=config)
 
         has_results = False
         keys = []

--- a/tests/hooks/test_s3_hook.py
+++ b/tests/hooks/test_s3_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -96,13 +96,16 @@ class TestS3Hook(unittest.TestCase):
         b = hook.get_bucket('bucket')
         b.create()
 
-        keys = ["%s/b" % i for i in range(5000)]
-        dirs = ["%s/" % i for i in range(5000)]
+        # we dont need to test the paginator
+        # that's covered by boto tests
+        keys = ["%s/b" % i for i in range(2)]
+        dirs = ["%s/" % i for i in range(2)]
         for key in keys:
             b.put_object(Key=key, Body=b'a')
 
         self.assertListEqual(sorted(dirs),
-                             sorted(hook.list_prefixes('bucket', delimiter='/')))
+                             sorted(hook.list_prefixes('bucket', delimiter='/',
+                                                       page_size=1)))
 
     @mock_s3
     def test_list_keys(self):
@@ -123,12 +126,13 @@ class TestS3Hook(unittest.TestCase):
         b = hook.get_bucket('bucket')
         b.create()
 
-        keys = [str(i) for i in range(5000)]
+        keys = [str(i) for i in range(2)]
         for key in keys:
             b.put_object(Key=key, Body=b'a')
 
         self.assertListEqual(sorted(keys),
-                             sorted(hook.list_keys('bucket', delimiter='/')))
+                             sorted(hook.list_keys('bucket', delimiter='/',
+                                                   page_size=1)))
 
     @mock_s3
     def test_check_for_key(self):


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2557
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

Paged tests for s3 are taking over 120 seconds. The
functionality testes is part of the standard boto suite
and part of its own tests.

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

tests removed.

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

cc @Fokko @NielsZeilemaker 
