### PR TITLE
[AIRFLOW-2956] added kubernetes tolerations to kubernetes pod operator

### DIFF
--- a/airflow/contrib/example_dags/example_kubernetes_operator.py
+++ b/airflow/contrib/example_dags/example_kubernetes_operator.py
@@ -38,6 +38,14 @@ try:
         default_args=args,
         schedule_interval=None)
 
+    tolerations = [
+        {
+            'key': "key",
+            'operator': 'Equal',
+            'value': 'value'
+        }
+    ]
+
     k = KubernetesPodOperator(
         namespace='default',
         image="ubuntu:16.04",
@@ -49,7 +57,9 @@ try:
         task_id="task",
         get_logs=True,
         dag=dag,
-        is_delete_operator_pod=False)
+        is_delete_operator_pod=False,
+        tolerations=tolerations
+    )
 
 except ImportError as e:
     log.warn("Could not import KubernetesPodOperator: " + str(e))

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -186,3 +186,8 @@ class KubernetesRequestFactory:
             req['spec']['imagePullSecrets'] = [{
                 'name': pull_secret
             } for pull_secret in pod.image_pull_secrets.split(',')]
+
+    @staticmethod
+    def extract_tolerations(pod, req):
+        if pod.tolerations:
+            req['spec']['tolerations'] = pod.tolerations

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
@@ -60,6 +60,7 @@ spec:
         self.extract_annotations(pod, req)
         self.extract_affinity(pod, req)
         self.extract_hostnetwork(pod, req)
+        self.extract_tolerations(pod, req)
         return req
 
 
@@ -118,4 +119,5 @@ spec:
         self.extract_annotations(pod, req)
         self.extract_affinity(pod, req)
         self.extract_hostnetwork(pod, req)
+        self.extract_tolerations(pod, req)
         return req

--- a/airflow/contrib/kubernetes/pod.py
+++ b/airflow/contrib/kubernetes/pod.py
@@ -78,7 +78,8 @@ class Pod:
             resources=None,
             annotations=None,
             affinity=None,
-            hostnetwork=False
+            hostnetwork=False,
+            tolerations=None,
     ):
         self.image = image
         self.envs = envs or {}
@@ -100,3 +101,4 @@ class Pod:
         self.annotations = annotations or {}
         self.affinity = affinity or {}
         self.hostnetwork = hostnetwork or False
+        self.tolerations = tolerations or []

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -78,6 +78,8 @@ class KubernetesPodOperator(BaseOperator):
         /airflow/xcom/return.json in the container will also be pushed to an
         XCom when the container completes.
     :type xcom_push: bool
+    :param tolerations: Kubernetes tolerations
+    :type list of tolerations
     """
     template_fields = ('cmds', 'arguments', 'env_vars', 'config_file')
 
@@ -111,6 +113,7 @@ class KubernetesPodOperator(BaseOperator):
             pod.affinity = self.affinity
             pod.node_selectors = self.node_selectors
             pod.hostnetwork = self.hostnetwork
+            pod.tolerations = self.tolerations
 
             launcher = pod_launcher.PodLauncher(kube_client=client,
                                                 extract_xcom=self.xcom_push)
@@ -158,6 +161,7 @@ class KubernetesPodOperator(BaseOperator):
                  service_account_name="default",
                  is_delete_operator_pod=False,
                  hostnetwork=False,
+                 tolerations=None,
                  *args,
                  **kwargs):
         super(KubernetesPodOperator, self).__init__(*args, **kwargs)
@@ -186,3 +190,4 @@ class KubernetesPodOperator(BaseOperator):
         self.service_account_name = service_account_name
         self.is_delete_operator_pod = is_delete_operator_pod
         self.hostnetwork = hostnetwork
+        self.tolerations = tolerations or []

--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -82,6 +82,14 @@ Kubernetes Operator
         }
     }
 
+    tolerations = [
+        {
+            'key': "key",
+            'operator': 'Equal',
+            'value': 'value'
+         }
+    ]
+
     k = KubernetesPodOperator(namespace='default',
                               image="ubuntu:16.04",
                               cmds=["bash", "-cx"],
@@ -94,7 +102,8 @@ Kubernetes Operator
                               task_id="task",
                               affinity=affinity,
                               is_delete_operator_pod=True,
-                              hostnetwork=False
+                              hostnetwork=False,
+                              tolerations=tolerations
                               )
 
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-2956\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2956
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-2956\], code changes always need a Jira issue.

### Description
 Adds ability to specify kubernetes tolerations for dags using kubernetes pod operator

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
