### PR TITLE
[AIRFLOW-2847] Remove legacy imports support for plugins for 2.0 deprecation.

### DIFF
--- a/airflow/hooks/__init__.py
+++ b/airflow/hooks/__init__.py
@@ -22,55 +22,8 @@ import os
 import sys
 
 
-# ------------------------------------------------------------------------
-#
-# #TODO #FIXME Airflow 2.0
-#
-# Old import machinary below.
-#
-# This is deprecated but should be kept until Airflow 2.0
-# for compatibility.
-#
-# ------------------------------------------------------------------------
-
 # Imports the hooks dynamically while keeping the package API clean,
 # abstracting the underlying modules
-
-
-_hooks = {
-    'base_hook': ['BaseHook'],
-    'hive_hooks': [
-        'HiveCliHook',
-        'HiveMetastoreHook',
-        'HiveServer2Hook',
-    ],
-    'hdfs_hook': ['HDFSHook'],
-    'webhdfs_hook': ['WebHDFSHook'],
-    'pig_hook': ['PigCliHook'],
-    'mysql_hook': ['MySqlHook'],
-    'postgres_hook': ['PostgresHook'],
-    'presto_hook': ['PrestoHook'],
-    'samba_hook': ['SambaHook'],
-    'sqlite_hook': ['SqliteHook'],
-    'S3_hook': ['S3Hook'],
-    'zendesk_hook': ['ZendeskHook'],
-    'http_hook': ['HttpHook'],
-    'druid_hook': [
-        'DruidHook',
-        'DruidDbApiHook',
-    ],
-    'jdbc_hook': ['JdbcHook'],
-    'dbapi_hook': ['DbApiHook'],
-    'mssql_hook': ['MsSqlHook'],
-    'oracle_hook': ['OracleHook'],
-    'slack_hook': ['SlackHook'],
-}
-
-
-if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
-    from airflow.utils.helpers import AirflowImporter
-    airflow_importer = AirflowImporter(sys.modules[__name__], _hooks)
-
 
 def _integrate_plugins():
     """Integrate plugins to the context"""
@@ -78,19 +31,3 @@ def _integrate_plugins():
     for hooks_module in hooks_modules:
         sys.modules[hooks_module.__name__] = hooks_module
         globals()[hooks_module._name] = hooks_module
-
-        ##########################################################
-        # TODO FIXME Remove in Airflow 2.0
-
-        if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
-            from zope.deprecation import deprecated
-            for _hook in hooks_module._objects:
-                hook_name = _hook.__name__
-                globals()[hook_name] = _hook
-                deprecated(
-                    hook_name,
-                    "Importing plugin hook '{i}' directly from "
-                    "'airflow.hooks' has been deprecated. Please "
-                    "import from 'airflow.hooks.[plugin_module]' "
-                    "instead. Support for direct imports will be dropped "
-                    "entirely in Airflow 2.0.".format(i=hook_name))

--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -74,20 +74,3 @@ def _integrate_plugins():
     for macros_module in macros_modules:
         sys.modules[macros_module.__name__] = macros_module
         globals()[macros_module._name] = macros_module
-
-        ##########################################################
-        # TODO FIXME Remove in Airflow 2.0
-
-        import os
-        if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
-            from zope.deprecation import deprecated
-            for _macro in macros_module._objects:
-                macro_name = _macro.__name__
-                globals()[macro_name] = _macro
-                deprecated(
-                    macro_name,
-                    "Importing plugin macro '{i}' directly from "
-                    "'airflow.macros' has been deprecated. Please "
-                    "import from 'airflow.macros.[plugin_module]' "
-                    "instead. Support for direct imports will be dropped "
-                    "entirely in Airflow 2.0.".format(i=macro_name))

--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -90,19 +90,3 @@ def _integrate_plugins():
     for operators_module in operators_modules:
         sys.modules[operators_module.__name__] = operators_module
         globals()[operators_module._name] = operators_module
-
-        ##########################################################
-        # TODO FIXME Remove in Airflow 2.0
-
-        if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
-            from zope.deprecation import deprecated
-            for _operator in operators_module._objects:
-                operator_name = _operator.__name__
-                globals()[operator_name] = _operator
-                deprecated(
-                    operator_name,
-                    "Importing plugin operator '{i}' directly from "
-                    "'airflow.operators' has been deprecated. Please "
-                    "import from 'airflow.operators.[plugin_module]' "
-                    "instead. Support for direct imports will be dropped "
-                    "entirely in Airflow 2.0.".format(i=operator_name))

--- a/airflow/sensors/__init__.py
+++ b/airflow/sensors/__init__.py
@@ -47,19 +47,3 @@ def _integrate_plugins():
     for sensors_module in sensors_modules:
         sys.modules[sensors_module.__name__] = sensors_module
         globals()[sensors_module._name] = sensors_module
-
-        ##########################################################
-        # TODO FIXME Remove in Airflow 2.0
-
-        if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
-            from zope.deprecation import deprecated
-            for _sensor in sensors_module._objects:
-                sensor_name = _sensor.__name__
-                globals()[sensor_name] = _sensor
-                deprecated(
-                    sensor_name,
-                    "Importing plugin operator '{i}' directly from "
-                    "'airflow.operators' has been deprecated. Please "
-                    "import from 'airflow.operators.[plugin_module]' "
-                    "instead. Support for direct imports will be dropped "
-                    "entirely in Airflow 2.0.".format(i=sensor_name))


### PR DESCRIPTION
[AIRFLOW-2847] Remove legacy imports support for plugins

This is a WIP since the tests on master aren't passing locally on my machine (5 out of 8 for `./run_unit_tests.sh  ./tests/plugins_manager.py` pass), I'll drop the WIP if this passes CI.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Existing unit tests for plugins.

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ X ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
