### PR TITLE
[AIRFLOW-3132] Add option for DockerOperator

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -47,6 +47,10 @@ class DockerOperator(BaseOperator):
     :param api_version: Remote API version. Set to ``auto`` to automatically
         detect the server's version.
     :type api_version: str
+    :param auto_remove: Auto-removal of the container on daemon side when the
+        container's process exits.
+        The default is False.
+    :type auto_remove: bool
     :param command: Command to be run in the container. (templated)
     :type command: str or list
     :param cpus: Number of CPUs to assign to the container.
@@ -133,11 +137,13 @@ class DockerOperator(BaseOperator):
             docker_conn_id=None,
             dns=None,
             dns_search=None,
+            auto_remove=False,
             *args,
             **kwargs):
 
         super(DockerOperator, self).__init__(*args, **kwargs)
         self.api_version = api_version
+        self.auto_remove = auto_remove
         self.command = command
         self.cpus = cpus
         self.dns = dns
@@ -209,6 +215,7 @@ class DockerOperator(BaseOperator):
                 cpu_shares=cpu_shares,
                 environment=self.environment,
                 host_config=self.cli.create_host_config(
+                    auto_remove=self.auto_remove,
                     binds=self.volumes,
                     network_mode=self.network_mode,
                     shm_size=self.shm_size,


### PR DESCRIPTION
Enable specifying auto_remove option for DockerOperator. Duplicates:

https://issues.apache.org/jira/browse/AIRFLOW-3132
https://issues.apache.org/jira/browse/AIRFLOW-1368
https://issues.apache.org/jira/browse/AIRFLOW-516
https://issues.apache.org/jira/browse/AIRFLOW-465