### PR TITLE
[AIRFLOW-2638] dbapi_hook: add support for replace into instead of insert into

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -205,7 +205,8 @@ class DbApiHook(BaseHook):
         """
         return self.get_conn().cursor()
 
-    def insert_rows(self, table, rows, target_fields=None, commit_every=1000):
+    def insert_rows(self, table, rows, target_fields=None, commit_every=1000,
+                    replace=False):
         """
         A generic way to insert a set of tuples into a table,
         a new transaction is created every commit_every rows
@@ -219,6 +220,8 @@ class DbApiHook(BaseHook):
         :param commit_every: The maximum number of rows to insert in one
             transaction. Set to 0 to insert all rows in one transaction.
         :type commit_every: int
+        :param replace: Whether to replace instead of insert
+        :type replace: bool
         """
         if target_fields:
             target_fields = ", ".join(target_fields)
@@ -239,7 +242,11 @@ class DbApiHook(BaseHook):
                         lst.append(self._serialize_cell(cell, conn))
                     values = tuple(lst)
                     placeholders = ["%s", ] * len(values)
-                    sql = "INSERT INTO {0} {1} VALUES ({2})".format(
+                    if not replace:
+                        sql = "INSERT INTO "
+                    else:
+                        sql = "REPLACE INTO "
+                    sql += "{0} {1} VALUES ({2})".format(
                         table,
                         target_fields,
                         ",".join(placeholders))

--- a/tests/hooks/test_dbapi_hook.py
+++ b/tests/hooks/test_dbapi_hook.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -46,36 +46,36 @@ class TestDbApiHook(unittest.TestCase):
         statement = "SQL"
         rows = [("hello",),
                 ("world",)]
-        
+
         self.cur.fetchall.return_value = rows
-        
+
         self.assertEqual(rows, self.db_hook.get_records(statement))
-        
+
         self.conn.close.assert_called_once()
         self.cur.close.assert_called_once()
         self.cur.execute.assert_called_once_with(statement)
-        
+
     def test_get_records_parameters(self):
         statement = "SQL"
         parameters = ["X", "Y", "Z"]
         rows = [("hello",),
                 ("world",)]
-        
+
         self.cur.fetchall.return_value = rows
 
         self.assertEqual(rows, self.db_hook.get_records(statement, parameters))
-        
+
         self.conn.close.assert_called_once()
         self.cur.close.assert_called_once()
         self.cur.execute.assert_called_once_with(statement, parameters)
-        
+
     def test_get_records_exception(self):
         statement = "SQL"
         self.cur.fetchall.side_effect = RuntimeError('Great Problems')
-        
+
         with self.assertRaises(RuntimeError):
             self.db_hook.get_records(statement)
-        
+
         self.conn.close.assert_called_once()
         self.cur.close.assert_called_once()
         self.cur.execute.assert_called_once_with(statement)
@@ -94,6 +94,23 @@ class TestDbApiHook(unittest.TestCase):
         self.assertEqual(commit_count, self.conn.commit.call_count)
 
         sql = "INSERT INTO {}  VALUES (%s)".format(table)
+        for row in rows:
+            self.cur.execute.assert_any_call(sql, row)
+
+    def test_insert_rows_replace(self):
+        table = "table"
+        rows = [("hello",),
+                ("world",)]
+
+        self.db_hook.insert_rows(table, rows, replace=True)
+
+        self.conn.close.assert_called_once()
+        self.cur.close.assert_called_once()
+
+        commit_count = 2  # The first and last commit
+        self.assertEqual(commit_count, self.conn.commit.call_count)
+
+        sql = "REPLACE INTO {}  VALUES (%s)".format(table)
         for row in rows:
             self.cur.execute.assert_any_call(sql, row)
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2638


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
No UI changes.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`test_dbapi_hook.test_insert_rows_replace`

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
