### PR TITLE
[AIRFLOW-2776] Compress tree view JSON

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1477,7 +1477,8 @@ class Airflow(BaseView):
                 for d in dates],
         }
 
-        data = json.dumps(data, indent=4, default=json_ser)
+        # minimize whitespace as this can be huge for bigger dags
+        data = json.dumps(data, default=json_ser, separators=(',', ':'))
         session.commit()
 
         form = DateTimeWithNumRunsForm(data={'base_date': max_date,

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -1205,7 +1205,8 @@ class Airflow(AirflowBaseView):
                 for d in dates],
         }
 
-        data = json.dumps(data, indent=4, default=json_ser)
+        # minimize whitespace as this can be huge for bigger dags
+        data = json.dumps(data, default=json_ser, separators=(',', ':'))
         session.commit()
 
         form = DateTimeWithNumRunsForm(data={'base_date': max_date,


### PR DESCRIPTION
The tree view generates JSON that can be massive for bigger DAGs,
up to 10s of MBs. The JSON is currently prettified, which both
takes up more CPU time during serialization, and slows down
everything else that uses it. Considering the JSON is only
meant to be used programmatically, this is an easy win

We've already been using this patch internally at stripe and had huge speedups

### Checklist
- [x] [JIRA issue](https://issues.apache.org/jira/browse/AIRFLOW-2776?filter=-2)
- [x] good PR description
- [x] covered by existing tests
- [x] good commit message
- [x] documentation
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
