### PR TITLE
[AIRFLOW-3086] Add extras group for google auth to setup.py.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -41,71 +41,75 @@ these extra dependencies.
 
 Here's the list of the subpackages and what they enable:
 
-+---------------+----------------------------------------------+-------------------------------------------------+
-| subpackage    | install command                              | enables                                         |
-+===============+==============================================+=================================================+
-| all           | ``pip install apache-airflow[all]``          | All Airflow features known to man               |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| all_dbs       | ``pip install apache-airflow[all_dbs]``      | All databases integrations                      |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| async         | ``pip install apache-airflow[async]``        | Async worker classes for Gunicorn               |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| celery        | ``pip install apache-airflow[celery]``       | CeleryExecutor                                  |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| cloudant      | ``pip install apache-airflow[cloudant]``     | Cloudant hook                                   |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| crypto        | ``pip install apache-airflow[crypto]``       | Encrypt connection passwords in metadata db     |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| devel         | ``pip install apache-airflow[devel]``        | Minimum dev tools requirements                  |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| devel_hadoop  | ``pip install apache-airflow[devel_hadoop]`` | Airflow + dependencies on the Hadoop stack      |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| druid         | ``pip install apache-airflow[druid]``        | Druid related operators & hooks                 |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| gcp_api       | ``pip install apache-airflow[gcp_api]``      | Google Cloud Platform hooks and operators       |
-|               |                                              | (using ``google-api-python-client``)            |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| hdfs          | ``pip install apache-airflow[hdfs]``         | HDFS hooks and operators                        |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| hive          | ``pip install apache-airflow[hive]``         | All Hive related operators                      |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| jdbc          | ``pip install apache-airflow[jdbc]``         | JDBC hooks and operators                        |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| kerberos      | ``pip install apache-airflow[kerberos]``     | Kerberos integration for Kerberized Hadoop      |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| ldap          | ``pip install apache-airflow[ldap]``         | LDAP authentication for users                   |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| mssql         | ``pip install apache-airflow[mssql]``        | Microsoft SQL Server operators and hook,        |
-|               |                                              | support as an Airflow backend                   |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| mysql         | ``pip install apache-airflow[mysql]``        | MySQL operators and hook, support as an Airflow |
-|               |                                              | backend. The version of MySQL server has to be  |
-|               |                                              | 5.6.4+. The exact version upper bound depends   |
-|               |                                              | on version of ``mysqlclient`` package. For      |
-|               |                                              | example, ``mysqlclient`` 1.3.12 can only be     |
-|               |                                              | used with MySQL server 5.6.4 through 5.7.       |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| password      | ``pip install apache-airflow[password]``     | Password authentication for users               |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| postgres      | ``pip install apache-airflow[postgres]``     | PostgreSQL operators and hook, support as an    |
-|               |                                              | Airflow backend                                 |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| qds           | ``pip install apache-airflow[qds]``          | Enable QDS (Qubole Data Service) support        |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| rabbitmq      | ``pip install apache-airflow[rabbitmq]``     | RabbitMQ support as a Celery backend            |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| redis         | ``pip install apache-airflow[redis]``        | Redis hooks and sensors                         |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| s3            | ``pip install apache-airflow[s3]``           | ``S3KeySensor``, ``S3PrefixSensor``             |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| samba         | ``pip install apache-airflow[samba]``        | ``Hive2SambaOperator``                          |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| slack         | ``pip install apache-airflow[slack]``        | ``SlackAPIPostOperator``                        |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| ssh           | ``pip install apache-airflow[ssh]``          | SSH hooks and Operator                          |
-+---------------+----------------------------------------------+-------------------------------------------------+
-| vertica       | ``pip install apache-airflow[vertica]``      | Vertica hook support as an Airflow backend      |
-+---------------+----------------------------------------------+-------------------------------------------------+
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| subpackage          | install command                                   | enables                                         |
++=====================+===================================================+=================================================+
+| all                 | ``pip install apache-airflow[all]``               | All Airflow features known to man               |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| all_dbs             | ``pip install apache-airflow[all_dbs]``           | All databases integrations                      |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| async               | ``pip install apache-airflow[async]``             | Async worker classes for Gunicorn               |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| celery              | ``pip install apache-airflow[celery]``            | CeleryExecutor                                  |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| cloudant            | ``pip install apache-airflow[cloudant]``          | Cloudant hook                                   |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| crypto              | ``pip install apache-airflow[crypto]``            | Encrypt connection passwords in metadata db     |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| devel               | ``pip install apache-airflow[devel]``             | Minimum dev tools requirements                  |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| devel_hadoop        | ``pip install apache-airflow[devel_hadoop]``      | Airflow + dependencies on the Hadoop stack      |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| druid               | ``pip install apache-airflow[druid]``             | Druid related operators & hooks                 |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| gcp_api             | ``pip install apache-airflow[gcp_api]``           | Google Cloud Platform hooks and operators       |
+|                     |                                                   | (using ``google-api-python-client``)            |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| github_enterprise   | ``pip install apache-airflow[github_enterprise]`` | Github Enterprise auth backend                  |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| google_auth         | ``pip install apache-airflow[google_auth]``       | Google auth backend                             |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| hdfs                | ``pip install apache-airflow[hdfs]``              | HDFS hooks and operators                        |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| hive                | ``pip install apache-airflow[hive]``              | All Hive related operators                      |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| jdbc                | ``pip install apache-airflow[jdbc]``              | JDBC hooks and operators                        |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| kerberos            | ``pip install apache-airflow[kerberos]``          | Kerberos integration for Kerberized Hadoop      |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| ldap                | ``pip install apache-airflow[ldap]``              | LDAP authentication for users                   |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| mssql               | ``pip install apache-airflow[mssql]``             | Microsoft SQL Server operators and hook,        |
+|                     |                                                   | support as an Airflow backend                   |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| mysql               | ``pip install apache-airflow[mysql]``             | MySQL operators and hook, support as an Airflow |
+|                     |                                                   | backend. The version of MySQL server has to be  |
+|                     |                                                   | 5.6.4+. The exact version upper bound depends   |
+|                     |                                                   | on version of ``mysqlclient`` package. For      |
+|                     |                                                   | example, ``mysqlclient`` 1.3.12 can only be     |
+|                     |                                                   | used with MySQL server 5.6.4 through 5.7.       |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| password            | ``pip install apache-airflow[password]``          | Password authentication for users               |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| postgres            | ``pip install apache-airflow[postgres]``          | PostgreSQL operators and hook, support as an    |
+|                     |                                                   | Airflow backend                                 |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| qds                 | ``pip install apache-airflow[qds]``               | Enable QDS (Qubole Data Service) support        |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| rabbitmq            | ``pip install apache-airflow[rabbitmq]``          | RabbitMQ support as a Celery backend            |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| redis               | ``pip install apache-airflow[redis]``             | Redis hooks and sensors                         |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| s3                  | ``pip install apache-airflow[s3]``                | ``S3KeySensor``, ``S3PrefixSensor``             |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| samba               | ``pip install apache-airflow[samba]``             | ``Hive2SambaOperator``                          |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| slack               | ``pip install apache-airflow[slack]``             | ``SlackAPIPostOperator``                        |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| ssh                 | ``pip install apache-airflow[ssh]``               | SSH hooks and Operator                          |
++---------------------+---------------------------------------------------+-------------------------------------------------+
+| vertica             | ``pip install apache-airflow[vertica]``           | Vertica hook support as an Airflow backend      |
++---------------------+---------------------------------------------------+-------------------------------------------------+
 
 Initiating Airflow Database
 '''''''''''''''''''''''''''

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -231,6 +231,12 @@ and in your DAG, when initializing the HiveOperator, specify:
 
     run_as_owner=True
 
+To use kerberos authentication, you must install Airflow with the `kerberos` extras group:
+
+.. code-block:: base
+
+   pip install airflow[kerberos]
+
 OAuth Authentication
 --------------------
 
@@ -257,6 +263,12 @@ to only members of those teams.
 
 .. note:: If you do not specify a team whitelist, anyone with a valid account on
    your GHE installation will be able to login to Airflow.
+
+To use GHE authentication, you must install Airflow with the `github_enterprise` extras group:
+
+.. code-block:: base
+
+   pip install airflow[github_enterprise]
 
 Setting up GHE Authentication
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -299,6 +311,12 @@ login, separated with a comma, to only members of those domains.
     client_secret = google_client_secret
     oauth_callback_route = /oauth2callback
     domain = "example1.com,example2.com"
+
+To use Google authentication, you must install Airflow with the `google_auth` extras group:
+
+.. code-block:: base
+
+   pip install airflow[google_auth]
 
 Setting up Google Authentication
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -192,6 +192,7 @@ gcp_api = [
     'pandas-gbq'
 ]
 github_enterprise = ['Flask-OAuthlib>=0.9.1']
+google_auth = ['Flask-OAuthlib>=0.9.1']
 hdfs = ['snakebite>=2.7.8']
 hive = [
     'hmsclient>=0.1.0',
@@ -358,6 +359,7 @@ def do_setup():
             'emr': emr,
             'gcp_api': gcp_api,
             'github_enterprise': github_enterprise,
+            'google_auth': google_auth,
             'hdfs': hdfs,
             'hive': hive,
             'jdbc': jdbc,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3086


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

To clarify installation instructions for the google auth backend, add an
install group to `setup.py` that installs dependencies google auth via
`pip install apache-airflow[google_auth]`.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This patch just adds an item to `setup.py`.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
