### PR TITLE
[AIRFLOW-2550] Implements API endpoint to list DAG runs

### DIFF
--- a/airflow/api/common/experimental/get_dag_runs.py
+++ b/airflow/api/common/experimental/get_dag_runs.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from flask import url_for
+
+from airflow.exceptions import AirflowException
+from airflow.models import DagBag, DagRun
+
+
+def get_dag_runs(dag_id, state=None):
+    """
+    Returns a list of Dag Runs for a specific DAG ID.
+    :param dag_id: String identifier of a DAG
+    :param state: queued|running|success...
+    :return: List of DAG runs of a DAG with requested state,
+    or all runs if the state is not specified
+    """
+    dagbag = DagBag()
+
+    # Check DAG exists.
+    if dag_id not in dagbag.dags:
+        error_message = "Dag id {} not found".format(dag_id)
+        raise AirflowException(error_message)
+
+    dag_runs = list()
+    state = state.lower() if state else None
+    for run in DagRun.find(dag_id=dag_id, state=state):
+        dag_runs.append({
+            'id': run.id,
+            'run_id': run.run_id,
+            'state': run.state,
+            'dag_id': run.dag_id,
+            'execution_date': run.execution_date.isoformat(),
+            'start_date': ((run.start_date or '') and
+                           run.start_date.isoformat()),
+            'dag_run_url': url_for('Airflow.graph', dag_id=run.dag_id,
+                                   execution_date=run.execution_date)
+        })
+
+    return dag_runs

--- a/tests/www_rbac/api/experimental/test_dag_runs_endpoint.py
+++ b/tests/www_rbac/api/experimental/test_dag_runs_endpoint.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import json
+import unittest
+
+from airflow import configuration
+from airflow.api.common.experimental.trigger_dag import trigger_dag
+from airflow.models import DagRun
+from airflow.settings import Session
+from airflow.www_rbac import app as application
+
+
+class TestDagRunsEndpoint(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestDagRunsEndpoint, cls).setUpClass()
+        session = Session()
+        session.query(DagRun).delete()
+        session.commit()
+        session.close()
+
+    def setUp(self):
+        super(TestDagRunsEndpoint, self).setUp()
+        configuration.load_test_config()
+        app, _ = application.create_app(testing=True)
+        self.app = app.test_client()
+
+    def tearDown(self):
+        session = Session()
+        session.query(DagRun).delete()
+        session.commit()
+        session.close()
+        super(TestDagRunsEndpoint, self).tearDown()
+
+    def test_get_dag_runs_success(self):
+        url_template = '/api/experimental/dags/{}/dag_runs'
+        dag_id = 'example_bash_operator'
+        # Create DagRun
+        dag_run = trigger_dag(dag_id=dag_id, run_id='test_get_dag_runs_success')
+
+        response = self.app.get(url_template.format(dag_id))
+        self.assertEqual(200, response.status_code)
+        data = json.loads(response.data.decode('utf-8'))
+
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['dag_id'], dag_id)
+        self.assertEqual(data[0]['id'], dag_run.id)
+
+    def test_get_dag_runs_success_with_state_parameter(self):
+        url_template = '/api/experimental/dags/{}/dag_runs?state=running'
+        dag_id = 'example_bash_operator'
+        # Create DagRun
+        dag_run = trigger_dag(dag_id=dag_id, run_id='test_get_dag_runs_success')
+
+        response = self.app.get(url_template.format(dag_id))
+        self.assertEqual(200, response.status_code)
+        data = json.loads(response.data.decode('utf-8'))
+
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['dag_id'], dag_id)
+        self.assertEqual(data[0]['id'], dag_run.id)
+
+    def test_get_dag_runs_success_with_capital_state_parameter(self):
+        url_template = '/api/experimental/dags/{}/dag_runs?state=RUNNING'
+        dag_id = 'example_bash_operator'
+        # Create DagRun
+        dag_run = trigger_dag(dag_id=dag_id, run_id='test_get_dag_runs_success')
+
+        response = self.app.get(url_template.format(dag_id))
+        self.assertEqual(200, response.status_code)
+        data = json.loads(response.data.decode('utf-8'))
+
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['dag_id'], dag_id)
+        self.assertEqual(data[0]['id'], dag_run.id)
+
+    def test_get_dag_runs_success_with_state_no_result(self):
+        url_template = '/api/experimental/dags/{}/dag_runs?state=dummy'
+        dag_id = 'example_bash_operator'
+        # Create DagRun
+        trigger_dag(dag_id=dag_id, run_id='test_get_dag_runs_success')
+
+        response = self.app.get(url_template.format(dag_id))
+        self.assertEqual(200, response.status_code)
+        data = json.loads(response.data.decode('utf-8'))
+
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 0)
+
+    def test_get_dag_runs_invalid_dag_id(self):
+        url_template = '/api/experimental/dags/{}/dag_runs'
+        dag_id = 'DUMMY_DAG'
+
+        response = self.app.get(url_template.format(dag_id))
+        self.assertEqual(400, response.status_code)
+        data = json.loads(response.data.decode('utf-8'))
+
+        self.assertNotIsInstance(data, list)
+
+    def test_get_dag_runs_no_runs(self):
+        url_template = '/api/experimental/dags/{}/dag_runs'
+        dag_id = 'example_bash_operator'
+
+        response = self.app.get(url_template.format(dag_id))
+        self.assertEqual(200, response.status_code)
+        data = json.loads(response.data.decode('utf-8'))
+
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 0)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2550/) issues and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Implements a new endpoint to get a list of all DAG runs. It also supports a query parameter to filter out the DAG runs based on the "state" i.e., `?state=queued|running|success...`. 
*Usage: api/experimental/dags/<string:dag_id>/dag_runs?state=<queued|running|success...>*


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`tests/www_rbac/api/experimental/test_dag_runs_endpoint.py:TestDagRunsEndpoint`


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
