### PR TITLE
[AIRFLOW-3100][AIRFLOW-3101] Improve docker compose local testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,8 +146,17 @@ There are three ways to setup an Apache Airflow development environment.
   # From the container
   pip install -e .[devel]
   # Run all the tests with python and mysql through tox
+  pip install tox
   tox -e py35-backend_mysql
   ```
+
+  If you wish to run individual tests inside of docker enviroment you can do as follows:
+
+  ```bash
+    # From the container (with your desired enviroment) with druid hook
+    tox -e py35-backend_mysql -- tests/hooks/test_druid_hook.py
+ ```
+
 
 ### Running unit tests
 

--- a/scripts/ci/docker-compose.yml
+++ b/scripts/ci/docker-compose.yml
@@ -66,6 +66,7 @@ services:
     init: true
     environment:
       - USER=airflow
+      - PATH=$PATH:~/.local/bin
       - SLUGIFY_USES_TEXT_UNIDECODE=yes
       - TOX_ENV
       - PYTHON_VERSION

--- a/scripts/ci/docker-compose.yml
+++ b/scripts/ci/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     init: true
     environment:
       - USER=airflow
-      - PATH=$PATH:~/.local/bin
+      - ADDITIONAL_PATH=~/.local/bin
       - SLUGIFY_USES_TEXT_UNIDECODE=yes
       - TOX_ENV
       - PYTHON_VERSION

--- a/scripts/ci/kubernetes/docker/Dockerfile
+++ b/scripts/ci/kubernetes/docker/Dockerfile
@@ -36,8 +36,7 @@ RUN apt-get update -y && apt-get install -y \
     && apt-get clean
 
 RUN pip install --upgrade pip
-RUN pip install wheel
-RUN pip install tox
+RUN pip install wheel tox
 
 # Since we install vanilla Airflow, we also want to have support for Postgres and Kubernetes
 RUN pip install -U setuptools && \

--- a/scripts/ci/kubernetes/docker/Dockerfile
+++ b/scripts/ci/kubernetes/docker/Dockerfile
@@ -36,6 +36,8 @@ RUN apt-get update -y && apt-get install -y \
     && apt-get clean
 
 RUN pip install --upgrade pip
+RUN pip install wheel
+RUN pip install tox
 
 # Since we install vanilla Airflow, we also want to have support for Postgres and Kubernetes
 RUN pip install -U setuptools && \

--- a/scripts/ci/kubernetes/docker/Dockerfile
+++ b/scripts/ci/kubernetes/docker/Dockerfile
@@ -36,7 +36,6 @@ RUN apt-get update -y && apt-get install -y \
     && apt-get clean
 
 RUN pip install --upgrade pip
-RUN pip install wheel tox
 
 # Since we install vanilla Airflow, we also want to have support for Postgres and Kubernetes
 RUN pip install -U setuptools && \

--- a/scripts/ci/run-ci.sh
+++ b/scripts/ci/run-ci.sh
@@ -32,8 +32,8 @@ else
   PIP=pip
 fi
 
-sudo $PIP install --upgrade pip
-sudo $PIP install tox
+sudo -H $PIP install --upgrade pip
+sudo -H $PIP install tox
 
 cd $AIRFLOW_ROOT && $PIP --version && tox --version
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

Update the contributing guide for folks who want to run docker compose for a single test (e.g. debugging while developing), clarify tox install requirements (including in image bake script for later and for now updating contributing guide until a new image can be rolled), fix path for users who launch docker-compose while not running as a user named airflow.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This is for improved local testing, existing CI tests should catch any breaking changes.

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

Updates contributing docs.

### Code Quality

- [ X ] Passes ` git diff upstream/master -u -- "*.py" | flake8 --diff`
