### PR TITLE
[AIRFLOW-2578] Add option to use proxies in JiraHook

### DIFF
--- a/airflow/contrib/hooks/jira_hook.py
+++ b/airflow/contrib/hooks/jira_hook.py
@@ -32,9 +32,11 @@ class JiraHook(BaseHook, LoggingMixin):
     :type jira_conn_id: string
     """
     def __init__(self,
-                 jira_conn_id='jira_default'):
+                 jira_conn_id='jira_default',
+                 proxies=None):
         super(JiraHook, self).__init__(jira_conn_id)
         self.jira_conn_id = jira_conn_id
+        self.proxies = proxies
         self.client = None
         self.get_conn()
 
@@ -73,7 +75,8 @@ class JiraHook(BaseHook, LoggingMixin):
                                        options=extra_options,
                                        basic_auth=(conn.login, conn.password),
                                        get_server_info=get_server_info,
-                                       validate=validate)
+                                       validate=validate,
+                                       proxies=self.proxies)
                 except JIRAError as jira_error:
                     raise AirflowException('Failed to create jira client, jira error: %s'
                                            % str(jira_error))


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2578) issues and references them in the PR title.

### Description
Sometimes the Jira API is not directly accessible on certain machines for security reasons. Proxies can be used to get around that and the Python Jira library offers support for that. This PR simply adds the option to include proxies when creating the JiraHook.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Difficult to test since we'd have to set up test environment with no access to a Jira host except through a proxy + since default params are used this has no impact on anybody's existing usage of the JiraHook.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"

### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

@pahwaranger @saguziel 