### PR TITLE
[AIRFLOW-3021] Add Censys to who uses Airflow list

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Currently **officially** using Airflow:
 1. [California Data Collaborative](https://github.com/California-Data-Collaborative) powered by [ARGO Labs](http://www.argolabs.org)
 1. [Carbonite](https://www.carbonite.com) [[@ajbosco](https://github.com/ajbosco)]
 1. [Celect](http://www.celect.com) [[@superdosh](https://github.com/superdosh) & [@chadcelect](https://github.com/chadcelect)]
+1. [Censys](https://censys.io) [[@zakird](https://github.com/zakird), [@dadrian](https://github.com/dadrian), & [@andrewsardone](https://github.com/andrewsardone)]
 1. [Change.org](https://www.change.org) [[@change](https://github.com/change), [@vijaykramesh](https://github.com/vijaykramesh)]
 1. [Checkr](https://checkr.com) [[@tongboh](https://github.com/tongboh)]
 1. [Children's Hospital of Philadelphia Division of Genomic Diagnostics](http://www.chop.edu/centers-programs/division-genomic-diagnostics) [[@genomics-geek]](https://github.com/genomics-geek/)


### PR DESCRIPTION
Add [Censys](https://censys.io) to the [`README.md` list of who uses Airflow](https://github.com/apache/incubator-airflow/blob/master/README.md#who-uses-airflow).

> [Censys](https://censys.io/)
> Find and analyze every reachable server and device on the Internet

closes [AIRFLOW-3021](https://issues.apache.org/jira/browse/AIRFLOW-3021)
