### PR TITLE
[AIRFLOW-2854] kubernetes_pod_operator add more configuration items

### DIFF
--- a/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -176,6 +176,11 @@ class KubernetesRequestFactory:
             req['spec']['serviceAccountName'] = pod.service_account_name
 
     @staticmethod
+    def extract_hostnetwork(pod, req):
+        if pod.hostnetwork:
+            req['spec']['hostNetwork'] = pod.hostnetwork
+
+    @staticmethod
     def extract_image_pull_secrets(pod, req):
         if pod.image_pull_secrets:
             req['spec']['imagePullSecrets'] = [{

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
@@ -59,6 +59,7 @@ spec:
         self.extract_image_pull_secrets(pod, req)
         self.extract_annotations(pod, req)
         self.extract_affinity(pod, req)
+        self.extract_hostnetwork(pod, req)
         return req
 
 
@@ -116,4 +117,5 @@ spec:
         self.extract_image_pull_secrets(pod, req)
         self.extract_annotations(pod, req)
         self.extract_affinity(pod, req)
+        self.extract_hostnetwork(pod, req)
         return req

--- a/airflow/contrib/kubernetes/pod.py
+++ b/airflow/contrib/kubernetes/pod.py
@@ -77,7 +77,8 @@ class Pod:
             service_account_name=None,
             resources=None,
             annotations=None,
-            affinity=None
+            affinity=None,
+            hostnetwork=False
     ):
         self.image = image
         self.envs = envs or {}
@@ -98,3 +99,4 @@ class Pod:
         self.resources = resources or Resources()
         self.annotations = annotations or {}
         self.affinity = affinity or {}
+        self.hostnetwork = hostnetwork or False

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -102,6 +102,7 @@ class KubernetesPodOperator(BaseOperator):
                 labels=self.labels,
             )
 
+            pod.service_account_name = self.service_account_name
             pod.secrets = self.secrets
             pod.envs = self.env_vars
             pod.image_pull_policy = self.image_pull_policy
@@ -116,6 +117,10 @@ class KubernetesPodOperator(BaseOperator):
                 pod,
                 startup_timeout=self.startup_timeout_seconds,
                 get_logs=self.get_logs)
+
+            if self.is_delete_operator_pod:
+                launcher.delete_pod(pod)
+
             if final_state != State.SUCCESS:
                 raise AirflowException(
                     'Pod returned a failure: {state}'.format(state=final_state)
@@ -148,6 +153,9 @@ class KubernetesPodOperator(BaseOperator):
                  config_file=None,
                  xcom_push=False,
                  node_selectors=None,
+                 image_pull_secrets=None,
+                 service_account_name="default",
+                 is_delete_operator_pod=False,
                  *args,
                  **kwargs):
         super(KubernetesPodOperator, self).__init__(*args, **kwargs)
@@ -172,3 +180,6 @@ class KubernetesPodOperator(BaseOperator):
         self.xcom_push = xcom_push
         self.resources = resources or Resources()
         self.config_file = config_file
+        self.image_pull_secrets = image_pull_secrets
+        self.service_account_name = service_account_name
+        self.is_delete_operator_pod = is_delete_operator_pod

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -110,6 +110,7 @@ class KubernetesPodOperator(BaseOperator):
             pod.resources = self.resources
             pod.affinity = self.affinity
             pod.node_selectors = self.node_selectors
+            pod.hostnetwork = self.hostnetwork
 
             launcher = pod_launcher.PodLauncher(kube_client=client,
                                                 extract_xcom=self.xcom_push)
@@ -156,6 +157,7 @@ class KubernetesPodOperator(BaseOperator):
                  image_pull_secrets=None,
                  service_account_name="default",
                  is_delete_operator_pod=False,
+                 hostnetwork=False,
                  *args,
                  **kwargs):
         super(KubernetesPodOperator, self).__init__(*args, **kwargs)
@@ -183,3 +185,4 @@ class KubernetesPodOperator(BaseOperator):
         self.image_pull_secrets = image_pull_secrets
         self.service_account_name = service_account_name
         self.is_delete_operator_pod = is_delete_operator_pod
+        self.hostnetwork = hostnetwork

--- a/airflow/example_dags/example_kubernetes_operator.py
+++ b/airflow/example_dags/example_kubernetes_operator.py
@@ -48,7 +48,8 @@ try:
         in_cluster=False,
         task_id="task",
         get_logs=True,
-        dag=dag)
+        dag=dag,
+        is_delete_operator_pod=False)
 
 except ImportError as e:
     log.warn("Could not import KubernetesPodOperator: " + str(e))

