### PR TITLE
[AIRFLOW-2533] Fix path to DAG's on kubernetes executor workers

### DIFF
--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -178,9 +178,6 @@ class WorkerConfiguration(LoggingMixin):
         annotations = {
             'iam.cloud.google.com/service-account': gcp_sa_key
         } if gcp_sa_key else {}
-        airflow_path = airflow_command.split('-sd')[-1]
-        airflow_path = self.worker_airflow_home + airflow_path.split('/')[-1]
-        airflow_command = airflow_command.split('-sd')[0] + '-sd ' + airflow_path
 
         return Pod(
             namespace=namespace,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2533
 
### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
When triggering a DAG using the kubernetes executor, the path to the DAG on the worker node is not properly set due to the modification of the command that is sent to the pod for the worker node to perform.  



### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Prior to removing airflow command modification: 

<img width="1135" alt="screen shot 2018-05-31 at 4 15 11 pm" src="https://issues.apache.org/jira/secure/attachment/12925528/12925528_Screen+Shot+2018-05-24+at+5.06.25+PM.png">

After removal of modification:

<img width="1135" alt="screen shot 2018-05-31 at 4 15 11 pm" src="https://user-images.githubusercontent.com/6414172/40784417-48018a9e-64ee-11e8-9ff2-e5b2dfcde960.png">


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
