### PR TITLE
[AIRFLOW-3155] Add ability to filter by a last modified time in GoogleCloudStorageToGoogleCloudStorageOperator

### DIFF
--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -56,11 +56,6 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
         of copied to the new location. This is the equivalent of a mv command
         as opposed to a cp command.
     :type move_object: bool
-    :param filter_by_last_modified: When True, only copies/moves source object(s)
-        that were last modified after last_modified_time
-    :type: bool
-    :param last_modified_time: Timestamp in GMT to filter source object(s)
-    :type datetime
     :param google_cloud_storage_conn_id: The connection ID to use when
         connecting to Google cloud storage.
     :type google_cloud_storage_conn_id: str
@@ -68,6 +63,11 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
         For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
+    :param filter_by_last_modified: When True, only copies/moves source object(s)
+        that were last modified after last_modified_time
+    :type: bool
+    :param last_modified_time: Timestamp in GMT to filter source object(s)
+    :type datetime
 
     **Examples**:
         The following Operator would copy a single file named
@@ -118,10 +118,10 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
                  destination_bucket=None,
                  destination_object=None,
                  move_object=False,
-                 filter_by_last_modified=False,
-                 last_modified_time=datetime.utcnow(),
                  google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
+                 filter_by_last_modified=False,
+                 last_modified_time=datetime.utcnow(),
                  *args,
                  **kwargs):
         super(GoogleCloudStorageToGoogleCloudStorageOperator,
@@ -131,10 +131,10 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
         self.destination_bucket = destination_bucket
         self.destination_object = destination_object
         self.move_object = move_object
-        self.filter_by_last_modified = filter_by_last_modified
-        self.last_modified_time = last_modified_time
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
         self.delegate_to = delegate_to
+        self.filter_by_last_modified = filter_by_last_modified
+        self.last_modified_time = last_modified_time
         self.wildcard = '*'
 
     def execute(self, context):

--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -20,7 +20,6 @@
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
-from datetime import datetime
 
 
 class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
@@ -63,9 +62,6 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
         For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
-    :param filter_by_last_modified: When True, only copies/moves source object(s)
-        that were last modified after last_modified_time
-    :type filter_by_last_modified: bool
     :param last_modified_time: Timestamp in GMT to filter source object(s)
     :type last_modified_time: datetime
 
@@ -120,8 +116,7 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
                  move_object=False,
                  google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
-                 filter_by_last_modified=False,
-                 last_modified_time=datetime.utcnow(),
+                 last_modified_time=None,
                  *args,
                  **kwargs):
         super(GoogleCloudStorageToGoogleCloudStorageOperator,
@@ -133,7 +128,6 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
         self.move_object = move_object
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
         self.delegate_to = delegate_to
-        self.filter_by_last_modified = filter_by_last_modified
         self.last_modified_time = last_modified_time
         self.wildcard = '*'
 
@@ -150,7 +144,7 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
             objects = hook.list(self.source_bucket, prefix=prefix, delimiter=delimiter)
 
             for source_object in objects:
-                if self.filter_by_last_modified:
+                if self.last_modified_time is not None:
                     # Check to see if object was modified after last_modified_time
                     if hook.is_updated_after(self.source_bucket, source_object,
                                              self.last_modified_time):
@@ -173,7 +167,7 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
                     hook.delete(self.source_bucket, source_object)
 
         else:
-            if self.filter_by_last_modified:
+            if self.last_modified_time is not None:
                 if hook.is_updated_after(self.source_bucket,
                                          self.source_object,
                                          self.last_modified_time):

--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -65,9 +65,9 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
     :type delegate_to: str
     :param filter_by_last_modified: When True, only copies/moves source object(s)
         that were last modified after last_modified_time
-    :type: bool
+    :type filter_by_last_modified: bool
     :param last_modified_time: Timestamp in GMT to filter source object(s)
-    :type datetime
+    :type last_modified_time: datetime
 
     **Examples**:
         The following Operator would copy a single file named

--- a/airflow/contrib/operators/gcs_to_gcs.py
+++ b/airflow/contrib/operators/gcs_to_gcs.py
@@ -62,7 +62,9 @@ class GoogleCloudStorageToGoogleCloudStorageOperator(BaseOperator):
         For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :type delegate_to: str
-    :param last_modified_time: Timestamp in GMT to filter source object(s)
+    :param last_modified_time: When specified, if the object(s) were
+        modified after last_modified_time, they will be copied/moved.
+        If tzinfo has not been set, UTC will be assumed.
     :type last_modified_time: datetime
 
     **Examples**:

--- a/tests/contrib/operators/test_gcs_to_gcs_operator.py
+++ b/tests/contrib/operators/test_gcs_to_gcs_operator.py
@@ -172,14 +172,13 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
         mock_hook.return_value.rewrite.assert_has_calls(mock_calls_empty)
 
     @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
-    def test_execute_filter_by_last_modified(self, mock_hook):
+    def test_execute_last_modified_time(self, mock_hook):
         mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
         operator = GoogleCloudStorageToGoogleCloudStorageOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_4,
             destination_bucket=DESTINATION_BUCKET,
-            filter_by_last_modified=False,
-            last_modified_time=MOD_TIME_1)
+            last_modified_time=None)
 
         operator.execute(None)
         mock_calls_none = [
@@ -191,14 +190,13 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
         mock_hook.return_value.rewrite.assert_has_calls(mock_calls_none)
 
     @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
-    def test_wc_with_filter_by_last_modified_true_with_all_true_cond(self, mock_hook):
+    def test_wc_with_last_modified_time_with_all_true_cond(self, mock_hook):
         mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
         mock_hook.return_value.is_updated_after.side_effect = [True, True, True]
         operator = GoogleCloudStorageToGoogleCloudStorageOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_4,
             destination_bucket=DESTINATION_BUCKET,
-            filter_by_last_modified=True,
             last_modified_time=MOD_TIME_1)
 
         operator.execute(None)
