### PR TITLE
[AIRFLOW-2851] Canonicalize "as _..." etc imports

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -36,7 +36,7 @@ import sys
 import warnings
 
 from backports.configparser import ConfigParser
-from zope.deprecation import deprecated as _deprecated
+from zope.deprecation import deprecated
 
 from airflow.exceptions import AirflowConfigException
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -534,7 +534,7 @@ set = conf.set # noqa
 
 for func in [load_test_config, get, getboolean, getfloat, getint, has_option,
              remove_option, as_dict, set]:
-    _deprecated(
+    deprecated(
         func,
         "Accessing configuration method '{f.__name__}' directly from "
         "the configuration module is deprecated. Please access the "

--- a/airflow/contrib/auth/backends/kerberos_auth.py
+++ b/airflow/contrib/auth/backends/kerberos_auth.py
@@ -28,7 +28,7 @@ from wtforms.validators import InputRequired
 # pykerberos should be used as it verifies the KDC, the "kerberos" module does not do so
 # and make it possible to spoof the KDC
 import kerberos
-import airflow.security.utils as utils
+from airflow.security import utils
 
 from flask import url_for, redirect
 

--- a/airflow/contrib/hooks/__init__.py
+++ b/airflow/contrib/hooks/__init__.py
@@ -24,7 +24,7 @@
 
 
 import sys
-import os as _os
+import os
 
 # ------------------------------------------------------------------------
 #
@@ -64,7 +64,7 @@ _hooks = {
 }
 
 
-if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
+if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
     from airflow.utils.helpers import AirflowImporter
 
     airflow_importer = AirflowImporter(sys.modules[__name__], _hooks)

--- a/airflow/contrib/operators/__init__.py
+++ b/airflow/contrib/operators/__init__.py
@@ -24,7 +24,7 @@
 
 
 import sys
-import os as _os
+import os
 
 # ------------------------------------------------------------------------
 #
@@ -48,6 +48,6 @@ _operators = {
     'hive_to_dynamodb': ['HiveToDynamoDBTransferOperator']
 }
 
-if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
+if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
     from airflow.utils.helpers import AirflowImporter
     airflow_importer = AirflowImporter(sys.modules[__name__], _operators)

--- a/airflow/hooks/__init__.py
+++ b/airflow/hooks/__init__.py
@@ -18,7 +18,7 @@
 # under the License.
 
 
-import os as _os
+import os
 import sys
 
 
@@ -67,7 +67,7 @@ _hooks = {
 }
 
 
-if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
+if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
     from airflow.utils.helpers import AirflowImporter
     airflow_importer = AirflowImporter(sys.modules[__name__], _hooks)
 
@@ -82,12 +82,12 @@ def _integrate_plugins():
         ##########################################################
         # TODO FIXME Remove in Airflow 2.0
 
-        if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
-            from zope.deprecation import deprecated as _deprecated
+        if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
+            from zope.deprecation import deprecated
             for _hook in hooks_module._objects:
                 hook_name = _hook.__name__
                 globals()[hook_name] = _hook
-                _deprecated(
+                deprecated(
                     hook_name,
                     "Importing plugin hook '{i}' directly from "
                     "'airflow.hooks' has been deprecated. Please "

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -34,10 +34,10 @@ from past.builtins import basestring
 from past.builtins import unicode
 from six.moves import zip
 
-import airflow.security.utils as utils
 from airflow import configuration
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
+from airflow.security import utils
 from airflow.utils.file import TemporaryDirectory
 from airflow.utils.helpers import as_flattened_list
 from airflow.utils.operator_helpers import AIRFLOW_VAR_NAME_FORMAT_MAPPING

--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -78,13 +78,13 @@ def _integrate_plugins():
         ##########################################################
         # TODO FIXME Remove in Airflow 2.0
 
-        import os as _os
-        if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
-            from zope.deprecation import deprecated as _deprecated
+        import os
+        if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
+            from zope.deprecation import deprecated
             for _macro in macros_module._objects:
                 macro_name = _macro.__name__
                 globals()[macro_name] = _macro
-                _deprecated(
+                deprecated(
                     macro_name,
                     "Importing plugin macro '{i}' directly from "
                     "'airflow.macros' has been deprecated. Please "

--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -110,11 +110,11 @@ def _integrate_plugins():
         # TODO FIXME Remove in Airflow 2.0
 
         if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
-            from zope.deprecation import deprecated as _deprecated
+            from zope.deprecation import deprecated
             for _operator in operators_module._objects:
                 operator_name = _operator.__name__
                 globals()[operator_name] = _operator
-                _deprecated(
+                deprecated(
                     operator_name,
                     "Importing plugin operator '{i}' directly from "
                     "'airflow.operators' has been deprecated. Please "

--- a/airflow/sensors/__init__.py
+++ b/airflow/sensors/__init__.py
@@ -18,7 +18,7 @@
 # under the License.
 #
 import sys
-import os as _os
+import os
 
 _sensors = {
     'base_sensor_operator': ['BaseSensorOperator'],
@@ -36,7 +36,7 @@ _sensors = {
     'web_hdfs_sensor': ['WebHdfsSensor']
 }
 
-if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
+if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
     from airflow.utils.helpers import AirflowImporter
     airflow_importer = AirflowImporter(sys.modules[__name__], _sensors)
 
@@ -51,12 +51,12 @@ def _integrate_plugins():
         ##########################################################
         # TODO FIXME Remove in Airflow 2.0
 
-        if not _os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
-            from zope.deprecation import deprecated as _deprecated
+        if not os.environ.get('AIRFLOW_USE_NEW_IMPORTS', False):
+            from zope.deprecation import deprecated
             for _sensor in sensors_module._objects:
                 sensor_name = _sensor.__name__
                 globals()[sensor_name] = _sensor
-                _deprecated(
+                deprecated(
                     sensor_name,
                     "Importing plugin operator '{i}' directly from "
                     "'airflow.operators' has been deprecated. Please "

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -19,8 +19,7 @@
 
 import unittest
 
-import airflow.contrib.hooks.gcs_hook as gcs_hook
-
+from airflow.contrib.hooks import gcs_hook
 from airflow.exceptions import AirflowException
 from apiclient.errors import HttpError
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2851
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR:

1. Replaces `import foo as _foo` style imports with the more common `import foo` used everywhere else across the codebase.  I dug through history and couldn't find special reasons to maintain the as style imports here (I think it's just old code).  Currently (33dd33c89d4b6454d224ca34bab5ae37fb9812a6), there are just a handful of import lines using `as _...` vs thousands not using it, so the goal here is to improve consistency.

2. It also simplifies `import foo.bar as bar` style imports to equivalent `from foo import bar`.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Coverage by existing tests.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
