### PR TITLE
[AIRFLOW-2884] Fix Flask SECRET_KEY security issue in www_rbac

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -250,6 +250,8 @@ worker_refresh_batch_size = 1
 worker_refresh_interval = 30
 
 # Secret key used to run your flask app
+# If default value is given ("temporary_key"), a random secret_key will be generated
+# when you launch your webserver for security reason
 secret_key = temporary_key
 
 # Number of workers to run the Gunicorn web server

--- a/airflow/www_rbac/app.py
+++ b/airflow/www_rbac/app.py
@@ -19,6 +19,7 @@
 #
 import socket
 import six
+import os
 
 from flask import Flask
 from flask_appbuilder import AppBuilder, SQLA
@@ -42,7 +43,10 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
     global app, appbuilder
     app = Flask(__name__)
     app.wsgi_app = ProxyFix(app.wsgi_app)
-    app.secret_key = conf.get('webserver', 'SECRET_KEY')
+    if conf.get('webserver', 'SECRET_KEY') == "temporary_key":
+        app.secret_key = os.urandom(16)
+    else:
+        app.secret_key = conf.get('webserver', 'SECRET_KEY')
 
     airflow_home_path = conf.get('core', 'AIRFLOW_HOME')
     webserver_config_path = airflow_home_path + '/webserver_config.py'


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2884
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The same issue was fixed for `/www` previously in PR https://github.com/apache/incubator-airflow/pull/3651 , (JIRA ticket 2809, https://issues.apache.org/jira/browse/AIRFLOW-2809)

This commit is to fix the same issue for `/www_rbac`.

In addition, updated the comment in `airflow/config_templates/default_airflow.cfg`.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
