### PR TITLE
[AIRFLOW-2601] Allow user to specify k8s config

### DIFF
--- a/airflow/contrib/kubernetes/kube_client.py
+++ b/airflow/contrib/kubernetes/kube_client.py
@@ -17,20 +17,22 @@
 from airflow.configuration import conf
 
 
-def _load_kube_config(in_cluster, cluster_context):
+def _load_kube_config(in_cluster, cluster_context, config_file):
     from kubernetes import config, client
     if in_cluster:
         config.load_incluster_config()
         return client.CoreV1Api()
     else:
-        if cluster_context is None:
+        if cluster_context is None and config_file is None:
             config.load_kube_config()
             return client.CoreV1Api()
         else:
             return client.CoreV1Api(
-                api_client=config.new_client_from_config(context=cluster_context))
+                api_client=config.new_client_from_config(config_file=config_file,
+                                                         context=cluster_context))
 
 
 def get_kube_client(in_cluster=conf.getboolean('kubernetes', 'in_cluster'),
-                    cluster_context=None):
-    return _load_kube_config(in_cluster, cluster_context)
+                    cluster_context=None,
+                    config_file=None):
+    return _load_kube_config(in_cluster, cluster_context, config_file)

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -70,13 +70,16 @@ class KubernetesPodOperator(BaseOperator):
     :type get_logs: bool
     :param affinity: A dict containing a group of affinity scheduling rules
     :type affinity: dict
+    :param config_file: The path to the Kubernetes config file
+    :type config_file: str
     """
-    template_fields = ('cmds', 'arguments', 'env_vars')
+    template_fields = ('cmds', 'arguments', 'env_vars', 'config_file')
 
     def execute(self, context):
         try:
             client = kube_client.get_kube_client(in_cluster=self.in_cluster,
-                                                 cluster_context=self.cluster_context)
+                                                 cluster_context=self.cluster_context,
+                                                 config_file=self.config_file)
             gen = pod_generator.PodGenerator()
 
             for mount in self.volume_mounts:
@@ -132,6 +135,7 @@ class KubernetesPodOperator(BaseOperator):
                  annotations=None,
                  resources=None,
                  affinity=None,
+                 config_file=None,
                  *args,
                  **kwargs):
         super(KubernetesPodOperator, self).__init__(*args, **kwargs)
@@ -153,3 +157,4 @@ class KubernetesPodOperator(BaseOperator):
         self.annotations = annotations or {}
         self.affinity = affinity or {}
         self.resources = resources or Resources()
+        self.config_file = config_file


### PR DESCRIPTION
This adds the ability in the Kubernetes operator to specify the config file, if it is different than default.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2601

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
