### PR TITLE
[AIRFLOW-3117] Add instructions to allow GPL dependency

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,6 +19,9 @@ You can also install Airflow with support for extra features like ``s3`` or ``po
 .. note:: GPL dependency
 
     One of the dependencies of Apache Airflow by default pulls in a GPL library ('unidecode').
+    
+    If you are not concerned about the GPL dependency, export the following environment variable prior to installing airflow: ``export AIRFLOW_GPL_UNIDECODE=yes``.
+    
     In case this is a concern you can force a non GPL library by issuing
     ``export SLUGIFY_USES_TEXT_UNIDECODE=yes`` and then proceed with the normal installation.
     Please note that this needs to be specified at every upgrade. Also note that if `unidecode`


### PR DESCRIPTION
The installation instructions failed to mention how to proceed with the GPL dependency. For those who are not concerned by GPL, it is useful to know how to proceed with GPL dependency.

### Description

Add instructions for allowing the GPL software installation during installation process.


