### PR TITLE
[AIRFLOW-2846] Add missing python test dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -256,7 +256,8 @@ devel = [
     'qds-sdk>=1.9.6',
     'rednose',
     'requests_mock',
-    'flake8'
+    'flake8',
+    'tox'
 ]
 
 if not PY3:


### PR DESCRIPTION
Add missing python test dependency (tox) to setup.py dev requirement.

Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-2846\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2846

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Adds test dependency.

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ X ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
