### PR TITLE
[AIRFLOW-2592] Bump bleach dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -248,7 +248,7 @@ def do_setup():
         scripts=['airflow/bin/airflow'],
         install_requires=[
             'alembic>=0.8.3, <0.9',
-            'bleach==2.1.2',
+            'bleach~=2.1.3',
             'configparser>=3.5.0, <3.6.0',
             'croniter>=0.3.17, <0.4',
             'dill>=0.2.2, <0.3',


### PR DESCRIPTION
Bleach dependency is updated to 2.1.3 to address CVE-2018-7753

Jira link: https://issues.apache.org/jira/browse/AIRFLOW-2592

Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
Bump version of package dependency (bleach) to address security issue CVE-2018-7753

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Just a version bump of a package dependency, no new code

### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
No new functionality

### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
