### PR TITLE
[AIRFLOW-2561] Fix typo in EmailOperator

### DIFF
--- a/airflow/operators/email_operator.py
+++ b/airflow/operators/email_operator.py
@@ -75,4 +75,4 @@ class EmailOperator(BaseOperator):
     def execute(self, context):
         send_email(self.to, self.subject, self.html_content,
                    files=self.files, cc=self.cc, bcc=self.bcc,
-                   mime_subtype=self.mime_subtype, mine_charset=self.mime_charset)
+                   mime_subtype=self.mime_subtype, mime_charset=self.mime_charset)

--- a/tests/operators/test_email_operator.py
+++ b/tests/operators/test_email_operator.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import print_function, unicode_literals
+
+import datetime
+import mock
+import unittest
+
+from airflow import configuration, DAG
+from airflow.operators.email_operator import EmailOperator
+from airflow.utils import timezone
+
+DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+END_DATE = timezone.datetime(2016, 1, 2)
+INTERVAL = datetime.timedelta(hours=12)
+FROZEN_NOW = timezone.datetime(2016, 1, 2, 12, 1, 1)
+
+send_email_test = mock.Mock()
+
+
+class TestEmailOperator(unittest.TestCase):
+
+    def setUp(self):
+        super(TestEmailOperator, self).setUp()
+        configuration.load_test_config()
+        self.dag = DAG(
+            'test_dag',
+            default_args={
+                'owner': 'airflow',
+                'start_date': DEFAULT_DATE},
+            schedule_interval=INTERVAL)
+        self.addCleanup(self.dag.clear)
+
+    def _run_as_operator(self, **kwargs):
+        task = EmailOperator(
+            to='airflow@example.com',
+            subject='Test Run',
+            html_content='The quick brown fox jumps over the lazy dog',
+            task_id='task',
+            dag=self.dag,
+            **kwargs)
+        task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+    def test_execute(self):
+        configuration.conf.set('email', 'EMAIL_BACKEND',
+                               'tests.operators.test_email_operator.send_email_test')
+        self._run_as_operator()
+        send_email_test.assert_called_once()


### PR DESCRIPTION
There's a typo in the params in send_email.
It should be mime_charset instead of mine_charset.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2561/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
There's a typo in the params in send_email.
It should be mime_charset instead of mine_charset.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added **test_execute** in **tests/operators/test_email_operator.py**


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
