### PR TITLE
[AIRFLOW-3073] Add a note - Profiling features are not supported in new webserver

### DIFF
--- a/docs/profiling.rst
+++ b/docs/profiling.rst
@@ -1,5 +1,11 @@
+.. TODO: This section would be removed after we migrate to www_rbac completely.
+
 Data Profiling
 ==============
+
+.. note::
+   ``Adhoc Queries`` and ``Charts`` are no longer supported in the new FAB-based webserver
+   and UI, due to security concerns.
 
 Part of being productive with data is having the right weapons to
 profile the data you are working with. Airflow provides a simple query


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3073
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

`Adhoc queries` and `Charts` features are no longer supported in new FAB-based webserver and UI. But this is not mentioned at all in the doc "Data Profiling" (https://airflow.incubator.apache.org/profiling.html). This may confuse users.

Ref: https://github.com/apache/incubator-airflow/blob/master/UPDATING.md#breaking-changes

This commit adds a note to remind users for this.

Later after the `www` is removed (completely migrated to `www_rbac`), this `profiling.rst` should be removed as well.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Documentation chagne.


### Commits

- [] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
