### PR TITLE
[AIRFLOW-3030] Fix doc of command line interface

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -80,6 +80,11 @@ api_client = api_module.Client(api_base_url=conf.get('cli', 'endpoint_url'),
 
 log = LoggingMixin().log
 
+DAGS_FOLDER = settings.DAGS_FOLDER
+
+if "BUILDING_AIRFLOW_DOCS" in os.environ:
+    DAGS_FOLDER = '[AIRFLOW_HOME]/dags'
+
 
 def sigint_handler(sig, frame):
     sys.exit(0)
@@ -133,7 +138,7 @@ def setup_locations(process, pid=None, stdout=None, stderr=None, log=None):
 
 def process_subdir(subdir):
     if subdir:
-        subdir = subdir.replace('DAGS_FOLDER', settings.DAGS_FOLDER)
+        subdir = subdir.replace('DAGS_FOLDER', DAGS_FOLDER)
         subdir = os.path.abspath(os.path.expanduser(subdir))
         return subdir
 
@@ -1456,8 +1461,10 @@ class CLIFactory(object):
             "The regex to filter specific task_ids to backfill (optional)"),
         'subdir': Arg(
             ("-sd", "--subdir"),
-            "File location or directory from which to look for the dag",
-            default=settings.DAGS_FOLDER),
+            "File location or directory from which to look for the dag. "
+            "Defaults to '[AIRFLOW_HOME]/dags' where [AIRFLOW_HOME] is the "
+            "value you set for 'AIRFLOW_HOME' config you set in 'airflow.cfg' ",
+            default=DAGS_FOLDER),
         'start_date': Arg(
             ("-s", "--start_date"), "Override start_date YYYY-MM-DD",
             type=parsedate),
@@ -1874,7 +1881,7 @@ class CLIFactory(object):
                     "If reset_dag_run option is used,"
                     " backfill will first prompt users whether airflow "
                     "should clear all the previous dag_run and task_instances "
-                    "within the backfill date range."
+                    "within the backfill date range. "
                     "If rerun_failed_tasks is used, backfill "
                     "will auto re-run the previous failed task instances"
                     " within the backfill date range.",


### PR DESCRIPTION
This issue was found at https://github.com/apache/incubator-airflow/pull/3861
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-3030


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

There are two issues found in documentation of command line interface

**Issue 1**
<img width="761" alt="screen shot 2018-09-07 at 4 34 12 pm" src="https://user-images.githubusercontent.com/11539188/45207953-01e23d80-b2bc-11e8-92a7-d08e7d5c54bf.png">
The default value of `--subdir` is generated dynamically, so Kaxil's Dag Folder during compiling is used in the final documentation (this appeared 14 times in https://airflow.apache.org/cli.html). I believe this should be "hardcoded" into `[AIRFLOW_HOME]/dags`.

**Issue 2**
A minor typo (a space is missing).
<img width="769" alt="screen shot 2018-09-07 at 4 38 34 pm" src="https://user-images.githubusercontent.com/11539188/45208164-89c84780-b2bc-11e8-9ae9-4f72f48e8b37.png">


**After Fixing**:
![image](https://user-images.githubusercontent.com/8811558/45268427-03566600-b474-11e8-8d0f-1a0a7b3dab56.png)


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
