### PR TITLE
[AIRFLOW-2938] Handle improperly formatted extra field in connection …

### DIFF
--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -70,7 +70,11 @@ class HttpHook(BaseHook):
         if conn.login:
             session.auth = (conn.login, conn.password)
         if conn.extra:
-            session.headers.update(conn.extra_dejson)
+            try:
+                session.headers.update(conn.extra_dejson)
+            except TypeError:
+                self.log.warn('Connection to {} has invalid extra field.'.format(
+                    conn.host))
         if headers:
             session.headers.update(headers)
 

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -1922,6 +1922,11 @@ class ConnectionModelView(AirflowModelView):
         except Exception:
             d = {}
 
+        if not hasattr(d, 'get'):
+            logging.warning('extra field for {} is not iterable'.format(
+                form.data.get('conn_id', '<unknown>')))
+            return
+
         for field in self.extra_fields:
             value = d.get(field, '')
             if value:


### PR DESCRIPTION
…gracefully

Make sure you have checked _all_ steps below.

### Jira

- [ X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2938
 

### Description

- [X ] Here are some details about my PR, including screenshots of any UI changes:
Catch exceptions raised by 'd.get' when hasattr(d, 'get') is false. 

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
