### PR TITLE
[AIRFLOW-XXX] Removing the renaming of TaskRunner from update

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -5,13 +5,6 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
-### Rename of BashTaskRunner to StandardTaskRunner
-
-BashTaskRunner has been renamed to StandardTaskRunner. It is the default task runner
-so you might need to update your config.
-
-`task_runner = StandardTaskRunner`
-
 ### min_file_parsing_loop_time config option temporarily disabled
 
 The scheduler.min_file_parsing_loop_time config option has been temporarily removed due to


### PR DESCRIPTION
### Description
In released version 1.10.0, default task runner is still BashTaskRunner. The change "Renaming of BashTaskRunner to StandardTaskRunner" is only in the master branch not in the 1.10.0 released version.
Removing the note from updating documentation.

https://github.com/apache/incubator-airflow/blob/v1-10-stable/airflow/task/task_runner/__init__.py