### PR TITLE
[AIRFLOW-3133] Implement xcom_push flag for contrib's operators

### DIFF
--- a/airflow/contrib/operators/bigquery_get_data.py
+++ b/airflow/contrib/operators/bigquery_get_data.py
@@ -66,6 +66,8 @@ class BigQueryGetDataOperator(BaseOperator):
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
     :type delegate_to: str
+    :param do_xcom_push: return the result which also get set in XCOM
+    :type do_xcom_push: bool
     """
     template_fields = ('dataset_id', 'table_id', 'max_results')
     ui_color = '#e4f0e8'
@@ -78,6 +80,7 @@ class BigQueryGetDataOperator(BaseOperator):
                  selected_fields=None,
                  bigquery_conn_id='bigquery_default',
                  delegate_to=None,
+                 do_xcom_push=True,
                  *args,
                  **kwargs):
         super(BigQueryGetDataOperator, self).__init__(*args, **kwargs)
@@ -87,6 +90,7 @@ class BigQueryGetDataOperator(BaseOperator):
         self.selected_fields = selected_fields
         self.bigquery_conn_id = bigquery_conn_id
         self.delegate_to = delegate_to
+        self.do_xcom_push = do_xcom_push
 
     def execute(self, context):
         self.log.info('Fetching Data from:')
@@ -113,4 +117,5 @@ class BigQueryGetDataOperator(BaseOperator):
                 single_row.append(fields['v'])
             table_data.append(single_row)
 
-        return table_data
+        if self.do_xcom_push:
+            return table_data

--- a/airflow/contrib/operators/bigquery_get_data.py
+++ b/airflow/contrib/operators/bigquery_get_data.py
@@ -66,8 +66,8 @@ class BigQueryGetDataOperator(BaseOperator):
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
     :type delegate_to: str
-    :param do_xcom_push: return the result which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the result which also get set in XCOM
+    :type xcom_push: bool
     """
     template_fields = ('dataset_id', 'table_id', 'max_results')
     ui_color = '#e4f0e8'
@@ -80,7 +80,7 @@ class BigQueryGetDataOperator(BaseOperator):
                  selected_fields=None,
                  bigquery_conn_id='bigquery_default',
                  delegate_to=None,
-                 do_xcom_push=True,
+                 xcom_push=True,
                  *args,
                  **kwargs):
         super(BigQueryGetDataOperator, self).__init__(*args, **kwargs)
@@ -90,7 +90,7 @@ class BigQueryGetDataOperator(BaseOperator):
         self.selected_fields = selected_fields
         self.bigquery_conn_id = bigquery_conn_id
         self.delegate_to = delegate_to
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
         self.log.info('Fetching Data from:')
@@ -117,5 +117,5 @@ class BigQueryGetDataOperator(BaseOperator):
                 single_row.append(fields['v'])
             table_data.append(single_row)
 
-        if self.do_xcom_push:
+        if self.xcom_push_flag:
             return table_data

--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -63,11 +63,11 @@ def _handle_databricks_operator_execution(operator, hook, log, context):
     :param operator: Databricks operator being handled
     :param context: Airflow context
     """
-    if operator.do_xcom_push:
+    if operator.xcom_push:
         context['ti'].xcom_push(key=XCOM_RUN_ID_KEY, value=operator.run_id)
     log.info('Run submitted with run_id: %s', operator.run_id)
     run_page_url = hook.get_run_page_url(operator.run_id)
-    if operator.do_xcom_push:
+    if operator.xcom_push:
         context['ti'].xcom_push(key=XCOM_RUN_PAGE_URL_KEY, value=run_page_url)
 
     log.info('View run status, Spark UI, and logs at %s', run_page_url)
@@ -209,8 +209,8 @@ class DatabricksSubmitRunOperator(BaseOperator):
     :param databricks_retry_delay: Number of seconds to wait between retries (it
             might be a floating point number).
     :type databricks_retry_delay: float
-    :param do_xcom_push: Whether we should push run_id and run_page_url to xcom.
-    :type do_xcom_push: bool
+    :param xcom_push: Whether we should push run_id and run_page_url to xcom.
+    :type xcom_push: bool
     """
     # Used in airflow.models.BaseOperator
     template_fields = ('json',)
@@ -232,7 +232,7 @@ class DatabricksSubmitRunOperator(BaseOperator):
             polling_period_seconds=30,
             databricks_retry_limit=3,
             databricks_retry_delay=1,
-            do_xcom_push=False,
+            xcom_push=False,
             **kwargs):
         """
         Creates a new ``DatabricksSubmitRunOperator``.
@@ -263,7 +263,7 @@ class DatabricksSubmitRunOperator(BaseOperator):
         self.json = _deep_string_coerce(self.json)
         # This variable will be used in case our task gets killed.
         self.run_id = None
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def get_hook(self):
         return DatabricksHook(
@@ -410,8 +410,8 @@ class DatabricksRunNowOperator(BaseOperator):
     :param databricks_retry_limit: Amount of times retry if the Databricks backend is
         unreachable. Its value must be greater than or equal to 1.
     :type databricks_retry_limit: int
-    :param do_xcom_push: Whether we should push run_id and run_page_url to xcom.
-    :type do_xcom_push: bool
+    :param xcom_push: Whether we should push run_id and run_page_url to xcom.
+    :type xcom_push: bool
     """
     # Used in airflow.models.BaseOperator
     template_fields = ('json',)
@@ -430,7 +430,7 @@ class DatabricksRunNowOperator(BaseOperator):
             polling_period_seconds=30,
             databricks_retry_limit=3,
             databricks_retry_delay=1,
-            do_xcom_push=False,
+            xcom_push=False,
             **kwargs):
 
         """
@@ -455,7 +455,7 @@ class DatabricksRunNowOperator(BaseOperator):
         self.json = _deep_string_coerce(self.json)
         # This variable will be used in case our task gets killed.
         self.run_id = None
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def get_hook(self):
         return DatabricksHook(

--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -311,7 +311,6 @@ class DataFlowPythonOperator(BaseOperator):
             poll_sleep=10,
             *args,
             **kwargs):
-
         super(DataFlowPythonOperator, self).__init__(*args, **kwargs)
 
         self.py_file = py_file
@@ -335,9 +334,11 @@ class DataFlowPythonOperator(BaseOperator):
                             poll_sleep=self.poll_sleep)
         dataflow_options = self.dataflow_default_options.copy()
         dataflow_options.update(self.options)
+
         # Convert argument names from lowerCamelCase to snake case.
-        camel_to_snake = lambda name: re.sub(
-            r'[A-Z]', lambda x: '_' + x.group(0).lower(), name)
+        def camel_to_snake(name):
+            return re.sub(r'[A-Z]', lambda x: '_' + x.group(0).lower(), name)
+
         formatted_options = {camel_to_snake(key): dataflow_options[key]
                              for key in dataflow_options}
         hook.start_python_dataflow(

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -221,14 +221,14 @@ class DataprocClusterCreateOperator(BaseOperator):
         cluster = [c for c in cluster_list if c['clusterName'] == self.cluster_name]
         if cluster:
             return cluster[0]
-        return None
+        return
 
     def _get_cluster_state(self, service):
         cluster = self._get_cluster(service)
         if 'status' in cluster:
             return cluster['status']['state']
         else:
-            return None
+            return
 
     def _cluster_ready(self, state, service):
         if state == 'RUNNING':
@@ -394,7 +394,7 @@ class DataprocClusterCreateOperator(BaseOperator):
                 self.cluster_name
             )
             self._wait_for_done(service)
-            return None
+            return
 
         cluster_data = self._build_cluster_data()
         try:
@@ -412,7 +412,7 @@ class DataprocClusterCreateOperator(BaseOperator):
                     self.cluster_name
                 )
                 self._wait_for_done(service)
-                return None
+                return
             else:
                 raise e
 

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -394,7 +394,7 @@ class DataprocClusterCreateOperator(BaseOperator):
                 self.cluster_name
             )
             self._wait_for_done(service)
-            return True
+            return None
 
         cluster_data = self._build_cluster_data()
         try:
@@ -412,7 +412,7 @@ class DataprocClusterCreateOperator(BaseOperator):
                     self.cluster_name
                 )
                 self._wait_for_done(service)
-                return True
+                return None
             else:
                 raise e
 

--- a/airflow/contrib/operators/datastore_export_operator.py
+++ b/airflow/contrib/operators/datastore_export_operator.py
@@ -82,7 +82,7 @@ class DatastoreExportOperator(BaseOperator):
         self.labels = labels
         self.polling_interval_in_seconds = polling_interval_in_seconds
         self.overwrite_existing = overwrite_existing
-        self.xcom_push = xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
         self.log.info('Exporting data to Cloud Storage bucket ' + self.bucket)
@@ -106,5 +106,5 @@ class DatastoreExportOperator(BaseOperator):
         if state != 'SUCCESSFUL':
             raise AirflowException('Operation failed: result={}'.format(result))
 
-        if self.xcom_push:
+        if self.xcom_push_flag:
             return result

--- a/airflow/contrib/operators/datastore_import_operator.py
+++ b/airflow/contrib/operators/datastore_import_operator.py
@@ -76,7 +76,7 @@ class DatastoreImportOperator(BaseOperator):
         self.entity_filter = entity_filter
         self.labels = labels
         self.polling_interval_in_seconds = polling_interval_in_seconds
-        self.xcom_push = xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
         self.log.info('Importing data from Cloud Storage bucket %s', self.bucket)
@@ -94,5 +94,5 @@ class DatastoreImportOperator(BaseOperator):
         if state != 'SUCCESSFUL':
             raise AirflowException('Operation failed: result={}'.format(result))
 
-        if self.xcom_push:
+        if self.xcom_push_flag:
             return result

--- a/airflow/contrib/operators/emr_add_steps_operator.py
+++ b/airflow/contrib/operators/emr_add_steps_operator.py
@@ -32,8 +32,8 @@ class EmrAddStepsOperator(BaseOperator):
     :type aws_conn_id: str
     :param steps: boto3 style steps to be added to the jobflow. (templated)
     :type steps: list
-    :param do_xcom_push: return the Step IDs which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the Step IDs which also get set in XCOM
+    :type xcom_push: bool
     """
     template_fields = ['job_flow_id', 'steps']
     template_ext = ()
