### PR TITLE
[AIRFLOW-2548] Output plugin import errors to web UI

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -34,6 +34,8 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 log = LoggingMixin().log
 
+import_errors = {}
+
 
 class AirflowPluginException(Exception):
     pass
@@ -99,6 +101,7 @@ for root, dirs, files in os.walk(plugins_folder, followlinks=True):
         except Exception as e:
             log.exception(e)
             log.error('Failed to import plugin %s', filepath)
+            import_errors[filepath] = str(e)
 
 
 def make_module(name, objects):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2126,6 +2126,14 @@ class HomeView(AdminIndexView):
                 "Broken DAG: [{ie.filename}] {ie.stacktrace}".format(ie=ie),
                 "error")
 
+        from airflow.plugins_manager import import_errors as plugin_import_errors
+        for filename, stacktrace in plugin_import_errors.items():
+            flash(
+                "Broken plugin: [{filename}] {stacktrace}".format(
+                    stacktrace=stacktrace,
+                    filename=filename),
+                "error")
+
         # get a list of all non-subdag dags visible to everyone
         # optionally filter out "paused" dags
         if hide_paused:

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -184,13 +184,18 @@ class Airflow(AirflowBaseView):
         if hide_paused:
             sql_query = sql_query.filter(~DM.is_paused)
 
-        # Get all the dag id the user could access
-        filter_dag_ids = appbuilder.sm.get_accessible_dag_ids()
-
         import_errors = session.query(models.ImportError).all()
         for ie in import_errors:
             flash(
                 "Broken DAG: [{ie.filename}] {ie.stacktrace}".format(ie=ie),
+                "error")
+
+        from airflow.plugins_manager import import_errors as plugin_import_errors
+        for filename, stacktrace in plugin_import_errors.items():
+            flash(
+                "Broken plugin: [{filename}] {stacktrace}".format(
+                    stacktrace=stacktrace,
+                    filename=filename),
                 "error")
 
         # get a list of all non-subdag dags visible to everyone
@@ -202,6 +207,9 @@ class Airflow(AirflowBaseView):
         else:
             unfiltered_webserver_dags = [dag for dag in dagbag.dags.values() if
                                          not dag.parent_dag]
+
+        # Get all the dag id the user could access
+        filter_dag_ids = appbuilder.sm.get_accessible_dag_ids()
 
         if 'all_dags' in filter_dag_ids:
             orm_dags = {dag.dag_id: dag for dag

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -119,6 +119,8 @@ For example,
 * For ``Operator`` plugin, an ``execute`` method is compulsory.
 * For ``Sensor`` plugin, a ``poke`` method returning a Boolean value is compulsory.
 
+Make sure you restart the webserver and scheduler after making changes to plugins so that they take effect.
+
 
 Example
 -------


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2548
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

![image](https://user-images.githubusercontent.com/199185/45848620-0bb86780-bce4-11e8-94fe-ea3df8b9c549.png)

This change displays an alert in the web interface for each ImportError that occurs on the DAGs homepage.

A limitation is that the presence of the error alert reflects the brokenness of the plugin according to the webserver, not the scheduler. So, if the user fixes the plugin and restarts *only* the webserver, that web UI will not show the error anymore, but the airflow DAGs may still be broken because the scheduler also needs a restart. In other words, the plugin can be simultaneously fixed for the webserver but broken for the scheduler.  After editing the plugin's code, both the scheduler and the webserver need to be restarted.

The proposer of the Jira issue @andscoop outlined a different approach to add this feature in the Jira issue. I may be mistaken, but that approach would cause the opposite limitation, where the error alert would reflect the brokenness of the plugin according to the scheduler, not the webserver?

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

It is unclear how I can unit test a small UI change like this.


### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

Added a sentence to clarify the need to restart both the webserver and the scheduler after plugin changes.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
