### PR TITLE
[AIRFLOW-3022] Add volume mount to KubernetesExecutorConfig

### DIFF
--- a/airflow/contrib/example_dags/example_kubernetes_executor.py
+++ b/airflow/contrib/example_dags/example_kubernetes_executor.py
@@ -66,5 +66,4 @@ three_task = PythonOperator(
         "KubernetesExecutor": {"request_memory": "128Mi", "limit_memory": "128Mi"}}
 )
 
-
 start_task.set_downstream([one_task, two_task, three_task])

--- a/airflow/contrib/example_dags/example_kubernetes_executor.py
+++ b/airflow/contrib/example_dags/example_kubernetes_executor.py
@@ -66,4 +66,25 @@ three_task = PythonOperator(
         "KubernetesExecutor": {"request_memory": "128Mi", "limit_memory": "128Mi"}}
 )
 
-start_task.set_downstream([one_task, two_task, three_task])
+# Mount volume or secret to the worker pod
+four_task = PythonOperator(
+    task_id="four_task", python_callable=print_stuff, dag=dag,
+    executor_config={
+        "KubernetesExecutor": {
+            "volumes": [
+                {
+                    "name": "test-volume",
+                    "hostPath": {"path": "/data"},
+                },
+            ],
+            "volume_mounts": [
+                {
+                    "mountPath": "/test-pd",
+                    "name": "test-volume",
+                },
+            ]
+        }
+    }
+)
+
+start_task.set_downstream([one_task, two_task, three_task, four_task])

--- a/airflow/contrib/example_dags/example_kubernetes_executor.py
+++ b/airflow/contrib/example_dags/example_kubernetes_executor.py
@@ -42,14 +42,6 @@ def use_zip_binary():
     assert rc == 0
 
 
-def test_volume_mount():
-    with open('/foo/volume_mount_test.txt', 'w') as foo:
-        foo.write('Hello')
-
-    rc = os.system("cat /foo/volume_mount_test.txt")
-    assert rc == 0
-
-
 # You don't have to use any special KubernetesExecutor configuration if you don't want to
 start_task = PythonOperator(
     task_id="start_task", python_callable=print_stuff, dag=dag
@@ -74,25 +66,5 @@ three_task = PythonOperator(
         "KubernetesExecutor": {"request_memory": "128Mi", "limit_memory": "128Mi"}}
 )
 
-# Mount volume or secret to the worker pod
-four_task = PythonOperator(
-    task_id="four_task", python_callable=test_volume_mount, dag=dag,
-    executor_config={
-        "KubernetesExecutor": {
-            "volumes": [
-                {
-                    "name": "test-volume",
-                    "hostPath": {"path": "/tmp/"},
-                },
-            ],
-            "volume_mounts": [
-                {
-                    "mountPath": "/foo/",
-                    "name": "test-volume",
-                },
-            ]
-        }
-    }
-)
 
-start_task.set_downstream([one_task, two_task, three_task, four_task])
+start_task.set_downstream([one_task, two_task, three_task])

--- a/airflow/contrib/example_dags/example_kubernetes_executor.py
+++ b/airflow/contrib/example_dags/example_kubernetes_executor.py
@@ -42,6 +42,14 @@ def use_zip_binary():
     assert rc == 0
 
 
