### PR TITLE
[AIRFLOW-2686] Fix Default Variables not base on default_timezone

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1809,14 +1809,15 @@ class TaskInstance(Base, LoggingMixin):
         tables = None
         if 'tables' in task.params:
             tables = task.params['tables']
+        # convert to default timezone
+        execution_date_tz = settings.TIMEZONE.convert(self.execution_date)
+        ds = execution_date_tz.strftime('%Y-%m-%d')
+        ts = execution_date_tz.isoformat()
+        yesterday_ds = (execution_date_tz - timedelta(1)).strftime('%Y-%m-%d')
+        tomorrow_ds = (execution_date_tz + timedelta(1)).strftime('%Y-%m-%d')
 
-        ds = self.execution_date.strftime('%Y-%m-%d')
-        ts = self.execution_date.isoformat()
-        yesterday_ds = (self.execution_date - timedelta(1)).strftime('%Y-%m-%d')
-        tomorrow_ds = (self.execution_date + timedelta(1)).strftime('%Y-%m-%d')
-
-        prev_execution_date = task.dag.previous_schedule(self.execution_date)
-        next_execution_date = task.dag.following_schedule(self.execution_date)
+        prev_execution_date = task.dag.previous_schedule(execution_date_tz)
+        next_execution_date = task.dag.following_schedule(execution_date_tz)
 
         next_ds = None
         if next_execution_date:
@@ -1903,7 +1904,7 @@ class TaskInstance(Base, LoggingMixin):
             'end_date': ds,
             'dag_run': dag_run,
             'run_id': run_id,
-            'execution_date': self.execution_date,
+            'execution_date': execution_date_tz,
             'prev_execution_date': prev_execution_date,
             'next_execution_date': next_execution_date,
             'latest_date': ds,


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2686

### Description
- [x] I have updated airflow.cfg `default_timezone`, but default variable is still base UTC timezone,
    update func:`TaskInstance.get_template_context` in model.py, convert datetime variables to default timezone


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
