### PR TITLE
[AIRFLOW-2658] Add GCP specific k8s pod operator

### DIFF
--- a/docs/code.rst
+++ b/docs/code.rst
@@ -153,6 +153,7 @@ Operators
 .. autoclass:: airflow.contrib.operators.file_to_wasb.FileToWasbOperator
 .. autoclass:: airflow.contrib.operators.gcp_container_operator.GKEClusterCreateOperator
 .. autoclass:: airflow.contrib.operators.gcp_container_operator.GKEClusterDeleteOperator
+.. autoclass:: airflow.contrib.operators.gcp_container_operator.GKEPodOperator
 .. autoclass:: airflow.contrib.operators.gcs_download_operator.GoogleCloudStorageDownloadOperator
 .. autoclass:: airflow.contrib.operators.gcs_list_operator.GoogleCloudStorageListOperator
 .. autoclass:: airflow.contrib.operators.gcs_operator.GoogleCloudStorageCreateBucketOperator

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -776,6 +776,12 @@ GKEClusterDeleteOperator
 .. autoclass:: airflow.contrib.operators.gcp_container_operator.GKEClusterDeleteOperator
 .. _GKEClusterDeleteOperator:
 
+GKEPodOperator
+^^^^^^^^^^^^^^
+
+.. autoclass:: airflow.contrib.operators.gcp_container_operator.GKEPodOperator
+.. _GKEPodOperator:
+
 Google Kubernetes Engine Hook
 """""""""""""""""""""""""""""
 

--- a/tests/contrib/operators/test_gcp_container_operator.py
+++ b/tests/contrib/operators/test_gcp_container_operator.py
@@ -17,11 +17,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import os
 import unittest
 
 from airflow import AirflowException
 from airflow.contrib.operators.gcp_container_operator import GKEClusterCreateOperator, \
-    GKEClusterDeleteOperator
+    GKEClusterDeleteOperator, GKEPodOperator
+from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 
 try:
     from unittest import mock
@@ -38,6 +40,15 @@ CLUSTER_NAME = 'test-cluster-name'
 
 PROJECT_BODY = {'name': 'test-name'}
 PROJECT_BODY_CREATE = {'name': 'test-name', 'initial_node_count': 1}
+
+TASK_NAME = 'test-task-name'
+NAMESPACE = 'default',
+IMAGE = 'bash'
+
+GCLOUD_COMMAND = "gcloud container clusters get-credentials {} --zone {} --project {}"
+KUBE_ENV_VAR = 'KUBECONFIG'
+GAC_ENV_VAR = 'GOOGLE_APPLICATION_CREDENTIALS'
+FILE_NAME = '/tmp/mock_name'
 
 
 class GoogleCloudPlatformContainerOperatorTest(unittest.TestCase):
@@ -123,3 +134,162 @@ class GoogleCloudPlatformContainerOperatorTest(unittest.TestCase):
 
             operator.execute(None)
             mock_hook.return_value.delete_cluster.assert_not_called()
+
+
+class GKEPodOperatorTest(unittest.TestCase):
+    def setUp(self):
+        self.gke_op = GKEPodOperator(project_id=PROJECT_ID,
+                                     location=PROJECT_LOCATION,
+                                     cluster_name=CLUSTER_NAME,
+                                     task_id=PROJECT_TASK_ID,
+                                     name=TASK_NAME,
+                                     namespace=NAMESPACE,
+                                     image=IMAGE)
+
+    def test_template_fields(self):
+        self.assertTrue(set(KubernetesPodOperator.template_fields).issubset(
+            GKEPodOperator.template_fields))
+
+    @mock.patch(
+        'airflow.contrib.operators.kubernetes_pod_operator.KubernetesPodOperator.execute')
+    @mock.patch('tempfile.NamedTemporaryFile')
+    @mock.patch("subprocess.check_call")
+    def test_execute_conn_id_none(self, proc_mock, file_mock, exec_mock):
+        self.gke_op.gcp_conn_id = None
+
+        file_mock.return_value.__enter__.return_value.name = FILE_NAME
+
+        self.gke_op.execute(None)
+
+        # Assert Environment Variable is being set correctly
+        self.assertIn(KUBE_ENV_VAR, os.environ)
+        self.assertEqual(os.environ[KUBE_ENV_VAR], FILE_NAME)
+
+        # Assert the gcloud command being called correctly
+        proc_mock.assert_called_with(
+            GCLOUD_COMMAND.format(CLUSTER_NAME, PROJECT_LOCATION, PROJECT_ID).split())
+
+        self.assertEqual(self.gke_op.config_file, FILE_NAME)
+
+    @mock.patch('airflow.hooks.base_hook.BaseHook.get_connection')
+    @mock.patch(
+        'airflow.contrib.operators.kubernetes_pod_operator.KubernetesPodOperator.execute')
+    @mock.patch('tempfile.NamedTemporaryFile')
+    @mock.patch("subprocess.check_call")
+    @mock.patch.dict(os.environ, {})
+    def test_execute_conn_id_path(self, proc_mock, file_mock, exec_mock, get_con_mock):
+        # gcp_conn_id is defaulted to `google_cloud_default`
+
+        FILE_PATH = '/path/to/file'
+        KEYFILE_DICT = {"extra__google_cloud_platform__key_path": FILE_PATH}
+        get_con_mock.return_value.extra_dejson = KEYFILE_DICT
+        file_mock.return_value.__enter__.return_value.name = FILE_NAME
+
+        self.gke_op.execute(None)
+
+        # Assert Environment Variable is being set correctly
+        self.assertIn(KUBE_ENV_VAR, os.environ)
+        self.assertEqual(os.environ[KUBE_ENV_VAR], FILE_NAME)
+
+        self.assertIn(GAC_ENV_VAR, os.environ)
+        # since we passed in keyfile_path we should get a file
+        self.assertEqual(os.environ[GAC_ENV_VAR], FILE_PATH)
+
+        # Assert the gcloud command being called correctly
+        proc_mock.assert_called_with(
+            GCLOUD_COMMAND.format(CLUSTER_NAME, PROJECT_LOCATION, PROJECT_ID).split())
+
+        self.assertEqual(self.gke_op.config_file, FILE_NAME)
+
+    @mock.patch.dict(os.environ, {})
+    @mock.patch('airflow.hooks.base_hook.BaseHook.get_connection')
+    @mock.patch(
+        'airflow.contrib.operators.kubernetes_pod_operator.KubernetesPodOperator.execute')
+    @mock.patch('tempfile.NamedTemporaryFile')
+    @mock.patch("subprocess.check_call")
+    def test_execute_conn_id_dict(self, proc_mock, file_mock, exec_mock, get_con_mock):
+        # gcp_conn_id is defaulted to `google_cloud_default`
+        FILE_PATH = '/path/to/file'
+
+        # This is used in the _set_env_from_extras method
+        file_mock.return_value.name = FILE_PATH
+        # This is used in the execute method
+        file_mock.return_value.__enter__.return_value.name = FILE_NAME
+
+        KEYFILE_DICT = {"extra__google_cloud_platform__keyfile_dict":
+                        '{"private_key": "r4nd0m_k3y"}'}
+        get_con_mock.return_value.extra_dejson = KEYFILE_DICT
+
+        self.gke_op.execute(None)
+
+        # Assert Environment Variable is being set correctly
+        self.assertIn(KUBE_ENV_VAR, os.environ)
+        self.assertEqual(os.environ[KUBE_ENV_VAR], FILE_NAME)
+
+        self.assertIn(GAC_ENV_VAR, os.environ)
+        # since we passed in keyfile_path we should get a file
+        self.assertEqual(os.environ[GAC_ENV_VAR], FILE_PATH)
+
+        # Assert the gcloud command being called correctly
+        proc_mock.assert_called_with(
+            GCLOUD_COMMAND.format(CLUSTER_NAME, PROJECT_LOCATION, PROJECT_ID).split())
+
+        self.assertEqual(self.gke_op.config_file, FILE_NAME)
+
+    @mock.patch.dict(os.environ, {})
+    def test_set_env_from_extras_none(self):
+        extras = {}
+        self.gke_op._set_env_from_extras(extras)
+        # _set_env_from_extras should not edit os.environ if extras does not specify
+        self.assertNotIn(GAC_ENV_VAR, os.environ)
+
+    @mock.patch.dict(os.environ, {})
+    @mock.patch('tempfile.NamedTemporaryFile')
+    def test_set_env_from_extras_dict(self, file_mock):
+        file_mock.return_value.name = FILE_NAME
+
+        KEYFILE_DICT_STR = '{ \"test\": \"cluster\" }'
+        extras = {
+            'extra__google_cloud_platform__keyfile_dict': KEYFILE_DICT_STR,
+        }
+
+        self.gke_op._set_env_from_extras(extras)
+        self.assertEquals(os.environ[GAC_ENV_VAR], FILE_NAME)
+
+        file_mock.return_value.write.assert_called_once_with(KEYFILE_DICT_STR)
+
+    @mock.patch.dict(os.environ, {})
+    def test_set_env_from_extras_path(self):
+        TEST_PATH = '/test/path'
+
+        extras = {
+            'extra__google_cloud_platform__key_path': TEST_PATH,
+        }
+
+        self.gke_op._set_env_from_extras(extras)
+        self.assertEquals(os.environ[GAC_ENV_VAR], TEST_PATH)
+
+    def test_get_field(self):
+        FIELD_NAME = 'test_field'
+        FIELD_VALUE = 'test_field_value'
+        extras = {
+            'extra__google_cloud_platform__{}'.format(FIELD_NAME):
+                FIELD_VALUE
+        }
+
+        ret_val = self.gke_op._get_field(extras, FIELD_NAME)
+        self.assertEqual(FIELD_VALUE, ret_val)
+
+    @mock.patch('airflow.contrib.operators.gcp_container_operator.GKEPodOperator.log')
+    def test_get_field_fail(self, log_mock):
+        log_mock.info = mock.Mock()
+        LOG_STR = 'Field {} not found in extras.'
+        FIELD_NAME = 'test_field'
+        FIELD_VALUE = 'test_field_value'
+
+        extras = {}
+
+        ret_val = self.gke_op._get_field(extras, FIELD_NAME, default=FIELD_VALUE)
+        # Assert default is returned upon failure
+        self.assertEqual(FIELD_VALUE, ret_val)
+        log_mock.info.assert_called_with(LOG_STR.format(FIELD_NAME))


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2658


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Executes a task in a Kubernetes pod in the specified Google Kubernetes
Engine cluster. This makes it easier to interact with GCP kubernetes
engine service because it encapsulates acquiring credentials.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Adds tests.contrib.operators.test_gcp_container_operator.GCPKubernetesPodTest

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
