### PR TITLE
[AIRFLOW-2512][AIRFLOW-2522] Use google-auth instead of oauth2client

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -72,7 +72,8 @@ class BigQueryHook(GoogleCloudBaseHook, DbApiHook, LoggingMixin):
         Returns a BigQuery service object.
         """
         http_authorized = self._authorize()
-        return build('bigquery', 'v2', http=http_authorized)
+        return build(
+            'bigquery', 'v2', http=http_authorized, cache_discovery=False)
 
     def insert_rows(self, table, rows, target_fields=None, commit_every=1000):
         """

--- a/airflow/contrib/hooks/datastore_hook.py
+++ b/airflow/contrib/hooks/datastore_hook.py
@@ -44,7 +44,8 @@ class DatastoreHook(GoogleCloudBaseHook):
         Returns a Google Cloud Storage service object.
         """
         http_authorized = self._authorize()
-        return build('datastore', version, http=http_authorized)
+        return build(
+            'datastore', version, http=http_authorized, cache_discovery=False)
 
     def allocate_ids(self, partialKeys):
         """

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -20,12 +20,16 @@
 import json
 
 import httplib2
-from oauth2client.client import GoogleCredentials
-from oauth2client.service_account import ServiceAccountCredentials
+import google.auth
+import google_auth_httplib2
+import google.oauth2.service_account
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin
+
+
+_DEFAULT_SCOPES = ('https://www.googleapis.com/auth/cloud-platform',)
 
 
 class GoogleCloudBaseHook(BaseHook, LoggingMixin):
@@ -41,8 +45,10 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
     All hook derived from this base hook use the 'Google Cloud Platform' connection
     type. Two ways of authentication are supported:
 
-    Default credentials: Only specify 'Project Id'. Then you need to have executed
-    ``gcloud auth`` on the Airflow worker machine.
+    Default credentials: Only the 'Project Id' is required. You'll need to
+    have set up default credentials, such as by the
+    ``GOOGLE_APPLICATION_DEFAULT`` environment variable or from the metadata
+    server on Google Compute Engine.
 
     JSON key file: Specify 'Project Id', 'Key Path' and 'Scope'.
 
@@ -68,32 +74,30 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
         """
         key_path = self._get_field('key_path', False)
         keyfile_dict = self._get_field('keyfile_dict', False)
-        scope = self._get_field('scope', False)
+        scope = self._get_field('scope', None)
+        if scope is not None:
+            scopes = [s.strip() for s in scope.split(',')]
+        else:
+            scopes = _DEFAULT_SCOPES
 
         if not key_path and not keyfile_dict:
-            self.log.info('Getting connection using `gcloud auth` user, '
+            self.log.info('Getting connection using `google.auth.default()` '
                           'since no key file is defined for hook.')
-            credentials = GoogleCredentials.get_application_default()
+            credentials, _ = google.auth.default(scopes=scopes)
         elif key_path:
-            if not scope:
-                raise AirflowException('Scope should be defined when using a key file.')
-            scopes = [s.strip() for s in scope.split(',')]
-
             # Get credentials from a JSON file.
             if key_path.endswith('.json'):
                 self.log.info('Getting connection using a JSON key file.')
-                credentials = ServiceAccountCredentials \
-                    .from_json_keyfile_name(key_path, scopes)
+                credentials = (
+                    google.oauth2.service_account.Credentials.from_service_account_file(
+                        key_path, scopes=scopes)
+                )
             elif key_path.endswith('.p12'):
                 raise AirflowException('Legacy P12 key file are not supported, '
                                        'use a JSON key file.')
             else:
                 raise AirflowException('Unrecognised extension for key file.')
         else:
-            if not scope:
-                raise AirflowException('Scope should be defined when using key JSON.')
-            scopes = [s.strip() for s in scope.split(',')]
-
             # Get credentials from JSON data provided in the UI.
             try:
                 keyfile_dict = json.loads(keyfile_dict)
@@ -103,19 +107,21 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
                 keyfile_dict['private_key'] = keyfile_dict['private_key'].replace(
                     '\\n', '\n')
 
-                credentials = ServiceAccountCredentials \
-                    .from_json_keyfile_dict(keyfile_dict, scopes)
+                credentials = (
+                    google.oauth2.service_account.Credentials.from_service_account_info(
+                        keyfile_dict, scopes=scopes)
+                )
             except json.decoder.JSONDecodeError:
                 raise AirflowException('Invalid key JSON.')
 
-        return credentials.create_delegated(self.delegate_to) \
+        return credentials.with_subject(self.delegate_to) \
             if self.delegate_to else credentials
 
     def _get_access_token(self):
         """
         Returns a valid access token from Google API Credentials
         """
-        return self._get_credentials().get_access_token().access_token
+        return self._get_credentials().token
 
     def _authorize(self):
         """
