### PR TITLE
[AIRFLOW-2705] Move class-level moto decorator to method-level

### DIFF
--- a/tests/contrib/hooks/test_redshift_hook.py
+++ b/tests/contrib/hooks/test_redshift_hook.py
@@ -31,10 +31,11 @@ except ImportError:
     mock_redshift = None
 
 
-@mock_redshift
 class TestRedshiftHook(unittest.TestCase):
     def setUp(self):
         configuration.load_test_config()
+
+    def _create_clusters(self):
         client = boto3.client('redshift', region_name='us-east-1')
         client.create_cluster(
             ClusterIdentifier='test_cluster',
@@ -52,7 +53,9 @@ class TestRedshiftHook(unittest.TestCase):
             raise ValueError('AWS not properly mocked')
 
     @unittest.skipIf(mock_redshift is None, 'mock_redshift package not present')
+    @mock_redshift
     def test_get_client_type_returns_a_boto3_client_of_the_requested_type(self):
+        self._create_clusters()
         hook = AwsHook(aws_conn_id='aws_default')
         client_from_hook = hook.get_client_type('redshift')
 
@@ -60,7 +63,9 @@ class TestRedshiftHook(unittest.TestCase):
         self.assertEqual(len(clusters), 2)
 
     @unittest.skipIf(mock_redshift is None, 'mock_redshift package not present')
+    @mock_redshift
     def test_restore_from_cluster_snapshot_returns_dict_with_cluster_data(self):
+        self._create_clusters()
         hook = RedshiftHook(aws_conn_id='aws_default')
         hook.create_cluster_snapshot('test_snapshot', 'test_cluster')
         self.assertEqual(
@@ -70,27 +75,35 @@ class TestRedshiftHook(unittest.TestCase):
             'test_cluster_3')
 
     @unittest.skipIf(mock_redshift is None, 'mock_redshift package not present')
+    @mock_redshift
     def test_delete_cluster_returns_a_dict_with_cluster_data(self):
+        self._create_clusters()
         hook = RedshiftHook(aws_conn_id='aws_default')
 
         cluster = hook.delete_cluster('test_cluster_2')
         self.assertNotEqual(cluster, None)
 
     @unittest.skipIf(mock_redshift is None, 'mock_redshift package not present')
+    @mock_redshift
     def test_create_cluster_snapshot_returns_snapshot_data(self):
+        self._create_clusters()
         hook = RedshiftHook(aws_conn_id='aws_default')
 
         snapshot = hook.create_cluster_snapshot('test_snapshot_2', 'test_cluster')
         self.assertNotEqual(snapshot, None)
 
     @unittest.skipIf(mock_redshift is None, 'mock_redshift package not present')
+    @mock_redshift
     def test_cluster_status_returns_cluster_not_found(self):
+        self._create_clusters()
         hook = RedshiftHook(aws_conn_id='aws_default')
         status = hook.cluster_status('test_cluster_not_here')
         self.assertEqual(status, 'cluster_not_found')
 
     @unittest.skipIf(mock_redshift is None, 'mock_redshift package not present')
+    @mock_redshift
     def test_cluster_status_returns_available_cluster(self):
+        self._create_clusters()
         hook = RedshiftHook(aws_conn_id='aws_default')
         status = hook.cluster_status('test_cluster')
         self.assertEqual(status, 'available')

--- a/tests/contrib/sensors/test_aws_redshift_cluster_sensor.py
+++ b/tests/contrib/sensors/test_aws_redshift_cluster_sensor.py
@@ -31,10 +31,11 @@ except ImportError:
     mock_redshift = None
 
 
-@mock_redshift
 class TestAwsRedshiftClusterSensor(unittest.TestCase):
     def setUp(self):
         configuration.load_test_config()
+
+    def _create_cluster(self):
         client = boto3.client('redshift', region_name='us-east-1')
         client.create_cluster(
             ClusterIdentifier='test_cluster',
@@ -46,7 +47,9 @@ class TestAwsRedshiftClusterSensor(unittest.TestCase):
             raise ValueError('AWS not properly mocked')
 
     @unittest.skipIf(mock_redshift is None, 'mock_redshift package not present')
+    @mock_redshift
     def test_poke(self):
+        self._create_cluster()
         op = AwsRedshiftClusterSensor(task_id='test_cluster_sensor',
                                       poke_interval=1,
                                       timeout=5,
@@ -56,7 +59,9 @@ class TestAwsRedshiftClusterSensor(unittest.TestCase):
         self.assertTrue(op.poke(None))
 
     @unittest.skipIf(mock_redshift is None, 'mock_redshift package not present')
+    @mock_redshift
     def test_poke_false(self):
+        self._create_cluster()
         op = AwsRedshiftClusterSensor(task_id='test_cluster_sensor',
                                       poke_interval=1,
                                       timeout=5,
@@ -67,7 +72,9 @@ class TestAwsRedshiftClusterSensor(unittest.TestCase):
         self.assertFalse(op.poke(None))
 
     @unittest.skipIf(mock_redshift is None, 'mock_redshift package not present')
+    @mock_redshift
     def test_poke_cluster_not_found(self):
+        self._create_cluster()
         op = AwsRedshiftClusterSensor(task_id='test_cluster_sensor',
                                       poke_interval=1,
                                       timeout=5,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2705
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Moto decorators at class-level make other
tests that sends HTTP request fail.
This PR moves them to method-level
so as to fix this problem.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's a fix for tests themselves.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`