### PR TITLE
[AIRFLOW-2099] Handle getsource() calls gracefully

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+import inspect
 from future import standard_library
 standard_library.install_aliases()
 from builtins import str
@@ -373,6 +374,33 @@ def make_cache_key(*args, **kwargs):
     path = request.path
     args = str(hash(frozenset(request.args.items())))
     return (path + args).encode('ascii', 'ignore')
+
+
+def get_python_source(x):
+    """
+    Helper function to get Python source (or not), preventing exceptions
+    """
+    source_code = None
+
+    if isinstance(x, functools.partial):
+        source_code = inspect.getsource(x.func)
+
+    if source_code is None:
+        try:
+            source_code = inspect.getsource(x)
+        except TypeError:
+            pass
+
+    if source_code is None:
+        try:
+            source_code = inspect.getsource(x.__call__)
+        except (TypeError, AttributeError):
+            pass
+
+    if source_code is None:
+        source_code = 'No source code available for {}'.format(type(x))
+
+    return source_code
 
 
 class AceEditorWidget(wtforms.widgets.TextArea):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -249,7 +249,9 @@ attr_renderer = {
     'doc_yaml': lambda x: render(x, lexers.YamlLexer),
     'doc_md': wrapped_markdown,
     'python_callable': lambda x: render(
-        inspect.getsource(x), lexers.PythonLexer),
+        wwwutils.get_python_source(x),
+        lexers.PythonLexer,
+    ),
 }
 
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -1842,6 +1842,20 @@ class WebUiTests(unittest.TestCase):
         response = self.app.get(url)
         self.assertIn("print_the_context", response.data.decode('utf-8'))
 
+    def test_dag_view_task_with_python_operator_using_partial(self):
+        response = self.app.get(
+            '/admin/airflow/task?'
+            'task_id=test_dagrun_functool_partial&dag_id=test_task_view_type_check&'
+            'execution_date={}'.format(DEFAULT_DATE_DS))
+        self.assertIn("A function with two args", response.data.decode('utf-8'))
+
+    def test_dag_view_task_with_python_operator_using_instance(self):
+        response = self.app.get(
+            '/admin/airflow/task?'
+            'task_id=test_dagrun_instance&dag_id=test_task_view_type_check&'
+            'execution_date={}'.format(DEFAULT_DATE_DS))
+        self.assertIn("A __call__ method", response.data.decode('utf-8'))
+
     def tearDown(self):
         configuration.conf.set("webserver", "expose_config", "False")
         self.dag_bash.clear(start_date=DEFAULT_DATE, end_date=timezone.utcnow())

--- a/tests/dags/test_task_view_type_check.py
+++ b/tests/dags/test_task_view_type_check.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+DAG designed to test a PythonOperator that calls a functool.partial
+"""
+import functools
+import logging
+
+from datetime import datetime
+
+from airflow.models import DAG
+from airflow.operators.python_operator import PythonOperator
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+default_args = dict(
+    start_date=DEFAULT_DATE,
+    owner='airflow')
+
+
+class CallableClass(object):
+    def __call__(self):
+        """ A __call__ method """
+        pass
+
+
+def a_function(arg_x, arg_y):
+    """ A function with two args """
+    pass
+
+
+partial_function = functools.partial(a_function, arg_x=1)
+class_instance = CallableClass()
+
+logging.info('class_instance type: {}'.format(type(class_instance)))
+
+dag = DAG(dag_id='test_task_view_type_check', default_args=default_args)
+
+dag_task1 = PythonOperator(
+    task_id='test_dagrun_functool_partial',
+    dag=dag,
+    python_callable=partial_function,
+)
+
+dag_task2 = PythonOperator(
+    task_id='test_dagrun_instance',
+    dag=dag,
+    python_callable=class_instance,
+)

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import functools
 import mock
 import unittest
 from xml.dom import minidom
@@ -189,6 +190,42 @@ class UtilsTest(unittest.TestCase):
                 self.assertEqual('some_func', kwargs['event'])
                 self.assertEqual(anonymous_username, kwargs['owner'])
                 mocked_session_instance.add.assert_called_once()
+
+    def test_get_python_source_from_method(self):
+        class AMockClass(object):
+            def a_method(self):
+                """ A method """
+                pass
+
+        mocked_class = AMockClass()
+
+        result = utils.get_python_source(mocked_class.a_method)
+        self.assertIn('A method', result)
+
+    def test_get_python_source_from_class(self):
+        class AMockClass(object):
+            def __call__(self):
+                """ A __call__ method """
+                pass
+
+        mocked_class = AMockClass()
+
+        result = utils.get_python_source(mocked_class)
+        self.assertIn('A __call__ method', result)
+
+    def test_get_python_source_from_partial_func(self):
+        def a_function(arg_x, arg_y):
+            """ A function with two args """
+            pass
+
+        partial_function = functools.partial(a_function, arg_x=1)
+
+        result = utils.get_python_source(partial_function)
+        self.assertIn('A function with two args', result)
+
+    def test_get_python_source_from_none(self):
+        result = utils.get_python_source(None)
+        self.assertIn('No source code available', result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are several scenarios where Task Instance view tries to render
Python callables where 'x' is not the correct artefact to target.

This commit adds a helper fuction to test for known scenarios, and
derives the source from the correct artifact or as a default returns
'No source available for <type>'. This means that even in unknown or
unfixable edge cases, the Task Instance view still renders instead of
displaying an exception.

Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2099


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
1. Adds a wrapper function for getting Python source code.
2. It tests for/catches known anomalies and implements a work around, finally returning 'source code not available for <type>' if no option works.

### Tests
- [x] My PR adds the following unit tests
1.  test_dag_view_task_with_python_operator_using_partial
2. test_dag_view_task_with_python_operator_using_instance

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