@@ -45,14 +45,14 @@ class EmrAddStepsOperator(BaseOperator):
             job_flow_id,
             aws_conn_id='s3_default',
             steps=None,
-            do_xcom_push=True,
+            xcom_push=True,
             *args, **kwargs):
         super(EmrAddStepsOperator, self).__init__(*args, **kwargs)
         steps = steps or []
         self.job_flow_id = job_flow_id
         self.aws_conn_id = aws_conn_id
         self.steps = steps
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
         emr = EmrHook(aws_conn_id=self.aws_conn_id).get_conn()
@@ -64,5 +64,5 @@ class EmrAddStepsOperator(BaseOperator):
             raise AirflowException('Adding steps failed: %s' % response)
         else:
             self.log.info('Steps %s added to JobFlow', response['StepIds'])
-            if self.do_xcom_push:
+            if self.xcom_push_flag:
                 return response['StepIds']

--- a/airflow/contrib/operators/emr_create_job_flow_operator.py
+++ b/airflow/contrib/operators/emr_create_job_flow_operator.py
@@ -35,8 +35,8 @@ class EmrCreateJobFlowOperator(BaseOperator):
     :param job_flow_overrides: boto3 style arguments to override
        emr_connection extra. (templated)
     :type steps: dict
-    :param do_xcom_push: return the status code which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the status code which also get set in XCOM
+    :type xcom_push: bool
     """
     template_fields = ['job_flow_overrides']
     template_ext = ()
@@ -48,7 +48,7 @@ class EmrCreateJobFlowOperator(BaseOperator):
             aws_conn_id='s3_default',
             emr_conn_id='emr_default',
             job_flow_overrides=None,
-            do_xcom_push=True,
+            xcom_push=True,
             *args, **kwargs):
         super(EmrCreateJobFlowOperator, self).__init__(*args, **kwargs)
         self.aws_conn_id = aws_conn_id
@@ -56,7 +56,7 @@ class EmrCreateJobFlowOperator(BaseOperator):
         if job_flow_overrides is None:
             job_flow_overrides = {}
         self.job_flow_overrides = job_flow_overrides
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
         emr = EmrHook(aws_conn_id=self.aws_conn_id, emr_conn_id=self.emr_conn_id)
@@ -71,5 +71,5 @@ class EmrCreateJobFlowOperator(BaseOperator):
             raise AirflowException('JobFlow creation failed: %s' % response)
         else:
             self.log.info('JobFlow with id %s created', response['JobFlowId'])
-            if self.do_xcom_push:
+            if self.xcom_push_flag:
                 return response['JobFlowId']

--- a/airflow/contrib/operators/emr_create_job_flow_operator.py
+++ b/airflow/contrib/operators/emr_create_job_flow_operator.py
@@ -35,6 +35,8 @@ class EmrCreateJobFlowOperator(BaseOperator):
     :param job_flow_overrides: boto3 style arguments to override
        emr_connection extra. (templated)
     :type steps: dict
+    :param do_xcom_push: return the status code which also get set in XCOM
+    :type do_xcom_push: bool
     """
     template_fields = ['job_flow_overrides']
     template_ext = ()
@@ -46,6 +48,7 @@ class EmrCreateJobFlowOperator(BaseOperator):
             aws_conn_id='s3_default',
             emr_conn_id='emr_default',
             job_flow_overrides=None,
+            do_xcom_push=True,
             *args, **kwargs):
         super(EmrCreateJobFlowOperator, self).__init__(*args, **kwargs)
         self.aws_conn_id = aws_conn_id
@@ -53,6 +56,7 @@ class EmrCreateJobFlowOperator(BaseOperator):
         if job_flow_overrides is None:
             job_flow_overrides = {}
         self.job_flow_overrides = job_flow_overrides
+        self.do_xcom_push = do_xcom_push
 
     def execute(self, context):
         emr = EmrHook(aws_conn_id=self.aws_conn_id, emr_conn_id=self.emr_conn_id)
@@ -67,4 +71,5 @@ class EmrCreateJobFlowOperator(BaseOperator):
             raise AirflowException('JobFlow creation failed: %s' % response)
         else:
             self.log.info('JobFlow with id %s created', response['JobFlowId'])
-            return response['JobFlowId']
+            if self.do_xcom_push:
+                return response['JobFlowId']

--- a/airflow/contrib/operators/gcp_container_operator.py
+++ b/airflow/contrib/operators/gcp_container_operator.py
@@ -133,6 +133,9 @@ class GKEClusterCreateOperator(BaseOperator):
     :type gcp_conn_id: str
     :param api_version: The api version to use
     :type api_version: str
+    :param do_xcom_push: return the result of cluster creation operation which also get
+        set in XCOM
+    :type do_xcom_push: bool
     """
     template_fields = ['project_id', 'gcp_conn_id', 'location', 'api_version', 'body']
 
@@ -143,6 +146,7 @@ class GKEClusterCreateOperator(BaseOperator):
                  body=None,
                  gcp_conn_id='google_cloud_default',
                  api_version='v2',
+                 do_xcom_push=True,
                  *args,
                  **kwargs):
         super(GKEClusterCreateOperator, self).__init__(*args, **kwargs)
@@ -154,6 +158,7 @@ class GKEClusterCreateOperator(BaseOperator):
         self.location = location
         self.api_version = api_version
         self.body = body
+        self.do_xcom_push = do_xcom_push
 
     def _check_input(self):
         if all([self.project_id, self.location, self.body]):
@@ -175,7 +180,9 @@ class GKEClusterCreateOperator(BaseOperator):
         self._check_input()
         hook = GKEClusterHook(self.project_id, self.location)
         create_op = hook.create_cluster(cluster=self.body)
-        return create_op
+
+        if self.do_xcom_push:
+            return create_op
 
 
 KUBE_CONFIG_ENV_VAR = "KUBECONFIG"

--- a/airflow/contrib/operators/gcp_container_operator.py
+++ b/airflow/contrib/operators/gcp_container_operator.py
@@ -133,9 +133,9 @@ class GKEClusterCreateOperator(BaseOperator):
     :type gcp_conn_id: str
     :param api_version: The api version to use
     :type api_version: str
-    :param do_xcom_push: return the result of cluster creation operation which also get
+    :param xcom_push: return the result of cluster creation operation which also get
         set in XCOM
-    :type do_xcom_push: bool
+    :type xcom_push: bool
     """
     template_fields = ['project_id', 'gcp_conn_id', 'location', 'api_version', 'body']
 
