### PR TITLE
[AIRFLOW-2924] Added Modernizing Medicine to list of "Who Uses Airflow?"  in readme.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Currently **officially** using Airflow:
 1. [Mercari](http://www.mercari.com/) [[@yu-iskw](https://github.com/yu-iskw)]
 1. [MFG Labs](https://github.com/MfgLabs)
 1. [MiNODES](https://www.minodes.com) [[@dice89](https://github.com/dice89), [@diazcelsa](https://github.com/diazcelsa)]
+1. [Modernizing Medicine](https://www.modmed.com/)[[@kehv1n](https://github.com/kehv1n), [@dalupus](https://github.com/dalupus)]
 1. [Multiply](https://www.multiply.com) [[@nrhvyc](https://github.com/nrhvyc)]
 1. [mytaxi](https://mytaxi.com) [[@mytaxi](https://github.com/mytaxi)]
 1. [Nerdwallet](https://www.nerdwallet.com)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.



### Description

- Added Modernizing Medicine to list of companies using Airflow with appropriate names of users 

