### PR TITLE
[AIRFLOW-2856] Pass in SLUGIFY_USES_TEXT_UNIDECODE=yes ENV to docker run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,10 +86,7 @@ Go to your Airflow directory and start a new docker container. You can choose be
 
 ```
 # Start docker in your Airflow directory
-docker run -t -i -v `pwd`:/airflow/ python:2 bash
-
-# Go to the Airflow directory
-cd /airflow/
+docker run -t -i -v `pwd`:/airflow/ -w /airflow/ -e SLUGIFY_USES_TEXT_UNIDECODE=yes python:2 bash
 
 # Install Airflow with all the required dependencies,
 # including the devel which will provide the development tools


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2856
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Setting up a local docker test environment was breaking due to the additional of the [verify_gpl_dependency](https://github.com/apache/incubator-airflow/blob/master/setup.py#L39
) in setup.py. This PR fixes that by passing in the SLUGIFY_USES_TEXT_UNIDECODE=yes env to `docker run`

It also now uses the -w arg on `docker run` in order to put user directly into /airflow dir. This removes the need to `cd` into that directory in the next step.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Who will test the tests?

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
