### PR TITLE
[AIRFLOW-XXX] Fix undocumented params in S3_hook

### DIFF
--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -72,6 +72,13 @@ class S3Hook(AwsHook):
     def check_for_prefix(self, bucket_name, prefix, delimiter):
         """
         Checks that a prefix exists in a bucket
+
+        :param bucket_name: the name of the bucket
+        :type bucket_name: str
+        :param prefix: a key prefix
+        :type prefix: str
+        :param delimiter: the delimiter marks key hierarchy.
+        :type delimiter: str
         """
         prefix = prefix + delimiter if prefix[-1] != delimiter else prefix
         prefix_split = re.split(r'(\w+[{d}])$'.format(d=delimiter), prefix, 1)
@@ -253,6 +260,13 @@ class S3Hook(AwsHook):
                                wildcard_key, bucket_name=None, delimiter=''):
         """
         Checks that a key matching a wildcard expression exists in a bucket
+
+        :param wildcard_key: the path to the key
+        :type wildcard_key: str
+        :param bucket_name: the name of the bucket
+        :type bucket_name: str
+        :param delimiter: the delimiter marks key hierarchy
+        :type delimiter: str
         """
         return self.get_wildcard_key(wildcard_key=wildcard_key,
                                      bucket_name=bucket_name,
@@ -266,6 +280,8 @@ class S3Hook(AwsHook):
         :type wildcard_key: str
         :param bucket_name: the name of the bucket
         :type bucket_name: str
+        :param delimiter: the delimiter marks key hierarchy
+        :type delimiter: str
         """
         if not bucket_name:
             (bucket_name, wildcard_key) = self.parse_s3_url(wildcard_key)


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue. -> ✅ 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Some function parameters in `S3_hook.py` were undocumented. Additional docstrings were added for clarity.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Just a doc change - no unit tests needed. 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
