### PR TITLE
[AIRFLOW-3011][CLI] Add cmd function printing config

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1443,6 +1443,19 @@ Arg = namedtuple(
 Arg.__new__.__defaults__ = (None, None, None, None, None, None, None)
 
 
+@cli_utils.action_logging
+def config(args):
+    """
+    Prints config file contents to STDOUT.
+    :param args:
+    :return:
+    """
+    config_file_path = os.path.join(settings.AIRFLOW_HOME, "airflow.cfg")
+    log.info("Config file location: {}".format(config_file_path))
+    with open(config_file_path, 'r') as config_file:
+        print(config_file.read())
+
+
 class CLIFactory(object):
     args = {
         # Shared
@@ -2039,6 +2052,11 @@ class CLIFactory(object):
         {
             'func': sync_perm,
             'help': "Update existing role's permissions.",
+            'args': tuple(),
+        },
+        {
+            'func': config,
+            'help': "Displaying config file",
             'args': tuple(),
         }
     )


### PR DESCRIPTION
…efined

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-3011\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3011
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Example of usage:
Bash command: airflow config` 
Example of printed config is described on a screenshoot below.
![image](https://user-images.githubusercontent.com/13046970/45258969-2547de00-b3cb-11e8-856e-3f3fa033f59a.png)

Output of the same command could be redirected into file and then used for further operations.
![image](https://user-images.githubusercontent.com/13046970/45258981-63450200-b3cb-11e8-9228-c700d041e9f5.png)

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
