### PR TITLE
[AIRFLOW-3099] Stop Missing Section Errors for optional sections

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -510,9 +510,18 @@ def run(args, dag=None):
                 try:
                     conf.set(section, option, value)
                 except NoSectionError:
-                    log.error('Section {section} Option {option} '
-                              'does not exist in the config!'.format(section=section,
-                                                                     option=option))
+                    optional_sections = [
+                        'atlas', 'mesos', 'elasticsearch', 'kubernetes',
+                        'lineage', 'hive'
+                    ]
+                    if section in optional_sections:
+                        log.debug('Section {section} Option {option} '
+                                  'does not exist in the config!'.format(section=section,
+                                                                         option=option))
+                    else:
+                        log.error('Section {section} Option {option} '
+                                  'does not exist in the config!'.format(section=section,
+                                                                         option=option))
 
         settings.configure_vars()
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3099


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When we upgrade from a version of airflow to another one and new config bloc are available or if we delete useless blocs, lots of errors are raised if we don't have some blocs in airflow.cfg file.

We need to avoid these errors for non-required blocs.

For the record logs (not exhaustive):

```
[2018-09-21 10:49:37,727] {cli.py:464} ERROR - Section atlas Option sasl_enabled does not exist in the config!
[2018-09-21 10:49:37,727] {cli.py:464} ERROR - Section atlas Option host does not exist in the config!
[2018-09-21 10:49:37,727] {cli.py:464} ERROR - Section atlas Option port does not exist in the config!
[2018-09-21 10:49:37,727] {cli.py:464} ERROR - Section atlas Option username does not exist in the config!
[2018-09-21 10:49:37,727] {cli.py:464} ERROR - Section atlas Option password does not exist in the config!
[2018-09-21 10:49:37,728] {cli.py:464} ERROR - Section hive Option default_hive_mapred_queue does not exist in the config!
[2018-09-21 10:49:37,728] {cli.py:464} ERROR - Section mesos Option master does not exist in the config!
[2018-09-21 10:49:37,728] {cli.py:464} ERROR - Section mesos Option framework_name does not exist in the config!
[2018-09-21 10:49:37,728] {cli.py:464} ERROR - Section mesos Option task_cpu does not exist in the config!
[2018-09-21 10:49:37,728] {cli.py:464} ERROR - Section mesos Option task_memory does not exist in the config!
[2018-09-21 10:49:37,728] {cli.py:464} ERROR - Section mesos Option checkpoint does not exist in the config!
[2018-09-21 10:49:37,728] {cli.py:464} ERROR - Section mesos Option authenticate does not exist in the config!
[2018-09-21 10:49:37,729] {cli.py:464} ERROR - Section elasticsearch Option elasticsearch_host does not exist in the config!
[2018-09-21 10:49:37,729] {cli.py:464} ERROR - Section elasticsearch Option elasticsearch_log_id_template does not exist in the config!
[2018-09-21 10:49:37,729] {cli.py:464} ERROR - Section elasticsearch Option elasticsearch_end_of_log_mark does not exist in the config!
[2018-09-21 10:49:37,729] {cli.py:464} ERROR - Section kubernetes Option worker_container_repository does not exist in the config!
[2018-09-21 10:49:37,729] {cli.py:464} ERROR - Section kubernetes Option worker_container_tag does not exist in the config!
[2018-09-21 10:49:37,729] {cli.py:464} ERROR - Section kubernetes Option delete_worker_pods does not exist in the config!
[2018-09-21 10:49:37,729] {cli.py:464} ERROR - Section kubernetes Option namespace does not exist in the config!
[2018-09-21 10:49:37,729] {cli.py:464} ERROR - Section kubernetes Option airflow_configmap does not exist in the config!
[2018-09-21 10:49:37,729] {cli.py:464} ERROR - Section kubernetes Option dags_volume_subpath does not exist in the config!
[2018-09-21 10:49:37,730] {cli.py:464} ERROR - Section kubernetes Option dags_volume_claim does not exist in the config!
[2018-09-21 10:49:37,730] {cli.py:464} ERROR - Section kubernetes Option logs_volume_subpath does not exist in the config!
[2018-09-21 10:49:37,730] {cli.py:464} ERROR - Section kubernetes Option logs_volume_claim does not exist in the config!
[2018-09-21 10:49:37,730] {cli.py:464} ERROR - Section kubernetes Option git_repo does not exist in the config!
[2018-09-21 10:49:37,730] {cli.py:464} ERROR - Section kubernetes Option git_branch does not exist in the config!
[2018-09-21 10:49:37,730] {cli.py:464} ERROR - Section kubernetes Option git_user does not exist in the config!
[2018-09-21 10:49:37,730] {cli.py:464} ERROR - Section kubernetes Option git_password does not exist in the config!
[2018-09-21 10:49:37,730] {cli.py:464} ERROR - Section kubernetes Option git_subpath does not exist in the config!
[2018-09-21 10:49:37,730] {cli.py:464} ERROR - Section kubernetes Option git_sync_container_repository does not exist in the config!
[2018-09-21 10:49:37,730] {cli.py:464} ERROR - Section kubernetes Option git_sync_container_tag does not exist in the config!
[2018-09-21 10:49:37,731] {cli.py:464} ERROR - Section kubernetes Option git_sync_init_container_name does not exist in the config!
[2018-09-21 10:49:37,731] {cli.py:464} ERROR - Section kubernetes Option worker_service_account_name does not exist in the config!
[2018-09-21 10:49:37,731] {cli.py:464} ERROR - Section kubernetes Option image_pull_secrets does not exist in the config!
[2018-09-21 10:49:37,731] {cli.py:464} ERROR - Section kubernetes Option gcp_service_account_keys does not exist in the config!
[2018-09-21 10:49:37,731] {cli.py:464} ERROR - Section kubernetes Option in_cluster does not exist in the config!{noformat}
```

