### PR TITLE
[AIRFLOW-2710] Clarify fernet key value in documentation

### DIFF
--- a/docs/howto/secure-connections.rst
+++ b/docs/howto/secure-connections.rst
@@ -16,7 +16,7 @@ connections by following steps below:
 
     from cryptography.fernet import Fernet
     fernet_key= Fernet.generate_key()
-    print(fernet_key) # your fernet_key, keep it in secured place!
+    print(fernet_key.decode()) # your fernet_key, keep it in secured place!
 
 3. Replace ``airflow.cfg`` fernet_key value with the one from step 2.
 Alternatively, you can store your fernet_key in OS environment variable. You


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Clarify the documentation. 
No UI changes. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
It's just a simple documentation change.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
No new functionality.

### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
