### PR TITLE
[AIRFLOW-2777] speed up dag.sub_dag(...)

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3904,10 +3904,15 @@ class DAG(BaseDag, LoggingMixin):
         upstream and downstream neighbours based on the flag passed.
         """
 
+        # deep-copying self.task_dict takes a long time, and we don't want all
+        # the tasks anyway, so we copy the tasks manually later
+        task_dict = self.task_dict
+        self.task_dict = {}
         dag = copy.deepcopy(self)
+        self.task_dict = task_dict
 
         regex_match = [
-            t for t in dag.tasks if re.findall(task_regex, t.task_id)]
+            t for t in self.tasks if re.findall(task_regex, t.task_id)]
         also_include = []
         for t in regex_match:
             if include_downstream:
@@ -3916,7 +3921,9 @@ class DAG(BaseDag, LoggingMixin):
                 also_include += t.get_flat_relatives(upstream=True)
 
         # Compiling the unique list of tasks that made the cut
-        dag.task_dict = {t.task_id: t for t in regex_match + also_include}
+        # Make sure to not recursively deepcopy the dag while copying the task
+        dag.task_dict = {t.task_id: copy.deepcopy(t, {id(t.dag): t.dag})
+                         for t in regex_match + also_include}
         for t in dag.tasks:
             # Removing upstream/downstream references to tasks that did not
             # made the cut


### PR DESCRIPTION
previous version created the subdag by copying over all the tasks, and
then filtering them down. it's a lot faster if we only copy over the
tasks we need

### Testing

We've been using this patch in production at stripe for a while now, so I'm pretty confident it works. Regarding automated tests, `sub_dag(...)` somewhat covered by [existing unit tests](https://git.corp.stripe.com/stripe-internal/airflow/blob/stripe-1.9/tests/jobs.py#L513). I'd appreciate any thoughts on additional automated testing! 

### Checklist
- [x] [Jira ticket](https://issues.apache.org/jira/browse/AIRFLOW-2777)
- [x] good PR description
- [x] testing
- [x] good commit
- [x] documentation
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
