### PR TITLE
[AIRFLOW-2882] Add import and export for pool cli using JSON

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -298,7 +298,7 @@ def pool_import_helper(filepath):
     try:
         d = json.loads(pl)
     except Exception as e:
-        print("Invalid pool json file with exception: " + str(e) + ". please check the validity of the json")
+        print("Please check the validity of the json file: " + str(e))
     else:
         try:
             pools = []

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -267,6 +267,7 @@ def pool(args):
                                  tablefmt="fancy_grid")
 
     try:
+        imp = getattr(args, 'import')
         if args.get is not None:
             pools = [api_client.get_pool(name=args.get)]
         elif args.set:
@@ -275,6 +276,14 @@ def pool(args):
                                             description=args.set[2])]
         elif args.delete:
             pools = [api_client.delete_pool(name=args.delete)]
+        elif imp:
+            if os.path.exists(imp):
+                pools = pool_import_helper(imp)
+            else:
+                print("Missing pools file.")
+                pools = api_client.get_pools()
+        elif args.export:
+            pools = pool_export_helper(args.export)
         else:
             pools = api_client.get_pools()
     except (AirflowException, IOError) as err:
@@ -282,6 +291,41 @@ def pool(args):
     else:
         log.info(_tabulate(pools=pools))
 
+def pool_import_helper(filepath):
+    with open(filepath, 'r') as poolfile:
+        pl = poolfile.read()
+    try:
+        d = json.loads(pl)
+    except Exception:
+        print("Invalid pool file.")
+    else:
+        try:
+            pools = []
+            n = 0
+            for k, v in d.items():
+                if isinstance(v, dict) and len(v) == 2:
+                    pools.append(api_client.create_pool(name=k,
+                                            slots=v["slots"],
+                                            description=v["description"]))
+                    n += 1                  
+                else:
+                    pass
+        except Exception:
+            pass
+        finally:
+            print("{} of {} pool(s) successfully updated.".format(n, len(d)))
+            return pools
+
+def pool_export_helper(filepath):
+    pool_dict = {}
+    d = json.JSONDecoder()   
+    pools = api_client.get_pools() 
+    for pool in pools:
+        pool_dict[pool[0]] = {"slots":pool[1],"description":pool[2]}
+    with open(filepath, 'w') as poolfile:
+        poolfile.write(json.dumps(pool_dict, sort_keys=True, indent=4))
+    print("{} pools successfully exported to {}".format(len(pool_dict), filepath))
+    return pools
 
 @cli_utils.action_logging
 def variables(args):
@@ -1551,6 +1595,14 @@ class CLIFactory(object):
             ("-x", "--delete"),
             metavar="NAME",
             help="Delete a pool"),
+        'pool_import': Arg(
+            ("-i", "--import"),
+            metavar="FILEPATH",
+            help="Import pool from JSON file"),
+        'pool_export': Arg(
+            ("-e", "--export"),
+            metavar="FILEPATH",
+            help="Export pool to JSON file"),
         # variables
         'set': Arg(
             ("-s", "--set"),
@@ -1870,7 +1922,7 @@ class CLIFactory(object):
         }, {
             'func': pool,
             'help': "CRUD operations on pools",
-            "args": ('pool_set', 'pool_get', 'pool_delete'),
+            "args": ('pool_set', 'pool_get', 'pool_delete', 'pool_import', 'pool_export'),
         }, {
             'func': variables,
             'help': "CRUD operations on variables",

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -297,8 +297,8 @@ def pool_import_helper(filepath):
         pl = poolfile.read()
     try:
         d = json.loads(pl)
-    except Exception:
-        print("Invalid pool file.")
+    except Exception as e:
+        print("Invalid pool json file with exception: " + str(e) + ". please check the validity of the json")
     else:
         try:
             pools = []

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -291,6 +291,7 @@ def pool(args):
     else:
         log.info(_tabulate(pools=pools))
 
+
 def pool_import_helper(filepath):
     with open(filepath, 'r') as poolfile:
         pl = poolfile.read()
@@ -305,9 +306,9 @@ def pool_import_helper(filepath):
             for k, v in d.items():
                 if isinstance(v, dict) and len(v) == 2:
                     pools.append(api_client.create_pool(name=k,
-                                            slots=v["slots"],
-                                            description=v["description"]))
-                    n += 1                  
+                                                        slots=v["slots"],
+                                                        description=v["description"]))
+                    n += 1
                 else:
                     pass
         except Exception:
