### PR TITLE
[AIRFLOW-2818] Handle DAG File with Upper Case Extension

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -372,7 +372,7 @@ class DagBag(BaseDagBag, LoggingMixin):
             for mod in zip_file.infolist():
                 head, _ = os.path.split(mod.filename)
                 mod_name, ext = os.path.splitext(mod.filename)
-                if not head and (ext == '.py' or ext == '.pyc'):
+                if not head and (ext.lower() == '.py' or ext.lower() == '.pyc'):
                     if mod_name == '__init__':
                         self.log.warning("Found __init__.%s at root of %s", ext, filepath)
                     if safe_mode:

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -76,7 +76,7 @@ for root, dirs, files in os.walk(plugins_folder, followlinks=True):
                 continue
             mod_name, file_ext = os.path.splitext(
                 os.path.split(filepath)[-1])
-            if file_ext != '.py':
+            if file_ext.lower() != '.py':
                 continue
 
             log.debug('Importing plugin module %s', filepath)

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -208,7 +208,7 @@ def list_py_file_paths(directory, safe_mode=True):
                         continue
                     mod_name, file_ext = os.path.splitext(
                         os.path.split(file_path)[-1])
-                    if file_ext != '.py' and not zipfile.is_zipfile(file_path):
+                    if file_ext.lower() != '.py' and not zipfile.is_zipfile(file_path):
                         continue
                     if any([re.findall(p, file_path) for p in patterns]):
                         continue

--- a/tests/jobs.py
+++ b/tests/jobs.py
@@ -3167,7 +3167,7 @@ class SchedulerJobTest(unittest.TestCase):
         detected_files = []
         expected_files = []
         for file_name in os.listdir(TEST_DAGS_FOLDER):
-            if file_name.endswith('.py') or file_name.endswith('.zip'):
+            if file_name.lower().endswith('.py') or file_name.lower().endswith('.zip'):
                 if file_name not in ['no_dags.py']:
                     expected_files.append(
                         '{}/{}'.format(TEST_DAGS_FOLDER, file_name))


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-2818
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

In current design, when trying to identify and list Python files, case is not considered.
Only DAG files with '.py' will be identified, while files ending with '.PY' or '.Py', or '.pY' will be missed. However, it is allowed to have capital case file extension in all file systems.

The solution is simply applying `.lower()`.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
