### PR TITLE
[AIRFLOW-2615] Makes sure DagBag doesn't parse DAGs twice during startup

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -787,9 +787,11 @@ def webserver(args):
         app.run(debug=True, port=args.port, host=args.hostname,
                 ssl_context=(ssl_cert, ssl_key) if ssl_cert and ssl_key else None)
     else:
+        os.environ['SKIP_DAGS_PARSING'] = 'True'
         app = cached_app_rbac(conf) if settings.RBAC else cached_app(conf)
         pid, stdout, stderr, log_file = setup_locations(
             "webserver", args.pid, args.stdout, args.stderr, args.log_file)
+        os.environ.pop('SKIP_DAGS_PARSING')
         if args.daemon:
             handle = setup_logging(log_file)
             stdout = open(stdout, 'w+')

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -73,7 +73,10 @@ from airflow.www_rbac.widgets import AirflowModelListWidget
 
 
 PAGE_SIZE = conf.getint('webserver', 'page_size')
-dagbag = models.DagBag(settings.DAGS_FOLDER)
+if os.environ.get('SKIP_DAGS_PARSING') != 'True':
+    dagbag = models.DagBag(settings.DAGS_FOLDER)
+else:
+    dagbag = models.DagBag
 
 
 def get_date_time_num_runs_dag_runs_form_data(request, session, dag):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW-2615) issues and references them in the PR title. 

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Webserver parses DagBag twice during start up, thus causes webserver start up being slow with large number of DAG files. This change reduces the start up time of webserver to almost half by making sure the DagBag model doesn't parse DAGs twice during the start up process. More details and discussions here: https://github.com/apache/incubator-airflow/pull/3506
FYI: @yrqls21 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
