### PR TITLE
[AIRFLOW-2920] Added downward API metadata to Kubernetes pods

### DIFF
--- a/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -58,6 +58,21 @@ class KubernetesRequestFactory:
         })
 
     @staticmethod
+    def add_downward_api_metadata_to_env(env):
+        env.append({
+            'name': 'POD_NAME',
+            'valueFrom': {
+                'fieldRef': {'fieldPath': 'metadata.name'}
+            }
+        })
+        env.append({
+            'name': 'POD_NAMESPACE',
+            'valueFrom': {
+                'fieldRef': {'fieldPath': 'metadata.namespace'}
+            }
+        })
+
+    @staticmethod
     def extract_labels(pod, req):
         req['metadata']['labels'] = req['metadata'].get('labels', {})
         for k, v in six.iteritems(pod.labels):
@@ -138,6 +153,7 @@ class KubernetesRequestFactory:
                 env.append({'name': k, 'value': pod.envs[k]})
             for secret in env_secrets:
                 KubernetesRequestFactory.add_secret_to_env(env, secret)
+            KubernetesRequestFactory.add_downward_api_metadata_to_env(env)
             req['spec']['containers'][0]['env'] = env
 
     @staticmethod


### PR DESCRIPTION
### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2920

### Description

This adds https://github.com/kubernetes/kubernetes/blob/release-1.0/docs/user-guide/downward-api.md metadata to pods spun up by the Kubernetes executor. This allows one to then dynamically specify a namespace in the DAG task definition with:

```
task1 = KubernetesPodOperator(
        namespace=os.getenv('POD_NAMESPACE'),
        ...
```

Thus allowing multiple Kubernetes deployments to use the same Docker image.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

There does not appear to be tests for the manifest the Kubernetes executor generates.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

@dimberman 