### PR TITLE
[AIRFLOW-3070] Refine web UI authentication-related docs

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -2024,7 +2024,7 @@ class CLIFactory(object):
                      'conn_id', 'conn_uri', 'conn_extra') + tuple(alternative_conn_specs),
         }, {
             'func': create_user,
-            'help': "Create an account for the Web UI",
+            'help': "Create an account for the Web UI (FAB-based)",
             'args': ('role', 'username', 'email', 'firstname', 'lastname',
                      'password', 'use_random_password'),
         }, {

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -265,6 +265,9 @@ access_logfile = -
 error_logfile = -
 
 # Expose the configuration file in the web server
+# This is only applicable for the flask-admin based web UI (non FAB-based).
+# In the FAB-based web UI with RBAC feature,
+# access to configuration is controlled by role permissions.
 expose_config = False
 
 # Set to true to turn on authentication:

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -16,9 +16,14 @@ Web Authentication
 Password
 ''''''''
 
+.. note::
+
+   This is for flask-admin based web UI only. If you are using FAB-based web UI with RBAC feature,
+   please use command line interface ``create_user`` to create accounts, or do that in the FAB-based UI itself.
+
 One of the simplest mechanisms for authentication is requiring users to specify a password before logging in.
 Password authentication requires the used of the ``password`` subpackage in your requirements file. Password hashing
-uses bcrypt before storing passwords.
+uses ``bcrypt`` before storing passwords.
 
 .. code-block:: bash
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3070
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Now in Airflow 1.10 we're already providing older version of web UI and new FAB-based UI at the same time. But the documentation is not differentiated very well. For example,
- this doc https://airflow.apache.org/security.html#password is only applicable for old web UI only, but it's not hightlighted.
- command line tool `create_user`  is only for new FAB-based UI only, it's not highlighted as well.

This may be confusing to users, especially given not everyone is aware of the existence of two UIs.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Doc change only

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
