### PR TITLE
[AIRFLOW-2640] Add Cassandra table sensor

### DIFF
--- a/airflow/contrib/hooks/cassandra_hook.py
+++ b/airflow/contrib/hooks/cassandra_hook.py
@@ -158,6 +158,21 @@ class CassandraHook(BaseHook, LoggingMixin):
                                                            child_policy_args)
                 return TokenAwarePolicy(child_policy)
 
+    def table_exists(self, table):
+        """
+        Checks if a table exists in Cassandra
+
+        :param table: Target Cassandra table.
+                      Use dot notation to target a specific keyspace.
+        :type table: string
+        """
+        keyspace = self.keyspace
+        if '.' in table:
+            keyspace, table = table.split('.', 1)
+        cluster_metadata = self.get_conn().cluster.metadata
+        return (keyspace in cluster_metadata.keyspaces and
+                table in cluster_metadata.keyspaces[keyspace].tables)
+
     def record_exists(self, table, keys):
         """
         Checks if a record exists in Cassandra
@@ -168,12 +183,12 @@ class CassandraHook(BaseHook, LoggingMixin):
         :param keys: The keys and their values to check the existence.
         :type keys: dict
         """
-        keyspace = None
+        keyspace = self.keyspace
         if '.' in table:
             keyspace, table = table.split('.', 1)
         ks = " AND ".join("{}=%({})s".format(key, key) for key in keys.keys())
         cql = "SELECT * FROM {keyspace}.{table} WHERE {keys}".format(
-            keyspace=(keyspace or self.keyspace), table=table, keys=ks)
+            keyspace=keyspace, table=table, keys=ks)
 
         try:
             rs = self.get_conn().execute(cql, keys)

--- a/airflow/contrib/sensors/cassandra_record_sensor.py
+++ b/airflow/contrib/sensors/cassandra_record_sensor.py
@@ -29,9 +29,10 @@ class CassandraRecordSensor(BaseSensorOperator):
     primary keys 'p1' and 'p2' to be populated in keyspace 'k' and table 't',
     instantiate it as follows:
 
-    >>> CassandraRecordSensor(table="k.t", keys={"p1": "v1", "p2": "v2"},
-    ...     cassandra_conn_id="cassandra_default", task_id="cassandra_sensor")
-    <Task(CassandraRecordSensor): cassandra_sensor>
+    >>> cassandra_sensor = CassandraRecordSensor(table="k.t",
+    ...                                          keys={"p1": "v1", "p2": "v2"},
+    ...                                          cassandra_conn_id="cassandra_default",
+    ...                                          task_id="cassandra_sensor")
     """
     template_fields = ('table', 'keys')
 

--- a/airflow/contrib/sensors/cassandra_table_sensor.py
+++ b/airflow/contrib/sensors/cassandra_table_sensor.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from airflow.contrib.hooks.cassandra_hook import CassandraHook
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class CassandraTableSensor(BaseSensorOperator):
+    """
+    Checks for the existence of a table in a Cassandra cluster.
+
+    For example, if you want to wait for a table called 't' to be created
+    in a keyspace 'k', instantiate it as follows:
+
+    >>> cassandra_sensor = CassandraTableSensor(table="k.t",
+    ...                                         cassandra_conn_id="cassandra_default",
+    ...                                         task_id="cassandra_sensor")
+    """
+    template_fields = ('table',)
+
+    @apply_defaults
+    def __init__(self, table, cassandra_conn_id, *args, **kwargs):
+        """
+        Create a new CassandraTableSensor
+
+        :param table: Target Cassandra table.
+                      Use dot notation to target a specific keyspace.
+        :type table: string
+        :param cassandra_conn_id: The connection ID to use
+                                  when connecting to Cassandra cluster
+        :type cassandra_conn_id: string
+        """
+        super(CassandraTableSensor, self).__init__(*args, **kwargs)
+        self.cassandra_conn_id = cassandra_conn_id
+        self.table = table
+
+    def poke(self, context):
+        self.log.info('Sensor check existence of table: %s', self.table)
+        hook = CassandraHook(self.cassandra_conn_id)
+        return hook.table_exists(self.table)

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -198,7 +198,8 @@ Sensors
 .. autoclass:: airflow.contrib.sensors.aws_redshift_cluster_sensor.AwsRedshiftClusterSensor
 .. autoclass:: airflow.contrib.sensors.bash_sensor.BashSensor
 .. autoclass:: airflow.contrib.sensors.bigquery_sensor.BigQueryTableSensor
-.. autoclass:: airflow.contrib.sensors.cassandra_sensor.CassandraRecordSensor
+.. autoclass:: airflow.contrib.sensors.cassandra_record_sensor.CassandraRecordSensor
+.. autoclass:: airflow.contrib.sensors.cassandra_table_sensor.CassandraTableSensor
 .. autoclass:: airflow.contrib.sensors.datadog_sensor.DatadogSensor
 .. autoclass:: airflow.contrib.sensors.emr_base_sensor.EmrBaseSensor
 .. autoclass:: airflow.contrib.sensors.emr_job_flow_sensor.EmrJobFlowSensor


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2640
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Just like a partition sensor for Hive,
this PR adds a sensor that waits for
a table to be created in Cassandra cluster.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

tests.contrib.hooks.test_cassandra_hook:CassandraHookTest.test_table_exists
tests.contrib.sensors.test_cassandra_sensor:TestCassandraTableSensor

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
