### PR TITLE
[AIRFLOW-2636] - fix task duration tab NoneType exception

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1653,8 +1653,9 @@ class Airflow(BaseView):
 
         fails_totals = defaultdict(int)
         for tf in ti_fails:
-            dict_key = (tf.dag_id, tf.task_id, tf.execution_date)
-            fails_totals[dict_key] += tf.duration
+            if tf.duration:
+                dict_key = (tf.dag_id, tf.task_id, tf.execution_date)
+                fails_totals[dict_key] += tf.duration
 
         for ti in tis:
             if ti.duration:


### PR DESCRIPTION
### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2636

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
There was a NoneType exception when the task failure duration was null in the database that was causing the duration page to not load. I added a null check so that the page now loads.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
I tested this in the Stripe fork of Airflow and it fixes this issue.

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
