### PR TITLE
[AIRFLOW-2624] Fix webserver login as anonymous

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -246,8 +246,8 @@ def action_logging(f):
     """
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        # Only AnonymousUserMixin() does not have user attribute
-        if current_user and hasattr(current_user, 'user'):
+        # AnonymousUserMixin() has user attribute but its value is None.
+        if current_user and hasattr(current_user, 'user') and current_user.user:
             user = current_user.user.username
         else:
             user = 'anonymous'
@@ -286,7 +286,7 @@ def notify_owner(f):
             dag = dagbag.get_dag(dag_id)
             task = dag.get_task(task_id)
 
-            if current_user and hasattr(current_user, 'username'):
+            if current_user and hasattr(current_user, 'user') and current_user.user:
                 user = current_user.username
             else:
                 user = 'anonymous'

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,8 +17,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import mock
 import unittest
 from xml.dom import minidom
+
+from airflow.www import app as application
 
 from airflow.www import utils
 
@@ -108,6 +111,84 @@ class UtilsTest(unittest.TestCase):
         """Should return params string ordered by param key"""
         self.assertEqual('page=3&search=bash_&showPaused=False',
                          utils.get_params(showPaused=False, page=3, search='bash_'))
+
+    # flask_login is loaded by calling flask_login._get_user.
+    @mock.patch("flask_login._get_user")
+    @mock.patch("airflow.settings.Session")
+    def test_action_logging_with_login_user(self, mocked_session, mocked_get_user):
+        fake_username = 'someone'
+        mocked_current_user = mock.MagicMock()
+        mocked_get_user.return_value = mocked_current_user
+        mocked_current_user.user.username = fake_username
+        mocked_session_instance = mock.MagicMock()
+        mocked_session.return_value = mocked_session_instance
+
+        app = application.create_app(testing=True)
+        # Patching here to avoid errors in applicant.create_app
+        with mock.patch("airflow.models.Log") as mocked_log:
+            with app.test_request_context():
+                @utils.action_logging
+                def some_func():
+                    pass
+
+                some_func()
+                mocked_log.assert_called_once()
+                (args, kwargs) = mocked_log.call_args_list[0]
+                self.assertEqual('some_func', kwargs['event'])
+                self.assertEqual(fake_username, kwargs['owner'])
+                mocked_session_instance.add.assert_called_once()
+
+    @mock.patch("flask_login._get_user")
+    @mock.patch("airflow.settings.Session")
+    def test_action_logging_with_invalid_user(self, mocked_session, mocked_get_user):
+        anonymous_username = 'anonymous'
+
+        # When the user returned by flask login_manager._load_user
+        # is invalid.
+        mocked_current_user = mock.MagicMock()
+        mocked_get_user.return_value = mocked_current_user
+        mocked_current_user.user = None
+        mocked_session_instance = mock.MagicMock()
+        mocked_session.return_value = mocked_session_instance
+
+        app = application.create_app(testing=True)
+        # Patching here to avoid errors in applicant.create_app
+        with mock.patch("airflow.models.Log") as mocked_log:
+            with app.test_request_context():
+                @utils.action_logging
+                def some_func():
+                    pass
+
+                some_func()
+                mocked_log.assert_called_once()
+                (args, kwargs) = mocked_log.call_args_list[0]
+                self.assertEqual('some_func', kwargs['event'])
+                self.assertEqual(anonymous_username, kwargs['owner'])
+                mocked_session_instance.add.assert_called_once()
+
+    # flask_login.current_user would be AnonymousUserMixin
+    # when there's no user_id in the flask session.
+    @mock.patch("airflow.settings.Session")
+    def test_action_logging_with_anonymous_user(self, mocked_session):
+        anonymous_username = 'anonymous'
+
+        mocked_session_instance = mock.MagicMock()
+        mocked_session.return_value = mocked_session_instance
+
+        app = application.create_app(testing=True)
+        # Patching here to avoid errors in applicant.create_app
+        with mock.patch("airflow.models.Log") as mocked_log:
+            with app.test_request_context():
+                @utils.action_logging
+                def some_func():
+                    pass
+
+                some_func()
+                mocked_log.assert_called_once()
+                (args, kwargs) = mocked_log.call_args_list[0]
+                self.assertEqual('some_func', kwargs['event'])
+                self.assertEqual(anonymous_username, kwargs['owner'])
+                mocked_session_instance.add.assert_called_once()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2624) issues and references them in the PR title.

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
`airflow webserver` and then click on any DAG will give
```
  File "/Users/kevin_yang/ext_repos/incubator-airflow/airflow/www/utils.py", line 364, in view_func
    return f(*args, **kwargs)
  File "/Users/kevin_yang/ext_repos/incubator-airflow/airflow/www/utils.py", line 251, in wrapper
    user = current_user.user.username
AttributeError: 'NoneType' object has no attribute 'username'
```

This fix it.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Manual test should be enough.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
