### PR TITLE
[AIRFLOW-3010] added support for date format to postgres_to_gcs_operator

### DIFF
--- a/airflow/contrib/operators/postgres_to_gcs_operator.py
+++ b/airflow/contrib/operators/postgres_to_gcs_operator.py
@@ -207,8 +207,10 @@ class PostgresToGoogleCloudStorageOperator(BaseOperator):
         JSON/Google Cloud Storage/BigQuery. Dates are converted to UTC seconds.
         Decimals are converted to floats. Times are converted to seconds.
         """
-        if type(value) in (datetime.datetime, datetime.date):
+        if type(value) == datetime.datetime:
             return time.mktime(value.timetuple())
+        elif type(value) == datetime.date:
+            return value.strftime('%Y-%m-%d')
         elif type(value) == datetime.time:
             formated_time = time.strptime(str(value), "%H:%M:%S")
             return datetime.timedelta(
@@ -229,8 +231,8 @@ class PostgresToGoogleCloudStorageOperator(BaseOperator):
         d = {
             1114: 'TIMESTAMP',
             1184: 'TIMESTAMP',
-            1082: 'TIMESTAMP',
             1083: 'TIMESTAMP',
+            1082: 'DATE',
             1005: 'INTEGER',
             1007: 'INTEGER',
             1016: 'INTEGER',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-3010\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3010
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-3010\], code changes always need a Jira issue.

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:

   I just changed it so the Date datatype would be acknowledged in write and read.

### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Currently the schema functionality is largely untested and this would be a larger undertaking if we wanted to create better testing for serialization.

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ X ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
