### PR TITLE
Revert "[AIRFLOW-2878] Fix www_rbac display issue"

### DIFF
--- a/airflow/www_rbac/templates/appbuilder/baselayout.html
+++ b/airflow/www_rbac/templates/appbuilder/baselayout.html
@@ -43,9 +43,6 @@
 
 
     <div class="container">
-      <br>
-      <br>
-      <br>
       <div class="row">
           {% block messages %}
             {% include 'appbuilder/flash.html' %}


### PR DESCRIPTION
Hi @r39132 , this is to revert my earlier PR https://github.com/apache/incubator-airflow/pull/3724.

As pointed out by @verdan , I encountered the issues that I tried to fix in my earlier PR because I didn't build the frontend packages using `npm` and `webpack`. That commit may also introduce extra spaces in each page.

Please refer to my conversation with Verdan in PR https://github.com/apache/incubator-airflow/pull/3724.

Sorry for the inconvenience cause, and thanks @verdan for having pointed this out.