### PR TITLE
[AIRFLOW-3055] add get_dataset and get_datasets_list to bigquery_hook

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1441,16 +1441,16 @@ class BigQueryBaseCursor(LoggingMixin):
                 'BigQuery job failed. Error was: {}'.format(err.content)
             )
 
-    def get_dataset(self, dataset_id="", project_id=""):
+    def get_dataset(self, dataset_id, project_id=None):
         """
         Method returns dataset_resource if dataset exist
         and raised 404 error if dataset does not exist
 
-        :param dataset_id: dataset_id to get
+        :param dataset_id: The BigQuery Dataset ID
         :type dataset_id: str
-        :param project_id: Google Cloud Project for which you try to get dataset
-        :type  project_id: str
-        :return dataset_resource
+        :param project_id: The GCP Project ID
+        :type project_id: str
+        :return: dataset_resource
 
             .. seealso::
                 For more information, see Dataset Resource content:
@@ -1459,7 +1459,7 @@ class BigQueryBaseCursor(LoggingMixin):
 
         if not dataset_id or not isinstance(dataset_id, str):
             raise ValueError("dataset_id argument must be provided and has "
-                             "a type 'str'. You provide: {}".format(dataset_id))
+                             "a type 'str'. You provided: {}".format(dataset_id))
 
         dataset_project_id = project_id if project_id else self.project_id
 
@@ -1473,9 +1473,9 @@ class BigQueryBaseCursor(LoggingMixin):
 
         return dataset_resource
 
-    def get_datasets_list(self, project_id=""):
+    def get_datasets_list(self, project_id=None):
         """
-        Method returned full list of BigQuery datasets into current project
+        Method returns full list of BigQuery datasets into current project
 
         .. seealso::
             For more information, see:
@@ -1483,10 +1483,10 @@ class BigQueryBaseCursor(LoggingMixin):
 
         :param project_id: Google Cloud Project for which you
             try to get all datasets
-        :type  project_id: str
-        :return datasets_list:
+        :type project_id: str
+        :return: datasets_list
 
-            Example of returned datasets_list:
+            Example of returned datasets_list: ::
 
                    {
                       "kind":"bigquery#dataset",

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1475,7 +1475,7 @@ class BigQueryBaseCursor(LoggingMixin):
 
     def get_datasets_list(self, project_id=None):
         """
-        Method returns full list of BigQuery datasets into current project
+        Method returns full list of BigQuery datasets in the current project
 
         .. seealso::
             For more information, see:

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1441,6 +1441,86 @@ class BigQueryBaseCursor(LoggingMixin):
                 'BigQuery job failed. Error was: {}'.format(err.content)
             )
 
+    def get_dataset(self, dataset_id="", project_id=""):
+        """
+        Method returns dataset_resource if dataset exist
+        and raised 404 error if dataset does not exist
+
+        :param dataset_id: dataset_id to get
+        :type dataset_id: str
+        :param project_id: Google Cloud Project for which you try to get dataset
+        :type  project_id: str
+        :return dataset_resource
+
+            .. seealso::
+                For more information, see Dataset Resource content:
+                https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets#resource
+        """
+
+        if not dataset_id or not isinstance(dataset_id, str):
+            raise ValueError("dataset_id argument must be provided and has "
+                             "a type 'str'. You provide: {}".format(dataset_id))
+
+        dataset_project_id = project_id if project_id else self.project_id
+
+        try:
+            dataset_resource = self.service.datasets().get(
+                datasetId=dataset_id, projectId=dataset_project_id).execute()
+            self.log.info("Dataset Resource: {}".format(dataset_resource))
+        except HttpError as err:
+            raise AirflowException(
+                'BigQuery job failed. Error was: {}'.format(err.content))
+
+        return dataset_resource
+
+    def get_datasets_list(self, project_id=""):
+        """
+        Method returned full list of BigQuery datasets into current project
+
+        .. seealso::
+            For more information, see:
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/list
+
+        :param project_id: Google Cloud Project for which you
+            try to get all datasets
+        :type  project_id: str
+        :return datasets_list:
+
+            Example of returned datasets_list:
+
+                   {
+                      "kind":"bigquery#dataset",
+                      "location":"US",
+                      "id":"your-project:dataset_2_test",
+                      "datasetReference":{
+                         "projectId":"your-project",
+                         "datasetId":"dataset_2_test"
+                      }
+                   },
+                   {
+                      "kind":"bigquery#dataset",
+                      "location":"US",
+                      "id":"your-project:dataset_1_test",
+                      "datasetReference":{
+                         "projectId":"your-project",
+                         "datasetId":"dataset_1_test"
+                      }
+                   }
+                ]
+        """
+        dataset_project_id = project_id if project_id else self.project_id
+
+        try:
+            datasets_list = self.service.datasets().list(
+                projectId=dataset_project_id).execute()['datasets']
+            self.log.info("Datasets List: {}".format(datasets_list))
+
+        except HttpError as err:
+            raise AirflowException(
+                'BigQuery job failed. Error was: {}'.format(err.content))
+
+        return datasets_list
+
 
 class BigQueryCursor(BigQueryBaseCursor):
     """


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3055
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
