### PR TITLE
[AIRFLOW-3048] Add access to self-manage pages for non-Admin roles

### DIFF
--- a/airflow/www_rbac/security.py
+++ b/airflow/www_rbac/security.py
@@ -131,6 +131,17 @@ dag_perms = {
 }
 
 ###########################################################################
+#         VIEW-PERMISSION COMBINATION FOR USER-SELF-MANAGEMENT
+###########################################################################
+
+user_self_manage_perms = {'can_userinfo'}
+user_self_manage_view_perms = {
+    'UserDBModelView': {'resetmypassword', 'userinfoedit'},
+    'UserInfoEditView': {'can_this_form_post', 'can_this_form_get'},
+    'ResetMyPasswordView': {'can_this_form_post', 'can_this_form_get'}
+}
+
+###########################################################################
 #                     DEFAULT ROLE CONFIGURATIONS
 ###########################################################################
 
@@ -183,6 +194,11 @@ class AirflowSecurityManager(SecurityManager):
         for pvm in pvms:
             if pvm.view_menu.name in role_vms and pvm.permission.name in role_perms:
                 role_pvms.append(pvm)
+            if pvm.permission.name in user_self_manage_perms:
+                role_pvms.append(pvm)
+            for view, perms in user_self_manage_view_perms.items():
+                if pvm.view_menu.name == view and pvm.permission.name in perms:
+                    role_pvms.append(pvm)
         role.permissions = list(set(role_pvms))
         self.get_session.merge(role)
         self.get_session.commit()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3048
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In the **www_rbac** app, at the top right corner, users can click to access "**Profile**" page, and in that page users are able to check their own profile, and further, they can change their own profile via **Edit User** (last and first name) and reset their OWN password ("**Reset my password**").

**_`However, in the current version (both 1.10 and master branch), the default role-view-permission only allows Admin roles to access this page.`_** This is because non-Admin users don't have corresponding permissions to `UserDBModelView`, `UserInfoEditView`, and `ResetPasswordView`.

Of course the Admin user can add access to these pages for other roles, but it should not be the case actually (it should be there by default. All users should be able to access their own profile and change their own profile as well as password).

**Screenshot-1**
<img width="1679" alt="attachment 1" src="https://user-images.githubusercontent.com/11539188/45432772-3d767080-b6dd-11e8-85d8-027de9e0e910.png">

**Screenshot-2**
<img width="1680" alt="attachment 2" src="https://user-images.githubusercontent.com/11539188/45432778-40716100-b6dd-11e8-9736-8bfde65b71c1.png">


### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