Log when running tutorial `print_date` task:
**Before**:
```
*** Reading local file: /Users/kaxil/airflow-dev/logs/tutorial/print_date/2018-09-21T20:55:02.964423+00:00/1.log
[2018-09-21 21:55:06,283] {models.py:1348} INFO - Dependencies all met for <TaskInstance: tutorial.print_date 2018-09-21T20:55:02.964423+00:00 [queued]>
[2018-09-21 21:55:06,286] {models.py:1348} INFO - Dependencies all met for <TaskInstance: tutorial.print_date 2018-09-21T20:55:02.964423+00:00 [queued]>
[2018-09-21 21:55:06,286] {models.py:1560} INFO - 
--------------------------------------------------------------------------------
Starting attempt 1 of 2
--------------------------------------------------------------------------------

[2018-09-21 21:55:06,299] {models.py:1582} INFO - Executing <Task(BashOperator): print_date> on 2018-09-21T20:55:02.964423+00:00
[2018-09-21 21:55:06,299] {base_task_runner.py:126} INFO - Running: [u'airflow', u'run', 'tutorial', 'print_date', '2018-09-21T20:55:02.964423+00:00', u'--job_id', '31', u'--raw', u'-sd', u'DAGS_FOLDER/example_dags/tutorial.py', u'--cfg_path', '/var/folders/nx/jf5splzj09bd5cfz98rs4_wr0000gq/T/tmpPNkKiO']
[2018-09-21 21:55:07,652] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,652] {__init__.py:51} INFO - Using executor SequentialExecutor
[2018-09-21 21:55:07,747] {base_task_runner.py:107} INFO - Job 31: Subtask print_date /Users/kaxil/Documents/GitHub/incubator-airflow/airflow/bin/cli.py:1799: DeprecationWarning: The celeryd_concurrency option in [celery] has been renamed to worker_concurrency - the old setting has been used, but please update your config.
[2018-09-21 21:55:07,748] {base_task_runner.py:107} INFO - Job 31: Subtask print_date   default=conf.get('celery', 'worker_concurrency')),
[2018-09-21 21:55:07,800] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,799] {cli.py:515} ERROR - Section atlas Option username does not exist in the config!
[2018-09-21 21:55:07,800] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,799] {cli.py:515} ERROR - Section atlas Option host does not exist in the config!
[2018-09-21 21:55:07,801] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,799] {cli.py:515} ERROR - Section atlas Option password does not exist in the config!
[2018-09-21 21:55:07,801] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,800] {cli.py:515} ERROR - Section atlas Option port does not exist in the config!
[2018-09-21 21:55:07,802] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,800] {cli.py:515} ERROR - Section atlas Option sasl_enabled does not exist in the config!
[2018-09-21 21:55:07,802] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,801] {cli.py:515} ERROR - Section kubernetes Option git_sync_container_repository does not exist in the config!
[2018-09-21 21:55:07,802] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,801] {cli.py:515} ERROR - Section kubernetes Option worker_container_image_pull_policy does not exist in the config!
[2018-09-21 21:55:07,803] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,802] {cli.py:515} ERROR - Section kubernetes Option worker_dags_folder does not exist in the config!
[2018-09-21 21:55:07,803] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,802] {cli.py:515} ERROR - Section kubernetes Option dags_volume_subpath does not exist in the config!
[2018-09-21 21:55:07,803] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,802] {cli.py:515} ERROR - Section kubernetes Option image_pull_secrets does not exist in the config!
[2018-09-21 21:55:07,803] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,802] {cli.py:515} ERROR - Section kubernetes Option namespace does not exist in the config!
[2018-09-21 21:55:07,804] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,802] {cli.py:515} ERROR - Section kubernetes Option logs_volume_claim does not exist in the config!
[2018-09-21 21:55:07,804] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,802] {cli.py:515} ERROR - Section kubernetes Option gcp_service_account_keys does not exist in the config!
[2018-09-21 21:55:07,805] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,802] {cli.py:515} ERROR - Section kubernetes Option git_password does not exist in the config!
[2018-09-21 21:55:07,805] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,802] {cli.py:515} ERROR - Section kubernetes Option worker_container_tag does not exist in the config!
[2018-09-21 21:55:07,806] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,803] {cli.py:515} ERROR - Section kubernetes Option git_sync_container_tag does not exist in the config!
[2018-09-21 21:55:07,807] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,803] {cli.py:515} ERROR - Section kubernetes Option dags_volume_claim does not exist in the config!
[2018-09-21 21:55:07,807] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,803] {cli.py:515} ERROR - Section kubernetes Option git_subpath does not exist in the config!
[2018-09-21 21:55:07,807] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,803] {cli.py:515} ERROR - Section kubernetes Option git_user does not exist in the config!
[2018-09-21 21:55:07,808] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,803] {cli.py:515} ERROR - Section kubernetes Option logs_volume_subpath does not exist in the config!
[2018-09-21 21:55:07,808] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,803] {cli.py:515} ERROR - Section kubernetes Option git_repo does not exist in the config!
[2018-09-21 21:55:07,808] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,803] {cli.py:515} ERROR - Section kubernetes Option worker_service_account_name does not exist in the config!
[2018-09-21 21:55:07,809] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,803] {cli.py:515} ERROR - Section kubernetes Option worker_container_repository does not exist in the config!
[2018-09-21 21:55:07,809] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,803] {cli.py:515} ERROR - Section kubernetes Option in_cluster does not exist in the config!
[2018-09-21 21:55:07,809] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,803] {cli.py:515} ERROR - Section kubernetes Option git_sync_init_container_name does not exist in the config!
[2018-09-21 21:55:07,809] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,804] {cli.py:515} ERROR - Section kubernetes Option git_branch does not exist in the config!
[2018-09-21 21:55:07,810] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,804] {cli.py:515} ERROR - Section kubernetes Option airflow_configmap does not exist in the config!
[2018-09-21 21:55:07,810] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,804] {cli.py:515} ERROR - Section kubernetes Option delete_worker_pods does not exist in the config!
[2018-09-21 21:55:07,810] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,805] {cli.py:515} ERROR - Section lineage Option backend does not exist in the config!
[2018-09-21 21:55:07,810] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,805] {cli.py:515} ERROR - Section hive Option default_hive_mapred_queue does not exist in the config!
[2018-09-21 21:55:07,811] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,805] {cli.py:515} ERROR - Section hive Option mapred_job_name_template does not exist in the config!
[2018-09-21 21:55:07,811] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,806] {cli.py:515} ERROR - Section elasticsearch Option elasticsearch_host does not exist in the config!
[2018-09-21 21:55:07,811] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,806] {cli.py:515} ERROR - Section elasticsearch Option elasticsearch_log_id_template does not exist in the config!
[2018-09-21 21:55:07,812] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,806] {cli.py:515} ERROR - Section elasticsearch Option elasticsearch_end_of_log_mark does not exist in the config!
[2018-09-21 21:55:07,812] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,811] {models.py:260} INFO - Filling up the DagBag from /Users/kaxil/airflow-dev/dags/example_dags/tutorial.py
[2018-09-21 21:55:07,886] {base_task_runner.py:107} INFO - Job 31: Subtask print_date [2018-09-21 21:55:07,886] {cli.py:543} INFO - Running <TaskInstance: tutorial.print_date 2018-09-21T20:55:02.964423+00:00 [running]> on host Kaxils-MacBook-Pro.local
[2018-09-21 21:55:07,905] {bash_operator.py:76} INFO - Tmp dir root location: 
 /var/folders/nx/jf5splzj09bd5cfz98rs4_wr0000gq/T
[2018-09-21 21:55:07,906] {bash_operator.py:85} INFO - Exporting the following env vars:
AIRFLOW_CTX_TASK_ID=print_date
AIRFLOW_CTX_DAG_ID=tutorial
AIRFLOW_CTX_EXECUTION_DATE=2018-09-21T20:55:02.964423+00:00
AIRFLOW_CTX_DAG_RUN_ID=manual__2018-09-21T20:55:02.964423+00:00
[2018-09-21 21:55:07,908] {bash_operator.py:99} INFO - Temporary script location: /var/folders/nx/jf5splzj09bd5cfz98rs4_wr0000gq/T/airflowtmpzlUPCE/print_dateowg0KJ
[2018-09-21 21:55:07,908] {bash_operator.py:109} INFO - Running command: date
[2018-09-21 21:55:07,916] {bash_operator.py:118} INFO - Output:
[2018-09-21 21:55:07,923] {bash_operator.py:122} INFO - Fri 21 Sep 2018 21:55:07 BST
[2018-09-21 21:55:07,925] {bash_operator.py:126} INFO - Command exited with return code 0
[2018-09-21 21:55:11,241] {logging_mixin.py:95} INFO - [2018-09-21 21:55:11,240] {jobs.py:2628} INFO - Task exited with return code 0
```

