### PR TITLE
[AIRFLOW-2864] Fix docstrings for SubDagOperator

### DIFF
--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -25,6 +25,18 @@ from airflow.utils.db import provide_session
 
 
 class SubDagOperator(BaseOperator):
+    """
+    This runs a sub dag. By convention, a sub dag's dag_id
+    should be prefixed by its parent and a dot. As in `parent.child`.
+
+    :param subdag: the DAG object to run as a subdag of the current DAG.
+    :type subdag: airflow.DAG.
+    :param dag: the parent DAG for the subdag.
+    :type dag: airflow.DAG.
+    :param executor: the executor for this subdag. Default to use SequentialExecutor.
+        Please find AIRFLOW-74 for more details.
+    :type executor: airflow.executors.
+    """
 
     template_fields = tuple()
     ui_color = '#555'
@@ -37,18 +49,6 @@ class SubDagOperator(BaseOperator):
             subdag,
             executor=SequentialExecutor(),
             *args, **kwargs):
-        """
-        This runs a sub dag. By convention, a sub dag's dag_id
-        should be prefixed by its parent and a dot. As in `parent.child`.
-
-        :param subdag: the DAG object to run as a subdag of the current DAG.
-        :type subdag: airflow.DAG.
-        :param dag: the parent DAG for the subdag.
-        :type dag: airflow.DAG.
-        :param executor: the executor for this subdag. Default to use SequentialExecutor.
-                         Please find AIRFLOW-74 for more details.
-        :type executor: airflow.executors.
-        """
         import airflow.models
         dag = kwargs.get('dag') or airflow.models._CONTEXT_MANAGER_DAG
         if not dag:


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2864

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The docstrings are currently in the `__init__` method, due to which they are not automatically shown in the Sphinx documentation.

![image](https://user-images.githubusercontent.com/8811558/43780557-c64636e0-9a52-11e8-966a-ece7b314bdd2.png)



### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
N/a - not needed. Just doc change

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
