### PR TITLE
[AIRFLOW-2921][AIRFLOW-2922] Fix two potential bugs in CeleryExecutor()

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -104,8 +104,8 @@ class CeleryExecutor(BaseExecutor):
                         del self.tasks[key]
                         del self.last_state[key]
                     else:
-                        self.log.info("Unexpected state: %s", task.state)
-                    self.last_state[key] = task.state
+                        self.log.info("Unexpected state: %s", state)
+                        self.last_state[key] = state
             except Exception as e:
                 self.log.error("Error syncing the celery executor, ignoring it:")
                 self.log.exception(e)

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -54,6 +54,8 @@ class CeleryExecutorTest(unittest.TestCase):
         self.assertNotIn('success', executor.tasks)
         self.assertNotIn('fail', executor.tasks)
 
+        self.assertNotIn('success', executor.last_state)
+        self.assertNotIn('fail', executor.last_state)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2921 https://issues.apache.org/jira/browse/AIRFLOW-2922
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### `Potential bug-1`
If a task state becomes either `SUCCESS` or `FAILURE` or `REVOKED`, it will be removed from `self.tasks` and `self.last_state`. However, because line 108 is not indented properly, this task will be added back to `self.last_state` again.

This will not lead to any error. But may still be worth changing.

**Solution**: indent line 108.

### `Potential bug-2`

Celery Task states normally change in ways like “PENDING -> STARTED -> SUCCESS/FAILURE” (http://docs.celeryproject.org/en/latest/reference/celery.states.html).

In lines 107 and 108, it’s `task.state` rather than `state`, i.e. it will reflect the latest real-time state of the Celery task. 

Let’s imagine: task state becomes **STARTED** first (initial state is **PENDING**), then the `if-elif-else` block will be triggered (line 93). It’s possible the Celery task state becomes **SUCCESS** when whichever line between 94-105 is running. At line 108, the latest state of the task will be changed to **SUCCESS** rather than **STARTED** in `self.last_state` because it’s referring to the latest state `task.state` rather than variable `state`.

Then this task will be dead-locked because the `if-elif-else block` will never be triggered for it again. It has no chance to be ended properly with methods `self.success()` or `self.fail()`. Although the chance that this happens is quite low (the time window is very short), the chance is not zero.

**Solution**: change `task.state` to `state` in lines 107 and 108.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`