### PR TITLE
[AIRFLOW-620] Feature to tail custom number of logs instead of rendering whole log

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1004,10 +1004,12 @@ def serve_logs(args):
 
     @flask_app.route('/log/<path:filename>')
     def serve_logs(filename):  # noqa
+        log = os.path.expanduser(conf.get('core', 'BASE_LOG_FOLDER'))
         num_lines = request.args.get("num_lines")
+        tail_logs = request.args.get('tail_logs', False)
         num_lines = int(num_lines) if num_lines and num_lines.isdigit() else None
         log_path = "{log}/{filename}".format(log=log, filename=filename)
-        if num_lines:
+        if tail_logs and num_lines:
             return Response(stream_with_context(tail_file(log_path, num_lines)))
         else:
             return send_from_directory(

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -322,6 +322,14 @@ default_dag_run_display_number = 25
 # Enable werkzeug `ProxyFix` middleware
 enable_proxy_fix = False
 
+# Flag to control tailing logs
+enable_tailing_logs = True
+
+# Default number of lines to tail when page loads
+default_lines_to_tail = 500
+
+# Entries to be shown in dropdown(mention as comma delimted string)
+tail_lines_list = 100,200,500,1000
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -334,7 +334,7 @@ def tail_file(filepath, lines):
         if current_position == 0:
             return None
         fl.seek(-num_bytes, os.SEEK_CUR)
-        data = str(fl.read(num_bytes), 'utf-8', 'ignore')
+        data = fl.read(num_bytes).decode('utf-8')
         fl.seek(-num_bytes, os.SEEK_CUR)
         return data
 

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -333,24 +333,24 @@ def tail_file(filepath, lines):
             num_bytes = current_position
         if current_position == 0:
             return None
-        fl.seek(-num_bytes, 1)
+        fl.seek(-num_bytes, os.SEEK_CUR)
         data = str(fl.read(num_bytes), 'utf-8', 'ignore')
-        fl.seek(-num_bytes, 1)
+        fl.seek(-num_bytes, os.SEEK_CUR)
         return data
 
     LINE_SIZE = 200  # Assuming each line will have 200 bytes
     lines_to_fetch = lines
     data = ""
-
+    if not os.path.exists(filepath):  # If file does not exists in file system, return default message
+        return "FileNotFound: No such file or directory: {}".format(filepath)
     with open(filepath, 'rb') as fl:  # Seek to a position from cur pointer is not supported in read text mode
-        fl.seek(0, 2)
+        fl.seek(0, os.SEEK_END)
         while True:
             num_bytes = lines_to_fetch * LINE_SIZE  # Calculate number of bytes to fetch based on lines
             tail_chunk = get_byte_range_file(fl, num_bytes)
             if tail_chunk is not None:
                 data = tail_chunk + data
             else:
-                print('Reached starting of the file.Exiting')
                 break
             if data.count('\n') > lines:
                 data = data.split('\n')
@@ -358,4 +358,4 @@ def tail_file(filepath, lines):
                 break
             else:
                 lines_to_fetch = lines - data.count('\n') + 1
-    return data[:-1]  # remove extra new line at the end of output
+    return data

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -334,7 +334,7 @@ def tail_file(filepath, lines):
         if current_position == 0:
             return None
         fl.seek(-num_bytes, 1)
-        data = fl.read(num_bytes)
+        data = str(fl.read(num_bytes), 'utf-8', 'ignore')
         fl.seek(-num_bytes, 1)
         return data
 
@@ -342,7 +342,7 @@ def tail_file(filepath, lines):
     lines_to_fetch = lines
     data = ""
 
-    with open(filepath) as fl:
+    with open(filepath, 'rb') as fl:  # Seek to a position from cur pointer is not supported in read text mode
         fl.seek(0, 2)
         while True:
             num_bytes = lines_to_fetch * LINE_SIZE  # Calculate number of bytes to fetch based on lines

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -317,3 +317,45 @@ def render_log_filename(ti, try_number, filename_template):
                                     task_id=ti.task_id,
                                     execution_date=ti.execution_date.isoformat(),
                                     try_number=try_number)
