### PR TITLE
[AIRFLOW-3006] Fix issue with schedule_interval='None'

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2313,6 +2313,7 @@ class BaseOperator(LoggingMixin):
     :type on_failure_callback: callable
     :param on_retry_callback: much like the ``on_failure_callback`` except
         that it is executed when retries occur.
+    :type on_retry_callback: callable
     :param on_success_callback: much like the ``on_failure_callback`` except
         that it is executed when the task succeeds.
     :type on_success_callback: callable

--- a/docs/scheduler.rst
+++ b/docs/scheduler.rst
@@ -63,6 +63,8 @@ use one of these cron "preset":
 | ``@yearly``  | Run once a year at midnight of January 1                       | ``0 0 1 1 *`` |
 +--------------+----------------------------------------------------------------+---------------+
 
+**Note**: Use ``schedule_interval=None`` and not ``schedule_interval='None'`` when
+you don't want to schedule your DAG.
 
 Your DAG will be instantiated
 for each schedule, while creating a ``DAG Run`` entry for each schedule.

--- a/tests/models.py
+++ b/tests/models.py
@@ -65,7 +65,7 @@ TEST_DAGS_FOLDER = os.path.join(
 
 class DagTest(unittest.TestCase):
 
-    def test_parms_not_passed_is_empty_dict(self):
+    def test_params_not_passed_is_empty_dict(self):
         """
         Test that when 'params' is _not_ passed to a new Dag, that the params
         attribute is set to an empty dictionary.
@@ -310,7 +310,6 @@ class DagTest(unittest.TestCase):
                  default_args={'owner': 'owner1'}) as dag:
             with self.assertRaises(AirflowException):
                 DummyOperator(task_id='should_fail', weight_rule='no rule')
-
 
     def test_get_num_task_instances(self):
         test_dag_id = 'test_get_num_task_instances_dag'
@@ -594,6 +593,7 @@ class DagStatTest(unittest.TestCase):
         res = qry2.all()
         for stat in res:
             self.assertFalse(stat.dirty)
+
 
 class DagRunTest(unittest.TestCase):
 
@@ -984,6 +984,7 @@ class DagRunTest(unittest.TestCase):
         dagrun.verify_integrity()
         flaky_ti.refresh_from_db()
         self.assertEquals(State.NONE, flaky_ti.state)
+
 
 class DagBagTest(unittest.TestCase):
 
@@ -1456,6 +1457,7 @@ class DagBagTest(unittest.TestCase):
         mock_ti.assert_called_with(ANY,
                                    configuration.getboolean('core', 'unit_test_mode'),
                                    ANY)
+
 
 class TaskInstanceTest(unittest.TestCase):
 
@@ -2473,6 +2475,7 @@ class ClearTasksTest(unittest.TestCase):
 
         for result in results:
             self.assertEqual(result.value, json_obj)
+
 
 class ConnectionTest(unittest.TestCase):
     @patch.object(configuration, 'get')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3006
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When `schedule_interval` is set to `"None"` (Not python literal `None` but 'None' string) as shown in the example below:
```python
dag = DAG('params-temp3',
          default_args=default_args, schedule_interval='None')
```

it gives the following error:

```python
[2018-09-04 23:26:21,515] {dag_processing.py:582} INFO - Started a process (PID: 65903) to generate tasks for /Users/kaxil/airflow/dags/params-temp1.py
Process DagFileProcessor386-Process:
Traceback (most recent call last):
  File "/Users/kaxil/anaconda2/lib/python2.7/multiprocessing/process.py", line 267, in _bootstrap
    self.run()
  File "/Users/kaxil/anaconda2/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/kaxil/.virtualenvs/tst-pip-airflow/lib/python2.7/site-packages/airflow/jobs.py", line 388, in helper
    pickle_dags)
  File "/Users/kaxil/.virtualenvs/tst-pip-airflow/lib/python2.7/site-packages/airflow/utils/db.py", line 74, in wrapper
    return func(*args, **kwargs)
  File "/Users/kaxil/.virtualenvs/tst-pip-airflow/lib/python2.7/site-packages/airflow/jobs.py", line 1832, in process_file
    self._process_dags(dagbag, dags, ti_keys_to_schedule)
  File "/Users/kaxil/.virtualenvs/tst-pip-airflow/lib/python2.7/site-packages/airflow/jobs.py", line 1422, in _process_dags
    dag_run = self.create_dag_run(dag)
  File "/Users/kaxil/.virtualenvs/tst-pip-airflow/lib/python2.7/site-packages/airflow/utils/db.py", line 74, in wrapper
    return func(*args, **kwargs)
  File "/Users/kaxil/.virtualenvs/tst-pip-airflow/lib/python2.7/site-packages/airflow/jobs.py", line 856, in create_dag_run
    next_run_date = dag.normalize_schedule(min(task_start_dates))
  File "/Users/kaxil/.virtualenvs/tst-pip-airflow/lib/python2.7/site-packages/airflow/models.py", line 3410, in normalize_schedule
    following = self.following_schedule(dttm)
  File "/Users/kaxil/.virtualenvs/tst-pip-airflow/lib/python2.7/site-packages/airflow/models.py", line 3353, in following_schedule
    cron = croniter(self._schedule_interval, dttm)
  File "/Users/kaxil/.virtualenvs/tst-pip-airflow/lib/python2.7/site-packages/croniter/croniter.py", line 92, in __init__
    self.expanded, self.nth_weekday_of_month = self.expand(expr_format)
  File "/Users/kaxil/.virtualenvs/tst-pip-airflow/lib/python2.7/site-packages/croniter/croniter.py", line 467, in expand
    raise CroniterBadCronError(cls.bad_length)
CroniterBadCronError: Exactly 5 or 6 columns has to be specified for iteratorexpression.
[2018-09-04 23:26:22,657] {dag_processing.py:495} INFO - Processor for /Users/kaxil/airflow/dags/params-temp1.py finished
```

Our documentation at https://airflow.apache.org/scheduler.html#dag-runs has 'None' as **preset** since 1.8.2 or even before, hence we should accept **"None"** as a valid `schedule_interval` apart from **None**

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- `test_scheduler_dagrun_none `
- `test_scheduler_interval_none_string_is_set_none`
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
