### PR TITLE
[AIRFLOW-1354] Fix pool_link() return value

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -207,7 +207,7 @@ def label_link(v, c, m, p):
 
 
 def pool_link(v, c, m, p):
-    url = '/admin/taskinstance/?flt1_pool_equals=' + m.pool
+    url = '/admin/pool/?flt1_pool_equals=' + m.pool
     return Markup("<a href='{url}'>{m.pool}</a>".format(**locals()))
 
 

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -317,7 +317,10 @@ class TestPoolModelView(unittest.TestCase):
         response = self.app.get(self.LIST_ENDPOINT)
         content = response.data.decode('utf-8')
         self.assertIn(self.pool['pool'], content)
-        self.assertIn("<a href='/admin/pool/?flt1_pool_equals=test-pool'>test-pool</a>", content)
+        self.assertIn(
+            "<a href='/admin/pool/?flt1_pool_equals=test-pool'>test-pool</a>",
+            content
+        )
 
 
 class TestLogView(unittest.TestCase):

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -242,6 +242,7 @@ class TestKnownEventView(unittest.TestCase):
 class TestPoolModelView(unittest.TestCase):
 
     CREATE_ENDPOINT = '/admin/pool/new/?url=/admin/pool/'
+    LIST_ENDPOINT = '/admin/pool/'
 
     @classmethod
     def setUpClass(cls):
@@ -304,6 +305,19 @@ class TestPoolModelView(unittest.TestCase):
         )
         self.assertIn('This field is required.', response.data.decode('utf-8'))
         self.assertEqual(self.session.query(models.Pool).count(), 0)
+
+    def test_list_pools(self):
+        # create test pool
+        self.app.post(
+            self.CREATE_ENDPOINT,
+            data=self.pool,
+            follow_redirects=True,
+        )
+        # Get the list of pools
+        response = self.app.get(self.LIST_ENDPOINT)
+        content = response.data.decode('utf-8')
+        self.assertIn(self.pool['pool'], content)
+        self.assertIn("<a href='/admin/pool/?flt1_pool_equals=test-pool'>test-pool</a>", content)
 
 
 class TestLogView(unittest.TestCase):


### PR DESCRIPTION
The URL had a copy-paste error

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
    When getting the list of pools at /admin/pool/, the link on the pool name is wrong.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
