### PR TITLE
[AIRFLOW-2687] Move unittest2 to devel in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -218,6 +218,10 @@ devel = [
     'rednose',
     'requests_mock'
 ]
+
+if not PY3:
+    devel += ['unittest2']
+
 devel_minreq = devel + kubernetes + mysql + doc + password + s3 + cgroups
 devel_hadoop = devel_minreq + hive + hdfs + webhdfs + kerberos
 devel_all = (sendgrid + devel + all_dbs + doc + samba + s3 + slack + crypto + oracle +
@@ -231,7 +235,7 @@ if PY3:
     devel_ci = [package for package in devel_all if package not in
                 ['snakebite>=2.7.8', 'snakebite[kerberos]>=2.7.8']]
 else:
-    devel_ci = devel_all + ['unittest2']
+    devel_ci = devel_all
 
 
 def do_setup():


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2687
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR moves the package unittest2 from
devel_ci to devel in setup.py, since
the latter is the minimal required packages
for development and unittest2 is considered
as one of them.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's a fix for library dependency, not for feature.
I ran `pip install -U -e "[.devel]"` locally, and confirmed that unittest2 is installed on Python2 and not on Python3.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