@@ -316,16 +317,17 @@ def pool_import_helper(filepath):
             print("{} of {} pool(s) successfully updated.".format(n, len(d)))
             return pools
 
+
 def pool_export_helper(filepath):
     pool_dict = {}
-    d = json.JSONDecoder()   
-    pools = api_client.get_pools() 
+    pools = api_client.get_pools()
     for pool in pools:
-        pool_dict[pool[0]] = {"slots":pool[1],"description":pool[2]}
+        pool_dict[pool[0]] = {"slots": pool[1], "description": pool[2]}
     with open(filepath, 'w') as poolfile:
         poolfile.write(json.dumps(pool_dict, sort_keys=True, indent=4))
     print("{} pools successfully exported to {}".format(len(pool_dict), filepath))
     return pools
+
 
 @cli_utils.action_logging
 def variables(args):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -33,7 +33,6 @@ from airflow.settings import Session
 from airflow import models
 
 import os
-import json
 
 dag_folder_path = '/'.join(os.path.realpath(__file__).split('/')[:-1])
 
@@ -166,45 +165,3 @@ class TestCLI(unittest.TestCase):
             ti.refresh_from_db()
             state = ti.current_state()
             self.assertEqual(state, State.SUCCESS)
-
-    def test_cli_pool_import_export(self):
-        pool_config_input = {
-            "s3_pool": {
-                "description": "This is my test s3_pool",
-                "slots": 5
-            },
-            "s3_pool2": {
-                "description": "This is my test s3_pool",
-                "slots": 8
-            }
-        }
-        with open('pool_import.json', mode='w') as f:
-            json.dump(pool_config_input, f)
-
-        with psutil.Popen(
-                ["airflow", "pool", "-i", "pool_import.json"]) as process_import:
-            import_return_code = process_import.wait()
-            self.assertEqual(
-                0,
-                import_return_code,
-                "pool import with return code {}".format(import_return_code))
-
-        with psutil.Popen(
-                ["airflow", "pool", "-e", "pool_export.json"]) as process_export:
-            export_return_code = process_export.wait()
-            self.assertEqual(
-                0,
-                export_return_code,
-                "pool export with return code {}".format(export_return_code))
-
-        with open('pool_export.json', mode='r') as f:
-            pool_config_output = json.load(f)
-            self.assertEqual(
-                pool_config_input,
-                pool_config_output,
-                "Input and output pool files are not same")
-
-        if os.path.exists("pool_import.json"):
-            os.remove("pool_import.json")
-        if os.path.exists("pool_export.json"):
-            os.remove("pool_export.json")

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -178,7 +178,7 @@ class TestCLI(unittest.TestCase):
                 "slots": 8
             }
         }
-        with open('pool_import.json', mode='w', encoding='utf-8') as f:
+        with open('pool_import.json', mode='w') as f:
             json.dump(pool_config_input, f)
 
         with psutil.Popen(
@@ -197,7 +197,7 @@ class TestCLI(unittest.TestCase):
                 export_return_code,
                 "pool export with return code {}".format(export_return_code))
 
-        with open('pool_export.json', mode='r', encoding='utf-8') as f:
+        with open('pool_export.json', mode='r') as f:
             pool_config_output = json.load(f)
             self.assertEqual(
                 pool_config_input,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -180,24 +180,31 @@ class TestCLI(unittest.TestCase):
         }
         with open('pool_import.json', mode='w', encoding='utf-8') as f:
             json.dump(pool_config_input, f)
-        process_import = psutil.Popen(["airflow", "pool", "-i", "pool_import.json"])
-        sleep(3)  # wait for webserver to start
-        import_return_code = process_import.poll()
-        self.assertEqual(
-            0,
-            import_return_code,
-            "pool import with return code {}".format(import_return_code))
 
