### PR TITLE
[AIRFLOW-2654] Fix incorret URL requested on refresh in Graph View of…

### DIFF
--- a/airflow/www_rbac/templates/airflow/graph.html
+++ b/airflow/www_rbac/templates/airflow/graph.html
@@ -1,13 +1,13 @@
-{# 
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -350,7 +350,7 @@
             $("#loading").css("display", "block");
             $("div#svg_container").css("opacity", "0.2");
             $.get(
-                "/airflow/object/task_instances",
+                "{{ url_for('Airflow.task_instances') }}",
                 {dag_id : "{{ dag.dag_id }}", execution_date : "{{ execution_date }}"})
             .done(
                 function(task_instances) {


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2654

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
- Fix incorrect URL requested on pressing the refresh button in the graph view of the new FAB UI.

As shown in the figure below, we currently get the error when the refresh button is pressed.
<img width="1263" alt="airflow-refresh-error" src="https://user-images.githubusercontent.com/8811558/41688365-c10012b2-74e3-11e8-9a7c-eda2769306bf.png">


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
N/A - UI changes

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
