### PR TITLE
[AIRFLOW-2734] Resolve setuptools normalized_version warning

### DIFF
--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '2.0.0dev0+incubating'
+version = '2.0.0.dev0+incubating'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2734


### Description

Hi all - I'm seeing the following warning from setuptools about the way the version string is currently set in `version.py` which gets loaded by `setup.py`.

	$ python setup.py
	/Users/taylor/.local/share/virtualenvs/airflow-no-hooks/lib/python3.6/site-packages/setuptools/dist.py:398: UserWarning: Normalizing '2.0.0dev0+incubating' to '2.0.0.dev0+incubating'
	  normalized_version,
	usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
	   or: setup.py --help [cmd1 cmd2 ...]
	   or: setup.py --help-commands
	   or: setup.py cmd --help

(Note the `.` that gets added in front of `dev`.)

I checked the [semver docs](https://semver.org/), and it looks like they prefer a hyphen like `2.0.0-dev0+incubating` but `setuptools` complains similarly about that.

It looks like Airflow versioning was previously done with the separator dot [pre-1.8](https://github.com/apache/incubator-airflow/commit/7bb750d7d20dc0c74b091edc4614d25c51615ac0#diff-c3edc8499f1784000f57b09b7c429e83).

Please excuse this PR if this was an intentional change in convention or there's some Apache release versioning guideline I'm missing.

I checked PySpark for a reference Python project under Apache and it looks like they're using the separator dot convention in [pyspark/version.py](https://github.com/apache/spark/blob/eb6e9880397dbac8b0b9ebc0796150b6924fc566/python/pyspark/version.py).

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - no code change

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
