### PR TITLE
[AIRFLOW-2585] Fix bugs in CassandraHook and CassandraToGCSOperator

### DIFF
--- a/tests/contrib/operators/test_cassandra_to_gcs_operator.py
+++ b/tests/contrib/operators/test_cassandra_to_gcs_operator.py
@@ -61,17 +61,18 @@ class CassandraToGCSTest(unittest.TestCase):
         self.assertEquals(op.convert_value('date', date), str(date_str))
 
         import uuid
+        from base64 import b64encode
         test_uuid = uuid.uuid4()
-        self.assertEquals(op.convert_value('uuid', test_uuid), str(test_uuid))
+        encoded_uuid = b64encode(test_uuid.bytes).decode('ascii')
+        self.assertEquals(op.convert_value('uuid', test_uuid), encoded_uuid)
+
+        b = b'abc'
+        encoded_b = b64encode(b).decode('ascii')
+        self.assertEquals(op.convert_value('binary', b), encoded_b)
 
         from decimal import Decimal
         d = Decimal(1.0)
         self.assertEquals(op.convert_value('decimal', d), float(d))
-
-        from base64 import b64encode
-        b = b'abc'
-        encoded_b = b64encode(b).decode('ascii')
-        self.assertEquals(op.convert_value('binary', b), encoded_b)
 
         from cassandra.util import Time
         time = Time(0)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2585


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR fixes:
 (1) issue with UUID type conversion: currently UUID is converted to hex string, but should be converted to base64-encoded as that is the required format in BigQuery for uploading.
 (2) Issue with configuring load balancing policy in CassandraHook: currently the hook only successfully instantiate with the default LB policy, but throw an exception if attempts to pass in a custom LB policy in the extra field.
(3) Issue with connections not closed properly after use: should always shut down the cluster in the operator to close all sessions/connections associated with the cluster instance.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
unit tests added/fixed:
  - tests.contrib.hooks.test_cassandra_hook
  - tests.contrib.operators.test_cassandra_to_gcs_operator

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
