### PR TITLE
[AIRFLOW-3077] Default Not to Raise Error When PyMongo Contruct JSON Data

### DIFF
--- a/airflow/contrib/hooks/mongo_hook.py
+++ b/airflow/contrib/hooks/mongo_hook.py
@@ -70,6 +70,9 @@ class MongoHook(BaseHook):
         if options.get('ssl', False):
             options.update({'ssl_cert_reqs': CERT_NONE})
 
+        if not options.get('unicode_decode_error_handler', False):
+            options.update({'unicode_decode_error_handler': 'ignore'})
+
         self.client = MongoClient(uri, **options)
 
         return self.client


### PR DESCRIPTION
This PR resolved [Encoding Problem](https://stackoverflow.com/questions/36314776/pymongo-error-bson-errors-invalidbson-utf8-codec-cant-decode-byte-0xa1-in-p) when we try to migrate data from Mongo Hook.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3077) issues and references them in the PR title. For example, "\[AIRFLOW-3077\] Mongo Hook Raise Error and Stop Migration Due to Bad Encoding from PyMongo"
  - https://issues.apache.org/jira/browse/AIRFLOW-3077
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-3077\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
