### PR TITLE
[AIRFLOW-3085] Bug fix to allow log display in RBAC UI

### DIFF
--- a/airflow/www_rbac/security.py
+++ b/airflow/www_rbac/security.py
@@ -96,6 +96,7 @@ viewer_perms = {
     'can_rendered',
     'can_pickle_info',
     'can_version',
+    'can_get_logs_with_metadata',
 }
 
 user_perms = {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3085

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Currently due to a change in method name, none of the roles beside Admin is capable of viewing logs in Airflow. Log viewing should be part of of the default rbac configuration for all roles (except public). 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested via UI

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
