### PR TITLE
[AIRFLOW-2428] Add AutoScalingRole key to emr_hook

### DIFF
--- a/airflow/contrib/hooks/emr_hook.py
+++ b/airflow/contrib/hooks/emr_hook.py
@@ -63,6 +63,8 @@ class EmrHook(AwsHook):
             VisibleToAllUsers=config.get('VisibleToAllUsers'),
             JobFlowRole=config.get('JobFlowRole'),
             ServiceRole=config.get('ServiceRole'),
+            AutoScalingRole=config.get('AutoScalingRole'),
+            ScaleDownBehavior=config.get('ScaleDownBehavior'),            
             Tags=config.get('Tags')
         )
 


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-2428)

### Description

- [x] Enable the use of the autoscaling functionality when creating an EMR cluster

### Tests

- [ ] None

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
