### PR TITLE
[AIRFLOW-2062] Add per-connection KMS encryption.

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1133,7 +1133,8 @@ def version(args):  # noqa
 
 
 alternative_conn_specs = ['conn_type', 'conn_host',
-                          'conn_login', 'conn_password', 'conn_schema', 'conn_port']
+                          'conn_login', 'conn_password', 'conn_schema', 'conn_port',
+                          'kms_conn_id', 'kms_extra']
 
 
 @cli_utils.action_logging
@@ -1235,7 +1236,10 @@ def connections(args):
             return
 
         if args.conn_uri:
-            new_conn = Connection(conn_id=args.conn_id, uri=args.conn_uri)
+            new_conn = Connection(conn_id=args.conn_id,
+                                  uri=args.conn_uri,
+                                  kms_conn_id=args.kms_conn_id,
+                                  kms_extra=args.kms_extra)
         else:
             new_conn = Connection(conn_id=args.conn_id,
                                   conn_type=args.conn_type,
@@ -1243,7 +1247,10 @@ def connections(args):
                                   login=args.conn_login,
                                   password=args.conn_password,
                                   schema=args.conn_schema,
-                                  port=args.conn_port)
+                                  port=args.conn_port,
+                                  kms_conn_id=args.kms_conn_id,
+                                  kms_extra=args.kms_extra
+                                  )
         if args.conn_extra is not None:
             new_conn.set_extra(args.conn_extra)
 
@@ -1882,6 +1889,15 @@ class CLIFactory(object):
         'conn_extra': Arg(
             ('--conn_extra',),
             help='Connection `Extra` field, optional when adding a connection',
+            type=str),
+        'kms_conn_id': Arg(
+            ('--kms_conn_id',),
+            help='An existing connection to use when encrypting this connection with a '
+                 'KMS, optional when adding a connection',
+            type=str),
+        'kms_extra': Arg(
+            ('--kms_extra',),
+            help='Connection `KMS Extra` field, optional when adding a connection',
             type=str),
         # users
         'username': Arg(

--- a/airflow/hooks/kmsapi_hook.py
+++ b/airflow/hooks/kmsapi_hook.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from airflow.hooks.base_hook import BaseHook
+
+
+class KmsApiHook(BaseHook):
+    """
+    Abstract base class for KMS hooks. KMS hooks should support encryption
+    and decryption services. In addition, a KMS hook should support encrypting
+    and decrypting connection keys.
+    """
+
+    def encrypt_conn_key(self, connection):
+        """
+        Accepts a Connection object and sets `connection.conn_key` by
+        encrypting `connection._plain_conn_key` via the KMS.
+        """
+        raise NotImplementedError()
+
+    def decrypt_conn_key(self, connection):
+        """
+        Accepts a Connection object and sets `connection._plain_conn_key` by
+        decrypting `connection.conn_key` via the KMS.
+        """
+        raise NotImplementedError()

--- a/airflow/migrations/versions/d7a2586b258a_add_kms_fields_to_connection.py
+++ b/airflow/migrations/versions/d7a2586b258a_add_kms_fields_to_connection.py
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""add KMS fields to connection
+
+Revision ID: d7a2586b258a
+Revises: 9635ae0956e7
+Create Date: 2018-07-19 09:13:46.044044
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'd7a2586b258a'
+down_revision = '9635ae0956e7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('connection', sa.Column('conn_key', sa.String(length=200),
+                                          nullable=True))
+    op.add_column('connection', sa.Column('_kms_conn_id', sa.String(length=250),
+                                          nullable=True))
+    op.add_column('connection', sa.Column('_kms_extra', sa.String(length=5000),
+                                          nullable=True))
+
+
+def downgrade():
+    op.drop_column('connection', 'conn_key')
+    op.drop_column('connection', '_kms_conn_id')
+    op.drop_column('connection', '_kms_extra')

--- a/docs/howto/manage-connections.rst
+++ b/docs/howto/manage-connections.rst
@@ -28,7 +28,9 @@ to create a new connection.
 2. Choose the connection type with the ``Conn Type`` field.
 3. Fill in the remaining fields. See
    :ref:`manage-connections-connection-types` for a description of the fields