@@ -146,7 +146,7 @@ class GKEClusterCreateOperator(BaseOperator):
                  body=None,
                  gcp_conn_id='google_cloud_default',
                  api_version='v2',
-                 do_xcom_push=True,
+                 xcom_push=True,
                  *args,
                  **kwargs):
         super(GKEClusterCreateOperator, self).__init__(*args, **kwargs)
@@ -158,7 +158,7 @@ class GKEClusterCreateOperator(BaseOperator):
         self.location = location
         self.api_version = api_version
         self.body = body
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def _check_input(self):
         if all([self.project_id, self.location, self.body]):
@@ -181,7 +181,7 @@ class GKEClusterCreateOperator(BaseOperator):
         hook = GKEClusterHook(self.project_id, self.location)
         create_op = hook.create_cluster(cluster=self.body)
 
-        if self.do_xcom_push:
+        if self.xcom_push_flag:
             return create_op
 
 

--- a/airflow/contrib/operators/gcp_function_operator.py
+++ b/airflow/contrib/operators/gcp_function_operator.py
@@ -527,8 +527,8 @@ class GcfFunctionDeleteOperator(BaseOperator):
     :type gcp_conn_id: str
     :param api_version: Version of the API used (for example v1).
     :type api_version: str
-    :param do_xcom_push: return the file list which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the file list which also get set in XCOM
+    :type xcom_push: bool
     """
 
     @apply_defaults
@@ -536,13 +536,13 @@ class GcfFunctionDeleteOperator(BaseOperator):
                  name,
                  gcp_conn_id='google_cloud_default',
                  api_version='v1',
-                 do_xcom_push=True,
+                 xcom_push=True,
                  *args,
                  **kwargs):
         self.name = name
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
         self._validate_inputs()
         self.hook = GcfHook(gcp_conn_id=self.gcp_conn_id, api_version=self.api_version)
         super(GcfFunctionDeleteOperator, self).__init__(*args, **kwargs)
@@ -560,7 +560,7 @@ class GcfFunctionDeleteOperator(BaseOperator):
         try:
             result = self.hook.delete_function(self.name)
 
-            if self.do_xcom_push:
+            if self.xcom_push_flag:
                 return result
         except HttpError as e:
             status = e.resp.status

--- a/airflow/contrib/operators/gcp_function_operator.py
+++ b/airflow/contrib/operators/gcp_function_operator.py
@@ -527,6 +527,8 @@ class GcfFunctionDeleteOperator(BaseOperator):
     :type gcp_conn_id: str
     :param api_version: Version of the API used (for example v1).
     :type api_version: str
+    :param do_xcom_push: return the file list which also get set in XCOM
+    :type do_xcom_push: bool
     """
 
     @apply_defaults
@@ -534,10 +536,13 @@ class GcfFunctionDeleteOperator(BaseOperator):
                  name,
                  gcp_conn_id='google_cloud_default',
                  api_version='v1',
-                 *args, **kwargs):
+                 do_xcom_push=True,
+                 *args,
+                 **kwargs):
         self.name = name
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
+        self.do_xcom_push = do_xcom_push
         self._validate_inputs()
         self.hook = GcfHook(gcp_conn_id=self.gcp_conn_id, api_version=self.api_version)
         super(GcfFunctionDeleteOperator, self).__init__(*args, **kwargs)
@@ -553,7 +558,10 @@ class GcfFunctionDeleteOperator(BaseOperator):
 
     def execute(self, context):
         try:
-            return self.hook.delete_function(self.name)
+            result = self.hook.delete_function(self.name)
+
+            if self.do_xcom_push:
+                return result
         except HttpError as e:
             status = e.resp.status
             if status == 404:

--- a/airflow/contrib/operators/gcs_list_operator.py
+++ b/airflow/contrib/operators/gcs_list_operator.py
@@ -45,9 +45,9 @@ class GoogleCloudStorageListOperator(BaseOperator):
         For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
-    :param do_xcom_push: return the list of Google Cloud Storage Hook which also get set
+    :param xcom_push: return the list of Google Cloud Storage Hook which also get set
         in XCOM
-    :type do_xcom_push: bool
+    :type xcom_push: bool
 
     **Example**:
         The following Operator would list all the Avro files from ``sales/sales-2017``
@@ -71,7 +71,7 @@ class GoogleCloudStorageListOperator(BaseOperator):
                  delimiter=None,
                  google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
-                 do_xcom_push=True,
+                 xcom_push=True,
                  *args,
                  **kwargs):
         super(GoogleCloudStorageListOperator, self).__init__(*args, **kwargs)
@@ -80,7 +80,7 @@ class GoogleCloudStorageListOperator(BaseOperator):
         self.delimiter = delimiter
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
         self.delegate_to = delegate_to
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
 
@@ -96,5 +96,5 @@ class GoogleCloudStorageListOperator(BaseOperator):
                           prefix=self.prefix,
                           delimiter=self.delimiter)
 
-        if self.do_xcom_push or __name__ != 'GoogleCloudStorageListOperator':
+        if self.xcom_push_flag or __name__ != 'GoogleCloudStorageListOperator':
             return files

--- a/airflow/contrib/operators/gcs_list_operator.py
+++ b/airflow/contrib/operators/gcs_list_operator.py
@@ -45,6 +45,9 @@ class GoogleCloudStorageListOperator(BaseOperator):
         For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param do_xcom_push: return the list of Google Cloud Storage Hook which also get set
+        in XCOM
+    :type do_xcom_push: bool
 
     **Example**:
         The following Operator would list all the Avro files from ``sales/sales-2017``
@@ -68,6 +71,7 @@ class GoogleCloudStorageListOperator(BaseOperator):
                  delimiter=None,
                  google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
+                 do_xcom_push=True,
                  *args,
                  **kwargs):
         super(GoogleCloudStorageListOperator, self).__init__(*args, **kwargs)
@@ -76,6 +80,7 @@ class GoogleCloudStorageListOperator(BaseOperator):
         self.delimiter = delimiter
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
         self.delegate_to = delegate_to
+        self.do_xcom_push = do_xcom_push
 
     def execute(self, context):
 
@@ -87,6 +92,9 @@ class GoogleCloudStorageListOperator(BaseOperator):
         self.log.info('Getting list of the files. Bucket: %s; Delimiter: %s; Prefix: %s',
                       self.bucket, self.delimiter, self.prefix)
 
-        return hook.list(bucket=self.bucket,
-                         prefix=self.prefix,
-                         delimiter=self.delimiter)
+        files = hook.list(bucket=self.bucket,
+                          prefix=self.prefix,
+                          delimiter=self.delimiter)
+
+        if self.do_xcom_push:
+            return files

--- a/airflow/contrib/operators/gcs_list_operator.py
+++ b/airflow/contrib/operators/gcs_list_operator.py
@@ -96,5 +96,5 @@ class GoogleCloudStorageListOperator(BaseOperator):
                           prefix=self.prefix,
                           delimiter=self.delimiter)
 
-        if self.do_xcom_push:
+        if self.do_xcom_push or __name__ != 'GoogleCloudStorageListOperator':
             return files

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -87,7 +87,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
     :type allow_jagged_rows: bool
     :param max_id_key: If set, the name of a column in the BigQuery table
         that's to be loaded. This will be used to select the MAX value from
-        BigQuery after the load occurs. (used in combination with do_xcom_push)
+        BigQuery after the load occurs. (used in combination with xcom_push)
     :type max_id_key: str
     :param bigquery_conn_id: Reference to a specific BigQuery hook.
     :type bigquery_conn_id: str
