### PR TITLE
[AIRFLOW-2707] Validate task_log_reader on upgrade from <=1.9

### DIFF
--- a/airflow/logging_config.py
+++ b/airflow/logging_config.py
@@ -18,6 +18,7 @@
 # under the License.
 #
 import logging
+import warnings
 from logging.config import dictConfig
 
 from airflow import configuration as conf
@@ -70,4 +71,36 @@ def configure_logging():
         # otherwise Airflow would silently fall back on the default config
         raise e
 
+    validate_logging_config(logging_config)
+
     return logging_config
+
+
+def validate_logging_config(logging_config):
+    # Now lets validate the other logging-related settings
+    task_log_reader = conf.get('core', 'task_log_reader')
+
+    logger = logging.getLogger('airflow.task')
+
+    def _get_handler(name):
+        return next((h for h in logger.handlers if h.name == name), None)
+
+    if _get_handler(task_log_reader) is None:
+        # Check for pre 1.10 setting that might be in deployed airflow.cfg files
+        if task_log_reader == "file.task" and _get_handler("task"):
+            warnings.warn(
+                "task_log_reader setting in [core] has a deprecated value of "
+                "{!r}, but no handler with this name was found. Please update "
+                "your config to use {!r}. Running config has been adjusted to "
+                "match".format(
+                    task_log_reader,
+                    "task",
+                ),
+                DeprecationWarning,
+            )
+            conf.set('core', 'task_log_reader', 'task')
+        else:
+            raise AirflowConfigException(
+                "Configured task_log_reader {!r} was not a handler of the 'airflow.task' "
+                "logger.".format(task_log_reader)
+            )


### PR DESCRIPTION
We changed the default logging config and config from 1.9 to 1.10, but
anyone who upgrades and has an existing airflow.cfg won't know they need
to change this value - instead they will get nothing displayed in the UI
(ajax request fails) and see "'NoneType' object has no attribute 'read'"
in the error log.

This validates that config section at start up, and seamlessly upgrades
the old previous value.

Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-2707

### Description

- [x] Someone in the slack channel was having trouble viewing logs after updating to 1.10, and we eventually tracked it down to this config setting which changed in default from 1.9 to 1.10, but their deploy still had the old value in it.

### Tests

- [x] Added

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] None added

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`