### PR TITLE
[AIRFLOW-2586] Stop getting AIRFLOW_HOME value from config file

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -24,20 +24,10 @@ import signal
 from subprocess import Popen, STDOUT, PIPE
 from tempfile import gettempdir, NamedTemporaryFile
 
-from airflow import configuration as conf
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.file import TemporaryDirectory
-
-
-# These variables are required in cases when BashOperator tasks use airflow specific code,
-# e.g. they import packages in the airflow context and the possibility of impersonation
-# gives not guarantee that these variables are available in the impersonated environment.
-# Hence, we need to propagate them in the Bash script used as a wrapper of commands in
-# this BashOperator.
-PYTHONPATH_VAR = 'PYTHONPATH'
-AIRFLOW_HOME_VAR = 'AIRFLOW_HOME'
 
 
 class BashOperator(BaseOperator):
@@ -83,18 +73,12 @@ class BashOperator(BaseOperator):
         """
         self.log.info("Tmp dir root location: \n %s", gettempdir())
 
-        airflow_home_value = conf.get('core', AIRFLOW_HOME_VAR)
-        pythonpath_value = os.environ.get(PYTHONPATH_VAR, '')
-
-        bash_command = ('export {}={}; '.format(AIRFLOW_HOME_VAR, airflow_home_value) +
-                        'export {}={}; '.format(PYTHONPATH_VAR, pythonpath_value) +
-                        self.bash_command)
-        self.lineage_data = bash_command
+        self.lineage_data = self.bash_command
 
         with TemporaryDirectory(prefix='airflowtmp') as tmp_dir:
             with NamedTemporaryFile(dir=tmp_dir, prefix=self.task_id) as f:
 
-                f.write(bytes(bash_command, 'utf_8'))
+                f.write(bytes(self.bash_command, 'utf_8'))
                 f.flush()
                 fname = f.name
                 script_location = os.path.abspath(fname)
@@ -110,7 +94,7 @@ class BashOperator(BaseOperator):
                             signal.signal(getattr(signal, sig), signal.SIG_DFL)
                     os.setsid()
 
-                self.log.info("Running command: %s", bash_command)
+                self.log.info("Running command: %s", self.bash_command)
                 sp = Popen(
                     ['bash', fname],
                     stdout=PIPE, stderr=STDOUT,

--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -48,7 +48,6 @@ def date_range(
     Get a set of dates as a list based on a start, end and delta, delta
     can be something that can be added to ``datetime.datetime``
     or a cron expression as a ``str``
-
     :param start_date: anchor date to start the series from
     :type start_date: datetime.datetime
     :param end_date: right boundary for the date range
@@ -57,13 +56,15 @@ def date_range(
         number of entries you want in the range. This number can be negative,
         output will always be sorted regardless
     :type num: int
-
     >>> date_range(datetime(2016, 1, 1), datetime(2016, 1, 3), delta=timedelta(1))
-    [datetime.datetime(2016, 1, 1, 0, 0), datetime.datetime(2016, 1, 2, 0, 0), datetime.datetime(2016, 1, 3, 0, 0)]
+    [datetime.datetime(2016, 1, 1, 0, 0), datetime.datetime(2016, 1, 2, 0, 0),
+     datetime.datetime(2016, 1, 3, 0, 0)]
     >>> date_range(datetime(2016, 1, 1), datetime(2016, 1, 3), delta='0 0 * * *')
-    [datetime.datetime(2016, 1, 1, 0, 0), datetime.datetime(2016, 1, 2, 0, 0), datetime.datetime(2016, 1, 3, 0, 0)]
+    [datetime.datetime(2016, 1, 1, 0, 0), datetime.datetime(2016, 1, 2, 0, 0),
+     datetime.datetime(2016, 1, 3, 0, 0)]
     >>> date_range(datetime(2016, 1, 1), datetime(2016, 3, 3), delta="0 0 0 * *")
-    [datetime.datetime(2016, 1, 1, 0, 0), datetime.datetime(2016, 2, 1, 0, 0), datetime.datetime(2016, 3, 1, 0, 0)]
+    [datetime.datetime(2016, 1, 1, 0, 0), datetime.datetime(2016, 2, 1, 0, 0),
+     datetime.datetime(2016, 3, 1, 0, 0)]
     """
     if not delta:
         return []
