### PR TITLE
AIRFLOW-2664: Support filtering dag runs by id prefix in API.

### DIFF
--- a/airflow/api/common/experimental/get_dag_runs.py
+++ b/airflow/api/common/experimental/get_dag_runs.py
@@ -22,11 +22,11 @@ from airflow.exceptions import AirflowException
 from airflow.models import DagBag, DagRun
 
 
-def get_dag_runs(dag_id, prefix=None, state=None):
+def get_dag_runs(dag_id, run_id__like=None, state=None):
     """
     Returns a list of Dag Runs for a specific DAG ID.
     :param dag_id: String identifier of a DAG
-    :param prefix: Limit result to runs with an ID starting with this prefix
+    :param run_id__like: Select runs with a run_id matching this pattern.
     :param state: queued|running|success...
     :return: List of DAG runs of a DAG with requested state,
     or all runs if the state is not specified
@@ -40,7 +40,8 @@ def get_dag_runs(dag_id, prefix=None, state=None):
 
     dag_runs = list()
     state = state.lower() if state else None
-    for run in DagRun.find(dag_id=dag_id, state=state, run_id_prefix=prefix):
+    for run in DagRun.find(dag_id=dag_id, state=state,
+                           run_id__like=run_id__like):
         dag_runs.append({
             'id': run.id,
             'run_id': run.run_id,

--- a/airflow/api/common/experimental/get_dag_runs.py
+++ b/airflow/api/common/experimental/get_dag_runs.py
@@ -22,10 +22,11 @@ from airflow.exceptions import AirflowException
 from airflow.models import DagBag, DagRun
 
 
-def get_dag_runs(dag_id, state=None):
+def get_dag_runs(dag_id, prefix=None, state=None):
     """
     Returns a list of Dag Runs for a specific DAG ID.
     :param dag_id: String identifier of a DAG
+    :param prefix: Limit result to runs with an ID starting with this prefix
     :param state: queued|running|success...
     :return: List of DAG runs of a DAG with requested state,
     or all runs if the state is not specified
@@ -39,7 +40,7 @@ def get_dag_runs(dag_id, state=None):
 
     dag_runs = list()
     state = state.lower() if state else None
