### PR TITLE
[AIRFLOW-XXX] Add docs for running Travis CI on fork

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ little bit helps, and credit will always be given.
 - [Development and Testing](#development-and-testing)
   - [Setting up a development environment](#setting-up-a-development-environment)
   - [Pull requests guidelines](#pull-request-guidelines)
+  - [Testing on Travis CI](#testing-on-travis-ci)
   - [Testing Locally](#testing-locally)
 - [Changing the Metadata Database](#changing-the-metadata-database)
 
@@ -138,7 +139,7 @@ Feel free to customize based on the extras available in [setup.py](./setup.py)
 Before you submit a pull request from your forked repo, check that it
 meets these guidelines:
 
-1. The pull request should include tests, either as doctests, unit tests, or both. The airflow repo uses [Travis CI](https://travis-ci.org/apache/incubator-airflow) to run the tests and [codecov](https://codecov.io/gh/apache/incubator-airflow) to track coverage. You can set up both for free on your fork. It will help you making sure you do not break the build with your PR and that you help increase coverage.
+1. The pull request should include tests, either as doctests, unit tests, or both. The airflow repo uses [Travis CI](https://travis-ci.org/apache/incubator-airflow) to run the tests and [codecov](https://codecov.io/gh/apache/incubator-airflow) to track coverage. You can set up both for free on your fork (see the "Testing on Travis CI" section below). It will help you making sure you do not break the build with your PR and that you help increase coverage.
 1. Please [rebase your fork](http://stackoverflow.com/a/7244456/1110993), squash commits, and resolve all conflicts.
 1. Every pull request should have an associated [JIRA](https://issues.apache.org/jira/browse/AIRFLOW/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). The JIRA link should also be contained in the PR description.
 1. Preface your commit's subject & PR's title with **[AIRFLOW-XXX]** where *XXX* is the JIRA number. We compose release notes (i.e. for Airflow releases) from all commit titles in a release. By placing the JIRA number in the commit title and hence in the release notes, Airflow users can look into JIRA and Github PRs for more details about a particular change.
@@ -147,6 +148,71 @@ meets these guidelines:
 1. The pull request should work for Python 2.7 and 3.4. If you need help writing code that works in both Python 2 and 3, see the documentation at the [Python-Future project](http://python-future.org) (the future package is an Airflow requirement and should be used where possible).
 1. As Airflow grows as a project, we try to enforce a more consistent style and try to follow the Python community guidelines. We track this using [landscape.io](https://landscape.io/github/apache/incubator-airflow/), which you can setup on your fork as well to check before you submit your PR. We currently enforce most [PEP8](https://www.python.org/dev/peps/pep-0008/) and a few other linting rules. It is usually a good idea to lint locally as well using [flake8](https://flake8.readthedocs.org/en/latest/) using `flake8 airflow tests`. `git diff upstream/master -u -- "*.py" | flake8 --diff` will return any changed files in your branch that require linting.
 1. Please read this excellent [article](http://chris.beams.io/posts/git-commit/) on commit messages and adhere to them. It makes the lives of those who come after you a lot easier.
+
+### Testing on Travis CI
+
+We currently rely heavily on Travis CI for running the full Airflow test suite
+as running all of the tests locally requires significant setup.  You can setup
+Travis CI in your fork of Airflow by following the
+[Travis CI Getting Started guide][travis-ci-getting-started].
+
+There are two different options available for running Travis CI which are
+setup as separate components on GitHub:
+
+1. **Travis CI GitHub App** (new version)
+1. **Travis CI GitHub Services** (legacy version)
+
+#### Travis CI GitHub App (new version)
+
+1. Once installed, you can configure the Travis CI GitHub App at
+https://github.com/settings/installations/169040.
+
+1. For the Travis CI GitHub App, you can set repository access to either "all
+repositories" for convenience, or "only select repositories" and choose
+`<username>/incubator-airflow` in the dropdown.
+
+1. You can access Travis CI for your fork at
+`https://travis-ci.com/<username>/incubator-airflow`.
+
+#### Travis CI GitHub Services (legacy version)
+
+The Travis CI GitHub Services versions uses an Authorized OAuth App.  Note
+that `apache/incubator-airflow` is currently still using the legacy version.
+
+1. Once installed, you can configure the Travis CI Authorized OAuth App at
+https://github.com/settings/connections/applications/88c5b97de2dbfc50f3ac.
+
+1. If you are a GitHub admin, click the "Grant" button next to your
+organization; otherwise, click the "Request" button.
+
+1. For the Travis CI Authorized OAuth App, you may have to grant access to the
+forked `<organization>/incubator-airflow` repo even though it is public.
+
+1. You can access Travis CI for your fork at
+`https://travis-ci.org/<organization>/incubator-airflow`.
+
+#### Prefer travis-ci.com over travis-ci.org
+
+The travis-ci.org site for open source projects is now legacy and new projects
+should instead be created on travis-ci.com for both private repos and open
+source.
+
+Note that there is a second Authorized OAuth App available called "Travis CI
+for Open Source" used for the
+[legacy travis-ci.org service][travis-ci-org-vs-com].  It should not be used
+for new projects.
+
+More information:
+
+- [Open Source on travis-ci.com][travis-ci-open-source]
+- [Legacy GitHub Services to GitHub Apps Migration Guide][travis-ci-migrating]
+- [Migrating Multiple Repositories to GitHub Apps Guide][travis-ci-migrating-2]
+
+[travis-ci-getting-started]: https://docs.travis-ci.com/user/getting-started/
+[travis-ci-migrating-2]: https://docs.travis-ci.com/user/travis-migrate-to-apps-gem-guide/
+[travis-ci-migrating]: https://docs.travis-ci.com/user/legacy-services-to-github-apps-migration-guide/
+[travis-ci-open-source]: https://docs.travis-ci.com/user/open-source-on-travis-ci-com/
+[travis-ci-org-vs-com]: https://devops.stackexchange.com/a/4305/8830
 
 ### Testing locally
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The addition of these docs was inspired by discussion about setting up Travis CI for one's Airflow fork in https://github.com/apache/incubator-airflow/pull/3646 and comments about the best way to run the tests today in https://github.com/apache/incubator-airflow/pull/3692.

I recently setup Travis CI for my personal account as well as an organization account on the new Travis CI setup and thought it'd be useful to clearly document this process to make it easy for and encourage others to do the same.

/cc @ashb 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

docs improvements

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
