### PR TITLE
[AIRFLOW-3138] Use current data type for migrations

### DIFF
--- a/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
+++ b/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
@@ -29,7 +29,6 @@ from alembic import op
 import sqlalchemy as sa
 from airflow import settings
 from airflow.models import DagBag
-from airflow.utils.sqlalchemy import UtcDateTime
 
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.engine.reflection import Inspector
@@ -51,7 +50,7 @@ class TaskInstance(Base):
 
     task_id = Column(String(ID_LEN), primary_key=True)
     dag_id = Column(String(ID_LEN), primary_key=True)
-    execution_date = Column(UtcDateTime, primary_key=True)
+    execution_date = Column(sa.DateTime, primary_key=True)
     max_tries = Column(Integer)
     try_number = Column(Integer, default=0)
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3138


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Migrations need to use not just the current model (with columns) as the current status of the DB but also the correct types. Go back to using basic sqlalchemy types and keep the timestamp as a timestamp without a timezone.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Ran DB migration manually against both sqlite and postgres. Following https://github.com/apache/incubator-airflow/pull/3720.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
