### PR TITLE
[AIRFLOW-2817] Force explicit choice on GPL dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ python:
   - "3.5"
 env:
   global:
+    - SLUGIFY_USES_TEXT_UNIDECODE=yes
     - TRAVIS_CACHE=$HOME/.travis_cache/
     - KRB5_CONFIG=/etc/krb5.conf
     - KRB5_KTNAME=/etc/airflow.keytab

--- a/INSTALL
+++ b/INSTALL
@@ -1,13 +1,30 @@
-# INSTALL / BUILD instruction for Apache Airflow (incubating)
-# fetch the tarball and untar the source
+# INSTALL / BUILD instructions for Apache Airflow (incubating)
+
+# [required] fetch the tarball and untar the source
+# change into the directory that was untarred.
 
 # [optional] run Apache RAT (release audit tool) to validate license headers
-# RAT docs here: https://creadur.apache.org/rat/
+# RAT docs here: https://creadur.apache.org/rat/. Requires Java and Apache Rat
 java -jar apache-rat.jar -E ./.rat-excludes -d .
 
-# [optional] by default one of Apache Airflow's dependencies pulls in a GPL
-# library. If this is a concern issue (also every upgrade):
-# export SLUGIFY_USES_TEXT_UNIDECODE=yes
+# [optional] Airflow pulls in quite a lot of dependencies in order
+# to connect to other services. You might want to test or run Airflow
+# from a virtual env to make sure those dependencies are separated
+# from your system wide versions
+python -m my_env
+source my_env/bin/activate
 
-# install the release
+# [required] by default one of Apache Airflow's dependencies pulls in a GPL
+# library. Airflow will not install (and upgrade) without an explicit choice.
+#
+# To make sure not to install the GPL dependency:
+#   export SLUGIFY_USES_TEXT_UNIDECODE=yes
+# In case you do not mind:
+#   export GPL_UNIDECODE=yes
+
+# [required] building and installing
+# by pip (preferred)
+pip install .
+
+# or directly
 python setup.py install

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -5,6 +5,12 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+## Airflow 1.10
+
+Installation and upgrading requires setting `SLUGIFY_USES_TEXT_UNIDECODE=yes` in your environment or
+`AIRFLOW_GPL_UNIDECODE=yes`. In case of the latter a GPL runtime dependency will be installed due to a
+dependency (python-nvd3 -> python-slugify -> unidecode).
+
 ### Replace DataProcHook.await calls to DataProcHook.wait
 
 The method name was changed to be compatible with the Python 3.7 async/await keywords

--- a/scripts/ci/kubernetes/docker/Dockerfile
+++ b/scripts/ci/kubernetes/docker/Dockerfile
@@ -17,6 +17,8 @@
 
 FROM ubuntu:16.04
 
+ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
+
 # install deps
 RUN apt-get update -y && apt-get install -y \
         wget \
@@ -32,7 +34,6 @@ RUN apt-get update -y && apt-get install -y \
         zip \
         unzip \
     && apt-get clean
-
 
 RUN pip install --upgrade pip
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,17 @@ version = imp.load_source(
 PY3 = sys.version_info[0] == 3
 
 
+# See LEGAL-362
+def verify_gpl_dependency():
+    if (not os.getenv("AIRFLOW_GPL_UNIDECODE")
+            and not os.getenv("SLUGIFY_USES_TEXT_UNIDECODE") == "yes"):
+        raise RuntimeError("By default one of Airflow's dependencies installs a GPL "
+                           "dependency (unidecode). To avoid this dependency set "
+                           "SLUGIFY_USES_TEXT_UNIDECODE=yes in your environment when you "
+                           "install or upgrade Airflow. To force installing the GPL "
+                           "version set AIRFLOW_GPL_UNIDECODE")
+
+
 class Tox(TestCommand):
     user_options = [('tox-args=', None, "Arguments to pass to tox")]
 
@@ -258,6 +269,7 @@ else:
 
 
 def do_setup():
+    verify_gpl_dependency()
     write_version()
     setup(
         name='apache-airflow',
@@ -376,6 +388,7 @@ def do_setup():
             'License :: OSI Approved :: Apache Software License',
             'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
             'Topic :: System :: Monitoring',
         ],
         author='Apache Software Foundation',
@@ -388,6 +401,7 @@ def do_setup():
             'extra_clean': CleanCommand,
             'compile_assets': CompileAssets
         },
+        python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -28,7 +28,7 @@ find_links =
 
 [flake8]
 max-line-length = 90
-ignore = E731
+ignore = E731,W503
 
 [testenv]
 deps =
@@ -64,6 +64,7 @@ passenv =
     BOTO_CONFIG
     KRB5_CONFIG
     KRB5_KTNAME
+    SLUGIFY_USES_TEXT_UNIDECODE
 
 commands =
   pip wheel -w {homedir}/.wheelhouse -f {homedir}/.wheelhouse -e .[devel_ci]


### PR DESCRIPTION
By default one of Apache Airflow's dependencies pulls in a GPL
library. Airflow should not install (and upgrade) without an explicit choice.

This is part of the Apache requirements as we cannot depend on Category X
software.

https://issues.apache.org/jira/browse/AIRFLOW-2817

cc @kaxil @Fokko This is required for 1.10 