### PR TITLE
[AIRFLOW-2886] Secure Flask SECRET_KEY

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -250,9 +250,8 @@ worker_refresh_batch_size = 1
 worker_refresh_interval = 30
 
 # Secret key used to run your flask app
-# If default value is given ("temporary_key"), a random secret_key will be generated
-# when you launch your webserver for security reason
-secret_key = temporary_key
+# It should be as random as possible
+secret_key = {SECRET_KEY}
 
 # Number of workers to run the Gunicorn web server
 workers = 4

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -22,6 +22,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from base64 import b64encode
 from builtins import str
 from collections import OrderedDict
 import copy
@@ -477,6 +478,8 @@ if not os.path.isfile(TEST_CONFIG_FILE) or not os.path.isfile(AIRFLOW_CONFIG):
     FERNET_KEY = generate_fernet_key()
 else:
     FERNET_KEY = ''
+
+SECRET_KEY = b64encode(os.urandom(16)).decode('utf-8')
 
 TEMPLATE_START = (
     '# ----------------------- TEMPLATE BEGINS HERE -----------------------')

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -49,13 +49,7 @@ def create_app(config=None, testing=False):
 
     app = Flask(__name__)
     app.wsgi_app = ProxyFix(app.wsgi_app)
-
-    if configuration.conf.get('webserver', 'SECRET_KEY') == "temporary_key":
-        log.info("SECRET_KEY for Flask App is not specified. Using a random one.")
-        app.secret_key = os.urandom(16)
-    else:
-        app.secret_key = configuration.conf.get('webserver', 'SECRET_KEY')
-
+    app.secret_key = configuration.conf.get('webserver', 'SECRET_KEY')
     app.config['LOGIN_DISABLED'] = not configuration.conf.getboolean(
         'webserver', 'AUTHENTICATE')
 

--- a/airflow/www_rbac/app.py
+++ b/airflow/www_rbac/app.py
@@ -43,10 +43,7 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
     global app, appbuilder
     app = Flask(__name__)
     app.wsgi_app = ProxyFix(app.wsgi_app)
-    if conf.get('webserver', 'SECRET_KEY') == "temporary_key":
-        app.secret_key = os.urandom(16)
-    else:
-        app.secret_key = conf.get('webserver', 'SECRET_KEY')
+    app.secret_key = conf.get('webserver', 'SECRET_KEY')
 
     airflow_home_path = conf.get('core', 'AIRFLOW_HOME')
     webserver_config_path = airflow_home_path + '/webserver_config.py'


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2886
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In my earlier PRs, https://github.com/apache/incubator-airflow/pull/3651 and https://github.com/apache/incubator-airflow/pull/3729 , I proposed to generate random `SECRET_KEY` for the `webserver` (Flask App).

However, I realise that we may encounter CSRF error `The CSRF session token is missing` when we have multiple workers for the Flask webserver, since the secret_key is not consistent among workers.

On the other hand, it's still very important to have as random SECRET_KEY as possible for security reasons. We can deal with it like how we dealt with `FERNET_KEY` (i.e. generate a random value when the airflow.cfg file is initiated).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
