### PR TITLE
[AIRFLOW-2858] Make tox.ini indentation and whitespace consistent

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@
 
 [tox]
 envlist = flake8,{py27,py35}-backend_{mysql,sqlite,postgres}
-skipsdist=True
+skipsdist = True
 
 [global]
 wheel_dir = {homedir}/.wheelhouse
@@ -36,19 +36,19 @@ deps =
     coveralls
 
 basepython =
-  py27: python2.7
-  py35: python3.5
+    py27: python2.7
+    py35: python3.5
 
 setenv =
-  HADOOP_DISTRO=cdh
-  HADOOP_HOME=/tmp/hadoop-cdh
-  HADOOP_OPTS=-D/tmp/krb5.conf
-  MINICLUSTER_HOME=/tmp/minicluster-1.1-SNAPSHOT
-  HIVE_HOME=/tmp/hive
-  backend_mysql: AIRFLOW__CORE__SQL_ALCHEMY_CONN=mysql://root@localhost/airflow
-  backend_postgres: AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://postgres@localhost/airflow
-  backend_sqlite: AIRFLOW__CORE__SQL_ALCHEMY_CONN=sqlite:///{homedir}/airflow/airflow.db
-  backend_sqlite: AIRFLOW__CORE__EXECUTOR=SequentialExecutor
+    HADOOP_DISTRO = cdh
+    HADOOP_HOME = /tmp/hadoop-cdh
+    HADOOP_OPTS = -D/tmp/krb5.conf
+    MINICLUSTER_HOME = /tmp/minicluster-1.1-SNAPSHOT
+    HIVE_HOME = /tmp/hive
+    backend_mysql: AIRFLOW__CORE__SQL_ALCHEMY_CONN = mysql://root@localhost/airflow
+    backend_postgres: AIRFLOW__CORE__SQL_ALCHEMY_CONN = postgresql+psycopg2://postgres@localhost/airflow
+    backend_sqlite: AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///{homedir}/airflow/airflow.db
+    backend_sqlite: AIRFLOW__CORE__EXECUTOR = SequentialExecutor
 
 passenv =
     HOME
@@ -67,15 +67,15 @@ passenv =
     SLUGIFY_USES_TEXT_UNIDECODE
 
 commands =
-  pip wheel -w {homedir}/.wheelhouse -f {homedir}/.wheelhouse -e .[devel_ci]
-  pip install --find-links={homedir}/.wheelhouse --no-index -e .[devel_ci]
-  sudo {toxinidir}/scripts/ci/setup_kdc.sh
-  {toxinidir}/scripts/ci/setup_env.sh
-  {toxinidir}/scripts/ci/ldap.sh
-  {toxinidir}/scripts/ci/load_fixtures.sh
-  {toxinidir}/scripts/ci/load_data.sh
-  {toxinidir}/scripts/ci/run_tests.sh []
-  {toxinidir}/scripts/ci/check-license.sh
+    pip wheel -w {homedir}/.wheelhouse -f {homedir}/.wheelhouse -e .[devel_ci]
+    pip install --find-links={homedir}/.wheelhouse --no-index -e .[devel_ci]
+    sudo {toxinidir}/scripts/ci/setup_kdc.sh
+    {toxinidir}/scripts/ci/setup_env.sh
+    {toxinidir}/scripts/ci/ldap.sh
+    {toxinidir}/scripts/ci/load_fixtures.sh
+    {toxinidir}/scripts/ci/load_data.sh
+    {toxinidir}/scripts/ci/run_tests.sh []
+    {toxinidir}/scripts/ci/check-license.sh
 
 [testenv:flake8]
 basepython = python3
@@ -85,4 +85,3 @@ deps =
 
 commands =
     {toxinidir}/scripts/ci/flake8_diff.sh
-


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2858
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The tox.ini file currently mixes multiple indentation and whitespace styles.

This PR makes tox.ini consistently use 4-space indentation to match Python code and the [examples in the official Tox docs](https://tox.readthedocs.io/en/latest/example/basic.html).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Verified by successful run of tox command on CI.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
