### PR TITLE
[AIRFLOW-2742] Fix invalid tez.job.queue.name key

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -197,7 +197,7 @@ class HiveCliHook(BaseHook):
                          'mapred.job.queue.name={}'
                          .format(self.mapred_queue),
                          '-hiveconf',
-                         'tez.job.queue.name={}'
+                         'tez.queue.name={}'
                          .format(self.mapred_queue)
                          ])
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2742.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
The property key should be tez.queue.name instead of tez.job.queue.name in HiveCliHook

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
I verifed on my company cluster


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
