### PR TITLE
[AIRFLOW-2918] Fix Flake8 violations

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -32,8 +32,8 @@ __version__ = version.version
 
 import sys
 
-from airflow import configuration as conf
-from airflow import settings
+# flake8: noqa: F401
+from airflow import settings, configuration as conf
 from airflow.models import DAG
 from flask_admin import BaseView
 from importlib import import_module

--- a/airflow/contrib/auth/backends/github_enterprise_auth.py
+++ b/airflow/contrib/auth/backends/github_enterprise_auth.py
@@ -19,18 +19,14 @@
 import flask_login
 
 # Need to expose these downstream
-# pylint: disable=unused-import
-from flask_login import (current_user,
-                         logout_user,
-                         login_required,
-                         login_user)
-# pylint: enable=unused-import
+# flake8: noqa: F401
+from flask_login import current_user, logout_user, login_required, login_user
 
 from flask import url_for, redirect, request
 
 from flask_oauthlib.client import OAuth
 
-from airflow import models, configuration, settings
+from airflow import models, configuration
 from airflow.configuration import AirflowConfigException
 from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin

--- a/airflow/contrib/auth/backends/google_auth.py
+++ b/airflow/contrib/auth/backends/google_auth.py
@@ -19,18 +19,14 @@
 import flask_login
 
 # Need to expose these downstream
-# pylint: disable=unused-import
-from flask_login import (current_user,
-                         logout_user,
-                         login_required,
-                         login_user)
-# pylint: enable=unused-import
+# flake8: noqa: F401
+from flask_login import current_user, logout_user, login_required, login_user
 
 from flask import url_for, redirect, request
 
 from flask_oauthlib.client import OAuth
 
-from airflow import models, configuration, settings
+from airflow import models, configuration
 from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
 

--- a/airflow/contrib/auth/backends/kerberos_auth.py
+++ b/airflow/contrib/auth/backends/kerberos_auth.py
@@ -21,8 +21,7 @@ import logging
 import flask_login
 from flask_login import current_user
 from flask import flash
-from wtforms import (
-    Form, PasswordField, StringField)
+from wtforms import Form, PasswordField, StringField
 from wtforms.validators import InputRequired
 
 # pykerberos should be used as it verifies the KDC, the "kerberos" module does not do so
@@ -32,7 +31,6 @@ from airflow.security import utils
 
 from flask import url_for, redirect
 
-from airflow import settings
 from airflow import models
 from airflow import configuration
 from airflow.utils.db import provide_session

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -19,13 +19,12 @@
 from future.utils import native
 
 import flask_login
-from flask_login import login_required, current_user, logout_user
+from flask_login import login_required, current_user, logout_user  # noqa: F401
 from flask import flash
-from wtforms import (
-    Form, PasswordField, StringField)
+from wtforms import Form, PasswordField, StringField
 from wtforms.validators import InputRequired
 
-from ldap3 import Server, Connection, Tls, LEVEL, SUBTREE, BASE
+from ldap3 import Server, Connection, Tls, LEVEL, SUBTREE
 import ssl
 
 from flask import url_for, redirect

--- a/airflow/contrib/operators/mlengine_prediction_summary.py
+++ b/airflow/contrib/operators/mlengine_prediction_summary.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F841
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/airflow/default_login.py
+++ b/airflow/default_login.py
@@ -25,11 +25,11 @@ the new module will override this one.
 """
 
 import flask_login
-from flask_login import login_required, current_user, logout_user
+from flask_login import login_required, current_user, logout_user  # noqa: F401
 
 from flask import url_for, redirect
 
-from airflow import settings
+from airflow import settings  # noqa: F401
 from airflow import models
 from airflow.utils.db import provide_session
 
@@ -63,9 +63,6 @@ class DefaultUser(object):
     def is_superuser(self):
         """Access all the things"""
         return True
-
-# models.User = User  # hack!
-# del User
 
 
 @login_manager.user_loader

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -658,7 +658,7 @@ class SchedulerJob(BaseJob):
         slas = (
             session
             .query(SlaMiss)
-            .filter(SlaMiss.notification_sent == False)
+            .filter(SlaMiss.notification_sent == False)  # noqa: E712
             .filter(SlaMiss.dag_id == dag.dag_id)
             .all()
         )
@@ -708,16 +708,13 @@ class SchedulerJob(BaseJob):
             Blocking tasks:
             <pre><code>{blocking_task_list}\n{bug}<code></pre>
             """.format(bug=asciiart.bug, **locals())
-            emails = []
-            for t in dag.tasks:
-                if t.email:
-                    if isinstance(t.email, basestring):
-                        l = [t.email]
-                    elif isinstance(t.email, (list, tuple)):
-                        l = t.email
-                    for email in l:
-                        if email not in emails:
-                            emails.append(email)
+            emails = set()
+            for task in dag.tasks:
+                if task.email:
+                    if isinstance(task.email, basestring):
+                        emails.add(task.email)
+                    elif isinstance(task.email, (list, tuple)):
+                        emails |= set(task.email)
             if emails and len(slas):
                 try:
                     send_email(
@@ -818,7 +815,7 @@ class SchedulerJob(BaseJob):
                 session.query(func.max(DagRun.execution_date))
                 .filter_by(dag_id=dag.dag_id)
                 .filter(or_(
-                    DagRun.external_trigger == False,
+                    DagRun.external_trigger == False,  # noqa: E712
                     # add % as a wildcard for the like query
                     DagRun.run_id.like(DagRun.ID_PREFIX + '%')
                 ))
@@ -1089,14 +1086,16 @@ class SchedulerJob(BaseJob):
                 DR,
                 and_(DR.dag_id == TI.dag_id, DR.execution_date == TI.execution_date)
             )
