### PR TITLE
[AIRFLOW-2807] Support STS Assume Role External ID

### DIFF
--- a/airflow/contrib/hooks/aws_hook.py
+++ b/airflow/contrib/hooks/aws_hook.py
@@ -116,6 +116,7 @@ class AwsHook(BaseHook):
                     region_name = connection_object.extra_dejson.get('region_name')
 
                 role_arn = connection_object.extra_dejson.get('role_arn')
+                external_id = connection_object.extra_dejson.get('external_id')
                 aws_account_id = connection_object.extra_dejson.get('aws_account_id')
                 aws_iam_role = connection_object.extra_dejson.get('aws_iam_role')
 
@@ -130,9 +131,17 @@ class AwsHook(BaseHook):
                         region_name=region_name)
 
                     sts_client = sts_session.client('sts')
-                    sts_response = sts_client.assume_role(
-                        RoleArn=role_arn,
-                        RoleSessionName='Airflow_' + self.aws_conn_id)
+
+                    if external_id is None:
+                        sts_response = sts_client.assume_role(
+                            RoleArn=role_arn,
+                            RoleSessionName='Airflow_' + self.aws_conn_id)
+                    else:
+                        sts_response = sts_client.assume_role(
+                            RoleArn=role_arn,
+                            RoleSessionName='Airflow_' + self.aws_conn_id,
+                            ExternalId=external_id)
+
                     aws_access_key_id = sts_response['Credentials']['AccessKeyId']
                     aws_secret_access_key = sts_response['Credentials']['SecretAccessKey']
                     aws_session_token = sts_response['Credentials']['SessionToken']

--- a/tests/contrib/hooks/test_aws_hook.py
+++ b/tests/contrib/hooks/test_aws_hook.py
@@ -164,6 +164,25 @@ class TestAwsHook(unittest.TestCase):
                          'gRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15'
                          'fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE')
 
+    @unittest.skipIf(mock_sts is None, 'mock_sts package not present')
+    @mock.patch.object(AwsHook, 'get_connection')
+    @mock_sts
+    def test_get_credentials_from_role_arn_with_external_id(self, mock_get_connection):
+        mock_connection = Connection(
+            extra='{"role_arn":"arn:aws:iam::123456:role/role_arn",'
+                  ' "external_id":"external_id"}')
+        mock_get_connection.return_value = mock_connection
+        hook = AwsHook()
+        credentials_from_hook = hook.get_credentials()
+        self.assertEqual(credentials_from_hook.access_key, 'AKIAIOSFODNN7EXAMPLE')
+        self.assertEqual(credentials_from_hook.secret_key,
+                         'aJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY')
+        self.assertEqual(credentials_from_hook.token,
+                         'BQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh'
+                         '3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4I'
+                         'gRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15'
+                         'fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently the role assumption method works only if the granting account
does not specify an External ID. The external ID is used to solved the
confused deputy problem. When using the AWS hook to export data to
multiple customers, it's good security practice to use the external ID.

There is no backwards compatibility break.

Documentation: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html