+
+
+def tail_file(filepath, lines):
+    """
+    Tail last n lines from give file.
+    :param filepath: Path to the file we have to tail
+    :param lines: Number of lines to tail
+    :return last n lines in the file
+    """
+    def get_byte_range_file(fl, num_bytes):
+        # Get current position of file pointer
+        current_position = fl.tell()
+        if current_position < num_bytes:
+            num_bytes = current_position
+        if current_position == 0:
+            return None
+        fl.seek(-num_bytes, 1)
+        data = fl.read(num_bytes)
+        fl.seek(-num_bytes, 1)
+        return data
+
+    LINE_SIZE = 200  # Assuming each line will have 200 bytes
+    lines_to_fetch = lines
+    data = ""
+
+    with open(filepath) as fl:
+        fl.seek(0, 2)
+        while True:
+            num_bytes = lines_to_fetch * LINE_SIZE  # Calculate number of bytes to fetch based on lines
+            tail_chunk = get_byte_range_file(fl, num_bytes)
+            if tail_chunk is not None:
+                data = tail_chunk + data
+            else:
+                print('Reached starting of the file.Exiting')
+                break
+            if data.count('\n') > lines:
+                data = data.split('\n')
+                data = '\n'.join(line for line in data[-lines - 1:])
+                break
+            else:
+                lines_to_fetch = lines - data.count('\n') + 1
+    return data[:-1]  # remove extra new line at the end of output

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -103,10 +103,12 @@ class FileTaskHandler(logging.Handler):
             num_lines = metadata.get('num_lines', 500)
         if os.path.exists(location):
             if tail_logs:
+                log = "*** Tailing last {n} lines from {location}\n\n".format(n=num_lines, location=location)
                 try:
-                    log = tail_file(location, num_lines)
+                    log += tail_file(location, num_lines)
+                    print('@!#@!#LOGGGGGGG    ', log)
                 except Exception as e:
-                    log = "*** Failed to load local log file: {}\n".format(location)
+                    log += "*** Failed to load local log file: {}\n".format(location)
                     log += "*** {}\n".format(str(e))
             else:
                 try:

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -100,13 +100,12 @@ class FileTaskHandler(logging.Handler):
         num_lines = None
         if metadata:
             tail_logs = metadata.get('tail_logs', False)
-            num_lines = metadata.get('num_lines', 500)
+            num_lines = metadata.get('num_lines', None)
         if os.path.exists(location):
-            if tail_logs:
+            if tail_logs and num_lines:
                 log = "*** Tailing last {n} lines from {location}\n\n".format(n=num_lines, location=location)
                 try:
                     log += tail_file(location, num_lines)
-                    print('@!#@!#LOGGGGGGG    ', log)
                 except Exception as e:
                     log += "*** Failed to load local log file: {}\n".format(location)
                     log += "*** {}\n".format(str(e))
@@ -127,8 +126,9 @@ class FileTaskHandler(logging.Handler):
             )
             log += "*** Log file does not exist: {}\n".format(location)
             log += "*** Fetching from: {}\n".format(url)
-            if tail_logs:
-                url = "{url}?num_lines={num_lines}".format(url=url, num_lines=num_lines)
+            if tail_logs and num_lines:
+                url = "{url}?num_lines={num_lines}&tail_logs={tail_logs}".format(url=url, num_lines=num_lines,
+                                                                                 tail_logs=tail_logs)
                 log += "***** Showing only last {num_lines} lines from {url} *****" \
                        "\n\n\n".format(num_lines=num_lines, url=url)
             try:

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -30,6 +30,28 @@ limitations under the License.
   </li>
   {% endfor %}
 </ul>
+{% if tailing_logs_enabled %}
+    <ul class="nav nav-pills pull-right">
+      <li>
+        <div class="dropdown">
+          <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" id="tailLinesList">
+            <span id="selected">Tail Logs</span><span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu" aria-labelledby="tailLinesList" id="linesList">
+            {% for tail_line in tail_lines_list %}
+              <li class="dropdown-item"><a href="#" onClick="select_tail_lines(this)">{{ tail_line }}</a></li>
+            {% endfor %}
+            <li class="dropdown-item"><a href="#" onClick="select_tail_lines(this)">{{ full_log_title }}</a></li>
+          </ul>
+        </div>
+      </li>
+      <li>
+        <button class="btn btn-default pull-right refresh_button" id="refresh-btn">
+          <span class="glyphicon glyphicon-refresh" aria-hidden="true" title="Refresh Logs"></span>
+        </button>
+      </li>
+    </ul>
+{% endif %}
 <div class="tab-content">
   {% for log in logs %}
   <div role="tabpanel" class="tab-pane {{ 'active' if loop.last else '' }}" id="{{ loop.index }}">
@@ -52,6 +74,8 @@ limitations under the License.
     const ANIMATION_SPEED = 1000;
     // Total number of tabs to show.
     const TOTAL_ATTEMPTS = "{{ logs|length }}";