-            .filter(or_(DR.run_id == None,  # noqa E711
+            .filter(or_(DR.run_id == None,  # noqa: E711
                     not_(DR.run_id.like(BackfillJob.ID_PREFIX + '%'))))
             .outerjoin(DM, DM.dag_id == TI.dag_id)
-            .filter(or_(DM.dag_id == None,  # noqa E711
+            .filter(or_(DM.dag_id == None,  # noqa: E711
                     not_(DM.is_paused)))
         )
         if None in states:
-            ti_query = ti_query.filter(or_(TI.state == None, TI.state.in_(states))) # noqa E711
+            ti_query = ti_query.filter(
+                or_(TI.state == None, TI.state.in_(states))  # noqa: E711
+            )
         else:
             ti_query = ti_query.filter(TI.state.in_(states))
 
@@ -1184,8 +1183,8 @@ class SchedulerJob(BaseJob):
                 )
                 if current_task_concurrency >= task_concurrency_limit:
                     self.log.info(
-                        "Not executing %s since the number of tasks running or queued from DAG %s"
-                        " is >= to the DAG's task concurrency limit of %s",
+                        "Not executing %s since the number of tasks running or queued "
+                        "from DAG %s is >= to the DAG's task concurrency limit of %s",
                         task_instance, dag_id, task_concurrency_limit
                     )
                     continue
@@ -1261,7 +1260,7 @@ class SchedulerJob(BaseJob):
 
         if None in acceptable_states:
             ti_query = ti_query.filter(
-                or_(TI.state == None, TI.state.in_(acceptable_states)) # noqa E711
+                or_(TI.state == None, TI.state.in_(acceptable_states))  # noqa: E711
             )
         else:
             ti_query = ti_query.filter(TI.state.in_(acceptable_states))

--- a/airflow/migrations/env.py
+++ b/airflow/migrations/env.py
@@ -85,6 +85,7 @@ def run_migrations_online():
         with context.begin_transaction():
             context.run_migrations()
 
+
 if context.is_offline_mode():
     run_migrations_offline()
 else:

--- a/airflow/migrations/versions/05f30312d566_merge_heads.py
+++ b/airflow/migrations/versions/05f30312d566_merge_heads.py
@@ -31,9 +31,6 @@ down_revision = ('86770d1215c0', '0e2a74e0fc9f')
 branch_labels = None
 depends_on = None
 
-from alembic import op
-import sqlalchemy as sa
-
 
 def upgrade():
     pass

--- a/airflow/migrations/versions/0e2a74e0fc9f_add_time_zone_awareness.py
+++ b/airflow/migrations/versions/0e2a74e0fc9f_add_time_zone_awareness.py
@@ -25,15 +25,15 @@ Create Date: 2017-11-10 22:22:31.326152
 
 """
 
+from alembic import op
+from sqlalchemy.dialects import mysql
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = '0e2a74e0fc9f'
 down_revision = 'd2ae31099d61'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-from sqlalchemy.dialects import mysql
-import sqlalchemy as sa
 
 
 def upgrade():
@@ -69,14 +69,16 @@ def upgrade():
         op.alter_column(table_name='log', column_name='dttm', type_=mysql.TIMESTAMP(fsp=6))
         op.alter_column(table_name='log', column_name='execution_date', type_=mysql.TIMESTAMP(fsp=6))
 
-        op.alter_column(table_name='sla_miss', column_name='execution_date', type_=mysql.TIMESTAMP(fsp=6), nullable=False)
+        op.alter_column(table_name='sla_miss', column_name='execution_date', type_=mysql.TIMESTAMP(fsp=6),
+                        nullable=False)
         op.alter_column(table_name='sla_miss', column_name='timestamp', type_=mysql.TIMESTAMP(fsp=6))
 
         op.alter_column(table_name='task_fail', column_name='execution_date', type_=mysql.TIMESTAMP(fsp=6))
         op.alter_column(table_name='task_fail', column_name='start_date', type_=mysql.TIMESTAMP(fsp=6))
         op.alter_column(table_name='task_fail', column_name='end_date', type_=mysql.TIMESTAMP(fsp=6))
 
-        op.alter_column(table_name='task_instance', column_name='execution_date', type_=mysql.TIMESTAMP(fsp=6), nullable=False)
+        op.alter_column(table_name='task_instance', column_name='execution_date', type_=mysql.TIMESTAMP(fsp=6),
+                        nullable=False)
         op.alter_column(table_name='task_instance', column_name='start_date', type_=mysql.TIMESTAMP(fsp=6))
         op.alter_column(table_name='task_instance', column_name='end_date', type_=mysql.TIMESTAMP(fsp=6))
         op.alter_column(table_name='task_instance', column_name='queued_dttm', type_=mysql.TIMESTAMP(fsp=6))
@@ -117,14 +119,16 @@ def upgrade():
         op.alter_column(table_name='log', column_name='dttm', type_=sa.TIMESTAMP(timezone=True))
         op.alter_column(table_name='log', column_name='execution_date', type_=sa.TIMESTAMP(timezone=True))
 
-        op.alter_column(table_name='sla_miss', column_name='execution_date', type_=sa.TIMESTAMP(timezone=True), nullable=False)
+        op.alter_column(table_name='sla_miss', column_name='execution_date', type_=sa.TIMESTAMP(timezone=True),
+                        nullable=False)
         op.alter_column(table_name='sla_miss', column_name='timestamp', type_=sa.TIMESTAMP(timezone=True))
 
         op.alter_column(table_name='task_fail', column_name='execution_date', type_=sa.TIMESTAMP(timezone=True))
         op.alter_column(table_name='task_fail', column_name='start_date', type_=sa.TIMESTAMP(timezone=True))
         op.alter_column(table_name='task_fail', column_name='end_date', type_=sa.TIMESTAMP(timezone=True))
 
-        op.alter_column(table_name='task_instance', column_name='execution_date', type_=sa.TIMESTAMP(timezone=True), nullable=False)
+        op.alter_column(table_name='task_instance', column_name='execution_date', type_=sa.TIMESTAMP(timezone=True),
+                        nullable=False)
         op.alter_column(table_name='task_instance', column_name='start_date', type_=sa.TIMESTAMP(timezone=True))
         op.alter_column(table_name='task_instance', column_name='end_date', type_=sa.TIMESTAMP(timezone=True))
         op.alter_column(table_name='task_instance', column_name='queued_dttm', type_=sa.TIMESTAMP(timezone=True))
@@ -161,14 +165,16 @@ def downgrade():
         op.alter_column(table_name='log', column_name='dttm', type_=mysql.DATETIME(fsp=6))
         op.alter_column(table_name='log', column_name='execution_date', type_=mysql.DATETIME(fsp=6))
 
-        op.alter_column(table_name='sla_miss', column_name='execution_date', type_=mysql.DATETIME(fsp=6), nullable=False)
+        op.alter_column(table_name='sla_miss', column_name='execution_date', type_=mysql.DATETIME(fsp=6),
+                        nullable=False)
         op.alter_column(table_name='sla_miss', column_name='DATETIME', type_=mysql.DATETIME(fsp=6))
 
         op.alter_column(table_name='task_fail', column_name='execution_date', type_=mysql.DATETIME(fsp=6))
         op.alter_column(table_name='task_fail', column_name='start_date', type_=mysql.DATETIME(fsp=6))
         op.alter_column(table_name='task_fail', column_name='end_date', type_=mysql.DATETIME(fsp=6))
 
-        op.alter_column(table_name='task_instance', column_name='execution_date', type_=mysql.DATETIME(fsp=6), nullable=False)
+        op.alter_column(table_name='task_instance', column_name='execution_date', type_=mysql.DATETIME(fsp=6),
+                        nullable=False)
         op.alter_column(table_name='task_instance', column_name='start_date', type_=mysql.DATETIME(fsp=6))
         op.alter_column(table_name='task_instance', column_name='end_date', type_=mysql.DATETIME(fsp=6))
         op.alter_column(table_name='task_instance', column_name='queued_dttm', type_=mysql.DATETIME(fsp=6))

--- a/airflow/migrations/versions/127d2bf2dfa7_add_dag_id_state_index_on_dag_run_table.py
+++ b/airflow/migrations/versions/127d2bf2dfa7_add_dag_id_state_index_on_dag_run_table.py
@@ -23,6 +23,7 @@ Revises: 5e7d17757c7a
 Create Date: 2017-01-25 11:43:51.635667
 
 """
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '127d2bf2dfa7'
@@ -30,8 +31,6 @@ down_revision = '5e7d17757c7a'
 branch_labels = None
 depends_on = None
 
-from alembic import op
-import sqlalchemy as sa
 
 def upgrade():
     op.create_index('dag_id_state', 'dag_run', ['dag_id', 'state'], unique=False)

--- a/airflow/migrations/versions/1507a7289a2f_create_is_encrypted.py
+++ b/airflow/migrations/versions/1507a7289a2f_create_is_encrypted.py
@@ -24,16 +24,15 @@ Revises: e3a246e0dc1
 Create Date: 2015-08-18 18:57:51.927315
 
 """
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.engine.reflection import Inspector
 
 # revision identifiers, used by Alembic.
 revision = '1507a7289a2f'
 down_revision = 'e3a246e0dc1'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.engine.reflection import Inspector
 
 connectionhelper = sa.Table(
     'connection',

--- a/airflow/migrations/versions/1968acfc09e3_add_is_encrypted_column_to_variable_.py
+++ b/airflow/migrations/versions/1968acfc09e3_add_is_encrypted_column_to_variable_.py
@@ -24,6 +24,8 @@ Revises: bba5a7cfc896
 Create Date: 2016-02-02 17:20:55.692295
 
 """
+from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '1968acfc09e3'
@@ -31,12 +33,9 @@ down_revision = 'bba5a7cfc896'
 branch_labels = None
 depends_on = None
 
-from alembic import op
-import sqlalchemy as sa
-
 
 def upgrade():
-    op.add_column('variable', sa.Column('is_encrypted', sa.Boolean,default=False))
+    op.add_column('variable', sa.Column('is_encrypted', sa.Boolean, default=False))
 
 
 def downgrade():

--- a/airflow/migrations/versions/1b38cef5b76e_add_dagrun.py
+++ b/airflow/migrations/versions/1b38cef5b76e_add_dagrun.py
@@ -25,28 +25,27 @@ Create Date: 2015-10-27 08:31:48.475140
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = '1b38cef5b76e'
 down_revision = '502898887f84'
 branch_labels = None
 depends_on = None
 
-from alembic import op
-import sqlalchemy as sa
-
 
 def upgrade():
     op.create_table('dag_run',
-        sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('dag_id', sa.String(length=250), nullable=True),
-        sa.Column('execution_date', sa.DateTime(), nullable=True),
-        sa.Column('state', sa.String(length=50), nullable=True),
-        sa.Column('run_id', sa.String(length=250), nullable=True),
-        sa.Column('external_trigger', sa.Boolean(), nullable=True),
-        sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('dag_id', 'execution_date'),
-        sa.UniqueConstraint('dag_id', 'run_id'),
-    )
+                    sa.Column('id', sa.Integer(), nullable=False),
+                    sa.Column('dag_id', sa.String(length=250), nullable=True),
+                    sa.Column('execution_date', sa.DateTime(), nullable=True),
+                    sa.Column('state', sa.String(length=50), nullable=True),
+                    sa.Column('run_id', sa.String(length=250), nullable=True),
+                    sa.Column('external_trigger', sa.Boolean(), nullable=True),
+                    sa.PrimaryKeyConstraint('id'),
+                    sa.UniqueConstraint('dag_id', 'execution_date'),
+                    sa.UniqueConstraint('dag_id', 'run_id'))
 
 
 def downgrade():

--- a/airflow/migrations/versions/211e584da130_add_ti_state_index.py
+++ b/airflow/migrations/versions/211e584da130_add_ti_state_index.py
@@ -24,15 +24,13 @@ Revises: 2e82aab8ef20
 Create Date: 2016-06-30 10:54:24.323588
 
 """
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '211e584da130'
 down_revision = '2e82aab8ef20'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/airflow/migrations/versions/27c6a30d7c24_add_executor_config_to_task_instance.py
+++ b/airflow/migrations/versions/27c6a30d7c24_add_executor_config_to_task_instance.py
@@ -26,17 +26,15 @@ Create Date: 2017-09-11 15:26:47.598494
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+import dill
+
 # revision identifiers, used by Alembic.
 revision = '27c6a30d7c24'
 down_revision = '33ae817a1ff4'
 branch_labels = None
 depends_on = None
-
-
-from alembic import op
-import sqlalchemy as sa
-import dill
-
 
 TASK_INSTANCE_TABLE = "task_instance"
 NEW_COLUMN = "executor_config"
@@ -48,4 +46,3 @@ def upgrade():
 
 def downgrade():
     op.drop_column(TASK_INSTANCE_TABLE, NEW_COLUMN)
-

--- a/airflow/migrations/versions/2e541a1dcfed_task_duration.py
+++ b/airflow/migrations/versions/2e541a1dcfed_task_duration.py
@@ -25,15 +25,15 @@ Create Date: 2015-10-28 20:38:41.266143
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
 # revision identifiers, used by Alembic.
 revision = '2e541a1dcfed'
 down_revision = '1b38cef5b76e'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.dialects import mysql
 
 
 def upgrade():

--- a/airflow/migrations/versions/2e82aab8ef20_rename_user_table.py
+++ b/airflow/migrations/versions/2e82aab8ef20_rename_user_table.py
@@ -24,15 +24,13 @@ Revises: 1968acfc09e3
 Create Date: 2016-04-02 19:28:15.211915
 
 """
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '2e82aab8ef20'
 down_revision = '1968acfc09e3'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/airflow/migrations/versions/338e90f54d61_more_logging_into_task_isntance.py
+++ b/airflow/migrations/versions/338e90f54d61_more_logging_into_task_isntance.py
@@ -17,22 +17,23 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""More logging into task_isntance
+"""More logging into task_instance
 
 Revision ID: 338e90f54d61
 Revises: 13eb55f81627
 Create Date: 2015-08-25 06:09:20.460147
 
 """
+# flake8: noqa: E266
+
+from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '338e90f54d61'
 down_revision = '13eb55f81627'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/airflow/migrations/versions/33ae817a1ff4_add_kubernetes_resource_checkpointing.py
+++ b/airflow/migrations/versions/33ae817a1ff4_add_kubernetes_resource_checkpointing.py
@@ -25,16 +25,14 @@ Revises: 947454bf1dff
 Create Date: 2017-09-11 15:26:47.598494
 
 """
+from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '33ae817a1ff4'
 down_revision = 'd2ae31099d61'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
-
 
 RESOURCE_TABLE = "kube_resource_version"
 
@@ -53,4 +51,3 @@ def upgrade():
 
 def downgrade():
     op.drop_table(RESOURCE_TABLE)
-

--- a/airflow/migrations/versions/40e67319e3a9_dagrun_config.py
+++ b/airflow/migrations/versions/40e67319e3a9_dagrun_config.py
@@ -24,15 +24,14 @@ Revises: 2e541a1dcfed
 Create Date: 2015-10-29 08:36:31.726728
 
 """
+from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '40e67319e3a9'
 down_revision = '2e541a1dcfed'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/airflow/migrations/versions/4446e08588_dagrun_start_end.py
+++ b/airflow/migrations/versions/4446e08588_dagrun_start_end.py
@@ -25,14 +25,14 @@ Create Date: 2015-12-10 11:26:18.439223
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = '4446e08588'
 down_revision = '561833c1c74b'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/airflow/migrations/versions/4addfa1236f1_add_fractional_seconds_to_mysql_tables.py
+++ b/airflow/migrations/versions/4addfa1236f1_add_fractional_seconds_to_mysql_tables.py
@@ -24,93 +24,147 @@ Create Date: 2016-09-11 13:39:18.592072
 
 """
 
+from alembic import op
+from sqlalchemy.dialects import mysql
+from alembic import context
+
 # revision identifiers, used by Alembic.
 revision = '4addfa1236f1'
 down_revision = 'f2ca10b85618'
 branch_labels = None
 depends_on = None
 
-from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.dialects import mysql
-from alembic import context
-
 
 def upgrade():
     if context.config.get_main_option('sqlalchemy.url').startswith('mysql'):
-        op.alter_column(table_name='dag', column_name='last_scheduler_run', type_=mysql.DATETIME(fsp=6))
-        op.alter_column(table_name='dag', column_name='last_pickled', type_=mysql.DATETIME(fsp=6))
-        op.alter_column(table_name='dag', column_name='last_expired', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='dag', column_name='last_scheduler_run',
+                        type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='dag', column_name='last_pickled',
+                        type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='dag', column_name='last_expired',
+                        type_=mysql.DATETIME(fsp=6))
 
-        op.alter_column(table_name='dag_pickle', column_name='created_dttm', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='dag_pickle', column_name='created_dttm',
+                        type_=mysql.DATETIME(fsp=6))
 
-        op.alter_column(table_name='dag_run', column_name='execution_date', type_=mysql.DATETIME(fsp=6))
-        op.alter_column(table_name='dag_run', column_name='start_date', type_=mysql.DATETIME(fsp=6))
-        op.alter_column(table_name='dag_run', column_name='end_date', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='dag_run', column_name='execution_date',
+                        type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='dag_run', column_name='start_date',
+                        type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='dag_run', column_name='end_date',
+                        type_=mysql.DATETIME(fsp=6))
 
-        op.alter_column(table_name='import_error', column_name='timestamp', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='import_error', column_name='timestamp',
+                        type_=mysql.DATETIME(fsp=6))
 
-        op.alter_column(table_name='job', column_name='start_date', type_=mysql.DATETIME(fsp=6))
-        op.alter_column(table_name='job', column_name='end_date', type_=mysql.DATETIME(fsp=6))
-        op.alter_column(table_name='job', column_name='latest_heartbeat', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='job', column_name='start_date',
+                        type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='job', column_name='end_date',
+                        type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='job', column_name='latest_heartbeat',
+                        type_=mysql.DATETIME(fsp=6))
 
-        op.alter_column(table_name='known_event', column_name='start_date', type_=mysql.DATETIME(fsp=6))
-        op.alter_column(table_name='known_event', column_name='end_date', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='known_event', column_name='start_date',
+                        type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='known_event', column_name='end_date',
+                        type_=mysql.DATETIME(fsp=6))
 
-        op.alter_column(table_name='log', column_name='dttm', type_=mysql.DATETIME(fsp=6))
-        op.alter_column(table_name='log', column_name='execution_date', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='log', column_name='dttm',
+                        type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='log', column_name='execution_date',
+                        type_=mysql.DATETIME(fsp=6))
 
-        op.alter_column(table_name='sla_miss', column_name='execution_date', type_=mysql.DATETIME(fsp=6), nullable=False)
-        op.alter_column(table_name='sla_miss', column_name='timestamp', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='sla_miss', column_name='execution_date',
+                        type_=mysql.DATETIME(fsp=6),
+                        nullable=False)
+        op.alter_column(table_name='sla_miss', column_name='timestamp',
+                        type_=mysql.DATETIME(fsp=6))
 
-        op.alter_column(table_name='task_fail', column_name='execution_date', type_=mysql.DATETIME(fsp=6))
-        op.alter_column(table_name='task_fail', column_name='start_date', type_=mysql.DATETIME(fsp=6))
-        op.alter_column(table_name='task_fail', column_name='end_date', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='task_fail', column_name='execution_date',
+                        type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='task_fail', column_name='start_date',
+                        type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='task_fail', column_name='end_date',
+                        type_=mysql.DATETIME(fsp=6))
 
-        op.alter_column(table_name='task_instance', column_name='execution_date', type_=mysql.DATETIME(fsp=6), nullable=False)
-        op.alter_column(table_name='task_instance', column_name='start_date', type_=mysql.DATETIME(fsp=6))
-        op.alter_column(table_name='task_instance', column_name='end_date', type_=mysql.DATETIME(fsp=6))
-        op.alter_column(table_name='task_instance', column_name='queued_dttm', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='task_instance', column_name='execution_date',
+                        type_=mysql.DATETIME(fsp=6),
+                        nullable=False)
+        op.alter_column(table_name='task_instance', column_name='start_date',
+                        type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='task_instance', column_name='end_date',
+                        type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='task_instance', column_name='queued_dttm',
+                        type_=mysql.DATETIME(fsp=6))
 
-        op.alter_column(table_name='xcom', column_name='timestamp', type_=mysql.DATETIME(fsp=6))
-        op.alter_column(table_name='xcom', column_name='execution_date', type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='xcom', column_name='timestamp',
+                        type_=mysql.DATETIME(fsp=6))
+        op.alter_column(table_name='xcom', column_name='execution_date',
+                        type_=mysql.DATETIME(fsp=6))
 
 
 def downgrade():
     if context.config.get_main_option('sqlalchemy.url').startswith('mysql'):
-        op.alter_column(table_name='dag', column_name='last_scheduler_run', type_=mysql.DATETIME())
-        op.alter_column(table_name='dag', column_name='last_pickled', type_=mysql.DATETIME())
-        op.alter_column(table_name='dag', column_name='last_expired', type_=mysql.DATETIME())
+        op.alter_column(table_name='dag', column_name='last_scheduler_run',
+                        type_=mysql.DATETIME())
+        op.alter_column(table_name='dag', column_name='last_pickled',
+                        type_=mysql.DATETIME())
+        op.alter_column(table_name='dag', column_name='last_expired',
+                        type_=mysql.DATETIME())
 
-        op.alter_column(table_name='dag_pickle', column_name='created_dttm', type_=mysql.DATETIME())
+        op.alter_column(table_name='dag_pickle', column_name='created_dttm',
+                        type_=mysql.DATETIME())
 
-        op.alter_column(table_name='dag_run', column_name='execution_date', type_=mysql.DATETIME())
-        op.alter_column(table_name='dag_run', column_name='start_date', type_=mysql.DATETIME())
-        op.alter_column(table_name='dag_run', column_name='end_date', type_=mysql.DATETIME())
+        op.alter_column(table_name='dag_run', column_name='execution_date',
+                        type_=mysql.DATETIME())
+        op.alter_column(table_name='dag_run', column_name='start_date',
+                        type_=mysql.DATETIME())
+        op.alter_column(table_name='dag_run', column_name='end_date',
+                        type_=mysql.DATETIME())
 
-        op.alter_column(table_name='import_error', column_name='timestamp', type_=mysql.DATETIME())
+        op.alter_column(table_name='import_error', column_name='timestamp',
+                        type_=mysql.DATETIME())
 
-        op.alter_column(table_name='job', column_name='start_date', type_=mysql.DATETIME())
-        op.alter_column(table_name='job', column_name='end_date', type_=mysql.DATETIME())
-        op.alter_column(table_name='job', column_name='latest_heartbeat', type_=mysql.DATETIME())
+        op.alter_column(table_name='job', column_name='start_date',
+                        type_=mysql.DATETIME())
+        op.alter_column(table_name='job', column_name='end_date',
+                        type_=mysql.DATETIME())
+        op.alter_column(table_name='job', column_name='latest_heartbeat',
+                        type_=mysql.DATETIME())
 
-        op.alter_column(table_name='known_event', column_name='start_date', type_=mysql.DATETIME())
-        op.alter_column(table_name='known_event', column_name='end_date', type_=mysql.DATETIME())
+        op.alter_column(table_name='known_event', column_name='start_date',
+                        type_=mysql.DATETIME())
+        op.alter_column(table_name='known_event', column_name='end_date',
+                        type_=mysql.DATETIME())
 
-        op.alter_column(table_name='log', column_name='dttm', type_=mysql.DATETIME())
-        op.alter_column(table_name='log', column_name='execution_date', type_=mysql.DATETIME())
+        op.alter_column(table_name='log', column_name='dttm',
+                        type_=mysql.DATETIME())
+        op.alter_column(table_name='log', column_name='execution_date',
+                        type_=mysql.DATETIME())
 
-        op.alter_column(table_name='sla_miss', column_name='execution_date', type_=mysql.DATETIME(), nullable=False)
-        op.alter_column(table_name='sla_miss', column_name='timestamp', type_=mysql.DATETIME())
+        op.alter_column(table_name='sla_miss', column_name='execution_date',
+                        type_=mysql.DATETIME(), nullable=False)
+        op.alter_column(table_name='sla_miss', column_name='timestamp',
+                        type_=mysql.DATETIME())
 
-        op.alter_column(table_name='task_fail', column_name='execution_date', type_=mysql.DATETIME())
-        op.alter_column(table_name='task_fail', column_name='start_date', type_=mysql.DATETIME())
-        op.alter_column(table_name='task_fail', column_name='end_date', type_=mysql.DATETIME())
+        op.alter_column(table_name='task_fail', column_name='execution_date',
+                        type_=mysql.DATETIME())
+        op.alter_column(table_name='task_fail', column_name='start_date',
+                        type_=mysql.DATETIME())
+        op.alter_column(table_name='task_fail', column_name='end_date',
+                        type_=mysql.DATETIME())
 
-        op.alter_column(table_name='task_instance', column_name='execution_date', type_=mysql.DATETIME(), nullable=False)
-        op.alter_column(table_name='task_instance', column_name='start_date', type_=mysql.DATETIME())
-        op.alter_column(table_name='task_instance', column_name='end_date', type_=mysql.DATETIME())
-        op.alter_column(table_name='task_instance', column_name='queued_dttm', type_=mysql.DATETIME())
+        op.alter_column(table_name='task_instance', column_name='execution_date',
+                        type_=mysql.DATETIME(),
+                        nullable=False)
+        op.alter_column(table_name='task_instance', column_name='start_date',
+                        type_=mysql.DATETIME())
+        op.alter_column(table_name='task_instance', column_name='end_date',
+                        type_=mysql.DATETIME())
+        op.alter_column(table_name='task_instance', column_name='queued_dttm',
+                        type_=mysql.DATETIME())
 
-        op.alter_column(table_name='xcom', column_name='timestamp', type_=mysql.DATETIME())
-        op.alter_column(table_name='xcom', column_name='execution_date', type_=mysql.DATETIME())
+        op.alter_column(table_name='xcom', column_name='timestamp',
+                        type_=mysql.DATETIME())
+        op.alter_column(table_name='xcom', column_name='execution_date',
+                        type_=mysql.DATETIME())

--- a/airflow/migrations/versions/502898887f84_adding_extra_to_log.py
+++ b/airflow/migrations/versions/502898887f84_adding_extra_to_log.py
@@ -24,15 +24,14 @@ Revises: 52d714495f0
 Create Date: 2015-11-03 22:50:49.794097
 
 """
+from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '502898887f84'
 down_revision = '52d714495f0'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/airflow/migrations/versions/52d714495f0_job_id_indices.py
+++ b/airflow/migrations/versions/52d714495f0_job_id_indices.py
@@ -24,6 +24,7 @@ Revises: 338e90f54d61
 Create Date: 2015-10-20 03:17:01.962542
 
 """
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '52d714495f0'
@@ -31,12 +32,10 @@ down_revision = '338e90f54d61'
 branch_labels = None
 depends_on = None
 
-from alembic import op
-import sqlalchemy as sa
-
 
 def upgrade():
-    op.create_index('idx_job_state_heartbeat', 'job', ['state', 'latest_heartbeat'], unique=False)
+    op.create_index('idx_job_state_heartbeat', 'job',
+                    ['state', 'latest_heartbeat'], unique=False)
 
 
 def downgrade():

--- a/airflow/migrations/versions/561833c1c74b_add_password_column_to_user.py
+++ b/airflow/migrations/versions/561833c1c74b_add_password_column_to_user.py
@@ -24,15 +24,14 @@ Revises: 40e67319e3a9
 Create Date: 2015-11-30 06:51:25.872557
 
 """
+from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '561833c1c74b'
 down_revision = '40e67319e3a9'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/airflow/migrations/versions/5e7d17757c7a_add_pid_field_to_taskinstance.py
+++ b/airflow/migrations/versions/5e7d17757c7a_add_pid_field_to_taskinstance.py
@@ -24,14 +24,14 @@ Create Date: 2016-12-07 15:51:37.119478
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = '5e7d17757c7a'
 down_revision = '8504051e801b'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/airflow/migrations/versions/64de9cddf6c9_add_task_fails_journal_table.py
+++ b/airflow/migrations/versions/64de9cddf6c9_add_task_fails_journal_table.py
@@ -23,15 +23,14 @@ Revises: 211e584da130
 Create Date: 2016-08-03 14:02:59.203021
 
 """
+from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '64de9cddf6c9'
 down_revision = '211e584da130'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():
@@ -46,6 +45,7 @@ def upgrade():
         sa.Column('duration', sa.Integer(), nullable=True),
         sa.PrimaryKeyConstraint('id'),
     )
+
 
 def downgrade():
     op.drop_table('task_fail')

--- a/airflow/migrations/versions/8504051e801b_xcom_dag_task_indices.py
+++ b/airflow/migrations/versions/8504051e801b_xcom_dag_task_indices.py
@@ -25,18 +25,18 @@ Create Date: 2016-11-29 08:13:03.253312
 
 """
 
+from alembic import op
+
 # revision identifiers, used by Alembic.
 revision = '8504051e801b'
 down_revision = '4addfa1236f1'
 branch_labels = None
 depends_on = None
 
-from alembic import op
-import sqlalchemy as sa
-
 
 def upgrade():
-    op.create_index('idx_xcom_dag_task_date', 'xcom', ['dag_id', 'task_id', 'execution_date'], unique=False)
+    op.create_index('idx_xcom_dag_task_date', 'xcom',
+                    ['dag_id', 'task_id', 'execution_date'], unique=False)
 
 
 def downgrade():

--- a/airflow/migrations/versions/856955da8476_fix_sqlite_foreign_key.py
+++ b/airflow/migrations/versions/856955da8476_fix_sqlite_foreign_key.py
@@ -25,14 +25,14 @@ Create Date: 2018-06-17 15:54:53.844230
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = '856955da8476'
 down_revision = 'f23433877c24'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():
@@ -45,41 +45,39 @@ def upgrade():
         #
         # Use batch_alter_table to support SQLite workaround.
         chart_table = sa.Table('chart',
-            sa.MetaData(),
-            sa.Column('id', sa.Integer(), nullable=False),
-            sa.Column('label', sa.String(length=200), nullable=True),
-            sa.Column('conn_id', sa.String(length=250), nullable=False),
-            sa.Column('user_id', sa.Integer(), nullable=True),
-            sa.Column('chart_type', sa.String(length=100), nullable=True),
-            sa.Column('sql_layout', sa.String(length=50), nullable=True),
-            sa.Column('sql', sa.Text(), nullable=True),
-            sa.Column('y_log_scale', sa.Boolean(), nullable=True),
-            sa.Column('show_datatable', sa.Boolean(), nullable=True),
-            sa.Column('show_sql', sa.Boolean(), nullable=True),
-            sa.Column('height', sa.Integer(), nullable=True),
-            sa.Column('default_params', sa.String(length=5000), nullable=True),
-            sa.Column('x_is_date', sa.Boolean(), nullable=True),
-            sa.Column('iteration_no', sa.Integer(), nullable=True),
-            sa.Column('last_modified', sa.DateTime(), nullable=True),
-            sa.PrimaryKeyConstraint('id')
-        )
+                               sa.MetaData(),
+                               sa.Column('id', sa.Integer(), nullable=False),
+                               sa.Column('label', sa.String(length=200), nullable=True),
+                               sa.Column('conn_id', sa.String(length=250), nullable=False),
+                               sa.Column('user_id', sa.Integer(), nullable=True),
+                               sa.Column('chart_type', sa.String(length=100), nullable=True),
+                               sa.Column('sql_layout', sa.String(length=50), nullable=True),
+                               sa.Column('sql', sa.Text(), nullable=True),
+                               sa.Column('y_log_scale', sa.Boolean(), nullable=True),
+                               sa.Column('show_datatable', sa.Boolean(), nullable=True),
+                               sa.Column('show_sql', sa.Boolean(), nullable=True),
+                               sa.Column('height', sa.Integer(), nullable=True),
+                               sa.Column('default_params', sa.String(length=5000), nullable=True),
+                               sa.Column('x_is_date', sa.Boolean(), nullable=True),
+                               sa.Column('iteration_no', sa.Integer(), nullable=True),
+                               sa.Column('last_modified', sa.DateTime(), nullable=True),
+                               sa.PrimaryKeyConstraint('id'))
         with op.batch_alter_table('chart', copy_from=chart_table) as batch_op:
             batch_op.create_foreign_key('chart_user_id_fkey', 'users',
                                         ['user_id'], ['id'])
 
         known_event_table = sa.Table('known_event',
-            sa.MetaData(),
-            sa.Column('id', sa.Integer(), nullable=False),
-            sa.Column('label', sa.String(length=200), nullable=True),
-            sa.Column('start_date', sa.DateTime(), nullable=True),
-            sa.Column('end_date', sa.DateTime(), nullable=True),
-            sa.Column('user_id', sa.Integer(), nullable=True),
-            sa.Column('known_event_type_id', sa.Integer(), nullable=True),
-            sa.Column('description', sa.Text(), nullable=True),
-            sa.ForeignKeyConstraint(['known_event_type_id'],
-                                    ['known_event_type.id'], ),
-            sa.PrimaryKeyConstraint('id')
-        )
+                                     sa.MetaData(),
+                                     sa.Column('id', sa.Integer(), nullable=False),
+                                     sa.Column('label', sa.String(length=200), nullable=True),
+                                     sa.Column('start_date', sa.DateTime(), nullable=True),
+                                     sa.Column('end_date', sa.DateTime(), nullable=True),
+                                     sa.Column('user_id', sa.Integer(), nullable=True),
+                                     sa.Column('known_event_type_id', sa.Integer(), nullable=True),
+                                     sa.Column('description', sa.Text(), nullable=True),
+                                     sa.ForeignKeyConstraint(['known_event_type_id'],
+                                                             ['known_event_type.id'], ),
+                                     sa.PrimaryKeyConstraint('id'))
         with op.batch_alter_table('chart', copy_from=known_event_table) as batch_op:
             batch_op.create_foreign_key('known_event_user_id_fkey', 'users',
                                         ['user_id'], ['id'])

