### PR TITLE
[AIRFLOW-2756] Fix bug in set DAG run state workflow

### DIFF
--- a/airflow/api/common/experimental/mark_tasks.py
+++ b/airflow/api/common/experimental/mark_tasks.py
@@ -206,7 +206,10 @@ def _set_dag_run_state(dag_id, execution_date, state, session=None):
         DR.execution_date == execution_date
     ).one()
     dr.state = state
-    dr.end_date = timezone.utcnow()
+    if state == State.RUNNING:
+        dr.start_date = timezone.utcnow()
+    else:
+        dr.end_date = timezone.utcnow()
     session.commit()
 
 

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1023,8 +1023,7 @@ class SchedulerJob(BaseJob):
                     models.TaskInstance.dag_id == subq.c.dag_id,
                     models.TaskInstance.task_id == subq.c.task_id,
                     models.TaskInstance.execution_date ==
-                    subq.c.execution_date,
-                    models.TaskInstance.task_id == subq.c.task_id)) \
+                    subq.c.execution_date)) \
                 .update({models.TaskInstance.state: new_state},
                         synchronize_session=False)
             session.commit()

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2741,7 +2741,8 @@ class DagRunModelView(ModelViewOnly):
             altered_tis = set_dag_run_state_to_success(
                 dagbag.get_dag(dagrun.dag_id),
                 dagrun.execution_date,
-                commit=True)
+                commit=True,
+                session=session)
         elif dagrun.state == State.FAILED:
             altered_tis = set_dag_run_state_to_failed(
                 dagbag.get_dag(dagrun.dag_id),


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2756) issues and references them in the PR title.

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Marking DAG run right now always set end_time while it should set start_time when marking RUNNING and otherwise end_time. This commit fixes it.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests/api/common/experimental/mark_tasks.py: _verify_dag_run_dates
Also added dag run dates checks in other related tests.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