-    for run in DagRun.find(dag_id=dag_id, state=state):
+    for run in DagRun.find(dag_id=dag_id, state=state, run_id_prefix=prefix):
         dag_runs.append({
             'id': run.id,
             'run_id': run.run_id,

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -4740,7 +4740,7 @@ class DagRun(Base, LoggingMixin):
     @provide_session
     def find(dag_id=None, run_id=None, execution_date=None,
              state=None, external_trigger=None, no_backfills=False,
-             run_id_prefix=None, session=None):
+             run_id__like=None, session=None):
         """
         Returns a set of dag runs for the given search criteria.
 
@@ -4757,7 +4757,7 @@ class DagRun(Base, LoggingMixin):
         :param no_backfills: return no backfills (True), return all (False).
         Defaults to False
         :type no_backfills: bool
-        :param run_id_prefix: match runs with the given prefix in the run_id.
+        :param run_id_prefix: select runs with a run_id matching this pattern.
         :type run_id_prefix: string
         :param session: database session
         :type session: Session
@@ -4769,8 +4769,8 @@ class DagRun(Base, LoggingMixin):
             qry = qry.filter(DR.dag_id == dag_id)
         if run_id:
             qry = qry.filter(DR.run_id == run_id)
-        elif run_id_prefix:
-            qry = qry.filter(DR.run_id.like(run_id_prefix + '%'))
+        elif run_id__like:
+            qry = qry.filter(DR.run_id.like(run_id__like))
         if execution_date:
             if isinstance(execution_date, list):
                 qry = qry.filter(DR.execution_date.in_(execution_date))

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -4738,9 +4738,9 @@ class DagRun(Base, LoggingMixin):
 
     @staticmethod
     @provide_session
-    def find(dag_id=None, run_id=None, execution_date=None, run_id_prefix=None,
+    def find(dag_id=None, run_id=None, execution_date=None,
              state=None, external_trigger=None, no_backfills=False,
-             session=None):
+             run_id_prefix=None, session=None):
         """
         Returns a set of dag runs for the given search criteria.
 
@@ -4749,8 +4749,6 @@ class DagRun(Base, LoggingMixin):
         :param run_id: defines the the run id for this dag run
         :type run_id: str
         :param execution_date: the execution date
-        :param run_id_prefix: match runs with the given prefix in the run_id.
-        :type run_id_prefix: string
         :type execution_date: datetime
         :param state: the state of the dag run
         :type state: State
@@ -4759,6 +4757,8 @@ class DagRun(Base, LoggingMixin):
         :param no_backfills: return no backfills (True), return all (False).
         Defaults to False
         :type no_backfills: bool
+        :param run_id_prefix: match runs with the given prefix in the run_id.
+        :type run_id_prefix: string
         :param session: database session
         :type session: Session
         """
@@ -4769,7 +4769,7 @@ class DagRun(Base, LoggingMixin):
             qry = qry.filter(DR.dag_id == dag_id)
         if run_id:
             qry = qry.filter(DR.run_id == run_id)
-        if run_id_prefix:
+        elif run_id_prefix:
             qry = qry.filter(DR.run_id.like(run_id_prefix + '%'))
         if execution_date:
             if isinstance(execution_date, list):
@@ -5052,19 +5052,6 @@ class DagRun(Base, LoggingMixin):
             .join(subquery,
                   and_(cls.dag_id == subquery.c.dag_id,
                        cls.execution_date == subquery.c.execution_date))
-            .all()
-        )
-        return dagruns
-
-    @classmethod
-    @provide_session
-    def get_runs(cls, dag_id, run_id_prefix, session=None):
-        """Returns all DagRuns for a given DAG."""
-        dagruns = (
-            session
-            .query(cls)
-            .filter(DagRun.dag_id == dag_id,
-                    DagRun.run_id.like(run_id_prefix + '%'))
             .all()
         )
         return dagruns

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -4738,7 +4738,7 @@ class DagRun(Base, LoggingMixin):
 
     @staticmethod
     @provide_session
-    def find(dag_id=None, run_id=None, execution_date=None,
+    def find(dag_id=None, run_id=None, execution_date=None, run_id_prefix=None,
              state=None, external_trigger=None, no_backfills=False,
              session=None):
         """
@@ -4749,6 +4749,8 @@ class DagRun(Base, LoggingMixin):
         :param run_id: defines the the run id for this dag run
         :type run_id: str
         :param execution_date: the execution date
+        :param run_id_prefix: match runs with the given prefix in the run_id.
+        :type run_id_prefix: string
         :type execution_date: datetime
         :param state: the state of the dag run
         :type state: State
@@ -4767,6 +4769,8 @@ class DagRun(Base, LoggingMixin):
             qry = qry.filter(DR.dag_id == dag_id)
         if run_id:
             qry = qry.filter(DR.run_id == run_id)
+        if run_id_prefix:
+            qry = qry.filter(DR.run_id.like(run_id_prefix + '%'))
         if execution_date:
             if isinstance(execution_date, list):
                 qry = qry.filter(DR.execution_date.in_(execution_date))
@@ -5048,6 +5052,19 @@ class DagRun(Base, LoggingMixin):
             .join(subquery,
                   and_(cls.dag_id == subquery.c.dag_id,
                        cls.execution_date == subquery.c.execution_date))
+            .all()
+        )
+        return dagruns
+
+    @classmethod
+    @provide_session
+    def get_runs(cls, dag_id, run_id_prefix, session=None):
+        """Returns all DagRuns for a given DAG."""
+        dagruns = (
+            session
+            .query(cls)
+            .filter(DagRun.dag_id == dag_id,
+                    DagRun.run_id.like(run_id_prefix + '%'))
             .all()
         )
         return dagruns

--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -114,13 +114,15 @@ def dag_runs(dag_id):
     """
     Returns a list of Dag Runs for a specific DAG ID.
     :query param state: a query string parameter '?state=queued|running|success...'
+    :query param run_id_prefix: a query string parameter '?run_id_prefix=<prefix>'
     :param dag_id: String identifier of a DAG
     :return: List of DAG runs of a DAG with requested state,
     or all runs if the state is not specified
     """
     try:
+        prefix = request.args.get('run_id_prefix')
         state = request.args.get('state')
-        dagruns = get_dag_runs(dag_id, state)
+        dagruns = get_dag_runs(dag_id, prefix, state)
     except AirflowException as err:
         _log.info(err)
         response = jsonify(error="{}".format(err))

