### PR TITLE
[AIRFLOW-2877] Make docs site URL consistent everywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,16 @@ If you are proposing a feature:
 
 ## Documentation
 
-The latest API documentation is usually available
-[here](https://airflow.incubator.apache.org/). To generate a local version,
+The Airflow documentation is located at:
+
+- <https://airflow.apache.org> (points to
+  <https://airflow.readthedocs.io/en/stable/>) (latest stable)
+- <https://airflow.readthedocs.io/en/latest/> (latest master)
+
+The documentation for release versions ≥ 1.9 can be accessed from the above
+links as well (e.g., 1.9.0 is https://airflow.readthedocs.io/en/1.9.0/).
+
+To generate a local version,
 you need to have set up an Airflow development environment (see below). Also
 install the `doc` extra.
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ monitor progress, and troubleshoot issues when needed.
 
 ## Getting started
 
-Please visit the Airflow Platform documentation (latest **stable** release) for help with [installing Airflow](https://airflow.incubator.apache.org/installation.html), getting a [quick start](https://airflow.incubator.apache.org/start.html), or a more complete [tutorial](https://airflow.incubator.apache.org/tutorial.html).
+Please visit the Airflow Platform documentation (latest **stable** release) for help with [installing Airflow](https://airflow.apache.org/installation.html), getting a [quick start](https://airflow.apache.org/start.html), or a more complete [tutorial](https://airflow.apache.org/tutorial.html).
 
-Documentation of GitHub master (latest development branch): [ReadTheDocs Documentation](https://airflow.readthedocs.io/en/latest/)
+Documentation for the latest master branch is available at <https://airflow.readthedocs.io/en/latest/>.
+
+The documentation for release versions ≥ 1.9 can be accessed from the above
+links as well (e.g., 1.9.0 is https://airflow.readthedocs.io/en/1.9.0/).
 
 For further information, please visit the [Airflow Wiki](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Home).
 
@@ -272,7 +275,7 @@ Currently **officially** using Airflow:
 
 ## Who Maintains Airflow?
 
-Airflow is the work of the 
+Airflow is the work of the
 [community](https://github.com/apache/incubator-airflow/graphs/contributors),
 but the [core committers/maintainers](https://people.apache.org/committers-by-project.html#airflow)
 are responsible for reviewing and merging PRs as well as steering conversation around new feature requests.
@@ -281,7 +284,7 @@ If you would like to become a maintainer, please review the Apache Airflow
 
 ## Links
 
-- [Documentation](https://airflow.incubator.apache.org/)
+- [Documentation](https://airflow.apache.org)
 - [Chat](https://gitter.im/apache/incubator-airflow)
 - [Apache Airflow Incubation Status](http://incubator.apache.org/projects/airflow.html)
 - [More](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Links)

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -326,7 +326,7 @@ The `file_task_handler` logger has been made more flexible. The default format c
 
 #### I'm using S3Log or GCSLogs, what do I do!?
 
-If you are logging to Google cloud storage, please see the [Google cloud platform documentation](https://airflow.incubator.apache.org/integration.html#gcp-google-cloud-platform) for logging instructions.
+If you are logging to Google cloud storage, please see the [Google cloud platform documentation](https://airflow.apache.org/integration.html#gcp-google-cloud-platform) for logging instructions.
 
 If you are using S3, the instructions should be largely the same as the Google cloud platform instructions above. You will need a custom logging config. The `REMOTE_BASE_LOG_FOLDER` configuration key in your airflow config has been removed, therefore you will need to take the following steps:
 

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -269,7 +269,7 @@ error_logfile = -
 expose_config = False
 
 # Set to true to turn on authentication:
-# https://airflow.incubator.apache.org/security.html#web-authentication
+# https://airflow.apache.org/security.html#web-authentication
 authenticate = False
 
 # Filter the list of dags by owner name (requires authentication to be enabled)

--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -20,7 +20,7 @@
 """
 ### Tutorial Documentation
 Documentation that goes along with the Airflow tutorial located
-[here](https://airflow.incubator.apache.org/tutorial.html)
+[here](https://airflow.apache.org/tutorial.html)
 """
 import airflow
 from airflow import DAG

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -121,7 +121,7 @@ def create_app(config=None, testing=False):
 
         admin.add_link(base.MenuLink(
             category='Docs', name='Documentation',
-            url='https://airflow.incubator.apache.org/'))
+            url='https://airflow.apache.org'))
         admin.add_link(
             base.MenuLink(category='Docs',
                           name='Github',

--- a/airflow/www_rbac/app.py
+++ b/airflow/www_rbac/app.py
@@ -126,7 +126,7 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
                                 "XComs",
                                 category="Admin")
             appbuilder.add_link("Documentation",
-                                href='https://airflow.apache.org/',
+                                href='https://airflow.apache.org',
                                 category="Docs",
                                 category_icon="fa-cube")
             appbuilder.add_link("Github",

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -157,7 +157,7 @@ definitions in Airflow.
     ml = MenuLink(
         category='Test Plugin',
         name='Test Menu Link',
-        url='https://airflow.incubator.apache.org/')
+        url='https://airflow.apache.org')
 
     # Defining the plugin class
     class AirflowTestPlugin(AirflowPlugin):

--- a/docs/project.rst
+++ b/docs/project.rst
@@ -40,7 +40,7 @@ Contributor page:
 Resources & links
 -----------------
 
-* `Airflow's official documentation <http://airflow.apache.org/>`_
+* `Airflow's official documentation <https://airflow.apache.org>`_
 * Mailing list (send emails to
   ``dev-subscribe@airflow.incubator.apache.org`` and/or
   ``commits-subscribe@airflow.incubator.apache.org``

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -278,7 +278,7 @@ something like this:
 
     """
     Code that goes along with the Airflow located at:
-    http://airflow.readthedocs.org/en/latest/tutorial.html
+    https://airflow.apache.org/tutorial.html
     """
     from airflow import DAG
     from airflow.operators.bash_operator import BashOperator

--- a/scripts/ci/kubernetes/kube/configmaps.yaml
+++ b/scripts/ci/kubernetes/kube/configmaps.yaml
@@ -122,7 +122,7 @@ data:
     expose_config = False
 
     # Set to true to turn on authentication:
-    # https://airflow.incubator.apache.org/security.html#web-authentication
+    # https://airflow.apache.org/security.html#web-authentication
     authenticate = False
 
     # Filter the list of dags by owner name (requires authentication to be enabled)

--- a/setup.py
+++ b/setup.py
@@ -402,7 +402,7 @@ def do_setup():
         ],
         author='Apache Software Foundation',
         author_email='dev@airflow.incubator.apache.org',
-        url='http://airflow.incubator.apache.org/',
+        url='https://airflow.apache.org',
         download_url=(
             'https://dist.apache.org/repos/dist/release/incubator/airflow/' + version),
         cmdclass={

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -70,7 +70,7 @@ bp = Blueprint(
 ml = MenuLink(
     category='Test Plugin',
     name='Test Menu Link',
-    url='https://airflow.incubator.apache.org/')
+    url='https://airflow.apache.org')
 
 
 # Defining the plugin class


### PR DESCRIPTION
With this commit, all references to the docs site now point to the
latest stable version, with the one exception being the top-level dev
docs site on master in the readme.  Also, use https everywhere.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2877
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We currently have several references to multiple docs sites throughout the repo (https://airflow.readthedocs.io/, https://airflow.apache.org/, https://airflow.incubator.apache.org/, etc).

With this PR, all references to the docs site now point to the latest stable version, with the one exception being the top-level dev docs site on master in the readme.  Also, use https everywhere.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

mostly docs changes

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