**Same logs after fixing i.e. applying this PR**:
```
*** Reading local file: /Users/kaxil/airflow-dev/logs/tutorial/print_date/2018-09-21T20:55:02.964423+00:00/3.log
[2018-09-21 21:59:10,714] {models.py:1348} INFO - Dependencies all met for <TaskInstance: tutorial.print_date 2018-09-21T20:55:02.964423+00:00 [queued]>
[2018-09-21 21:59:10,717] {models.py:1348} INFO - Dependencies all met for <TaskInstance: tutorial.print_date 2018-09-21T20:55:02.964423+00:00 [queued]>
[2018-09-21 21:59:10,717] {models.py:1560} INFO - 
--------------------------------------------------------------------------------
Starting attempt 3 of 4
--------------------------------------------------------------------------------

[2018-09-21 21:59:10,727] {models.py:1582} INFO - Executing <Task(BashOperator): print_date> on 2018-09-21T20:55:02.964423+00:00
[2018-09-21 21:59:10,728] {base_task_runner.py:126} INFO - Running: [u'airflow', u'run', 'tutorial', 'print_date', '2018-09-21T20:55:02.964423+00:00', u'--job_id', '39', u'--raw', u'-sd', u'DAGS_FOLDER/example_dags/tutorial.py', u'--cfg_path', '/var/folders/nx/jf5splzj09bd5cfz98rs4_wr0000gq/T/tmpDJvExx']
[2018-09-21 21:59:12,430] {base_task_runner.py:107} INFO - Job 39: Subtask print_date [2018-09-21 21:59:12,430] {__init__.py:51} INFO - Using executor SequentialExecutor
[2018-09-21 21:59:12,546] {base_task_runner.py:107} INFO - Job 39: Subtask print_date /Users/kaxil/Documents/GitHub/incubator-airflow/airflow/bin/cli.py:1804: DeprecationWarning: The celeryd_concurrency option in [celery] has been renamed to worker_concurrency - the old setting has been used, but please update your config.
[2018-09-21 21:59:12,547] {base_task_runner.py:107} INFO - Job 39: Subtask print_date   default=conf.get('celery', 'worker_concurrency')),
[2018-09-21 21:59:12,616] {base_task_runner.py:107} INFO - Job 39: Subtask print_date [2018-09-21 21:59:12,615] {models.py:260} INFO - Filling up the DagBag from /Users/kaxil/airflow-dev/dags/example_dags/tutorial.py
[2018-09-21 21:59:12,702] {base_task_runner.py:107} INFO - Job 39: Subtask print_date [2018-09-21 21:59:12,701] {cli.py:548} INFO - Running <TaskInstance: tutorial.print_date 2018-09-21T20:55:02.964423+00:00 [running]> on host Kaxils-MacBook-Pro.local
[2018-09-21 21:59:12,720] {bash_operator.py:76} INFO - Tmp dir root location: 
 /var/folders/nx/jf5splzj09bd5cfz98rs4_wr0000gq/T
[2018-09-21 21:59:12,721] {bash_operator.py:85} INFO - Exporting the following env vars:
AIRFLOW_CTX_TASK_ID=print_date
AIRFLOW_CTX_DAG_ID=tutorial
AIRFLOW_CTX_EXECUTION_DATE=2018-09-21T20:55:02.964423+00:00
AIRFLOW_CTX_DAG_RUN_ID=manual__2018-09-21T20:55:02.964423+00:00
[2018-09-21 21:59:12,722] {bash_operator.py:99} INFO - Temporary script location: /var/folders/nx/jf5splzj09bd5cfz98rs4_wr0000gq/T/airflowtmpAvS1xg/print_dateT8HW8r
[2018-09-21 21:59:12,722] {bash_operator.py:109} INFO - Running command: date
[2018-09-21 21:59:12,729] {bash_operator.py:118} INFO - Output:
[2018-09-21 21:59:12,737] {bash_operator.py:122} INFO - Fri 21 Sep 2018 21:59:12 BST
[2018-09-21 21:59:12,738] {bash_operator.py:126} INFO - Command exited with return code 0
```

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
