### PR TITLE
[AIRFLOW-2913] Check bucket_key/bucket_name combination in S3KeySensor()

### DIFF
--- a/airflow/sensors/s3_key_sensor.py
+++ b/airflow/sensors/s3_key_sensor.py
@@ -32,9 +32,11 @@ class S3KeySensor(BaseSensorOperator):
     a resource.
 
     :param bucket_key: The key being waited on. Supports full s3:// style url
-        or relative path from root level.
+        or relative path from root level. When it's specified as a full s3://
+        url, please leave bucket_name as `None`.
     :type bucket_key: str
-    :param bucket_name: Name of the S3 bucket
+    :param bucket_name: Name of the S3 bucket. Only needed when ``bucket_key``
+        is not provided as a full s3:// url.
     :type bucket_name: str
     :param wildcard_match: whether the bucket_key should be interpreted as a
         Unix wildcard pattern
@@ -64,6 +66,12 @@ class S3KeySensor(BaseSensorOperator):
                     bucket_key = parsed_url.path[1:]
                 else:
                     bucket_key = parsed_url.path
+        else:
+            parsed_url = urlparse(bucket_key)
+            if parsed_url.scheme != '' or parsed_url.netloc != '':
+                raise AirflowException('If bucket_name is provided, bucket_key' +
+                                       ' should be relative path from root' +
+                                       ' level, rather than a full s3:// url')
         self.bucket_name = bucket_name
         self.bucket_key = bucket_key
         self.wildcard_match = wildcard_match

--- a/tests/sensors/test_s3_key_sensor.py
+++ b/tests/sensors/test_s3_key_sensor.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from airflow.exceptions import AirflowException
+from airflow.sensors.s3_key_sensor import S3KeySensor
+
+
+class S3KeySensorTests(unittest.TestCase):
+
+    def test_bucket_name_None_and_bucket_key_as_relative_path(self):
+        """
+        Test if exception is raised when bucket_name is None
+        and bucket_key is provided as relative path rather than s3:// url.
+        :return:
+        """
+        with self.assertRaises(AirflowException):
+            S3KeySensor(bucket_key="file_in_bucket")
+
+    def test_bucket_name_provided_and_bucket_key_is_s3_url(self):
+        """
+        Test if exception is raised when bucket_name is provided
+        while bucket_key is provided as a full s3:// url.
+        :return:
+        """
+        with self.assertRaises(AirflowException):
+            S3KeySensor(bucket_key="s3://test_bucket/file",
+                        bucket_name='test_bucket')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2913
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

1. in `S3KeySensor()`, when `bucket_name` is provided, and `bucket_key` is also provided as a full S3:// url, the `full_url` obtained eventually will be wrong. It will be like "`s3://bucket_name/s3://bucket_name/object_key`". This should be avoided by adding checking and raise exception in such case.

2. Given the documentation is not clear enough, this issue may happen to new users of S3KeySensor(). I have improved the Documentation as well.

3. Unit tests are added for the `bucket_key` and `bucket_name` combination checking as well.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