@@ -116,11 +116,11 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         time_partitioning. The order of columns given determines the sort order.
         Not applicable for external tables.
     :type cluster_fields: list of str
-    :param do_xcom_push: return the max id which also get set in XCOM.
+    :param xcom_push: return the max id which also get set in XCOM.
         (max_id_key must be set)
         This can be helpful with incremental loads--during future executions, you can pick
         up from the max ID.
-    :type do_xcom_push: bool
+    :type xcom_push: bool
     """
     template_fields = ('bucket', 'source_objects',
                        'schema_object', 'destination_project_dataset_table')
@@ -154,7 +154,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                  external_table=False,
                  time_partitioning=None,
                  cluster_fields=None,
-                 do_xcom_push=True,
+                 xcom_push=True,
                  *args, **kwargs):
 
         super(GoogleCloudStorageToBigQueryOperator, self).__init__(*args, **kwargs)
@@ -193,7 +193,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         self.src_fmt_configs = src_fmt_configs
         self.time_partitioning = time_partitioning
         self.cluster_fields = cluster_fields
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
         bq_hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
@@ -252,7 +252,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                 time_partitioning=self.time_partitioning,
                 cluster_fields=self.cluster_fields)
 
-        if self.do_xcom_push and self.max_id_key:
+        if self.xcom_push_flag and self.max_id_key:
             cursor.execute('SELECT MAX({}) FROM {}'.format(
                 self.max_id_key,
                 self.destination_project_dataset_table))

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -87,10 +87,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
     :type allow_jagged_rows: bool
     :param max_id_key: If set, the name of a column in the BigQuery table
         that's to be loaded. This will be used to select the MAX value from
-        BigQuery after the load occurs. The results will be returned by the
-        execute() command, which in turn gets stored in XCom for future
-        operators to use. This can be helpful with incremental loads--during
-        future executions, you can pick up from the max ID.
+        BigQuery after the load occurs. (used in combination with do_xcom_push)
     :type max_id_key: str
     :param bigquery_conn_id: Reference to a specific BigQuery hook.
     :type bigquery_conn_id: str
@@ -119,6 +116,11 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         time_partitioning. The order of columns given determines the sort order.
         Not applicable for external tables.
     :type cluster_fields: list of str
+    :param do_xcom_push: return the max id which also get set in XCOM.
+        (max_id_key must be set)
+        This can be helpful with incremental loads--during future executions, you can pick
+        up from the max ID.
+    :type do_xcom_push: bool
     """
     template_fields = ('bucket', 'source_objects',
                        'schema_object', 'destination_project_dataset_table')
@@ -152,6 +154,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                  external_table=False,
                  time_partitioning=None,
                  cluster_fields=None,
+                 do_xcom_push=True,
                  *args, **kwargs):
 
         super(GoogleCloudStorageToBigQueryOperator, self).__init__(*args, **kwargs)
@@ -190,6 +193,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         self.src_fmt_configs = src_fmt_configs
         self.time_partitioning = time_partitioning
         self.cluster_fields = cluster_fields
+        self.do_xcom_push = do_xcom_push
 
     def execute(self, context):
         bq_hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
@@ -248,7 +252,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                 time_partitioning=self.time_partitioning,
                 cluster_fields=self.cluster_fields)
 
-        if self.max_id_key:
+        if self.do_xcom_push and self.max_id_key:
             cursor.execute('SELECT MAX({}) FROM {}'.format(
                 self.max_id_key,
                 self.destination_project_dataset_table))

--- a/airflow/contrib/operators/gcs_to_s3.py
+++ b/airflow/contrib/operators/gcs_to_s3.py
@@ -57,8 +57,8 @@ class GoogleCloudStorageToS3Operator(GoogleCloudStorageListOperator):
                  You can specify this argument if you want to use a different
                  CA cert bundle than the one used by botocore.
     :type dest_verify: bool or str
-    :param do_xcom_push: return the file list which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the file list which also get set in XCOM
+    :type xcom_push: bool
     """
     template_fields = ('bucket', 'prefix', 'delimiter', 'dest_s3_key')
     ui_color = '#f0eee4'
@@ -74,7 +74,7 @@ class GoogleCloudStorageToS3Operator(GoogleCloudStorageListOperator):
                  dest_s3_key=None,
                  dest_verify=None,
                  replace=False,
-                 do_xcom_push=True,
+                 xcom_push=True,
                  *args,
                  **kwargs):
 
@@ -91,7 +91,7 @@ class GoogleCloudStorageToS3Operator(GoogleCloudStorageListOperator):
         self.dest_s3_key = dest_s3_key
         self.dest_verify = dest_verify
         self.replace = replace
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
         # use the super to list all files in an Google Cloud Storage bucket
@@ -126,5 +126,5 @@ class GoogleCloudStorageToS3Operator(GoogleCloudStorageListOperator):
         else:
             self.log.info("In sync, no files needed to be uploaded to S3")
 
-        if self.do_xcom_push:
+        if self.xcom_push_flag:
             return files

--- a/airflow/contrib/operators/gcs_to_s3.py
+++ b/airflow/contrib/operators/gcs_to_s3.py
@@ -94,14 +94,9 @@ class GoogleCloudStorageToS3Operator(GoogleCloudStorageListOperator):
         self.do_xcom_push = do_xcom_push
 
     def execute(self, context):
-        # this operator calls super and uses the returned value, so we set do_xcom_push to
-        # True in order to make super return
-        do_xcom_push = self.do_xcom_push
-        self.do_xcom_push = True
         # use the super to list all files in an Google Cloud Storage bucket
         files = super(GoogleCloudStorageToS3Operator, self).execute(context)
         s3_hook = S3Hook(aws_conn_id=self.dest_aws_conn_id, verify=self.dest_verify)
-        self.do_xcom_push = do_xcom_push
 
         if not self.replace:
             # if we are not replacing -> list all files in the S3 bucket

--- a/airflow/contrib/operators/hive_to_dynamodb.py
+++ b/airflow/contrib/operators/hive_to_dynamodb.py
@@ -70,7 +70,8 @@ class HiveToDynamoDBTransferOperator(BaseOperator):
             schema='default',
             hiveserver2_conn_id='hiveserver2_default',
             aws_conn_id='aws_default',
-            *args, **kwargs):
+            *args,
+            **kwargs):
         super(HiveToDynamoDBTransferOperator, self).__init__(*args, **kwargs)
         self.sql = sql
         self.table_name = table_name

--- a/airflow/contrib/operators/jenkins_job_trigger_operator.py
+++ b/airflow/contrib/operators/jenkins_job_trigger_operator.py
@@ -106,8 +106,8 @@ class JenkinsJobTriggerOperator(BaseOperator):
     :param max_try_before_job_appears: The maximum number of requests to make
         while waiting for the job to appears on jenkins server (default 10)
     :type max_try_before_job_appears: int
-    :param do_xcom_push: return the build URL which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the build URL which also get set in XCOM
+    :type xcom_push: bool
     """
     template_fields = ('parameters',)
     template_ext = ('.json',)
@@ -120,7 +120,7 @@ class JenkinsJobTriggerOperator(BaseOperator):
                  parameters="",
                  sleep_time=10,
                  max_try_before_job_appears=10,
-                 do_xcom_push=True,
+                 xcom_push=True,
                  *args,
                  **kwargs):
         super(JenkinsJobTriggerOperator, self).__init__(*args, **kwargs)
