### PR TITLE
[AIRFLOW-3125] Monitor Task Instances creation rates

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -5282,6 +5282,9 @@ class DagRun(Base, LoggingMixin):
                 continue
 
             if task.task_id not in task_ids:
+                Stats.incr(
+                    "task_instance_created-{}".format(task.__class__.__name__),
+                    1, 1)
                 ti = TaskInstance(task, self.execution_date)
                 session.add(ti)
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [AIRFLOW-3125](https://issues.apache.org/jira/browse/AIRFLOW-3125) 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Montor Task Instances creation rates by Operator type.
These stats can provide some visibility on how much workload Airflow is getting. They can be used for resource allocation in the long run (i.e. to determine when we should scale up workers) and debugging in scenarios like the creation rate of certain type of Task Instances spikes.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Just adding stats.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - N/A

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
