### PR TITLE
[AIRFLOW-2731] Raise psutil restriction to <6.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -274,7 +274,7 @@ def do_setup():
             'markdown>=2.5.2, <3.0',
             'pandas>=0.17.1, <1.0.0',
             'pendulum==1.4.4',
-            'psutil>=4.2.0, <5.0.0',
+            'psutil>=4.2.0, <6.0.0',
             'pygments>=2.0.1, <3.0',
             'python-daemon>=2.1.1, <2.2',
             'python-dateutil>=2.3, <3',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2731

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
  - Allow Airflow to be co-installed with psutil >=5.0.0
  - Airflow's usage of psutil does not depend on features changed/removed between psutil 4.x and psutil 5.x so the prohibition is overly strict


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - Library bounds changed on library whose interface has not change w.r.t. Airflow


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
