### PR TITLE
[Airflow-1737] Handle `execution_date`s with fractional seconds in www/views

### DIFF
--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -225,3 +225,18 @@ def days_ago(n, hour=0, minute=0, second=0, microsecond=0):
         second=second,
         microsecond=microsecond)
     return today - timedelta(days=n)
+
+
+def execution_date_ptime(date_string):
+    """
+    Get datetime.datetime object from given date_string assuming format
+    string is ISO8601-like (aka looks like an execution_date).
+    Like datetime.strptime but for execution_dates.
+    Handles execution dates with *and* without fractional seconds.
+    """
+    ISO8601_FMT = '%Y-%m-%d %H:%M:%S'
+    ISO8601_FMT_FRACTIONAL = ISO8601_FMT + '.%f'
+    if len(date_string) > 19:  # eg: 'YYYY-MM-DD HH:MM:SS.fffffff'
+        return datetime.strptime(date_string, ISO8601_FMT_FRACTIONAL)
+    else:  # eg 'YYYY-MM-DD HH:MM:SS'
+        return datetime.strptime(ISO8601_FMT)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [AIRFLOW-1737](https://issues.apache.org/jira/browse/AIRFLOW-1737) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-1737

### Description

- [X] Adds a simple util method to handle `execution_date` strings with and without fractional seconds based on length & uses it to address linked issue.

### Tests

- [X] does not need (additional) testing for this extremely good reason: Should be covered under existing tests

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
well... `git diff 1b53882a7cc64358e09eed3afb53069c1fba2b94 -u -- "*.py" | flake8 --diff`
aka `git diff upstream/v1-9-test -u -- "*.py" | flake8 --diff`... yes.
