### PR TITLE
AIRFLOW-3014 Increase possible length of passwords in connection table

### DIFF
--- a/airflow/migrations/versions/5bb129a06791_allow_longer_passwords.py
+++ b/airflow/migrations/versions/5bb129a06791_allow_longer_passwords.py
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Increase length of password column in connection table
+
+Revision ID: 5bb129a06791
+Revises: dd25f486b8ea
+Create Date: 2018-09-05 09:07:19.143887
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '5bb129a06791'
+down_revision = 'dd25f486b8ea'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(table_name='connection',
+                    column_name='password',
+                    type_=sa.String(length=5000))
+
+
+def downgrade():
+    # This migration cannot be undone
+    pass


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3014
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [X ] Here are some details about my PR, including screenshots of any UI changes:
Adds a migration script to increase the size of the password column in the connection table

### Tests

- [X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
I did not see unit tests around migration scripts. If I was mistaken, I'd be happy to add a test.
### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
