### PR TITLE
[AIRFLOW-3193] Pin docker requirement version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,7 @@ doc = [
     'sphinx-rtd-theme>=0.1.6',
     'Sphinx-PyPI-upload>=0.2.1'
 ]
-docker = ['docker>=2.0.0']
+docker = ['docker>=2.0.0,<3.0.0']
 druid = ['pydruid>=0.4.1']
 elasticsearch = [
     'elasticsearch>=5.0.0,<6.0.0',


### PR DESCRIPTION
The method "create_container" in APIClient of docker has been
incompatible from version 3.0.0.

### Jira
  - https://issues.apache.org/jira/browse/AIRFLOW-3193
