### PR TITLE
[AIRFLOW-2642] fix wrong value git-sync initcontainer env GIT_SYNC_ROOT

### DIFF
--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -50,7 +50,10 @@ class WorkerConfiguration(LoggingMixin):
             'value': self.kube_config.git_branch
         }, {
             'name': 'GIT_SYNC_ROOT',
-            'value': '/tmp'
+            'value': os.path.join(
+                self.worker_airflow_dags,
+                self.kube_config.git_subpath
+            )
         }, {
             'name': 'GIT_SYNC_DEST',
             'value': 'dags'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2642


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
There are two way of syncing dags, pvc and git-sync. When we use git-sync this way, git-sync will synchronize dags to /tmp/dags directory. However the worker container command args (airflow run tutorial1 print_date 2018-06-19T07:57:15.011693+00:00 --local -sd
/root/airflow/dags/dags/example_dags/tutorial1.py) are generated by the scheduler. The worker cannot find the corresponding dag, so I think the environment variable GIT_SYNC_ROOT should be consistent with dag_volume_mount_path.  


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
