### PR TITLE
[AIRFLOW-2606] Fix DB schema and SQLAlchemy model

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -96,6 +96,7 @@ class BaseJob(Base, LoggingMixin):
 
     __table_args__ = (
         Index('job_type_heart', job_type, latest_heartbeat),
+        Index('idx_job_state_heartbeat', state, latest_heartbeat),
     )
 
     def __init__(

--- a/airflow/migrations/versions/05f30312d566_merge_heads.py
+++ b/airflow/migrations/versions/05f30312d566_merge_heads.py
@@ -1,0 +1,43 @@
+# flake8: noqa
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""merge heads
+
+Revision ID: 05f30312d566
+Revises: 86770d1215c0, 0e2a74e0fc9f
+Create Date: 2018-06-17 10:47:23.339972
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '05f30312d566'
+down_revision = ('86770d1215c0', '0e2a74e0fc9f')
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/airflow/migrations/versions/856955da8476_fix_sqlite_foreign_key.py
+++ b/airflow/migrations/versions/856955da8476_fix_sqlite_foreign_key.py
@@ -1,0 +1,90 @@
+# flake8: noqa
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""fix sqlite foreign key
+
+Revision ID: 856955da8476
+Revises: f23433877c24
+Create Date: 2018-06-17 15:54:53.844230
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '856955da8476'
+down_revision = 'f23433877c24'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    conn = op.get_bind()
+    if conn.dialect.name == 'sqlite':
+        # Fix broken foreign-key constraint for existing SQLite DBs.
+        #
+        # Re-define tables and use copy_from to avoid reflection
+        # which would fail because referenced user table doesn't exist.
+        #
+        # Use batch_alter_table to support SQLite workaround.
+        chart_table = sa.Table('chart',
+            sa.MetaData(),
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('label', sa.String(length=200), nullable=True),
+            sa.Column('conn_id', sa.String(length=250), nullable=False),
+            sa.Column('user_id', sa.Integer(), nullable=True),
+            sa.Column('chart_type', sa.String(length=100), nullable=True),
+            sa.Column('sql_layout', sa.String(length=50), nullable=True),
+            sa.Column('sql', sa.Text(), nullable=True),
+            sa.Column('y_log_scale', sa.Boolean(), nullable=True),
+            sa.Column('show_datatable', sa.Boolean(), nullable=True),
+            sa.Column('show_sql', sa.Boolean(), nullable=True),
+            sa.Column('height', sa.Integer(), nullable=True),
+            sa.Column('default_params', sa.String(length=5000), nullable=True),
+            sa.Column('x_is_date', sa.Boolean(), nullable=True),
+            sa.Column('iteration_no', sa.Integer(), nullable=True),
+            sa.Column('last_modified', sa.DateTime(), nullable=True),
+            sa.PrimaryKeyConstraint('id')
+        )
+        with op.batch_alter_table('chart', copy_from=chart_table) as batch_op:
+            batch_op.create_foreign_key('chart_user_id_fkey', 'users',
+                                        ['user_id'], ['id'])
+
+        known_event_table = sa.Table('known_event',
+            sa.MetaData(),
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('label', sa.String(length=200), nullable=True),
+            sa.Column('start_date', sa.DateTime(), nullable=True),
+            sa.Column('end_date', sa.DateTime(), nullable=True),
+            sa.Column('user_id', sa.Integer(), nullable=True),
+            sa.Column('known_event_type_id', sa.Integer(), nullable=True),
+            sa.Column('description', sa.Text(), nullable=True),
+            sa.ForeignKeyConstraint(['known_event_type_id'],
+                                    ['known_event_type.id'], ),
+            sa.PrimaryKeyConstraint('id')
+        )
+        with op.batch_alter_table('chart', copy_from=known_event_table) as batch_op:
+            batch_op.create_foreign_key('known_event_user_id_fkey', 'users',
+                                        ['user_id'], ['id'])
+
+
+def downgrade():
+    # Downgrade would fail because the broken FK constraint can't be re-created.
+    pass

--- a/airflow/migrations/versions/f23433877c24_fix_mysql_not_null_constraint.py
+++ b/airflow/migrations/versions/f23433877c24_fix_mysql_not_null_constraint.py
@@ -1,0 +1,54 @@
+# flake8: noqa
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""fix mysql not null constraint
+
+Revision ID: f23433877c24
+Revises: 05f30312d566
+Create Date: 2018-06-17 10:16:31.412131
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'f23433877c24'
+down_revision = '05f30312d566'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+def upgrade():
+    conn = op.get_bind()
+    if conn.dialect.name == 'mysql':
+        conn.execute("SET time_zone = '+00:00'")
+        op.alter_column('task_fail', 'execution_date', existing_type=mysql.TIMESTAMP(fsp=6), nullable=False)
+        op.alter_column('xcom', 'execution_date', existing_type=mysql.TIMESTAMP(fsp=6), nullable=False)
+        op.alter_column('xcom', 'timestamp', existing_type=mysql.TIMESTAMP(fsp=6), nullable=False)
+
+
+def downgrade():
+    conn = op.get_bind()
+    if conn.dialect.name == 'mysql':
+        conn.execute("SET time_zone = '+00:00'")
+        op.alter_column('xcom', 'timestamp', existing_type=mysql.TIMESTAMP(fsp=6), nullable=True)
+        op.alter_column('xcom', 'execution_date', existing_type=mysql.TIMESTAMP(fsp=6), nullable=True)
+        op.alter_column('task_fail', 'execution_date', existing_type=mysql.TIMESTAMP(fsp=6), nullable=True)
+

--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -101,6 +101,12 @@ def setup_event_handlers(
     def connect(dbapi_connection, connection_record):
         connection_record.info['pid'] = os.getpid()
 
+    @event.listens_for(engine, "connect")
+    def set_sqlite_pragma(dbapi_connection, connection_record):
+        if 'sqlite3.Connection' in str(type(dbapi_connection)):
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.close()
 
     @event.listens_for(engine, "checkout")
     def checkout(dbapi_connection, connection_record, connection_proxy):

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow.models import Base as airflow_base
+from flask_appbuilder.models.sqla import Base as fab_base
+
+from airflow.settings import engine, RBAC
+from alembic.autogenerate import compare_metadata
+from alembic.migration import MigrationContext
+from sqlalchemy import MetaData
+
+
+class DbTest(unittest.TestCase):
+
+    def test_database_schema_and_sqlalchemy_model_are_in_sync(self):
+        # combine Airflow and Flask-AppBuilder (if rbac enabled) models
+        all_meta_data = MetaData()
+        for (table_name, table) in airflow_base.metadata.tables.items():
+            all_meta_data._add_table(table_name, table.schema, table)
+        if RBAC:
+            for (table_name, table) in fab_base.metadata.tables.items():
+                all_meta_data._add_table(table_name, table.schema, table)
+
+        # create diff between database schema and SQLAlchemy model
+        mc = MigrationContext.configure(engine.connect())
+        diff = compare_metadata(mc, all_meta_data)
+
+        # known diffs to ignore
+        ignores = [
+            # users.password is not part of User model,
+            # otherwise it would show up in (old) UI
+            lambda t: (t[0] == 'remove_column' and
+                       t[2] == 'users' and
+                       t[3].name == 'password'),
+            # ignore tables created by other tests
+            lambda t: (t[0] == 'remove_table' and
+                       t[1].name == 't'),
+            lambda t: (t[0] == 'remove_table' and
+                       t[1].name == 'test_airflow'),
+            lambda t: (t[0] == 'remove_table' and
+                       t[1].name == 'test_postgres_to_postgres'),
+            lambda t: (t[0] == 'remove_table' and
+                       t[1].name == 'test_mysql_to_mysql'),
+            # ignore tables created by celery
+            lambda t: (t[0] == 'remove_table' and
+                       t[1].name == 'celery_taskmeta'),
+            lambda t: (t[0] == 'remove_table' and
+                       t[1].name == 'celery_tasksetmeta'),
+        ]
+        for ignore in ignores:
+            diff = [d for d in diff if not ignore(d)]
+
+        self.assertFalse(diff, 'Database schema and SQLAlchemy model are not in sync')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2606


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
    - Add test that verifies that database schema and SQLAlchemy model are in sync
    - Add exception for users.password that doesn't exist in model and tables created by other tests
    - Update SQLAlchemy models to match the current DB schema
    - Add migration script to merge the two heads
    - Add migration script to fix not-null constrains for MySQL that were lost by 0e2a74e0fc9f_add_time_zone_awareness
    - Enable ForeignKey support for SQLite, otherwise 2e82aab8ef20_rename_user_table won't change FK in chart and known_event tables

### Tests
- [X] My PR adds the following unit tests:
    - tests.utils.test_db.DbTest


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
