### PR TITLE
[AIRFLOW-620] Add a dropdown and refresh button to tail selected number of lines from worker log

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -317,6 +317,10 @@ default_dag_run_display_number = 25
 # Enable werkzeug `ProxyFix` middleware
 enable_proxy_fix = False
 
+# Flag to enable tailing logs
+tail_logs = True
+num_lines = 100
+tail_lines_list = 50,100,200,500,1000
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -29,6 +29,26 @@ limitations under the License.
     </a>
   </li>
   {% endfor %}
+  <ul class="nav nav-pills pull-right">
+    <li>
+      <div class="dropdown">
+        <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" id="tailLinesList">
+          <span id="selected">Tail Logs</span><span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" aria-labelledby="tailLinesList" id="linesList">
+          {% for tail_line in tail_lines_list %}
+            <li class="dropdown-item"><a href="#" onClick="select_tail_lines(this)">{{ tail_line }}</a></li>
+          {% endfor %}
+          <li class="dropdown-item"><a href="#" onClick="select_tail_lines(this)">{{ full_log_title }}</a></li>
+        </ul>
+      </div>
+    </li>
+    <li>
+      <button class="btn btn-default pull-right refresh_button" id="refresh-btn">
+        <span class="glyphicon glyphicon-refresh" aria-hidden="true" title="Refresh Logs"></span>
+      </button>
+    </li>
+  </ul>
 </ul>
 <div class="tab-content">
   {% for log in logs %}
@@ -52,6 +72,8 @@ limitations under the License.
     const ANIMATION_SPEED = 1000;
     // Total number of tabs to show.
     const TOTAL_ATTEMPTS = "{{ logs|length }}";
+    // Text filter to render full log
+    const FULL_LOG_TITLE = "{{ full_log_title }}";
 
     // Recursively fetch logs from flask endpoint.
     function recurse(delay=DELAY) {
@@ -71,7 +93,7 @@ limitations under the License.
     }
 
     // Streaming log with auto-tailing.
-    function autoTailingLog(try_number, metadata=null, auto_tailing=false) {
+    function autoTailingLog(try_number, metadata=null, auto_tailing=false, append_log=true) {
       console.debug("Auto-tailing log for dag_id: {{ dag_id }}, task_id: {{ task_id }}, \
        execution_date: {{ execution_date }}, try_number: " + try_number + ", metadata: " + JSON.stringify(metadata));
 
@@ -107,7 +129,11 @@ limitations under the License.
               var should_scroll = true
             }
             // The message may contain HTML, so either have to escape it or write it as text.
-            document.getElementById(`try-${try_number}`).textContent += res.message + "\n";
+            if(append_log){
+             document.getElementById(`try-${try_number}`).textContent += res.message + "\n";
+            }else{
+              document.getElementById(`try-${try_number}`).textContent = res.message + "\n";
+            }
             // Auto scroll window to the end if current window location is near the end.
             if(should_scroll) {
               $("html, body").animate({ scrollTop: $(document).height() }, ANIMATION_SPEED);
@@ -130,11 +156,55 @@ limitations under the License.
       // returns at most 10k documents. We want the ability
       // to display all logs in the front-end.
       // An optimization here is to render from latest attempt.
+      var metadata = {{ metadata|safe }}
       for(let i = TOTAL_ATTEMPTS; i >= 1; i--) {
         // Only auto_tailing the page when streaming the latest attempt.
-        autoTailingLog(i, null, auto_tailing=(i == TOTAL_ATTEMPTS));
+        autoTailingLog(i, metadata, auto_tailing=(i == TOTAL_ATTEMPTS));
+      }
+      var num_lines = parseInt(metadata.num_lines);
+      if(!isNaN(num_lines)){
+        $("span#selected").text(num_lines);
+        $('span#selected').attr('data-original-title', `Tail last ${num_lines} lines`);
+        $("ul#linesList").prepend(`<li class="dropdown-item"><a href="#" onClick="select_tail_lines(this)">${num_lines}</a></li><li class="dropdown-divider"></li>`)
+      }
+      var text = $("span#selected").text()
+      var tail_lines = parseInt(text);
+      if(isNaN(tail_lines) && text != FULL_LOG_TITLE){
+        $("#refresh-btn").attr("disabled", "disabled");
       }
     });
