### PR TITLE
[AIRFLOW-2836] Minor improvement of contrib.sensors.FileSensor

### DIFF
--- a/airflow/contrib/sensors/file_sensor.py
+++ b/airflow/contrib/sensors/file_sensor.py
@@ -46,7 +46,7 @@ class FileSensor(BaseSensorOperator):
     @apply_defaults
     def __init__(self,
                  filepath,
-                 fs_conn_id='fs_default2',
+                 fs_conn_id='fs_default',
                  *args,
                  **kwargs):
         super(FileSensor, self).__init__(*args, **kwargs)
@@ -56,7 +56,7 @@ class FileSensor(BaseSensorOperator):
     def poke(self, context):
         hook = FSHook(self.fs_conn_id)
         basepath = hook.get_path()
-        full_path = "/".join([basepath, self.filepath])
+        full_path = os.path.join(basepath, self.filepath)
         self.log.info('Poking for file {full_path}'.format(**locals()))
         try:
             if stat.S_ISDIR(os.stat(full_path).st_mode):

--- a/tests/contrib/sensors/test_file_sensor.py
+++ b/tests/contrib/sensors/test_file_sensor.py
@@ -125,6 +125,18 @@ class FileSensorTest(unittest.TestCase):
         finally:
             shutil.rmtree(dir)
 
+    def test_default_fs_conn_id(self):
+        with tempfile.NamedTemporaryFile() as tmp:
+            task = FileSensor(
+                task_id="test",
+                filepath=tmp.name[1:],
+                dag=self.dag,
+                timeout=0,
+            )
+            task._hook = self.hook
+            task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE,
+                     ignore_ti_state=True)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2836
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

#### Background

The default `fs_conn_id` in `contrib.sensors.FileSensor` is 'fs_default2'. However, when we initiate the database (https://github.com/apache/incubator-airflow/blob/master/airflow/utils/db.py#L88), there isn't such an entry. It doesn't exist anywhere else.

#### Issue

The purpose of `contrib.sensors.FileSensor` is mainly for checking local file system (of course can also be used for NAS). Then the path ("/") from default connection 'fs_default' would suffice.

However, given the default value for fs_conn_id in contrib.sensors.FileSensor is "fs_default2" (a value doesn't exist), it will make the situation much more complex. 

When users intend to check local file system only, they should be able to leave fs_conn_id default directly, instead of going setting up another connection separately.

#### Proposal

Change default value for `fs_conn_id` in `contrib.sensors.FileSensor` from "fs_default2" to "fs_default" (actually in the related test, the `fs_conn_id` are all specified to be "fs_default").

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
