### PR TITLE
[AIRFLOW-3151] Pin FlaskAppBuilder 1.11.1 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -274,7 +274,7 @@ def do_setup():
             'croniter>=0.3.17, <0.4',
             'dill>=0.2.2, <0.3',
             'flask>=0.12.4, <0.13',
-            'flask-appbuilder>=1.11.1, <2.0.0',
+            'flask-appbuilder==1.11.1',
             'flask-admin==1.4.1',
             'flask-caching>=1.3.3, <1.4.0',
             'flask-login==0.2.11',


### PR DESCRIPTION
### Jira

My PR addresses the following [AIRFLOW-3151](https://issues.apache.org/jira/browse/AIRFLOW-3151)

### Description

The PR pins the version of FlaskAppBuilder to 1.11.1 since the new release 1.12.0 breaks the www_rbac UI. 

### Tests

Doesn't require additional tests because not adding any code to source, just pinning flaskappbuilder like flask-admin is pinned. 