--- a/airflow/migrations/versions/86770d1215c0_add_kubernetes_scheduler_uniqueness.py
+++ b/airflow/migrations/versions/86770d1215c0_add_kubernetes_scheduler_uniqueness.py
@@ -25,16 +25,14 @@ Revises: 27c6a30d7c24
 Create Date: 2018-04-03 15:31:20.814328
 
 """
+from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '86770d1215c0'
 down_revision = '27c6a30d7c24'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
-
 
 RESOURCE_TABLE = "kube_worker_uuid"
 

--- a/airflow/migrations/versions/947454bf1dff_add_ti_job_id_index.py
+++ b/airflow/migrations/versions/947454bf1dff_add_ti_job_id_index.py
@@ -24,15 +24,13 @@ Revises: bdaa763e6c56
 Create Date: 2017-08-15 15:12:13.845074
 
 """
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '947454bf1dff'
 down_revision = 'bdaa763e6c56'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/airflow/migrations/versions/9635ae0956e7_index_faskfail.py
+++ b/airflow/migrations/versions/9635ae0956e7_index_faskfail.py
@@ -24,15 +24,13 @@ Revises: 856955da8476
 Create Date: 2018-06-17 21:40:01.963540
 
 """
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '9635ae0956e7'
 down_revision = '856955da8476'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():
@@ -41,4 +39,3 @@ def upgrade():
 
 def downgrade():
     op.drop_index('idx_task_fail_dag_task_date', table_name='task_fail')
-

--- a/airflow/migrations/versions/bba5a7cfc896_add_a_column_to_track_the_encryption_.py
+++ b/airflow/migrations/versions/bba5a7cfc896_add_a_column_to_track_the_encryption_.py
@@ -25,18 +25,19 @@ Create Date: 2016-01-29 15:10:32.656425
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = 'bba5a7cfc896'
 down_revision = 'bbc73705a13e'
 branch_labels = None
 depends_on = None
 
-from alembic import op
-import sqlalchemy as sa
-
 
 def upgrade():
-    op.add_column('connection', sa.Column('is_extra_encrypted', sa.Boolean,default=False))
+    op.add_column('connection',
+                  sa.Column('is_extra_encrypted', sa.Boolean, default=False))
 
 
 def downgrade():

--- a/airflow/migrations/versions/bbc73705a13e_add_notification_sent_column_to_sla_miss.py
+++ b/airflow/migrations/versions/bbc73705a13e_add_notification_sent_column_to_sla_miss.py
@@ -24,6 +24,8 @@ Revises: 4446e08588
 Create Date: 2016-01-14 18:05:54.871682
 
 """