+    // Text filter to render full log
+    const FULL_LOG_TITLE = "{{ full_log_title }}";
 
     // Recursively fetch logs from flask endpoint.
     function recurse(delay=DELAY) {
@@ -71,7 +95,7 @@ limitations under the License.
     }
 
     // Streaming log with auto-tailing.
-    function autoTailingLog(try_number, metadata=null, auto_tailing=false) {
+    function autoTailingLog(try_number, metadata=null, auto_tailing=false, append_log=true) {
       console.debug("Auto-tailing log for dag_id: {{ dag_id }}, task_id: {{ task_id }}, \
        execution_date: {{ execution_date }}, try_number: " + try_number + ", metadata: " + JSON.stringify(metadata));
 
@@ -130,11 +154,59 @@ limitations under the License.
       // returns at most 10k documents. We want the ability
       // to display all logs in the front-end.
       // An optimization here is to render from latest attempt.
+      var metadata = {{ metadata|safe }};
       for(let i = TOTAL_ATTEMPTS; i >= 1; i--) {
         // Only auto_tailing the page when streaming the latest attempt.
-        autoTailingLog(i, null, auto_tailing=(i == TOTAL_ATTEMPTS));
+        autoTailingLog(i, metadata, auto_tailing=(i == TOTAL_ATTEMPTS));
       }
+      {% if tailing_required %}
+        var num_lines = parseInt(metadata.num_lines);
+        if(!isNaN(num_lines)){
+          $("span#selected").text(num_lines);
+          $('span#selected').attr('data-original-title', `Tail last ${num_lines} lines`);
+          $("ul#linesList").prepend(`<li class="dropdown-item"><a href="#" onClick="select_tail_lines(this)">${num_lines}</a></li><li class="divider"></li>`)
+        }
+        var text = $("span#selected").text()
+        var tail_lines = parseInt(text);
+        if(isNaN(tail_lines) && text != FULL_LOG_TITLE){
+          $("#refresh-btn").attr("disabled", "disabled");
+        }
+      {% endif %}
     });
+
+    {% if tailing_required %}
+      function select_tail_lines(obj){
+        $('span#selected').text(obj.innerText);
+        if(!isNaN(parseInt(obj.innerText))){
+          $('span#selected').attr('data-original-title', `Tail last ${obj.innerText} lines`);
+        }
+        if(obj.innerText === FULL_LOG_TITLE){
+          $('span#selected').attr('data-original-title', "Fetch full log");
+        }
+        if(isNaN(parseInt(obj.innerText)) && obj.innerText != FULL_LOG_TITLE){
+          $("#refresh-btn").attr("disabled", "disabled");
+        }else{
+          $("#refresh-btn").prop("disabled", false);
+        }
+      }
+      $("#refresh-btn").click(() => {
+        var active_tab = parseInt($("li.active[role=presentation]").children()[0].innerText);
+        var text = $("span#selected").text();
+        var tail_lines = parseInt(text);
+        if(isNaN(tail_lines) && text != FULL_LOG_TITLE){
+          alert(`${text} is not a valid integer`);
+          return;
+        }else if(isNaN(active_tab)){
+          alert(`Invalid integer for active tab`);
+          return;
+        }
+        var metadata = {num_lines: tail_lines};
+        if(text === FULL_LOG_TITLE){
+          metadata = {};
+        }
+        autoTailingLog(active_tab, metadata, true, false);
+      });
+    {% endif %}
 
 </script>
 {% endblock %}

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -131,7 +131,11 @@ limitations under the License.
               var should_scroll = true
             }
             // The message may contain HTML, so either have to escape it or write it as text.
-            document.getElementById(`try-${try_number}`).textContent += res.message + "\n";
+            if(append_log){
+              document.getElementById(`try-${try_number}`).textContent += res.message + "\n";
+            }else{
+              document.getElementById(`try-${try_number}`).textContent = res.message + "\n";
+            }
             // Auto scroll window to the end if current window location is near the end.
             if(should_scroll) {
               $("html, body").animate({ scrollTop: $(document).height() }, ANIMATION_SPEED);
@@ -159,7 +163,7 @@ limitations under the License.
         // Only auto_tailing the page when streaming the latest attempt.
         autoTailingLog(i, metadata, auto_tailing=(i == TOTAL_ATTEMPTS));
       }
