### PR TITLE
[AIRFLOW-XXX] Fix SlackWebhookOperator docs

### DIFF
--- a/airflow/contrib/operators/slack_webhook_operator.py
+++ b/airflow/contrib/operators/slack_webhook_operator.py
@@ -31,8 +31,8 @@ class SlackWebhookOperator(SimpleHttpOperator):
     Each Slack webhook token can be pre-configured to use a specific channel, username and
     icon. You can override these defaults in this hook.
 
-    :param conn_id: connection that has Slack webhook token in the extra field
-    :type conn_id: str
+    :param http_conn_id: connection that has Slack webhook token in the extra field
+    :type http_conn_id: str
     :param webhook_token: Slack webhook token
     :type webhook_token: str
     :param message: The message you want to send on Slack


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue. -> ✅ 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The docs refer to `conn_id` while the actual argument is `http_conn_id`.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No tests - documentation fix only. 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
