### PR TITLE
[AIRFLOW-2698] Simplify Kerberos code

### DIFF
--- a/airflow/contrib/auth/backends/kerberos_auth.py
+++ b/airflow/contrib/auth/backends/kerberos_auth.py
@@ -19,6 +19,7 @@
 
 import logging
 import flask_login
+from airflow.exceptions import AirflowConfigException
 from flask_login import current_user
 from flask import flash
 from wtforms import (
@@ -32,7 +33,6 @@ import airflow.security.utils as utils
 
 from flask import url_for, redirect
 
-from airflow import settings
 from airflow import models
 from airflow import configuration
 from airflow.utils.db import provide_session
@@ -58,7 +58,13 @@ class KerberosUser(models.User, LoggingMixin):
             utils.get_fqdn()
         )
         realm = configuration.conf.get("kerberos", "default_realm")
-        user_principal = utils.principal_from_username(username)
+
+        try:
+            user_realm = configuration.conf.get("security", "default_realm")
+        except AirflowConfigException:
+            user_realm = realm
+
+        user_principal = utils.principal_from_username(username, user_realm)
 
         try:
             # this is pykerberos specific, verify = True is needed to prevent KDC spoofing
@@ -68,7 +74,8 @@ class KerberosUser(models.User, LoggingMixin):
                 raise AuthenticationError()
         except kerberos.KrbError as e:
             logging.error(
-                'Password validation for principal %s failed %s', user_principal, e)
+                'Password validation for user '
+                '%s in realm %s failed %s', user_principal, realm, e)
             raise AuthenticationError(e)
 
         return


### PR DESCRIPTION
Dear Airflow maintainers, please accept my pull request

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-2698) issues and references them in the PR title.

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Some functions were not used. On top of that, the
`principal_from_username` function was getting the wrong config value
("security" instead of "kerberos").

Since the results were only used by `kerberos.checkPassword`, and the
function can cope with needing a realm in the `username` when `realm` is
provided, we removed the `principal_from_username` function altogether.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No functionality has been added

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
No new functionality

### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
