### PR TITLE
[AIRFLOW-2785] Add context manager entry points to mongoHook

### DIFF
--- a/airflow/contrib/hooks/mongo_hook.py
+++ b/airflow/contrib/hooks/mongo_hook.py
@@ -37,6 +37,13 @@ class MongoHook(BaseHook):
         self.extras = self.connection.extra_dejson
         self.client = None
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.client is not None:
+            self.close_conn()
+
     def get_conn(self):
         """
         Fetches PyMongo Client
@@ -66,6 +73,12 @@ class MongoHook(BaseHook):
         self.client = MongoClient(uri, **options)
 
         return self.client
+
+    def close_conn(self):
+        client = self.client
+        if client is not None:
+            client.close()
+            self.client = None
 
     def get_collection(self, mongo_collection, mongo_db=None):
         """

--- a/tests/contrib/hooks/test_mongo_hook.py
+++ b/tests/contrib/hooks/test_mongo_hook.py
@@ -118,6 +118,15 @@ class TestMongoHook(unittest.TestCase):
         results = [result for result in results]
         self.assertEqual(len(results), 2)
 
+    def test_context_manager(self):
+        with MongoHook(conn_id='mongo_default', mongo_db='default') as ctxHook:
+            ctxHook.get_conn()
+
+            self.assertIsInstance(ctxHook, MongoHook)
+            self.assertIsNotNone(ctxHook.client)
+
+        self.assertIsNone(ctxHook.client)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ x ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [ x ] Here are some details about my PR, including screenshots of any UI changes:

Previously we left it up to user to manage connections with mongo hook, this change moves that logic to the hook via context manager entry and exit points. This gives the user the added ability of being able to use `with` statements to manager connections while not breaking backwards compatibility.


### Tests
- [ x ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added a unit test to ensure context management is working as expected

### Commits
- [ x ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ x ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ x ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
