### PR TITLE
[AIRFLOW-3067] Display www_rbac Flask flash msg properly

### DIFF
--- a/airflow/www_rbac/static/css/bootstrap-theme.css
+++ b/airflow/www_rbac/static/css/bootstrap-theme.css
@@ -4949,6 +4949,28 @@ a.thumbnail.active {
 .alert-danger .alert-link {
   color: #843534;
 }
+.alert-message {
+  background-color: #d9edf7;
+  border-color: #bce8f1;
+  color: #31708f;
+}
+.alert-message hr {
+  border-top-color: #a6e1ec;
+}
+.alert-message .alert-link {
+  color: #245269;
+}
+.alert-error {
+  background-color: #f2dede;
+  border-color: #ebccd1;
+  color: #a94442;
+}
+.alert-error hr {
+  border-top-color: #e4b9c0;
+}
+.alert-error .alert-link {
+  color: #843534;
+}
 @-webkit-keyframes progress-bar-stripes {
   from {
     background-position: 40px 0;

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -782,11 +782,12 @@ class Airflow(AirflowBaseView):
         try:
             delete_dag.delete_dag(dag_id)
         except DagNotFound:
-            flash("DAG with id {} not found. Cannot delete".format(dag_id))
+            flash("DAG with id {} not found. Cannot delete".format(dag_id), 'error')
             return redirect(request.referrer)
         except DagFileExists:
             flash("Dag id {} is still in DagBag. "
-                  "Remove the DAG file first.".format(dag_id))
+                  "Remove the DAG file first.".format(dag_id),
+                  'error')
             return redirect(request.referrer)
 
         flash("Deleting DAG with id {}. May take a couple minutes to fully"
@@ -2065,7 +2066,7 @@ class VariableModelView(AirflowModelView):
             else:
                 d = json.loads(out)
         except Exception:
-            flash("Missing file or syntax error.")
+            flash("Missing file or syntax error.", 'error')
         else:
             suc_count = fail_count = 0
             for k, v in d.items():
@@ -2076,7 +2077,7 @@ class VariableModelView(AirflowModelView):
                     fail_count += 1
                 else:
                     suc_count += 1
-            flash("{} variable(s) successfully updated.".format(suc_count), 'info')
+            flash("{} variable(s) successfully updated.".format(suc_count))
             if fail_count:
                 flash("{} variables(s) failed to be updated.".format(fail_count), 'error')
             self.update_redirect()
@@ -2166,10 +2167,9 @@ class DagRunModelView(AirflowModelView):
                 dr.state = State.RUNNING
             models.DagStat.update(dirty_ids, session=session)
             session.commit()
-            flash(
-                "{count} dag runs were set to running".format(**locals()))
+            flash("{count} dag runs were set to running".format(**locals()))
         except Exception as ex:
-            flash(str(ex))
+            flash(str(ex), 'error')
             flash('Failed to set state', 'error')
         return redirect(self.route_base + '/list')
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3067
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**LATEST UPDATE**
**Update `bootstrap-theme.css` instead, by adding `alert-message` and `alert-error` into it (rather than making too many changes in `www_rbac/views.py`).**

**Background**

For **`www_rbac`**, the Flask flash messages are not categorized properly (ref: http://flask.pocoo.org/docs/1.0/patterns/flashing/#flashing-with-categories), then the default category would be '`message`'. Flask Appbuilder would assign CSS class `alert-[category]` to that message when displaying it (ref: https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/templates/appbuilder/flash.html).

**Issue**

But CSS class '`alert-message`' is not specified in _bootstrap-theme.css_. This makes the the flash messages in the `www_rbac` UI come with no background color (please check the screenshots attached. We don't see this issue in `www` UI as all flash messages without categories are classed into 'info', and CSS class '`alert-info`' in available in _bootstrap-theme.css_).

For flash messages which are categorized as `'error'`, it would not work either since CSS class `alert-error` is not avaialbe in _bootstrap-theme.css_ as well. We can use category `danger` or `warning` instead.

We have this issue in 1.10.0 as well as master branch.

**Solution**
- Add proper category when we invoke **flash()**.
- Available categories: 'success', 'info', 'warning', 'danger'.

**Screenshots - Before**
<img width="1280" alt="1" src="https://user-images.githubusercontent.com/11539188/45587396-73af2c80-b937-11e8-864e-a19603ebfa02.png">

<img width="1280" alt="2" src="https://user-images.githubusercontent.com/11539188/45587398-76aa1d00-b937-11e8-84aa-ef9a249fd4de.png">

**Screenshots - After**
<img width="1280" alt="3" src="https://user-images.githubusercontent.com/11539188/45587400-7ad63a80-b937-11e8-98ae-637d09304afc.png">
<img width="1280" alt="4" src="https://user-images.githubusercontent.com/11539188/45587401-7d389480-b937-11e8-9a7e-b12f4598c333.png">


### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
