### PR TITLE
[AIRFLOW-161] New redirect route and extra links

### DIFF
--- a/airflow/contrib/operators/qubole_operator.py
+++ b/airflow/contrib/operators/qubole_operator.py
@@ -145,6 +145,7 @@ class QuboleOperator(BaseOperator):
     template_ext = ('.txt',)
     ui_color = '#3064A1'
     ui_fgcolor = '#fff'
+    extra_links = ['Go to QDS']
 
     @apply_defaults
     def __init__(self, qubole_conn_id="qubole_default", *args, **kwargs):
@@ -177,6 +178,9 @@ class QuboleOperator(BaseOperator):
     def get_hook(self):
         # Reinitiating the hook, as some template fields might have changed
         return QuboleHook(*self.args, **self.kwargs)
+
+    def get_extra_links(self, dttm, link_name):
+        return self.get_hook().get_extra_links(self, dttm)
 
     def __getattribute__(self, name):
         if name in QuboleOperator.template_fields:

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -2027,6 +2027,8 @@ class BaseOperator(LoggingMixin):
     template_fields = []
     # Defines which files extensions to look for in the templated fields
     template_ext = []
+    # Defines the extra buttons to display in the task instance model view
+    extra_links = []
     # Defines the color in the UI
     ui_color = '#fff'
     ui_fgcolor = '#000'
@@ -2752,6 +2754,19 @@ class BaseOperator(LoggingMixin):
             task_ids=task_ids,
             dag_id=dag_id,
             include_prior_dates=include_prior_dates)
+
+    def get_extra_links(self, dttm, link_name):
+        """
+        For an operator, gets the URL that the external links specified in
+        `extra_links` should point to.
+        :raise ValueError: The error message of a ValueError will be passed on through to
+        the fronted to show up as a tooltip on the disabled link
+        :param dttm: The datetime parsed execution date for the URL being searched for
+        :param link_name: The name of the link we're looking for the URL for. Should be
+        one of the options specified in `extra_links`
+        :return: A URL
+        """
+        pass
 
 
 class DagModel(Base):

