### PR TITLE
[AIRFLOW-2959] Make HTTPSensor doc clearer

### DIFF
--- a/airflow/sensors/http_sensor.py
+++ b/airflow/sensors/http_sensor.py
@@ -28,8 +28,11 @@ from airflow.utils.decorators import apply_defaults
 
 class HttpSensor(BaseSensorOperator):
     """
-    Executes a HTTP get statement and returns False on failure:
-        404 not found or response_check function returned False
+    Executes a HTTP GET statement and returns False on failure caused by
+    404 Not Found or `response_check` returning False.
+
+    HTTP Error codes other than 404 (like 403) or Connection Refused Error
+    would fail the sensor itself directly (no more poking).
 
     :param http_conn_id: The connection to run the sensor against
     :type http_conn_id: string


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2959
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The `HTTPSensor` is supposed to sense if a resource/endpoint if available at a location specified by http connection. It will return `False` when the HTTP Status code is 404 or check function returns `False`.

On the other hand, HTTP Error code OTHER THAN 404, or Connection Refused Error, would fail the sensor itself directly (**no more poking**) https://github.com/apache/incubator-airflow/blob/f6191fbd7a61766bd002873db371b74702b13ff3/airflow/sensors/http_sensor.py#L90
This is not clear enough in the doc. Users like myself may think these situations will also return False and try poking later, while it's not true.

This should be made clear in the documentation.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Only comment is changed. No change is made on the executable codes.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