-   belonging to the different connection types.
+   belonging to the different connection types, and 
+   :ref:`secure-connections-kms` if you want to encrypt connection
+   credentials using a Key Management System.
 4. Click the ``Save`` button to create the connection.
 
 Editing a Connection with the UI

--- a/docs/howto/secure-connections.rst
+++ b/docs/howto/secure-connections.rst
@@ -30,3 +30,16 @@ variable over the value in ``airflow.cfg``:
 
 4. Restart Airflow webserver.
 5. For existing connections (the ones that you had defined before installing ``airflow[crypto]`` and creating a Fernet key), you need to open each connection in the connection admin UI, re-type the password, and save it.
+
+.. _secure-connections-kms:
+
+Encrypting Connections with a KMS
+---------------------------------
+
+In addition to using a fernet_key, Airflow supports encrypting connections using keys 
+managed by a Key Management System. In order to encrypt a connection using a KMS, follow these steps:
+
+1. Setup or create an account on a KMS of your choice. Create at least one encryption/decryption key.
+2. Install crypto package ``pip install apache-airflow[crypto]``
+3. Create a regular (non-KMS encrypted) connection defining how to connect to your KMS.
+4. Create (or modify) the connection you wish to encrypt. Choose the connection from step 3 for the  "KMS Conn Id" field, and fill out the any additional fields that appear.

--- a/tests/contrib/hooks/test_gcp_kms_hook.py
+++ b/tests/contrib/hooks/test_gcp_kms_hook.py
@@ -158,3 +158,27 @@ class GoogleCloudKMSHookTest(unittest.TestCase):
                                           body=body)
         execute_method.assert_called_with()
         self.assertEqual(plaintext, ret_val)
+
+    @mock.patch(KMS_STRING.format('GoogleCloudKMSHook.encrypt'))
+    def test_encrypt_conn(self, mock_encrypt):
+        conn_key = "Test Key"
+        mock_conn = mock.Mock()
+        mock_conn._plain_conn_key = conn_key
+        mock_conn.kms_extra_dejson = {
+            "kms_extra__google_cloud_platform__key_name": TEST_KEY_ID}
+
+        self.kms_hook.encrypt_conn_key(mock_conn)
+
+        mock_encrypt.assert_called_with(TEST_KEY_ID, conn_key)
+
+    @mock.patch(KMS_STRING.format('GoogleCloudKMSHook.decrypt'))
+    def test_decrypt_conn(self, mock_decrypt):
+        conn_key = "Test Key"
+        mock_conn = mock.Mock()
+        mock_conn.conn_key = conn_key
+        mock_conn.kms_extra_dejson = {
+            "kms_extra__google_cloud_platform__key_name": TEST_KEY_ID}
+
+        self.kms_hook.decrypt_conn_key(mock_conn)
+
+        mock_decrypt.assert_called_with(TEST_KEY_ID, conn_key)


### PR DESCRIPTION
### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-2062

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
   - For an in-depth explanation of these changes, please see this [design doc](https://docs.google.com/document/d/1qaucGw52aoR96swHQqIYN9nQXn2QKSOWvw6-KyI6Wwc/edit?usp=sharing).
   - Connections can now be encrypted using a local key that is encrypted using a KMS before being stored, instead of the global fernet key. Enabling this behavior requires creating a connection through the CLI (web UI in a coming PR) with the new KMS fields specified.
   - `Connection` and `BaseHook` were also refactored to support loading connections from the `Connection` class (instead of `BaseHook`).

### Tests

- [X] My PR adds the following unit tests:
   - `tests/contrib/hooks/test_gcp_kms_hook.py`
      - `test_encrypt_conn`
      - `test_encrypt_conn`
   - `tests/models.py`
      - `FernetTest`
      - `test_connection_kms_encryption`
      - `test_connection_from_uri_kms_encryption`
      - `test_get_kms_hook_missing`
      - `test_update_kms`

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.

### Code Quality

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`