--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -120,9 +120,9 @@ def dag_runs(dag_id):
     or all runs if the state is not specified
     """
     try:
-        prefix = request.args.get('run_id_prefix')
+        run_id__like = request.args.get('run_id__like')
         state = request.args.get('state')
-        dagruns = get_dag_runs(dag_id, prefix, state)
+        dagruns = get_dag_runs(dag_id, run_id__like, state)
     except AirflowException as err:
         _log.info(err)
         response = jsonify(error="{}".format(err))

--- a/tests/www/api/experimental/test_dag_runs_endpoint.py
+++ b/tests/www/api/experimental/test_dag_runs_endpoint.py
@@ -80,8 +80,8 @@ class TestDagRunsEndpoint(unittest.TestCase):
         self.assertEqual(data[0]['dag_id'], dag_id)
         self.assertEqual(data[0]['id'], dag_run.id)
 
-    def test_get_dag_runs_success_with_prefix_parameter(self):
-        url_template = '/api/experimental/dags/{}/dag_runs?run_id_prefix=test'
+    def test_get_dag_runs_success_with_run_id__like_parameter(self):
+        url_template = '/api/experimental/dags/{}/dag_runs?run_id__like=test%'
         dag_id = 'example_bash_operator'
 
         dag_run = trigger_dag(

--- a/tests/www/api/experimental/test_dag_runs_endpoint.py
+++ b/tests/www/api/experimental/test_dag_runs_endpoint.py
@@ -18,6 +18,7 @@
 # under the License.
 import json
 import unittest
+import datetime
 
 from airflow import configuration
 from airflow.api.common.experimental.trigger_dag import trigger_dag
@@ -83,8 +84,16 @@ class TestDagRunsEndpoint(unittest.TestCase):
         url_template = '/api/experimental/dags/{}/dag_runs?run_id_prefix=test'
         dag_id = 'example_bash_operator'
 
-        dag_run = trigger_dag(dag_id=dag_id, run_id='test_get_dag_runs')
-        trigger_dag(dag_id=dag_id, run_id='other_get_dag_runs')
+        dag_run = trigger_dag(
+            dag_id=dag_id,
+            run_id='test_get_dag_runs',
+            execution_date=datetime.datetime.fromtimestamp('1539097214'),
+        )
+        trigger_dag(
+            dag_id=dag_id,
+            run_id='other_get_dag_runs',
+            execution_date=datetime.datetime.fromtimestamp('1539097218'),
+        )
 
         response = self.app.get(url_template.format(dag_id))
         self.assertEqual(200, response.status_code)

--- a/tests/www/api/experimental/test_dag_runs_endpoint.py
+++ b/tests/www/api/experimental/test_dag_runs_endpoint.py
@@ -79,6 +79,22 @@ class TestDagRunsEndpoint(unittest.TestCase):
         self.assertEqual(data[0]['dag_id'], dag_id)
         self.assertEqual(data[0]['id'], dag_run.id)
 
+    def test_get_dag_runs_success_with_prefix_parameter(self):
+        url_template = '/api/experimental/dags/{}/dag_runs?run_id_prefix=test'
+        dag_id = 'example_bash_operator'
+
+        dag_run = trigger_dag(dag_id=dag_id, run_id='test_get_dag_runs')
+        trigger_dag(dag_id=dag_id, run_id='other_get_dag_runs')
+
+        response = self.app.get(url_template.format(dag_id))
+        self.assertEqual(200, response.status_code)
+        data = json.loads(response.data.decode('utf-8'))
+
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['dag_id'], dag_id)
+        self.assertEqual(data[0]['id'], dag_run.id)
+
     def test_get_dag_runs_success_with_capital_state_parameter(self):
         url_template = '/api/experimental/dags/{}/dag_runs?state=RUNNING'
         dag_id = 'example_bash_operator'

--- a/tests/www/api/experimental/test_dag_runs_endpoint.py
+++ b/tests/www/api/experimental/test_dag_runs_endpoint.py
@@ -87,12 +87,12 @@ class TestDagRunsEndpoint(unittest.TestCase):
         dag_run = trigger_dag(
             dag_id=dag_id,
             run_id='test_get_dag_runs',
-            execution_date=datetime.datetime.fromtimestamp('1539097214'),
+            execution_date=datetime.datetime.fromtimestamp(1539097214),
         )
         trigger_dag(
             dag_id=dag_id,
             run_id='other_get_dag_runs',
-            execution_date=datetime.datetime.fromtimestamp('1539097218'),
+            execution_date=datetime.datetime.fromtimestamp(1539097218),
         )
 
         response = self.app.get(url_template.format(dag_id))


### PR DESCRIPTION
This allows users to choose run ids that will later allow them to filter
while retrieving runs.
Resolves part of AIRFLOW-2664.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/AIRFLOW-2664) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2664

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

`GET /dags/<dag_id>/dag_runs?run_id_prefix=<prefix>` will limit the
result to runs with an ID that starts with <prefix>.

For example, if you have a DAG that is used to provision namespaced
resources, you might name the runs like
`provision__$namespace__$timestamp`. You could then list runs for only a
given namespace using this query parameter.

This could be done client-side, but the result could be huge, so it is
useful to provide server-side filtering.

Filtering based on conf fields would be a more versatile solution, but I
didn't have an idea of how to cleanly do that through query parameters.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- tests/www_rbac/api/experimental/test_dag_runs_endpoint.py:TestDagRunsEndpoint:test_get_dag_runs_success_with_prefix_parameter

I couldn't figure out how to run it locally. After following the steps in `CONTRIBUTING.md`, to set up a local dev environment:

```
virtualenv .env
. .venv/bin/activate
pip install -e .[devel]
./run_unit_tests.sh tests/www_rbac/api/experimental/test_dag_runs_endpoint.py:TestDagRunsEndpoint
```

the tests fail with:
```
ModuleNotFoundError: No module named 'unicodecsv'
```

I set up travis and it is still chugging away [here](https://travis-ci.org/rcorre/incubator-airflow).

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

    Added to the API function docstring, I assume this is sufficient?


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
