### PR TITLE
[AIRFLOW-2907] Fix Sendgrid attachments bytes error

### DIFF
--- a/airflow/contrib/utils/sendgrid.py
+++ b/airflow/contrib/utils/sendgrid.py
@@ -88,7 +88,7 @@ def send_email(to, subject, html_content, files=None,
         basename = os.path.basename(fname)
         attachment = Attachment()
         with open(fname, "rb") as f:
-            attachment.content = base64.b64encode(f.read())
+            attachment.content = str(base64.b64encode(f.read()), 'utf-8')
             attachment.type = mimetypes.guess_type(basename)[0]
             attachment.filename = basename
             attachment.disposition = "attachment"


### PR DESCRIPTION
[AIRFLOW-2907] Fix Sendgrid - Attachments - ERROR - Object of type 'bytes' is not JSON serializable
https://issues.apache.org/jira/browse/AIRFLOW-2907

Attempting to attach files via Sendgrid operator always gives:

```
Sendgrid - Attachments - ERROR - Object of type 'bytes' is not JSON serializable
```

h4. How to reproduce:

By setting files=['/nfs/somefile_to_attach.ipynb'] while using the EmailOperator

```
export AIRFLOW__EMAIL__EMAIL_BACKEND="airflow.contrib.utils.sendgrid.send_email"
```

```
from airflow.operators.email_operator import EmailOperator

email_task = EmailOperator(
    task_id='email_task',
    to="someone@hola.com", 
    subject='This has an attachment',
    html_content='this has an attachment',
    files=['/nfs/somefile_to_attach.ipynb'],
    dag=dag)
```

h4. Root cause

Returned the encoded `bytes` type
https://docs.python.org/3/library/base64.html#base64.b64encode

However `attachment.content` expects a string.

Problem is in this line:
https://github.com/apache/incubator-airflow/blob/9d516c7134eb22a3c2fc63cf96626ef6e8b247f2/airflow/contrib/utils/sendgrid.py#L91

```
attachment.content = base64.b64encode(f.read())
```

h4. Solution via str()

By googling the found solution was:
https://stackoverflow.com/questions/47479205/e-mail-attachment-using-sendgird
https://stackoverflow.com/questions/44933816/encode-csv-file-for-sendgrids-email-api/44934090

```
attachment.content = str(base64.b64encode(f.read()), 'utf-8')
```
