### PR TITLE
[AIRFLOW-2648] Update mapred job name in HiveOperator

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -211,6 +211,9 @@ default_gpus = 0
 [hive]
 # Default mapreduce queue for HiveOperator tasks
 default_hive_mapred_queue =
+# Template for mapred_job_name in HiveOperator, supports the following named parameters:
+# hostname, dag_id, task_id, execution_date
+mapred_job_name_template = Airflow HiveOperator task for {{hostname}}.{{dag_id}}.{{task_id}}.{{execution_date}}
 
 [webserver]
 # The base url of your website as airflow cannot guess what domain or

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -64,6 +64,7 @@ default_owner = airflow
 
 [hive]
 default_hive_mapred_queue = airflow
+mapred_job_name_template = Airflow HiveOperator task for {{hostname}}.{{dag_id}}.{{task_id}}.{{execution_date}}
 
 [webserver]
 base_url = http://localhost:8080

--- a/airflow/operators/hive_operator.py
+++ b/airflow/operators/hive_operator.py
@@ -22,6 +22,7 @@ from __future__ import unicode_literals
 import re
 
 from airflow.hooks.hive_hooks import HiveCliHook
+from airflow import configuration
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.operator_helpers import context_to_airflow_vars
@@ -92,6 +93,8 @@ class HiveOperator(BaseOperator):
         self.mapred_queue = mapred_queue
         self.mapred_queue_priority = mapred_queue_priority
         self.mapred_job_name = mapred_job_name
+        self.mapred_job_name_template = configuration.get('hive',
+                                                          'mapred_job_name_template')
 
         # assigned lazily - just for consistency we can create the attribute with a
         # `None` initial value, later it will be populated by the execute method.
@@ -121,9 +124,10 @@ class HiveOperator(BaseOperator):
         # set the mapred_job_name if it's not set with dag, task, execution time info
         if not self.mapred_job_name:
             ti = context['ti']
-            self.hook.mapred_job_name = 'Airflow HiveOperator task for {}.{}.{}.{}'\
-                .format(ti.hostname.split('.')[0], ti.dag_id, ti.task_id,
-                        ti.execution_date.isoformat())
+            self.hook.mapred_job_name = self.mapred_job_name_template\
+                .format(dag_id=ti.dag_id, task_id=ti.task_id,
+                        execution_date=ti.execution_date.isoformat(),
+                        hostname=ti.hostname.split('.')[0])
 
         if self.hiveconf_jinja_translate:
             self.hiveconfs = context_to_airflow_vars(context)

--- a/scripts/ci/airflow_travis.cfg
+++ b/scripts/ci/airflow_travis.cfg
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2648) issues and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Proposing the change for the following reason:
- hostname within a mapred_job_name does not provide very useful info--dag_id, task_id and execution_date provide good enough observability.
- `Airflow HiveOperator task for` is redundant and makes it hard to parse. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests/operators/hive_operator.py:HiveOperatorTest.test_mapred_job_name

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
