### PR TITLE
[AIRFLOW-3195] Log query and task_id in druid-hook

### DIFF
--- a/airflow/hooks/druid_hook.py
+++ b/airflow/hooks/druid_hook.py
@@ -68,6 +68,7 @@ class DruidHook(BaseHook):
     def submit_indexing_job(self, json_index_spec):
         url = self.get_conn_url()
 
+        self.log.info(json_index_spec)
         req_index = requests.post(url, json=json_index_spec, headers=self.header)
         if req_index.status_code != 200:
             raise AirflowException('Did not get 200 when '
@@ -76,6 +77,7 @@ class DruidHook(BaseHook):
         req_json = req_index.json()
         # Wait until the job is completed
         druid_task_id = req_json['task']
+        self.log.info(druid_task_id)
 
         running = True
 

--- a/airflow/hooks/druid_hook.py
+++ b/airflow/hooks/druid_hook.py
@@ -68,7 +68,7 @@ class DruidHook(BaseHook):
     def submit_indexing_job(self, json_index_spec):
         url = self.get_conn_url()
 
-        self.log.info(json_index_spec)
+        self.log.info("Druid ingestion spec: {}".format(json_index_spec))
         req_index = requests.post(url, json=json_index_spec, headers=self.header)
         if req_index.status_code != 200:
             raise AirflowException('Did not get 200 when '
@@ -77,7 +77,7 @@ class DruidHook(BaseHook):
         req_json = req_index.json()
         # Wait until the job is completed
         druid_task_id = req_json['task']
-        self.log.info(druid_task_id)
+        self.log.info("Druid indexing task-id: {}".format(druid_task_id))
 
         running = True
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-3195
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
When the druid hook is used for ingestion it would be helpful to log the ingestion spec and the resulting task id.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`nosetests -v tests/hooks/test_druid_hook.py` ran successfully

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
