### PR TITLE
[AIRFLOW-3044] Dataflow operators accept templated job_name param

### DIFF
--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -37,8 +37,12 @@ class DataFlowJavaOperator(BaseOperator):
         For more detail on job submission have a look at the reference:
         https://cloud.google.com/dataflow/pipelines/specifying-exec-params
 
-    :param jar: The reference to a self executing DataFlow jar.
+    :param jar: The reference to a self executing DataFlow jar (templated).
     :type jar: str
+    :param job_name: The 'jobName' to use when executing the DataFlow job
+        (templated). This ends up being set in the pipeline options, so any entry
+        with key ``'jobName'`` in ``options`` will be overwritten.
+    :type job_name: str
     :param dataflow_default_options: Map of default job options.
     :type dataflow_default_options: dict
     :param options: Map of job specific options.
@@ -58,7 +62,7 @@ class DataFlowJavaOperator(BaseOperator):
         is often not the main class configured in the dataflow jar file.
     :type job_class: str
 
-    Both ``jar`` and ``options`` are templated so you can use variables in them.
+    ``jar``, ``options``, and ``job_name`` are templated so you can use variables in them.
 
     Note that both
     ``dataflow_default_options`` and ``options`` will be merged to specify pipeline
@@ -100,13 +104,14 @@ class DataFlowJavaOperator(BaseOperator):
            dag=my-dag)
 
     """
-    template_fields = ['options', 'jar']
+    template_fields = ['options', 'jar', 'job_name']
     ui_color = '#0273d4'
 
     @apply_defaults
     def __init__(
             self,
             jar,
+            job_name='{{task.task_id}}',
             dataflow_default_options=None,
             options=None,
             gcp_conn_id='google_cloud_default',
@@ -124,6 +129,7 @@ class DataFlowJavaOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.jar = jar
+        self.job_name = job_name
         self.dataflow_default_options = dataflow_default_options
         self.options = options
         self.poll_sleep = poll_sleep
@@ -140,7 +146,7 @@ class DataFlowJavaOperator(BaseOperator):
         dataflow_options = copy.copy(self.dataflow_default_options)
         dataflow_options.update(self.options)
 
-        hook.start_java_dataflow(self.task_id, dataflow_options,
+        hook.start_java_dataflow(self.job_name, dataflow_options,
                                  self.jar, self.job_class)
 
 
@@ -151,6 +157,8 @@ class DataflowTemplateOperator(BaseOperator):
 
     :param template: The reference to the DataFlow template.
     :type template: str
+    :param job_name: The 'jobName' to use when executing the DataFlow template
+        (templated).
     :param dataflow_default_options: Map of default job environment options.
     :type dataflow_default_options: dict
     :param parameters: Map of job specific parameters for the template.
@@ -201,8 +209,8 @@ class DataflowTemplateOperator(BaseOperator):
            gcp_conn_id='gcp-airflow-service-account',
            dag=my-dag)
 
-    ``template``, ``dataflow_default_options`` and ``parameters`` are templated so you can
-    use variables in them.
+    ``template``, ``dataflow_default_options``, ``parameters``, and ``job_name`` are
+    templated so you can use variables in them.
 
     Note that ``dataflow_default_options`` is expected to save high-level options
     for project information, which apply to all dataflow operators in the DAG.
@@ -214,13 +222,14 @@ class DataflowTemplateOperator(BaseOperator):
             For more detail on job template execution have a look at the reference:
             https://cloud.google.com/dataflow/docs/templates/executing-templates
     """
-    template_fields = ['parameters', 'dataflow_default_options', 'template']
+    template_fields = ['parameters', 'dataflow_default_options', 'template', 'job_name']
     ui_color = '#0273d4'
 
     @apply_defaults
     def __init__(
             self,
             template,
+            job_name='{{task.task_id}}',
             dataflow_default_options=None,
             parameters=None,
             gcp_conn_id='google_cloud_default',
@@ -238,6 +247,7 @@ class DataflowTemplateOperator(BaseOperator):
         self.dataflow_default_options = dataflow_default_options
         self.poll_sleep = poll_sleep
         self.template = template
+        self.job_name = job_name
         self.parameters = parameters
 
     def execute(self, context):
@@ -245,7 +255,7 @@ class DataflowTemplateOperator(BaseOperator):
                             delegate_to=self.delegate_to,
                             poll_sleep=self.poll_sleep)
 
