### PR TITLE
[AIRFLOW-2692] Add job_name as templated parameter in AWS Batch Operator

### DIFF
--- a/airflow/contrib/operators/awsbatch_operator.py
+++ b/airflow/contrib/operators/awsbatch_operator.py
@@ -36,7 +36,7 @@ class AWSBatchOperator(BaseOperator):
     .. warning: the queue parameter was renamed to job_queue to segreggate the
                 internal CeleryExecutor queue from the AWS Batch internal queue.
 
-    :param job_name: the name for the job that will run on AWS Batch
+    :param job_name: the name for the job that will run on AWS Batch (templated)
     :type job_name: str
     :param job_definition: the job definition name on AWS Batch
     :type job_definition: str
@@ -59,7 +59,7 @@ class AWSBatchOperator(BaseOperator):
     ui_color = '#c3dae0'
     client = None
     arn = None
-    template_fields = ('overrides',)
+    template_fields = ('job_name', 'overrides',)
 
     @apply_defaults
     def __init__(self, job_name, job_definition, job_queue, overrides, max_retries=4200,

--- a/tests/contrib/operators/test_awsbatch_operator.py
+++ b/tests/contrib/operators/test_awsbatch_operator.py
@@ -71,7 +71,7 @@ class TestAWSBatchOperator(unittest.TestCase):
         self.aws_hook_mock.assert_called_once_with(aws_conn_id=None)
 
     def test_template_fields_overrides(self):
-        self.assertEqual(self.batch.template_fields, ('overrides',))
+        self.assertEqual(self.batch.template_fields, ('job_name', 'overrides',))
 
     @mock.patch.object(AWSBatchOperator, '_wait_for_task_ended')
     @mock.patch.object(AWSBatchOperator, '_check_success_task')
@@ -176,7 +176,7 @@ class TestAWSBatchOperator(unittest.TestCase):
         # Ordering of str(dict) is not guaranteed.
         self.assertIn('This task is still pending ', str(e.exception))
 
-    def test_check_success_tasks_raises_mutliple(self):
+    def test_check_success_tasks_raises_multiple(self):
         client_mock = mock.Mock()
         self.batch.jobId = '8ba9d676-4108-4474-9dca-8bbac1da9b19'
         self.batch.client = client_mock


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2692
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

When using the AWS Batch Operator, having the `job_name` field be templated allows easier traceability in the AWS console of which jobs were triggered by which Airflow task instance.  In particular, I see using `{{ ds_nodash }}` as being used heavily in my deployments.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Updated existing test case to check for new field.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`