### PR TITLE
[AIRFLOW-3121] Define closed property on StreamLogWriter

### DIFF
--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -90,7 +90,7 @@ class StreamLogWriter(object):
         Returns False to indicate that the stream is not closed (as it will be
         open for the duration of Airflow's lifecycle).
 
-        For compatibility.
+        For compatibility with the io.IOBase interface.
         """
         return False
 

--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -68,6 +68,7 @@ class LoggingMixin(object):
             set_context(self.log, context)
 
 
+# TODO: Formally inherit from io.IOBase
 class StreamLogWriter(object):
     encoding = False
 
@@ -82,6 +83,16 @@ class StreamLogWriter(object):
         self.logger = logger
         self.level = level
         self._buffer = str()
+
+    @property
+    def closed(self):
+        """
+        Returns False to indicate that the stream is not closed (as it will be
+        open for the duration of Airflow's lifecycle).
+
+        For compatibility.
+        """
+        return False
 
     def write(self, message):
         """


### PR DESCRIPTION
CC: @aoen 

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3121
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR adds the `closed` property to the `StreamLogWriter` class—a stub function that simply returns `False` for compatibility reasons.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR adds a straightforward property.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [X] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
