### PR TITLE
[AIRFLOW-2857] Fix broken RTD env 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,4 +22,4 @@ python:
         - doc
         - docker
         - gcp_api
-        - emr 
+        - emr

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,14 @@ PY3 = sys.version_info[0] == 3
 
 # See LEGAL-362
 def verify_gpl_dependency():
+    # The Read the Docs build environment [1] does a pip install of Airflow which cannot
+    # be overridden with custom environment variables, so we detect the READTHEDOCS env
+    # var they provide to set the env var that avoids the GPL dependency on install when
+    # building the docs site.
+    # [1]: http://docs.readthedocs.io/en/latest/builds.html#build-environment
+    if os.getenv("READTHEDOCS") == "True":
+        os.environ["SLUGIFY_USES_TEXT_UNIDECODE"] = "yes"
+
     if (not os.getenv("AIRFLOW_GPL_UNIDECODE")
             and not os.getenv("SLUGIFY_USES_TEXT_UNIDECODE") == "yes"):
         raise RuntimeError("By default one of Airflow's dependencies installs a GPL "
@@ -161,6 +169,7 @@ dask = [
 databricks = ['requests>=2.5.1, <3']
 datadog = ['datadog>=0.14.0']
 doc = [
+    'mock',
     'sphinx>=1.2.3',
     'sphinx-argparse>=0.1.13',
     'sphinx-rtd-theme>=0.1.6',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2857
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Per the mailing list thread "Readthedocs is Broken" on Aug 5, 2018, the Read the Docs build process is currently broken per the recent addition of https://github.com/apache/incubator-airflow/pull/3660.

The [RTD build environment](http://docs.readthedocs.io/en/latest/builds.html#build-environment) provides a `READTHEDOCS` env var boolean which it sets to true.  I have used that to toggle on `SLUGIFY_USES_TEXT_UNIDECODE` only when that env var is supplied to restrict it to that environment.

Related change: The mock module [is used in conf.py](https://github.com/apache/incubator-airflow/blob/3157287e8c1aba7649cb7de80dd4026666889725/docs/conf.py#L16) is supplied to Sphinx to build the docs, but it was missing from the `doc` install extra in setup.py, so I've added that.

Here's how I tested this:

```
pip install -e .[doc]  # (fails)

READTHEDOCS=True pip install -e .[doc]  # (succeeds)

cd docs/
./build.sh
./start_doc_server.sh
```

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

A successful build on https://readthedocs.org/projects/airflow/builds/ will confirm that this is working in the Read the Docs environment.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