@@ -211,14 +209,13 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
         mock_hook.return_value.rewrite.assert_has_calls(mock_calls_none)
 
     @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
-    def test_wc_with_filter_by_last_modified_true_with_one_true_cond(self, mock_hook):
+    def test_wc_with_last_modified_time_with_one_true_cond(self, mock_hook):
         mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
         mock_hook.return_value.is_updated_after.side_effect = [True, False, False]
         operator = GoogleCloudStorageToGoogleCloudStorageOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_4,
             destination_bucket=DESTINATION_BUCKET,
-            filter_by_last_modified=True,
             last_modified_time=MOD_TIME_1)
 
         operator.execute(None)
@@ -227,14 +224,13 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
             DESTINATION_BUCKET, 'test_object/file1.txt')
 
     @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
-    def test_wc_with_filter_by_last_modified_false(self, mock_hook):
+    def test_wc_with_no_last_modified_time(self, mock_hook):
         mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
         operator = GoogleCloudStorageToGoogleCloudStorageOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_4,
             destination_bucket=DESTINATION_BUCKET,
-            filter_by_last_modified=False,
-            last_modified_time=MOD_TIME_1)
+            last_modified_time=None)
 
         operator.execute(None)
         mock_calls_none = [
@@ -246,14 +242,13 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
         mock_hook.return_value.rewrite.assert_has_calls(mock_calls_none)
 
     @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
-    def test_no_prefix_with_filter_by_last_modified_true_with_true_cond(self, mock_hook):
+    def test_no_prefix_with_last_modified_time_with_true_cond(self, mock_hook):
         mock_hook.return_value.is_updated_after.return_value = True
         operator = GoogleCloudStorageToGoogleCloudStorageOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_5,
             destination_bucket=DESTINATION_BUCKET,
             destination_object=SOURCE_OBJECT_5,
-            filter_by_last_modified=True,
             last_modified_time=MOD_TIME_1)
 
         operator.execute(None)
@@ -261,28 +256,26 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
             TEST_BUCKET, 'test_object.txt', DESTINATION_BUCKET, 'test_object.txt')
 
     @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
-    def test_execute_no_prefix_with_filter_by_last_modified_false(self, mock_hook):
+    def test_execute_no_prefix_with_no_last_modified_time(self, mock_hook):
         operator = GoogleCloudStorageToGoogleCloudStorageOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_5,
             destination_bucket=DESTINATION_BUCKET,
             destination_object=SOURCE_OBJECT_5,
