### PR TITLE
[AIRFLOW-3162] Fix HttpHook URL parse error when port is specified

### DIFF
--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -98,7 +98,11 @@ class HttpHook(BaseHook):
 
         session = self.get_conn(headers)
 
-        url = self.base_url + endpoint
+        if not self.base_url.endswith('/') and not endpoint.startswith('/'):
+            url = self.base_url + '/' + endpoint
+        else:
+            url = self.base_url + endpoint
+
         req = None
         if self.method == 'GET':
             # GET uses params

--- a/tests/hooks/test_http_hook.py
+++ b/tests/hooks/test_http_hook.py
@@ -42,6 +42,15 @@ def get_airflow_connection(conn_id=None):
     )
 
 
+def get_airflow_connection_with_port(conn_id=None):
+    return models.Connection(
+        conn_id='http_default',
+        conn_type='http',
+        host='test.com',
+        port=1234
+    )
+
+
 class TestHttpHook(unittest.TestCase):
     """Test get, post and raise_for_status"""
     def setUp(self):
@@ -68,6 +77,32 @@ class TestHttpHook(unittest.TestCase):
 
             resp = self.get_hook.run('v1/test')
             self.assertEquals(resp.text, '{"status":{"status": 200}}')
+
+    @requests_mock.mock()
+    @mock.patch('requests.Request')
+    def test_get_request_with_port(self, m, request_mock):
+        from requests.exceptions import MissingSchema
+
+        with mock.patch(
+            'airflow.hooks.base_hook.BaseHook.get_connection',
+            side_effect=get_airflow_connection_with_port
+        ):
+            expected_url = 'http://test.com:1234/some/endpoint'
+            for endpoint in ['some/endpoint', '/some/endpoint']:
+
+                try:
+                    self.get_hook.run(endpoint)
+                except MissingSchema:
+                    pass
+
+                request_mock.assert_called_once_with(
+                    mock.ANY,
+                    expected_url,
+                    headers=mock.ANY,
+                    params=mock.ANY
+                )
+
+                request_mock.reset_mock()
 
     @requests_mock.mock()
     def test_get_request_do_not_raise_for_status_if_check_response_is_false(self, m):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3162
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This is a fix for a regression on `HttpHook.get()` where if a port is specified on `airflow.models.Connection` and the provided endpoint has no leading slash, the URL will fail to parse.

```
# with the connection
airflow.models.Connection(
    conn_id='test_conn',
    conn_type='http',
    host='test.com',
    port=1234
)

>>> hook = HttpHook(method='GET', http_conn_id='test_conn')
>>> hook.get(endpoint='some/endpoint')
...
InvalidURL: Failed to parse: test.com:1234some/endpoint
```

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

`tests.hooks.test_http_hook:TestHttpHook.test_get_request_with_port`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
