### PR TITLE
[AIRFLOW-2915] Add example DAG for GoogleCloudStorageToBigQueryOperator

### DIFF
--- a/airflow/contrib/example_dags/example_gcs_to_bq_operator.py
+++ b/airflow/contrib/example_dags/example_gcs_to_bq_operator.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import airflow
+try:
+    from airflow.contrib.operators import gcs_to_bq
+except ImportError:
+    gcs_to_bq = None
+from airflow import models
+from airflow.operators import bash_operator
+
+
+if gcs_to_bq is not None:
+    args = {
+        'owner': 'airflow',
+        'start_date': airflow.utils.dates.days_ago(2)
+    }
+
+    dag = models.DAG(
+        dag_id='example_gcs_to_bq_operator', default_args=args,
+        schedule_interval=None)
+
+    create_test_dataset = bash_operator.BashOperator(
+        task_id='create_airflow_test_dataset',
+        bash_command='bq mk airflow_test',
+        dag=dag)
+
+    # [START howto_operator_gcs_to_bq]
+    load_csv = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+        task_id='gcs_to_bq_example',
+        bucket='cloud-samples-data',
+        source_objects=['bigquery/us-states/us-states.csv'],
+        destination_project_dataset_table='airflow_test.gcs_to_bq_table',
+        schema_fields=[
+            {'name': 'name', 'type': 'STRING', 'mode': 'NULLABLE'},
+            {'name': 'post_abbr', 'type': 'STRING', 'mode': 'NULLABLE'},
+        ],
+        write_disposition='WRITE_TRUNCATE',
+        dag=dag)
+    # [END howto_operator_gcs_to_bq]
+
+    delete_test_dataset = bash_operator.BashOperator(
+        task_id='delete_airflow_test_dataset',
+        bash_command='bq rm -rf airflow_test',
+        dag=dag)
+
+    create_test_dataset >> load_csv >> delete_test_dataset

--- a/docs/howto/operator.rst
+++ b/docs/howto/operator.rst
@@ -85,3 +85,19 @@ template variables <macros>` and a ``templates_dict`` argument.
 
 The ``templates_dict`` argument is templated, so each value in the dictionary
 is evaluated as a :ref:`Jinja template <jinja-templating>`.
+
+Google Cloud Platform Operators
+-------------------------------
+
+GoogleCloudStorageToBigQueryOperator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use the
+:class:`~airflow.contrib.operators.gcs_to_bq.GoogleCloudStorageToBigQueryOperator`
+to execute a BigQuery load job.
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcs_to_bq_operator.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcs_to_bq]
+    :end-before: [END howto_operator_gcs_to_bq]


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2915

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Docs-only change to add an example DAG and a section for GoogleCloudStorageToBigQueryOperator to the operators how-to guides.

![image](https://user-images.githubusercontent.com/247555/44287343-5c3e3000-a221-11e8-8f76-1cd5df53445d.png)


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

N/A docs-only.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