@@ -124,7 +130,9 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
         """
         credentials = self._get_credentials()
         http = httplib2.Http()
-        return credentials.authorize(http)
+        authed_http = google_auth_httplib2.AuthorizedHttp(
+            credentials, http=http)
+        return authed_http
 
     def _get_field(self, f, default=None):
         """

--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -169,7 +169,8 @@ class DataFlowHook(GoogleCloudBaseHook):
         Returns a Google Cloud Storage service object.
         """
         http_authorized = self._authorize()
-        return build('dataflow', 'v1b3', http=http_authorized)
+        return build(
+            'dataflow', 'v1b3', http=http_authorized, cache_discovery=False)
 
     def _start_dataflow(self, task_id, variables, name,
                         command_prefix, label_formatter):

--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -204,7 +204,9 @@ class DataProcHook(GoogleCloudBaseHook):
     def get_conn(self):
         """Returns a Google Cloud Dataproc service object."""
         http_authorized = self._authorize()
-        return build('dataproc', self.api_version, http=http_authorized)
+        return build(
+            'dataproc', self.api_version, http=http_authorized,
+            cache_discovery=False)
 
     def get_cluster(self, project_id, region, cluster_name):
         return self.get_conn().projects().regions().clusters().get(

--- a/airflow/contrib/hooks/gcp_mlengine_hook.py
+++ b/airflow/contrib/hooks/gcp_mlengine_hook.py
@@ -17,7 +17,6 @@ import random
 import time
 from apiclient import errors
 from apiclient.discovery import build
-from oauth2client.client import GoogleCredentials
 
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -55,8 +54,8 @@ class MLEngineHook(GoogleCloudBaseHook):
         """
         Returns a Google MLEngine service object.
         """
-        credentials = GoogleCredentials.get_application_default()
-        return build('ml', 'v1', credentials=credentials)
+        authed_http = self._authorize()
+        return build('ml', 'v1', http=authed_http, cache_discovery=False)
 
     def create_job(self, project_id, job, use_existing_job_fn=None):
         """

