### PR TITLE
[AIRFLOW-XXX] Fix doc of command line interface

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1457,7 +1457,7 @@ class CLIFactory(object):
         'subdir': Arg(
             ("-sd", "--subdir"),
             "File location or directory from which to look for the dag",
-            default=settings.DAGS_FOLDER),
+            default="[AIRFLOW_HOME]/dags"),
         'start_date': Arg(
             ("-s", "--start_date"), "Override start_date YYYY-MM-DD",
             type=parsedate),
@@ -1874,7 +1874,7 @@ class CLIFactory(object):
                     "If reset_dag_run option is used,"
                     " backfill will first prompt users whether airflow "
                     "should clear all the previous dag_run and task_instances "
-                    "within the backfill date range."
+                    "within the backfill date range. "
                     "If rerun_failed_tasks is used, backfill "
                     "will auto re-run the previous failed task instances"
                     " within the backfill date range.",


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

There are two issues found in documentation of command line interface

**Issue 1**
<img width="761" alt="screen shot 2018-09-07 at 4 34 12 pm" src="https://user-images.githubusercontent.com/11539188/45207953-01e23d80-b2bc-11e8-92a7-d08e7d5c54bf.png">
The default value of `--subdir` is generated dynamically, so Kaxil's Dag Folder during compiling is used in the final documentation (this appeared 14 times in https://airflow.apache.org/cli.html). I believe this should be "hardcoded" into `[AIRFLOW_HOME]/dags`.

**Issue 2**
A minor typo (a space is missing).
<img width="769" alt="screen shot 2018-09-07 at 4 38 34 pm" src="https://user-images.githubusercontent.com/11539188/45208164-89c84780-b2bc-11e8-9ae9-4f72f48e8b37.png">


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Only doc is changed

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