+from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'bbc73705a13e'
@@ -31,12 +33,9 @@ down_revision = '4446e08588'
 branch_labels = None
 depends_on = None
 
-from alembic import op
-import sqlalchemy as sa
-
 
 def upgrade():
-    op.add_column('sla_miss', sa.Column('notification_sent', sa.Boolean,default=False))
+    op.add_column('sla_miss', sa.Column('notification_sent', sa.Boolean, default=False))
 
 
 def downgrade():

--- a/airflow/migrations/versions/bdaa763e6c56_make_xcom_value_column_a_large_binary.py
+++ b/airflow/migrations/versions/bdaa763e6c56_make_xcom_value_column_a_large_binary.py
@@ -23,6 +23,9 @@ Revises: cc1e65623dc7
 Create Date: 2017-08-14 16:06:31.568971
 
 """
+from alembic import op
+import dill
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'bdaa763e6c56'
@@ -30,15 +33,10 @@ down_revision = 'cc1e65623dc7'
 branch_labels = None
 depends_on = None
 
-from alembic import op
-import dill
-import sqlalchemy as sa
-
 
 def upgrade():
     # There can be data truncation here as LargeBinary can be smaller than the pickle
     # type.
-
     # use batch_alter_table to support SQLite workaround
     with op.batch_alter_table("xcom") as batch_op:
         batch_op.alter_column('value', type_=sa.LargeBinary())

--- a/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
+++ b/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
@@ -25,22 +25,21 @@ Create Date: 2017-06-19 16:53:12.851141
 
 """
 
