### PR TITLE
[AIRFLOW-2937] Support HTTPS in Http connection form environment variables

### DIFF
--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -62,7 +62,7 @@ class HttpHook(BaseHook):
             self.base_url = conn.host
         else:
             # schema defaults to HTTP
-            schema = conn.schema if conn.schema else "http"
+            schema = conn.conn_type if conn.conn_type else conn.schema if conn.schema else "http"
             self.base_url = schema + "://" + conn.host
 
         if conn.port:


### PR DESCRIPTION
Per airflow.models.Connection.parse_from_uri, the URI scheme is stored in Connection.conn_type. Preserving conn.schema fallback for backward compatibility.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2937
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
 
Per airflow.models.Connection.parse_from_uri, the URI scheme is stored in Connection.conn_type. Preserving conn.schema fallback for backward compatibility.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
