### PR TITLE
[AIRFLOW-3106] Validate Postgres connection after saving it

### DIFF
--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -60,6 +60,15 @@ class PostgresHook(DbApiHook):
         self.conn = psycopg2.connect(**conn_args)
         return self.conn
 
+    def validate_conn(self):
+        try:
+            conn = self.get_conn()
+            with conn.cursor() as cursor:
+                cursor.execute("SELECT 1")
+                return True, None
+        except psycopg2.DatabaseError as e:
+            return False, "An error occured connecting to the database: {}".format(e)
+
     def copy_expert(self, sql, filename, open=open):
         """
         Executes SQL using psycopg2 copy_expert method.

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3005,6 +3005,20 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
                 for key in self.form_extra_fields.keys() if key in formdata}
             model.extra = json.dumps(extra)
 
+    def after_model_change(self, form, model, is_created):
+        hook = model.get_hook()
+        if hasattr(hook, "validate_conn"):
+            succes, msg = hook.validate_conn()
+            if not succes:
+                flash(
+                    message=(
+                        "Could not validate connection \"{0}\"."
+                        " Check connection details."
+                        " Error: {1}".format(form.data["conn_id"], msg)
+                    ),
+                    category="error",
+                )
+
     @classmethod
     def alert_fernet_key(cls):
         fk = None


### PR DESCRIPTION
I want to create connection validation when saving a connection. I started with Postgres. Would be nice to know if you agree with the PR, before I implement validation for other connection types.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - [https://issues.apache.org/jira/browse/AIRFLOW-3106](https://issues.apache.org/jira/browse/AIRFLOW-3106)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds validation for the Postgres connection type. After saving a Connection, it validates by creating a new database connection and executing `SELECT 1`. In case this fails, an error is displayed:

![image](https://user-images.githubusercontent.com/6249654/45939662-9e9f1d80-bfd4-11e8-8057-f08acb2a9062.png)

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
