### PR TITLE
[AIRFLOW-2263] Fix 500 for null DAG

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1379,6 +1379,8 @@ class Airflow(BaseView):
         dag_id = request.args.get('dag_id')
         blur = conf.getboolean('webserver', 'demo_mode')
         dag = dagbag.get_dag(dag_id)
+        if dag is None:
+            abort(404)
         if dag_id not in dagbag.dags:
             flash('DAG "{0}" seems to be missing.'.format(dag_id), "error")
             return redirect('/admin/')


### PR DESCRIPTION
### Jira

My PR addresses the following [AIRFLOW-2263](https://issues.apache.org/jira/browse/AIRFLOW-2263) 
### Description

Remove 500-error when opening non-existent DAG in webserver UI `/admin/airflow/tree?dag_id=some_garbage`
Return 404 response instead


### Tests
My PR do not add new unit tests