### PR TITLE
[AIRFLOW-3069] Log all output of the S3 file transform script

### DIFF
--- a/tests/operators/test_s3_file_transform_operator.py
+++ b/tests/operators/test_s3_file_transform_operator.py
@@ -22,6 +22,7 @@ import errno
 import io
 import os
 import shutil
+import sys
 import unittest
 from tempfile import mkdtemp
 
@@ -29,6 +30,7 @@ import boto3
 import mock
 from moto import mock_s3
 
+from airflow.exceptions import AirflowException
 from airflow.operators.s3_file_transform_operator import S3FileTransformOperator
 
 
@@ -48,11 +50,15 @@ class TestS3FileTransformOperator(unittest.TestCase):
                 raise e
 
     @mock.patch('subprocess.Popen')
+    @mock.patch.object(S3FileTransformOperator, 'log')
     @mock_s3
-    def test_execute_with_transform_script(self, mock_Popen):
-        transform_script_process = mock_Popen.return_value
-        transform_script_process.communicate.return_value = [None, None]
-        transform_script_process.returncode = 0
+    def test_execute_with_transform_script(self, mock_log, mock_Popen):
+        process_output = [b"Foo", b"Bar", b"Baz"]
+
+        process = mock_Popen.return_value
+        process.stdout.readline.side_effect = process_output
+        process.wait.return_value = None
+        process.returncode = 0
 
         bucket = "bucket"
         input_key = "foo"
@@ -71,6 +77,40 @@ class TestS3FileTransformOperator(unittest.TestCase):
             replace=True,
             task_id="task_id")
         t.execute(None)
+
+        mock_log.info.assert_has_calls([
+            mock.call(line.decode(sys.getdefaultencoding())) for line in process_output
+        ])
+
+    @mock.patch('subprocess.Popen')
+    @mock_s3
+    def test_execute_with_failing_transform_script(self, mock_Popen):
+        process = mock_Popen.return_value
+        process.stdout.readline.side_effect = []
+        process.wait.return_value = None
+        process.returncode = 42
+
+        bucket = "bucket"
+        input_key = "foo"
+        output_key = "bar"
+        bio = io.BytesIO(b"input")
+
+        conn = boto3.client('s3')
+        conn.create_bucket(Bucket=bucket)
+        conn.upload_fileobj(Bucket=bucket, Key=input_key, Fileobj=bio)
+
+        s3_url = "s3://{0}/{1}"
+        t = S3FileTransformOperator(
+            source_s3_key=s3_url.format(bucket, input_key),
+            dest_s3_key=s3_url.format(bucket, output_key),
+            transform_script=self.transform_script,
+            replace=True,
+            task_id="task_id")
+
+        with self.assertRaises(AirflowException) as e:
+            t.execute(None)
+
+        self.assertEqual('Transform script failed: 42', str(e.exception))
 
     @mock.patch('airflow.hooks.S3_hook.S3Hook.select_key', return_value="input")
     @mock_s3


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - [https://jira.apache.org/jira/browse/AIRFLOW-3069](https://jira.apache.org/jira/browse/AIRFLOW-3069)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The output of the process spawned by `S3FileTransformOperator` is not properly decoded, which makes reading logs rather difficult. Additionally, the `stderr` stream is only shown when process exit code is not equal to `0`.

I would like to propose the following changes to `S3FileTransformOperator`:

- Send both output streams (stdout & stderr) to the logger, regardless of the outcome (if any data is present)
- Decode the output, so that new lines can be displayed correctly.
- Include process exit code in the exception message, if the process fails.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I've added a separate case for testing `transform_script` with output present. Since logging is essential in this case, the test checks if a valid message was passed to the logging module. 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
