### PR TITLE
[AIRFLOW-3174] Refine Docstring for SQL Operators & Hooks

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -191,6 +191,7 @@ class DbApiHook(BaseHook):
         Return True if conn.autocommit is set to True.
         Return False if conn.autocommit is not set or set to False or conn
         does not support autocommit.
+
         :param conn: Connection to get autocommit setting from.
         :type conn: connection object.
         :return: connection autocommit setting.

--- a/airflow/hooks/mysql_hook.py
+++ b/airflow/hooks/mysql_hook.py
@@ -49,6 +49,7 @@ class MySqlHook(DbApiHook):
     def get_autocommit(self, conn):
         """
         MySql connection gets autocommit in a different way.
+
         :param conn: connection to get autocommit setting from.
         :type conn: connection object.
         :return: connection autocommit setting

--- a/airflow/operators/jdbc_operator.py
+++ b/airflow/operators/jdbc_operator.py
@@ -28,12 +28,17 @@ class JdbcOperator(BaseOperator):
 
     Requires jaydebeapi.
 
-    :param jdbc_conn_id: reference to a predefined database
-    :type jdbc_conn_id: str
     :param sql: the sql code to be executed. (templated)
     :type sql: Can receive a str representing a sql statement,
         a list of str (sql statements), or reference to a template file.
         Template reference are recognized by str ending in '.sql'
+    :param jdbc_conn_id: reference to a predefined database
+    :type jdbc_conn_id: str
+    :param autocommit: if True, each command is automatically committed.
+        (default value: False)
+    :type autocommit: bool
+    :param parameters: (optional) the parameters to render the SQL query with.
+    :type parameters: mapping or iterable
     """
 
     template_fields = ('sql',)

--- a/airflow/operators/mssql_operator.py
+++ b/airflow/operators/mssql_operator.py
@@ -26,11 +26,16 @@ class MsSqlOperator(BaseOperator):
     """
     Executes sql code in a specific Microsoft SQL database
 
-    :param mssql_conn_id: reference to a specific mssql database
-    :type mssql_conn_id: str
     :param sql: the sql code to be executed
     :type sql: str or string pointing to a template file with .sql
         extension. (templated)
+    :param mssql_conn_id: reference to a specific mssql database
+    :type mssql_conn_id: str
+    :param parameters: (optional) the parameters to render the SQL query with.
+    :type parameters: mapping or iterable
+    :param autocommit: if True, each command is automatically committed.
+        (default value: False)
+    :type autocommit: bool
     :param database: name of database which overwrite defined one in connection
     :type database: str
     """

--- a/airflow/operators/mysql_operator.py
+++ b/airflow/operators/mysql_operator.py
@@ -26,12 +26,17 @@ class MySqlOperator(BaseOperator):
     """
     Executes sql code in a specific MySQL database
 
-    :param mysql_conn_id: reference to a specific mysql database
-    :type mysql_conn_id: str
     :param sql: the sql code to be executed. (templated)
     :type sql: Can receive a str representing a sql statement,
         a list of str (sql statements), or reference to a template file.
         Template reference are recognized by str ending in '.sql'
+    :param mysql_conn_id: reference to a specific mysql database
+    :type mysql_conn_id: str
+    :param parameters: (optional) the parameters to render the SQL query with.
+    :type parameters: mapping or iterable
+    :param autocommit: if True, each command is automatically committed.
+        (default value: False)
+    :type autocommit: bool
     :param database: name of database which overwrite defined one in connection
     :type database: str
     """

--- a/airflow/operators/oracle_operator.py
+++ b/airflow/operators/oracle_operator.py
@@ -26,12 +26,17 @@ class OracleOperator(BaseOperator):
     """
     Executes sql code in a specific Oracle database
 
-    :param oracle_conn_id: reference to a specific Oracle database
-    :type oracle_conn_id: str
     :param sql: the sql code to be executed. (templated)
     :type sql: Can receive a str representing a sql statement,
         a list of str (sql statements), or reference to a template file.
         Template reference are recognized by str ending in '.sql'
+    :param oracle_conn_id: reference to a specific Oracle database
+    :type oracle_conn_id: str
+    :param parameters: (optional) the parameters to render the SQL query with.
+    :type parameters: mapping or iterable
+    :param autocommit: if True, each command is automatically committed.
+        (default value: False)
+    :type autocommit: bool
     """
 
     template_fields = ('sql',)

--- a/airflow/operators/postgres_operator.py
+++ b/airflow/operators/postgres_operator.py
@@ -25,12 +25,17 @@ class PostgresOperator(BaseOperator):
     """
     Executes sql code in a specific Postgres database
 
-    :param postgres_conn_id: reference to a specific postgres database
-    :type postgres_conn_id: str
     :param sql: the sql code to be executed. (templated)
     :type sql: Can receive a str representing a sql statement,
         a list of str (sql statements), or reference to a template file.
         Template reference are recognized by str ending in '.sql'
+    :param postgres_conn_id: reference to a specific postgres database
+    :type postgres_conn_id: str
+    :param autocommit: if True, each command is automatically committed.
+        (default value: False)
+    :type autocommit: bool
+    :param parameters: (optional) the parameters to render the SQL query with.
+    :type parameters: mapping or iterable
     :param database: name of database which overwrite defined one in connection
     :type database: str
     """

--- a/airflow/operators/sqlite_operator.py
+++ b/airflow/operators/sqlite_operator.py
@@ -26,11 +26,13 @@ class SqliteOperator(BaseOperator):
     """
     Executes sql code in a specific Sqlite database
 
-    :param sqlite_conn_id: reference to a specific sqlite database
-    :type sqlite_conn_id: str
     :param sql: the sql code to be executed. (templated)
     :type sql: str or string pointing to a template file. File must have
         a '.sql' extensions.
+    :param sqlite_conn_id: reference to a specific sqlite database
+    :type sqlite_conn_id: str
+    :param parameters: (optional) the parameters to render the SQL query with.
+    :type parameters: mapping or iterable
     """
 
     template_fields = ('sql',)


### PR DESCRIPTION
### JIRA
  https://issues.apache.org/jira/browse/AIRFLOW-3174

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

- These SQL operators (based on `DbApiHook`) receive `sql` and `parameters` (optional) as arguments. But `parameters` were not documented. The contents I added is based on the docstring in https://github.com/apache/incubator-airflow/blob/master/airflow/hooks/dbapi_hook.py#L88

- Fixed two minor style errors which would cause incorrect documentation rendering

- Added docstring for `autocommit` parameter in relevant operators. The content is based on https://db.apache.org/derby/docs/10.9/devguide/cdevconcepts29416.html and https://www.postgresql.org/docs/9.1/static/ecpg-commands.html

- Adjusted order or docstring items to make sure they are consistent with the order of arguments.

