### PR TITLE
[AIRFLOW-3009] Fix Python 3.7 deprecation warning for import collections abc

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -26,7 +26,13 @@ from future.standard_library import install_aliases
 
 from builtins import str, object, bytes, ImportError as BuiltinImportError
 import copy
-from collections import namedtuple, defaultdict, Hashable
+from collections import namedtuple, defaultdict
+try:
+    # Fix Python > 3.7 deprecation
+    from collections.abc import Hashable
+except ImportError:
+    # Preserve Python < 3.3 compatibility
+    from collections import Hashable
 from datetime import timedelta
 
 import dill


### PR DESCRIPTION
This is a fix for https://issues.apache.org/jira/browse/AIRFLOW-3009

After pip-installing Airflow from source, the following warning message appears upon entering any airflow command from the prompt:
```
/usr/lib/python3.7/site-packages/airflow/models.py:29: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop workingfrom collections import namedtuple, defaultdict, Hashable
```
