### PR TITLE
[AIRFLOW-3178] Handle percents signs in configs for airflow run

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -154,9 +154,9 @@ class AirflowConfigParser(ConfigParser):
     def __init__(self, default_config=None, *args, **kwargs):
         super(AirflowConfigParser, self).__init__(*args, **kwargs)
 
-        self.defaults = ConfigParser(*args, **kwargs)
+        self.airflow_defaults = ConfigParser(*args, **kwargs)
         if default_config is not None:
-            self.defaults.read_string(default_config)
+            self.airflow_defaults.read_string(default_config)
 
         self.is_validated = False
 
@@ -246,9 +246,9 @@ class AirflowConfigParser(ConfigParser):
                 return option
 
         # ...then the default config
-        if self.defaults.has_option(section, key):
+        if self.airflow_defaults.has_option(section, key):
             return expand_env_var(
-                self.defaults.get(section, key, **kwargs))
+                self.airflow_defaults.get(section, key, **kwargs))
 
         else:
             log.warning(
@@ -300,8 +300,8 @@ class AirflowConfigParser(ConfigParser):
         if super(AirflowConfigParser, self).has_option(section, option):
             super(AirflowConfigParser, self).remove_option(section, option)
 
-        if self.defaults.has_option(section, option) and remove_default:
-            self.defaults.remove_option(section, option)
+        if self.airflow_defaults.has_option(section, option) and remove_default:
+            self.airflow_defaults.remove_option(section, option)
 
     def getsection(self, section):
         """
@@ -310,10 +310,11 @@ class AirflowConfigParser(ConfigParser):
         :param section: section from the config
         :return: dict
         """
-        if section not in self._sections and section not in self.defaults._sections:
+        if (section not in self._sections and
+                section not in self.airflow_defaults._sections):
             return None
 
-        _section = copy.deepcopy(self.defaults._sections[section])
+        _section = copy.deepcopy(self.airflow_defaults._sections[section])
 
         if section in self._sections:
             _section.update(copy.deepcopy(self._sections[section]))
@@ -344,7 +345,7 @@ class AirflowConfigParser(ConfigParser):
             are shown as '< hidden >'
         :type display_sensitive: bool
         """
-        cfg = copy.deepcopy(self.defaults._sections)
+        cfg = copy.deepcopy(self.airflow_defaults._sections)
         cfg.update(copy.deepcopy(self._sections))
 
         # remove __name__ (affects Python 2 only)

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -60,12 +60,6 @@ class BaseTaskRunner(LoggingMixin):
 
         # Always provide a copy of the configuration file settings
         cfg_path = tmp_configuration_copy()
-        # The following command should always work since the user doing chmod is the same
-        # as the one who just created the file.
-        subprocess.call(
-            ['chmod', '600', cfg_path],
-            close_fds=True
-        )
 
         # Add sudo commands to change user if we need to. Needed to handle SubDagOperator
         # case using a SequentialExecutor.

--- a/airflow/utils/configuration.py
+++ b/airflow/utils/configuration.py
@@ -26,7 +26,7 @@ from tempfile import mkstemp
 from airflow import configuration as conf
 
 
-def tmp_configuration_copy():
+def tmp_configuration_copy(chmod=0o600):
     """
     Returns a path for a temporary file including a full copy of the configuration
     settings.
@@ -36,6 +36,8 @@ def tmp_configuration_copy():
     temp_fd, cfg_path = mkstemp()
 
     with os.fdopen(temp_fd, 'w') as temp_file:
+        if chmod is not None:
+            os.fchmod(temp_fd, chmod)
         json.dump(cfg_dict, temp_file)
 
     return cfg_path

--- a/airflow/utils/configuration.py
+++ b/airflow/utils/configuration.py
@@ -32,7 +32,7 @@ def tmp_configuration_copy():
     settings.
     :return: a path to a temporary file
     """
-    cfg_dict = conf.as_dict(display_sensitive=True)
+    cfg_dict = conf.as_dict(display_sensitive=True, raw=True)
     temp_fd, cfg_path = mkstemp()
 
     with os.fdopen(temp_fd, 'w') as temp_file:

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -12,9 +12,10 @@ Be sure to checkout :doc:`api` for securing the API.
 
 .. note::
 
-   Airflow uses the config parser of Python. This config parser interpolates '%'-signs.
-   Make sure not to have those in your passwords if they do not make sense, otherwise
-   Airflow might leak these passwords on a config parser exception to a log.
+   Airflow uses the config parser of Python. This config parser interpolates
+   '%'-signs.  Make sure escape any ``%`` signs in your config file (but not
+   environment variables) as ``%%``, otherwise Airflow might leak these
+   passwords on a config parser exception to a log.
 
 Web Authentication
 ------------------

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -24,9 +24,6 @@ set -x
 export AIRFLOW_HOME=${AIRFLOW_HOME:=~}
 export AIRFLOW__CORE__UNIT_TEST_MODE=True
 
-# configuration test
-export AIRFLOW__TESTSECTION__TESTKEY=testvalue
-
 # add test/contrib to PYTHONPATH
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export PYTHONPATH=$PYTHONPATH:${DIR}/tests/test_utils

--- a/scripts/ci/5-run-tests.sh
+++ b/scripts/ci/5-run-tests.sh
@@ -45,9 +45,6 @@ echo Backend: $AIRFLOW__CORE__SQL_ALCHEMY_CONN
 export AIRFLOW_HOME=${AIRFLOW_HOME:=~}
 export AIRFLOW__CORE__UNIT_TEST_MODE=True
 
-# configuration test
-export AIRFLOW__TESTSECTION__TESTKEY=testvalue
-
 # any argument received is overriding the default nose execution arguments:
 nose_args=$@
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-3178  

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

To have a `%` appear in the config file, it needs to appear as `%%`. However the way we were generating the temporary config for `airflow run` it would loose that escaping and cause a config error.

This fixes the way we generate that temp config by using methods built-in to ConfigParser to get the raw values (rather than grubbing around with `deepcopy()`). I have left this PR as three individual commits as I think it will be easier to review in it's current form. 

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
