### PR TITLE
[AIRFLOW-2795] Oracle to Oracle Transfer Operator

### DIFF
--- a/airflow/contrib/operators/oracle_to_oracle_transfer.py
+++ b/airflow/contrib/operators/oracle_to_oracle_transfer.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.hooks.oracle_hook import OracleHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class OracleToOracleTransfer(BaseOperator):
+    """
+    Moves data from Oracle to Oracle.
+
+
+    :param oracle_destination_conn_id: destination Oracle connection.
+    :type oracle_destination_conn_id: str
+    :param destination_table: destination table to insert rows.
+    :type destination_table: str
+    :param oracle_source_conn_id: source Oracle connection.
+    :type oracle_source_conn_id: str
+    :param source_sql: SQL query to execute against the source Oracle
+        database. (templated)
+    :type source_sql: str
+    :param source_sql_params: Parameters to use in sql query. (templated)
+    :type source_sql_params: dict
+    :param rows_chunk: number of rows per chunk to commit.
+    :type rows_chunk: int
+    """
+
+    template_fields = ('source_sql', 'source_sql_params')
+    ui_color = '#e08c8c'
+
+    @apply_defaults
+    def __init__(
+            self,
+            oracle_destination_conn_id,
+            destination_table,
+            oracle_source_conn_id,
+            source_sql,
+            source_sql_params={},
+            rows_chunk=5000,
+            *args, **kwargs):
+        super(OracleToOracleTransfer, self).__init__(*args, **kwargs)
+        self.oracle_destination_conn_id = oracle_destination_conn_id
+        self.destination_table = destination_table
+        self.oracle_source_conn_id = oracle_source_conn_id
+        self.source_sql = source_sql
+        self.source_sql_params = source_sql_params
+        self.rows_chunk = rows_chunk
+
+    def _execute(self, src_hook, dest_hook, context):
+        with src_hook.get_conn() as src_conn:
+            cursor = src_conn.cursor()
+            self.log.info("Querying data from source: {0}".format(
+                self.oracle_source_conn_id))
+            cursor.execute(self.source_sql, self.source_sql_params)
+            target_fields = list(map(lambda field: field[0], cursor.description))
+
+            rows_total = 0
+            rows = cursor.fetchmany(self.rows_chunk)
+            while len(rows) > 0:
+                rows_total = rows_total + len(rows)
+                dest_hook.bulk_insert_rows(self.destination_table, rows,
+                                           target_fields=target_fields,
+                                           commit_every=self.rows_chunk)
+                rows = cursor.fetchmany(self.rows_chunk)
+                self.log.info("Total inserted: {0} rows".format(rows_total))
+
+            self.log.info("Finished data transfer.")
+            cursor.close()
+
+    def execute(self, context):
+        src_hook = OracleHook(oracle_conn_id=self.oracle_source_conn_id)
+        dest_hook = OracleHook(oracle_conn_id=self.oracle_destination_conn_id)
+        self._execute(src_hook, dest_hook, context)

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -172,6 +172,7 @@ Operators
 .. autoclass:: airflow.contrib.operators.mongo_to_s3.MongoToS3Operator
 .. autoclass:: airflow.contrib.operators.mysql_to_gcs.MySqlToGoogleCloudStorageOperator
 .. autoclass:: airflow.contrib.operators.oracle_to_azure_data_lake_transfer.OracleToAzureDataLakeTransfer
+.. autoclass:: airflow.contrib.operators.oracle_to_oracle_transfer.OracleToOracleTransfer
 .. autoclass:: airflow.contrib.operators.postgres_to_gcs_operator.PostgresToGoogleCloudStorageOperator
 .. autoclass:: airflow.contrib.operators.pubsub_operator.PubSubTopicCreateOperator
 .. autoclass:: airflow.contrib.operators.pubsub_operator.PubSubTopicDeleteOperator

--- a/tests/contrib/operators/test_oracle_to_oracle_transfer.py
+++ b/tests/contrib/operators/test_oracle_to_oracle_transfer.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from airflow.contrib.operators.oracle_to_oracle_transfer \
+    import OracleToOracleTransfer
+
+try:
+    from unittest import mock
+    from unittest.mock import MagicMock
+except ImportError:
+    try:
+        import mock
+        from mock import MagicMock
+    except ImportError:
+        mock = None
+
+
+class OracleToOracleTransferTest(unittest.TestCase):
+
+    def test_execute(self):
+        oracle_destination_conn_id = 'oracle_destination_conn_id'
+        destination_table = 'destination_table'
+        oracle_source_conn_id = 'oracle_source_conn_id'
+        source_sql = "select sysdate from dual where trunc(sysdate) = :p_data"
+        source_sql_params = {':p_data': "2018-01-01"}
+        rows_chunk = 5000
+        cursor_description = [
+            ('id', "<class 'cx_Oracle.NUMBER'>", 39, None, 38, 0, 0),
+            ('description', "<class 'cx_Oracle.STRING'>", 60, 240, None, None, 1)
+        ]
+        cursor_rows = [[1, 'description 1'], [2, 'description 2']]
+
+        mock_dest_hook = MagicMock()
+        mock_src_hook = MagicMock()
+        mock_src_conn = mock_src_hook.get_conn.return_value.__enter__.return_value
+        mock_cursor = mock_src_conn.cursor.return_value
+        mock_cursor.description.__iter__.return_value = cursor_description
+        mock_cursor.fetchmany.side_effect = [cursor_rows, []]
+
+        op = OracleToOracleTransfer(
+            task_id='copy_data',
+            oracle_destination_conn_id=oracle_destination_conn_id,
+            destination_table=destination_table,
+            oracle_source_conn_id=oracle_source_conn_id,
+            source_sql=source_sql,
+            source_sql_params=source_sql_params,
+            rows_chunk=rows_chunk)
+
+        op._execute(mock_src_hook, mock_dest_hook, None)
+
+        assert mock_src_hook.get_conn.called
+        assert mock_src_conn.cursor.called
+        mock_cursor.execute.assert_called_with(source_sql, source_sql_params)
+        mock_cursor.fetchmany.assert_called_with(rows_chunk)
+        mock_dest_hook.bulk_insert_rows.assert_called_once_with(
+            destination_table,
+            cursor_rows,
+            commit_every=rows_chunk,
+            target_fields=['id', 'description'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-2795) issues and references them in the PR title.
    - [https://issues.apache.org/jira/browse/AIRFLOW-2795](https://issues.apache.org/jira/browse/AIRFLOW-2795)


### Description
- [x] This PR adds a OracleToOracleTransfer operator in contrib operators.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - tests/contrib/operators/test_oracle_to_oracle_transfer.py

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`