### PR TITLE
[AIRFLOW-2581] Fix DbApiHook autocommit

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -137,7 +137,7 @@ class DbApiHook(BaseHook):
                     cur.execute(sql)
                 return cur.fetchone()
 
-    def run(self, sql, autocommit=False, parameters=None):
+    def run(self, sql, autocommit=True, parameters=None):
         """
         Runs a command or a list of commands. Pass a list of sql
         statements to the sql parameter to get them to execute
@@ -169,7 +169,9 @@ class DbApiHook(BaseHook):
                     else:
                         cur.execute(s)
 
-            if not getattr(conn, 'autocommit', False):
+            should_commit = getattr(conn, 'autocommit', False)
+
+            if should_commit:
                 conn.commit()
 
     def set_autocommit(self, conn, autocommit):


### PR DESCRIPTION

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2581

### Description
- [x] Here are some details about my PR:
DbApiHook.run actually do not commit when I set to autocommit=True
For example: hook.run(sql,autocommit=True)
This commit fixed this problem.

### Tests
- [x] My PR does not need testing for this extremely good reason:
bug fix, no need for tests

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

