### PR TITLE
[AIRFLOW-2617] add imagePullPolicy config for kubernetes executor

### DIFF
--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -37,9 +37,11 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 
 class KubernetesExecutorConfig:
-    def __init__(self, image=None, request_memory=None, request_cpu=None,
-                 limit_memory=None, limit_cpu=None, gcp_service_account_key=None):
+    def __init__(self, image=None, image_pull_policy=None, request_memory=None,
+                 request_cpu=None, limit_memory=None, limit_cpu=None,
+                 gcp_service_account_key=None):
         self.image = image
+        self.image_pull_policy = image_pull_policy
         self.request_memory = request_memory
         self.request_cpu = request_cpu
         self.limit_memory = limit_memory
@@ -47,11 +49,11 @@ class KubernetesExecutorConfig:
         self.gcp_service_account_key = gcp_service_account_key
 
     def __repr__(self):
-        return "{}(image={}, request_memory={} ,request_cpu={}, limit_memory={}, " \
-               "limit_cpu={}, gcp_service_account_key={})" \
-            .format(KubernetesExecutorConfig.__name__, self.image, self.request_memory,
-                    self.request_cpu, self.limit_memory, self.limit_cpu,
-                    self.gcp_service_account_key)
+        return "{}(image={}, image_pull_policy={}, request_memory={}, request_cpu={}, " \
+               "limit_memory={}, limit_cpu={}, gcp_service_account_key={})" \
+            .format(KubernetesExecutorConfig.__name__, self.image, self.image_pull_policy,
+                    self.request_memory, self.request_cpu, self.limit_memory,
+                    self.limit_cpu, self.gcp_service_account_key)
 
     @staticmethod
     def from_dict(obj):
@@ -66,6 +68,7 @@ class KubernetesExecutorConfig:
 
         return KubernetesExecutorConfig(
             image=namespaced.get('image', None),
+            image_pull_policy=namespaced.get('image_pull_policy', None),
             request_memory=namespaced.get('request_memory', None),
             request_cpu=namespaced.get('request_cpu', None),
             limit_memory=namespaced.get('limit_memory', None),
@@ -76,6 +79,7 @@ class KubernetesExecutorConfig:
     def as_dict(self):
         return {
             'image': self.image,
+            'image_pull_policy': self.image_pull_policy,
             'request_memory': self.request_memory,
             'request_cpu': self.request_cpu,
             'limit_memory': self.limit_memory,
@@ -101,6 +105,9 @@ class KubeConfig:
             self.kubernetes_section, 'worker_container_tag')
         self.kube_image = '{}:{}'.format(
             self.worker_container_repository, self.worker_container_tag)
+        self.kube_image_pull_policy = configuration.get(
+            self.kubernetes_section, "worker_container_image_pull_policy"
+        )
         self.delete_worker_pods = conf.getboolean(
             self.kubernetes_section, 'delete_worker_pods')
 

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -183,6 +183,8 @@ class WorkerConfiguration(LoggingMixin):
             namespace=namespace,
             name=pod_id,
             image=kube_executor_config.image or self.kube_config.kube_image,
+            image_pull_policy=(kube_executor_config.image_pull_policy or
+                               self.kube_config.kube_image_pull_policy),
             cmds=['bash', '-cx', '--'],
             args=[airflow_command],
             labels={

--- a/scripts/ci/kubernetes/kube/configmaps.yaml
+++ b/scripts/ci/kubernetes/kube/configmaps.yaml
@@ -178,6 +178,7 @@ data:
     airflow_configmap = airflow-configmap
     worker_container_repository = airflow
     worker_container_tag = latest
+    worker_container_image_pull_policy = IfNotPresent
     delete_worker_pods = True
     git_repo = https://github.com/apache/incubator-airflow.git
     git_branch = master


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2617


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
I think this configuration of imagepullPolicy is required for kubernetes executor. When the newer airflow image of the work node is built, it needs to be configured by configuring imagepullpolicy=always
```
worker_container_repository = airflow 
worker_container_tag = latest
worker_container_image_pull_policy = Always
```

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

