### PR TITLE
[AIRFLOW-3090] Specify path of key file in log message

### DIFF
--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -87,7 +87,7 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
         elif key_path:
             # Get credentials from a JSON file.
             if key_path.endswith('.json'):
-                self.log.info('Getting connection using a JSON key file.')
+                self.log.debug('Getting connection using JSON key file %s' % key_path)
                 credentials = (
                     google.oauth2.service_account.Credentials.from_service_account_file(
                         key_path, scopes=scopes)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3090
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x ] Here are some details about my PR, including screenshots of any UI changes:
Move logging message providing details about gcs connection to debug.  Also, provide specific on the path being used.  This message is clearly intended for used when debugging connection issues, and should not be considered informational.

### Tests

- [ x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests seem unnecessary
### Commits

- [ x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