-# revision identifiers, used by Alembic.
-revision = 'cc1e65623dc7'
-down_revision = '127d2bf2dfa7'
-branch_labels = None
-depends_on = None
-
 from alembic import op
 import sqlalchemy as sa
 from airflow import settings
 from airflow.models import DagBag
 from airflow.utils.sqlalchemy import UtcDateTime
 
-from sqlalchemy import (
-    Column, Integer, String)
+from sqlalchemy import Column, Integer, String
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.ext.declarative import declarative_base
+
+# revision identifiers, used by Alembic.
+revision = 'cc1e65623dc7'
+down_revision = '127d2bf2dfa7'
+branch_labels = None
+depends_on = None
 
 Base = declarative_base()
 BATCH_SIZE = 5000
@@ -58,8 +57,7 @@ class TaskInstance(Base):
 
 
 def upgrade():
-    op.add_column('task_instance', sa.Column('max_tries', sa.Integer,
-        server_default="-1"))
+    op.add_column('task_instance', sa.Column('max_tries', sa.Integer, server_default="-1"))
     # Check if table task_instance exist before data migration. This check is
     # needed for database that does not create table until migration finishes.
     # Checking task_instance table exists prevent the error of querying
@@ -129,7 +127,7 @@ def downgrade():
                     # max number of self retry (task.retries) minus number of
                     # times left for task instance to try the task.
                     ti.try_number = max(0, task.retries - (ti.max_tries -
-                        ti.try_number))
+                                                           ti.try_number))
                 ti.max_tries = -1
                 session.merge(ti)
             session.commit()

