### PR TITLE
[AIRFLOW-3127] Fix out-dated doc for Celery SSL

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -342,10 +342,10 @@ certs and keys.
 .. code-block:: bash
 
     [celery]
-    CELERY_SSL_ACTIVE = True
-    CELERY_SSL_KEY = <path to key>
-    CELERY_SSL_CERT = <path to cert>
-    CELERY_SSL_CACERT = <path to cacert>
+    ssl_active = True
+    ssl_key = <path to key>
+    ssl_cert = <path to cert>
+    ssl_cacert = <path to cacert>
 
 Impersonation
 -------------


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3127
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Now in `airflow.cfg`, for Celery-SSL, the item names are "**ssl_active**", "**ssl_key**", "**ssl_cert**", and "**ssl_cacert**" (since PR https://github.com/apache/incubator-airflow/pull/2806/files).

But in the documentation https://airflow.incubator.apache.org/security.html?highlight=celery#ssl
or https://github.com/apache/incubator-airflow/blob/master/docs/security.rst,
it's "**CELERY_SSL_ACTIVE**", "**CELERY_SSL_KEY**", "**CELERY_SSL_CERT**", and
"**CELERY_SSL_CACERT**", which is out-dated and may confuse readers.

**Screenshot of out-dated doc**
<img width="757" alt="screen shot 2018-09-28 at 4 09 18 pm" src="https://user-images.githubusercontent.com/11539188/46196186-e86f6700-c338-11e8-9e86-bca7126c5612.png">

