### PR TITLE
[AIRFLOW-2632] [AIRFLOW-2633]

### DIFF
--- a/airflow/contrib/operators/awsbatch_operator.py
+++ b/airflow/contrib/operators/awsbatch_operator.py
@@ -40,8 +40,11 @@ class AWSBatchOperator(BaseOperator):
     :param queue: the queue name on AWS Batch
     :type queue: str
     :param: overrides: the same parameter that boto3 will receive on
-            containerOverrides (templated):
+            containerOverrides:
             http://boto3.readthedocs.io/en/latest/reference/services/batch.html#submit_job
+            * No longer templated to avoid issue
+            with integers not being able to be templated - for example
+            when trying to specify vcpu or memory headroom
     :type: overrides: dict
     :param max_retries: exponential backoff retries while waiter is not merged
     :type max_retries: int
@@ -56,7 +59,6 @@ class AWSBatchOperator(BaseOperator):
     ui_color = '#c3dae0'
     client = None
     arn = None
-    template_fields = ('overrides',)
 
     @apply_defaults
     def __init__(self, job_name, job_definition, queue, overrides, max_retries=288,
@@ -128,7 +130,7 @@ class AWSBatchOperator(BaseOperator):
             retry = True
             retries = 0
 
-            while retries < self.max_retries or retry:
+            while retries < self.max_retries and retry:
                 response = self.client.describe_jobs(
                     jobs=[self.jobId]
                 )


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following issues: [this one](https://issues.apache.org/jira/browse/AIRFLOW-2633) and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

* Removed templating from overrides param in AWSBatchOperator due to issues templating ints. Ints must be allowed to e.g. allow the user to specify memory and vcpus for an AWS Batch Job. Right now, the inability to put ints in a templated field prohibits this. 

* Fixed control flow issue with the exponential backoff method of querying batch job for success. Previously, wouldn't quit until it hit max retries. Just had to change an `or` to an `and`!

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

* Two one line changes which are obvious in and of themselves. Additionally hard to write a test to submit a Batch job since you need AWS creds. 

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
