### PR TITLE
[AIRFLOW-3165] Document interpolation of '%' and warn

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -10,6 +10,12 @@ backends or creating your own.
 
 Be sure to checkout :doc:`api` for securing the API.
 
+.. note::
+
+   Airflow uses the config parser of Python. This config parser interpolates '%'-signs.
+   Make sure not to have those in your passwords if they do not make sense, otherwise
+   Airflow might leak these passwords on a config parser exception to a log.
+
 Web Authentication
 ------------------
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3165
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

Only doc update.

cc: @ashb 