### PR TITLE
[AIRFLOW-3139] include parameters into log.info in SQL operators, if any

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -163,10 +163,11 @@ class DbApiHook(BaseHook):
                 for s in sql:
                     if sys.version_info[0] < 3:
                         s = s.encode('utf-8')
-                    self.log.info(s)
                     if parameters is not None:
+                        self.log.info("{} with parameters {}".format(s, parameters))
                         cur.execute(s, parameters)
                     else:
+                        self.log.info(s)
                         cur.execute(s)
 
             # If autocommit was set to False for db that supports autocommit,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3139
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

For all SQL-operators based on `DbApiHook`, sql command itself is printed into `log.info`. But if parameters are used for the sql command, the parameters would not be included in the printing. This makes the log less useful.

This commit ensures that the parameters are also printed into the `log.info`, if any.

**Before this commit**
<img width="1099" alt="screen shot 2018-10-02 at 3 24 21 pm" src="https://user-images.githubusercontent.com/11539188/46335691-d94f2880-c65a-11e8-888d-5a0679a3730b.png">


**After this commit**
(if no parameters is given for the sql command, there will be no change)
<img width="1120" alt="screen shot 2018-10-02 at 3 40 44 pm" src="https://user-images.githubusercontent.com/11539188/46335700-de13dc80-c65a-11e8-95ed-cf84b73ba9f5.png">


### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
