### PR TITLE
[AIRFLOW-2824] - Add config to disable default conn creation

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -122,6 +122,10 @@ non_pooled_task_slot_count = 128
 # The maximum number of active DAG runs per DAG
 max_active_runs_per_dag = 16
 
+# Whether to load the default connections during the CLI command
+# `airflow initdb`.
+load_default_conns = True
+
 # Whether to load the examples that ship with Airflow. It's good to
 # get started, but you probably want to set this to False in a production
 # environment

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -27,6 +27,7 @@ from functools import wraps
 import os
 import contextlib
 
+from airflow import configuration
 from airflow import settings
 from airflow.utils.log.logging_mixin import LoggingMixin
 
@@ -85,11 +86,8 @@ def merge_conn(conn, session=None):
         session.commit()
 
 
-def initdb(rbac=False):
-    session = settings.Session()
-
+def load_default_conns():
     from airflow import models
-    upgradedb()
 
     merge_conn(
         models.Connection(
@@ -285,6 +283,16 @@ def initdb(rbac=False):
         models.Connection(
             conn_id='cassandra_default', conn_type='cassandra',
             host='cassandra', port=9042))
+
+
+def initdb(rbac=False):
+    session = settings.Session()
+
+    from airflow import models
+    upgradedb()
+
+    if configuration.conf.getboolean('core', 'LOAD_DEFAULT_CONNS'):
+        load_default_conns()
 
     # Known event types
     KET = models.KnownEventType


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2824
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR gives users a way to avoid recreating default connections when running initDB via the airflow.cfg file

Before merging - I wanted feedback from the maintainers on whether or not they feel this is the way to approach resolving this issue.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
Documented in config code comments

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
