### PR TITLE
[AIRFLOW-2814] Fix inconsistent default config

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -428,8 +428,8 @@ scheduler_heartbeat_sec = 5
 # -1 indicates to run continuously (see also num_runs)
 run_duration = -1
 
-# after how much time a new DAGs should be picked up from the filesystem
-min_file_process_interval = 0
+# after how much time (seconds) a new DAGs should be picked up from the filesystem
+min_file_process_interval = 180
 
 # How many seconds to wait between file-parsing loops to prevent the logs from being spammed.
 min_file_parsing_loop_time = 1


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2814
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

#### Backgrond
In https://github.com/XD-DENG/incubator-airflow/blob/master/airflow/jobs.py#L592 , it was mentioned the default value of argument `file_process_interval` should be 3 minutes (`file_process_interval`: Parse and schedule each file no faster than this interval).

The value is normally parsed from the default configuration `min_file_process_interval`. However, in the default config_template, its value is 0 rather than 180 seconds (https://github.com/XD-DENG/incubator-airflow/blob/master/airflow/config_templates/default_airflow.cfg#L432 ). 

#### Issue
This means that actually that each file is parsed and scheduled without letting Airflow "rest". This conflicts with the design purpose (by default let it be 180 seconds) and may affect performance significantly.

#### My Proposal
Change the value in the config template from 0 to 180.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
