### PR TITLE
[AIRFLOW-2751] add job properties update in hive to druid operator to solve library conflict problem.

### DIFF
--- a/airflow/operators/hive_to_druid.py
+++ b/airflow/operators/hive_to_druid.py
@@ -55,6 +55,8 @@ class HiveToDruidTransfer(BaseOperator):
     :param hive_tblproperties: additional properties for tblproperties in
         hive for the staging table
     :type hive_tblproperties: dict
+    :param job_properties: additional properties for job
+    :type job_properties: dict
     """
 
     template_fields = ('sql', 'intervals')
@@ -77,6 +79,7 @@ class HiveToDruidTransfer(BaseOperator):
             query_granularity="NONE",
             segment_granularity="DAY",
             hive_tblproperties=None,
+            job_properties=None,
             *args, **kwargs):
         super(HiveToDruidTransfer, self).__init__(*args, **kwargs)
         self.sql = sql
@@ -95,6 +98,7 @@ class HiveToDruidTransfer(BaseOperator):
         self.druid_ingest_conn_id = druid_ingest_conn_id
         self.metastore_conn_id = metastore_conn_id
         self.hive_tblproperties = hive_tblproperties
+        self.job_properties = job_properties
 
     def execute(self, context):
         hive = HiveCliHook(hive_cli_conn_id=self.hive_cli_conn_id)
@@ -230,6 +234,10 @@ class HiveToDruidTransfer(BaseOperator):
                 }
             }
         }
+
+        if self.job_properties:
+            ingest_query_dict['spec']['tuningConfig']['jobProperties'] \
+                .update(self.job_properties)
 
         if self.hadoop_dependency_coordinates:
             ingest_query_dict['hadoopDependencyCoordinates'] \

--- a/tests/operators/test_hive_to_druid.py
+++ b/tests/operators/test_hive_to_druid.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -47,7 +47,12 @@ class TestDruidHook(unittest.TestCase):
         'num_shards': -1,
         'target_partition_size': 1925,
         'query_granularity': 'month',
-        'segment_granularity': 'week'
+        'segment_granularity': 'week',
+        'job_properties': {
+            "mapreduce.job.user.classpath.first": "false",
+            "mapreduce.map.output.compress": "false",
+            "mapreduce.output.fileoutputformat.compress": "false"
+        }
     }
 
     index_spec_config = {
@@ -112,11 +117,7 @@ class TestDruidHook(unittest.TestCase):
                 },
                 "tuningConfig": {
                     "type": "hadoop",
-                    "jobProperties": {
-                        "mapreduce.job.user.classpath.first": "false",
-                        "mapreduce.map.output.compress": "false",
-                        "mapreduce.output.fileoutputformat.compress": "false",
-                    },
+                    "jobProperties": self.hook_config['job_properties'],
                     "partitionsSpec": {
                         "type": "hashed",
                         "targetPartitionSize": self.hook_config['target_partition_size'],


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2751) issues and references them in the PR title. 
    - https://issues.apache.org/jira/browse/AIRFLOW-2751

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
I ran `nosetests /tests/operators/test_hive_to_druid.py` locally.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
