### PR TITLE
[AIRFLOW-2883] Not search dag owner if owners are missing

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2127,8 +2127,9 @@ class HomeView(AdminIndexView):
             }
 
             all_dag_ids = (set([dag.dag_id for dag in orm_dags.values()
-                                if lower_search_query in dag.dag_id.lower() or
-                                lower_search_query in dag.owners.lower()]) |
+                                if dag.owners is not None and
+                                (lower_search_query in dag.dag_id.lower() or
+                                lower_search_query in dag.owners.lower())]) |
                            set(webserver_dags_filtered.keys()))
 
             sorted_dag_ids = sorted(all_dag_ids)

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -231,8 +231,9 @@ class Airflow(AirflowBaseView):
             }
 
             all_dag_ids = (set([dag.dag_id for dag in orm_dags.values()
-                                if lower_search_query in dag.dag_id.lower() or
-                                lower_search_query in dag.owners.lower()]) |
+                                if dag.owners is not None and
+                                (lower_search_query in dag.dag_id.lower() or
+                                lower_search_query in dag.owners.lower())]) |
                            set(webserver_dags_filtered.keys()))
 
             sorted_dag_ids = sorted(all_dag_ids)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2883
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
If the owners field are missing for a dag in airflow metadata db table(DAG),  we will encounter "NoneType" object has no attribute 'lower' when we do a search in UI. We should skip that dags in this case.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
no test. Trivial fix.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
