### PR TITLE
[AIRFLOW-2748] dbexportcmd & dbimportcmd should support use_customer_cluster, use_customer_label in QuboleOperator

### DIFF
--- a/airflow/contrib/hooks/qubole_hook.py
+++ b/airflow/contrib/hooks/qubole_hook.py
@@ -66,10 +66,12 @@ COMMAND_ARGS = {
                  'user_program_arguments'],
     'dbexportcmd': ['mode', 'hive_table', 'partition_spec', 'dbtap_id', 'db_table',
                     'db_update_mode', 'db_update_keys', 'export_dir',
-                    'fields_terminated_by', 'tags', 'name'],
+                    'fields_terminated_by', 'tags', 'name', 'customer_cluster_label',
+                    'use_customer_cluster', 'additional_options'],
     'dbimportcmd': ['mode', 'hive_table', 'dbtap_id', 'db_table', 'where_clause',
                     'parallelism', 'extract_query', 'boundary_query', 'split_column',
-                    'tags', 'name']
+                    'tags', 'name', 'hive_serde', 'customer_cluster_label',
+                    'use_customer_cluster', 'schema', 'additional_options']
 }
 
 


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2748) 


### Description
- [x] Currently the QuboleOperator & qubole_hook in the Airflow codebase doesn't support `use_customer_cluster`, `customer_cluster_label`  and `hive_serde` command arguments in Airflow. This PR is for adding the above functionality. 


### Tests
- [x] This is a very small change to add additional parameters to the API (Qubole SDK) call, hence doesn't require adding test cases.


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
