### PR TITLE
[WIP][AIRFLOW-2625] [AIRFLOW-2616] Implements an API to fetch all DAGs 

### DIFF
--- a/airflow/api/common/experimental/dags.py
+++ b/airflow/api/common/experimental/dags.py
@@ -16,28 +16,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-from airflow.api.common.experimental.dags import get_dags
-from airflow.www_rbac.api.experimental.base import AirflowAPIView
-
-
-class DagListView(AirflowAPIView):
-    # noinspection PyMethodMayBeStatic
-    def get(self):
-        # Retrieve a list of all DAGs
-        dags = get_dags()
-        response = {
-            'total_dags': len(dags),
-            'dags': [dag.to_json() for dag in dags]
-        }
-        return response
+from airflow.models import DagModel
+from airflow.utils.db import provide_session
 
 
-class DagView(AirflowAPIView):
-    def get(self, dag_id):
-        # Retrieve details of a DAG
-        pass
-
-    def put(self, dag_id):
-        # Update details of a DAG
-        pass
+@provide_session
+def get_dags(session=None):
+    """Get all DAGs."""
+    return session.query(DagModel).all()

--- a/airflow/api/common/experimental/get_dag_runs.py
+++ b/airflow/api/common/experimental/get_dag_runs.py
@@ -18,7 +18,7 @@
 # under the License.
 from flask import url_for
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import DagNotFound
 from airflow.models import DagBag, DagRun
 
 
@@ -35,7 +35,7 @@ def get_dag_runs(dag_id, state=None):
     # Check DAG exists.
     if dag_id not in dagbag.dags:
         error_message = "Dag id {} not found".format(dag_id)
-        raise AirflowException(error_message)
+        raise DagNotFound(error_message)
 
     dag_runs = list()
     state = state.lower() if state else None

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3057,6 +3057,20 @@ class DagModel(Base):
     def get_current(cls, dag_id, session=None):
         return session.query(cls).filter(cls.dag_id == dag_id).first()
 
+    def to_json(self):
+        return {
+            'id': self.dag_id,
+            'is_paused': self.is_paused,
+            'is_subdag': self.is_subdag,
+            'is_active': self.is_active,
+            'last_scheduler_run': self.last_scheduler_run,
+            'last_pickled': self.last_pickled,
+            'last_expired': self.last_expired,
+            'pickle_id': self.pickle_id,
+            'fileloc': self.fileloc,
+            'owners': self.owners,
+        }
+
 
 @functools.total_ordering
 class DAG(BaseDag, LoggingMixin):

--- a/airflow/www_rbac/api/experimental/base.py
+++ b/airflow/www_rbac/api/experimental/base.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from flask import jsonify
+from flask.views import MethodView
+
+import airflow.api
+from airflow import AirflowException
+from airflow.utils.log.logging_mixin import LoggingMixin
+
+_log = LoggingMixin().log
+requires_authentication = airflow.api.api_auth.requires_authentication
+
+
+def json_response(func):
+    """
+    Converts Response to JSON, using flask's jsonify()
+    :param func:
+    :return:
+    """
+
+    def decorator(*args, **kwargs):
+        try:
+            response = jsonify(func(*args, **kwargs))
+        except AirflowException as err:
+            _log.error(err)
+            response = jsonify(error="{}".format(err))
+            response.status_code = err.status_code
+
+        return response
+
+    return decorator
+
+
+class BaseEndpointView(MethodView):
+    decorators = [json_response, requires_authentication]

--- a/airflow/www_rbac/api/experimental/base.py
+++ b/airflow/www_rbac/api/experimental/base.py
@@ -47,5 +47,5 @@ def json_response(func):
     return decorator
 
 
-class BaseEndpointView(MethodView):
+class AirflowAPIView(MethodView):
     decorators = [json_response, requires_authentication]

--- a/airflow/www_rbac/api/experimental/endpoints.py
+++ b/airflow/www_rbac/api/experimental/endpoints.py
@@ -27,6 +27,7 @@ from airflow.api.common.experimental.get_dag_run_state import get_dag_run_state
 from airflow.exceptions import AirflowException
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils import timezone
+from airflow.www_rbac.api.experimental.views.dags import DagListView
 from airflow.www_rbac.app import csrf
 from airflow import models
 from airflow.utils.db import create_session
@@ -318,3 +319,6 @@ def delete_pool(name):
         return response
     else:
         return jsonify(pool.to_json())
+
+
+api_experimental.add_url_rule('/dags/', view_func=DagListView.as_view('dags'))

--- a/airflow/www_rbac/api/experimental/views/__init__.py
+++ b/airflow/www_rbac/api/experimental/views/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/www_rbac/api/experimental/views/dags.py
+++ b/airflow/www_rbac/api/experimental/views/dags.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.www_rbac.api.experimental.base import BaseEndpointView
+
+
+class DagListView(BaseEndpointView):
+    # noinspection PyMethodMayBeStatic
+    def get(self):
+        # Retrieve a list of all DAGs
+        return {'Success': 'Hurrayyyy!!'}
+
+
+class DagView(BaseEndpointView):
+    def get(self, dag_id):
+        # Retrieve details of a DAG
+        pass
+
+    def put(self, dag_id):
+        # Update details of a DAG
+        pass


### PR DESCRIPTION
**This PR is WIP. 
Opened this PR for community approval to use MethodView instead of developing APIs using functional views. It would help in organizing the APIs using modular approach, else our endpoints.py file will eventually grow bigger, and hard to maintain.**

Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2625) issues and references them in the PR title.

### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:
It adds a basic functionality of an API to get all DAGs and the count using the MethodView. I still need to add the searching/filtering and ordering features for this endpoint.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
