### PR TITLE
[AIRFLOW-3029] New Operator - SqlOperator

### DIFF
--- a/airflow/contrib/operators/sql_operator.py
+++ b/airflow/contrib/operators/sql_operator.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.hooks.base_hook import BaseHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class SqlOperator(BaseOperator):
+    """
+    Executes sql code in a database.
+
+    This abstract operator can be instantiated directly,
+    and does not need to be derived into subclasses for each DbApiHook subclass.
+    It will automatically usesthe correct DbApiHook subclass implmenetation,
+    made possible by reflecting upon the Connection's assigned `conn_type`.
+
+    :param conn_id: reference to a predefined sql database connection
+    :type conn_id: str
+    :param sql: the sql code to be executed. (templated)
+    :type sql: Can receive a str representing a sql statement,
+        a list of str (sql statements), or reference to a template file.
+        Template reference are recognized by str ending in '.sql'
+    """
+
+    template_fields = ('sql',)
+    template_ext = ('.sql',)
+    ui_color = '#ededed'
+
+    @apply_defaults
+    def __init__(
+            self,
+            sql,
+            conn_id,
+            autocommit=False,
+            parameters=None,
+            *args, **kwargs):
+        super(SqlOperator, self).__init__(*args, **kwargs)
+        self.parameters = parameters
+        self.sql = sql
+        self.conn_id = conn_id
+        self.autocommit = autocommit
+
+    def execute(self, context):
+        self.log.info('Executing: %s', self.sql)
+        hook = BaseHook.get_hook(conn_id=self.conn_id)
+        hook.run(sql=self.sql,
+                 autocommit=self.autocommit,
+                 parameters=self.parameters)

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -116,7 +116,7 @@ Airflow provides operators for many common tasks, including:
 - ``PythonOperator`` - calls an arbitrary Python function
 - ``EmailOperator`` - sends an email
 - ``SimpleHttpOperator`` - sends an HTTP request
-- ``MySqlOperator``, ``SqliteOperator``, ``PostgresOperator``, ``MsSqlOperator``, ``OracleOperator``, ``JdbcOperator``, etc. - executes a SQL command
+- ``SqlOperator``, ``MySqlOperator``, ``SqliteOperator``, ``PostgresOperator``, ``MsSqlOperator``, ``OracleOperator``, ``JdbcOperator``, etc. - executes a SQL command
 - ``Sensor`` - waits for a certain time, file, database row, S3 key, etc...
 
 In addition to these basic building blocks, there are many more specific

--- a/tests/contrib/operators/test_sql_operator.py
+++ b/tests/contrib/operators/test_sql_operator.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from airflow.contrib.operators.sql_operator import SqlOperator
+from airflow import DAG
+from airflow import configuration
+from airflow.utils.tests import skipUnlessImported
+from airflow.utils import timezone
+import unittest
+
+
+class SqlOperatorTest(unittest.TestCase):
+
+    DEFAULT_DATE = timezone.datetime(2015, 1, 1)
+
+    def setUp(self):
+        configuration.load_test_config()
+        args = {'owner': 'airflow', 'start_date': self.DEFAULT_DATE}
+        dag = DAG('unit_test_dag', default_args=args)
+        self.dag = dag
+
+    @skipUnlessImported('airflow.operators.postgres_operator', 'PostgresOperator')
+    def test_sql_operator_postgres_test(self):
+        sql = """
+        CREATE TABLE IF NOT EXISTS test_airflow (
+            dummy VARCHAR(50)
+        );
+        """
+        task_basic = SqlOperator(task_id='sql_operator_postgres_test',
+                                 sql=sql,
+                                 conn_id='postgres_default',
+                                 dag=self.dag)
+        task_basic.run(start_date=self.DEFAULT_DATE,
+                       end_date=self.DEFAULT_DATE,
+                       ignore_ti_state=True)
+
+        task_autocommit = SqlOperator(task_id='sql_operator_postgres_test_autocommit',
+                                      sql=sql,
+                                      conn_id='postgres_default',
+                                      dag=self.dag,
+                                      autocommit=True)
+        task_autocommit.run(start_date=self.DEFAULT_DATE,
+                            end_date=self.DEFAULT_DATE,
+                            ignore_ti_state=True)
+        sql = [
+            "TRUNCATE TABLE test_airflow",
+            "INSERT INTO test_airflow VALUES ('X')",
+        ]
+        task_multi = SqlOperator(task_id='sql_operator_postgres_test_multi',
+                                 sql=sql,
+                                 conn_id='postgres_default',
+                                 dag=self.dag)
+        task_multi.run(start_date=self.DEFAULT_DATE,
+                       end_date=self.DEFAULT_DATE,
+                       ignore_ti_state=True)
+
+    @skipUnlessImported('airflow.operators.mysql_operator', 'MySqlOperator')
+    def test_sql_operator_mysql_test(self):
+        sql = """
+        CREATE TABLE IF NOT EXISTS test_airflow (
+            dummy VARCHAR(50)
+        );
+        """
+        task_basic = SqlOperator(task_id='sql_operator_mysql_test',
+                                 sql=sql,
+                                 conn_id='airflow_db',
+                                 dag=self.dag)
+        task_basic.run(start_date=self.DEFAULT_DATE,
+                       end_date=self.DEFAULT_DATE,
+                       ignore_ti_state=True)
+
+        task_autocommit = SqlOperator(task_id='sql_operator_mysql_test_autocommit',
+                                      sql=sql,
+                                      conn_id='airflow_db',
+                                      dag=self.dag,
+                                      autocommit=True)
+        task_autocommit.run(start_date=self.DEFAULT_DATE,
+                            end_date=self.DEFAULT_DATE,
+                            ignore_ti_state=True)
+        sql = [
+            "TRUNCATE TABLE test_airflow",
+            "INSERT INTO test_airflow VALUES ('X')",
+        ]
+        task_multi = SqlOperator(task_id='sql_operator_mysql_test_multi',
+                                 sql=sql,
+                                 conn_id='airflow_db',
+                                 dag=self.dag)
+        task_multi.run(start_date=self.DEFAULT_DATE,
+                       end_date=self.DEFAULT_DATE,
+                       ignore_ti_state=True)


### PR DESCRIPTION
Introduces a new `SqlOperator` that executes sql code in a database. Surprisingly this operator doesn't already exist. It is not always necessary to implement individual operators for each SQL database (`PostgresOperator`, `MySqlOperator`,etc..), which this operator shows. Similar to `SqlSensor`.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3029) issues and references them in the PR title. 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This abstract operator can be instantiated directly,
and does not need to be derived into subclasses for each DbApiHook subclass.
It will automatically uses the correct DbApiHook subclass implementation,
made possible by reflecting upon the specified Connection's `conn_type`.

Date:      Fri Sep 7 16:06:56 2018 -0700
new file:   airflow/contrib/operators/sql_operator.py
new file:   tests/contrib/operators/test_sql_operator.py

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

`/tests/contrib/operators/test_sql_operator.py`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
