### PR TITLE
[AIRFLOW-2238] Use SSH protocol for pushing to Github

### DIFF
--- a/dev/airflow-pr
+++ b/dev/airflow-pr
@@ -1022,7 +1022,7 @@ def setup_git_remotes():
 
     error = False
     try:
-        run_cmd('git remote add github https://github.com/apache/incubator-airflow.git')
+        run_cmd('git remote add github git@github.com:apache/incubator-airflow.git')
     except:
         click.echo(click.style(reflow(
             '>>ERROR: Could not create github remote. If it already exists, '


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2238


### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes: Since we have MFA enforced we won't be able to use passwords to push and will have to use SSH keypairs. I missed this in the original PR.



### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: tested manually on another PR

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