--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -91,7 +91,8 @@ Kubernetes Operator
                               volume_mounts=[volume_mount]
                               name="test",
                               task_id="task",
-                              affinity=affinity
+                              affinity=affinity,
+                              is_delete_operator_pod=True
                               )
 
 

--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -92,7 +92,8 @@ Kubernetes Operator
                               name="test",
                               task_id="task",
                               affinity=affinity,
-                              is_delete_operator_pod=True
+                              is_delete_operator_pod=True,
+                              hostnetwork=False
                               )
 
 

--- a/tests/contrib/minikube/test_kubernetes_pod_operator.py
+++ b/tests/contrib/minikube/test_kubernetes_pod_operator.py
@@ -109,6 +109,20 @@ class KubernetesPodOperatorTest(unittest.TestCase):
         k.execute(None)
 
     @staticmethod
+    def test_pod_hostnetwork():
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            hostnetwork=True
+        )
+        k.execute(None)
+
+    @staticmethod
     def test_pod_node_selectors():
         node_selectors = {
             'beta.kubernetes.io/os': 'linux'

--- a/tests/contrib/minikube/test_kubernetes_pod_operator.py
+++ b/tests/contrib/minikube/test_kubernetes_pod_operator.py
@@ -20,6 +20,7 @@ import os
 import shutil
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 from airflow import AirflowException
+from kubernetes.client.rest import ApiException
 from subprocess import check_call
 import mock
 import json
@@ -232,7 +233,7 @@ class KubernetesPodOperatorTest(unittest.TestCase):
             startup_timeout_seconds=5,
             service_account_name=bad_service_account_name
         )
-        with self.assertRaises(AirflowException) as cm:
+        with self.assertRaises(ApiException) as cm:
             k.execute(None),
 
         print("exception: {}".format(cm))

--- a/tests/contrib/minikube/test_kubernetes_pod_operator.py
+++ b/tests/contrib/minikube/test_kubernetes_pod_operator.py
@@ -94,6 +94,20 @@ class KubernetesPodOperatorTest(unittest.TestCase):
         k.execute(None)
 
     @staticmethod
+    def test_delete_operator_pod():
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            is_delete_operator_pod=True
+        )
+        k.execute(None)
+
+    @staticmethod
     def test_pod_node_selectors():
         node_selectors = {
             'beta.kubernetes.io/os': 'linux'
@@ -199,6 +213,24 @@ class KubernetesPodOperatorTest(unittest.TestCase):
             name="test",
             task_id="task",
             startup_timeout_seconds=5
+        )
+        with self.assertRaises(AirflowException) as cm:
+            k.execute(None),
+
+        print("exception: {}".format(cm))
+
+    def test_faulty_service_account(self):
+        bad_service_account_name = "foobar"
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            startup_timeout_seconds=5,
+            service_account_name=bad_service_account_name
         )
         with self.assertRaises(AirflowException) as cm:
             k.execute(None),

--- a/tests/contrib/minikube/test_kubernetes_pod_operator.py
+++ b/tests/contrib/minikube/test_kubernetes_pod_operator.py
@@ -215,10 +215,8 @@ class KubernetesPodOperatorTest(unittest.TestCase):
             task_id="task",
             startup_timeout_seconds=5
         )
-        with self.assertRaises(AirflowException) as cm:
-            k.execute(None),
-
-        print("exception: {}".format(cm))
+        with self.assertRaises(AirflowException):
+            k.execute(None)
 
     def test_faulty_service_account(self):
         bad_service_account_name = "foobar"
@@ -233,10 +231,8 @@ class KubernetesPodOperatorTest(unittest.TestCase):
             startup_timeout_seconds=5,
             service_account_name=bad_service_account_name
         )
-        with self.assertRaises(ApiException) as cm:
-            k.execute(None),
-
-        print("exception: {}".format(cm))
+        with self.assertRaises(ApiException):
+            k.execute(None)
 
     def test_pod_failure(self):
         """


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2854

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
kubernetes_pod_operator is missing kubernetes pods related configuration items, as follows:

1. image_pull_secrets

Pull secrets are used to pull private container images from registries. In this case, we need to configure the image_pull_secrets in pod spec file

2. service_account_name

When kubernetes is running on rbac Authorization. If it is a job that needs to operate on kubernetes resources, we need to configure service account.

3. is_delete_operator_pod

This option can be given to the user to decide whether to delete the job pod created by pod_operator, which is currently not processed.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
