### PR TITLE
[AIRFLOW-XXX] Fix typo in docs/timezone.rst

### DIFF
--- a/docs/timezone.rst
+++ b/docs/timezone.rst
@@ -134,13 +134,13 @@ Cron schedules
 
 In case you set a cron schedule, Airflow assumes you will always want to run at the exact same time. It will
 then ignore day light savings time. Thus, if you have a schedule that says
-run at end of interval every day at 08:00 GMT+1 it will always run end of interval 08:00 GMT+1,
+run at the end of interval every day at 08:00 GMT+1 it will always run at the end of interval 08:00 GMT+1,
 regardless if day light savings time is in place.
 
 
 Time deltas
 '''''''''''
 For schedules with time deltas Airflow assumes you always will want to run with the specified interval. So if you
-specify a timedelta(hours=2) you will always want to run to hours later. In this case day light savings time will
+specify a timedelta(hours=2) you will always want to run two hours later. In this case day light savings time will
 be taken into account.
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
To fix minor typos.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Only minor doc change.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