-            filter_by_last_modified=False,
-            last_modified_time=MOD_TIME_1)
+            last_modified_time=None)
 
         operator.execute(None)
         mock_hook.return_value.rewrite.assert_called_once_with(
             TEST_BUCKET, 'test_object.txt', DESTINATION_BUCKET, 'test_object.txt')
 
     @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
-    def test_no_prefix_with_filter_by_last_modified_true_with_false_cond(self, mock_hook):
+    def test_no_prefix_with_last_modified_time_with_false_cond(self, mock_hook):
         mock_hook.return_value.is_updated_after.return_value = False
         operator = GoogleCloudStorageToGoogleCloudStorageOperator(
             task_id=TASK_ID, source_bucket=TEST_BUCKET,
             source_object=SOURCE_OBJECT_5,
             destination_bucket=DESTINATION_BUCKET,
             destination_object=SOURCE_OBJECT_5,
-            filter_by_last_modified=True,
             last_modified_time=MOD_TIME_1)
 
         operator.execute(None)

--- a/tests/contrib/operators/test_gcs_to_gcs_operator.py
+++ b/tests/contrib/operators/test_gcs_to_gcs_operator.py
@@ -18,6 +18,7 @@
 # under the License.
 
 import unittest
+from datetime import datetime
 
 from airflow.contrib.operators.gcs_to_gcs import \
     GoogleCloudStorageToGoogleCloudStorageOperator
@@ -38,6 +39,7 @@ SOURCE_OBJECT_1 = '*test_object'
 SOURCE_OBJECT_2 = 'test_object*'
 SOURCE_OBJECT_3 = 'test*object'
 SOURCE_OBJECT_4 = 'test_object*.txt'
+SOURCE_OBJECT_5 = 'test_object.txt'
 DESTINATION_BUCKET = 'archive'
 DESTINATION_OBJECT_PREFIX = 'foo/bar'
 SOURCE_FILES_LIST = [
@@ -45,6 +47,7 @@ SOURCE_FILES_LIST = [
     'test_object/file2.txt',
     'test_object/file3.json',
 ]
+MOD_TIME_1 = datetime(2016, 1, 1)
 
 
 class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
@@ -167,3 +170,120 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
                       DESTINATION_BUCKET, '/file2.txt'),
         ]
         mock_hook.return_value.rewrite.assert_has_calls(mock_calls_empty)