--- a/airflow/migrations/versions/d2ae31099d61_increase_text_size_for_mysql.py
+++ b/airflow/migrations/versions/d2ae31099d61_increase_text_size_for_mysql.py
@@ -23,17 +23,15 @@ Revises: 947454bf1dff
 Create Date: 2017-08-18 17:07:16.686130
 
 """
+from alembic import op
+from sqlalchemy.dialects import mysql
+from alembic import context
 
 # revision identifiers, used by Alembic.
 revision = 'd2ae31099d61'
 down_revision = '947454bf1dff'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.dialects import mysql
-from alembic import context
 
 
 def upgrade():

--- a/airflow/migrations/versions/e3a246e0dc1_current_schema.py
+++ b/airflow/migrations/versions/e3a246e0dc1_current_schema.py
@@ -25,16 +25,16 @@ Create Date: 2015-08-18 16:35:00.883495
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import func
+from sqlalchemy.engine.reflection import Inspector
+
 # revision identifiers, used by Alembic.
 revision = 'e3a246e0dc1'
 down_revision = None
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
-from sqlalchemy import func
-from sqlalchemy.engine.reflection import Inspector
 
 
 def upgrade():

--- a/airflow/migrations/versions/f23433877c24_fix_mysql_not_null_constraint.py
+++ b/airflow/migrations/versions/f23433877c24_fix_mysql_not_null_constraint.py
@@ -24,6 +24,8 @@ Revises: 05f30312d566
 Create Date: 2018-06-17 10:16:31.412131
 
 """