+    function select_tail_lines(obj){
+      $('span#selected').text(obj.innerText);
+      if(!isNaN(parseInt(obj.innerText))){
+        $('span#selected').attr('data-original-title', `Tail last ${obj.innerText} lines`);
+      }
+      if(obj.innerText === FULL_LOG_TITLE){
+        $('span#selected').attr('data-original-title', "Fetch full log");
+      }
+      if(isNaN(parseInt(obj.innerText)) && obj.innerText != FULL_LOG_TITLE){
+        $("#refresh-btn").attr("disabled", "disabled");
+      }else{
+        $("#refresh-btn").prop("disabled", false);
+      }
+    }
+    $("#refresh-btn").click(() => {
+      var active_tab = parseInt($("li.active[role=presentation]").children()[0].innerText);
+      var text = $("span#selected").text();
+      var tail_lines = parseInt(text);
+      if(isNaN(tail_lines) && text != FULL_LOG_TITLE){
+        alert(`${text} is not a valid integer`);
+        return;
+      }else if(isNaN(active_tab)){
+        alert(`Invalid integer for active tab`)
+        return;
+      }
+      var metadata = {num_lines: tail_lines};
+      if(text === FULL_LOG_TITLE){
+        metadata = {}
+      }
+      autoTailingLog(active_tab, metadata, true, false);
+    });
+
 
 </script>
 {% endblock %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -777,10 +777,13 @@ class Airflow(BaseView):
         dttm = pendulum.parse(execution_date)
         try_number = int(request.args.get('try_number'))
         metadata = request.args.get('metadata')
-        metadata = json.loads(metadata)
-
         # metadata may be null
-        if not metadata:
+        if metadata:
+            try:
+                metadata = json.loads(metadata)
+            except TypeError or json.decoder.JSONDecodeError:
+                metadata = {}
+        else:
             metadata = {}
 
         # Convert string datetime into actual datetime
@@ -836,6 +839,23 @@ class Airflow(BaseView):
         dttm = pendulum.parse(execution_date)
         form = DateTimeForm(data={'execution_date': dttm})
         dag = dagbag.get_dag(dag_id)
+        metadata = {}
+        try:
+            tailing_required = conf.getboolean('webserver', 'tail_logs')
+            if tailing_required:
+                num_lines = conf.getint('webserver', 'num_lines')
+                metadata = {
+                    "num_lines": num_lines
+                }
+        except Exception:
+            pass
+        tail_lines_list = [100, 200, 500, 1000]
+        try:
+            tail_lines_list = conf.get('webserver', 'tail_lines_list')
+            tail_lines_list = list(map(int, tail_lines_list.split(',')))
+        except Exception:
+            pass
+        tail_lines_list.sort()
 
         ti = session.query(models.TaskInstance).filter(
             models.TaskInstance.dag_id == dag_id,
@@ -847,7 +867,8 @@ class Airflow(BaseView):
             'airflow/ti_log.html',
             logs=logs, dag=dag, title="Log by attempts",
             dag_id=dag.dag_id, task_id=task_id,
-            execution_date=execution_date, form=form)
+            execution_date=execution_date, form=form, full_log_title="Full Log",
+            metadata=json.dumps(metadata), tail_lines_list=tail_lines_list)
 
     @expose('/task')
     @login_required

--- a/airflow/www_rbac/templates/airflow/ti_log.html
+++ b/airflow/www_rbac/templates/airflow/ti_log.html
@@ -29,6 +29,26 @@ limitations under the License.
     </a>
   </li>
   {% endfor %}
+  <ul class="nav nav-pills pull-right">
+    <li>
+      <div class="dropdown">
+        <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" id="tailLinesList">
+          <span id="selected">Tail Logs</span><span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" aria-labelledby="tailLinesList" id="linesList">
+          {% for tail_line in tail_lines_list %}
+            <li class="dropdown-item"><a href="#" onClick="select_tail_lines(this)">{{ tail_line }}</a></li>
+          {% endfor %}
+          <li class="dropdown-item"><a href="#" onClick="select_tail_lines(this)">{{ full_log_title }}</a></li>
+        </ul>
+      </div>
+    </li>
+    <li>
+      <button class="btn btn-default pull-right refresh_button" id="refresh-btn">
+        <span class="glyphicon glyphicon-refresh" aria-hidden="true" title="Refresh Logs"></span>
+      </button>
+    </li>
+  </ul>
 </ul>
 <div class="tab-content">
   {% for log in logs %}
@@ -52,6 +72,8 @@ limitations under the License.
     const ANIMATION_SPEED = 1000;
     // Total number of tabs to show.
     const TOTAL_ATTEMPTS = "{{ logs|length }}";
