### PR TITLE
[AIRFLOW-2614] in trigger_dag API making the DagBag to load specific DAG instead of loading all the dags

### DIFF
--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -20,7 +20,7 @@
 import json
 
 from airflow.exceptions import DagRunAlreadyExists, DagNotFound
-from airflow.models import DagRun, DagBag
+from airflow.models import DagRun, DagBag, DagModel
 from airflow.utils import timezone
 from airflow.utils.state import State
 
@@ -86,7 +86,10 @@ def trigger_dag(
         execution_date=None,
         replace_microseconds=True,
 ):
-    dagbag = DagBag()
+    dag_model = DagModel.get_current(dag_id)
+    if dag_model is None:
+        raise DagNotFound("Dag id {} not found in DagModel".format(dag_id))
+    dagbag = DagBag(dag_folder=dag_model.fileloc)
     dag_run = DagRun()
     triggers = _trigger_dag(
         dag_id=dag_id,


### PR DESCRIPTION

Problem: trigger_dag processes all the dags before creating DAG runs. Processing all the files increases the latency.

Goal: reduce the latency my processing only required dag files.


Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2614) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2614
  


### Description
- [x] to speed up the  trigger_dag API, DagBag is loading only those dag which is triggered and its subdags instead of loading all the dags.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
no new test case




### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