-      {% if tailing_required %}
+      {% if tailing_logs_enabled %}
         var num_lines = parseInt(metadata.num_lines);
         if(!isNaN(num_lines)){
           $("span#selected").text(num_lines);
@@ -174,7 +178,7 @@ limitations under the License.
       {% endif %}
     });
 
-    {% if tailing_required %}
+    {% if tailing_logs_enabled %}
       function select_tail_lines(obj){
         $('span#selected').text(obj.innerText);
         if(!isNaN(parseInt(obj.innerText))){
@@ -190,21 +194,27 @@ limitations under the License.
         }
       }
       $("#refresh-btn").click(() => {
-        var active_tab = parseInt($("li.active[role=presentation]").children()[0].innerText);
-        var text = $("span#selected").text();
-        var tail_lines = parseInt(text);
-        if(isNaN(tail_lines) && text != FULL_LOG_TITLE){
-          alert(`${text} is not a valid integer`);
-          return;
-        }else if(isNaN(active_tab)){
-          alert(`Invalid integer for active tab`);
-          return;
+        var active_tab = $("li.active[role=presentation]").children()[0];
+        if(active_tab){
+          var active_tab_value = parseInt(active_tab.innerText);
+          var text = $("span#selected").text();
+          var tail_lines = parseInt(text);
+          if(isNaN(tail_lines) && text != FULL_LOG_TITLE){
+            alert(`${text} is not a valid integer`);
+            return;
+          }else if(isNaN(active_tab_value)){
+            alert(`Invalid integer for active tab`);
+            return;
+          }
+          var metadata = {{ metadata|safe }};
+          metadata['num_lines'] = tail_lines;
+          if(text === FULL_LOG_TITLE){
+            metadata['tail_logs']=false;
+          }
+          autoTailingLog(active_tab_value, metadata, true, false);
+        }else{
+          alert(`Not Active Tabs found.`);
         }
-        var metadata = {num_lines: tail_lines};
-        if(text === FULL_LOG_TITLE){
-          metadata = {};
-        }
-        autoTailingLog(active_tab, metadata, true, false);
       });
     {% endif %}
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -600,10 +600,12 @@ class Airflow(AirflowBaseView):
         form = DateTimeForm(data={'execution_date': dttm})
         dag = dagbag.get_dag(dag_id)
 
+        task_log_reader = conf.get('core', 'task_log_reader')
         metadata = {}
         tail_lines_list = conf.get('webserver', 'tail_lines_list')
         tail_lines_list = [int(line) for line in tail_lines_list.split(',') if line.isdigit()]
-        tailing_logs_enabled = conf.getboolean('webserver', 'enable_tailing_logs')
+        tailing_logs_enabled = conf.getboolean('webserver', 'enable_tailing_logs') \
+            if task_log_reader == "task" else False
         if tailing_logs_enabled and conf.has_option('webserver', 'default_lines_to_tail'):
             # Default number of lines to tail when page loads
             default_lines_to_tail = conf.getint('webserver', 'default_lines_to_tail')

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -610,6 +610,7 @@ class Airflow(AirflowBaseView):
             # Default number of lines to tail when page loads
             default_lines_to_tail = conf.getint('webserver', 'default_lines_to_tail')
             metadata["num_lines"] = default_lines_to_tail
+            metadata['tail_logs'] = True
             # Delete default number of line from list if it already exists in list
             if default_lines_to_tail in tail_lines_list:
                 tail_lines_list.remove(default_lines_to_tail)

--- a/scripts/ci/kubernetes/docker/Dockerfile
+++ b/scripts/ci/kubernetes/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN pip install -U setuptools && \
 
 # install airflow
 COPY airflow.tar.gz /tmp/airflow.tar.gz
-RUN pip install /tmp/airflow.tar.gz
+RUN pip install --no-use-pep517 /tmp/airflow.tar.gz
 
 COPY airflow-test-env-init.sh /tmp/airflow-test-env-init.sh
 


### PR DESCRIPTION
Dear Airflow Maintainers,

This is a change in the way we render logs. This PR will give a dropdown of number of lines to be tailed with a refresh button. On refresh webserver fetch selected number of lines from local worker logs or remote worker logs. On can toggle this feature using config variable tail_logs in webserver, default number of lines to tail via config variable num_lines in webserver and items in dropdown can be controlled via config variable tail_lines_list in webserver in csv format

Please accept this PR that addresses the following issues:
https://issues.apache.org/jira/browse/AIRFLOW-620

Testing Done:

Manually tested on all major browsers.
This will add a dropdown of number of lines to be tailed and refresh button to get latest logs instead of refreshing the whole page.