### PR TITLE
[AIRFLOW-XXX] Fix PythonVirtualenvOperator tests

### DIFF
--- a/scripts/ci/run-ci.sh
+++ b/scripts/ci/run-ci.sh
@@ -29,7 +29,7 @@ sudo chown -R airflow.airflow . $HOME/.cache $HOME/.wheelhouse/ $HOME/.cache/pip
 if [[ $PYTHON_VERSION == '3' ]]; then
   PIP=pip3
 else
-  PIP=pip
+  PIP=pip2
 fi
 
 sudo -H $PIP install --upgrade pip

--- a/tests/operators/test_virtualenv_operator.py
+++ b/tests/operators/test_virtualenv_operator.py
@@ -52,9 +52,10 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
             schedule_interval=INTERVAL)
         self.addCleanup(self.dag.clear)
 
-    def _run_as_operator(self, fn, **kwargs):
+    def _run_as_operator(self, fn, python_version=sys.version_info[0], **kwargs):
         task = PythonVirtualenvOperator(
             python_callable=fn,
+            python_version=python_version,
             task_id='task',
             dag=self.dag,
             **kwargs)


### PR DESCRIPTION
The recent update to the CI image changed the default python from python2 to python3. The PythonVirtualenvOperator tests expected python2 as default and fail due to serialisation errors.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
