### PR TITLE
[AIRFLOW-2766] Respect the Date Time selected in any tab on DAG detail page

### DIFF
--- a/airflow/www_rbac/templates/airflow/dag.html
+++ b/airflow/www_rbac/templates/airflow/dag.html
@@ -45,6 +45,8 @@
   </div>
   <div class="clearfix"></div>
   <div>
+    {% set base_date_arg = request.args.get('base_date') %}
+    {% set num_runs_arg = request.args.get('num_runs') %}
     <ul class="nav nav-pills">
       {% if dag.parent_dag %}
           <li class="never_active"><a href="{{ url_for('Airflow.' + dag.default_view, dag_id=dag.parent_dag.dag_id) }}">
@@ -52,29 +54,29 @@
               Back to {{ dag.parent_dag.dag_id }}</a>
           </li>
       {% endif %}
-      <li><a href="{{ url_for('Airflow.graph', dag_id=dag.dag_id, root=root) }}">
+      <li><a href="{{ url_for('Airflow.graph', dag_id=dag.dag_id, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
           <span class="glyphicon glyphicon-certificate" aria-hidden="true"></span>
         Graph View</a></li>
-      <li><a href="{{ url_for('Airflow.tree', dag_id=dag.dag_id, num_runs=num_runs, root=root) }}">
+      <li><a href="{{ url_for('Airflow.tree', dag_id=dag.dag_id, num_runs=num_runs_arg, root=root, base_date=base_date_arg) }}">
           <span class="glyphicon glyphicon-tree-deciduous" aria-hidden="true"></span>
         Tree View
       </a></li>
-      <li><a href="{{ url_for('Airflow.duration', dag_id=dag.dag_id, days=30, root=root) }}">
+      <li><a href="{{ url_for('Airflow.duration', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
           <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
           Task Duration
       </a></li>
-      <li><a href="{{ url_for('Airflow.tries', dag_id=dag.dag_id, days=30, root=root) }}">
+      <li><a href="{{ url_for('Airflow.tries', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
           <span class="glyphicon glyphicon-duplicate" aria-hidden="true"></span>
           Task Tries
       </a></li>
       <li>
-        <a href="{{ url_for('Airflow.landing_times', dag_id=dag.dag_id, days=30, root=root) }}">
+        <a href="{{ url_for('Airflow.landing_times', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
           <span class="glyphicon glyphicon-plane" aria-hidden="true"></span>
           Landing Times
         </a>
       </li>
       <li>
-        <a href="{{ url_for('Airflow.gantt', dag_id=dag.dag_id, root=root) }}">
+        <a href="{{ url_for('Airflow.gantt', dag_id=dag.dag_id, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
           <span class="glyphicon glyphicon-align-left" aria-hidden="true"></span>
           <i class="icon-align-left"></i>
           Gantt


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow-2766](https://issues.apache.org/jira/browse/AIRFLOW-2766) issues and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Really small UX improvement. 
From end user's perspective, when I set date time in one tab on DAG detail page I expect to see other graphs for the same datetime. Current UX is confusing as when you select Base date in one tab, and goes to the second tab, the second tab reset the datetime and shows all the records. This implementation keeps the datetime same for all the tabs/charts. 

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
It's .html file changes, and does not need unit tests


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
