### PR TITLE
Fix doc typo in http_operator.py

### DIFF
--- a/airflow/operators/http_operator.py
+++ b/airflow/operators/http_operator.py
@@ -27,7 +27,7 @@ class SimpleHttpOperator(BaseOperator):
     """
     Calls an endpoint on an HTTP system to execute an action
 
-    :param http_conn_id: The connection to run the sensor against
+    :param http_conn_id: The connection to run the operator against
     :type http_conn_id: string
     :param endpoint: The relative part of the full url. (templated)
     :type endpoint: string


### PR DESCRIPTION
Replace `sensor` by `operator` in the comment.

Make sure you have checked _all_ steps below.

### JIRA
PR is just a quick typo fix and will not impact the airflow changelog so I didn't create ticket on JIRA
