### PR TITLE
[AIRFLOW-2671] Monitor gunicorn process, and exit if it exits

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -844,8 +844,10 @@ def webserver(args):
                 master_timeout = conf.getint('webserver', 'web_server_master_timeout')
                 restart_workers(gunicorn_master_proc, num_workers, master_timeout)
             else:
-                while True:
+                while gunicorn_master_proc.poll() is None:
                     time.sleep(1)
+
+                sys.exit(gunicorn_master_proc.returncode)
 
         if args.daemon:
             base, ext = os.path.splitext(pid)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [X] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2671
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [X] Here are some details about my PR, including screenshots of any UI changes:
The webserver did not exit if the gunicorn master process exited. 


### Tests
- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No clue how to test this, open for suggestions though


### Commits
- [X] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
