### PR TITLE
[AIRFLOW-2875] Escape env vars in tmp config

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -330,7 +330,7 @@ class AirflowConfigParser(ConfigParser):
             _section[key] = val
         return _section
 
-    def as_dict(self, display_source=False, display_sensitive=False):
+    def as_dict(self, display_source=False, display_sensitive=False, escape_env_vars=False):
         """
         Returns the current configuration as an OrderedDict of OrderedDicts.
         :param display_source: If False, the option value is returned. If True,
@@ -378,6 +378,8 @@ class AirflowConfigParser(ConfigParser):
             if opt:
                 if not display_sensitive:
                     opt = '< hidden >'
+                if escape_env_vars:
+                    opt = opt.replace('%', '%%')
                 if display_source:
                     opt = (opt, 'bash cmd')
                 cfg.setdefault(section, OrderedDict()).update({key: opt})

--- a/airflow/utils/configuration.py
+++ b/airflow/utils/configuration.py
@@ -32,7 +32,7 @@ def tmp_configuration_copy():
     settings.
     :return: a path to a temporary file
     """
-    cfg_dict = conf.as_dict(display_sensitive=True)
+    cfg_dict = conf.as_dict(display_sensitive=True, escape_env_vars=True)
     temp_fd, cfg_path = mkstemp()
 
     with os.fdopen(temp_fd, 'w') as temp_file:

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -26,6 +26,7 @@ export AIRFLOW__CORE__UNIT_TEST_MODE=True
 
 # configuration test
 export AIRFLOW__TESTSECTION__TESTKEY=testvalue
+export AIRFLOW__TESTSECTION__TESTKEYWITHPERCENT=test%with%percent
 
 # use Airflow 2.0-style imports
 export AIRFLOW_USE_NEW_IMPORTS=1

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -68,6 +68,11 @@ class ConfTest(unittest.TestCase):
         cfg_dict = conf.as_dict(display_sensitive=True, display_source=True)
         self.assertEqual(
             cfg_dict['testsection']['testkey'], ('testvalue', 'env var'))
+
+        # test escape_env_vars
+        cfg_dict = conf.as_dict(escape_env_vars=True)
+        self.assertEqual(
+            cfg_dict['testsection']['testkeywithpercent'], 'test%%with%%percent')
 
     def test_command_config(self):
         TEST_CONFIG = '''[test]


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-2875\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2875
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-2875\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
When writing tmp config files, escapes the env variables, since they are read by `ConfigParser` when the tmp config file is loaded when the task is being run.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
