### PR TITLE
[AIRFLOW-2597] Restore original dbapi.run() behavior

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -169,10 +169,9 @@ class DbApiHook(BaseHook):
                     else:
                         cur.execute(s)
 
-            should_commit = getattr(conn, 'autocommit',
-                                    False) or not self.supports_autocommit
-
-            if should_commit:
+            # If autocommit was set to False for db that supports autocommit,
+            # or if db does not supports autocommit, we do a manual commit.
+            if not getattr(conn, 'autocommit', False):
                 conn.commit()
 
     def set_autocommit(self, conn, autocommit):


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2597) issues and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes
dbapi.run() right now commits only when autocommit is set to true or db does not support autocommit. Restoring behavior before [this commit](https://github.com/apache/incubator-airflow/commit/d642e38ec7eac129739042e77f78b1dae4f2615e#diff-3f191f9ec6c3dfda1cd2ef79a01725aa).
This is breaking CI now.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
fixes tests/operators/operators.py:PostgresTest.test_postgres_to_postgres

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
