### PR TITLE
[AIRFLOW-2829] Brush up the CI script for minikube

### DIFF
--- a/scripts/ci/kubernetes/minikube/start_minikube.sh
+++ b/scripts/ci/kubernetes/minikube/start_minikube.sh
@@ -24,19 +24,19 @@ _MY_SCRIPT="${BASH_SOURCE[0]}"
 _MY_DIR=$(cd "$(dirname "$_MY_SCRIPT")" && pwd)
 # Avoids 1.7.x because of https://github.com/kubernetes/minikube/issues/2240
 _KUBERNETES_VERSION="${KUBERNETES_VERSION}"
+_MINIKUBE_VERSION="${MINIKUBE_VERSION:-v0.26.0}"
 
-echo "setting up kubernetes ${_KUBERNETES_VERSION}"
+echo "setting up kubernetes ${_KUBERNETES_VERSION}, using minikube ${_MINIKUBE_VERSION}"
 
-_MINIKUBE_VERSION="v0.26.0"
-_HELM_VERSION=v2.8.1
-_VM_DRIVER=none
+_VM_DRIVER="${VM_DRIVER:-none}"
 USE_MINIKUBE_DRIVER_NONE=true
 
 _UNAME_OUT=$(uname -s)
 case "${_UNAME_OUT}" in
     Linux*)     _MY_OS=linux;;
     Darwin*)    _MY_OS=darwin;;
-    *)          _MY_OS="UNKNOWN:${unameOut}"
+    *)          echo "${_UNAME_OUT} is unsupported."
+                exit 1;;
 esac
 echo "Local OS is ${_MY_OS}"
 
@@ -58,27 +58,25 @@ if [[ ! -x /usr/local/bin/kubectl ]]; then
   curl -Lo bin/kubectl  \
     https://storage.googleapis.com/kubernetes-release/release/${_KUBERNETES_VERSION}/bin/${_MY_OS}/amd64/kubectl
   chmod +x bin/kubectl
+  sudo mv bin/kubectl /usr/local/bin/kubectl
 fi
 if [[ ! -x /usr/local/bin/minikube ]]; then
   echo Downloading minikube.
   curl -Lo bin/minikube  \
     https://storage.googleapis.com/minikube/releases/${_MINIKUBE_VERSION}/minikube-${_MY_OS}-amd64
   chmod +x bin/minikube
+  sudo mv bin/minikube /usr/local/bin/minikube
 fi
-
-sudo mv bin/minikube /usr/local/bin/minikube
-sudo mv bin/kubectl /usr/local/bin/kubectl
 
 export PATH="${_MY_DIR}/bin:$PATH"
 
 if [[ "${USE_MINIKUBE_DRIVER_NONE:-}" = "true" ]]; then
   # Run minikube with none driver.
   # See https://blog.travis-ci.com/2017-10-26-running-kubernetes-on-travis-ci-with-minikube
-  _VM_DRIVER="--vm-driver=none"
+  _VM_DRIVER=none
   if [[ ! -x /usr/local/bin/nsenter ]]; then
     # From https://engineering.bitnami.com/articles/implementing-kubernetes-integration-tests-in-travis.html
     # Travis ubuntu trusty env doesn't have nsenter, needed for --vm-driver=none
-    which nsenter >/dev/null && return 0
     echo "INFO: Building 'nsenter' ..."
 cat <<-EOF | docker run -i --rm -v "$(pwd):/build" ubuntu:14.04 >& nsenter.build.log
         apt-get update
@@ -93,7 +91,7 @@ EOF
     if [ ! -f ./nsenter ]; then
         echo "ERROR: nsenter build failed, log:"
         cat nsenter.build.log
-        return 1
+        exit 1
     fi
     echo "INFO: nsenter build OK"
     sudo mv ./nsenter /usr/local/bin
@@ -102,10 +100,10 @@ fi
 
 echo "your path is ${PATH}"
 
-_MINIKUBE="sudo PATH=$PATH minikube"
+_MINIKUBE="sudo -E PATH=$PATH minikube"
 
 $_MINIKUBE config set bootstrapper localkube
-$_MINIKUBE start --kubernetes-version=${_KUBERNETES_VERSION}  --vm-driver=none
+$_MINIKUBE start --kubernetes-version=${_KUBERNETES_VERSION} --vm-driver=${_VM_DRIVER}
 $_MINIKUBE update-context
 
 # Wait for Kubernetes to be up and ready.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2829
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Fix scripts/ci/kubernetes/minikube/start_minikube.sh
as follows:

- Make minikube version configurable via
  environment variable
- Remove unused variables for readability
- Reorder some lines to remove warnings
- Replace ineffective `return` with `exit`
- Add -E to `sudo minikube` so that non-root
  users can use this script locally

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's a fix on the setup script for CI.
Instead, I ran the revised script locally on Ubuntu 16.04 LTS and confirmed that it worked for both root and non-root user, with the following environmental variables:

```
export KUBERNETES_VERSION=v1.10.0
export MINIKUBE_VERSION=v0.28.2
```

In addition, I confirmed it worked fine on Travis:
https://travis-ci.org/sekikn/incubator-airflow/builds/410712117

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
