### PR TITLE
[AIRFLOW-2735] Use equality, not identity, check for detecting AWS Batch failures

### DIFF
--- a/airflow/contrib/operators/awsbatch_operator.py
+++ b/airflow/contrib/operators/awsbatch_operator.py
@@ -153,7 +153,7 @@ class AWSBatchOperator(BaseOperator):
 
         for job in response['jobs']:
             job_status = job['status']
-            if job_status is 'FAILED':
+            if job_status == 'FAILED':
                 reason = job['statusReason']
                 raise AirflowException('Job failed with status {}'.format(reason))
             elif job_status in [


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2735
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

Apologies for the rookie mistake, I'm relatively new to Python and missed this on my last patch (https://github.com/apache/incubator-airflow/pull/3567).

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`