### PR TITLE
[AIRFLOW-2789] Create single node DataProc cluster

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -133,6 +133,8 @@ class DataprocClusterCreateOperator(BaseOperator):
         auto-deleted at the end of this duration.
         A duration in seconds. (If auto_delete_time is set this parameter will be ignored)
     :type auto_delete_ttl: int
+    :param single_node: Create single node cluster
+    :type single_node: bool
     """
 
     template_fields = ['cluster_name', 'project_id', 'zone', 'region']
@@ -170,6 +172,7 @@ class DataprocClusterCreateOperator(BaseOperator):
                  idle_delete_ttl=None,
                  auto_delete_time=None,
                  auto_delete_ttl=None,
+                 single_node=False,
                  *args,
                  **kwargs):
 
@@ -186,7 +189,7 @@ class DataprocClusterCreateOperator(BaseOperator):
         self.metadata = metadata
         self.custom_image = custom_image
         self.image_version = image_version
-        self.properties = properties
+        self.properties = properties or dict()
         self.master_machine_type = master_machine_type
         self.master_disk_type = master_disk_type
         self.master_disk_size = master_disk_size
@@ -205,9 +208,18 @@ class DataprocClusterCreateOperator(BaseOperator):
         self.idle_delete_ttl = idle_delete_ttl
         self.auto_delete_time = auto_delete_time
         self.auto_delete_ttl = auto_delete_ttl
+        self.single_node = single_node
 
         assert not (self.custom_image and self.image_version), \
             "custom_image and image_version can't be both set"
+
+        assert (
+            self.single_node and
+            self.num_preemptible_workers + self.num_workers == 0
+        ) or (
+            not self.single_node and
+            self.num_preemptible_workers + self.num_workers != 0
+        )
 
     def _get_cluster_list_for_project(self, service):
         result = service.projects().regions().clusters().list(
@@ -351,7 +363,12 @@ class DataprocClusterCreateOperator(BaseOperator):
                                '{}/global/images/{}'.format(self.project_id,
                                                             self.custom_image)
             cluster_data['config']['masterConfig']['imageUri'] = custom_image_url
-            cluster_data['config']['workerConfig']['imageUri'] = custom_image_url
+            if not self.single_node:
+                cluster_data['config']['workerConfig']['imageUri'] = custom_image_url
+
+        if self.single_node:
+            self.properties["dataproc:dataproc.allow.zero.workers"] = "true"
+
         if self.properties:
             cluster_data['config']['softwareConfig']['properties'] = self.properties
         if self.idle_delete_ttl:

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -298,6 +298,35 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
         self.assertEqual(cluster_data['config']['workerConfig']['imageUri'],
                          expected_custom_image_url)
 
+    def test_build_single_node_cluster(self):
+        dataproc_operator = DataprocClusterCreateOperator(
+            task_id=TASK_ID,
+            cluster_name=CLUSTER_NAME,
+            project_id=PROJECT_ID,
+            num_workers=0,
+            num_preemptible_workers=0,
+            zone=ZONE,
+            dag=self.dag,
+            single_node=True
+        )
+        cluster_data = dataproc_operator._build_cluster_data()
+        self.assertEqual(
+            cluster_data['config']['softwareConfig']['properties']
+            ['dataproc:dataproc.allow.zero.workers'], "true")
+
+    def test_init_with_single_node_and_non_zero_workers(self):
+        with self.assertRaises(AssertionError):
+            DataprocClusterCreateOperator(
+                task_id=TASK_ID,
+                cluster_name=CLUSTER_NAME,
+                project_id=PROJECT_ID,
+                num_workers=NUM_WORKERS,
+                zone=ZONE,
+                dag=self.dag,
+                image_version=IMAGE_VERSION,
+                single_node=True
+            )
+
     def test_cluster_name_log_no_sub(self):
         with patch('airflow.contrib.operators.dataproc_operator.DataProcHook') \
                 as mock_hook:

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -306,25 +306,24 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
             num_workers=0,
             num_preemptible_workers=0,
             zone=ZONE,
-            dag=self.dag,
-            single_node=True
+            dag=self.dag
         )
         cluster_data = dataproc_operator._build_cluster_data()
         self.assertEqual(
             cluster_data['config']['softwareConfig']['properties']
             ['dataproc:dataproc.allow.zero.workers'], "true")
 
-    def test_init_with_single_node_and_non_zero_workers(self):
+    def test_init_cluster_with_zero_workers_and_not_non_zero_preemtibles(self):
         with self.assertRaises(AssertionError):
             DataprocClusterCreateOperator(
                 task_id=TASK_ID,
                 cluster_name=CLUSTER_NAME,
                 project_id=PROJECT_ID,
-                num_workers=NUM_WORKERS,
+                num_workers=0,
+                num_preemptible_workers=2,
                 zone=ZONE,
                 dag=self.dag,
                 image_version=IMAGE_VERSION,
-                single_node=True
             )
 
     def test_cluster_name_log_no_sub(self):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-2789) 

### Description

In GCP, it is possible to set up [Single node clusters](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/single-node-clusters)

Since the minimal size of the cluster (without this modification) is 3 (one master + two workers). It may be very helpful while doing, for example, small-scale non-critical data processing or building proof-of-concept.

### Tests

- [x] My PR adds the following unit tests `test_build_single_node_cluster` and `test_init_with_single_node_and_non_zero_workers`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
