### PR TITLE
[AIRFLOW-3163] add operator to enable setting table description in BigQuery table

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -135,6 +135,34 @@ class BigQueryHook(GoogleCloudBaseHook, DbApiHook, LoggingMixin):
                 return False
             raise
 
+    def set_table_description(self, dataset_id, table_id, description, project_id=None):
+        """
+        Sets the description for the given table
+
+        :param project_id: The Google cloud project in which to look for the
+            table. The connection supplied to the hook must provide access to
+            the specified project.
+        :type project_id: string
+        :param dataset_id: The name of the dataset in which to look for the
+            table.
+        :type dataset_id: string
+        :param table_id: The name of the table to set the description for.
+        :type table_id: string
+        :param description: The description to set
+        :type description: string
+        """
+        service = self.get_service()
+        project_id = project_id if project_id is not None else self._get_field('project')
+        table = service.tables().get(
+            projectId=project_id, datasetId=dataset_id,
+            tableId=table_id).execute()
+        table['description'] = description
+        service.tables().patch(
+            projectId=project_id,
+            datasetId=dataset_id,
+            tableId=table_id,
+            body=table).execute()
+
 
 class BigQueryPandasConnector(GbqConnector):
     """

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -629,3 +629,57 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
             project_id=self.project_id,
             dataset_id=self.dataset_id,
             dataset_reference=self.dataset_reference)
+
+
+class BigQuerySetTableDescriptionOperator(BaseOperator):
+    """
+    This operator is called to set the desription on a table
+
+    :param project_id: The Google cloud project in which to look for the
+        table. The connection supplied must provide access to
+        the specified project.
+    :type project_id: string
+    :param dataset_id: The name of the dataset in which to look for the
+        table.
+    :type dataset_id: string
+    :param table_id: The name of the table to set the description for.
+    :type table_id: string
+    :param description: The description to set
+    :type description: string
+    :param bigquery_conn_id: The connection ID to use when
+        connecting to BigQuery.
+    :type google_cloud_storage_conn_id: string
+    :param delegate_to: The account to impersonate, if any. For this to
+        work, the service account making the request must have domain-wide
+        delegation enabled.
+    :type delegate_to: string
+    """
+    template_fields = ('project_id', 'dataset_id', 'table_id', 'description')
+    ui_color = '#f0eee4'
+
+    @apply_defaults
+    def __init__(self,
+                 project_id=None,
+                 dataset_id=None,
+                 table_id=None,
+                 description=None,
+                 bigquery_conn_id='bigquery_default',
+                 delegate_to=None,
+                 *args,
+                 **kwargs):
+        super(BigQuerySetTableDescriptionOperator, self).__init__(*args, **kwargs)
+        self.project_id = project_id
+        self.dataset_id = dataset_id
+        self.table_id = table_id
+        self.description = description
+        self.bigquery_conn_id = bigquery_conn_id
+        self.delegate_to = delegate_to
+
+    def execute(self, context):
+        bq_hook = BigQueryHook(
+            bigquery_conn_id=self.bigquery_conn_id,
+            delegate_to=self.delegate_to)
+        bq_hook.set_table_description(project_id=self.project_id,
+                                      dataset_id=self.dataset_id,
+                                      table_id=self.table_id,
+                                      description=self.description)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3163
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

This adds a BigQuery operator to allow setting a table description

