### PR TITLE
PYODBC MSSQL HOOK WORKS with Azure SQL DB

### DIFF
--- a/airflow/hooks/mssqlpyodbc_hook.py
+++ b/airflow/hooks/mssqlpyodbc_hook.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pyodbc
+
+from airflow.hooks.dbapi_hook import DbApiHook
+
+
+class MsSqlPyODBCHook(DbApiHook):
+    """
+    Interact with Microsoft SQL Server.
+    """
+
+    conn_name_attr = 'mssql_conn_id'
+    default_conn_name = 'mssql_default'
+    supports_autocommit = True
+
+    def __init__(self, *args, **kwargs):
+        super(MsSqlPyODBCHook, self).__init__(*args, **kwargs)
+        self.schema = kwargs.pop("schema", None)
+
+    def get_conn(self):
+        """
+        Returns a mssql connection object
+        """
+        conn = self.get_connection(self.mssql_conn_id)
+        conn = pyodbc.connect(
+            "DRIVER={0};SERVER={1};PORT={2};DATABASE={3};UID={4};PWD={5}"
+            .format(
+                '{ODBC Driver 17 for SQL Server}'
+                , conn.host
+                , conn.port
+                , self.schema or conn.schema
+                , conn.login
+                , conn.password
+            )
+        )
+
+        return conn
+
+    def set_autocommit(self, conn, autocommit):
+        conn.autocommit(autocommit)


### PR DESCRIPTION
When there was a large insert to MSSQL Azure Database, the insert always timedout, but when tested with PYODBC hook it worked without any problem. thats why i created this hook so that it would be helpful to people who has problems like me.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