@@ -82,13 +83,15 @@ def date_range(
         cron = croniter(delta, start_date)
     elif isinstance(delta, timedelta):
         delta = abs(delta)
-    l = []
+    dates = []
     if end_date:
+        if timezone.is_naive(start_date):
+            end_date = timezone.make_naive(end_date, tz)
         while start_date <= end_date:
             if timezone.is_naive(start_date):
-                l.append(timezone.make_aware(start_date, tz))
+                dates.append(timezone.make_aware(start_date, tz))
             else:
-                l.append(start_date)
+                dates.append(start_date)
 
             if delta_iscron:
                 start_date = cron.get_next(datetime)
@@ -97,9 +100,9 @@ def date_range(
     else:
         for _ in range(abs(num)):
             if timezone.is_naive(start_date):
-                l.append(timezone.make_aware(start_date, tz))
+                dates.append(timezone.make_aware(start_date, tz))
             else:
-                l.append(start_date)
+                dates.append(start_date)
 
             if delta_iscron:
                 if num > 0:
@@ -111,16 +114,14 @@ def date_range(
                     start_date += delta
                 else:
                     start_date -= delta
-    return sorted(l)
+    return sorted(dates)
 
 
 def round_time(dt, delta, start_date=timezone.make_aware(datetime.min)):
     """
     Returns the datetime of the form start_date + i * delta
     which is closest to dt for any non-negative integer i.
-
     Note that delta may be a datetime.timedelta or a dateutil.relativedelta
-
     >>> round_time(datetime(2015, 1, 1, 6), timedelta(days=1))
     datetime.datetime(2015, 1, 1, 0, 0)
     >>> round_time(datetime(2015, 1, 2), relativedelta(months=1))
@@ -203,7 +204,6 @@ def infer_time_unit(time_seconds_arr):
     """
     Determine the most appropriate time unit for an array of time durations
     specified in seconds.
-
     e.g. 5400 seconds => 'minutes', 36000 seconds => 'hours'
     """
     if len(time_seconds_arr) == 0:

--- a/tests/operators/bash_operator.py
+++ b/tests/operators/bash_operator.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.models import State
+from airflow.operators.bash_operator import BashOperator
+from airflow.utils import timezone
+
+DEFAULT_DATE = datetime(2016, 1, 1, tzinfo=timezone.utc)
+END_DATE = datetime(2016, 1, 2, tzinfo=timezone.utc)
+INTERVAL = timedelta(hours=12)
+
+
+class BashOperatorTestCase(unittest.TestCase):
+    def test_echo_env_variables(self):
+        """
+        Test that env variables are exported correctly to the
+        task bash environment.
+        """
+        now = datetime.utcnow()
+        now = now.replace(tzinfo=timezone.utc)
+
+        self.dag = DAG(
+            dag_id='bash_op_test', default_args={
+                'owner': 'airflow',
+                'retries': 100,
+                'start_date': DEFAULT_DATE
+            },
+            schedule_interval='@daily',
+            dagrun_timeout=timedelta(minutes=60))
+
+        self.dag.create_dagrun(
+            run_id='manual__' + DEFAULT_DATE.isoformat(),
+            execution_date=DEFAULT_DATE,
+            start_date=now,
+            state=State.RUNNING,
+            external_trigger=False,
+        )
+
+        import tempfile
+        with tempfile.NamedTemporaryFile() as f:
+            fname = f.name
+            t = BashOperator(
+                task_id='echo_env_vars',
+                dag=self.dag,
+                bash_command='echo $AIRFLOW_HOME>> {0};'
+                             'echo $PYTHONPATH>> {0};'.format(fname)
+            )
+            os.environ['AIRFLOW_HOME'] = 'MY_PATH_TO_AIRFLOW_HOME'
+            t.run(DEFAULT_DATE, DEFAULT_DATE,
+                  ignore_first_depends_on_past=True, ignore_ti_state=True)
+
+            with open(fname, 'r') as fr:
+                output = ''.join(fr.readlines())
+                self.assertIn('MY_PATH_TO_AIRFLOW_HOME', output)
+                # exported in run_unit_tests.sh as part of PYTHONPATH
+                self.assertIn('tests/test_utils', output)


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2586/) issues and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Before [this commit](https://github.com/apache/incubator-airflow/commit/a0deb506c070637abc3c426bc7d060e3fe6c854d#diff-30054b6fa334216ba6e66c9f07025cd2R35), subprocess created by bash operator only inherits env vars from the parent process. However, it does not inherit the proper env var from the `airflow worker` process because we had a bug in the [`sudo airflow run --raw` command](https://github.com/apache/incubator-airflow/blob/master/airflow/task/task_runner/base_task_runner.py#L81). The commit was created to address the bug for bash operator. The bug was later on fixed in [this commit](https://github.com/apache/incubator-airflow/commit/354492bc597130f43c76e7bec4bc894fb6deb7fe) and thus bash operator does not need and should not get AIRFLOW_HOME value from the config (otherwise there might be discrepancy between the AIRFLOW_HOME value in the parent process and the child process).

PYTHONPATH on the otherhand, is always passed to the subprocess in the env var maps so we don't need it.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests/operators/bash_operators.py

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
