### PR TITLE
[AIRFLOW-1970] Let empty Fernet key or special `no encryption` phrase.

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -57,12 +57,9 @@ def generate_fernet_key():
     try:
         from cryptography.fernet import Fernet
     except ImportError:
-        pass
-    try:
-        key = Fernet.generate_key().decode()
-    except NameError:
-        key = "cryptography_not_found_storing_passwords_in_plain_text"
-    return key
+        return ''
+    else:
+        return Fernet.generate_key().decode()
 
 
 def expand_env_var(env_var):

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -151,8 +151,6 @@ def get_fernet():
     """
     global _fernet
     log = LoggingMixin().log
-    no_encryption_phrase = \
-        'cryptography_not_found_storing_passwords_in_plain_text'
 
     if _fernet:
         return _fernet
@@ -163,14 +161,14 @@ def get_fernet():
 
     except BuiltinImportError:
         log.warning(
-            "cryptography not found - values will not be stored encrypted.",
-            exc_info=1
+            "cryptography not found - values will not be stored encrypted."
         )
         _fernet = NullFernet()
+        return _fernet
 
     try:
         fernet_key = configuration.conf.get('core', 'FERNET_KEY')
-        if not fernet_key or fernet_key == no_encryption_phrase:
+        if not fernet_key:
             log.warning(
                 "empty cryptography key - values will not be stored encrypted."
             )

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -150,6 +150,10 @@ def get_fernet():
     :raises: AirflowException if there's a problem trying to load Fernet
     """
     global _fernet
+    log = LoggingMixin().log
+    no_encryption_phrase = \
+        'cryptography_not_found_storing_passwords_in_plain_text'
+
     if _fernet:
         return _fernet
     try:
@@ -158,18 +162,26 @@ def get_fernet():
         InvalidFernetToken = InvalidToken
 
     except BuiltinImportError:
-        LoggingMixin().log.warn("cryptography not found - values will not be stored "
-                                "encrypted.",
-                                exc_info=1)
+        log.warning(
+            "cryptography not found - values will not be stored encrypted.",
+            exc_info=1
+        )
         _fernet = NullFernet()
-        return _fernet
 
     try:
-        _fernet = Fernet(configuration.conf.get('core', 'FERNET_KEY').encode('utf-8'))
-        _fernet.is_encrypted = True
-        return _fernet
+        fernet_key = configuration.conf.get('core', 'FERNET_KEY')
+        if not fernet_key or fernet_key == no_encryption_phrase:
+            log.warning(
+                "empty cryptography key - values will not be stored encrypted."
+            )
+            _fernet = NullFernet()
+        else:
+            _fernet = Fernet(fernet_key.encode('utf-8'))
+            _fernet.is_encrypted = True
     except (ValueError, TypeError) as ve:
         raise AirflowException("Could not create Fernet object: {}".format(ve))
+
+    return _fernet
 
 
 # Used by DAG context_managers

--- a/docs/howto/secure-connections.rst
+++ b/docs/howto/secure-connections.rst
@@ -4,13 +4,14 @@ Securing Connections
 By default, Airflow will save the passwords for the connection in plain text
 within the metadata database. The ``crypto`` package is highly recommended
 during installation. The ``crypto`` package does require that your operating
-system have libffi-dev installed.
+system has ``libffi-dev`` installed.
 
-If ``crypto`` package was not installed initially, you can still enable encryption for
-connections by following steps below:
+If ``crypto`` package was not installed initially, it means that your Fernet key in ``airflow.cfg`` is empty.
+
+You can still enable encryption for passwords within connections by following below steps:
 
 1. Install crypto package ``pip install apache-airflow[crypto]``
-2. Generate fernet_key, using this code snippet below. fernet_key must be a base64-encoded 32-byte key.
+2. Generate fernet_key, using this code snippet below. ``fernet_key`` must be a base64-encoded 32-byte key.
 
 .. code:: python
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -2786,7 +2786,6 @@ class ConnectionTest(unittest.TestCase):
         is set to a non-base64-encoded string and the extra is stored without
         encryption.
         """
-        mock_get.return_value = 'cryptography_not_found_storing_passwords_in_plain_text'
         test_connection = Connection(extra='testextra')
         self.assertEqual(test_connection.extra, 'testextra')
 


### PR DESCRIPTION
### Jira

My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-1970) issues and references them in the PR title. 

### Description

Once the user has installed Fernet package then the application enforces setting valid Fernet key.
This change will alter this behavior into letting empty Fernet key or special `no encryption` phrase and interpreting those two cases as no encryption desirable.

### Tests

My PR adds no tests as of now.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
