### PR TITLE
[AIRFLOW-2216] Use profile for AWS hook if S3 config file provided in aws_default connection extra parameters

### DIFF
--- a/airflow/contrib/hooks/aws_hook.py
+++ b/airflow/contrib/hooks/aws_hook.py
@@ -97,34 +97,36 @@ class AwsHook(BaseHook):
         if self.aws_conn_id:
             try:
                 connection_object = self.get_connection(self.aws_conn_id)
+                extra_config = connection_object.extra_dejson
                 if connection_object.login:
                     aws_access_key_id = connection_object.login
                     aws_secret_access_key = connection_object.password
 
-                elif 'aws_secret_access_key' in connection_object.extra_dejson:
-                    aws_access_key_id = connection_object.extra_dejson[
+                elif 'aws_secret_access_key' in extra_config:
+                    aws_access_key_id = extra_config[
                         'aws_access_key_id']
-                    aws_secret_access_key = connection_object.extra_dejson[
+                    aws_secret_access_key = extra_config[
                         'aws_secret_access_key']
 
-                elif 's3_config_file' in connection_object.extra_dejson:
+                elif 's3_config_file' in extra_config:
                     aws_access_key_id, aws_secret_access_key = \
                         _parse_s3_config(
-                            connection_object.extra_dejson['s3_config_file'],
-                            connection_object.extra_dejson.get('s3_config_format'),
-                            connection_object.extra_dejson.get('profile'))
+                            extra_config['s3_config_file'],
+                            extra_config.get('s3_config_format'),
+                            extra_config.get('profile'))
 
                 if region_name is None:
-                    region_name = connection_object.extra_dejson.get('region_name')
+                    region_name = extra_config.get('region_name')
 
-                role_arn = connection_object.extra_dejson.get('role_arn')
-                external_id = connection_object.extra_dejson.get('external_id')
-                aws_account_id = connection_object.extra_dejson.get('aws_account_id')
-                aws_iam_role = connection_object.extra_dejson.get('aws_iam_role')
+                role_arn = extra_config.get('role_arn')
+                external_id = extra_config.get('external_id')
+                aws_account_id = extra_config.get('aws_account_id')
+                aws_iam_role = extra_config.get('aws_iam_role')
 
                 if role_arn is None and aws_account_id is not None and \
                         aws_iam_role is not None:
-                    role_arn = "arn:aws:iam::" + aws_account_id + ":role/" + aws_iam_role
+                    role_arn = "arn:aws:iam::{}:role/{}" \
+                        .format(aws_account_id, aws_iam_role)
 
                 if role_arn is not None:
                     sts_session = boto3.session.Session(
@@ -144,11 +146,12 @@ class AwsHook(BaseHook):
                             RoleSessionName='Airflow_' + self.aws_conn_id,
                             ExternalId=external_id)
 
-                    aws_access_key_id = sts_response['Credentials']['AccessKeyId']
-                    aws_secret_access_key = sts_response['Credentials']['SecretAccessKey']
-                    aws_session_token = sts_response['Credentials']['SessionToken']
+                    credentials = sts_response['Credentials']
+                    aws_access_key_id = credentials['AccessKeyId']
+                    aws_secret_access_key = credentials['SecretAccessKey']
+                    aws_session_token = credentials['SessionToken']
 
-                endpoint_url = connection_object.extra_dejson.get('host')
+                endpoint_url = extra_config.get('host')
 
             except AirflowException:
                 # No connection found: fallback on boto3 credential strategy
@@ -184,7 +187,7 @@ class AwsHook(BaseHook):
         This contains the attributes: access_key, secret_key and token.
         """
         session, _ = self._get_credentials(region_name)
-        # Credentials are refreshable, so accessing your access key / secret key
-        # separately can lead to a race condition.
+        # Credentials are refreshable, so accessing your access key and
+        # secret key separately can lead to a race condition.
         # See https://stackoverflow.com/a/36291428/8283373
         return session.get_credentials().get_frozen_credentials()

--- a/airflow/contrib/hooks/aws_hook.py
+++ b/airflow/contrib/hooks/aws_hook.py
@@ -111,7 +111,8 @@ class AwsHook(BaseHook):
                     aws_access_key_id, aws_secret_access_key = \
                         _parse_s3_config(
                             connection_object.extra_dejson['s3_config_file'],
-                            connection_object.extra_dejson.get('s3_config_format'))
+                            connection_object.extra_dejson.get('s3_config_format'),
+                            connection_object.extra_dejson.get('profile'))
 
                 if region_name is None:
                     region_name = connection_object.extra_dejson.get('region_name')


### PR DESCRIPTION
Based on PR #3172. 

[AIRFLOW-2216] Use profile for AWS hook if S3 config file provided in aws_default connection extra parameters; add test to validate profile set

Make sure you have checked all steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. \[AIRFLOW-2216\] Cannot specify a profile for AWS Hook to load with s3 config file
  - https://issues.apache.org/jira/browse/AIRFLOW-2216

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

NO UI CHANGES MADE

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

UNIT TEST ADDED

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
