### PR TITLE
[AIRFLOW-2566] Change backfill to rerun failed tasks

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -214,6 +214,7 @@ def backfill(args, dag=None):
             delay_on_limit_secs=args.delay_on_limit,
             verbose=args.verbose,
             conf=run_conf,
+            rerun_failed_tasks=args.rerun_failed_tasks,
         )
 
 
@@ -1375,10 +1376,19 @@ class CLIFactory(object):
             default=1.0),
         'reset_dag_run': Arg(
             ("--reset_dagruns",),
-            ("if set, the backfill will delete existing "
-             "backfill-related DAG runs and start "
-             "anew with fresh, running DAG runs"),
+            (
+                "if set, the backfill will delete existing "
+                "backfill-related DAG runs and start "
+                "anew with fresh, running DAG runs"),
             "store_true"),
+        'rerun_failed_tasks': Arg(
+            ("--rerun_failed_tasks",),
+            (
+                "if set, the backfill will auto-rerun "
+                "all the failed tasks for the backfill date range "
+                "instead of throwing exceptions"),
+            "store_true"),
+
         # list_tasks
         'tree': Arg(("-t", "--tree"), "Tree view", "store_true"),
         # list_dags
@@ -1693,13 +1703,20 @@ class CLIFactory(object):
     subparsers = (
         {
             'func': backfill,
-            'help': "Run subsections of a DAG for a specified date range",
+            'help': "Run subsections of a DAG for a specified date range. "
+                    "If reset_dag_run option is used,"
+                    " backfill will first prompt users whether airflow "
+                    "should clear all the previous dag_run and task_instances "
+                    "within the backfill date range."
+                    "If rerun_failed_tasks is used, backfill "
+                    "will auto re-run the previous failed task instances"
+                    " within the backfill date range.",
             'args': (
                 'dag_id', 'task_regex', 'start_date', 'end_date',
                 'mark_success', 'local', 'donot_pickle',
                 'bf_ignore_dependencies', 'bf_ignore_first_depends_on_past',
                 'subdir', 'pool', 'delay_on_limit', 'dry_run', 'verbose', 'conf',
-                'reset_dag_run'
+                'reset_dag_run', 'rerun_failed_tasks',
             )
         }, {
             'func': list_tasks,

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4010,6 +4010,7 @@ class DAG(BaseDag, LoggingMixin):
             delay_on_limit_secs=1.0,
             verbose=False,
             conf=None,
+            rerun_failed_tasks=False,
     ):
         """
         Runs the DAG.
@@ -4059,6 +4060,7 @@ class DAG(BaseDag, LoggingMixin):
             delay_on_limit_secs=delay_on_limit_secs,
             verbose=verbose,
             conf=conf,
+            rerun_failed_tasks=rerun_failed_tasks,
         )
         job.run()
 
@@ -4950,7 +4952,7 @@ class DagRun(Base, LoggingMixin):
 
         tis = self.get_task_instances(session=session)
 
-        self.log.info("Updating state for %s considering %s task(s)", self, len(tis))
+        self.log.debug("Updating state for %s considering %s task(s)", self, len(tis))
 
         for ti in list(tis):
             # skip in db?

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -151,7 +151,7 @@ def configure_orm(disable_connection_pool=False):
     pool_connections = conf.getboolean('core', 'SQL_ALCHEMY_POOL_ENABLED')
     if disable_connection_pool or not pool_connections:
         engine_args['poolclass'] = NullPool
-        log.info("settings.configure_orm(): Using NullPool")
+        log.debug("settings.configure_orm(): Using NullPool")
     elif 'sqlite' not in SQL_ALCHEMY_CONN:
         # Engine args not supported by sqlite.
         # If no config value is defined for the pool size, select a reasonable value.

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -214,6 +214,122 @@ class BackfillJobTest(unittest.TestCase):
 
         self.assertEqual(conf, dr[0].conf)
 
+    def test_backfill_rerun_failed_tasks(self):
+        dag = DAG(
+            dag_id='test_backfill_rerun_failed',
+            start_date=DEFAULT_DATE,
+            schedule_interval='@daily')
+
+        with dag:
+            DummyOperator(
+                task_id='test_backfill_rerun_failed_task-1',
+                dag=dag)
+
+        dag.clear()
+
+        executor = TestExecutor(do_update=True)
+
+        job = BackfillJob(dag=dag,
+                          executor=executor,
+                          start_date=DEFAULT_DATE,
+                          end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+                          )
+        job.run()
+
+        ti = TI(task=dag.get_task('test_backfill_rerun_failed_task-1'),
+                execution_date=DEFAULT_DATE)
+        ti.refresh_from_db()
+        ti.set_state(State.FAILED)
+
+        job = BackfillJob(dag=dag,
+                          executor=executor,
+                          start_date=DEFAULT_DATE,
+                          end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+                          rerun_failed_tasks=True
+                          )
+        job.run()
+        ti = TI(task=dag.get_task('test_backfill_rerun_failed_task-1'),
+                execution_date=DEFAULT_DATE)
+        ti.refresh_from_db()
+        self.assertEquals(ti.state, State.SUCCESS)
+
+    def test_backfill_rerun_upstream_failed_tasks(self):
+            dag = DAG(
+                dag_id='test_backfill_rerun_upstream_failed',
+                start_date=DEFAULT_DATE,
+                schedule_interval='@daily')
+
+            with dag:
+                t1 = DummyOperator(task_id='test_backfill_rerun_upstream_failed_task-1',
+                                   dag=dag)
+                t2 = DummyOperator(task_id='test_backfill_rerun_upstream_failed_task-2',
+                                   dag=dag)
+                t1.set_upstream(t2)
+
+            dag.clear()
+            executor = TestExecutor(do_update=True)
+
+            job = BackfillJob(dag=dag,
+                              executor=executor,
+                              start_date=DEFAULT_DATE,
+                              end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+                              )
+            job.run()
+
+            ti = TI(task=dag.get_task('test_backfill_rerun_upstream_failed_task-1'),
+                    execution_date=DEFAULT_DATE)
+            ti.refresh_from_db()
+            ti.set_state(State.UPSTREAM_FAILED)
+
+            job = BackfillJob(dag=dag,
+                              executor=executor,
+                              start_date=DEFAULT_DATE,
+                              end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+                              rerun_failed_tasks=True
+                              )
+            job.run()
+            ti = TI(task=dag.get_task('test_backfill_rerun_upstream_failed_task-1'),
+                    execution_date=DEFAULT_DATE)
+            ti.refresh_from_db()
+            self.assertEquals(ti.state, State.SUCCESS)
+
+    def test_backfill_rerun_failed_tasks_without_flag(self):
+        dag = DAG(
+            dag_id='test_backfill_rerun_failed',
+            start_date=DEFAULT_DATE,
+            schedule_interval='@daily')
+
+        with dag:
+            DummyOperator(
+                task_id='test_backfill_rerun_failed_task-1',
+                dag=dag)
+
+        dag.clear()
+
+        executor = TestExecutor(do_update=True)
+
+        job = BackfillJob(dag=dag,
+                          executor=executor,
+                          start_date=DEFAULT_DATE,
+                          end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+                          )
+        job.run()
+
+        ti = TI(task=dag.get_task('test_backfill_rerun_failed_task-1'),
+                execution_date=DEFAULT_DATE)
+        ti.refresh_from_db()
+        ti.set_state(State.FAILED)
+
+        job = BackfillJob(dag=dag,
+                          executor=executor,
+                          start_date=DEFAULT_DATE,
+                          end_date=DEFAULT_DATE + datetime.timedelta(days=2),
+                          rerun_failed_tasks=False
+                          )
+
+        with self.assertRaises(AirflowException):
+            job.run()
+
     def test_backfill_ordered_concurrent_execute(self):
         dag = DAG(
             dag_id='test_backfill_ordered_concurrent_execute',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2566
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
1. remove some debug messages for backfill
2. change the backfill to only rerun the failed tasks instead of throwing exceptions.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