-        process_export = psutil.Popen(["airflow", "pool", "-e", "pool_export.json"])
-        sleep(3)
-        export_return_code = process_export.poll()
-        self.assertEqual(
-            0,
-            export_return_code,
-            "pool export with return code {}".format(export_return_code))
+        with psutil.Popen(
+                ["airflow", "pool", "-i", "pool_import.json"]) as process_import:
+            import_return_code = process_import.wait()
+            self.assertEqual(
+                0,
+                import_return_code,
+                "pool import with return code {}".format(import_return_code))
+
+        with psutil.Popen(
+                ["airflow", "pool", "-e", "pool_export.json"]) as process_export:
+            export_return_code = process_export.wait()
+            self.assertEqual(
+                0,
+                export_return_code,
+                "pool export with return code {}".format(export_return_code))
+
         with open('pool_export.json', mode='r', encoding='utf-8') as f:
             pool_config_output = json.load(f)
             self.assertEqual(
                 pool_config_input,
                 pool_config_output,
                 "Input and output pool files are not same")
+
+        if os.path.exists("pool_import.json"):
+            os.remove("pool_import.json")
+        if os.path.exists("pool_export.json"):
+            os.remove("pool_export.json")

--- a/tests/core.py
+++ b/tests/core.py
@@ -1512,6 +1512,42 @@ class CliTests(unittest.TestCase):
         except Exception as e:
             self.fail("The 'pool' command raised unexpectedly: %s" % e)
 
+    def test_pool_import_export(self):
+        # Create two pools first
+        pool_config_input = {
+            "foo": {
+                "description": "foo_test",
+                "slots": 1
+            },
+            "baz": {
+                "description": "baz_test",
+                "slots": 2
+            }
+        }
+        with open('pools_import.json', mode='w') as f:
+            json.dump(pool_config_input, f)
+
+        # Import json
+        try:
+            cli.pool(self.parser.parse_args(['pool', '-i', 'pools_import.json']))
+        except Exception as e:
+            self.fail("The 'pool -i pools_import.json' failed: %s" % e)
+
+        # Export json
+        try:
+            cli.pool(self.parser.parse_args(['pool', '-e', 'pools_export.json']))
+        except Exception as e:
+            self.fail("The 'pool -e pools_export.json' failed: %s" % e)
+
+        with open('pools_export.json', mode='r') as f:
+            pool_config_output = json.load(f)
+            self.assertEqual(
+                pool_config_input,
+                pool_config_output,
+                "Input and output pool files are not same")
+        os.remove('pools_import.json')
+        os.remove('pools_export.json')
+
     def test_variables(self):
         # Checks if all subcommands are properly received
         cli.variables(self.parser.parse_args([


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [✓] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2882
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [✓] Here are some details about my PR, including screenshots of any UI changes:
Currently, the pool only support set and get by one elements,
`airflow pool [-h] [-s NAME SLOT_COUNT POOL_DESCRIPTION] [-g NAME] [-x NAME]`
With this changes, user can perform import & export similar as Variables so cli use JSON file to perform import & export operations. This will make deployment easier by setting up the pools via CICD pipeline as well. 
For example, the import json file`{"s3_pool": {"slots":5, "description":"This is my test s3_pool"}}`
--for import `airflow pool -i pools.json`
--for export `airflow pool -e pools_e.json`

### Tests

- [✓] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Using `{
    "s3_pool": {"slots":5, "description":"This is my test s3_pool"},
    "s3_pool2": {"slots":5, "description":"This is my test s3_pool"}
}`

- Tested `airflow pool -i pools.json` and use `airflow pool --get s3_pool` ╒═════════╤═════════╤═════════════════════════╕
│ Pool    │   Slots │ Description             │
╞═════════╪═════════╪═════════════════════════╡
│ s3_pool │       5 │ This is my test s3_pool │
╘═════════╧═════════╧═════════════════════════╛

- Tested `airflow pool -e pools_e.json` and got 

```
{
    "s3_pool": {
        "description": "This is my test s3_pool",
        "slots": 5
    },
    "s3_pool2": {
        "description": "This is my test s3_pool",
        "slots": 5
    }
}
```

### Commits

- [✓ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [✓] In case of new functionality, my PR adds documentation that describes how to use it.
  Added named arguments:
`airflow pool -help`
```
  -i FILEPATH, --import FILEPATH
                        Import pool from JSON file
  -e FILEPATH, --export FILEPATH
                        Export pool to JSON file
```

### Code Quality

- [✓] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
