### PR TITLE
[AIRFLOW-2754] Fix invalid hive static path in case of using HDP.

### DIFF
--- a/airflow/operators/hive_to_druid.py
+++ b/airflow/operators/hive_to_druid.py
@@ -129,9 +129,7 @@ class HiveToDruidTransfer(BaseOperator):
         columns = [col.name for col in t.sd.cols]
 
         # Get the path on hdfs
-        hdfs_uri = m.get_table(hive_table).sd.location
-        pos = hdfs_uri.find('/user')
-        static_path = hdfs_uri[pos:]
+        static_path = m.get_table(hive_table).sd.location
 
         schema, table = hive_table.split('.')
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2754) issues and references them in the PR title.
    - https://issues.apache.org/jira/browse/AIRFLOW-2754


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
I tested locally. Also I ran `nosetests /tests/operators/test_hive_to_druid.py` successfully. 

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
