### PR TITLE
[AIRFLOW-2590] Fix commit in DbApiHook.run() for no-autocommit DB

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -169,7 +169,8 @@ class DbApiHook(BaseHook):
                     else:
                         cur.execute(s)
 
-            should_commit = getattr(conn, 'autocommit', False)
+            should_commit = getattr(conn, 'autocommit',
+                                    False) or not self.supports_autocommit
 
             if should_commit:
                 conn.commit()


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2590) issues and references them in the PR title.

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

After [this commit](https://github.com/apache/incubator-airflow/commit/d642e38ec7eac129739042e77f78b1dae4f2615e#diff-3f191f9ec6c3dfda1cd2ef79a01725aa), DbApiHook.run() will only commit when the autocommit field is set for the connection. For those don't support autocommit (e.g. sqlite_hook), the connection won't commit the query, which is a change of behavior.

This is currently breaking CI (tests/core.py:CoreTest.test_check_operators).

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
fixes tests/core.py:CoreTest.test_check_operators

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