+
+    @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
+    def test_execute_filter_by_last_modified(self, mock_hook):
+        mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
+        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+            task_id=TASK_ID, source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_4,
+            destination_bucket=DESTINATION_BUCKET,
+            filter_by_last_modified=False,
+            last_modified_time=MOD_TIME_1)
+
+        operator.execute(None)
+        mock_calls_none = [
+            mock.call(TEST_BUCKET, 'test_object/file1.txt',
+                      DESTINATION_BUCKET, 'test_object/file1.txt'),
+            mock.call(TEST_BUCKET, 'test_object/file2.txt',
+                      DESTINATION_BUCKET, 'test_object/file2.txt'),
+        ]
+        mock_hook.return_value.rewrite.assert_has_calls(mock_calls_none)
+
+    @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
+    def test_wc_with_filter_by_last_modified_true_with_all_true_cond(self, mock_hook):
+        mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
+        mock_hook.return_value.is_updated_after.side_effect = [True, True, True]
+        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+            task_id=TASK_ID, source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_4,
+            destination_bucket=DESTINATION_BUCKET,
+            filter_by_last_modified=True,
+            last_modified_time=MOD_TIME_1)
+
+        operator.execute(None)
+        mock_calls_none = [
+            mock.call(TEST_BUCKET, 'test_object/file1.txt',
+                      DESTINATION_BUCKET, 'test_object/file1.txt'),
+            mock.call(TEST_BUCKET, 'test_object/file2.txt',
+                      DESTINATION_BUCKET, 'test_object/file2.txt'),
+        ]
+        mock_hook.return_value.rewrite.assert_has_calls(mock_calls_none)
+
+    @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
+    def test_wc_with_filter_by_last_modified_true_with_one_true_cond(self, mock_hook):
+        mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
+        mock_hook.return_value.is_updated_after.side_effect = [True, False, False]
+        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+            task_id=TASK_ID, source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_4,
+            destination_bucket=DESTINATION_BUCKET,
+            filter_by_last_modified=True,
+            last_modified_time=MOD_TIME_1)
+
+        operator.execute(None)
+        mock_hook.return_value.rewrite.assert_called_once_with(
+            TEST_BUCKET, 'test_object/file1.txt',
+            DESTINATION_BUCKET, 'test_object/file1.txt')
+
+    @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
+    def test_wc_with_filter_by_last_modified_false(self, mock_hook):
+        mock_hook.return_value.list.return_value = SOURCE_FILES_LIST
+        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+            task_id=TASK_ID, source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_4,
+            destination_bucket=DESTINATION_BUCKET,
+            filter_by_last_modified=False,
+            last_modified_time=MOD_TIME_1)
+
+        operator.execute(None)
+        mock_calls_none = [
+            mock.call(TEST_BUCKET, 'test_object/file1.txt',
+                      DESTINATION_BUCKET, 'test_object/file1.txt'),
+            mock.call(TEST_BUCKET, 'test_object/file2.txt',
+                      DESTINATION_BUCKET, 'test_object/file2.txt'),
+        ]
+        mock_hook.return_value.rewrite.assert_has_calls(mock_calls_none)
+
+    @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
+    def test_no_prefix_with_filter_by_last_modified_true_with_true_cond(self, mock_hook):
+        mock_hook.return_value.is_updated_after.return_value = True
+        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+            task_id=TASK_ID, source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_5,
+            destination_bucket=DESTINATION_BUCKET,
+            destination_object=SOURCE_OBJECT_5,
+            filter_by_last_modified=True,
+            last_modified_time=MOD_TIME_1)
+
+        operator.execute(None)
+        mock_hook.return_value.rewrite.assert_called_once_with(
+            TEST_BUCKET, 'test_object.txt', DESTINATION_BUCKET, 'test_object.txt')
+
+    @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
+    def test_execute_no_prefix_with_filter_by_last_modified_false(self, mock_hook):
+        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+            task_id=TASK_ID, source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_5,
+            destination_bucket=DESTINATION_BUCKET,
+            destination_object=SOURCE_OBJECT_5,
+            filter_by_last_modified=False,
+            last_modified_time=MOD_TIME_1)
+
+        operator.execute(None)
+        mock_hook.return_value.rewrite.assert_called_once_with(
+            TEST_BUCKET, 'test_object.txt', DESTINATION_BUCKET, 'test_object.txt')
+
+    @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
+    def test_no_prefix_with_filter_by_last_modified_true_with_false_cond(self, mock_hook):
+        mock_hook.return_value.is_updated_after.return_value = False
+        operator = GoogleCloudStorageToGoogleCloudStorageOperator(
+            task_id=TASK_ID, source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_5,
+            destination_bucket=DESTINATION_BUCKET,
+            destination_object=SOURCE_OBJECT_5,
+            filter_by_last_modified=True,
+            last_modified_time=MOD_TIME_1)
+
+        operator.execute(None)
+        mock_hook.return_value.rewrite.assert_not_called()


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3155
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

Currently the GoogleCloudStorageToGoogleCloudStorageOperator doesn't support filtering objects based on a last modified time/date. This would add the ability to further filter source object(s) to copy/move based on a last modified time threshold (for example, if the objects were updated after the last run at 10:00 yesterday, then copy/move them; otherwise, do not.) 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
test_no_prefix_with_filter_by_last_modified_true_with_false_cond
test_execute_no_prefix_with_filter_by_last_modified_false
test_no_prefix_with_filter_by_last_modified_true_with_true_cond
test_wc_with_filter_by_last_modified_false
test_wc_with_filter_by_last_modified_true_with_one_true_cond
test_wc_with_filter_by_last_modified_true_with_all_true_cond
test_execute_filter_by_last_modified



### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
