### PR TITLE
[AIRFLOW-2573] Cast BigQuery TIMESTAMP field to float

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1450,9 +1450,9 @@ def _bq_cast(string_field, bq_type):
     """
     if string_field is None:
         return None
-    elif bq_type == 'INTEGER' or bq_type == 'TIMESTAMP':
+    elif bq_type == 'INTEGER':
         return int(string_field)
-    elif bq_type == 'FLOAT':
+    elif bq_type == 'FLOAT' or bq_type == 'TIMESTAMP':
         return float(string_field)
     elif bq_type == 'BOOLEAN':
         assert string_field in set(['true', 'false'])


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2573

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

In current bigquery_hook.py, we have a `_bq_cast(string_field, bq_type)` function that help casts a BigQuery row to the appropriate data types. 
```
elif bq_type == 'INTEGER' or bq_type == 'TIMESTAMP':
    return int(string_field)
```
However, when a bq_type equals to 'TIMESTAMP', it causes ValueError.
```
>>> int('1.458668898E9')
ValueError: invalid literal for int() with base 10: '1.458668898E9'
```
To solve this, we should instead cast to `TIMESTAMP` field to float.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested locally.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
