### PR TITLE
[AIRFLOW-1874] use_legacy_sql added to BigQueryCheck operators

### DIFF
--- a/airflow/contrib/operators/bigquery_check_operator.py
+++ b/airflow/contrib/operators/bigquery_check_operator.py
@@ -55,21 +55,25 @@ class BigQueryCheckOperator(CheckOperator):
     :type sql: string
     :param bigquery_conn_id: reference to the BigQuery database
     :type bigquery_conn_id: string
+    :param use_legacy_sql: Whether to use legacy SQL (true)
+    or standard SQL (false).
+    :type use_legacy_sql: boolean
     """
 
     @apply_defaults
-    def __init__(
-            self,
-            sql,
-            bigquery_conn_id='bigquery_default',
-            *args,
-            **kwargs):
+    def __init__(self,
+                 sql,
+                 bigquery_conn_id='bigquery_default',
+                 use_legacy_sql=True,
+                 *args, **kwargs):
         super(BigQueryCheckOperator, self).__init__(sql=sql, *args, **kwargs)
         self.bigquery_conn_id = bigquery_conn_id
         self.sql = sql
+        self.use_legacy_sql = use_legacy_sql
 
     def get_db_hook(self):
-        return BigQueryHook(bigquery_conn_id=self.bigquery_conn_id)
+        return BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
+                            use_legacy_sql=self.use_legacy_sql)
 
 
 class BigQueryValueCheckOperator(ValueCheckOperator):
@@ -78,20 +82,27 @@ class BigQueryValueCheckOperator(ValueCheckOperator):
 
     :param sql: the sql to be executed
     :type sql: string
+    :param use_legacy_sql: Whether to use legacy SQL (true)
+    or standard SQL (false).
+    :type use_legacy_sql: boolean
     """
 
     @apply_defaults
-    def __init__(
-            self, sql, pass_value, tolerance=None,
-            bigquery_conn_id='bigquery_default',
-            *args, **kwargs):
+    def __init__(self, sql,
+                 pass_value,
+                 tolerance=None,
+                 bigquery_conn_id='bigquery_default',
+                 use_legacy_sql=True,
+                 *args, **kwargs):
         super(BigQueryValueCheckOperator, self).__init__(
             sql=sql, pass_value=pass_value, tolerance=tolerance,
             *args, **kwargs)
         self.bigquery_conn_id = bigquery_conn_id
+        self.use_legacy_sql = use_legacy_sql
 
     def get_db_hook(self):
-        return BigQueryHook(bigquery_conn_id=self.bigquery_conn_id)
+        return BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
+                            use_legacy_sql=self.use_legacy_sql)
 
 
 class BigQueryIntervalCheckOperator(IntervalCheckOperator):
@@ -113,19 +124,22 @@ class BigQueryIntervalCheckOperator(IntervalCheckOperator):
         example 'COUNT(*)': 1.5 would require a 50 percent or less difference
         between the current day, and the prior days_back.
     :type metrics_threshold: dict
+    :param use_legacy_sql: Whether to use legacy SQL (true)
+    or standard SQL (false).
+    :type use_legacy_sql: boolean
     """
 
     @apply_defaults
-    def __init__(
-            self, table, metrics_thresholds,
-            date_filter_column='ds', days_back=-7,
-            bigquery_conn_id='bigquery_default',
-            *args, **kwargs):
+    def __init__(self, table, metrics_thresholds, date_filter_column='ds',
+                 days_back=-7, bigquery_conn_id='bigquery_default',
+                 use_legacy_sql=True, *args, **kwargs):
         super(BigQueryIntervalCheckOperator, self).__init__(
             table=table, metrics_thresholds=metrics_thresholds,
             date_filter_column=date_filter_column, days_back=days_back,
             *args, **kwargs)
         self.bigquery_conn_id = bigquery_conn_id
+        self.use_legacy_sql = use_legacy_sql
 
     def get_db_hook(self):
-        return BigQueryHook(bigquery_conn_id=self.bigquery_conn_id)
+        return BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
+                            use_legacy_sql=self.use_legacy_sql)


### PR DESCRIPTION
[AIRFLOW-1874] use_legacy_sql added to BigQueryCheck operators

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-1874
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Just adding use_legacy_sql to BigQueryCheck operator.

Changes with *args and **kwargs base on this: https://issues.apache.org/jira/browse/AIRFLOW-559 
really many additional params, but I think it's okay if they are described in class doc string - but on your opinion


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
