### PR TITLE
[AIRFLOW-3124] Fix RBAC webserver debug mode

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -870,8 +870,12 @@ def webserver(args):
         print(
             "Starting the web server on port {0} and host {1}.".format(
                 args.port, args.hostname))
-        app = create_app_rbac(conf) if settings.RBAC else create_app(conf)
-        app.run(debug=True, port=args.port, host=args.hostname,
+        if settings.RBAC:
+            app, _ = create_app_rbac(conf, testing=conf.get('core', 'unit_test_mode'))
+        else:
+            app = create_app(conf, testing=conf.get('core', 'unit_test_mode'))
+        app.run(debug=True, use_reloader=False if app.config['TESTING'] else True,
+                port=args.port, host=args.hostname,
                 ssl_context=(ssl_cert, ssl_key) if ssl_cert and ssl_key else None)
     else:
         os.environ['SKIP_DAGS_PARSING'] = 'True'

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -139,7 +139,21 @@ class TestCLI(unittest.TestCase):
             self.assertEqual(get_num_ready_workers_running(self.gunicorn_master_proc), 0)
 
     def test_cli_webserver_debug(self):
-        p = psutil.Popen(["airflow", "webserver", "-d"])
+        env = os.environ.copy()
+        p = psutil.Popen(["airflow", "webserver", "-d"], env=env)
+        sleep(3)  # wait for webserver to start
+        return_code = p.poll()
+        self.assertEqual(
+            None,
+            return_code,
+            "webserver terminated with return code {} in debug mode".format(return_code))
+        p.terminate()
+        p.wait()
+
+    def test_cli_rbac_webserver_debug(self):
+        env = os.environ.copy()
+        env['AIRFLOW__WEBSERVER__RBAC'] = 'True'
+        p = psutil.Popen(["airflow", "webserver", "-d"], env=env)
         sleep(3)  # wait for webserver to start
         return_code = p.poll()
         self.assertEqual(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3124) issues and references them in the PR title.
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The command `airflow webserver -d` crashes when `settings.RBAC == True`. This is because `create_app` currently returns `app, appbuilder`, which causes the app to crash with an `AttributeError`. As a side comment, it might not be ideal for the two `create_app`'s to have a difference interface, so wondering if the more proper fix is have `create_app` only return the flask application and then update the tests that rely on this to retrieve the appbuilder from the `cached_appbuilder` function. I can do that if it seems worthwhile, but figured I'd wait for feedback before doing that larger change.

### Tests

- [x] My PR adds the following unit tests

I set up the CLI to pass in the `unit_test_mode` setting to the flask app so we can disable the werkzeug reloader when running tests. If the reloader runs, there is an extra monitoring process left running after killing the main webserver process. This causes conflicts if multiple tests rely on being able to start a webserver (as the process will not be able to bind to the default socket). 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
