### PR TITLE
[AIRFLOW-2965] CLI tool to show the next execution datetime

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -552,6 +552,31 @@ def dag_state(args):
 
 
 @cli_utils.action_logging
+def next_execution(args):
+    """
+    Returns the next execution datetime of a DAG at the command line.
+    >>> airflow next_execution tutorial
+    2018-08-31 10:38:00
+    """
+    dag = get_dag(args)
+
+    if dag.is_paused:
+        print("[INFO] Please be reminded this DAG is PAUSED now.")
+
+    if dag.latest_execution_date:
+        next_execution_dttm = dag.following_schedule(dag.latest_execution_date)
+
+        if next_execution_dttm is None:
+            print("[WARN] No following schedule can be found. " +
+                  "This DAG may have schedule interval '@once' or `None`.")
+
+        print(next_execution_dttm)
+    else:
+        print("[WARN] Only applicable when there is execution record found for the DAG.")
+        print(None)
+
+
+@cli_utils.action_logging
 def list_dags(args):
     dagbag = DagBag(process_subdir(args.subdir))
     s = textwrap.dedent("""\n
@@ -1986,6 +2011,11 @@ class CLIFactory(object):
             'func': sync_perm,
             'help': "Update existing role's permissions.",
             'args': tuple(),
+        },
+        {
+            'func': next_execution,
+            'help': "Get the next execution datetime of a DAG.",
+            'args': ('dag_id', 'subdir')
         }
     )
     subparsers_dict = {sp['func'].__name__: sp for sp in subparsers}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2965
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR is to address the request proposed by JIRA user Jack , in JIRA ticket [2965](https://issues.apache.org/jira/browse/AIRFLOW-2965).
@r39132 suggested a PR in this ticket.

This new CLI tool can help show the next execution datetime, given DAG id. Under the hood, its checking the following schedule of the latest execution datetime.

Let's say I have DAG `basic_dag` whose schedule_interval is `*/2 * * * *`. The latest execution_date is 2018-08-31 10:36:00 (start time is 2018-08-31 10:38:00).

If I run this new CLI tool `airflow next_execution basic_dag`, the result would be 
<img width="855" alt="screen shot 2018-09-02 at 10 29 05 pm" src="https://user-images.githubusercontent.com/11539188/44957068-ef54b680-aeff-11e8-831d-9319b85135d2.png">

After I change the schedule_interval to `0 23 * * *` and run the same command again, the result is 
<img width="868" alt="screen shot 2018-09-02 at 10 30 02 pm" src="https://user-images.githubusercontent.com/11539188/44957070-f8de1e80-aeff-11e8-9785-87ffaf2e74ce.png">
**(actual start time would be 2018-09-01 23:00:00)**

Again, we change the scheduler_interval to `0 3 * * *`, the result is 
<img width="876" alt="screen shot 2018-09-02 at 10 30 42 pm" src="https://user-images.githubusercontent.com/11539188/44957071-faa7e200-aeff-11e8-83a1-f25a008394ac.png">
**(actual start time would be 2018-09-02 03:00:00)**

Running with `-h` would return the usage and arguments needed.
<img width="662" alt="screen shot 2018-09-02 at 10 36 14 pm" src="https://user-images.githubusercontent.com/11539188/44957110-a2251480-af00-11e8-97df-cd8077c6ba76.png">




### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

I believe the documentation generation of CLI is self-contained in script `airflow/bin/cli.py`.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
