### PR TITLE
[AIRFLOW-59] Implement bulk_dump and bulk_load for the Postgres hook

### DIFF
--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -82,6 +82,18 @@ class PostgresHook(DbApiHook):
                     f.truncate(f.tell())
                     conn.commit()
 
+    def bulk_load(self, table, tmp_file):
+        """
+        Loads a tab-delimited file into a database table
+        """
+        self.copy_expert("COPY {table} FROM STDIN".format(table=table), tmp_file)
+
+    def bulk_dump(self, table, tmp_file):
+        """
+        Dumps a database table into a tab-delimited file
+        """
+        self.copy_expert("COPY {table} TO STDOUT".format(table=table), tmp_file)
+
     @staticmethod
     def _serialize_cell(cell, conn):
         """

--- a/tests/hooks/test_postgres_hook.py
+++ b/tests/hooks/test_postgres_hook.py
@@ -21,6 +21,8 @@
 import mock
 import unittest
 
+from tempfile import NamedTemporaryFile
+
 from airflow.hooks.postgres_hook import PostgresHook
 
 
@@ -56,3 +58,44 @@ class TestPostgresHook(unittest.TestCase):
             self.conn.commit.assert_called_once()
             self.cur.copy_expert.assert_called_once_with(statement, m.return_value)
             self.assertEqual(m.call_args[0], (filename, "r+"))
+
+    def test_bulk_load(self):
+        hook = PostgresHook()
+        table = "t"
+        input_data = ["foo", "bar", "baz"]
+
+        with hook.get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("DROP TABLE IF EXISTS {}".format(table))
+                cur.execute("CREATE TABLE {} (c VARCHAR)".format(table))
+                conn.commit()
+
+                with NamedTemporaryFile() as f:
+                    f.write("\n".join(input_data).encode("utf-8"))
+                    f.flush()
+                    hook.bulk_load(table, f.name)
+
+                cur.execute("SELECT * FROM {}".format(table))
+                results = [row[0] for row in cur.fetchall()]
+
+        self.assertEqual(sorted(input_data), sorted(results))
+
+    def test_bulk_dump(self):
+        hook = PostgresHook()
+        table = "t"
+        input_data = ["foo", "bar", "baz"]
+
+        with hook.get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("DROP TABLE IF EXISTS {}".format(table))
+                cur.execute("CREATE TABLE {} (c VARCHAR)".format(table))
+                values = ",".join("('{}')".format(data) for data in input_data)
+                cur.execute("INSERT INTO {} VALUES {}".format(table, values))
+                conn.commit()
+
+                with NamedTemporaryFile() as f:
+                    hook.bulk_dump(table, f.name)
+                    f.seek(0)
+                    results = [line.rstrip().decode("utf-8") for line in f.readlines()]
+
+        self.assertEqual(sorted(input_data), sorted(results))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-59
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR implements bulk_dump and bulk_load,
which are inherited from DbApiHook and
already implemented for MySqlHook.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- tests.hooks.test_postgres_hook:TestPostgresHook.test_bulk_load
- tests.hooks.test_postgres_hook:TestPostgresHook.test_bulk_dump

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
