### PR TITLE
[AIRFLOW-2565] make cluster_label a templated_field in QuboleOperator

### DIFF
--- a/airflow/contrib/example_dags/example_qubole_operator.py
+++ b/airflow/contrib/example_dags/example_qubole_operator.py
@@ -61,7 +61,7 @@ t1 = QuboleOperator(
     task_id='hive_show_table',
     command_type='hivecmd',
     query='show tables',
-    cluster_label='default',
+    cluster_label='{{ params.cluster_label }}',
     fetch_logs=True,
     # If `fetch_logs`=true, will fetch qubole command logs and concatenate
     # them into corresponding airflow task logs
@@ -69,7 +69,11 @@ t1 = QuboleOperator(
     # To attach tags to qubole command, auto attach 3 tags - dag_id, task_id, run_id
     qubole_conn_id='qubole_default',
     # Connection id to submit commands inside QDS, if not set "qubole_default" is used
-    dag=dag)
+    dag=dag,
+    params={
+        'cluster_label': 'default',
+    }
+)
 
 t2 = QuboleOperator(
     task_id='hive_s3_location',
@@ -115,9 +119,13 @@ t4 = QuboleOperator(
                 '-numReduceTasks 0 -input s3://paid-qubole/HadoopAPITests/'
                 'data/3.tsv -output '
                 's3://paid-qubole/HadoopAPITests/data/3_wc',
-    cluster_label='default',
+    cluster_label='{{ params.cluster_label }}',
     fetch_logs=True,
-    dag=dag)
+    dag=dag,
+    params={
+        'cluster_label': 'default',
+    }
+)
 
 t5 = QuboleOperator(
     task_id='pig_cmd',

--- a/airflow/contrib/operators/qubole_operator.py
+++ b/airflow/contrib/operators/qubole_operator.py
@@ -122,7 +122,7 @@ class QuboleOperator(BaseOperator):
                        'extract_query', 'boundary_query', 'macros', 'name', 'parameters',
                        'dbtap_id', 'hive_table', 'db_table', 'split_column', 'note_id',
                        'db_update_keys', 'export_dir', 'partition_spec', 'qubole_conn_id',
-                       'arguments', 'user_program_arguments')
+                       'arguments', 'user_program_arguments', 'cluster_label')
 
     template_ext = ('.txt',)
     ui_color = '#3064A1'

--- a/tests/contrib/operators/test_qubole_operator.py
+++ b/tests/contrib/operators/test_qubole_operator.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
 import unittest
 from datetime import datetime
 
-from airflow.models import DAG, Connection
+from airflow.models import DAG, Connection, TaskInstance
 from airflow.utils import db
 
 from airflow.contrib.hooks.qubole_hook import QuboleHook
@@ -63,6 +63,22 @@ class QuboleOperatorTest(unittest.TestCase):
                                       {'qubole_conn_id' : TEMPLATE_CONN})
         self.assertEqual(task.task_id, TASK_ID)
         self.assertEqual(result, TEMPLATE_CONN)
+
+    def test_init_with_template_cluster_label(self):
+        dag = DAG(DAG_ID, start_date=DEFAULT_DATE)
+        task = QuboleOperator(
+            task_id=TASK_ID,
+            dag=dag,
+            cluster_label='{{ params.cluster_label }}',
+            params={
+                'cluster_label': 'default'
+            }
+        )
+
+        ti = TaskInstance(task, DEFAULT_DATE)
+        ti.render_templates()
+
+        self.assertEqual(task.cluster_label, 'default')
 
     def test_get_hook(self):
         dag = DAG(DAG_ID, start_date=DEFAULT_DATE)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2565
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Make cluster_label a templated_field in QuboleOperator

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