--- a/airflow/www/static/js/gantt-chart-d3v2.js
+++ b/airflow/www/static/js/gantt-chart-d3v2.js
@@ -126,7 +126,7 @@ d3.gantt = function() {
     .on('mouseover', tip.show)
     .on('mouseout', tip.hide)
     .on('click', function(d) {
-      call_modal(d.taskName, d.executionDate);
+      call_modal(d.taskName, d.executionDate, d.extraLinks);
     })
     .attr("class", function(d){
       if(taskStatus[d.status] == null){ return "null";}

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -245,6 +245,9 @@
               Downstream
             </button>
           </span>
+          <hr/>
+          <span class="btn-group" id="extra_links">
+          </span>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">
@@ -315,7 +318,8 @@ function updateQueryStringParameter(uri, key, value) {
     var task_id = '';
     var exection_date = '';
     var subdag_id = '';
-    function call_modal(t, d, try_numbers, sd) {
+
+    function call_modal(t, d, extra_links, sd, try_numbers) {
       task_id = t;
       loc = String(window.location);
       $("#btn_filter").on("click", function(){
@@ -326,12 +330,14 @@ function updateQueryStringParameter(uri, key, value) {
       $('#task_id').html(t);
       $('#execution_date').html(d);
       $('#myModal').modal({});
-      $("#myModal").css("margin-top","0px")
+      $("#myModal").css("margin-top","0px");
+      $('#extra_links').prev('hr').hide();
+      $('#extra_links').empty().hide();
       if (subdag_id === undefined)
           $("#div_btn_subdag").hide();
       else {
           $("#div_btn_subdag").show();
-          subdag_id = "{{ dag.dag_id }}."+t;
+          subdag_id = "{{ dag.dag_id }}." + t;
       }
 
       $("#try_index > li").remove();
@@ -356,6 +362,45 @@ function updateQueryStringParameter(uri, key, value) {
           </li>`
         );
       }
+
+      if (extra_links && extra_links.length > 0){
+        var markupArr = [];
+
+        $.each(extra_links, function(i, link){
+          var url = "{{ url_for('airflow.extra_links') }}" +
+                  "?task_id=" + encodeURIComponent(task_id) +
+                  "&dag_id=" + encodeURIComponent(dag_id) +
+                  "&execution_date=" + encodeURIComponent(execution_date) +
+                  "&link_name=" + encodeURIComponent(link);
+
+          var underscore_link = link.split(" ").join("_");
+          var a = '<span class="tool-tip" data-toggle="tooltip" style="padding-right: 1px; padding-left: 1px" data-placement="top" ' +
+                  'title="link not yet available" id="tooltip-' + underscore_link +'">' +
+                    '<a id="link-' + underscore_link +'" href="#" data-toggle="tooltip" class="btn btn-primary disabled" target="_blank">' + link + '</a>' +
+                  '</span>';
+          $.ajax(
+            {url: url,
+             cache: false,
+             success: function (data, textStatus, jqXHR) {
+               var external_link = $( "#link-" + underscore_link );
+               external_link.attr('href', data['url']);
+               external_link.removeClass('disabled');
+               $("#tooltip-" + underscore_link).tooltip('disable');
+             },
+             error:  function (data) {
+               var link_tooltip = $("#tooltip-" + underscore_link);
+               link_tooltip.tooltip('hide').attr('title', data['responseJSON']['error']).tooltip('fixTitle');
+             }
+           });
+
+          markupArr.push(a)
+        });
+
+        $('#extra_links').prev('hr').show();
+        $('#extra_links').append(markupArr.join('')).show();
+        $('[data-toggle="tooltip"]').tooltip();
+      }
+
     }
 
     function call_modal_dag(dag) {

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -163,9 +163,9 @@
     d3.selectAll("g.node").on("click", function(d){
         task = tasks[d];
         if (task.task_type == "SubDagOperator")
-            call_modal(d, execution_date, true);
+            call_modal(d, execution_date, task.extra_links, true);
         else
-            call_modal(d, execution_date);
+            call_modal(d, execution_date, task.extra_links);
     });
 
 

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -236,9 +236,10 @@ function update(source) {
         if(d.task_id === undefined)
             call_modal_dag(d);
         else if(nodeobj[d.task_id].operator=='SubDagOperator')
-            call_modal(d.task_id, d.execution_date, d.try_number, true);
+            // I'm pretty sure that true is not a valid subdag id, which is what call_modal wants
+            call_modal(d.task_id, d.execution_date, nodeobj[d.task_id].extra_links, true, d.try_number);
         else
-            call_modal(d.task_id, d.execution_date, d.try_number);
+            call_modal(d.task_id, d.execution_date, nodeobj[d.task_id].extra_links, undefined, d.try_number);
       })
       .attr("class", function(d) {return "state " + d.state})
       .attr("data-toggle", "tooltip")

--- a/tests/contrib/operators/test_qubole_operator.py
+++ b/tests/contrib/operators/test_qubole_operator.py
@@ -19,8 +19,9 @@
 #
 
 import unittest
-from datetime import datetime
+from airflow.utils.timezone import datetime
 
+from airflow import settings
 from airflow.models import DAG, TaskInstance
 from airflow.models.connection import Connection
 from airflow.utils import db
@@ -40,6 +41,7 @@ DAG_ID = "qubole_test_dag"
 TASK_ID = "test_task"
 DEFAULT_CONN = "qubole_default"
 TEMPLATE_CONN = "my_conn_id"
+TEST_CONN = "qubole_test_conn"
 DEFAULT_DATE = datetime(2017, 1, 1)
 
 
@@ -47,6 +49,16 @@ class QuboleOperatorTest(unittest.TestCase):
     def setUp(self):
         db.merge_conn(
             Connection(conn_id=DEFAULT_CONN, conn_type='HTTP'))
+        db.merge_conn(
+            Connection(conn_id=TEST_CONN, conn_type='HTTP',
+                       host='http://localhost/api'))
+
+    def tearDown(self):
+        session = settings.Session()
+        session.query(Connection).filter(
+            Connection.conn_id == TEST_CONN).delete()
+        session.commit()
+        session.close()
 
     def test_init_with_default_connection(self):
         op = QuboleOperator(task_id=TASK_ID)
@@ -121,3 +133,24 @@ class QuboleOperatorTest(unittest.TestCase):
                          "--dest")
         self.assertEqual(task.get_hook().create_cmd_args({'run_id': 'dummy'})[5],
                          "s3n://airflow/destination_hadoopcmd")
+
+    def test_get_redirect_url(self):
+        dag = DAG(DAG_ID, start_date=DEFAULT_DATE)
+
+        with dag:
+            task = QuboleOperator(task_id=TASK_ID,
+                                  qubole_conn_id=TEST_CONN,
+                                  command_type='shellcmd',
+                                  parameters="param1 param2",
+                                  dag=dag)
+
+        ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
+        ti.xcom_push('qbol_cmd_id', 12345)
+
+        # check for positive case
+        url = task.get_extra_links(DEFAULT_DATE, 'Go to QDS')
+        self.assertEqual(url, 'http://localhost/v2/analyze?command_id=12345')
+
+        # check for negative case
+        url2 = task.get_extra_links('2017-09-01', 'Go to QDS')
+        self.assertEqual(url2, '')

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -40,7 +40,7 @@ from airflow import configuration as conf
 from airflow import models, settings
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.jobs import BaseJob
-from airflow.models import DAG, DagRun, TaskInstance
+from airflow.models import DAG, DagRun, TaskInstance, BaseOperator
 from airflow.models.connection import Connection
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.settings import Session
@@ -1597,6 +1597,80 @@ class TestTriggerDag(TestBase):
         run = self.session.query(DR).filter(DR.dag_id == test_dag_id).first()
         self.assertIsNotNone(run)
         self.assertIn("manual__", run.run_id)
+
+
+class TestExtraLinks(unittest.TestCase):
+    def setUp(self):
+        self.ENDPOINT = '/admin/airflow/extra_links'
+        self.DEFAULT_DATE = datetime(2017, 1, 1)
+        self.app = application.create_app().test_client()
+
+        class DummyTestOperator(BaseOperator):
+            extra_links = ['foo-bar']
+
+            def get_extra_links(self, dttm, link_name):
+                if link_name == 'raise_error':
+                    raise ValueError('This is an error')
+                if link_name == 'no_response':
+                    return None
+                return 'http://www.example.com/{0}/{1}/{2}'.format(self.task_id,
+                                                                   link_name, dttm)
+
+        self.dag = DAG('dag', start_date=self.DEFAULT_DATE)
+        self.task = DummyTestOperator(task_id="some_dummy_task", dag=self.dag)
+
+    @mock.patch('airflow.www.views.dagbag.get_dag')
+    def test_extra_links_works(self, get_dag_function):
+        get_dag_function.return_value = self.dag
+
+        response = self.app.get(
+            "{0}?dag_id={1}&task_id={2}&execution_date={3}&link_name=foo-bar"
+            .format(self.ENDPOINT, self.dag.dag_id, self.task.task_id, self.DEFAULT_DATE),
+            follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        response_str = response.data
+        if isinstance(response.data, bytes):
+            response_str = response_str.decode()
+        self.assertEqual(json.loads(response_str), {
+            'url': ('http://www.example.com/some_dummy_task/'
+                    'foo-bar/2017-01-01T00:00:00+00:00'),
+            'error': None
+        })
+
+    @mock.patch('airflow.www.views.dagbag.get_dag')
+    def test_extra_links_error_raised(self, get_dag_function):
+        get_dag_function.return_value = self.dag
+
+        response = self.app.get(
+            "{0}?dag_id={1}&task_id={2}&execution_date={3}&link_name=raise_error"
+            .format(self.ENDPOINT, self.dag.dag_id, self.task.task_id, self.DEFAULT_DATE),
+            follow_redirects=True)
+
+        self.assertEqual(404, response.status_code)
+        response_str = response.data
+        if isinstance(response.data, bytes):
+            response_str = response_str.decode()
+        self.assertEqual(json.loads(response_str), {
+            'url': None,
+            'error': 'This is an error'})
+
+    @mock.patch('airflow.www.views.dagbag.get_dag')
+    def test_extra_links_no_response(self, get_dag_function):
+        get_dag_function.return_value = self.dag
+
+        response = self.app.get(
+            "{0}?dag_id={1}&task_id={2}&execution_date={3}&link_name=no_response"
+            .format(self.ENDPOINT, self.dag.dag_id, self.task.task_id, self.DEFAULT_DATE),
+            follow_redirects=True)
+
+        self.assertEqual(response.status_code, 404)
+        response_str = response.data
+        if isinstance(response.data, bytes):
+            response_str = response_str.decode()
+        self.assertEqual(json.loads(response_str), {
+            'url': None,
+            'error': 'No URL found for no_response'})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-161


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR is an attempt to finish the work started in #2657

With this change different operators would be able to customize the
task instance model view with extra links, those can be used to
redirect users to systems which are out of Airflow.

In order to be able to display the link on UI, and not have the backend do the external routing, I had to setup the endpoint to
be a RESTful endpoint that the frontend could ping whenever. I also wanted to handle a handful of error cases, so it returns different errors
If the URL is not whitelisted, if the URL is not provided, and there is even a way for operator to provide their own custom errors


Update the modal box to make a AJAX call for link resolutions
This gives us multiple benefits:
 1. It enables us to disable links when actionable
 2. It enables us to give better feedback to the user on whitelisting and errors without navigating the page
 3. You can see and interact with the link as it points to it's real destination, as opposed to the airflow backend doing the routing
   This let's you see where the link will resolve in advance

**Note**: A lot of the changes here are duplicating UI work between `www` and `www_rbac`

New additions: 
You can now see where the link will resolve in advance of clicking it:
<img width="808" alt="screenshot 2018-06-21 18 33 22" src="https://user-images.githubusercontent.com/3519697/41753344-be1bcd5e-7581-11e8-8764-2bc790a655b7.png">

Domains that aren't whitelisted will show a tooltip and be disabled
<img width="627" alt="screenshot 2018-06-21 18 33 36" src="https://user-images.githubusercontent.com/3519697/41753345-be304432-7581-11e8-85cd-052b4a9df0cf.png">

An operator can set a custom error message to show up on a tooltip (for example, if a link is not yet available for some reason, e.g. A job hasn't run yet, so no logs exist)
<img width="622" alt="screenshot 2018-06-21 18 33 42" src="https://user-images.githubusercontent.com/3519697/41753346-be47819c-7581-11e8-99c6-c355ae2d694f.png">

I should also mention here that at Lyft, we've had this running in production for half a year, and it's been really useful so far. 

I will also make a follow up PR with some improvements we've made to extra_links, allowing the user to specify extra_links as plugins that will apply to all operators. We use this feature to link to some logging tools we use (Kibana)

### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests/www/test_views.py::TestRedirect
tests/www_rbac/test_views.py::TestRedirect
tests/contrib/operators/test_qubole_operator.py::QuboleOperatorTest::test_get_redirect_url
tests/models.py::DagTest::test_extra_links_no_affect
tests/models.py::DagTest:: test_extra_links


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