--- a/airflow/contrib/hooks/gcp_pubsub_hook.py
+++ b/airflow/contrib/hooks/gcp_pubsub_hook.py
@@ -53,7 +53,8 @@ class PubSubHook(GoogleCloudBaseHook):
         :rtype: apiclient.discovery.Resource
         """
         http_authorized = self._authorize()
-        return build('pubsub', 'v1', http=http_authorized)
+        return build(
+            'pubsub', 'v1', http=http_authorized, cache_discovery=False)
 
     def publish(self, project, topic, messages):
         """Publishes messages to a Pub/Sub topic.

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -44,7 +44,8 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         Returns a Google Cloud Storage service object.
         """
         http_authorized = self._authorize()
-        return build('storage', 'v1', http=http_authorized)
+        return build(
+            'storage', 'v1', http=http_authorized, cache_discovery=False)
 
     # pylint:disable=redefined-builtin
     def copy(self, source_bucket, source_object, destination_bucket=None,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,9 @@ MOCK_MODULES = [
     'mesos',
     'mesos.interface',
     'mesos.native',
-    'oauth2client.service_account',
+    'google.auth.default',
+    'google_auth_httplib2',
+    'google.oauth2.service_account',
     'pandas.io.gbq',
     'vertica_python',
     'pymssql'

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -41,7 +41,9 @@ Flask-WTF
 flower
 freezegun
 future
-google-api-python-client>=1.5.0,<1.6.0
+google-api-python-client>=1.6.0,<2.0.0dev
+google-auth>=1.0.0,<2.0.0dev
+google-auth-httplib2
 gunicorn
 hdfs
 hive-thrift-py
@@ -60,7 +62,6 @@ nose
 nose-exclude
 nose-ignore-docstring==0.2
 nose-timer
-oauth2client>=2.0.2,<2.1.0
 pandas
 pandas-gbq
 parameterized

--- a/setup.py
+++ b/setup.py
@@ -144,9 +144,10 @@ elasticsearch = [
 ]
 emr = ['boto3>=1.0.0']
 gcp_api = [
-    'httplib2',
-    'google-api-python-client>=1.5.0, <1.6.0',
-    'oauth2client>=2.0.2, <2.1.0',
+    'httplib2>=0.9.2',
+    'google-api-python-client>=1.6.0, <2.0.0dev',
+    'google-auth>=1.0.0, <2.0.0dev',
+    'google-auth-httplib2>=0.0.1',
     'PyOpenSSL',
     'pandas-gbq'
 ]

--- a/tests/contrib/hooks/test_gcp_api_base_hook.py
+++ b/tests/contrib/hooks/test_gcp_api_base_hook.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+
+from airflow.contrib.hooks import gcp_api_base_hook as hook
+
+import google.auth
+from google.auth.exceptions import GoogleAuthError
+
+
+default_creds_available = True
+default_project = None
+try:
+    _, default_project = google.auth.default(scopes=hook._DEFAULT_SCOPES)
+except GoogleAuthError:
+    default_creds_available = False
+
+
+class TestGoogleCloudBaseHook(unittest.TestCase):
+    def setUp(self):
+        self.instance = hook.GoogleCloudBaseHook()
+
+    @unittest.skipIf(
+        not default_creds_available,
+        'Default GCP credentials not available to run tests')
+    def test_default_creds_with_scopes(self):
+        self.instance.extras = {
+            'extra__google_cloud_platform__project': default_project,
+            'extra__google_cloud_platform__scope': (
+                ','.join((
+                    'https://www.googleapis.com/auth/bigquery',
+                    'https://www.googleapis.com/auth/devstorage.read_only',
+                ))
+            ),
+        }
+
+        credentials = self.instance._get_credentials()
+
+        if not hasattr(credentials, 'scopes') or credentials.scopes is None:
+            # Some default credentials don't have any scopes associated with
+            # them, and that's okay.
+            return
+
+        scopes = credentials.scopes
+        self.assertIn('https://www.googleapis.com/auth/bigquery', scopes)
+        self.assertIn(
+            'https://www.googleapis.com/auth/devstorage.read_only', scopes)
+
+    @unittest.skipIf(
+        not default_creds_available,
+        'Default GCP credentials not available to run tests')
+    def test_default_creds_no_scopes(self):
+        self.instance.extras = {
+            'extra__google_cloud_platform__project': default_project,
+        }
+
+        credentials = self.instance._get_credentials()
+
+        if not hasattr(credentials, 'scopes') or credentials.scopes is None:
+            # Some default credentials don't have any scopes associated with
+            # them, and that's okay.
+            return
+
+        scopes = credentials.scopes
+        self.assertEqual(tuple(hook._DEFAULT_SCOPES), tuple(scopes))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2512 GoogleCloudBaseHook using deprecated oauth2client
    - https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-2522 Cannot use GOOGLE_APPLICATION_CREDENTIALS to authenticate for GCP connections


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

* Updates the GCP hooks to use the google-auth library and removes
  dependencies on the deprecated oauth2client package.
* Removes inconsistent handling of the scope parameter for different
  auth methods.

Note: using google-auth for credentials requires a newer version of the
google-api-python-client package, so this commit also updates the
minimum version for that.

To avoid some annoying warnings about the discovery cache not being
supported, so disable the discovery cache explicitly as recommend here:
https://stackoverflow.com/a/44518587/101923

No UI changes.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added `test_gcp_api_base_hook.py` to test fix for [AIRFLOW-2522] (allowing scopes for default credentials).

Tested by running:

    nosetests tests/contrib/operators/test_dataflow_operator.py \
        tests/contrib/operators/test_gcs*.py \
        tests/contrib/operators/test_mlengine_*.py \
        tests/contrib/operators/test_pubsub_operator.py \
        tests/contrib/hooks/test_gcp*.py \
        tests/contrib/hooks/test_gcs_hook.py \
        tests/contrib/hooks/test_bigquery_hook.py

and also tested by running some GCP-related DAGs locally, such as the
Dataproc DAG example at
https://cloud.google.com/composer/docs/quickstart


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

Tweaked explanation of default credentials since they can be many different kinds of credentials besides those from the `gcloud` command.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
