### PR TITLE
[AIRFLOW-2860] DruidHook: time check is wrong

### DIFF
--- a/airflow/hooks/druid_hook.py
+++ b/airflow/hooks/druid_hook.py
@@ -85,8 +85,6 @@ class DruidHook(BaseHook):
 
             self.log.info("Job still running for %s seconds...", sec)
 
-            sec = sec + 1
-
             if self.max_ingestion_time and sec > self.max_ingestion_time:
                 # ensure that the job gets killed if the max ingestion time is exceeded
                 requests.post("{0}/{1}/shutdown".format(url, druid_task_id))
@@ -94,6 +92,8 @@ class DruidHook(BaseHook):
                                        '%s seconds', self.max_ingestion_time)
 
             time.sleep(self.timeout)
+
+            sec = sec + self.timeout
 
             status = req_status.json()['status']['status']
             if status == 'RUNNING':


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow-2860](https://issues.apache.org/jira/browse/AIRFLOW-2860) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Initial pull request (#3707) was merged then reverted due to Travis build failing. Tests have been updated and merged in (#3710). This pull request is to fix a bug where the time variable that gets checked to see if the Druid ingestion task has exceeded max ingestion time is incorrectly updated.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tests were updated in (#3710)

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
