### PR TITLE
[AIRFLOW-2991] Log path to driver output after Dataproc job is completed

### DIFF
--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -53,6 +53,8 @@ class _DataProcJob(LoggingMixin):
                 self.log.error('DataProc job %s has errors', self.job_id)
                 self.log.error(self.job['status']['details'])
                 self.log.debug(str(self.job))
+                self.log.info('Driver output location: %s',
+                              self.job['driverOutputResourceUri'])
                 return False
             if 'CANCELLED' == self.job['status']['state']:
                 print(str(self.job))
@@ -60,8 +62,12 @@ class _DataProcJob(LoggingMixin):
                 if 'details' in self.job['status']:
                     self.log.warning(self.job['status']['details'])
                 self.log.debug(str(self.job))
+                self.log.info('Driver output location: %s',
+                              self.job['driverOutputResourceUri'])
                 return False
             if 'DONE' == self.job['status']['state']:
+                self.log.info('Driver output location: %s',
+                              self.job['driverOutputResourceUri'])
                 return True
             self.log.debug(
                 'DataProc job %s is %s',


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2991
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

It's difficult to keep track of logs from Google Cloud Dataproc jobs invoked by Airflow. Dataproc API provides an output property driverOutputResourceUri containing path to stdout of job's driver. It's very convenient to be able to quickly check the output log in case of errors without opening Google Cloud Console. The change involves printing INFO-level log with value of driverOutputResourceUri after Dataproc job is finished.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Log-only changes, no tests required.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
