### PR TITLE
[AIRFLOW-1762] Implement key_file support in ssh_hook create_tunnel

### DIFF
--- a/airflow/contrib/operators/sftp_operator.py
+++ b/airflow/contrib/operators/sftp_operator.py
@@ -86,20 +86,20 @@ class SFTPOperator(BaseOperator):
             if self.remote_host is not None:
                 self.ssh_hook.remote_host = self.remote_host
 
-            ssh_client = self.ssh_hook.get_conn()
-            sftp_client = ssh_client.open_sftp()
-            if self.operation.lower() == SFTPOperation.GET:
-                file_msg = "from {0} to {1}".format(self.remote_filepath,
-                                                    self.local_filepath)
-                self.log.debug("Starting to transfer %s", file_msg)
-                sftp_client.get(self.remote_filepath, self.local_filepath)
-            else:
-                file_msg = "from {0} to {1}".format(self.local_filepath,
-                                                    self.remote_filepath)
-                self.log.debug("Starting to transfer file %s", file_msg)
-                sftp_client.put(self.local_filepath,
-                                self.remote_filepath,
-                                confirm=self.confirm)
+            with self.ssh_hook.get_conn() as ssh_client:
+                sftp_client = ssh_client.open_sftp()
+                if self.operation.lower() == SFTPOperation.GET:
+                    file_msg = "from {0} to {1}".format(self.remote_filepath,
+                                                        self.local_filepath)
+                    self.log.debug("Starting to transfer %s", file_msg)
+                    sftp_client.get(self.remote_filepath, self.local_filepath)
+                else:
+                    file_msg = "from {0} to {1}".format(self.local_filepath,
+                                                        self.remote_filepath)
+                    self.log.debug("Starting to transfer file %s", file_msg)
+                    sftp_client.put(self.local_filepath,
+                                    self.remote_filepath,
+                                    confirm=self.confirm)
 
         except Exception as e:
             raise AirflowException("Error while transferring {0}, error: {1}"

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,7 @@ slack = ['slackclient>=1.0.0']
 mongo = ['pymongo>=3.6.0']
 snowflake = ['snowflake-connector-python>=1.5.2',
              'snowflake-sqlalchemy>=1.1.0']
-ssh = ['paramiko>=2.1.1', 'pysftp>=0.2.9']
+ssh = ['paramiko>=2.1.1', 'pysftp>=0.2.9', 'sshtunnel>=0.1.4,<0.2']
 statsd = ['statsd>=3.0.1, <4.0']
 vertica = ['vertica-python>=0.5.1']
 webhdfs = ['hdfs[dataframe,avro,kerberos]>=2.0.4']

--- a/tests/contrib/hooks/test_ssh_hook.py
+++ b/tests/contrib/hooks/test_ssh_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,6 +21,17 @@ import unittest
 from airflow import configuration
 from airflow.utils import db
 from airflow import models
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+from airflow.contrib.hooks.ssh_hook import SSHHook
+
 
 HELLO_SERVER_CMD = """
 import socket, sys
@@ -36,43 +47,90 @@ conn.sendall(b'hello')
 
 
 class SSHHookTest(unittest.TestCase):
+
     def setUp(self):
         configuration.load_test_config()
-        from airflow.contrib.hooks.ssh_hook import SSHHook
-        self.hook = SSHHook(ssh_conn_id='ssh_default', keepalive_interval=10)
-        self.hook.no_host_key_check = True
 
-    def test_ssh_connection(self):
-        ssh_hook = self.hook.get_conn()
-        self.assertIsNotNone(ssh_hook)
+    @mock.patch('airflow.contrib.hooks.ssh_hook.paramiko.SSHClient')
+    def test_ssh_connection_with_password(self, ssh_mock):
+        hook = SSHHook(remote_host='remote_host',
+                       port='port',
+                       username='username',
+                       password='password',
+                       timeout=10,
+                       key_file='fake.file')
 
-    def test_tunnel(self):
-        print("Setting up remote listener")
-        import subprocess
-        import socket
+        with hook.get_conn():
+            ssh_mock.return_value.connect.assert_called_once_with(
+                hostname='remote_host',
+                username='username',
+                password='password',
+                key_filename='fake.file',
+                timeout=10,
+                compress=True,
+                port='port',
+                sock=None
+            )
 
-        self.server_handle = subprocess.Popen(["python", "-c", HELLO_SERVER_CMD],
-                                              stdout=subprocess.PIPE)
-        print("Setting up tunnel")
-        with self.hook.create_tunnel(2135, 2134):
-            print("Tunnel up")
-            server_output = self.server_handle.stdout.read(5)
-            self.assertEqual(server_output, b"ready")
-            print("Connecting to server via tunnel")
-            s = socket.socket()
-            s.connect(("localhost", 2135))
-            print("Receiving...",)
-            response = s.recv(5)
-            self.assertEqual(response, b"hello")
-            print("Closing connection")
-            s.close()
-            print("Waiting for listener...")
-            output, _ = self.server_handle.communicate()
-            self.assertEqual(self.server_handle.returncode, 0)
-            print("Closing tunnel")
+    @mock.patch('airflow.contrib.hooks.ssh_hook.paramiko.SSHClient')
+    def test_ssh_connection_without_password(self, ssh_mock):
+        hook = SSHHook(remote_host='remote_host',
+                       port='port',
+                       username='username',
+                       timeout=10,
+                       key_file='fake.file')
+
+        with hook.get_conn():
+            ssh_mock.return_value.connect.assert_called_once_with(
+                hostname='remote_host',
+                username='username',
+                key_filename='fake.file',
+                timeout=10,
+                compress=True,
+                port='port',
+                sock=None
+            )
+
+    @mock.patch('airflow.contrib.hooks.ssh_hook.SSHTunnelForwarder')
+    def test_tunnel_with_password(self, ssh_mock):
+        hook = SSHHook(remote_host='remote_host',
+                       port='port',
+                       username='username',
+                       password='password',
+                       timeout=10,
+                       key_file='fake.file')
+
+        with hook.get_tunnel(1234):
+            ssh_mock.assert_called_once_with('remote_host',
+                                             ssh_port='port',
+                                             ssh_username='username',
+                                             ssh_password='password',
+                                             ssh_pkey='fake.file',
+                                             ssh_proxy=None,
+                                             local_bind_address=('localhost', ),
+                                             remote_bind_address=('localhost', 1234),
+                                             logger=hook.log)
+
+    @mock.patch('airflow.contrib.hooks.ssh_hook.SSHTunnelForwarder')
+    def test_tunnel_without_password(self, ssh_mock):
+        hook = SSHHook(remote_host='remote_host',
+                       port='port',
+                       username='username',
+                       timeout=10,
+                       key_file='fake.file')
+
+        with hook.get_tunnel(1234):
+            ssh_mock.assert_called_once_with('remote_host',
+                                             ssh_port='port',
+                                             ssh_username='username',
+                                             ssh_pkey='fake.file',
+                                             ssh_proxy=None,
+                                             local_bind_address=('localhost', ),
+                                             remote_bind_address=('localhost', 1234),
+                                             host_pkey_directories=[],
+                                             logger=hook.log)
 
     def test_conn_with_extra_parameters(self):
-        from airflow.contrib.hooks.ssh_hook import SSHHook
         db.merge_conn(
             models.Connection(conn_id='ssh_with_extra',
                               host='localhost',
@@ -80,10 +138,40 @@ class SSHHookTest(unittest.TestCase):
                               extra='{"compress" : true, "no_host_key_check" : "true"}'
                               )
         )
-        ssh_hook = SSHHook(ssh_conn_id='ssh_with_extra', keepalive_interval=10)
-        ssh_hook.get_conn()
+        ssh_hook = SSHHook(ssh_conn_id='ssh_with_extra')
         self.assertEqual(ssh_hook.compress, True)
         self.assertEqual(ssh_hook.no_host_key_check, True)
+
+    def test_ssh_connection(self):
+        hook = SSHHook(ssh_conn_id='ssh_default')
+        with hook.get_conn() as client:
+            (_, stdout, _) = client.exec_command('ls')
+            self.assertIsNotNone(stdout.read())
+
+    def test_ssh_connection_old_cm(self):
+        with SSHHook(ssh_conn_id='ssh_default') as hook:
+            client = hook.get_conn()
+            (_, stdout, _) = client.exec_command('ls')
+            self.assertIsNotNone(stdout.read())
+
+    def test_tunnel(self):
+        hook = SSHHook(ssh_conn_id='ssh_default')
+
+        import subprocess
+        import socket
+
+        server_handle = subprocess.Popen(["python", "-c", HELLO_SERVER_CMD],
+                                         stdout=subprocess.PIPE)
+        with hook.create_tunnel(2135, 2134):
+            server_output = server_handle.stdout.read(5)
+            self.assertEqual(server_output, b"ready")
+            s = socket.socket()
+            s.connect(("localhost", 2135))
+            response = s.recv(5)
+            self.assertEqual(response, b"hello")
+            s.close()
+            output, _ = server_handle.communicate()
+            self.assertEqual(server_handle.returncode, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Switched to using sshtunnel package instead of popen approach

Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1762
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
The ssh_hook.create_tunnel was opening a tunnel using a popen. Moreover, it had the local port as a required argument. This PR refactored it to use the sshtunnel package build ontop of paramiko.


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
