### PR TITLE
[AIRFLOW-2811] Fix scheduler_ops_metrics.py to work

### DIFF
--- a/scripts/perf/scheduler_ops_metrics.py
+++ b/scripts/perf/scheduler_ops_metrics.py
@@ -17,7 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from datetime import datetime
 import logging
 import pandas as pd
 import sys
@@ -25,6 +24,7 @@ import sys
 from airflow import configuration, settings
 from airflow.jobs import SchedulerJob
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
+from airflow.utils import timezone
 from airflow.utils.state import State
 
 SUBDIR = 'scripts/perf/dags'
@@ -53,7 +53,10 @@ class SchedulerMetricsJob(SchedulerJob):
     run on remote systems and spend the majority of their time on I/O wait.
 
     To Run:
-        $ python scripts/perf/scheduler_ops_metrics.py
+        $ python scripts/perf/scheduler_ops_metrics.py [timeout]
+
+    You can specify timeout in seconds as an optional parameter.
+    Its default value is 6 seconds.
     """
     __mapper_args__ = {
         'polymorphic_identity': 'SchedulerMetricsJob'
@@ -71,7 +74,7 @@ class SchedulerMetricsJob(SchedulerJob):
             .filter(TI.dag_id.in_(DAG_IDS))
             .all()
         )
-        successful_tis = filter(lambda x: x.state == State.SUCCESS, tis)
+        successful_tis = [x for x in tis if x.state == State.SUCCESS]
         ti_perf = [(ti.dag_id, ti.task_id, ti.execution_date,
                     (ti.queued_dttm - self.start_date).total_seconds(),
                     (ti.start_date - self.start_date).total_seconds(),
@@ -117,11 +120,11 @@ class SchedulerMetricsJob(SchedulerJob):
         dagbag = DagBag(SUBDIR)
         dags = [dagbag.dags[dag_id] for dag_id in DAG_IDS]
         # the tasks in perf_dag_1 and per_dag_2 have a daily schedule interval.
-        num_task_instances = sum([(datetime.today() - task.start_date).days
+        num_task_instances = sum([(timezone.utcnow() - task.start_date).days
                                  for dag in dags for task in dag.tasks])
 
         if (len(successful_tis) == num_task_instances or
-                (datetime.now()-self.start_date).total_seconds() >
+                (timezone.utcnow() - self.start_date).total_seconds() >
                 MAX_RUNTIME_SECS):
             if (len(successful_tis) == num_task_instances):
                 self.log.info("All tasks processed! Printing stats.")
@@ -178,6 +181,17 @@ def set_dags_paused_state(is_paused):
 
 
 def main():
+    global MAX_RUNTIME_SECS
+    if len(sys.argv) > 1:
+        try:
+            max_runtime_secs = int(sys.argv[1])
+            if max_runtime_secs < 1:
+                raise ValueError
+            MAX_RUNTIME_SECS = max_runtime_secs
+        except ValueError:
+            logging.error('Specify a positive integer for timeout.')
+            sys.exit(1)
+
     configuration.load_test_config()
 
     set_dags_paused_state(False)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2811
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR fixes timezone problem in
scheduler_ops_metrics.py and makes
its timeout configurable.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's just a simple benchmark tool.
I ran the fixed one locally and confirmed that it worked as follows:

```
$ python scripts/perf/scheduler_ops_metrics.py 600

(snip)

[2018-07-27 10:18:40,622] {scheduler_ops_metrics.py:130} INFO - All tasks processed! Printing stats.
Performance Results
###################
DAG perf_dag_1
        dag_id      task_id            execution_date  queue_delay  \
0   perf_dag_1  perf_task_1 2018-07-24 00:00:00+00:00     3.135073   
1   perf_dag_1  perf_task_3 2018-07-24 00:00:00+00:00    30.941977   
2   perf_dag_1  perf_task_2 2018-07-24 00:00:00+00:00    30.942074   
3   perf_dag_1  perf_task_4 2018-07-24 00:00:00+00:00    30.942115   
4   perf_dag_1  perf_task_1 2018-07-25 00:00:00+00:00    30.942147   
5   perf_dag_1  perf_task_3 2018-07-25 00:00:00+00:00   135.108274   
6   perf_dag_1  perf_task_2 2018-07-25 00:00:00+00:00   135.108330   
7   perf_dag_1  perf_task_4 2018-07-25 00:00:00+00:00   135.108363   
8   perf_dag_1  perf_task_1 2018-07-26 00:00:00+00:00   135.108393   
9   perf_dag_1  perf_task_3 2018-07-26 00:00:00+00:00   239.457929   
10  perf_dag_1  perf_task_2 2018-07-26 00:00:00+00:00   239.458035   
11  perf_dag_1  perf_task_4 2018-07-26 00:00:00+00:00   239.458075   

    start_delay   land_time  duration  
0      5.753828   13.474063  7.720235  
1     46.649262   54.261263  7.612001  
2     72.090184   79.751435  7.661251  
3     59.639579   68.095187  8.455608  
4     33.650920   41.268058  7.617138  
5    150.765460  158.545801  7.780341  
6    176.362889  184.095333  7.732444  
7    163.527021  171.198786  7.671765  
8    137.912502  145.571243  7.658741  
9    255.088458  262.767807  7.679349  
10   242.181959  249.833807  7.651848  
11   267.866819  275.636975  7.770156  
DAG perf_dag_2
        dag_id      task_id            execution_date  queue_delay  \
12  perf_dag_2  perf_task_1 2018-07-24 00:00:00+00:00    17.061669   
13  perf_dag_2  perf_task_3 2018-07-24 00:00:00+00:00    83.053659   
14  perf_dag_2  perf_task_2 2018-07-24 00:00:00+00:00    83.053717   
15  perf_dag_2  perf_task_4 2018-07-24 00:00:00+00:00    83.053750   
16  perf_dag_2  perf_task_1 2018-07-25 00:00:00+00:00    83.053781   
17  perf_dag_2  perf_task_3 2018-07-25 00:00:00+00:00   187.194547   
18  perf_dag_2  perf_task_2 2018-07-25 00:00:00+00:00   187.194657   
19  perf_dag_2  perf_task_4 2018-07-25 00:00:00+00:00   187.194697   
20  perf_dag_2  perf_task_1 2018-07-26 00:00:00+00:00   187.194728   
21  perf_dag_2  perf_task_3 2018-07-26 00:00:00+00:00   278.740757   
22  perf_dag_2  perf_task_2 2018-07-26 00:00:00+00:00   278.740814   
23  perf_dag_2  perf_task_4 2018-07-26 00:00:00+00:00   278.740846   

    start_delay   land_time  duration  
12    19.822354   27.441253  7.618899  
13   111.452991  119.296895  7.843904  
14    98.684003  106.432997  7.748994  
15   124.171275  131.829952  7.658677  
16    85.834745   93.479540  7.644795  
17   228.614274  236.259984  7.645710  
18   202.729704  210.382846  7.653142  
19   215.742879  223.420997  7.678118  
20   189.848958  197.538583  7.689625  
21   294.593320  302.268516  7.675196  
22   307.478050  315.145167  7.667117  
23   281.577134  289.273013  7.695879  
###################
```

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