+from alembic import op
+from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
 revision = 'f23433877c24'
@@ -31,9 +33,6 @@ down_revision = '05f30312d566'
 branch_labels = None
 depends_on = None
 
-from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.dialects import mysql
 
 def upgrade():
     conn = op.get_bind()
@@ -51,4 +50,3 @@ def downgrade():
         op.alter_column('xcom', 'timestamp', existing_type=mysql.TIMESTAMP(fsp=6), nullable=True)
         op.alter_column('xcom', 'execution_date', existing_type=mysql.TIMESTAMP(fsp=6), nullable=True)
         op.alter_column('task_fail', 'execution_date', existing_type=mysql.TIMESTAMP(fsp=6), nullable=True)
-

--- a/airflow/migrations/versions/f2ca10b85618_add_dag_stats_table.py
+++ b/airflow/migrations/versions/f2ca10b85618_add_dag_stats_table.py
@@ -23,15 +23,14 @@ Revises: 64de9cddf6c9
 Create Date: 2016-07-20 15:08:28.247537
 
 """
+from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'f2ca10b85618'
 down_revision = '64de9cddf6c9'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -19,7 +19,7 @@
 
 import sys
 import os
-from airflow.models import BaseOperator
+from airflow.models import BaseOperator  # noqa: F401
 
 # ------------------------------------------------------------------------
 #

--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -24,11 +24,10 @@ from __future__ import unicode_literals
 
 from airflow.utils import timezone
 from datetime import datetime, timedelta
-from dateutil.relativedelta import relativedelta  # for doctest
+from dateutil.relativedelta import relativedelta  # flake8: noqa: F401 for doctest
 import six
 
 from croniter import croniter
-
 
 cron_presets = {
     '@hourly': '0 * * * *',
@@ -39,11 +38,7 @@ cron_presets = {
 }
 
 
-def date_range(
-        start_date,
-        end_date=None,
-        num=None,
-        delta=None):
+def date_range(start_date, end_date=None, num=None, delta=None):
     """
     Get a set of dates as a list based on a start, end and delta, delta
     can be something that can be added to ``datetime.datetime``
@@ -181,8 +176,8 @@ def round_time(dt, delta, start_date=timezone.make_aware(datetime.min)):
             # Check if start_date + (lower + 1)*delta or
             # start_date + lower*delta is closer to dt and return the solution
             if (
-                    (start_date + (lower + 1) * delta) - dt <=
-                    dt - (start_date + lower * delta)):
+                (start_date + (lower + 1) * delta) - dt <=
+                dt - (start_date + lower * delta)):
                 return start_date + (lower + 1) * delta
             else:
                 return start_date + lower * delta

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -100,5 +100,6 @@ def apply_defaults(func):
     return wrapper
 
 if 'BUILDING_AIRFLOW_DOCS' in os.environ:
+    # flake8: noqa: F811
     # Monkey patch hook to get good function headers while building docs
     apply_defaults = lambda x: x

--- a/airflow/utils/email.py
+++ b/airflow/utils/email.py
@@ -22,7 +22,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from builtins import str
 from past.builtins import basestring
 
 import importlib
