### PR TITLE
[AIRFLOW-3001] Add index 'ti_dag_date' to taskinstance

### DIFF
--- a/airflow/migrations/versions/bf00311e1990_add_index_to_taskinstance.py
+++ b/airflow/migrations/versions/bf00311e1990_add_index_to_taskinstance.py
@@ -1,0 +1,46 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""add index to taskinstance
+
+Revision ID: bf00311e1990
+Revises: dd25f486b8ea
+Create Date: 2018-09-12 09:53:52.007433
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'bf00311e1990'
+down_revision = 'dd25f486b8ea'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        'ti_dag_date',
+        'task_instance',
+        ['dag_id', 'execution_date'],
+        unique=False
+    )
+
+
+def downgrade():
+    op.drop_index('ti_dag_date', table_name='task_instance')

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -893,6 +893,7 @@ class TaskInstance(Base, LoggingMixin):
 
     __table_args__ = (
         Index('ti_dag_state', dag_id, state),
+        Index('ti_dag_date', dag_id, execution_date),
         Index('ti_state', state),
         Index('ti_state_lkp', dag_id, task_id, execution_date, state),
         Index('ti_pool', pool, state, priority_weight),


### PR DESCRIPTION
[ Description ]
There was no index composed of dag_id and execution_date. So, when scheduler finds all tis of dagrun like this "select * from task_instance where dag_id = 'some_id' and execution_date = '2018-09-01 ...'", this query will be using ti_dag_state index (I was testing it in mysql workbench. I was expecting 'ti_state_lkp' but, it was not that case). Perhaps there's no problem when range of execution_date is small (under 1000 dagrun), but I had experienced slow allocation of tis when the dag had 1000+ accumulative dagrun. So, now I was using airflow with adding new index ti_dag_date (dag_id, execution_date) on task_instance table. I have attached result of my test :)

[ Test ] I have tested using 1.10 version
1. just running scheduler with past start_date and high concurrency. (3 years ago, 10 minute interval)
2. scheduler may be executing  backfill and "select tis" query (like below sequence)
models.py > DAG.run
jobs.py > BaseJob.run
jobs.py > BackfillJob._execute
jobs.py > BackfillJob._execute_for_run_dates
jobs.py > BackfillJob._task_instances_for_dag_run
models.py > DagRun.get_task_instances
tis = session.query(TI).filter(
    TI.dag_id == self.dag_id,
    TI.execution_date == self.execution_date,
)
3. wait until enough dagruns will be accumlated.
I can find that many slow query logs get to occur from mysql log file. (query like below sample)
"select * from task_instance where dag_id = 'some_id' and execution_date = '2018-09-01 ...'"


[ASIS] current
![image](https://user-images.githubusercontent.com/6738941/45285016-fb9ecc00-b51c-11e8-945c-c28d81aece02.png)

[TOBE] after adding new index
![image](https://user-images.githubusercontent.com/6738941/45285019-fe012600-b51c-11e8-91fa-a66c2293ca5d.png)

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-3001\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3001
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-3001\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