@@ -131,7 +131,7 @@ class JenkinsJobTriggerOperator(BaseOperator):
         self.sleep_time = sleep_time
         self.jenkins_connection_id = jenkins_connection_id
         self.max_try_before_job_appears = max_try_before_job_appears
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def build_job(self, jenkins_server):
         """
@@ -248,7 +248,7 @@ class JenkinsJobTriggerOperator(BaseOperator):
                     'You can also check logs for more details on this exception '
                     '(jenkins_url/log/rss)', str(err))
 
-        if self.do_xcom_push and build_info:
+        if self.xcom_push_flag and build_info:
             # If we can we return the url of the job
             # for later use (like retrieving an artifact)
             return build_info['url']

--- a/airflow/contrib/operators/jenkins_job_trigger_operator.py
+++ b/airflow/contrib/operators/jenkins_job_trigger_operator.py
@@ -248,8 +248,7 @@ class JenkinsJobTriggerOperator(BaseOperator):
                     'You can also check logs for more details on this exception '
                     '(jenkins_url/log/rss)', str(err))
 
-        if self.do_xcom_push:
-            if build_info:
-                # If we can we return the url of the job
-                # for later use (like retrieving an artifact)
-                return build_info['url']
+        if self.do_xcom_push and build_info:
+            # If we can we return the url of the job
+            # for later use (like retrieving an artifact)
+            return build_info['url']

--- a/airflow/contrib/operators/jenkins_job_trigger_operator.py
+++ b/airflow/contrib/operators/jenkins_job_trigger_operator.py
@@ -106,6 +106,8 @@ class JenkinsJobTriggerOperator(BaseOperator):
     :param max_try_before_job_appears: The maximum number of requests to make
         while waiting for the job to appears on jenkins server (default 10)
     :type max_try_before_job_appears: int
+    :param do_xcom_push: return the build URL which also get set in XCOM
+    :type do_xcom_push: bool
     """
     template_fields = ('parameters',)
     template_ext = ('.json',)
@@ -118,6 +120,7 @@ class JenkinsJobTriggerOperator(BaseOperator):
                  parameters="",
                  sleep_time=10,
                  max_try_before_job_appears=10,
+                 do_xcom_push=True,
                  *args,
                  **kwargs):
         super(JenkinsJobTriggerOperator, self).__init__(*args, **kwargs)
@@ -128,6 +131,7 @@ class JenkinsJobTriggerOperator(BaseOperator):
         self.sleep_time = sleep_time
         self.jenkins_connection_id = jenkins_connection_id
         self.max_try_before_job_appears = max_try_before_job_appears
+        self.do_xcom_push = do_xcom_push
 
     def build_job(self, jenkins_server):
         """
@@ -243,7 +247,9 @@ class JenkinsJobTriggerOperator(BaseOperator):
                     'this exception for unknown parameters'
                     'You can also check logs for more details on this exception '
                     '(jenkins_url/log/rss)', str(err))
-        if build_info:
-            # If we can we return the url of the job
-            # for later use (like retrieving an artifact)
-            return build_info['url']
+
+        if self.do_xcom_push:
+            if build_info:
+                # If we can we return the url of the job
+                # for later use (like retrieving an artifact)
+                return build_info['url']

--- a/airflow/contrib/operators/jira_operator.py
+++ b/airflow/contrib/operators/jira_operator.py
@@ -41,8 +41,8 @@ class JiraOperator(BaseOperator):
     :param get_jira_resource_method: function or operator to get jira resource
                                     on which the provided jira_method will be executed
     :type get_jira_resource_method: function
-    :param do_xcom_push: return the result which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the result which also get set in XCOM
+    :type xcom_push: bool
     """
 
     template_fields = ("jira_method_args",)
@@ -54,7 +54,7 @@ class JiraOperator(BaseOperator):
                  jira_method_args=None,
                  result_processor=None,
                  get_jira_resource_method=None,
-                 do_xcom_push=True,
+                 xcom_push=True,
                  *args,
                  **kwargs):
         super(JiraOperator, self).__init__(*args, **kwargs)
@@ -63,7 +63,7 @@ class JiraOperator(BaseOperator):
         self.jira_method_args = jira_method_args
         self.result_processor = result_processor
         self.get_jira_resource_method = get_jira_resource_method
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
         try:
@@ -87,7 +87,7 @@ class JiraOperator(BaseOperator):
             # This could potentially throw error if jira_result is not picklable
             jira_result = getattr(resource, self.method_name)(**self.jira_method_args)
 
-            if self.do_xcom_push:
+            if self.xcom_push_flag:
                 if self.result_processor:
                     return self.result_processor(context, jira_result)
 

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -126,7 +126,7 @@ class KubernetesPodOperator(BaseOperator):
                 raise AirflowException(
                     'Pod returned a failure: {state}'.format(state=final_state)
                 )
-            if self.xcom_push:
+            if self.xcom_push_flag:
                 return result
         except AirflowException as ex:
             raise AirflowException('Pod Launching failed: {error}'.format(error=ex))
@@ -179,7 +179,7 @@ class KubernetesPodOperator(BaseOperator):
         self.node_selectors = node_selectors or {}
         self.annotations = annotations or {}
         self.affinity = affinity or {}
-        self.xcom_push = xcom_push
+        self.xcom_push_flag = xcom_push
         self.resources = resources or Resources()
         self.config_file = config_file
         self.image_pull_secrets = image_pull_secrets

--- a/airflow/contrib/operators/mlengine_operator.py
+++ b/airflow/contrib/operators/mlengine_operator.py
@@ -150,7 +150,6 @@ class MLEngineBatchPredictionOperator(BaseOperator):
         For this to work, the service account making the request must
         have doamin-wide delegation enabled.
     :type delegate_to: str
-
     :param do_xcom_push: return the result which also get set in XCOM
     :type do_xcom_push: bool
 
@@ -400,7 +399,6 @@ class MLEngineVersionOperator(BaseOperator):
         For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
-
     :param do_xcom_push: return the result which also get set in XCOM
     :type do_xcom_push: bool
     """

--- a/airflow/contrib/operators/mlengine_operator.py
+++ b/airflow/contrib/operators/mlengine_operator.py
@@ -264,7 +264,7 @@ class MLEngineBatchPredictionOperator(BaseOperator):
         # same as the request we get here.
         def check_existing_job(existing_job):
             return existing_job.get('predictionInput', None) == \
-                   prediction_request['predictionInput']
+                prediction_request['predictionInput']
 
         try:
             finished_prediction_job = hook.create_job(
@@ -606,8 +606,7 @@ class MLEngineTrainingOperator(BaseOperator):
 
         if self._mode == 'DRY_RUN':
             self.log.info('In dry_run mode.')
-            self.log.info('MLEngine Training job request is: {}'.format(
-                training_request))
+            self.log.info('MLEngine Training job request is: {}'.format(training_request))
             return
 
         hook = MLEngineHook(
@@ -617,7 +616,7 @@ class MLEngineTrainingOperator(BaseOperator):
         # same as the request we get here.
         def check_existing_job(existing_job):
             return existing_job.get('trainingInput', None) == \
-                   training_request['trainingInput']
+                training_request['trainingInput']
 
         try:
             finished_training_job = hook.create_job(

--- a/airflow/contrib/operators/mlengine_operator.py
+++ b/airflow/contrib/operators/mlengine_operator.py
@@ -150,8 +150,8 @@ class MLEngineBatchPredictionOperator(BaseOperator):
         For this to work, the service account making the request must
         have doamin-wide delegation enabled.
     :type delegate_to: str
-    :param do_xcom_push: return the result which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the result which also get set in XCOM
+    :type xcom_push: bool
 
     Raises:
         ``ValueError``: if a unique model/version origin cannot be determined.
@@ -183,7 +183,7 @@ class MLEngineBatchPredictionOperator(BaseOperator):
                  runtime_version=None,
                  gcp_conn_id='google_cloud_default',
                  delegate_to=None,
-                 do_xcom_push=True,
+                 xcom_push=True,
                  *args,
                  **kwargs):
         super(MLEngineBatchPredictionOperator, self).__init__(*args, **kwargs)
@@ -201,7 +201,7 @@ class MLEngineBatchPredictionOperator(BaseOperator):
         self._runtime_version = runtime_version
         self._gcp_conn_id = gcp_conn_id
         self._delegate_to = delegate_to
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
         if not self._project_id:
             raise AirflowException('Google Cloud project id is required.')
@@ -276,7 +276,7 @@ class MLEngineBatchPredictionOperator(BaseOperator):
                 str(finished_prediction_job)))
             raise RuntimeError(finished_prediction_job['errorMessage'])
 
-        if self.do_xcom_push:
+        if self.xcom_push_flag:
             return finished_prediction_job['predictionOutput']
 
 
@@ -305,8 +305,8 @@ class MLEngineModelOperator(BaseOperator):
         For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
-    :param do_xcom_push: return the result which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the result which also get set in XCOM
+    :type xcom_push: bool
     """
 
     template_fields = [
@@ -320,7 +320,7 @@ class MLEngineModelOperator(BaseOperator):
                  operation='create',
                  gcp_conn_id='google_cloud_default',
                  delegate_to=None,
-                 do_xcom_push=True,
+                 xcom_push=True,
                  *args,
                  **kwargs):
         super(MLEngineModelOperator, self).__init__(*args, **kwargs)
