### PR TITLE
[AIRFLOW-2611] Fix wrong dag volume mount path for kubernetes executor

### DIFF
--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -132,12 +132,19 @@ class WorkerConfiguration(LoggingMixin):
                 self.kube_config.logs_volume_subpath
             )
         ]
-        volume_mounts = [{
-            'name': dags_volume_name,
-            'mountPath': os.path.join(
+
+        dag_volume_mount_path = ""
+        if self.kube_config.dags_volume_claim:
+            dag_volume_mount_path = self.worker_airflow_dags
+        else:
+            dag_volume_mount_path = os.path.join(
                 self.worker_airflow_dags,
                 self.kube_config.git_subpath
-            ),
+            )
+
+        volume_mounts = [{
+            'name': dags_volume_name,
+            'mountPath': dag_volume_mount_path,
             'readOnly': True
         }, {
             'name': logs_volume_name,


### PR DESCRIPTION

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2611


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
There are two way of syncing dags, pvc and git-sync, if set both
(dags_volume_claim and git_subpath), I won't get the mountPath what I
want. I think the priority of pvc should higher than git-sync, so I
think when dags_volume_claim is been set, the mountPath shuold not join the git_subpath.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