@@ -62,13 +61,13 @@ def send_email_smtp(to, subject, html_content, files=None,
 
     >>> send_email('test@example.com', 'foo', '<b>Foo</b> bar', ['/dev/null'], dryrun=True)
     """
-    SMTP_MAIL_FROM = configuration.conf.get('smtp', 'SMTP_MAIL_FROM')
+    smtp_mail_from = configuration.conf.get('smtp', 'SMTP_MAIL_FROM')
 
     to = get_email_address_list(to)
 
     msg = MIMEMultipart(mime_subtype)
     msg['Subject'] = subject
-    msg['From'] = SMTP_MAIL_FROM
+    msg['From'] = smtp_mail_from
     msg['To'] = ", ".join(to)
     recipients = to
     if cc:
@@ -96,7 +95,7 @@ def send_email_smtp(to, subject, html_content, files=None,
             part['Content-ID'] = '<%s>' % basename
             msg.attach(part)
 
-    send_MIME_email(SMTP_MAIL_FROM, recipients, msg, dryrun)
+    send_MIME_email(smtp_mail_from, recipients, msg, dryrun)
 
 
 def send_MIME_email(e_from, e_to, mime_msg, dryrun=False):

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -32,7 +32,6 @@ import imp
 import os
 import re
 import signal
-import subprocess
 import sys
 import warnings
 
@@ -226,6 +225,7 @@ def reap_process_group(pid, log, sig=signal.SIGTERM,
     :param sig: signal type
     :param timeout: how much time a process has to terminate
     """
+
     def on_terminate(p):
         log.info("Process %s (%s) terminated with exit code %s", p, p.pid, p.returncode)
 

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Using `from elasticsearch import *` would break elasticseach mocking used in unit test.
+# Using `from elasticsearch import *` would break elasticsearch mocking used in unit test.
 import elasticsearch
 import pendulum
 from elasticsearch_dsl import Search

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -18,7 +18,6 @@
 # under the License.
 #
 import six
-import os
 
 from flask import Flask
 from flask_admin import Admin, base
@@ -64,8 +63,8 @@ def create_app(config=None, testing=False):
     api.load_auth()
     api.api_auth.init_app(app)
 
-    cache = Cache(
-        app=app, config={'CACHE_TYPE': 'filesystem', 'CACHE_DIR': '/tmp'})
+    # flake8: noqa: F841
+    cache = Cache(app=app, config={'CACHE_TYPE': 'filesystem', 'CACHE_DIR': '/tmp'})
 
     app.register_blueprint(routes)
 

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -17,11 +17,11 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# flake8: noqa: E402
 import inspect
 from future import standard_library
 standard_library.install_aliases()
-from builtins import str
-from builtins import object
+from builtins import str, object
 
 from cgi import escape
 from io import BytesIO as IO
@@ -29,13 +29,13 @@ import functools
 import gzip
 import json
 import time
-
-from flask import after_this_request, request, Response
-from flask_admin.contrib.sqla.filters import FilterConverter
-from flask_admin.model import filters
-from flask_login import current_user
 import wtforms
 from wtforms.compat import text_type
+
+from flask import after_this_request, request, Response
+from flask_admin.model import filters
+from flask_admin.contrib.sqla.filters import FilterConverter
+from flask_login import current_user
 
 from airflow import configuration, models, settings
 from airflow.utils.db import create_session

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -22,7 +22,6 @@ import ast
 import codecs
 import copy
 import datetime as dt
-import inspect
 import itertools
 import json
 import logging
@@ -365,6 +364,7 @@ def get_date_time_num_runs_dag_runs_form_data(request, session, dag):
         'dr_state': dr_state,
     }
 
+
 class Airflow(BaseView):
     def is_visible(self):
         return False
@@ -481,8 +481,6 @@ class Airflow(BaseView):
             else:
                 if chart.sql_layout == 'series':
                     # User provides columns (series, x, y)
-                    xaxis_label = df.columns[1]
-                    yaxis_label = df.columns[2]
                     df[df.columns[2]] = df[df.columns[2]].astype(np.float)
                     df = df.pivot_table(
                         index=df.columns[1],
@@ -490,8 +488,6 @@ class Airflow(BaseView):
                         values=df.columns[2], aggfunc=np.sum)
                 else:
                     # User provides columns (x, y, metric1, metric2, ...)
-                    xaxis_label = df.columns[0]
-                    yaxis_label = 'y'
                     df.index = df[df.columns[0]]
                     df = df.sort(df.columns[0])
                     del df[df.columns[0]]
@@ -599,8 +595,8 @@ class Airflow(BaseView):
             session.query(DagRun.dag_id, sqla.func.max(DagRun.execution_date).label('execution_date'))
                 .join(Dag, Dag.dag_id == DagRun.dag_id)
                 .filter(DagRun.state != State.RUNNING)
-                .filter(Dag.is_active == True)
-                .filter(Dag.is_subdag == False)
+                .filter(Dag.is_active == True)  # noqa: E712
+                .filter(Dag.is_subdag == False)  # noqa: E712
                 .group_by(DagRun.dag_id)
                 .subquery('last_dag_run')
         )
@@ -608,8 +604,8 @@ class Airflow(BaseView):
             session.query(DagRun.dag_id, DagRun.execution_date)
                 .join(Dag, Dag.dag_id == DagRun.dag_id)
                 .filter(DagRun.state == State.RUNNING)
-                .filter(Dag.is_active == True)
-                .filter(Dag.is_subdag == False)
+                .filter(Dag.is_active == True)  # noqa: E712
+                .filter(Dag.is_subdag == False)  # noqa: E712
                 .subquery('running_dag_run')
         )
 
@@ -883,7 +879,7 @@ class Airflow(BaseView):
         for attr_name in dir(ti):
             if not attr_name.startswith('_'):
                 attr = getattr(ti, attr_name)
-                if type(attr) != type(self.task):
+                if type(attr) != type(self.task):  # noqa: E721
                     ti_attrs.append((attr_name, str(attr)))
 
         task_attrs = []
@@ -891,7 +887,7 @@ class Airflow(BaseView):
             if not attr_name.startswith('_'):
                 attr = getattr(task, attr_name)
                 if type(attr) != type(self.task) and \
-                        attr_name not in attr_renderer:
+                        attr_name not in attr_renderer:  # noqa: E721
                     task_attrs.append((attr_name, str(attr)))
 
         # Color coding the special attributes that are code
@@ -1166,7 +1162,6 @@ class Airflow(BaseView):
     @wwwutils.notify_owner
     def dagrun_clear(self):
         dag_id = request.args.get('dag_id')
-        task_id = request.args.get('task_id')
         origin = request.args.get('origin')
         execution_date = request.args.get('execution_date')
         confirmed = request.args.get('confirmed') == "true"

--- a/airflow/www_rbac/app.py
+++ b/airflow/www_rbac/app.py
@@ -19,7 +19,6 @@
 #
 import socket
 import six
-import os
 
 from flask import Flask
 from flask_appbuilder import AppBuilder, SQLA
@@ -59,7 +58,8 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
     api.load_auth()
     api.api_auth.init_app(app)
 
-    cache = Cache(app=app, config={'CACHE_TYPE': 'filesystem', 'CACHE_DIR': '/tmp'})  # noqa
+    # flake8: noqa: F841
+    cache = Cache(app=app, config={'CACHE_TYPE': 'filesystem', 'CACHE_DIR': '/tmp'})
 
     from airflow.www_rbac.blueprints import routes
     app.register_blueprint(routes)

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -35,7 +35,7 @@ import nvd3
 import pendulum
 import sqlalchemy as sqla
 from flask import (
-    g, redirect, request, Markup, Response, render_template,
+    redirect, request, Markup, Response, render_template,
     make_response, flash, jsonify)
 from flask._compat import PY2
 from flask_appbuilder import BaseView, ModelView, expose, has_access

--- a/dags/test_dag.py
+++ b/dags/test_dag.py
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -23,7 +23,9 @@ from airflow.operators.dummy_operator import DummyOperator
 from datetime import datetime, timedelta
 
 now = datetime.now()
-now_to_the_hour = (now - timedelta(0, 0, 0, 0, 0, 3)).replace(minute=0, second=0, microsecond=0)
+now_to_the_hour = (
+    now - timedelta(0, 0, 0, 0, 0, 3)
+).replace(minute=0, second=0, microsecond=0)
 START_DATE = now_to_the_hour
 DAG_NAME = 'test_dag_v1'
 


### PR DESCRIPTION
A lot of small issues that I've fixed to enforce Flake8 globally instead of on the diffs.
- Unused imports
- Wrong import order
- Small identation fixes
- Remove one letter variables
- Fix noqa annotations

There are still a lot of violations. But I would like to use Black, YAPF or autopep8 to enforce style. Then we have a solid codebase again I'd say.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-2918\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2918
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
