### PR TITLE
[AIRFLOW-2245] Add remote_host of SSH/SFTP operator as templated field

### DIFF
--- a/airflow/contrib/operators/sftp_operator.py
+++ b/airflow/contrib/operators/sftp_operator.py
@@ -37,7 +37,7 @@ class SFTPOperator(BaseOperator):
     :type ssh_hook: :class:`SSHHook`
     :param ssh_conn_id: connection id from airflow Connections
     :type ssh_conn_id: str
-    :param remote_host: remote host to connect
+    :param remote_host: remote host to connect (templated)
     :type remote_host: str
     :param local_filepath: local file path to get or put. (templated)
     :type local_filepath: str
@@ -48,7 +48,7 @@ class SFTPOperator(BaseOperator):
     :param confirm: specify if the SFTP operation should be confirmed, defaults to True
     :type confirm: bool
     """
-    template_fields = ('local_filepath', 'remote_filepath')
+    template_fields = ('local_filepath', 'remote_filepath', 'remote_host')
 
     @apply_defaults
     def __init__(self,

--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -35,7 +35,7 @@ class SSHOperator(BaseOperator):
     :type ssh_hook: :class:`SSHHook`
     :param ssh_conn_id: connection id from airflow Connections
     :type ssh_conn_id: str
-    :param remote_host: remote host to connect
+    :param remote_host: remote host to connect (templated)
     :type remote_host: str
     :param command: command to execute on remote host. (templated)
     :type command: str
@@ -45,7 +45,7 @@ class SSHOperator(BaseOperator):
     :type do_xcom_push: bool
     """
 
-    template_fields = ('command',)
+    template_fields = ('command', 'remote_host')
     template_ext = ('.sh',)
 
     @apply_defaults


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2245
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
It added `remote_host` to the templated fields .`remote_host` can be obtained at the beginning of the DAG and pass to SSH/SFTP operator with xcom.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
My PR does not add tests because this is a small change, and there are no tests currently in-place to test the templated fields.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