@@ -329,7 +329,7 @@ class MLEngineModelOperator(BaseOperator):
         self._operation = operation
         self._gcp_conn_id = gcp_conn_id
         self._delegate_to = delegate_to
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
         hook = MLEngineHook(
@@ -341,7 +341,7 @@ class MLEngineModelOperator(BaseOperator):
         else:
             raise ValueError('Unknown operation: {}'.format(self._operation))
 
-        if self.do_xcom_push:
+        if self.xcom_push_flag:
             return result
 
 
@@ -399,8 +399,8 @@ class MLEngineVersionOperator(BaseOperator):
         For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
-    :param do_xcom_push: return the result which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the result which also get set in XCOM
+    :type xcom_push: bool
     """
 
     template_fields = [
@@ -418,7 +418,7 @@ class MLEngineVersionOperator(BaseOperator):
                  operation='create',
                  gcp_conn_id='google_cloud_default',
                  delegate_to=None,
-                 do_xcom_push=True,
+                 xcom_push=True,
                  *args,
                  **kwargs):
 
@@ -430,7 +430,7 @@ class MLEngineVersionOperator(BaseOperator):
         self._operation = operation
         self._gcp_conn_id = gcp_conn_id
         self._delegate_to = delegate_to
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
         if 'name' not in self._version:
@@ -456,7 +456,7 @@ class MLEngineVersionOperator(BaseOperator):
         else:
             raise ValueError('Unknown operation: {}'.format(self._operation))
 
-        if self.do_xcom_push:
+        if self.xcom_push_flag:
             return result
 
 

--- a/airflow/contrib/operators/mlengine_prediction_summary.py
+++ b/airflow/contrib/operators/mlengine_prediction_summary.py
@@ -113,7 +113,7 @@ class JsonCoder(object):
 
 
 @beam.ptransform_fn
-def MakeSummary(pcoll, metric_fn, metric_keys):  # pylint: disable=invalid-name
+def make_summary(pcoll, metric_fn, metric_keys):  # pylint: disable=invalid-name
     return (
         pcoll |
         "ApplyMetricFnPerInstance" >> beam.Map(metric_fn) |
@@ -156,8 +156,7 @@ def run(argv=None):
         raise ValueError("--metric_fn_encoded must be an encoded callable.")
     metric_keys = known_args.metric_keys.split(",")
 
-    with beam.Pipeline(
-        options=beam.pipeline.PipelineOptions(pipeline_args)) as p:
+    with beam.Pipeline(options=beam.pipeline.PipelineOptions(pipeline_args)) as p:
         # This is apache-beam ptransform's convention
         # pylint: disable=no-value-for-parameter
         _ = (p
@@ -165,7 +164,7 @@ def run(argv=None):
                  os.path.join(known_args.prediction_path,
                               "prediction.results-*-of-*"),
                  coder=JsonCoder())
-             | "Summary" >> MakeSummary(metric_fn, metric_keys)
+             | "Summary" >> make_summary(metric_fn, metric_keys)
              | "Write" >> beam.io.WriteToText(
                  os.path.join(known_args.prediction_path,
                               "prediction.summary.json"),

--- a/airflow/contrib/operators/mongo_to_s3.py
+++ b/airflow/contrib/operators/mongo_to_s3.py
@@ -94,8 +94,6 @@ class MongoToS3Operator(BaseOperator):
             replace=self.replace
         )
 
-        return True
-
     @staticmethod
     def _stringify(iterable, joinable='\n'):
         """

--- a/airflow/contrib/operators/pubsub_operator.py
+++ b/airflow/contrib/operators/pubsub_operator.py
@@ -159,6 +159,7 @@ class PubSubSubscriptionCreateOperator(BaseOperator):
             fail_if_exists=False,
             gcp_conn_id='google_cloud_default',
             delegate_to=None,
+            do_xcom_push=True,
             *args,
             **kwargs):
         """
@@ -185,6 +186,8 @@ class PubSubSubscriptionCreateOperator(BaseOperator):
             For this to work, the service account making the request
             must have domain-wide delegation enabled.
         :type delegate_to: str
+        :param do_xcom_push: return the result which also get set in XCOM
+        :type do_xcom_push: bool
         """
         super(PubSubSubscriptionCreateOperator, self).__init__(*args, **kwargs)
 
@@ -196,15 +199,19 @@ class PubSubSubscriptionCreateOperator(BaseOperator):
         self.fail_if_exists = fail_if_exists
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.do_xcom_push = do_xcom_push
 
     def execute(self, context):
         hook = PubSubHook(gcp_conn_id=self.gcp_conn_id,
                           delegate_to=self.delegate_to)
 
-        return hook.create_subscription(
+        result = hook.create_subscription(
             self.topic_project, self.topic, self.subscription,
             self.subscription_project, self.ack_deadline_secs,
             self.fail_if_exists)
+
+        if self.do_xcom_push:
+            return result
 
 
 class PubSubTopicDeleteOperator(BaseOperator):

--- a/airflow/contrib/operators/pubsub_operator.py
+++ b/airflow/contrib/operators/pubsub_operator.py
@@ -159,7 +159,7 @@ class PubSubSubscriptionCreateOperator(BaseOperator):
             fail_if_exists=False,
             gcp_conn_id='google_cloud_default',
             delegate_to=None,
-            do_xcom_push=True,
+            xcom_push=True,
             *args,
             **kwargs):
         """
@@ -186,8 +186,8 @@ class PubSubSubscriptionCreateOperator(BaseOperator):
             For this to work, the service account making the request
             must have domain-wide delegation enabled.
         :type delegate_to: str
-        :param do_xcom_push: return the result which also get set in XCOM
-        :type do_xcom_push: bool
+        :param xcom_push: return the result which also get set in XCOM
+        :type xcom_push: bool
         """
         super(PubSubSubscriptionCreateOperator, self).__init__(*args, **kwargs)
 
@@ -199,7 +199,7 @@ class PubSubSubscriptionCreateOperator(BaseOperator):
         self.fail_if_exists = fail_if_exists
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
         hook = PubSubHook(gcp_conn_id=self.gcp_conn_id,
@@ -210,7 +210,7 @@ class PubSubSubscriptionCreateOperator(BaseOperator):
             self.subscription_project, self.ack_deadline_secs,
             self.fail_if_exists)
 
-        if self.do_xcom_push:
+        if self.xcom_push_flag:
             return result
 
 

--- a/airflow/contrib/operators/qubole_operator.py
+++ b/airflow/contrib/operators/qubole_operator.py
@@ -28,8 +28,8 @@ class QuboleOperator(BaseOperator):
 
     :param qubole_conn_id: Connection id which consists of qds auth_token
     :type qubole_conn_id: str
-    :param do_xcom_push: return the result which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the result which also get set in XCOM
+    :type xcom_push: bool
 
     kwargs:
         :command_type: type of command to be executed, e.g. hivecmd, shellcmd, hadoopcmd
@@ -133,14 +133,14 @@ class QuboleOperator(BaseOperator):
     @apply_defaults
     def __init__(self,
                  qubole_conn_id="qubole_default",
-                 do_xcom_push=True,
+                 xcom_push=True,
                  *args,
                  **kwargs):
         self.args = args
         self.kwargs = kwargs
         self.kwargs['qubole_conn_id'] = qubole_conn_id
         super(QuboleOperator, self).__init__(*args, **kwargs)
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
         if self.on_failure_callback is None:
             self.on_failure_callback = QuboleHook.handle_failure_retry
