### PR TITLE
Adding REA Group to list of users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Currently **officially** using Airflow:
 1. [Zenly](https://zen.ly) [[@cerisier](https://github.com/cerisier) & [@jbdalido](https://github.com/jbdalido)]
 1. [Zymergen](https://www.zymergen.com/)
 1. [99](https://99taxis.com) [[@fbenevides](https://github.com/fbenevides), [@gustavoamigo](https://github.com/gustavoamigo) & [@mmmaia](https://github.com/mmmaia)]
+1. [REA Group](https://www.rea-group.com/)
 
 ## Links
 


### PR DESCRIPTION
We are using Airflow in a few of the data engineering teams.