### PR TITLE
[AIRFLOW-2622] Support Confirm=False for SFTPOperator

### DIFF
--- a/airflow/contrib/operators/sftp_operator.py
+++ b/airflow/contrib/operators/sftp_operator.py
@@ -43,8 +43,10 @@ class SFTPOperator(BaseOperator):
     :type local_filepath: str
     :param remote_filepath: remote file path to get or put. (templated)
     :type remote_filepath: str
-    :param operation: specify operation 'get' or 'put', defaults to get
+    :param operation: specify operation 'get' or 'put', defaults to put
     :type get: bool
+    :param confirm: specify if the SFTP operation should be confirmed, defaults to True
+    :type confirm: bool
     """
     template_fields = ('local_filepath', 'remote_filepath')
 
@@ -56,6 +58,7 @@ class SFTPOperator(BaseOperator):
                  local_filepath=None,
                  remote_filepath=None,
                  operation=SFTPOperation.PUT,
+                 confirm=True,
                  *args,
                  **kwargs):
         super(SFTPOperator, self).__init__(*args, **kwargs)
@@ -65,6 +68,7 @@ class SFTPOperator(BaseOperator):
         self.local_filepath = local_filepath
         self.remote_filepath = remote_filepath
         self.operation = operation
+        self.confirm = confirm
         if not (self.operation.lower() == SFTPOperation.GET or
                 self.operation.lower() == SFTPOperation.PUT):
             raise TypeError("unsupported operation value {0}, expected {1} or {2}"
@@ -93,7 +97,9 @@ class SFTPOperator(BaseOperator):
                 file_msg = "from {0} to {1}".format(self.local_filepath,
                                                     self.remote_filepath)
                 self.log.debug("Starting to transfer file %s", file_msg)
-                sftp_client.put(self.local_filepath, self.remote_filepath)
+                sftp_client.put(self.local_filepath,
+                                self.remote_filepath,
+                                confirm=self.confirm)
 
         except Exception as e:
             raise AirflowException("Error while transferring {0}, error: {1}"


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2622) issues and references them in the PR title. 


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Exposes the `confirm=False` option on the Paramiko library when SFTPing a file. This feature is needed because the server I'm sending to removes files from the remote directory before I the library is able to to confirm the file transfer.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    Added method documentation (and fixed documentation for the operation param)


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
