### PR TITLE
[AIRFLOW-2602] Show failed attempts in Gantt view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -35,6 +35,7 @@ import bleach
 import pendulum
 import codecs
 from collections import defaultdict
+import itertools
 
 import inspect
 from textwrap import dedent
@@ -1816,10 +1817,21 @@ class Airflow(BaseView):
             ti for ti in dag.get_task_instances(session, dttm, dttm)
             if ti.start_date]
         tis = sorted(tis, key=lambda ti: ti.start_date)
+        TF = models.TaskFail
+        ti_fails = list(itertools.chain(*[(
+            session
+            .query(TF)
+            .filter(TF.dag_id == ti.dag_id,
+                    TF.task_id == ti.task_id,
+                    TF.execution_date == ti.execution_date)
+            .all()
+        ) for ti in tis]))
+        tis_with_fails = sorted(tis + ti_fails, key=lambda ti: ti.start_date)
 
         tasks = []
-        for ti in tis:
+        for ti in tis_with_fails:
             end_date = ti.end_date if ti.end_date else timezone.utcnow()
+            state = ti.state if type(ti) == models.TaskInstance else State.FAILED
             tasks.append({
                 'startDate': wwwutils.epoch(ti.start_date),
                 'endDate': wwwutils.epoch(end_date),
@@ -1827,10 +1839,10 @@ class Airflow(BaseView):
                 'isoEnd': end_date.isoformat()[:-4],
                 'taskName': ti.task_id,
                 'duration': "{}".format(end_date - ti.start_date)[:-4],
-                'status': ti.state,
+                'status': state,
                 'executionDate': ti.execution_date.isoformat(),
             })
-        states = {ti.state: ti.state for ti in tis}
+        states = {task['status']: task['status'] for task in tasks}
         data = {
             'taskNames': [ti.task_id for ti in tis],
             'tasks': tasks,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2602


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
    - Get failed attempts from `task_fail` table and show them in Gantt view.
    - Fix TaskFail class column definition to match actual database schema. Change was required to retrieve all records for one task instance run otherwise only one was returned by SQLAlchemy.
    - See screenshot attached to the Jira

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
