### PR TITLE
[AIRFLOW-3173] Add _cmd options for password config options

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -130,6 +130,10 @@ class AirflowConfigParser(ConfigParser):
         ('celery', 'result_backend'),
         # Todo: remove this in Airflow 1.11
         ('celery', 'celery_result_backend'),
+        ('atlas', 'password'),
+        ('smtp', 'smtp_password'),
+        ('ldap', 'bind_password'),
+        ('kubernetes', 'git_password'),
     }
 
     # A two-level mapping of (section -> new_name -> old_name). When reading

--- a/docs/howto/set-config.rst
+++ b/docs/howto/set-config.rst
@@ -20,16 +20,30 @@ or by creating a corresponding environment variable:
 
     AIRFLOW__CORE__SQL_ALCHEMY_CONN=my_conn_string
 
-You can also derive the connection string at run time by appending ``_cmd`` to the key like this:
+You can also derive the connection string at run time by appending ``_cmd`` to
+the key like this:
 
 .. code-block:: bash
 
     [core]
     sql_alchemy_conn_cmd = bash_command_to_run
 
--But only three such configuration elements namely sql_alchemy_conn, broker_url and result_backend can be fetched as a command. The idea behind this is to not store passwords on boxes in plain text files. The order of precedence is as follows -
+The following config options support this ``_cmd`` version:
+
+* ``sql_alchemy_conn`` in ``[core]`` section
+* ``fernet_key`` in ``[core]`` section
+* ``broker_url`` in ``[celery]`` section
+* ``result_backend`` in ``[celery]`` section
+* ``password`` in ``[atlas]`` section
+* ``smtp_password`` in ``[smtp]`` section
+* ``bind_password`` in ``[ldap]`` section
+* ``git_password`` in ``[kubernetes]`` section
+
+The idea behind this is to not store passwords on boxes in plain text files.
+
+The order of precedence for all connfig options is as follows -
 
 1. environment variable
 2. configuration in airflow.cfg
 3. command in airflow.cfg
-4. default
+4. Airflow's built in defaults


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-3173

### Description

There were a few more "password" config options added over the last few
months that didn't have _cmd options. Any config option that is a
password should be able to be provided via a _cmd version.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: None needed really?

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - Updated docs to mention all config options that are supported by _cmd

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
