### PR TITLE
[AIRFLOW-2639] Dagrun of subdags is set to RUNNING immediately

### DIFF
--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -61,22 +61,14 @@ def _trigger_dag(
     if conf:
         run_conf = json.loads(conf)
 
-    triggers = list()
-    dags_to_trigger = list()
-    dags_to_trigger.append(dag)
-    while dags_to_trigger:
-        dag = dags_to_trigger.pop()
-        trigger = dag.create_dagrun(
-            run_id=run_id,
-            execution_date=execution_date,
-            state=State.RUNNING,
-            conf=run_conf,
-            external_trigger=True,
-        )
-        triggers.append(trigger)
-        if dag.subdags:
-            dags_to_trigger.extend(dag.subdags)
-    return triggers
+    trigger = dag.create_dagrun(
+        run_id=run_id,
+        execution_date=execution_date,
+        state=State.RUNNING,
+        conf=run_conf,
+        external_trigger=True,
+    )
+    return trigger
 
 
 def trigger_dag(
@@ -88,7 +80,7 @@ def trigger_dag(
 ):
     dagbag = DagBag()
     dag_run = DagRun()
-    triggers = _trigger_dag(
+    trigger = _trigger_dag(
         dag_id=dag_id,
         dag_run=dag_run,
         dag_bag=dagbag,
@@ -98,4 +90,4 @@ def trigger_dag(
         replace_microseconds=replace_microseconds,
     )
 
-    return triggers[0] if triggers else None
+    return trigger

--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -98,6 +98,7 @@ class SubDagOperator(BaseOperator):
 
     def execute(self, context):
         ed = context['execution_date']
+        conf = context['dag_run'].conf
         self.subdag.run(
             start_date=ed, end_date=ed, donot_pickle=True,
-            executor=self.executor)
+            executor=self.executor, conf=conf)

--- a/tests/api/common/experimental/trigger_dag_tests.py
+++ b/tests/api/common/experimental/trigger_dag_tests.py
@@ -77,7 +77,7 @@ class TriggerDagTests(unittest.TestCase):
         dag2.subdags = []
         dag_mock.subdags = [dag1, dag2]
 
-        triggers = _trigger_dag(
+        trigger = _trigger_dag(
             dag_id,
             dag_bag_mock,
             dag_run_mock,
@@ -86,7 +86,7 @@ class TriggerDagTests(unittest.TestCase):
             execution_date=None,
             replace_microseconds=True)
 
-        self.assertEqual(3, len(triggers))
+        self.assertTrue(trigger)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2639


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
    - Forward dagrun conf to subdag directly in SubdagOperator
    - Remove eager creation of subdags when triggering a DAG


### Tests
- [X] My PR adds the following unit tests
    - test_forwards_dag_run_conf


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.


### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
