### PR TITLE
[AIRFLOW-3025] Enable specifying dns and dns_search options for DockerOperator

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -53,6 +53,10 @@ class DockerOperator(BaseOperator):
         This value gets multiplied with 1024. See
         https://docs.docker.com/engine/reference/run/#cpu-share-constraint
     :type cpus: float
+    :param dns: Docker custom DNS servers
+    :type dns: str
+    :param dns_search: Docker custom DNS search domain
+    :type dns_search: str
     :param docker_url: URL of the host running the docker daemon.
         Default is unix://var/run/docker.sock
     :type docker_url: str
@@ -110,6 +114,8 @@ class DockerOperator(BaseOperator):
             api_version=None,
             command=None,
             cpus=1.0,
+            dns=None,
+            dns_search=None,
             docker_url='unix://var/run/docker.sock',
             environment=None,
             force_pull=False,
@@ -134,6 +140,8 @@ class DockerOperator(BaseOperator):
         self.api_version = api_version
         self.command = command
         self.cpus = cpus
+        self.dns = dns
+        self.dns_search = dns_search
         self.docker_url = docker_url
         self.environment = environment or {}
         self.force_pull = force_pull
@@ -203,7 +211,9 @@ class DockerOperator(BaseOperator):
                 host_config=self.cli.create_host_config(
                     binds=self.volumes,
                     network_mode=self.network_mode,
-                    shm_size=self.shm_size),
+                    shm_size=self.shm_size,
+                    dns=self.dns,
+                    dns_search=self.dns_search),
                 image=image,
                 mem_limit=self.mem_limit,
                 user=self.user,

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -114,8 +114,6 @@ class DockerOperator(BaseOperator):
             api_version=None,
             command=None,
             cpus=1.0,
-            dns=None,
-            dns_search=None,
             docker_url='unix://var/run/docker.sock',
             environment=None,
             force_pull=False,
@@ -133,6 +131,8 @@ class DockerOperator(BaseOperator):
             xcom_push=False,
             xcom_all=False,
             docker_conn_id=None,
+            dns=None,
+            dns_search=None,
             *args,
             **kwargs):
 

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -54,9 +54,9 @@ class DockerOperator(BaseOperator):
         https://docs.docker.com/engine/reference/run/#cpu-share-constraint
     :type cpus: float
     :param dns: Docker custom DNS servers
-    :type dns: str
+    :type dns: list of strings
     :param dns_search: Docker custom DNS search domain
-    :type dns_search: str
+    :type dns_search: list of strings
     :param docker_url: URL of the host running the docker daemon.
         Default is unix://var/run/docker.sock
     :type docker_url: str

--- a/tests/operators/docker_operator.py
+++ b/tests/operators/docker_operator.py
@@ -77,7 +77,9 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock.create_host_config.assert_called_with(binds=['/host/path:/container/path',
                                                                  '/mkdtemp:/tmp/airflow'],
                                                           network_mode='bridge',
-                                                          shm_size=1000)
+                                                          shm_size=1000,
+                                                          dns=None,
+                                                          dns_search=None)
         client_mock.images.assert_called_with(name='ubuntu:latest')
         client_mock.logs.assert_called_with(container='some_id', stream=True)
         client_mock.pull.assert_called_with('ubuntu:latest', stream=True)


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3025
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
