### PR TITLE
[AIRFLOW-2960] Pin boto3 to <1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ elasticsearch = [
     'elasticsearch>=5.0.0,<6.0.0',
     'elasticsearch-dsl>=5.0.0,<6.0.0'
 ]
-emr = ['boto3>=1.0.0']
+emr = ['boto3>=1.0.0, <1.8.0']
 gcp_api = [
     'httplib2>=0.9.2',
     'google-api-python-client>=1.6.0, <2.0.0dev',
@@ -219,7 +219,7 @@ postgres = ['psycopg2-binary>=2.7.4']
 qds = ['qds-sdk>=1.9.6']
 rabbitmq = ['librabbitmq>=1.6.1']
 redis = ['redis>=2.10.5']
-s3 = ['boto3>=1.7.0']
+s3 = ['boto3>=1.7.0, <1.8.0']
 salesforce = ['simple-salesforce>=0.72']
 samba = ['pysmbclient>=0.1.3']
 segment = ['analytics-python>=1.2.9']


### PR DESCRIPTION
Boto 1.8 has been released a few days ago and it breaks our tests.

cc @seelmann 

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-2960\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2960
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-2960\], code changes always need a Jira issue.
