### PR TITLE
[AIRFLOW-XXX] Reduce logging for used pool settings

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -172,8 +172,8 @@ def configure_orm(disable_connection_pool=False):
         except conf.AirflowConfigException:
             pool_recycle = 1800
 
-        log.info("setting.configure_orm(): Using pool settings. pool_size={}, "
-                 "pool_recycle={}".format(pool_size, pool_recycle))
+        log.debug("setting.configure_orm(): Using pool settings. pool_size={}, "
+                  "pool_recycle={}".format(pool_size, pool_recycle))
         engine_args['pool_size'] = pool_size
         engine_args['pool_recycle'] = pool_recycle
 


### PR DESCRIPTION
Log level should be consistent with previous `log.debug("settings.configure_orm(): Using NullPool")`

However my main motivation is that I'm importing it from a Jupyter notebook and don't find valuable this log.info output there.

Similar merged PRs in the past #1336 #2967