### PR TITLE
[AIRFLOW-2711] zendesk hook doesn't handle search endpoint properly

### DIFF
--- a/airflow/hooks/zendesk_hook.py
+++ b/airflow/hooks/zendesk_hook.py
@@ -74,7 +74,11 @@ class ZendeskHook(BaseHook):
                 self.__handle_rate_limit_exception(rle)
 
         # Find the key with the results
-        keys = [path.split("/")[-1].split(".json")[0]]
+        key = path.split("/")[-1].split(".json")[0]
+        if key == 'search':
+            keys = ['results']
+        else:
+            keys = [key]
         next_page = results['next_page']
         if side_loading:
             keys += query['include'].split(',')


### PR DESCRIPTION


### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2711) 

### Description
The zendesk api usually returns its results in a key in the json response with the same name as the endpoint, one exception being the search endpoint, which returns its results in 'results' instead of 'search'. This special-cases that endpoint.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
none of the other service-specific API hooks have tests.

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
