### PR TITLE
[AIRFLOW-2929] Add get and set for pool class in models

### DIFF
--- a/airflow/api/client/local_client.py
+++ b/airflow/api/client/local_client.py
@@ -18,7 +18,7 @@
 # under the License.
 
 from airflow.api.client import api_client
-from airflow.api.common.experimental import pool
+from airflow.models import Pool
 from airflow.api.common.experimental import trigger_dag
 from airflow.api.common.experimental import delete_dag
 
@@ -38,16 +38,16 @@ class Client(api_client.Client):
         return "Removed {} record(s)".format(count)
 
     def get_pool(self, name):
-        p = pool.get_pool(name=name)
+        p = Pool.get_pool(name=name)
         return p.pool, p.slots, p.description
 
     def get_pools(self):
-        return [(p.pool, p.slots, p.description) for p in pool.get_pools()]
+        return [(p.pool, p.slots, p.description) for p in Pool.get_pools()]
 
     def create_pool(self, name, slots, description):
-        p = pool.create_pool(name=name, slots=slots, description=description)
+        p = Pool.create_pool(name=name, slots=slots, description=description)
         return p.pool, p.slots, p.description
 
     def delete_pool(self, name):
-        p = pool.delete_pool(name=name)
+        p = Pool.delete_pool(name=name)
         return p.pool, p.slots, p.description


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Currently Pool class in models.py doesn't have get and set method, I suggest we add those methods to make them similar as Variable/Connection class, it will also be easier to have cli get more descriptive response as discussed [here](https://github.com/apache/incubator-airflow/pull/3730#discussion_r210185544)

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This PR is code refactoring so unit tests have been already includes.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
