### PR TITLE
[HOLD][AIRFLOW-2973] Use Python 3.6.x everywhere possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,12 @@ env:
     - TOX_ENV=py35-backend_mysql PYTHON_VERSION=3
     - TOX_ENV=py35-backend_sqlite PYTHON_VERSION=3
     - TOX_ENV=py35-backend_postgres PYTHON_VERSION=3
+    - TOX_ENV=py36-backend_mysql PYTHON_VERSION=3
+    - TOX_ENV=py36-backend_sqlite PYTHON_VERSION=3
+    - TOX_ENV=py36-backend_postgres PYTHON_VERSION=3
     - TOX_ENV=py27-backend_postgres KUBERNETES_VERSION=v1.9.0
     - TOX_ENV=py35-backend_postgres KUBERNETES_VERSION=v1.10.0 PYTHON_VERSION=3
+    - TOX_ENV=py36-backend_postgres KUBERNETES_VERSION=v1.10.0 PYTHON_VERSION=3
 cache:
   directories:
     - $HOME/.wheelhouse/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ There are three ways to setup an Apache Airflow development environment.
 
 1. Using tools and libraries installed directly on your system.
 
-  Install Python (2.7.x or 3.4.x), MySQL, and libxml by using system-level package
+  Install Python (2.7.x or 3.6.x), MySQL, and libxml by using system-level package
   managers like yum, apt-get for Linux, or Homebrew for Mac OS at first. Refer to the [base CI Dockerfile](https://github.com/apache/incubator-airflow-ci/blob/master/Dockerfile.base) for
   a comprehensive list of required packages.
 
@@ -146,7 +146,7 @@ There are three ways to setup an Apache Airflow development environment.
   # From the container
   pip install -e .[devel]
   # Run all the tests with python and mysql through tox
-  tox -e py35-backend_mysql
+  tox -e py36-backend_mysql
   ```
 
 ### Running unit tests
@@ -195,7 +195,7 @@ meets these guidelines:
 1. Preface your commit's subject & PR's title with **[AIRFLOW-XXX]** where *XXX* is the JIRA number. We compose release notes (i.e. for Airflow releases) from all commit titles in a release. By placing the JIRA number in the commit title and hence in the release notes, Airflow users can look into JIRA and Github PRs for more details about a particular change.
 1. Add an [Apache License](http://www.apache.org/legal/src-headers.html) header to all new files
 1. If the pull request adds functionality, the docs should be updated as part of the same PR. Doc string are often sufficient.  Make sure to follow the Sphinx compatible standards.
-1. The pull request should work for Python 2.7 and 3.4. If you need help writing code that works in both Python 2 and 3, see the documentation at the [Python-Future project](http://python-future.org) (the future package is an Airflow requirement and should be used where possible).
+1. The pull request should work for Python 2.7 and 3.6. If you need help writing code that works in both Python 2 and 3, see the documentation at the [Python-Future project](http://python-future.org) (the future package is an Airflow requirement and should be used where possible).
 1. As Airflow grows as a project, we try to enforce a more consistent style and try to follow the Python community guidelines. We track this using [landscape.io](https://landscape.io/github/apache/incubator-airflow/), which you can setup on your fork as well to check before you submit your PR. We currently enforce most [PEP8](https://www.python.org/dev/peps/pep-0008/) and a few other linting rules. It is usually a good idea to lint locally as well using [flake8](https://flake8.readthedocs.org/en/latest/) using `flake8 airflow tests`. `git diff upstream/master -u -- "*.py" | flake8 --diff` will return any changed files in your branch that require linting.
 1. Please read this excellent [article](http://chris.beams.io/posts/git-commit/) on commit messages and adhere to them. It makes the lives of those who come after you a lot easier.
 

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
@@ -85,7 +85,7 @@ spec:
         - name: xcom
           mountPath: {xcomMountPath}
     - name: {sidecarContainerName}
-      image: python:3.5-alpine
+      image: python:3.6-alpine
       command: ["python", "-m", "http.server"]
       volumeMounts:
         - name: xcom

--- a/setup.py
+++ b/setup.py
@@ -398,6 +398,7 @@ def do_setup():
             'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
             'Topic :: System :: Monitoring',
         ],
         author='Apache Software Foundation',

--- a/tests/contrib/operators/test_mlengine_operator.py
+++ b/tests/contrib/operators/test_mlengine_operator.py
@@ -327,7 +327,7 @@ class MLEngineTrainingOperatorTest(unittest.TestCase):
     def testSuccessCreateTrainingJobWithOptionalArgs(self):
         training_input = copy.deepcopy(self.TRAINING_INPUT)
         training_input['trainingInput']['runtimeVersion'] = '1.6'
-        training_input['trainingInput']['pythonVersion'] = '3.5'
+        training_input['trainingInput']['pythonVersion'] = '3.6'
         training_input['trainingInput']['jobDir'] = 'gs://some-bucket/jobs/test_training'
 
         with patch('airflow.contrib.operators.mlengine_operator.MLEngineHook') \
@@ -339,7 +339,7 @@ class MLEngineTrainingOperatorTest(unittest.TestCase):
 
             training_op = MLEngineTrainingOperator(
                 runtime_version='1.6',
-                python_version='3.5',
+                python_version='3.6',
                 job_dir='gs://some-bucket/jobs/test_training',
                 **self.TRAINING_DEFAULT_ARGS)
             training_op.execute(None)

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@
 # under the License.
 
 [tox]
-envlist = flake8,{py27,py35}-backend_{mysql,sqlite,postgres}
+envlist = flake8,{py27,py35,py36}-backend_{mysql,sqlite,postgres}
 skipsdist = True
 
 [global]
@@ -38,6 +38,7 @@ deps =
 basepython =
     py27: python2.7
     py35: python3.5
+    py36: python3.6
 
 setenv =
   HADOOP_DISTRO=cdh


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2973
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR is similar in nature / complementary to @kaxil's #3815.

- Add Python 3.6 support to PyPI, tox, Travis CI
- Update dev docs to recommend 3.6.x
- Update MLEngine operator tests to use 3.6
- Update Kubernetes ExtractXcomPodRequestFactory pod spec to use 3.6

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Already covered by existing tests.  I'm currently waiting on the CI to see if this breaks any existing unit tests.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