@@ -151,7 +151,7 @@ class QuboleOperator(BaseOperator):
     def execute(self, context):
         result = self.get_hook().execute(context)
 
-        if self.do_xcom_push:
+        if self.xcom_push_flag:
             return result
 
     def on_kill(self, ti=None):

--- a/airflow/contrib/operators/s3_list_operator.py
+++ b/airflow/contrib/operators/s3_list_operator.py
@@ -48,6 +48,8 @@ class S3ListOperator(BaseOperator):
                  You can specify this argument if you want to use a different
                  CA cert bundle than the one used by botocore.
     :type verify: bool or str
+    :param do_xcom_push: return the key list which also get set in XCOM
+    :type do_xcom_push: bool
 
     **Example**:
         The following operator would list all the files
@@ -72,6 +74,7 @@ class S3ListOperator(BaseOperator):
                  delimiter='',
                  aws_conn_id='aws_default',
                  verify=None,
+                 do_xcom_push=True,
                  *args,
                  **kwargs):
         super(S3ListOperator, self).__init__(*args, **kwargs)
@@ -80,6 +83,7 @@ class S3ListOperator(BaseOperator):
         self.delimiter = delimiter
         self.aws_conn_id = aws_conn_id
         self.verify = verify
+        self.do_xcom_push = do_xcom_push
 
     def execute(self, context):
         hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
@@ -88,7 +92,10 @@ class S3ListOperator(BaseOperator):
             'Getting the list of files from bucket: {0} in prefix: {1} (Delimiter {2})'.
             format(self.bucket, self.prefix, self.delimiter))
 
-        return hook.list_keys(
+        list_keys = hook.list_keys(
             bucket_name=self.bucket,
             prefix=self.prefix,
             delimiter=self.delimiter)
+
+        if self.do_xcom_push:
+            return list_keys

--- a/airflow/contrib/operators/s3_list_operator.py
+++ b/airflow/contrib/operators/s3_list_operator.py
@@ -48,8 +48,8 @@ class S3ListOperator(BaseOperator):
                  You can specify this argument if you want to use a different
                  CA cert bundle than the one used by botocore.
     :type verify: bool or str
-    :param do_xcom_push: return the key list which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the key list which also get set in XCOM
+    :type xcom_push: bool
 
     **Example**:
         The following operator would list all the files
@@ -74,7 +74,7 @@ class S3ListOperator(BaseOperator):
                  delimiter='',
                  aws_conn_id='aws_default',
                  verify=None,
-                 do_xcom_push=True,
+                 xcom_push=True,
                  *args,
                  **kwargs):
         super(S3ListOperator, self).__init__(*args, **kwargs)
@@ -83,7 +83,7 @@ class S3ListOperator(BaseOperator):
         self.delimiter = delimiter
         self.aws_conn_id = aws_conn_id
         self.verify = verify
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
         hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
@@ -97,5 +97,5 @@ class S3ListOperator(BaseOperator):
             prefix=self.prefix,
             delimiter=self.delimiter)
 
-        if self.do_xcom_push:
+        if self.xcom_push_flag:
             return list_keys

--- a/airflow/contrib/operators/s3_to_gcs_operator.py
+++ b/airflow/contrib/operators/s3_to_gcs_operator.py
@@ -64,6 +64,8 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
     :param replace: Whether you want to replace existing destination files
         or not.
     :type replace: bool
+    :param do_xcom_push: return the file list which also get set in XCOM
+    :type do_xcom_push: bool
 
 
     **Example**:
@@ -97,6 +99,7 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
                  dest_gcs=None,
                  delegate_to=None,
                  replace=False,
+                 do_xcom_push=True,
                  *args,
                  **kwargs):
 
@@ -112,6 +115,7 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
         self.delegate_to = delegate_to
         self.replace = replace
         self.verify = verify
+        self.do_xcom_push = do_xcom_push
 
         if dest_gcs and not self._gcs_object_is_directory(self.dest_gcs):
             self.log.info(
@@ -194,7 +198,8 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
                 'In sync, no files needed to be uploaded to Google Cloud'
                 'Storage')
 
-        return files
+        if self.do_xcom_push:
+            return files
 
     # Following functionality may be better suited in
     # airflow/contrib/hooks/gcs_hook.py

--- a/airflow/contrib/operators/s3_to_gcs_operator.py
+++ b/airflow/contrib/operators/s3_to_gcs_operator.py
@@ -64,8 +64,8 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
     :param replace: Whether you want to replace existing destination files
         or not.
     :type replace: bool
-    :param do_xcom_push: return the file list which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the file list which also get set in XCOM
+    :type xcom_push: bool
 
 
     **Example**:
@@ -99,7 +99,7 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
                  dest_gcs=None,
                  delegate_to=None,
                  replace=False,
-                 do_xcom_push=True,
+                 xcom_push=True,
                  *args,
                  **kwargs):
 
@@ -115,7 +115,7 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
         self.delegate_to = delegate_to
         self.replace = replace
         self.verify = verify
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
         if dest_gcs and not self._gcs_object_is_directory(self.dest_gcs):
             self.log.info(
@@ -198,7 +198,7 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
                 'In sync, no files needed to be uploaded to Google Cloud'
                 'Storage')
 
-        if self.do_xcom_push:
+        if self.xcom_push_flag:
             return files
 
     # Following functionality may be better suited in

--- a/airflow/contrib/operators/sftp_operator.py
+++ b/airflow/contrib/operators/sftp_operator.py
@@ -117,4 +117,4 @@ class SFTPOperator(BaseOperator):
             raise AirflowException("Error while transferring {0}, error: {1}"
                                    .format(file_msg, str(e)))
 
-        return None
+        return

--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -45,8 +45,8 @@ class SSHOperator(BaseOperator):
     :type command: str
     :param timeout: timeout (in seconds) for executing the command.
     :type timeout: int
-    :param do_xcom_push: return the stdout which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the stdout which also get set in XCOM
+    :type xcom_push: bool
     """
 
     template_fields = ('command', 'remote_host')
@@ -59,7 +59,7 @@ class SSHOperator(BaseOperator):
                  remote_host=None,
                  command=None,
                  timeout=10,
-                 do_xcom_push=False,
+                 xcom_push=False,
                  *args,
                  **kwargs):
         super(SSHOperator, self).__init__(*args, **kwargs)
@@ -68,7 +68,7 @@ class SSHOperator(BaseOperator):
         self.remote_host = remote_host
         self.command = command
         self.timeout = timeout
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
         try:
@@ -148,8 +148,8 @@ class SSHOperator(BaseOperator):
 
                 exit_status = stdout.channel.recv_exit_status()
                 if exit_status is 0:
-                    # returning output if do_xcom_push is set
-                    if self.do_xcom_push:
+                    # returning output if xcom_push is set
+                    if self.xcom_push_flag:
                         enable_pickling = configuration.conf.getboolean(
                             'core', 'enable_xcom_pickling'
                         )

--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -166,8 +166,6 @@ class SSHOperator(BaseOperator):
         except Exception as e:
             raise AirflowException("SSH operator error: {0}".format(str(e)))
 
-        return True
-
     def tunnel(self):
         ssh_client = self.ssh_hook.get_conn()
         ssh_client.get_transport()

--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -45,7 +45,7 @@ class SSHOperator(BaseOperator):
     :type command: str
     :param timeout: timeout (in seconds) for executing the command.
     :type timeout: int
-    :param do_xcom_push: return the stdout which also get set in xcom by airflow platform
+    :param do_xcom_push: return the stdout which also get set in XCOM
     :type do_xcom_push: bool
     """
 

--- a/airflow/contrib/operators/winrm_operator.py
+++ b/airflow/contrib/operators/winrm_operator.py
@@ -48,7 +48,7 @@ class WinRMOperator(BaseOperator):
     :type command: str
     :param timeout: timeout for executing the command.
     :type timeout: int
