### PR TITLE
editting zendesk_hook.py https://citybase.atlassian.net/browse/DS-78 

### DIFF
--- a/airflow/hooks/zendesk_hook.py
+++ b/airflow/hooks/zendesk_hook.py
@@ -78,7 +78,7 @@ class ZendeskHook(BaseHook):
         next_page = results['next_page']
         if side_loading:
             keys += query['include'].split(',')
-        results = {key: results[key] for key in keys}
+            results = {key: results[key] for key in keys}
 
         if get_all_pages:
             while next_page is not None:


### PR DESCRIPTION
**Description:**
When I am using zendesk_hook.py file in incubator-airflow/airflow/hooks, I am getting an error: "KeyError: 'search'" - the error is due to line 81 in the zendesk_hook file "results ={key: results[key] for key in keys}"

I believe the line needs an extra tab at line 81, because this line is running regardless if sideloading is set to true. I believe it should only run when sideloading is set to true. 

**Tests:**
My code runs once the tab has been added.



### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
