### PR TITLE
[AIRFLOW-1298] Add clear option 'only_failed_or_upstream_failed'

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1401,7 +1401,8 @@ class CLIFactory(object):
         'only_failed': Arg(
             ("-f", "--only_failed"), "Only failed jobs", "store_true"),
         'only_failed_or_upstream_failed': Arg(
-            ("-p", "--only_failed_or_upstream_failed"), "Only failed or upstream_failed jobs", "store_true"),
+            ("-p", "--only_failed_or_upstream_failed"),
+            "Only failed or upstream_failed jobs", "store_true"),
         'only_running': Arg(
             ("-r", "--only_running"), "Only running jobs", "store_true"),
         'downstream': Arg(
@@ -1730,7 +1731,8 @@ class CLIFactory(object):
             'help': "Clear a set of task instance, as if they never ran",
             'args': (
                 'dag_id', 'task_regex', 'start_date', 'end_date', 'subdir',
-                'upstream', 'downstream', 'no_confirm', 'only_failed', 'only_failed_or_upstream_failed',
+                'upstream', 'downstream', 'no_confirm', 'only_failed',
+                'only_failed_or_upstream_failed',
                 'only_running', 'exclude_subdags', 'dag_regex'),
         }, {
             'func': pause,

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -627,6 +627,7 @@ def clear(args):
         start_date=args.start_date,
         end_date=args.end_date,
         only_failed=args.only_failed,
+        only_failed_or_upstream_failed=args.only_failed_or_upstream_failed,
         only_running=args.only_running,
         confirm_prompt=not args.no_confirm,
         include_subdags=not args.exclude_subdags)
@@ -1399,6 +1400,8 @@ class CLIFactory(object):
             ("-u", "--upstream"), "Include upstream tasks", "store_true"),
         'only_failed': Arg(
             ("-f", "--only_failed"), "Only failed jobs", "store_true"),
+        'only_failed_or_upstream_failed': Arg(
+            ("-p", "--only_failed_or_upstream_failed"), "Only failed or upstream_failed jobs", "store_true"),
         'only_running': Arg(
             ("-r", "--only_running"), "Only running jobs", "store_true"),
         'downstream': Arg(
@@ -1727,7 +1730,7 @@ class CLIFactory(object):
             'help': "Clear a set of task instance, as if they never ran",
             'args': (
                 'dag_id', 'task_regex', 'start_date', 'end_date', 'subdir',
-                'upstream', 'downstream', 'no_confirm', 'only_failed',
+                'upstream', 'downstream', 'no_confirm', 'only_failed', 'only_failed_or_upstream_failed',
                 'only_running', 'exclude_subdags', 'dag_regex'),
         }, {
             'func': pause,

--- a/airflow/migrations/versions/e3a246e0dc1_current_schema.py
+++ b/airflow/migrations/versions/e3a246e0dc1_current_schema.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -177,6 +177,12 @@ def upgrade():
             unique=False
         )
         op.create_index(
+            'ti_dag_date',
+            'task_instance',
+            ['dag_id', 'execution_date'],
+            unique=False
+        )
+        op.create_index(
             'ti_pool',
             'task_instance',
             ['pool', 'state', 'priority_weight'],
@@ -269,6 +275,7 @@ def downgrade():
     op.drop_index('ti_state_lkp', table_name='task_instance')
     op.drop_index('ti_pool', table_name='task_instance')
     op.drop_index('ti_dag_state', table_name='task_instance')
+    op.drop_index('ti_dag_date', table_name='task_instance')
     op.drop_table('task_instance')
     op.drop_table('slot_pool')
     op.drop_table('sla_miss')

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3785,7 +3785,8 @@ class DAG(BaseDag, LoggingMixin):
         if only_failed:
             tis = tis.filter(TI.state == State.FAILED)
         if only_failed_or_upstream_failed:
-            tis = tis.filter(or_(TI.state == State.FAILED, TI.state == State.UPSTREAM_FAILED))
+            tis = tis.filter(or_(TI.state == State.FAILED,
+                                 TI.state == State.UPSTREAM_FAILED))
         if only_running:
             tis = tis.filter(TI.state == State.RUNNING)
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -880,6 +880,7 @@ class TaskInstance(Base, LoggingMixin):
 
     __table_args__ = (
         Index('ti_dag_state', dag_id, state),
+        Index('ti_dag_date', dag_id, execution_date),
         Index('ti_state', state),
         Index('ti_state_lkp', dag_id, task_id, execution_date, state),
         Index('ti_pool', pool, state, priority_weight),

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3751,6 +3751,7 @@ class DAG(BaseDag, LoggingMixin):
     def clear(
             self, start_date=None, end_date=None,
             only_failed=False,
+            only_failed_or_upstream_failed=False,
             only_running=False,
             confirm_prompt=False,
             include_subdags=True,
@@ -3783,6 +3784,8 @@ class DAG(BaseDag, LoggingMixin):
             tis = tis.filter(TI.execution_date <= end_date)
         if only_failed:
             tis = tis.filter(TI.state == State.FAILED)
+        if only_failed_or_upstream_failed:
+            tis = tis.filter(or_(TI.state == State.FAILED, TI.state == State.UPSTREAM_FAILED))
         if only_running:
             tis = tis.filter(TI.state == State.RUNNING)
 
@@ -3826,6 +3829,7 @@ class DAG(BaseDag, LoggingMixin):
             start_date=None,
             end_date=None,
             only_failed=False,
+            only_failed_or_upstream_failed=False,
             only_running=False,
             confirm_prompt=False,
             include_subdags=True,
@@ -3838,6 +3842,7 @@ class DAG(BaseDag, LoggingMixin):
                 start_date=start_date,
                 end_date=end_date,
                 only_failed=only_failed,
+                only_failed_or_upstream_failed=only_failed_or_upstream_failed,
                 only_running=only_running,
                 confirm_prompt=False,
                 include_subdags=include_subdags,
@@ -3866,6 +3871,7 @@ class DAG(BaseDag, LoggingMixin):
                 dag.clear(start_date=start_date,
                           end_date=end_date,
                           only_failed=only_failed,
+                          only_failed_or_upstream_failed=only_failed_or_upstream_failed,
                           only_running=only_running,
                           confirm_prompt=False,
                           include_subdags=include_subdags,


### PR DESCRIPTION
### JIRA
- [x] My PR addresses the following [Airflow Jira]
- https://issues.apache.org/jira/browse/AIRFLOW-1298

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
In my operations team, it is necessary to clear all tasks in one command line (because of so many schedules should be reprocessed cause of some reasons)
But, 'clear -cdf ...' is only clearing failed tasks without upstream_failed. It is not fit for our operator's needs.
So, I want to add new options to clear failed or upstream_failed jobs all at once.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
1. clear only one schedule of this task : airflow clear -cp -s 2018-07-22T05:00:00 -e 2018-07-22T05:00:00 -t ^task_name$ schedule_name
2. clear only multiple schedules of this task : airflow clear -cp -s 2018-07-22T05:00:00 -e 2018-07-22T09:00:00 -t ^task_name$ schedule_name
3. clear multiple schedules of this task with downstream : airflow clear -cdp -s 2018-07-22T05:00:00 -e 2018-07-22T09:00:00 -t ^task_name$ schedule_name

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
new option of clear command
option is 'p' of upstream_failed's p character.
Usage sample is like below :
airflow clear -cdp -s 2018-07-22T05:00:00 -e 2018-07-22T09:00:00 -t ^task_name$ schedule_name

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`