### PR TITLE
[AIRFLOW-XXX] Specify email domain, less ambigious

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -280,7 +280,7 @@ Google Authentication
 '''''''''''''''''''''
 
 The Google authentication backend can be used to authenticate users
-against Google using OAuth2. You must specify the domains to restrict
+against Google using OAuth2. You must specify the email domains to restrict
 login, separated with a comma, to only members of those domains.
 
 .. code-block:: bash


### PR DESCRIPTION
### Description

- [x] I didn't realise that the domain in the google oauth docs meant your email domain until looking at the code. Small fix to rectify this.

### Tests

- [x] one word documentation change, no extra tests

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
