### PR TITLE
[AIRFLOW-3090] Make "No tasks to consider for execution." a debug msg

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1101,7 +1101,7 @@ class SchedulerJob(BaseJob):
         task_instances_to_examine = ti_query.all()
 
         if len(task_instances_to_examine) == 0:
-            self.log.info("No tasks to consider for execution.")
+            self.log.debug("No tasks to consider for execution.")
             return executable_tis
 
         # Put one task instance on each line


### PR DESCRIPTION
During normal operation, it is not necessary to see the message.  This
can only be useful when debugging an issue.

Make sure you have checked _all_ steps below.

### Jira

- [ x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3090
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x ] Here are some details about my PR, including screenshots of any UI changes:
  Make a debug message only log in debug, not info

### Tests

- [ x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  not needed

### Commits

- [x ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [ x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
