### PR TITLE
 [Airflow-XXX] Add MySQL connection to the docs 

### DIFF
--- a/docs/howto/manage-connections.rst
+++ b/docs/howto/manage-connections.rst
@@ -133,3 +133,26 @@ Scopes (comma separated)
         Scopes are ignored when using application default credentials. See
         issue `AIRFLOW-2522
         <https://issues.apache.org/jira/browse/AIRFLOW-2522>`_.
+MySQL
+~~~~~~~~~~~~~~~~~~~~~
+The MySQL connect type allows to connect with MySQL database.
+
+Configuring the Connection
+''''''''''''''''''''''''''
+Host (required)
+    The host to connect to.
+
+Schema (optional)
+    Specify the schema name to be used in the database.
+
+Login (required)
+    Specify the user name to connect.
+    
+Password (required)
+    Specify the password to connect.    
+    
+Extra (optional)
+    Specify the charset. Example: {"charset": "utf8"}
+    
+    .. note::
+        If encounter UnicodeDecodeError while working with MySQL connection check the charset defined is matched to the database charset.


### PR DESCRIPTION
Explain how to connect with MySQL
Add the example here: https://stackoverflow.com/questions/46084744/how-to-explicitly-declare-charset-utf8-for-airflow-connections  to the documentation.

Also explain how to avoid error as described here:
https://stackoverflow.com/questions/52699046/mysqltogooglecloudstorageoperator-fails-unexpectadly