### PR TITLE
AIRFLOW-1104 Update jobs.py so Airflow does not over schedule tasks

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1075,9 +1075,6 @@ class SchedulerJob(BaseJob):
         :type states: Tuple[State]
         :return: List[TaskInstance]
         """
-        # TODO(saguziel): Change this to include QUEUED, for concurrency
-        # purposes we may want to count queued tasks
-        states_to_count_as_running = [State.RUNNING]
         executable_tis = []
 
         # Get all the queued task instances from associated with scheduled
@@ -1123,6 +1120,7 @@ class SchedulerJob(BaseJob):
         for task_instance in task_instances_to_examine:
             pool_to_task_instances[task_instance.pool].append(task_instance)
 
+        states_to_count_as_running = [State.RUNNING, State.QUEUED]
         task_concurrency_map = self.__get_task_concurrency_map(
             states=states_to_count_as_running, session=session)
 
@@ -1173,7 +1171,6 @@ class SchedulerJob(BaseJob):
                 simple_dag = simple_dag_bag.get_dag(dag_id)
 
                 if dag_id not in dag_id_to_possibly_running_task_count:
-                    # TODO(saguziel): also check against QUEUED state, see AIRFLOW-1104
                     dag_id_to_possibly_running_task_count[dag_id] = \
                         DAG.get_num_task_instances(
                             dag_id,


### PR DESCRIPTION
This change will prevent tasks from getting scheduled and queued over
the concurrency limits set for the dag

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-1104).
    - https://issues.apache.org/jira/browse/AIRFLOW-1104

### Description
- This fix updates jobs.py so it will count queued tasks against the concurrency limits. Currently the scheduler will over schedule highly concurrent dags producing the following message in the logs:

```FIXME: Rescheduling due to concurrency limits reached at task runtime.```

### Tests
- [x] Added a unit test 