### PR TITLE
[AIRFLOW-2899] Hide sensitive data when Exporting Variables

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2566,10 +2566,13 @@ class VariableView(wwwutils.DataProfilingMixin, AirflowModelView):
         d = json.JSONDecoder()
         for var in qry:
             val = None
-            try:
-                val = d.decode(var.val)
-            except Exception:
-                val = var.val
+            if wwwutils.should_hide_value_for_key(var):
+                val = '*' * 8
+            else:
+                try:
+                    val = d.decode(var.val)
+                except Exception:
+                    val = var.val
             var_dict[var.key] = val
 
         response = make_response(json.dumps(var_dict, sort_keys=True, indent=4))

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -2030,10 +2030,13 @@ class VariableModelView(AirflowModelView):
         var_dict = {}
         d = json.JSONDecoder()
         for var in items:
-            try:
-                val = d.decode(var.val)
-            except Exception:
-                val = var.val
+            if wwwutils.should_hide_value_for_key(var):
+                val = '*' * 8
+            else:
+                try:
+                    val = d.decode(var.val)
+                except Exception:
+                    val = var.val
             var_dict[var.key] = val
 
         response = make_response(json.dumps(var_dict, sort_keys=True, indent=4))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2899
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Currently, the sensitive variable is hidden from being exposed in the Web UI. However, if the UI is compromised, someone can export variables where all the sensitive variables are exported in plain text format.

![image](https://user-images.githubusercontent.com/8811558/44098679-bfbf885e-9fd8-11e8-9486-864a93f2ef61.png)

This will still allow an admin to export all the variables from the CLI. The main intention here would be incase of an exposed Web UI, the sensitive data should still be inaccessible.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
