### PR TITLE
[AIRFLOW-2889] Fix typos detected by github.com/client9/misspell

### DIFF
--- a/airflow/contrib/example_dags/example_databricks_operator.py
+++ b/airflow/contrib/example_dags/example_databricks_operator.py
@@ -32,7 +32,7 @@ from airflow.contrib.operators.databricks_operator import DatabricksSubmitRunOpe
 # the spark jar task will NOT run until the notebook task completes
 # successfully.
 #
-# The definition of a succesful run is if the run has a result_state of "SUCCESS".
+# The definition of a successful run is if the run has a result_state of "SUCCESS".
 # For more information about the state of a run refer to
 # https://docs.databricks.com/api/latest/jobs.html#runstate
 

--- a/airflow/contrib/hooks/azure_fileshare_hook.py
+++ b/airflow/contrib/hooks/azure_fileshare_hook.py
@@ -100,7 +100,7 @@ class AzureFileShareHook(BaseHook):
 
     def create_directory(self, share_name, directory_name, **kwargs):
         """
-        Create a new direcotry on a Azure File Share.
+        Create a new directory on a Azure File Share.
 
         :param share_name: Name of the share.
         :type share_name: str

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -627,7 +627,7 @@ class BigQueryBaseCursor(LoggingMixin):
 
         if query_params:
             if self.use_legacy_sql:
-                raise ValueError("Query paramaters are not allowed when using "
+                raise ValueError("Query parameters are not allowed when using "
                                  "legacy SQL")
             else:
                 configuration['query']['queryParameters'] = query_params

--- a/airflow/contrib/hooks/emr_hook.py
+++ b/airflow/contrib/hooks/emr_hook.py
@@ -23,7 +23,7 @@ from airflow.contrib.hooks.aws_hook import AwsHook
 
 class EmrHook(AwsHook):
     """
-    Interact with AWS EMR. emr_conn_id is only neccessary for using the
+    Interact with AWS EMR. emr_conn_id is only necessary for using the
     create_job_flow method.
     """
 

--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -235,6 +235,6 @@ setattr(
     DataProcHook,
     "await",
     deprecation.deprecated(
-        DataProcHook.wait, "renamed to 'wait' for Python3.7 compatability"
+        DataProcHook.wait, "renamed to 'wait' for Python3.7 compatibility"
     ),
 )

--- a/airflow/contrib/hooks/qubole_hook.py
+++ b/airflow/contrib/hooks/qubole_hook.py
@@ -125,7 +125,7 @@ class QuboleHook(BaseHook, LoggingMixin):
 
     def kill(self, ti):
         """
-        Kill (cancel) a Qubole commmand
+        Kill (cancel) a Qubole command
         :param ti: Task Instance of the dag, used to determine the Quboles command id
         :return: response from Qubole
         """

--- a/airflow/contrib/hooks/salesforce_hook.py
+++ b/airflow/contrib/hooks/salesforce_hook.py
@@ -53,14 +53,14 @@ class SalesforceHook(BaseHook, LoggingMixin):
 
         :param conn_id:     the name of the connection that has the parameters
                             we need to connect to Salesforce.
-                            The conenction shoud be type `http` and include a
+                            The connection shoud be type `http` and include a
                             user's security token in the `Extras` field.
         .. note::
             For the HTTP connection type, you can include a
             JSON structure in the `Extras` field.
             We need a user's security token to connect to Salesforce.
             So we define it in the `Extras` field as:
-                `{"security_token":"YOUR_SECRUITY_TOKEN"}`
+                `{"security_token":"YOUR_SECURITY_TOKEN"}`
         """
         self.conn_id = conn_id
         self._args = args

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -86,7 +86,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         for other formats.
     :type allow_jagged_rows: bool
     :param max_id_key: If set, the name of a column in the BigQuery table
-        that's to be loaded. Thsi will be used to select the MAX value from
+        that's to be loaded. This will be used to select the MAX value from
         BigQuery after the load occurs. The results will be returned by the
         execute() command, which in turn gets stored in XCom for future
         operators to use. This can be helpful with incremental loads--during

