### PR TITLE
[AIRFLOW-XXX] Remove extra debug log at info level

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -521,7 +521,6 @@ class DagBag(BaseDagBag, LoggingMixin):
         FileLoadStat = namedtuple(
             'FileLoadStat', "file duration dag_num task_num dags")
         for filepath in utils.dag_processing.list_py_file_paths(dag_folder):
-            self.log.info(filepath)
             try:
                 ts = timezone.utcnow()
                 found_dags = self.process_file(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-1729
    - I'm not sure if this should be attributed to the same Jira or left as AIRFLOW-XXX?


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes: I left an extra log call, at info level in #3602 that was being used for debugging.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: removing logging doesn't need tests really


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
