### PR TITLE
[AIRFLOW-2765] Set default mime_charset to UTF-8

### DIFF
--- a/airflow/operators/email_operator.py
+++ b/airflow/operators/email_operator.py
@@ -60,7 +60,7 @@ class EmailOperator(BaseOperator):
             cc=None,
             bcc=None,
             mime_subtype='mixed',
-            mime_charset='us_ascii',
+            mime_charset='utf-8',
             *args, **kwargs):
         super(EmailOperator, self).__init__(*args, **kwargs)
         self.to = to


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2765
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
From https://issues.apache.org/jira/browse/AIRFLOW-2765:
Assuming we would want both EmailOperator() and utils.email.send_email() to use the same default value for the mime_charset parameter.  The default for utils.email.send_email() was recently changed to UTF-8.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - Simple change of a default parameter.
    - Existing unit tests in `tests/operators/test_email_operator.py` pass.

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
