### PR TITLE
[AIRFLOW-2869] Remove smart quote from default config

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -612,7 +612,7 @@ image_pull_secrets =
 gcp_service_account_keys =
 
 # Use the service account kubernetes gives to pods to connect to kubernetes cluster.
-# It’s intended for clients that expect to be running inside a pod running on kubernetes.
+# It's intended for clients that expect to be running inside a pod running on kubernetes.
 # It will raise an exception if called from a process not running in a kubernetes environment.
 in_cluster = True
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-2869\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2869
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-2869\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

I removed a [smart quotation mark](https://www.fileformat.info/info/unicode/char/2019/index.htm) from the default config, as it could cause problems with tooling because of unicode issues, and there's no real need for it. In my case, I was trying to use Fabric and cuisine to copy a config to a remote machine and it crashed with this error:
```
  File "/Users/william.horton/development/urbancompass/build-support/python/venvs/shorts/lib/python2.7/site-packages/cuisine.py", line 545, in file_write
    sig            = hashlib.md5(content).hexdigest()
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 20037: ordinal not in range(128)
```

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Just changing a quotation mark in a comment in the default config

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
