### PR TITLE
AIRFLOW-2787 Allow is_backfill to handle NULL DagRun.run_id

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -5141,7 +5141,10 @@ class DagRun(Base, LoggingMixin):
     @property
     def is_backfill(self):
         from airflow.jobs import BackfillJob
-        return self.run_id.startswith(BackfillJob.ID_PREFIX)
+        return (
+            self.run_id is not None and
+            self.run_id.startswith(BackfillJob.ID_PREFIX)
+        )
 
     @classmethod
     @provide_session

--- a/tests/models.py
+++ b/tests/models.py
@@ -946,11 +946,20 @@ class DagRunTest(unittest.TestCase):
 
     def test_is_backfill(self):
         dag = DAG(dag_id='test_is_backfill', start_date=DEFAULT_DATE)
+
         dagrun = self.create_dag_run(dag, execution_date=DEFAULT_DATE)
         dagrun.run_id = BackfillJob.ID_PREFIX + '_sfddsffds'
-        dagrun2 = self.create_dag_run(dag, execution_date=DEFAULT_DATE + datetime.timedelta(days=1))
+
+        dagrun2 = self.create_dag_run(
+            dag, execution_date=DEFAULT_DATE + datetime.timedelta(days=1))
+
+        dagrun3 = self.create_dag_run(
+            dag, execution_date=DEFAULT_DATE + datetime.timedelta(days=2))
+        dagrun3.run_id = None
+
         self.assertTrue(dagrun.is_backfill)
         self.assertFalse(dagrun2.is_backfill)
+        self.assertFalse(dagrun3.is_backfill)
 
     def test_removed_task_instances_can_be_restored(self):
         def with_all_tasks_removed(dag):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2787


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
  - `is_backfill` will fail with a `AttributeError: 'NoneType' object has no attribute 'startswith'` error when called on a DagRun with NULL `run_id` (allowed by model definition). This PR introduces a None check to prevent the crash.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - extension to `test_is_backfill` to check the NULL run_id case


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
