### PR TITLE
[AIRFLOW-2796] Expand code coverage for utils/helpers.py

### DIFF
--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -117,5 +117,62 @@ class TestHelpers(unittest.TestCase):
                          14)
 
 
+class HelpersTest(unittest.TestCase):
+    def test_as_tuple_iter(self):
+        test_list = ['test_str']
+        as_tup = helpers.as_tuple(test_list)
+        self.assertTupleEqual(tuple(test_list), as_tup)
+
+    def test_as_tuple_no_iter(self):
+        test_str = 'test_str'
+        as_tup = helpers.as_tuple(test_str)
+        self.assertTupleEqual((test_str,), as_tup)
+
+    def test_is_in(self):
+        from airflow.utils import helpers
+        # `is_in` expects an object, and a list as input
+
+        test_dict = {'test': 1}
+        test_list = ['test', 1, dict()]
+        small_i = 3
+        big_i = 2 ** 31
+        test_str = 'test_str'
+        test_tup = ('test', 'tuple')
+
+        test_container = [test_dict, test_list, small_i, big_i, test_str, test_tup]
+
+        # Test that integers are referenced as the same object
+        self.assertTrue(helpers.is_in(small_i, test_container))
+        self.assertTrue(helpers.is_in(3, test_container))
+
+        # python caches small integers, so i is 3 will be True,
+        # but `big_i is 2 ** 31` is False.
+        self.assertTrue(helpers.is_in(big_i, test_container))
+        self.assertFalse(helpers.is_in(2 ** 31, test_container))
+
+        self.assertTrue(helpers.is_in(test_dict, test_container))
+        self.assertFalse(helpers.is_in({'test': 1}, test_container))
+
+        self.assertTrue(helpers.is_in(test_list, test_container))
+        self.assertFalse(helpers.is_in(['test', 1, dict()], test_container))
+
+        self.assertTrue(helpers.is_in(test_str, test_container))
+        self.assertTrue(helpers.is_in('test_str', test_container))
+        bad_str = 'test_'
+        bad_str += 'str'
+        self.assertFalse(helpers.is_in(bad_str, test_container))
+
+        self.assertTrue(helpers.is_in(test_tup, test_container))
+        self.assertFalse(helpers.is_in(('test', 'tuple'), test_container))
+        bad_tup = ('test', 'tuple', 'hello')
+        self.assertFalse(helpers.is_in(bad_tup[:2], test_container))
+
+    def test_is_container(self):
+        self.assertTrue(helpers.is_container(['test_list']))
+        self.assertFalse(helpers.is_container('test_str_not_iterable'))
+        # Pass an object that is not iter nor a string.
+        self.assertFalse(helpers.is_container(10))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2796

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add more tests for utils/helpers.py

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

-`tests/utils/test_helpers.py`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
