### PR TITLE
[AIRFLOW-2928] replace uuid1 with uuid4 for better randomness

### DIFF
--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -250,7 +250,7 @@ class DataFlowHook(GoogleCloudBaseHook):
                 'letter and ending with a letter or number '.format(task_id))
 
         if append_job_name:
-            job_name = task_id + "-" + str(uuid.uuid1())[:8]
+            job_name = task_id + "-" + str(uuid.uuid4())[:8]
         else:
             job_name = task_id
 

--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -81,7 +81,7 @@ class _DataProcJob(LoggingMixin):
 
 class _DataProcJobBuilder:
     def __init__(self, project_id, task_id, cluster_name, job_type, properties):
-        name = task_id + "_" + str(uuid.uuid1())[:8]
+        name = task_id + "_" + str(uuid.uuid4())[:8]
         self.job_type = job_type
         self.job = {
             "job": {
@@ -141,7 +141,7 @@ class _DataProcJobBuilder:
         self.job["job"][self.job_type]["mainPythonFileUri"] = main
 
     def set_job_name(self, name):
-        self.job["job"]["reference"]["jobId"] = name + "_" + str(uuid.uuid1())[:8]
+        self.job["job"]["reference"]["jobId"] = name + "_" + str(uuid.uuid4())[:8]
 
     def build(self):
         return self.job

--- a/airflow/contrib/kubernetes/pod_generator.py
+++ b/airflow/contrib/kubernetes/pod_generator.py
@@ -149,7 +149,7 @@ class PodGenerator:
 
         return Pod(
             namespace=namespace,
-            name=pod_id + "-" + str(uuid.uuid1())[:8],
+            name=pod_id + "-" + str(uuid.uuid4())[:8],
             image=image,
             cmds=cmds,
             args=arguments,

--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -365,7 +365,7 @@ class GoogleCloudBucketHelper(object):
 
         bucket_id = path_components[0]
         object_id = '/'.join(path_components[1:])
-        local_file = '/tmp/dataflow{}-{}'.format(str(uuid.uuid1())[:8],
+        local_file = '/tmp/dataflow{}-{}'.format(str(uuid.uuid4())[:8],
                                                  path_components[-1])
         file_size = self._gcs_hook.download(bucket_id, object_id, local_file)
 

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -1158,7 +1158,7 @@ class DataProcPySparkOperator(BaseOperator):
     @staticmethod
     def _generate_temp_filename(filename):
         dt = time.strftime('%Y%m%d%H%M%S')
-        return "{}_{}_{}".format(dt, str(uuid.uuid1())[:8], ntpath.basename(filename))
+        return "{}_{}_{}".format(dt, str(uuid.uuid4())[:8], ntpath.basename(filename))
 
     """
     Upload a local file to a Google Cloud Storage bucket
@@ -1312,7 +1312,7 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocWorkflowTemplateBaseOp
             .instantiate(
                 name=('projects/%s/regions/%s/workflowTemplates/%s' %
                       (self.project_id, self.region, self.template_id)),
-                body={'instanceId': str(uuid.uuid1())})
+                body={'instanceId': str(uuid.uuid4())})
             .execute())
 
 
@@ -1355,6 +1355,6 @@ class DataprocWorkflowTemplateInstantiateInlineOperator(
             self.hook.get_conn().projects().regions().workflowTemplates()
             .instantiateInline(
                 parent='projects/%s/regions/%s' % (self.project_id, self.region),
-                instanceId=str(uuid.uuid1()),
+                instanceId=str(uuid.uuid4()),
                 body=self.template)
             .execute())

--- a/airflow/contrib/task_runner/cgroup_task_runner.py
+++ b/airflow/contrib/task_runner/cgroup_task_runner.py
@@ -123,7 +123,7 @@ class CgroupTaskRunner(BaseTaskRunner):
         # Create a unique cgroup name
         cgroup_name = "airflow/{}/{}".format(datetime.datetime.utcnow().
                                              strftime("%Y-%m-%d"),
-                                             str(uuid.uuid1()))
+                                             str(uuid.uuid4()))
 
         self.mem_cgroup_name = "memory/{}".format(cgroup_name)
         self.cpu_cgroup_name = "cpu/{}".format(cgroup_name)

--- a/tests/contrib/hooks/test_gcp_dataflow_hook.py
+++ b/tests/contrib/hooks/test_gcp_dataflow_hook.py
@@ -79,7 +79,7 @@ class DataFlowHookTest(unittest.TestCase):
                         new=mock_init):
             self.dataflow_hook = DataFlowHook(gcp_conn_id='test')
 
-    @mock.patch(DATAFLOW_STRING.format('uuid.uuid1'))
+    @mock.patch(DATAFLOW_STRING.format('uuid.uuid4'))
     @mock.patch(DATAFLOW_STRING.format('_DataflowJob'))
     @mock.patch(DATAFLOW_STRING.format('_Dataflow'))
     @mock.patch(DATAFLOW_STRING.format('DataFlowHook.get_conn'))
@@ -103,7 +103,7 @@ class DataFlowHookTest(unittest.TestCase):
         self.assertListEqual(sorted(mock_dataflow.call_args[0][0]),
                              sorted(EXPECTED_CMD))
 
-    @mock.patch(DATAFLOW_STRING.format('uuid.uuid1'))
+    @mock.patch(DATAFLOW_STRING.format('uuid.uuid4'))
     @mock.patch(DATAFLOW_STRING.format('_DataflowJob'))
     @mock.patch(DATAFLOW_STRING.format('_Dataflow'))
     @mock.patch(DATAFLOW_STRING.format('DataFlowHook.get_conn'))
@@ -127,7 +127,7 @@ class DataFlowHookTest(unittest.TestCase):
         self.assertListEqual(sorted(mock_dataflow.call_args[0][0]),
                              sorted(EXPECTED_CMD))
 
-    @mock.patch(DATAFLOW_STRING.format('uuid.uuid1'))
+    @mock.patch(DATAFLOW_STRING.format('uuid.uuid4'))
     @mock.patch(DATAFLOW_STRING.format('_DataflowJob'))
     @mock.patch(DATAFLOW_STRING.format('_Dataflow'))
     @mock.patch(DATAFLOW_STRING.format('DataFlowHook.get_conn'))


### PR DESCRIPTION
### Description

some components in Airflow use the first 8 bytes of uuid.uuid1 to generate a unique job name. The first 8 bytes, however, seem to come from clock. so if this is called multiple times in a short time period, two ids will likely collide.
uuid.uuid4 provides random values.

### Tests

```py
Python 2.7.15 (default, Jun 17 2018, 12:46:58)
[GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import uuid
>>> for i in range(10):
...   uuid.uuid1()
...
UUID('e8bc9959-a586-11e8-ab8c-8c859010d0c2')
UUID('e8c254e3-a586-11e8-ac39-8c859010d0c2')
UUID('e8c2560f-a586-11e8-8251-8c859010d0c2')
UUID('e8c256c2-a586-11e8-994a-8c859010d0c2')
UUID('e8c25759-a586-11e8-9ba6-8c859010d0c2')
UUID('e8c257e6-a586-11e8-a854-8c859010d0c2')
UUID('e8c2587d-a586-11e8-89e9-8c859010d0c2')
UUID('e8c2590a-a586-11e8-a825-8c859010d0c2')
UUID('e8c25994-a586-11e8-9421-8c859010d0c2')
UUID('e8c25a21-a586-11e8-83fd-8c859010d0c2')
>>> for i in range(10):
...   uuid.uuid4()
...
UUID('f1eba69f-18ea-467e-a414-b18d67f34a51')
UUID('aaa4e18e-d4e6-42c9-905c-3cde714c2741')
UUID('82f55c27-69ae-474b-ab9a-afcc7891587c')
UUID('fab63643-ad33-4307-837b-68444fce7240')
UUID('c4efca6c-3d1b-436c-8b09-e9b7f55ccefb')
UUID('58de3a76-9d98-4427-8232-d6d7df2a1904')
UUID('4f0a55e8-1357-4697-a345-e60891685b00')
UUID('0fed47a3-07b6-423e-ae2e-d821c440cb63')
UUID('144b2c55-a9bd-431d-b536-239fb2048a5e')
UUID('d47fd8a0-48e9-4dcc-87f7-42c022c309a8')
Attachments
```
