### PR TITLE
[AIRFLOW-2665] Use shlex to split args and remove shell true

### DIFF
--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -46,7 +46,9 @@ locally, into just one `LocalExecutor` with multiple modes.
 
 import multiprocessing
 import subprocess
+import shlex
 import time
+
 
 from builtins import range
 
@@ -82,8 +84,11 @@ class LocalWorker(multiprocessing.Process, LoggingMixin):
         if key is None:
             return
         self.log.info("%s running %s", self.__class__.__name__, command)
+        if isinstance(command, list):
+            command = " ".join(command)
+        args = shlex.split(command)
         try:
-            subprocess.check_call(command, close_fds=True)
+            subprocess.check_call(args, close_fds=True)
             state = State.SUCCESS
         except subprocess.CalledProcessError as e:
             state = State.FAILED


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] Jira ticket: https://issues.apache.org/jira/browse/AIRFLOW-2665

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently airflow doesn't support running commands without a `bash` available, there are not UI changes.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This part was already covered by tests.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
