### PR TITLE
[AIRFLOW-3148] Remove unnecessary arg "parameters" in RedshiftToS3Transfer

### DIFF
--- a/airflow/operators/redshift_to_s3_operator.py
+++ b/airflow/operators/redshift_to_s3_operator.py
@@ -42,6 +42,7 @@ class RedshiftToS3Transfer(BaseOperator):
     :parame verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
         You can provide the following values:
+
         - False: do not validate SSL certificates. SSL will still be used
                  (unless use_ssl is False), but SSL certificates will not be
                  verified.
@@ -69,7 +70,6 @@ class RedshiftToS3Transfer(BaseOperator):
             verify=None,
             unload_options=tuple(),
             autocommit=False,
-            parameters=None,
             include_header=False,
             *args, **kwargs):
         super(RedshiftToS3Transfer, self).__init__(*args, **kwargs)
@@ -82,7 +82,6 @@ class RedshiftToS3Transfer(BaseOperator):
         self.verify = verify
         self.unload_options = unload_options
         self.autocommit = autocommit
-        self.parameters = parameters
         self.include_header = include_header
 
         if self.include_header and \


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3148
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:



"Parameters" are normally used to help render the SQL command. But in this operator, only schema and table are needed. There is no SQL command to render.

By checking the code, we can also find argument "parameters" is never really used.

(Fix a minor issue in the docstring as well)

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
