### PR TITLE
[AIRFLOW-3361] Log the task_id in the PendingDeprecationWarning for BaseOperator

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2499,7 +2499,8 @@ class BaseOperator(LoggingMixin):
                 'Airflow 2.0. Invalid arguments were:'
                 '\n*args: {a}\n**kwargs: {k}'.format(
                     c=self.__class__.__name__, a=args, k=kwargs, t=task_id),
-                category=PendingDeprecationWarning
+                category=PendingDeprecationWarning,
+                stacklevel=3
             )
 
         validate_key(task_id)

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2494,11 +2494,11 @@ class BaseOperator(LoggingMixin):
         if args or kwargs:
             # TODO remove *args and **kwargs in Airflow 2.0
             warnings.warn(
-                'Invalid arguments were passed to {c}. Support for '
-                'passing such arguments will be dropped in Airflow 2.0. '
-                'Invalid arguments were:'
+                'Invalid arguments were passed to {c} (task_id: {t}). '
+                'Support for passing such arguments will be dropped in '
+                'Airflow 2.0. Invalid arguments were:'
                 '\n*args: {a}\n**kwargs: {k}'.format(
-                    c=self.__class__.__name__, a=args, k=kwargs),
+                    c=self.__class__.__name__, a=args, k=kwargs, t=task_id),
                 category=PendingDeprecationWarning
             )
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -443,7 +443,8 @@ class CoreTest(unittest.TestCase):
             self.assertTrue(
                 issubclass(w[0].category, PendingDeprecationWarning))
             self.assertIn(
-                'Invalid arguments were passed to BashOperator.',
+                ('Invalid arguments were passed to BashOperator '
+                 '(task_id: test_illegal_args).'),
                 w[0].message.args[0])
 
     def test_bash_operator(self):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the [Airflow-3361](https://issues.apache.org/jira/browse/AIRFLOW-3361) issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In 2.0 passing invalid keywords to `BaseOperator` will be deprecated. Prior to that, there is a `PendingDeprecationWarning` raised, however it can be hard to track down which specific task is raising this warning. This PR adds the `task_id` to aid this.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
