### PR TITLE
[AIRFLOW-1298] Fix 'clear only_failed'

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3821,7 +3821,7 @@ class DAG(BaseDag, LoggingMixin):
         if end_date:
             tis = tis.filter(TI.execution_date <= end_date)
         if only_failed:
-            tis = tis.filter(TI.state == State.FAILED)
+            tis = tis.filter(or_(TI.state == State.FAILED, TI.state == State.UPSTREAM_FAILED))
         if only_running:
             tis = tis.filter(TI.state == State.RUNNING)
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3821,7 +3821,9 @@ class DAG(BaseDag, LoggingMixin):
         if end_date:
             tis = tis.filter(TI.execution_date <= end_date)
         if only_failed:
-            tis = tis.filter(or_(TI.state == State.FAILED, TI.state == State.UPSTREAM_FAILED))
+            tis = tis.filter(or_(
+                TI.state == State.FAILED,
+                TI.state == State.UPSTREAM_FAILED))
         if only_running:
             tis = tis.filter(TI.state == State.RUNNING)
 


### PR DESCRIPTION
[Description]
In general, when users clear failed tasks in CLI, they expect that all downstreams which is upstream_failed should be cleared together. But, current clear -f option could clear only 'failed' tasks, so operators have to clear downstream tasks (upstream_failed) manually.
I often use 'airflow clear -f' for reprocessing massive failed tasks. So, modified models.py like this.

[ASIS] origin
if only_failed: tis = tis.filter(TI.state == State.FAILED)

[TOBE] modified
if only_failed: tis = tis.filter(or_(TI.state == State.FAILED, TI.state == State.UPSTREAM_FAILED))

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
