### PR TITLE
 [AIRFLOW-2575] Make gcs to gcs operator work with large files

### DIFF
--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -151,8 +151,8 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
                                        self.destination_bucket, destination_object)
                 )
 
-                hook.copy(self.source_bucket, source_object,
-                          self.destination_bucket, destination_object)
+                hook.rewrite(self.source_bucket, source_object,
+                             self.destination_bucket, destination_object)
                 if self.move_object:
                     hook.delete(self.source_bucket, source_object)
 
@@ -162,8 +162,8 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
                                    self.destination_bucket or self.source_bucket,
                                    self.destination_object or self.source_object)
             )
-            hook.copy(self.source_bucket, self.source_object,
-                      self.destination_bucket, self.destination_object)
+            hook.rewrite(self.source_bucket, self.source_object,
+                         self.destination_bucket, self.destination_object)
 
             if self.move_object:
                 hook.delete(self.source_bucket, self.source_object)

--- a/tests/contrib/operators/test_gcs_to_gcs_operator.py
+++ b/tests/contrib/operators/test_gcs_to_gcs_operator.py
@@ -111,7 +111,7 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
             mock.call(TEST_BUCKET, 'test_object/file2.txt',
                       DESTINATION_BUCKET, 'foo/bar/file2.txt'),
         ]
-        mock_hook.return_value.copy.assert_has_calls(mock_calls)
+        mock_hook.return_value.rewrite.assert_has_calls(mock_calls)
 
     @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
     def test_execute_wildcard_with_destination_object_retained_prefix(self, mock_hook):
@@ -131,7 +131,7 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
             mock.call(TEST_BUCKET, 'test_object/file2.txt',
                       DESTINATION_BUCKET, 'foo/bar/test_object/file2.txt'),
         ]
-        mock_hook.return_value.copy.assert_has_calls(mock_calls_retained)
+        mock_hook.return_value.rewrite.assert_has_calls(mock_calls_retained)
 
     @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
     def test_execute_wildcard_without_destination_object(self, mock_hook):
@@ -148,7 +148,7 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
             mock.call(TEST_BUCKET, 'test_object/file2.txt',
                       DESTINATION_BUCKET, 'test_object/file2.txt'),
         ]
-        mock_hook.return_value.copy.assert_has_calls(mock_calls_none)
+        mock_hook.return_value.rewrite.assert_has_calls(mock_calls_none)
 
     @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
     def test_execute_wildcard_empty_destination_object(self, mock_hook):
@@ -166,4 +166,4 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
             mock.call(TEST_BUCKET, 'test_object/file2.txt',
                       DESTINATION_BUCKET, '/file2.txt'),
         ]
-        mock_hook.return_value.copy.assert_has_calls(mock_calls_empty)
+        mock_hook.return_value.rewrite.assert_has_calls(mock_calls_empty)


### PR DESCRIPTION
### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title:
    - https://issues.apache.org/jira/browse/AIRFLOW-2575

### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

Use `GoogleCloudStorageHook.rewrite` instead of `copy` so that it
works with files > 5TB

### Tests
- [X] My PR updates existing tests to pass after the change. 

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