+def test_volume_mount():
+    with open('/foo/volume_mount_test.txt', 'w') as foo:
+        foo.write('Hello')
+
+    rc = os.system("cat /foo/volume_mount_test.txt")
+    assert rc == 0
+
+
 # You don't have to use any special KubernetesExecutor configuration if you don't want to
 start_task = PythonOperator(
     task_id="start_task", python_callable=print_stuff, dag=dag
@@ -68,18 +76,18 @@ three_task = PythonOperator(
 
 # Mount volume or secret to the worker pod
 four_task = PythonOperator(
-    task_id="four_task", python_callable=print_stuff, dag=dag,
+    task_id="four_task", python_callable=test_volume_mount, dag=dag,
     executor_config={
         "KubernetesExecutor": {
             "volumes": [
                 {
                     "name": "test-volume",
-                    "hostPath": {"path": "/data"},
+                    "hostPath": {"path": "/tmp/"},
                 },
             ],
             "volume_mounts": [
                 {
-                    "mountPath": "/test-pd",
+                    "mountPath": "/foo/",
                     "name": "test-volume",
                 },
             ]

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -40,7 +40,7 @@ class KubernetesExecutorConfig:
     def __init__(self, image=None, image_pull_policy=None, request_memory=None,
                  request_cpu=None, limit_memory=None, limit_cpu=None,
                  gcp_service_account_key=None, node_selectors=None, affinity=None,
-                 annotations=None):
+                 annotations=None, volumes=None, volume_mounts=None):
         self.image = image
         self.image_pull_policy = image_pull_policy
         self.request_memory = request_memory
@@ -51,15 +51,18 @@ class KubernetesExecutorConfig:
         self.node_selectors = node_selectors
         self.affinity = affinity
         self.annotations = annotations
+        self.volumes = volumes
+        self.volume_mounts = volume_mounts
 
     def __repr__(self):
         return "{}(image={}, image_pull_policy={}, request_memory={}, request_cpu={}, " \
                "limit_memory={}, limit_cpu={}, gcp_service_account_key={}, " \
-               "node_selectors={}, affinity={}, annotations={})" \
+               "node_selectors={}, affinity={}, annotations={}, volumes={}, " \
+               "volume_mounts={})" \
             .format(KubernetesExecutorConfig.__name__, self.image, self.image_pull_policy,
                     self.request_memory, self.request_cpu, self.limit_memory,
                     self.limit_cpu, self.gcp_service_account_key, self.node_selectors,
-                    self.affinity, self.annotations)
+                    self.affinity, self.annotations, self.volumes, self.volume_mounts)
 
     @staticmethod
     def from_dict(obj):
@@ -83,6 +86,8 @@ class KubernetesExecutorConfig:
             node_selectors=namespaced.get('node_selectors', None),
             affinity=namespaced.get('affinity', None),
             annotations=namespaced.get('annotations', {}),
+            volumes=namespaced.get('volumes', []),
+            volume_mounts=namespaced.get('volume_mounts', []),
         )
 
     def as_dict(self):
@@ -97,6 +102,8 @@ class KubernetesExecutorConfig:
             'node_selectors': self.node_selectors,
             'affinity': self.affinity,
             'annotations': self.annotations,
+            'volumes': self.volumes,
+            'volume_mounts': self.volume_mounts,
         }
 
 

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -186,6 +186,8 @@ class WorkerConfiguration(LoggingMixin):
     def make_pod(self, namespace, worker_uuid, pod_id, dag_id, task_id, execution_date,
                  airflow_command, kube_executor_config):
         volumes, volume_mounts = self.init_volumes_and_mounts()
+        volumes += kube_executor_config.volumes
+        volume_mounts += kube_executor_config.volume_mounts
         worker_init_container_spec = self._get_init_containers(
             copy.deepcopy(volume_mounts))
         resources = Resources(

--- a/tests/contrib/minikube/test_kubernetes_executor.py
+++ b/tests/contrib/minikube/test_kubernetes_executor.py
@@ -158,55 +158,53 @@ class KubernetesExecutorTest(unittest.TestCase):
 
     def test_integration_run_dag(self):
         host = get_minikube_host()
-        dag_ids = ['example_kubernetes_annotation', 'example_kubernetes_executor']
+        dag_id = 'example_kubernetes_executor_config'
 
-        for dag_id in dag_ids:
-            result_json = self.start_dag(dag_id=dag_id, host=host)
+        result_json = self.start_dag(dag_id=dag_id, host=host)
 
-            self.assertGreater(len(result_json['items']), 0)
+        self.assertGreater(len(result_json['items']), 0)
 
-            execution_date = result_json['items'][0]['execution_date']
-            print("Found the job with execution date {}".format(execution_date))
+        execution_date = result_json['items'][0]['execution_date']
+        print("Found the job with execution date {}".format(execution_date))
 
-            # Wait 100 seconds for the operator to complete
-            self.monitor_task(host=host,
-                              execution_date=execution_date,
-                              dag_id=dag_id,
-                              task_id='start_task',
-                              expected_final_state='success', timeout=100)
+        # Wait 100 seconds for the operator to complete
+        self.monitor_task(host=host,
+                          execution_date=execution_date,
+                          dag_id=dag_id,
+                          task_id='start_task',
+                          expected_final_state='success', timeout=100)
 
-            self.ensure_dag_expected_state(host=host,
-                                           execution_date=execution_date,
-                                           dag_id=dag_id,
-                                           expected_final_state='success', timeout=100)
+        self.ensure_dag_expected_state(host=host,
+                                       execution_date=execution_date,
+                                       dag_id=dag_id,
+                                       expected_final_state='success', timeout=100)
 
     def test_integration_run_dag_with_scheduler_failure(self):
         host = get_minikube_host()
-        dag_ids = ['example_kubernetes_annotation', 'example_kubernetes_executor']
+        dag_id = 'example_kubernetes_executor_config'
 
-        for dag_id in dag_ids:
-            result_json = self.start_dag(dag_id=dag_id, host=host)
+        result_json = self.start_dag(dag_id=dag_id, host=host)
 
-            self.assertGreater(len(result_json['items']), 0)
+        self.assertGreater(len(result_json['items']), 0)
 
-            execution_date = result_json['items'][0]['execution_date']
-            print("Found the job with execution date {}".format(execution_date))
+        execution_date = result_json['items'][0]['execution_date']
+        print("Found the job with execution date {}".format(execution_date))
 
-            self._delete_airflow_pod()
+        self._delete_airflow_pod()
 
-            time.sleep(10)  # give time for pod to restart
+        time.sleep(10)  # give time for pod to restart
 
-            # Wait 100 seconds for the operator to complete
-            self.monitor_task(host=host,
-                              execution_date=execution_date,
-                              dag_id=dag_id,
-                              task_id='start_task',
-                              expected_final_state='success', timeout=120)
+        # Wait 100 seconds for the operator to complete
+        self.monitor_task(host=host,
+                          execution_date=execution_date,
+                          dag_id=dag_id,
+                          task_id='start_task',
+                          expected_final_state='success', timeout=120)
 
-            self.ensure_dag_expected_state(host=host,
-                                           execution_date=execution_date,
-                                           dag_id=dag_id,
-                                           expected_final_state='success', timeout=100)
+        self.ensure_dag_expected_state(host=host,
+                                       execution_date=execution_date,
+                                       dag_id=dag_id,
+                                       expected_final_state='success', timeout=100)
 
 
 if __name__ == '__main__':

--- a/tests/contrib/minikube/test_kubernetes_executor.py
+++ b/tests/contrib/minikube/test_kubernetes_executor.py
@@ -158,53 +158,55 @@ class KubernetesExecutorTest(unittest.TestCase):
 
     def test_integration_run_dag(self):
         host = get_minikube_host()
-        dag_id = 'example_kubernetes_annotation'
+        dag_ids = ['example_kubernetes_annotation', 'example_kubernetes_executor']
 
-        result_json = self.start_dag(dag_id=dag_id, host=host)
+        for dag_id in dag_ids:
+            result_json = self.start_dag(dag_id=dag_id, host=host)
 
-        self.assertGreater(len(result_json['items']), 0)
+            self.assertGreater(len(result_json['items']), 0)
 
-        execution_date = result_json['items'][0]['execution_date']
-        print("Found the job with execution date {}".format(execution_date))
+            execution_date = result_json['items'][0]['execution_date']
+            print("Found the job with execution date {}".format(execution_date))
 
-        # Wait 100 seconds for the operator to complete
-        self.monitor_task(host=host,
-                          execution_date=execution_date,
-                          dag_id=dag_id,
-                          task_id='start_task',
-                          expected_final_state='success', timeout=100)
+            # Wait 100 seconds for the operator to complete
+            self.monitor_task(host=host,
+                              execution_date=execution_date,
+                              dag_id=dag_id,
+                              task_id='start_task',
+                              expected_final_state='success', timeout=100)
 
-        self.ensure_dag_expected_state(host=host,
-                                       execution_date=execution_date,
-                                       dag_id=dag_id,
-                                       expected_final_state='success', timeout=100)
+            self.ensure_dag_expected_state(host=host,
+                                           execution_date=execution_date,
+                                           dag_id=dag_id,
+                                           expected_final_state='success', timeout=100)
 
     def test_integration_run_dag_with_scheduler_failure(self):
         host = get_minikube_host()
-        dag_id = 'example_kubernetes_annotation'
+        dag_ids = ['example_kubernetes_annotation', 'example_kubernetes_executor']
 
-        result_json = self.start_dag(dag_id=dag_id, host=host)
+        for dag_id in dag_ids:
+            result_json = self.start_dag(dag_id=dag_id, host=host)
 
-        self.assertGreater(len(result_json['items']), 0)
+            self.assertGreater(len(result_json['items']), 0)
 
-        execution_date = result_json['items'][0]['execution_date']
-        print("Found the job with execution date {}".format(execution_date))
+            execution_date = result_json['items'][0]['execution_date']
+            print("Found the job with execution date {}".format(execution_date))
 
-        self._delete_airflow_pod()
+            self._delete_airflow_pod()
 
-        time.sleep(10)  # give time for pod to restart
+            time.sleep(10)  # give time for pod to restart
 
-        # Wait 100 seconds for the operator to complete
-        self.monitor_task(host=host,
-                          execution_date=execution_date,
-                          dag_id=dag_id,
-                          task_id='start_task',
-                          expected_final_state='success', timeout=120)
+            # Wait 100 seconds for the operator to complete
+            self.monitor_task(host=host,
+                              execution_date=execution_date,
+                              dag_id=dag_id,
+                              task_id='start_task',
+                              expected_final_state='success', timeout=120)
 
-        self.ensure_dag_expected_state(host=host,
-                                       execution_date=execution_date,
-                                       dag_id=dag_id,
-                                       expected_final_state='success', timeout=100)
+            self.ensure_dag_expected_state(host=host,
+                                           execution_date=execution_date,
+                                           dag_id=dag_id,
+                                           expected_final_state='success', timeout=100)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3022
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Added `volumes` and `volume_mounts` to the KubernetesExecutorConfig so volumes or secrets can be mount to worker pod.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added in `example_kubernetes_executor_config.py` which will be tested with `test_integration_run_dag ` and `test_integration_run_dag_with_scheduler_failure`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
Added a task to showcase the functionality.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