+    // Text filter to render full log
+    const FULL_LOG_TITLE = "{{ full_log_title }}";
 
     // Recursively fetch logs from flask endpoint.
     function recurse(delay=DELAY) {
@@ -71,7 +93,7 @@ limitations under the License.
     }
 
     // Streaming log with auto-tailing.
-    function autoTailingLog(try_number, metadata=null, auto_tailing=false) {
+    function autoTailingLog(try_number, metadata=null, auto_tailing=false, append_log=true) {
       console.debug("Auto-tailing log for dag_id: {{ dag_id }}, task_id: {{ task_id }}, \
        execution_date: {{ execution_date }}, try_number: " + try_number + ", metadata: " + JSON.stringify(metadata));
 
@@ -107,7 +129,11 @@ limitations under the License.
               var should_scroll = true
             }
             // The message may contain HTML, so either have to escape it or write it as text.
-            document.getElementById(`try-${try_number}`).textContent += res.message + "\n";
+            if(append_log){
+             document.getElementById(`try-${try_number}`).textContent += res.message + "\n";
+            }else{
+              document.getElementById(`try-${try_number}`).textContent = res.message + "\n";
+            }
             // Auto scroll window to the end if current window location is near the end.
             if(should_scroll) {
               $("html, body").animate({ scrollTop: $(document).height() }, ANIMATION_SPEED);
@@ -130,11 +156,55 @@ limitations under the License.
       // returns at most 10k documents. We want the ability
       // to display all logs in the front-end.
       // An optimization here is to render from latest attempt.
+      var metadata = {{ metadata|safe }}
       for(let i = TOTAL_ATTEMPTS; i >= 1; i--) {
         // Only auto_tailing the page when streaming the latest attempt.
-        autoTailingLog(i, null, auto_tailing=(i == TOTAL_ATTEMPTS));
+        autoTailingLog(i, metadata, auto_tailing=(i == TOTAL_ATTEMPTS));
+      }
+      var num_lines = parseInt(metadata.num_lines);
+      if(!isNaN(num_lines)){
+        $("span#selected").text(num_lines);
+        $('span#selected').attr('data-original-title', `Tail last ${num_lines} lines`);
+        $("ul#linesList").prepend(`<li class="dropdown-item"><a href="#" onClick="select_tail_lines(this)">${num_lines}</a></li><li class="dropdown-divider"></li>`)
+      }
+      var text = $("span#selected").text()
+      var tail_lines = parseInt(text);
+      if(isNaN(tail_lines) && text != FULL_LOG_TITLE){
+        $("#refresh-btn").attr("disabled", "disabled");
       }
     });
+    function select_tail_lines(obj){
+      $('span#selected').text(obj.innerText);
+      if(!isNaN(parseInt(obj.innerText))){
+        $('span#selected').attr('data-original-title', `Tail last ${obj.innerText} lines`);
+      }
+      if(obj.innerText === FULL_LOG_TITLE){
+        $('span#selected').attr('data-original-title', "Fetch full log");
+      }
+      if(isNaN(parseInt(obj.innerText)) && obj.innerText != FULL_LOG_TITLE){
+        $("#refresh-btn").attr("disabled", "disabled");
+      }else{
+        $("#refresh-btn").prop("disabled", false);
+      }
+    }
+    $("#refresh-btn").click(() => {
+      var active_tab = parseInt($("li.active[role=presentation]").children()[0].innerText);
+      var text = $("span#selected").text();
+      var tail_lines = parseInt(text);
+      if(isNaN(tail_lines) && text != FULL_LOG_TITLE){
+        alert(`${text} is not a valid integer`);
+        return;
+      }else if(isNaN(active_tab)){
+        alert(`Invalid integer for active tab`)
+        return;
+      }
+      var metadata = {num_lines: tail_lines};
+      if(text === FULL_LOG_TITLE){
+        metadata = {}
+      }
+      autoTailingLog(active_tab, metadata, true, false);
+    });
+
 
 </script>
 {% endblock %}


### PR DESCRIPTION
Dear Airflow Maintainers,

This is a change in the way we render logs. This PR will give a dropdown of number of lines to be tailed with a refresh button. On refresh webserver fetch selected number of lines from local worker logs or remote worker logs. On can toggle this feature using config variable `tail_logs` in `webserver`, default number of lines to tail via config variable `num_lines ` in `webserver` and items in dropdown can be controlled via config variable `tail_lines_list ` in `webserver` in csv format

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-620

**Testing Done:**

Manually tested on all major browsers.
`This will add a dropdown of number of lines to be tailed and refresh button to get latest logs instead of refreshing the whole page.`