-        hook.start_template_dataflow(self.task_id, self.dataflow_default_options,
+        hook.start_template_dataflow(self.job_name, self.dataflow_default_options,
                                      self.parameters, self.template)
 
 
@@ -264,6 +274,10 @@ class DataFlowPythonOperator(BaseOperator):
     :param py_file: Reference to the python dataflow pipleline file.py, e.g.,
         /some/local/file/path/to/your/python/pipeline/file.
     :type py_file: str
+    :param job_name: The 'job_name' to use when executing the DataFlow job
+        (templated). This ends up being set in the pipeline options, so any entry
+        with key ``'jobName'`` or ``'job_name'`` in ``options`` will be overwritten.
+    :type job_name: str
     :param py_options: Additional python options.
     :type pyt_options: list of strings, e.g., ["-m", "-v"].
     :param dataflow_default_options: Map of default job options.
@@ -282,12 +296,13 @@ class DataFlowPythonOperator(BaseOperator):
         JOB_STATE_RUNNING state.
     :type poll_sleep: int
     """
-    template_fields = ['options', 'dataflow_default_options']
+    template_fields = ['options', 'dataflow_default_options', 'job_name']
 
     @apply_defaults
     def __init__(
             self,
             py_file,
+            job_name='{{task.task_id}}',
             py_options=None,
             dataflow_default_options=None,
             options=None,
@@ -300,6 +315,7 @@ class DataFlowPythonOperator(BaseOperator):
         super(DataFlowPythonOperator, self).__init__(*args, **kwargs)
 
         self.py_file = py_file
+        self.job_name = job_name
         self.py_options = py_options or []
         self.dataflow_default_options = dataflow_default_options or {}
         self.options = options or {}
@@ -325,7 +341,7 @@ class DataFlowPythonOperator(BaseOperator):
         formatted_options = {camel_to_snake(key): dataflow_options[key]
                              for key in dataflow_options}
         hook.start_python_dataflow(
-            self.task_id, formatted_options,
+            self.job_name, formatted_options,
             self.py_file, self.py_options)
 
 

--- a/tests/contrib/hooks/test_gcp_dataflow_hook.py
+++ b/tests/contrib/hooks/test_gcp_dataflow_hook.py
@@ -35,6 +35,7 @@ except ImportError:
 
 
 TASK_ID = 'test-dataflow-operator'
+JOB_NAME = 'test-dataflow-pipeline'
 TEMPLATE = 'gs://dataflow-templates/wordcount/template_file'
 PARAMETERS = {
     'inputFile': 'gs://dataflow-samples/shakespeare/kinglear.txt',
@@ -92,14 +93,14 @@ class DataFlowHookTest(unittest.TestCase):
         dataflowjob_instance = mock_dataflowjob.return_value
         dataflowjob_instance.wait_for_done.return_value = None
         self.dataflow_hook.start_python_dataflow(
-            task_id=TASK_ID, variables=DATAFLOW_OPTIONS_PY,
+            job_name=JOB_NAME, variables=DATAFLOW_OPTIONS_PY,
             dataflow=PY_FILE, py_options=PY_OPTIONS)
         EXPECTED_CMD = ['python2', '-m', PY_FILE,
                         '--region=us-central1',
                         '--runner=DataflowRunner', '--project=test',
                         '--labels=foo=bar',
                         '--staging_location=gs://test/staging',
-                        '--job_name={}-{}'.format(TASK_ID, MOCK_UUID)]
+                        '--job_name={}-{}'.format(JOB_NAME, MOCK_UUID)]
         self.assertListEqual(sorted(mock_dataflow.call_args[0][0]),
                              sorted(EXPECTED_CMD))
 
@@ -116,14 +117,14 @@ class DataFlowHookTest(unittest.TestCase):
         dataflowjob_instance = mock_dataflowjob.return_value
         dataflowjob_instance.wait_for_done.return_value = None
         self.dataflow_hook.start_java_dataflow(
-            task_id=TASK_ID, variables=DATAFLOW_OPTIONS_JAVA,
+            job_name=JOB_NAME, variables=DATAFLOW_OPTIONS_JAVA,
             dataflow=JAR_FILE)
         EXPECTED_CMD = ['java', '-jar', JAR_FILE,
                         '--region=us-central1',
                         '--runner=DataflowRunner', '--project=test',
                         '--stagingLocation=gs://test/staging',
                         '--labels={"foo":"bar"}',
-                        '--jobName={}-{}'.format(TASK_ID, MOCK_UUID)]
+                        '--jobName={}-{}'.format(JOB_NAME, MOCK_UUID)]
         self.assertListEqual(sorted(mock_dataflow.call_args[0][0]),
                              sorted(EXPECTED_CMD))
 
@@ -140,17 +141,16 @@ class DataFlowHookTest(unittest.TestCase):
         dataflowjob_instance = mock_dataflowjob.return_value
         dataflowjob_instance.wait_for_done.return_value = None
         self.dataflow_hook.start_java_dataflow(
-            task_id=TASK_ID, variables=DATAFLOW_OPTIONS_JAVA,
+            job_name=JOB_NAME, variables=DATAFLOW_OPTIONS_JAVA,
             dataflow=JAR_FILE, job_class=JOB_CLASS)
         EXPECTED_CMD = ['java', '-cp', JAR_FILE, JOB_CLASS,
                         '--region=us-central1',
                         '--runner=DataflowRunner', '--project=test',
                         '--stagingLocation=gs://test/staging',
                         '--labels={"foo":"bar"}',
-                        '--jobName={}-{}'.format(TASK_ID, MOCK_UUID)]
+                        '--jobName={}-{}'.format(JOB_NAME, MOCK_UUID)]
         self.assertListEqual(sorted(mock_dataflow.call_args[0][0]),
                              sorted(EXPECTED_CMD))
-
 
     @mock.patch('airflow.contrib.hooks.gcp_dataflow_hook._Dataflow.log')
     @mock.patch('subprocess.Popen')
@@ -178,18 +178,18 @@ class DataFlowHookTest(unittest.TestCase):
 
     def test_valid_dataflow_job_name(self):
         job_name = self.dataflow_hook._build_dataflow_job_name(
-            task_id=TASK_ID, append_job_name=False
+            job_name=JOB_NAME, append_job_name=False
         )
 
-        self.assertEquals(job_name, TASK_ID)
+        self.assertEquals(job_name, JOB_NAME)
 
-    def test_fix_underscore_in_task_id(self):
-        task_id_with_underscore = 'test_example'
-        fixed_job_name = task_id_with_underscore.replace(
+    def test_fix_underscore_in_job_name(self):
+        job_name_with_underscore = 'test_example'
+        fixed_job_name = job_name_with_underscore.replace(
             '_', '-'
         )
         job_name = self.dataflow_hook._build_dataflow_job_name(
-            task_id=task_id_with_underscore, append_job_name=False
+            job_name=job_name_with_underscore, append_job_name=False
         )
 
         self.assertEquals(job_name, fixed_job_name)
@@ -201,7 +201,7 @@ class DataFlowHookTest(unittest.TestCase):
 
         with self.assertRaises(ValueError) as e:
             self.dataflow_hook._build_dataflow_job_name(
-                task_id=invalid_job_name, append_job_name=False
+                job_name=invalid_job_name, append_job_name=False
             )
         #   Test whether the job_name is present in the Error msg
         self.assertIn('Invalid job_name ({})'.format(fixed_name),
@@ -210,37 +210,37 @@ class DataFlowHookTest(unittest.TestCase):
     def test_dataflow_job_regex_check(self):
 
         self.assertEquals(self.dataflow_hook._build_dataflow_job_name(
-            task_id='df-job-1', append_job_name=False
+            job_name='df-job-1', append_job_name=False
         ), 'df-job-1')
 
         self.assertEquals(self.dataflow_hook._build_dataflow_job_name(
-            task_id='df-job', append_job_name=False
+            job_name='df-job', append_job_name=False
         ), 'df-job')
 
         self.assertEquals(self.dataflow_hook._build_dataflow_job_name(
-            task_id='dfjob', append_job_name=False
+            job_name='dfjob', append_job_name=False
         ), 'dfjob')
 
         self.assertEquals(self.dataflow_hook._build_dataflow_job_name(
-            task_id='dfjob1', append_job_name=False
+            job_name='dfjob1', append_job_name=False
         ), 'dfjob1')
 
         self.assertRaises(
             ValueError,
             self.dataflow_hook._build_dataflow_job_name,
-            task_id='1dfjob', append_job_name=False
+            job_name='1dfjob', append_job_name=False
         )
 
         self.assertRaises(
             ValueError,
             self.dataflow_hook._build_dataflow_job_name,
-            task_id='dfjob@', append_job_name=False
+            job_name='dfjob@', append_job_name=False
         )
 
         self.assertRaises(
             ValueError,
             self.dataflow_hook._build_dataflow_job_name,
-            task_id='df^jo', append_job_name=False
+            job_name='df^jo', append_job_name=False
         )
 
 
@@ -254,7 +254,7 @@ class DataFlowTemplateHookTest(unittest.TestCase):
     @mock.patch(DATAFLOW_STRING.format('DataFlowHook._start_template_dataflow'))
     def test_start_template_dataflow(self, internal_dataflow_mock):
         self.dataflow_hook.start_template_dataflow(
-            task_id=TASK_ID, variables=DATAFLOW_OPTIONS_TEMPLATE, parameters=PARAMETERS,
+            job_name=JOB_NAME, variables=DATAFLOW_OPTIONS_TEMPLATE, parameters=PARAMETERS,
             dataflow_template=TEMPLATE)
         internal_dataflow_mock.assert_called_once_with(
             mock.ANY, DATAFLOW_OPTIONS_TEMPLATE, PARAMETERS, TEMPLATE)

--- a/tests/contrib/operators/test_dataflow_operator.py
+++ b/tests/contrib/operators/test_dataflow_operator.py
@@ -36,6 +36,7 @@ except ImportError:
 
 
 TASK_ID = 'test-dataflow-operator'
+JOB_NAME = 'test-dataflow-pipeline'
 TEMPLATE = 'gs://dataflow-templates/wordcount/template_file'
 PARAMETERS = {
     'inputFile': 'gs://dataflow-samples/shakespeare/kinglear.txt',
@@ -74,6 +75,7 @@ class DataFlowPythonOperatorTest(unittest.TestCase):
         self.dataflow = DataFlowPythonOperator(
             task_id=TASK_ID,
             py_file=PY_FILE,
+            job_name=JOB_NAME,
             py_options=PY_OPTIONS,
             dataflow_default_options=DEFAULT_OPTIONS_PYTHON,
             options=ADDITIONAL_OPTIONS,
@@ -82,6 +84,7 @@ class DataFlowPythonOperatorTest(unittest.TestCase):
     def test_init(self):
         """Test DataFlowPythonOperator instance is properly initialized."""
         self.assertEqual(self.dataflow.task_id, TASK_ID)
+        self.assertEqual(self.dataflow.job_name, JOB_NAME)
         self.assertEqual(self.dataflow.py_file, PY_FILE)
         self.assertEqual(self.dataflow.py_options, PY_OPTIONS)
         self.assertEqual(self.dataflow.poll_sleep, POLL_SLEEP)
@@ -108,8 +111,8 @@ class DataFlowPythonOperatorTest(unittest.TestCase):
             'labels': {'foo': 'bar', 'airflow-version': TEST_VERSION}
         }
         gcs_download_hook.assert_called_once_with(PY_FILE)
-        start_python_hook.assert_called_once_with(TASK_ID, expected_options,
-                                                  mock.ANY, PY_OPTIONS)
+        start_python_hook.assert_called_once_with(JOB_NAME, expected_options, mock.ANY,
+                                                  PY_OPTIONS)
         self.assertTrue(self.dataflow.py_file.startswith('/tmp/dataflow'))
 
 
@@ -119,6 +122,7 @@ class DataFlowJavaOperatorTest(unittest.TestCase):
         self.dataflow = DataFlowJavaOperator(
             task_id=TASK_ID,
             jar=JAR_FILE,
+            job_name=JOB_NAME,
             job_class=JOB_CLASS,
             dataflow_default_options=DEFAULT_OPTIONS_JAVA,
             options=ADDITIONAL_OPTIONS,
@@ -127,6 +131,7 @@ class DataFlowJavaOperatorTest(unittest.TestCase):
     def test_init(self):
         """Test DataflowTemplateOperator instance is properly initialized."""
         self.assertEqual(self.dataflow.task_id, TASK_ID)
+        self.assertEqual(self.dataflow.job_name, JOB_NAME)
         self.assertEqual(self.dataflow.poll_sleep, POLL_SLEEP)
         self.assertEqual(self.dataflow.dataflow_default_options,
                          DEFAULT_OPTIONS_JAVA)
@@ -147,7 +152,7 @@ class DataFlowJavaOperatorTest(unittest.TestCase):
         self.dataflow.execute(None)
         self.assertTrue(dataflow_mock.called)
         gcs_download_hook.assert_called_once_with(JAR_FILE)
-        start_java_hook.assert_called_once_with(TASK_ID, mock.ANY,
+        start_java_hook.assert_called_once_with(JOB_NAME, mock.ANY,
                                                 mock.ANY, JOB_CLASS)
 
 
@@ -157,6 +162,7 @@ class DataFlowTemplateOperatorTest(unittest.TestCase):
         self.dataflow = DataflowTemplateOperator(
             task_id=TASK_ID,
             template=TEMPLATE,
+            job_name=JOB_NAME,
             parameters=PARAMETERS,
             dataflow_default_options=DEFAULT_OPTIONS_TEMPLATE,
             poll_sleep=POLL_SLEEP)
@@ -164,6 +170,7 @@ class DataFlowTemplateOperatorTest(unittest.TestCase):
     def test_init(self):
         """Test DataflowTemplateOperator instance is properly initialized."""
         self.assertEqual(self.dataflow.task_id, TASK_ID)
+        self.assertEqual(self.dataflow.job_name, JOB_NAME)
         self.assertEqual(self.dataflow.template, TEMPLATE)
         self.assertEqual(self.dataflow.parameters, PARAMETERS)
         self.assertEqual(self.dataflow.poll_sleep, POLL_SLEEP)
@@ -185,7 +192,7 @@ class DataFlowTemplateOperatorTest(unittest.TestCase):
             'tempLocation': 'gs://test/temp',
             'zone': 'us-central1-f'
         }
-        start_template_hook.assert_called_once_with(TASK_ID, expected_options,
+        start_template_hook.assert_called_once_with(JOB_NAME, expected_options,
                                                     PARAMETERS, TEMPLATE)
 
 

--- a/tests/contrib/operators/test_mlengine_operator_utils.py
+++ b/tests/contrib/operators/test_mlengine_operator_utils.py
@@ -114,7 +114,7 @@ class CreateEvaluateOpsTest(unittest.TestCase):
             mock_dataflow_hook.assert_called_with(
                 gcp_conn_id='google_cloud_default', delegate_to=None, poll_sleep=10)
             hook_instance.start_python_dataflow.assert_called_once_with(
-                'eval-test-summary',
+                '{{task.task_id}}',
                 {
                     'prediction_path': 'gs://legal-bucket/fake-output-path',
                     'labels': {'airflow-version': TEST_VERSION},


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3044
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
See https://issues.apache.org/jira/browse/AIRFLOW-3044

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Updated `tests.contrib.hooks.test_gcp_dataflow_hook.*` and `tests.contrib.operators.test_dataflow_operator.*`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
