### PR TITLE
[AIRFLOW-1368] Add auto_remove for DockerOperator

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -117,7 +117,6 @@ class DockerOperator(BaseOperator):
             force_pull=False,
             mem_limit=None,
             network_mode=None,
-            auto_remove=False,
             tls_ca_cert=None,
             tls_client_cert=None,
             tls_client_key=None,
@@ -130,6 +129,7 @@ class DockerOperator(BaseOperator):
             xcom_push=False,
             xcom_all=False,
             docker_conn_id=None,
+            auto_remove=False,
             *args,
             **kwargs):
 

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -66,6 +66,8 @@ class DockerOperator(BaseOperator):
     :type mem_limit: float or str
     :param network_mode: Network mode for the container.
     :type network_mode: str
+    :param auto_remove: Remove the container after execution. Default is false.
+    :type auto_remove: bool
     :param tls_ca_cert: Path to a PEM-encoded certificate authority
         to secure the docker connection.
     :type tls_ca_cert: str
@@ -115,6 +117,7 @@ class DockerOperator(BaseOperator):
             force_pull=False,
             mem_limit=None,
             network_mode=None,
+            auto_remove=False,
             tls_ca_cert=None,
             tls_client_cert=None,
             tls_client_key=None,
@@ -131,6 +134,7 @@ class DockerOperator(BaseOperator):
             **kwargs):
 
         super(DockerOperator, self).__init__(*args, **kwargs)
+        self.auto_remove = auto_remove
         self.api_version = api_version
         self.command = command
         self.cpus = cpus
@@ -203,7 +207,8 @@ class DockerOperator(BaseOperator):
                 host_config=self.cli.create_host_config(
                     binds=self.volumes,
                     network_mode=self.network_mode,
-                    shm_size=self.shm_size),
+                    shm_size=self.shm_size,
+                    auto_remove=self.auto_remove),
                 image=image,
                 mem_limit=self.mem_limit,
                 user=self.user,

--- a/tests/operators/docker_operator.py
+++ b/tests/operators/docker_operator.py
@@ -77,7 +77,8 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock.create_host_config.assert_called_with(binds=['/host/path:/container/path',
                                                                  '/mkdtemp:/tmp/airflow'],
                                                           network_mode='bridge',
-                                                          shm_size=1000)
+                                                          shm_size=1000,
+                                                          auto_remove=False)
         client_mock.images.assert_called_with(name='ubuntu:latest')
         client_mock.logs.assert_called_with(container='some_id', stream=True)
         client_mock.pull.assert_called_with('ubuntu:latest', stream=True)


### PR DESCRIPTION
Dear Airflow maintainers,

Please take this PR into consideration. It adds the ability for containers created by the `DockerOperator` to be removed automatically after execution. 

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-1368

Other issues which seem to be duplicate:
- https://issues.apache.org/jira/browse/AIRFLOW-516
- https://issues.apache.org/jira/browse/AIRFLOW-465

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds back the `auto_remove` option to the `DockerOperator`, which will automatically delete the Docker container once it exits. This was added before in PR #2411, but something went wrong there and it somehow got lost.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I have changed one of the unit tests to work with the change, ran the test cases for the docker_operator, and testing airflow locally to check the docker container gets removed if `auto_remove=True` and not removed if `auto_remove=False`.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

I updated the doc comment.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
