### PR TITLE
[AIRFLOW-2682] Add how-to guides for bash and python operators

### DIFF
--- a/airflow/example_dags/example_bash_operator.py
+++ b/airflow/example_dags/example_bash_operator.py
@@ -38,8 +38,10 @@ dag = DAG(
 cmd = 'ls -l'
 run_this_last = DummyOperator(task_id='run_this_last', dag=dag)
 
+# [START howto_operator_bash]
 run_this = BashOperator(
     task_id='run_after_loop', bash_command='echo 1', dag=dag)
+# [END howto_operator_bash]
 run_this.set_downstream(run_this_last)
 
 for i in range(3):
@@ -50,10 +52,12 @@ for i in range(3):
         dag=dag)
     task.set_downstream(run_this)
 
+# [START howto_operator_bash_template]
 task = BashOperator(
     task_id='also_run_this',
     bash_command='echo "run_id={{ run_id }} | dag_run={{ dag_run }}"',
     dag=dag)
+# [END howto_operator_bash_template]
 task.set_downstream(run_this_last)
 
 if __name__ == "__main__":

--- a/airflow/example_dags/example_python_operator.py
+++ b/airflow/example_dags/example_python_operator.py
@@ -26,6 +26,7 @@ from airflow.models import DAG
 import time
 from pprint import pprint
 
+
 args = {
     'owner': 'airflow',
     'start_date': airflow.utils.dates.days_ago(2)
@@ -36,11 +37,7 @@ dag = DAG(
     schedule_interval=None)
 
 
-def my_sleeping_function(random_base):
-    """This is a function that will run within the DAG execution"""
-    time.sleep(random_base)
-
-
+# [START howto_operator_python]
 def print_context(ds, **kwargs):
     pprint(kwargs)
     print(ds)
@@ -52,6 +49,14 @@ run_this = PythonOperator(
     provide_context=True,
     python_callable=print_context,
     dag=dag)
+# [END howto_operator_python]
+
+
+# [START howto_operator_python_kwargs]
+def my_sleeping_function(random_base):
+    """This is a function that will run within the DAG execution"""
+    time.sleep(random_base)
+
 
 # Generate 10 sleeping tasks, sleeping from 0 to 4 seconds respectively
 for i in range(5):
@@ -62,3 +67,4 @@ for i in range(5):
         dag=dag)
 
     task.set_upstream(run_this)
+# [END howto_operator_python_kwargs]

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -1,6 +1,8 @@
 API Reference
 =============
 
+.. _api-reference-operators:
+
 Operators
 ---------
 Operators allow for generation of certain types of tasks that become nodes in

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -90,6 +90,8 @@ DAGs can be used as context managers to automatically assign new operators to th
 
     op.dag is dag # True
 
+.. _concepts-operators:
+
 Operators
 =========
 
@@ -128,6 +130,8 @@ the main distribution, but allow users to more easily add new functionality to
 the platform.
 
 Operators are only loaded by Airflow if they are assigned to a DAG.
+
+See :doc:`howto/operator` for how to use Airflow operators.
 
 DAG Assignment
 --------------

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -12,6 +12,7 @@ configuring an Airflow environment.
 
     set-config
     initialize-database
+    operator
     manage-connections
     secure-connections
     write-logs

--- a/docs/howto/operator.rst
+++ b/docs/howto/operator.rst
@@ -1,0 +1,87 @@
+Using Operators
+===============
+
+An operator represents a single, ideally idempotent, task. Operators
+determine what actually executes when your DAG runs.
+
+See the :ref:`Operators Concepts <concepts-operators>` documentation and the
+:ref:`Operators API Reference <api-reference-operators>` for more
+information.
+
+.. contents:: :local:
+
+BashOperator
+------------
+
+Use the :class:`~airflow.operators.bash_operator.BashOperator` to execute
+commands in a `Bash <https://www.gnu.org/software/bash/>`__ shell.
+
+.. literalinclude:: ../../airflow/example_dags/example_bash_operator.py
+    :language: python
+    :start-after: [START howto_operator_bash]
+    :end-before: [END howto_operator_bash]
+
+Templating
+^^^^^^^^^^
+
+You can use :ref:`Jinja templates <jinja-templating>` to parameterize the
+``bash_command`` argument.
+
+.. literalinclude:: ../../airflow/example_dags/example_bash_operator.py
+    :language: python
+    :start-after: [START howto_operator_bash_template]
+    :end-before: [END howto_operator_bash_template]
+
+Troubleshooting
+^^^^^^^^^^^^^^^
+
+Jinja template not found
+""""""""""""""""""""""""
+
+Add a space after the script name when directly calling a Bash script with
+the ``bash_command`` argument. This is because Airflow tries to apply a Jinja
+template to it, which will fail.
+
+.. code-block:: python
+
+    t2 = BashOperator(
+        task_id='bash_example',
+
+        # This fails with `Jinja template not found` error
+        # bash_command="/home/batcher/test.sh",
+
+        # This works (has a space after)
+        bash_command="/home/batcher/test.sh ",
+        dag=dag)
+
+PythonOperator
+--------------
+
+Use the :class:`~airflow.operators.python_operator.PythonOperator` to execute
+Python callables.
+
+.. literalinclude:: ../../airflow/example_dags/example_python_operator.py
+    :language: python
+    :start-after: [START howto_operator_python]
+    :end-before: [END howto_operator_python]
+
+Passing in arguments
+^^^^^^^^^^^^^^^^^^^^
+
+Use the ``op_args`` and ``op_kwargs`` arguments to pass additional arguments
+to the Python callable.
+
+.. literalinclude:: ../../airflow/example_dags/example_python_operator.py
+    :language: python
+    :start-after: [START howto_operator_python_kwargs]
+    :end-before: [END howto_operator_python_kwargs]
+
+Templating
+^^^^^^^^^^
+
+When you set the ``provide_context`` argument to ``True``, Airflow passes in
+an additional set of keyword arguments: one for each of the :ref:`Jinja
+template variables <macros>` and a ``templates_dict`` argument.
+
+The ``templates_dict`` argument is templated, so each value in the dictionary
+is evaluated as a :ref:`Jinja template <jinja-templating>`.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2682


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Add a how-to guide page with code examples from the `airflow/example_dags` directory.

![image](https://user-images.githubusercontent.com/247555/41990631-db20edba-79f7-11e8-87dd-7e257f7d346a.png)


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Documentation-only change.

Question: How are the example DAGs tested? I couldn't find documentation in the CONTRIBUTING file on how to add examples or tests for them.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

Documentation-only change.

### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
