### PR TITLE
[AIRFLOW-2634] Remove dependency for impyla

### DIFF
--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -47,7 +47,6 @@ google-auth-httplib2
 gunicorn
 hdfs
 hive-thrift-py
-impyla
 ipython
 jaydebeapi
 jinja2<2.9.0

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,6 @@ hdfs = ['snakebite>=2.7.8']
 hive = [
     'hmsclient>=0.1.0',
     'pyhive>=0.6.0',
-    'impyla>=0.13.3'
 ]
 jdbc = ['jaydebeapi>=1.1.1']
 jenkins = ['python-jenkins>=0.4.15']


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2634
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

As a follow-up for AIRFLOW-2534, removing impyla from dependencies since it's never used now.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's just a dependency fix. I confirmed that the existent tests passed and HiveServer2Hook worked well with PyHive instead of impyla.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
