### PR TITLE
[AIRFLOW-3123] Allow nested use of  DAG as a context manager

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3391,7 +3391,7 @@ class DAG(BaseDag, LoggingMixin):
         self.on_success_callback = on_success_callback
         self.on_failure_callback = on_failure_callback
 
-        self._context_manager_set = False
+        self._old_context_manager_dags = []
 
         self._comps = {
             'dag_id',
@@ -3440,16 +3440,13 @@ class DAG(BaseDag, LoggingMixin):
 
     def __enter__(self):
         global _CONTEXT_MANAGER_DAG
-        if not self._context_manager_set:
-            self._old_context_manager_dag = _CONTEXT_MANAGER_DAG
-            _CONTEXT_MANAGER_DAG = self
-            self._context_manager_set = True
+        self._old_context_manager_dags.append(_CONTEXT_MANAGER_DAG)
+        _CONTEXT_MANAGER_DAG = self
         return self
 
     def __exit__(self, _type, _value, _tb):
         global _CONTEXT_MANAGER_DAG
-        _CONTEXT_MANAGER_DAG = self._old_context_manager_dag
-        self._context_manager_set = False
+        _CONTEXT_MANAGER_DAG = self._old_context_manager_dags.pop()
 
     # /Context Manager ----------------------------------------------
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -141,11 +141,13 @@ class DagTest(unittest.TestCase):
         with dag:
             with dag:
                 op7 = DummyOperator(task_id='op7')
-        op8 = DummyOperator(task_id='op8')
-        op8.dag = dag2
+            op8 = DummyOperator(task_id='op8')
+        op9 = DummyOperator(task_id='op8')
+        op9.dag = dag2
 
         self.assertEqual(op7.dag, dag)
-        self.assertEqual(op8.dag, dag2)
+        self.assertEqual(op8.dag, dag)
+        self.assertEqual(op9.dag, dag2)
 
     def test_dag_topological_sort(self):
         dag = DAG(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3123
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Implemented a stack to manage the DAG context. Entering a DAG context pushes the past context on the stack. Exiting pops the stack to reset the context. This allows arbitrary nesting of contexts, particularly if the same DAG object is used in the nesting.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Modified `test_dag_as_context_manager` in `models.py` to capture this condition.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
