### PR TITLE
[AIRFLOW-2621] Remove unnecessary return statement in TaskConcurrencyDep

### DIFF
--- a/airflow/ti_deps/deps/task_concurrency_dep.py
+++ b/airflow/ti_deps/deps/task_concurrency_dep.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -32,11 +32,10 @@ class TaskConcurrencyDep(BaseTIDep):
     def _get_dep_statuses(self, ti, session, dep_context):
         if ti.task.task_concurrency is None:
             yield self._passing_status(reason="Task concurrency is not set.")
-            return
 
         if ti.get_num_running_task_instances(session) >= ti.task.task_concurrency:
-            yield self._failing_status(reason="The max task concurrency has been reached.")
-            return
+            yield self._failing_status(reason="The max task concurrency "
+                                              "has been reached.")
         else:
-            yield self._passing_status(reason="The max task concurrency has not been reached.")
-            return
+            yield self._passing_status(reason="The max task concurrency "
+                                              "has not been reached.")


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2621
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
 since TaskConcurrencyDep returns a generator, remove the unnecessary return statement

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 trivial fix

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
