### PR TITLE
[AIRFLOW-2696] Setting UTF-8 as default mime_charset in email utils

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -5,6 +5,8 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Setting UTF-8 as default mime_charset in email utils
+
 ### Add a configuration variable(default_dag_run_display_number) to control numbers of dag run for display
 Add a configuration variable(default_dag_run_display_number) under webserver section to control num of dag run to show in UI.
 

--- a/airflow/utils/email.py
+++ b/airflow/utils/email.py
@@ -41,7 +41,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 def send_email(to, subject, html_content,
                files=None, dryrun=False, cc=None, bcc=None,
-               mime_subtype='mixed', mime_charset='us-ascii', **kwargs):
+               mime_subtype='mixed', mime_charset='utf-8', **kwargs):
     """
     Send email using backend specified in EMAIL_BACKEND.
     """
@@ -55,7 +55,7 @@ def send_email(to, subject, html_content,
 
 def send_email_smtp(to, subject, html_content, files=None,
                     dryrun=False, cc=None, bcc=None,
-                    mime_subtype='mixed', mime_charset='us-ascii',
+                    mime_subtype='mixed', mime_charset='utf-8',
                     **kwargs):
     """
     Send an email with html content

--- a/tests/core.py
+++ b/tests/core.py
@@ -2429,7 +2429,7 @@ class EmailTest(unittest.TestCase):
         utils.email.send_email('to', 'subject', 'content')
         send_email_test.assert_called_with(
             'to', 'subject', 'content', files=None, dryrun=False,
-            cc=None, bcc=None, mime_charset='us-ascii', mime_subtype='mixed')
+            cc=None, bcc=None, mime_charset='utf-8', mime_subtype='mixed')
         self.assertFalse(mock_send_email.called)
 
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2696

### Description
- [x] Setting UTF-8 as default mime_charset in email utils

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