-    :param do_xcom_push: return the stdout which also get set in xcom by airflow platform
+    :param do_xcom_push: return the stdout which also get set in XCOM
     :type do_xcom_push: bool
     """
     template_fields = ('command',)
@@ -145,5 +145,3 @@ class WinRMOperator(BaseOperator):
             raise AirflowException(error_msg)
 
         self.log.info("Finished!")
-
-        return True

--- a/airflow/contrib/operators/winrm_operator.py
+++ b/airflow/contrib/operators/winrm_operator.py
@@ -48,8 +48,8 @@ class WinRMOperator(BaseOperator):
     :type command: str
     :param timeout: timeout for executing the command.
     :type timeout: int
-    :param do_xcom_push: return the stdout which also get set in XCOM
-    :type do_xcom_push: bool
+    :param xcom_push: return the stdout which also get set in XCOM
+    :type xcom_push: bool
     """
     template_fields = ('command',)
 
@@ -60,7 +60,7 @@ class WinRMOperator(BaseOperator):
                  remote_host=None,
                  command=None,
                  timeout=10,
-                 do_xcom_push=False,
+                 xcom_push=False,
                  *args,
                  **kwargs):
         super(WinRMOperator, self).__init__(*args, **kwargs)
@@ -69,7 +69,7 @@ class WinRMOperator(BaseOperator):
         self.remote_host = remote_host
         self.command = command
         self.timeout = timeout
-        self.do_xcom_push = do_xcom_push
+        self.xcom_push_flag = xcom_push
 
     def execute(self, context):
         if self.ssh_conn_id and not self.winrm_hook:
@@ -107,7 +107,7 @@ class WinRMOperator(BaseOperator):
                         )
 
                     # Only buffer stdout if we need to so that we minimize memory usage.
-                    if self.do_xcom_push:
+                    if self.xcom_push_flag:
                         stdout_buffer.append(stdout)
                     stderr_buffer.append(stderr)
 
@@ -127,8 +127,8 @@ class WinRMOperator(BaseOperator):
             raise AirflowException("WinRM operator error: {0}".format(str(e)))
 
         if return_code is 0:
-            # returning output if do_xcom_push is set
-            if self.do_xcom_push:
+            # returning output if xcom_push is set
+            if self.xcom_push_flag:
                 enable_pickling = configuration.conf.getboolean(
                     'core', 'enable_xcom_pickling'
                 )

--- a/tests/contrib/operators/test_gcs_list_operator.py
+++ b/tests/contrib/operators/test_gcs_list_operator.py
@@ -61,7 +61,7 @@ class GoogleCloudStorageListOperatorTest(unittest.TestCase):
                                                   bucket=TEST_BUCKET,
                                                   prefix=PREFIX,
                                                   delimiter=DELIMITER,
-                                                  do_xcom_push=False)
+                                                  xcom_push=False)
 
         files = operator.execute(None)
         mock_hook.return_value.list.assert_called_once_with(

--- a/tests/contrib/operators/test_gcs_list_operator.py
+++ b/tests/contrib/operators/test_gcs_list_operator.py
@@ -52,3 +52,19 @@ class GoogleCloudStorageListOperatorTest(unittest.TestCase):
             bucket=TEST_BUCKET, prefix=PREFIX, delimiter=DELIMITER
         )
         self.assertEqual(sorted(files), sorted(MOCK_FILES))
+
+    @mock.patch('airflow.contrib.operators.gcs_list_operator.GoogleCloudStorageHook')
+    def test_execute_without_xcom_push(self, mock_hook):
+        mock_hook.return_value.list.return_value = MOCK_FILES
+
+        operator = GoogleCloudStorageListOperator(task_id=TASK_ID,
+                                                  bucket=TEST_BUCKET,
+                                                  prefix=PREFIX,
+                                                  delimiter=DELIMITER,
+                                                  do_xcom_push=False)
+
+        files = operator.execute(None)
+        mock_hook.return_value.list.assert_called_once_with(
+            bucket=TEST_BUCKET, prefix=PREFIX, delimiter=DELIMITER
+        )
+        self.assertEqual(files, None)

--- a/tests/contrib/operators/test_gcs_to_s3_operator.py
+++ b/tests/contrib/operators/test_gcs_to_s3_operator.py
@@ -87,7 +87,7 @@ class GoogleCloudStorageToS3OperatorTest(unittest.TestCase):
                                                   delimiter=DELIMITER,
                                                   dest_aws_conn_id=None,
                                                   dest_s3_key=S3_BUCKET,
-                                                  do_xcom_push=False)
+                                                  xcom_push=False)
         # create dest bucket
         hook = S3Hook(aws_conn_id=None)
         b = hook.get_bucket('bucket')

--- a/tests/contrib/operators/test_sftp_operator.py
+++ b/tests/contrib/operators/test_sftp_operator.py
@@ -95,7 +95,7 @@ class SFTPOperatorTest(unittest.TestCase):
                 task_id="test_check_file",
                 ssh_hook=self.hook,
                 command="cat {0}".format(self.test_remote_filepath),
-                do_xcom_push=True,
+                xcom_push=True,
                 dag=self.dag
         )
         self.assertIsNotNone(check_file_task)
@@ -132,7 +132,7 @@ class SFTPOperatorTest(unittest.TestCase):
                 task_id="test_check_file",
                 ssh_hook=self.hook,
                 command="cat {0}".format(self.test_remote_filepath),
-                do_xcom_push=True,
+                xcom_push=True,
                 dag=self.dag
         )
         self.assertIsNotNone(check_file_task)
@@ -155,7 +155,7 @@ class SFTPOperatorTest(unittest.TestCase):
                 ssh_hook=self.hook,
                 command="echo '{0}' > {1}".format(test_remote_file_content,
                                                   self.test_remote_filepath),
-                do_xcom_push=True,
+                xcom_push=True,
                 dag=self.dag
         )
         self.assertIsNotNone(create_file_task)
@@ -193,7 +193,7 @@ class SFTPOperatorTest(unittest.TestCase):
                 ssh_hook=self.hook,
                 command="echo '{0}' > {1}".format(test_remote_file_content,
                                                   self.test_remote_filepath),
-                do_xcom_push=True,
+                xcom_push=True,
                 dag=self.dag
         )
         self.assertIsNotNone(create_file_task)
@@ -295,7 +295,7 @@ class SFTPOperatorTest(unittest.TestCase):
             task_id="test_check_file",
             ssh_hook=self.hook,
             command="rm {0}".format(self.test_remote_filepath),
-            do_xcom_push=True,
+            xcom_push=True,
             dag=self.dag
         )
         self.assertIsNotNone(remove_file_task)

--- a/tests/contrib/operators/test_ssh_operator.py
+++ b/tests/contrib/operators/test_ssh_operator.py
@@ -82,7 +82,7 @@ class SSHOperatorTest(unittest.TestCase):
                 task_id="test",
                 ssh_hook=self.hook,
                 command="echo -n airflow",
-                do_xcom_push=True,
+                xcom_push=True,
                 dag=self.dag,
         )
 
@@ -101,7 +101,7 @@ class SSHOperatorTest(unittest.TestCase):
                 task_id="test",
                 ssh_hook=self.hook,
                 command="echo -n airflow",
-                do_xcom_push=True,
+                xcom_push=True,
                 dag=self.dag,
         )
 
@@ -119,7 +119,7 @@ class SSHOperatorTest(unittest.TestCase):
             task_id="test",
             ssh_hook=self.hook,
             command="echo -n airflow",
-            do_xcom_push=True,
+            xcom_push=True,
             dag=self.dag,
         )
 
@@ -137,7 +137,7 @@ class SSHOperatorTest(unittest.TestCase):
             task_id="test",
             ssh_hook=self.hook,
             command="sleep 1",
-            do_xcom_push=True,
+            xcom_push=True,
             dag=self.dag,
         )
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3133

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

> since there is already a flag to push to XCOM the stdout, pushing True to XCOM automatically might be too noisy for XCOM database

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

When the operator returns something, that value is pushed to XCOM by `xcom_push` in `base_operator.py`, when the operator returns None, nothing is pushed to XCOM

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
