### PR TITLE
[AIRFLOW-2782] Removes unused hard-coded dagreD3 (Follow up issue)

### DIFF
--- a/airflow/www_rbac/webpack.config.js
+++ b/airflow/www_rbac/webpack.config.js
@@ -36,7 +36,6 @@ const config = {
   entry: {
     connectionForm: STATIC_DIR + '/js/connection_form.js',
     clock: STATIC_DIR + '/js/clock.js',
-    dagreD3: STATIC_DIR + '/js/dagre-d3.js',
     ganttChartD3v2: STATIC_DIR + '/js/gantt-chart-d3v2.js',
     styleBundle: [
       STATIC_DIR + '/css/main.css',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow 2782](https://issues.apache.org/jira/browse/AIRFLOW-2782) issues and references them in the PR title.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
With the change implemented in this PR: https://github.com/apache/incubator-airflow/pull/3634 we managed to upgrade the DagreD3 package and that package can now be managed using npm and webpack. I also removed the hard-coded file DagreD3 from the code base but forgot to remove one statement using that file, which is restricting the frontend to build. This PR fixes that issue. 


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
