### PR TITLE
[AIRFLOW-2706] AWS Batch Operator should use top-level job state to determine status

### DIFF
--- a/tests/contrib/operators/test_awsbatch_operator.py
+++ b/tests/contrib/operators/test_awsbatch_operator.py
@@ -147,6 +147,7 @@ class TestAWSBatchOperator(unittest.TestCase):
         client_mock.describe_jobs.return_value = {
             'jobs': [{
                 'status': 'FAILED',
+                'statusReason': 'This is an error reason',
                 'attempts': [{
                     'exitCode': 1
                 }]
@@ -157,7 +158,7 @@ class TestAWSBatchOperator(unittest.TestCase):
             self.batch._check_success_task()
 
         # Ordering of str(dict) is not guaranteed.
-        self.assertIn('This containers encounter an error during execution ', str(e.exception))
+        self.assertIn('Job failed with status ', str(e.exception))
 
     def test_check_success_tasks_raises_pending(self):
         client_mock = mock.Mock()
@@ -184,6 +185,7 @@ class TestAWSBatchOperator(unittest.TestCase):
         client_mock.describe_jobs.return_value = {
             'jobs': [{
                 'status': 'FAILED',
+                'statusReason': 'This is an error reason',
                 'attempts': [{
                     'exitCode': 1
                 }, {
@@ -196,7 +198,7 @@ class TestAWSBatchOperator(unittest.TestCase):
             self.batch._check_success_task()
 
         # Ordering of str(dict) is not guaranteed.
-        self.assertIn('This containers encounter an error during execution ', str(e.exception))
+        self.assertIn('Job failed with status ', str(e.exception))
 
     def test_check_success_task_not_raises(self):
         client_mock = mock.Mock()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2706
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Rather than inspecting the state of job attempts, the operator should use the top-level job status
to determine the overall success or failure of the task. This means the following cases are handled
correctly:

1. Any infrastructure failure that results in no attempts being performed is now detected.
2. Any retry policy that AWS Batch will do is now honored -- the job isn't marked `FAILED` until all
   attempts to retry have failed. Previously, the first failed *attempt* would make the task as
   failed.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`