### PR TITLE
[AIRFLOW-2702] Handle uncaught statsd configuration errors

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -26,6 +26,7 @@ import atexit
 import logging
 import os
 import pendulum
+import socket
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -71,16 +72,17 @@ class DummyStatsLogger(object):
 
 Stats = DummyStatsLogger
 
-if conf.getboolean('scheduler', 'statsd_on'):
-    from statsd import StatsClient
+try:
+    if conf.getboolean('scheduler', 'statsd_on'):
+        from statsd import StatsClient
 
-    statsd = StatsClient(
-        host=conf.get('scheduler', 'statsd_host'),
-        port=conf.getint('scheduler', 'statsd_port'),
-        prefix=conf.get('scheduler', 'statsd_prefix'))
-    Stats = statsd
-else:
-    Stats = DummyStatsLogger
+        statsd = StatsClient(
+            host=conf.get('scheduler', 'statsd_host'),
+            port=conf.getint('scheduler', 'statsd_port'),
+            prefix=conf.get('scheduler', 'statsd_prefix'))
+        Stats = statsd
+except (socket.gaierror, ImportError):
+    log.warning("Could not configure StatsClient, using DummyStatsLogger instead.")
 
 HEADER = """\
   ____________       _____________


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2702


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently if airflow.cfg has [scheduler/statsd_on] set to True, but doesn't have the statsd package installed it will error and crash the process, stopping it from proceeding. Also if you have an invalid hostname in your config file it will crash upon trying to getaddrinfo() from socket. 

Since statsd isn't a required package it shouldn't stop the web server and scheduler from proceeding, thus this fix catches the corresponding errors, and logs the fact that we couldn't use statsd.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Thanks!