--- a/airflow/contrib/operators/mlengine_operator_utils.py
+++ b/airflow/contrib/operators/mlengine_operator_utils.py
@@ -160,7 +160,7 @@ def create_evaluate_ops(task_prefix,
         then the `dag`'s `default_args['model_name']` will be used.
     :type model_name: string
 
-    :param version_name: Used to indicate a model version to use for prediciton,
+    :param version_name: Used to indicate a model version to use for prediction,
         in combination with model_name. Cannot be used together with model_uri.
         See MLEngineBatchPredictionOperator for more detail. If None, then the
         `dag`'s `default_args['version_name']` will be used.

--- a/airflow/contrib/operators/qubole_check_operator.py
+++ b/airflow/contrib/operators/qubole_check_operator.py
@@ -28,7 +28,7 @@ class QuboleCheckOperator(CheckOperator, QuboleOperator):
     """
     Performs checks against Qubole Commands. ``QuboleCheckOperator`` expects
     a command that will be executed on QDS.
-    By default, each value on first row of the result of this Qubole Commmand
+    By default, each value on first row of the result of this Qubole Command
     is evaluated using python ``bool`` casting. If any of the
     values return ``False``, the check is failed and errors out.
 

--- a/airflow/contrib/plugins/metastore_browser/templates/metastore_browser/table.html
+++ b/airflow/contrib/plugins/metastore_browser/templates/metastore_browser/table.html
@@ -28,7 +28,7 @@
     <li role="presentation" class="active"><a href="#home" aria-controls="fields" role="tab" data-toggle="tab">Fields</a></li>
     <li role="presentation"><a href="#data" aria-controls="data" role="tab" data-toggle="tab">Sample Data</a></li>
     <li role="presentation"><a href="#partitions" aria-controls="partitions" role="tab" data-toggle="tab">Partitions</a></li>
-    <li role="presentation"><a href="#attributes" aria-controls="attributes" role="tab" data-toggle="tab">Atributes</a></li>
+    <li role="presentation"><a href="#attributes" aria-controls="attributes" role="tab" data-toggle="tab">Attributes</a></li>
     <li role="presentation"><a href="#parameters" aria-controls="parameters" role="tab" data-toggle="tab">Parameters</a></li>
     <li role="presentation"><a href="#ddl" aria-controls="ddl" role="tab" data-toggle="tab">DDL</a></li>
 </ul>

--- a/airflow/hooks/mysql_hook.py
+++ b/airflow/hooks/mysql_hook.py
@@ -121,7 +121,7 @@ class MySqlHook(DbApiHook):
     def _serialize_cell(cell, conn):
         """
         MySQLdb converts an argument to a literal
-        when passing those seperately to execute. Hence, this method does nothing.
+        when passing those separately to execute. Hence, this method does nothing.
 
         :param cell: The cell to insert into the table
         :type cell: object

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -942,7 +942,7 @@ class TaskInstance(Base, LoggingMixin):
     @property
     def try_number(self):
         """
-        Return the try number that this task number will be when it is acutally
+        Return the try number that this task number will be when it is actually
         run.
 
         If the TI is currently running, this will match the column in the

--- a/airflow/operators/hive_to_druid.py
+++ b/airflow/operators/hive_to_druid.py
@@ -164,7 +164,7 @@ class HiveToDruidTransfer(BaseOperator):
         :type columns: list
         """
 
-        # backward compatibilty for num_shards,
+        # backward compatibility for num_shards,
         # but target_partition_size is the default setting
         # and overwrites the num_shards
         num_shards = self.num_shards

--- a/airflow/sensors/hdfs_sensor.py
+++ b/airflow/sensors/hdfs_sensor.py
@@ -88,12 +88,12 @@ class HdfsSensor(BaseSensorOperator):
         if ignore_copying:
             log = LoggingMixin().log
             regex_builder = "^.*\.(%s$)$" % '$|'.join(ignored_ext)
-            ignored_extentions_regex = re.compile(regex_builder)
+            ignored_extensions_regex = re.compile(regex_builder)
             log.debug(
                 'Filtering result for ignored extensions: %s in files %s',
-                ignored_extentions_regex.pattern, map(lambda x: x['path'], result)
+                ignored_extensions_regex.pattern, map(lambda x: x['path'], result)
             )
-            result = [x for x in result if not ignored_extentions_regex.match(x['path'])]
+            result = [x for x in result if not ignored_extensions_regex.match(x['path'])]
             log.debug('HdfsSensor.poke: after ext filter result is %s', result)
         return result
 

--- a/dev/airflow-pr
+++ b/dev/airflow-pr
@@ -714,8 +714,8 @@ def standardize_jira_ref(text, only_jira=False):
     '[AIRFLOW-5954][MLLIB] Top by key'
     >>> standardize_jira_ref("[AIRFLOW-979] a LRU scheduler for load balancing in TaskSchedulerImpl")
     '[AIRFLOW-979] a LRU scheduler for load balancing in TaskSchedulerImpl'
-    >>> standardize_jira_ref("AIRFLOW-1094 Support MiMa for reporting binary compatibility accross versions.")
-    '[AIRFLOW-1094] Support MiMa for reporting binary compatibility accross versions.'
+    >>> standardize_jira_ref("AIRFLOW-1094 Support MiMa for reporting binary compatibility across versions.")
+    '[AIRFLOW-1094] Support MiMa for reporting binary compatibility across versions.'
     >>> standardize_jira_ref("[WIP]  [AIRFLOW-1146] Vagrant support for Spark")
     '[AIRFLOW-1146][WIP] Vagrant support for Spark'
     >>> standardize_jira_ref("AIRFLOW-1032. If Yarn app fails before registering, app master stays aroun...")
@@ -942,7 +942,7 @@ def cli():
     status = run_cmd('git status --porcelain', echo_cmd=False)
     if status:
         msg = (
-            'You have uncomitted changes in this branch. Running this tool\n'
+            'You have uncommitted changes in this branch. Running this tool\n'
             'will delete them permanently. Continue?')
         if click.confirm(click.style(msg, fg='red', bold=True)):
             run_cmd('git reset --hard', echo_cmd=False)

--- a/docs/howto/write-logs.rst
+++ b/docs/howto/write-logs.rst
@@ -11,7 +11,7 @@ directory.
 In addition, users can supply a remote location for storing logs and log
 backups in cloud storage.
 
-In the Airflow Web UI, local logs take precedance over remote logs. If local logs
+In the Airflow Web UI, local logs take precedence over remote logs. If local logs
 can not be found or accessed, the remote logs will be displayed. Note that logs
 are only sent to remote storage once a task completes (including failure). In other
 words, remote logs for running tasks are unavailable. Logs are stored in the log

--- a/scripts/ci/kubernetes/kube/secrets.yaml
+++ b/scripts/ci/kubernetes/kube/secrets.yaml
@@ -20,6 +20,6 @@ metadata:
   name: airflow-secrets
 type: Opaque
 data:
-  # The sql_alchemy_conn value is a base64 encoded represenation of this connection string:
+  # The sql_alchemy_conn value is a base64 encoded representation of this connection string:
   # postgresql+psycopg2://root:root@postgres-airflow:5432/airflow
   sql_alchemy_conn: cG9zdGdyZXNxbCtwc3ljb3BnMjovL3Jvb3Q6cm9vdEBwb3N0Z3Jlcy1haXJmbG93OjU0MzIvYWlyZmxvdwo=

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -52,12 +52,12 @@ class TestBigQueryDataframeResults(unittest.TestCase):
         self.assertIn('Reason: ', str(context.exception), "")
 
     @unittest.skipIf(not bq_available, 'BQ is not available to run tests')
-    def test_suceeds_with_explicit_legacy_query(self):
+    def test_succeeds_with_explicit_legacy_query(self):
         df = self.instance.get_pandas_df('select 1', dialect='legacy')
         self.assertEqual(df.iloc(0)[0][0], 1)
 
     @unittest.skipIf(not bq_available, 'BQ is not available to run tests')
-    def test_suceeds_with_explicit_std_query(self):
+    def test_succeeds_with_explicit_std_query(self):
         df = self.instance.get_pandas_df(
             'select * except(b) from (select 1 a, 2 b)', dialect='standard')
         self.assertEqual(df.iloc(0)[0][0], 1)

--- a/tests/contrib/operators/test_ecs_operator.py
+++ b/tests/contrib/operators/test_ecs_operator.py
@@ -181,7 +181,7 @@ class TestECSOperator(unittest.TestCase):
         self.assertIn("'lastStatus': 'PENDING'", str(e.exception))
         client_mock.describe_tasks.assert_called_once_with(cluster='c', tasks=['arn'])
 
-    def test_check_success_tasks_raises_mutliple(self):
+    def test_check_success_tasks_raises_multiple(self):
         client_mock = mock.Mock()
         self.ecs.client = client_mock
         self.ecs.arn = 'arn'

--- a/tests/core.py
+++ b/tests/core.py
@@ -831,7 +831,7 @@ class CoreTest(unittest.TestCase):
         with self.assertRaises(AirflowException):
             DummyOperator(
                 task_id='test_bad_trigger',
-                trigger_rule="non_existant",
+                trigger_rule="non_existent",
                 dag=self.dag)
 
     def test_terminate_task(self):

--- a/tests/models.py
+++ b/tests/models.py
@@ -97,7 +97,7 @@ class DagTest(unittest.TestCase):
         """
         Test DAG as a context manager.
         When used as a context manager, Operators are automatically added to
-        the DAG (unless they specifiy a different DAG)
+        the DAG (unless they specify a different DAG)
         """
         dag = DAG(
             'dag',


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-2889

### Description

Fixing typos is sometimes very hard. It's not so easy to visually review them. Recently, I discovered a very useful tool for it, [misspell](https://github.com/client9/misspell). 

This pull request fixes minor typos detected by [misspell](https://github.com/client9/misspell) except for the false positives. If you would like me to work on other files as well, let me know. 

#### before

```
$ misspell airflow/ | grep -v CHANGELOG.txt | grep -v www
2018/08/10 18:14:00 Unable to stat "airflow/www/static/docs": stat airflow/www/static/docs: no such file or directory
2018/08/10 18:14:00 Unable to stat "airflow/www_rbac/static/docs": stat airflow/www_rbac/static/docs: no such file or directory
airflow/contrib/example_dags/example_databricks_operator.py:35:22: "succesful" is a misspelling of "successful"
airflow/contrib/hooks/emr_hook.py:26:47: "neccessary" is a misspelling of "necessary"
airflow/contrib/hooks/azure_fileshare_hook.py:103:21: "direcotry" is a misspelling of "directory"
airflow/contrib/hooks/gcp_dataproc_hook.py:238:60: "compatability" is a misspelling of "compatibility"
airflow/contrib/hooks/bigquery_hook.py:630:40: "paramaters" is a misspelling of "parameters"
airflow/contrib/hooks/qubole_hook.py:128:31: "commmand" is a misspelling of "command"
airflow/contrib/hooks/salesforce_hook.py:56:32: "conenction" is a misspelling of "connection"
airflow/contrib/hooks/salesforce_hook.py:63:41: "SECRUITY" is a misspelling of "SECURITY"
airflow/contrib/operators/gcs_to_bq.py:89:29: "Thsi" is a misspelling of "This"
airflow/contrib/operators/mlengine_operator_utils.py:163:69: "prediciton" is a misspelling of "prediction"
airflow/contrib/operators/qubole_check_operator.py:31:69: "Commmand" is a misspelling of "Command"
airflow/contrib/plugins/metastore_browser/templates/metastore_browser/table.html:31:106: "Atributes" is a misspelling of "Attributes"
airflow/hooks/mysql_hook.py:124:27: "seperately" is a misspelling of "separately"
airflow/operators/hive_to_druid.py:167:19: "compatibilty" is a misspelling of "compatibility"
airflow/sensors/hdfs_sensor.py:91:20: "extentions" is a misspelling of "extensions"
airflow/sensors/hdfs_sensor.py:94:24: "extentions" is a misspelling of "extensions"
airflow/sensors/hdfs_sensor.py:96:55: "extentions" is a misspelling of "extensions"
airflow/models.py:945:71: "acutally" is a misspelling of "actually"
```

#### after

```
$ misspell airflow/ | grep -v CHANGELOG.txt | grep -v www
2018/08/10 18:13:50 Unable to stat "airflow/www/static/docs": stat airflow/www/static/docs: no such file or directory
2018/08/10 18:13:50 Unable to stat "airflow/www_rbac/static/docs": stat airflow/www_rbac/static/docs: no such file or directory
```


### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

hmm, I am not sure if I can fix this.

```
$ git diff upstream/master -u -- "*.py" | flake8 --dif
fatal: bad revision 'upstream/master'
```