### PR TITLE
[AIRFLOW-2645] Add worker_container_image_pull_policy to default_airflow.cfg

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -554,9 +554,10 @@ elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_
 elasticsearch_end_of_log_mark = end_of_log
 
 [kubernetes]
-# The repository and tag of the Kubernetes Image for the Worker to Run
+# The repository, tag and imagePullPolicy of the Kubernetes Image for the Worker to Run
 worker_container_repository =
 worker_container_tag =
+worker_container_image_pull_policy = IfNotPresent
 
 # If True (default), worker pods will be deleted upon termination
 delete_worker_pods = True


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2617



### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
As [AIRFLOW-2617](https://github.com/apache/incubator-airflow/pull/3500) added worker_container_image_pull_policy config to the section of kubernetes, but the airflow_default.cfg was not updated, this PR add worker_container_image_pull_policy to default_airflow.cfg.



### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"
