### PR TITLE
[AIRFLOW-2591] Set default value of autocommit to False in DbApiHook.run()

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -137,7 +137,7 @@ class DbApiHook(BaseHook):
                     cur.execute(sql)
                 return cur.fetchone()
 
-    def run(self, sql, autocommit=True, parameters=None):
+    def run(self, sql, autocommit=False, parameters=None):
         """
         Runs a command or a list of commands. Pass a list of sql
         statements to the sql parameter to get them to execute


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2591


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In previous PR [AIRFLOW-2581](https://github.com/apache/incubator-airflow/pull/3482), I changed the default value  of
autocommit to True in DbApiHook.run(), which may cause some performance
issues, so I changed it back to False.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
