### PR TITLE
[WIP][AIRFLOW-2577] Add New JdbcGetFirstOperator

### DIFF
--- a/airflow/contrib/operators/jdbc_get_first_operator.py
+++ b/airflow/contrib/operators/jdbc_get_first_operator.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from airflow.hooks.jdbc_hook import JdbcHook
+from airflow.operators.jdbc_operator import JdbcOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class JdbcGetFirstOperator(JdbcOperator):
+    """
+    Executes sql code in a database using jdbc driver.
+    Requires jaydebeapi.
+
+    Intended for queries which select row(s).
+    Fetches just the first row of data from the database.
+    Row value is both logged and xcom'd (by default)
+
+    :param print_row: specifies whether row should be printed to the logs.
+    :type print_row: boolean
+    :default print_row: True
+
+    :param xcom_push: specifies whether row is xcom'd with key 'return_value'
+    :type xcom_push: boolean
+    :default xcom_push: True
+    """
+    @apply_defaults
+    def __init__(
+            self,
+            print_row=True,
+            xcom_push=True,
+            *args,
+            **kwargs):
+        super(JdbcGetFirstOperator, self).__init__(*args, **kwargs)
+        self.print_row = print_row
+        self.xcom_push = xcom_push
+
+    def execute(self, context):
+        self.log.info('Executing: %s', self.sql)
+        self.hook = JdbcHook(jdbc_conn_id=self.jdbc_conn_id)
+        row = self.hook.get_first(self.sql, parameters=self.parameters)
+        if self.print_row:
+            self.log.info('Row: ' + str(row))
+        if self.xcom_push:
+            return row


### PR DESCRIPTION
Please accept my PR to add a new operator `JdbcGetFirstOperator`

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2577


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
This PR adds a new contrib operator `JdbcGetFirstOperator` which is intended for use audit/validation/aggreagation
SQL queries that select a single row. This operator will fetch the first row from the database and xcom it so that it can be evaluated by down_stream tasks to make decisions within the DAG.  

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: I could not find any existing JdbcOperator tests, I'm not sure how I would mock this operator? If there are any ideas/examples for mocking this, I'd be happy to write up a test. 


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
