### PR TITLE
[AIRFLOW-2885] Fix a bug in www_rbac.utils.get_params

### DIFF
--- a/airflow/www_rbac/utils.py
+++ b/airflow/www_rbac/utils.py
@@ -66,7 +66,7 @@ def get_params(**kwargs):
             if v or v is None:
                 continue
             params.append('{}={}'.format(k, v))
-        elif v:
+        elif v is not None:
             params.append('{}={}'.format(k, v))
     params = sorted(params, key=lambda x: x.split('=')[0])
     return '&'.join(params)

--- a/tests/www_rbac/test_utils.py
+++ b/tests/www_rbac/test_utils.py
@@ -109,6 +109,11 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual('page=3&search=bash_&showPaused=False',
                          utils.get_params(showPaused=False, page=3, search='bash_'))
 
+    def test_params_all_page_zero(self):
+        """Should return params string ordered by param key"""
+        self.assertEqual('page=0&search=bash_&showPaused=False',
+                         utils.get_params(showPaused=False, page=0, search='bash_'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2885
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

`get_params(page=0, search="abc",showPaused=False)` returns `search=abc&showPaused=False`, while it's supposed to return `page=0&search=abc&showPaused=False` (`page` is 0-indexed).

This issue arose since `0` is considered as `False` by Python in conditional statement. `elif v` will not continue when `v` is `0` here, while it's supposed to continue.

A test is added as well. 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
