### PR TITLE
[AIRFLOW-2587] Add TIMESTAMP type mapping to MySqlToHiveTransfer

### DIFF
--- a/airflow/operators/mysql_to_hive.py
+++ b/airflow/operators/mysql_to_hive.py
@@ -109,6 +109,7 @@ class MySqlToHiveTransfer(BaseOperator):
             t.SHORT: 'INT',
             t.TINY: 'SMALLINT',
             t.YEAR: 'INT',
+            t.TIMESTAMP: 'TIMESTAMP',
         }
         return d[mysql_type] if mysql_type in d else 'STRING'
 

--- a/tests/operators/operators.py
+++ b/tests/operators/operators.py
@@ -334,7 +334,8 @@ class TransferTests(unittest.TestCase):
                         c1 SMALLINT,
                         c2 MEDIUMINT,
                         c3 INT,
-                        c4 BIGINT
+                        c4 BIGINT,
+                        c5 TIMESTAMP
                     )
                 """.format(mysql_table))
 
@@ -355,6 +356,7 @@ class TransferTests(unittest.TestCase):
             d["c2"] = "INT"
             d["c3"] = "BIGINT"
             d["c4"] = "DECIMAL(38,0)"
+            d["c5"] = "TIMESTAMP"
             self.assertEqual(mock_load_file.call_args[1]["field_dict"], d)
         finally:
             with m.get_conn() as c:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2587
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR fixes MySqlToHiveTransfer to map
MySQL TIMESTAMP to Hive TIMESTAMP
(not STRING) so that users are not
required to cast it explicitly.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Fixed tests.operators.operators:TransferTests.test_mysql_to_hive_type_conversion.
Also, I confirmed that this fix works with MySQL 5.7.22 and Hive 1.2.1.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
