### PR TITLE
[AIRFLOW-3197] EMRHook is missing new parameters of the AWS API

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -72,6 +72,16 @@ then you need to change it like this
     def is_active(self):
       return self.active
 
+### EMRHook now passes all of connection's extra to CreateJobFlow API
+
+EMRHook.create_job_flow has been changed to pass all keys to the create_job_flow API, rather than
+just specific known keys for greater flexibility.
+
+However prior to this release the "emr_default" sample connection that was created had invalid
+configuration, so creating EMR clusters might fail until your connection is updated. (Ec2KeyName,
+Ec2SubnetId, TerminationProtection and KeepJobFlowAliveWhenNoSteps were all top-level keys when they
+should be inside the "Instances" dict)
+
 ## Airflow 1.10
 
 Installation and upgrading requires setting `SLUGIFY_USES_TEXT_UNIDECODE=yes` in your environment or

--- a/airflow/contrib/hooks/emr_hook.py
+++ b/airflow/contrib/hooks/emr_hook.py
@@ -23,7 +23,7 @@ from airflow.contrib.hooks.aws_hook import AwsHook
 
 class EmrHook(AwsHook):
     """
-    Interact with AWS EMR. emr_conn_id is only necessary for using the
+    Interact with AWS EMR. emr_conn_id is only neccessary for using the
     create_job_flow method.
     """
 
@@ -51,19 +51,6 @@ class EmrHook(AwsHook):
         config = emr_conn.extra_dejson.copy()
         config.update(job_flow_overrides)
 
-        response = self.get_conn().run_job_flow(
-            Name=config.get('Name'),
-            LogUri=config.get('LogUri'),
-            ReleaseLabel=config.get('ReleaseLabel'),
-            Instances=config.get('Instances'),
-            Steps=config.get('Steps', []),
-            BootstrapActions=config.get('BootstrapActions', []),
-            Applications=config.get('Applications'),
-            Configurations=config.get('Configurations', []),
-            VisibleToAllUsers=config.get('VisibleToAllUsers'),
-            JobFlowRole=config.get('JobFlowRole'),
-            ServiceRole=config.get('ServiceRole'),
-            Tags=config.get('Tags')
-        )
+        response = self.get_conn().run_job_flow(**config)
 
         return response

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -222,6 +222,8 @@ def initdb(rbac=False):
                     "LogUri": "s3://my-emr-log-bucket/default_job_flow_location",
                     "ReleaseLabel": "emr-4.6.0",
                     "Instances": {
+                        "Ec2KeyName": "mykey",
+                        "Ec2SubnetId": "somesubnet",
                         "InstanceGroups": [
                             {
                                 "Name": "Master nodes",
@@ -237,12 +239,10 @@ def initdb(rbac=False):
                                 "InstanceType": "r3.2xlarge",
                                 "InstanceCount": 1
                             }
-                        ]
+                        ],
+                        "TerminationProtected": false,
+                        "KeepJobFlowAliveWhenNoSteps": false
                     },
-                    "Ec2KeyName": "mykey",
-                    "KeepJobFlowAliveWhenNoSteps": false,
-                    "TerminationProtected": false,
-                    "Ec2SubnetId": "somesubnet",
                     "Applications":[
                         { "Name": "Spark" }
                     ],

--- a/tests/contrib/hooks/test_emr_hook.py
+++ b/tests/contrib/hooks/test_emr_hook.py
@@ -31,28 +31,49 @@ except ImportError:
     mock_emr = None
 
 
+@unittest.skipIf(mock_emr is None, 'moto package not present')
 class TestEmrHook(unittest.TestCase):
     @mock_emr
     def setUp(self):
         configuration.load_test_config()
 
-    @unittest.skipIf(mock_emr is None, 'mock_emr package not present')
     @mock_emr
     def test_get_conn_returns_a_boto3_connection(self):
         hook = EmrHook(aws_conn_id='aws_default')
         self.assertIsNotNone(hook.get_conn().list_clusters())
 
-    @unittest.skipIf(mock_emr is None, 'mock_emr package not present')
     @mock_emr
     def test_create_job_flow_uses_the_emr_config_to_create_a_cluster(self):
         client = boto3.client('emr', region_name='us-east-1')
-        if len(client.list_clusters()['Clusters']):
-            raise ValueError('AWS not properly mocked')
 
         hook = EmrHook(aws_conn_id='aws_default', emr_conn_id='emr_default')
         cluster = hook.create_job_flow({'Name': 'test_cluster'})
 
-        self.assertEqual(client.list_clusters()['Clusters'][0]['Id'], cluster['JobFlowId'])
+        self.assertEqual(client.list_clusters()['Clusters'][0]['Id'],
+                         cluster['JobFlowId'])
+
+    @mock_emr
+    def test_create_job_flow_extra_args(self):
+        """
+        Test that we can add extra arguments to the launch call.
+
+        This is useful for when AWS add new options, such as
+        "SecurityConfiguration" so that we don't have to change our code
+        """
+        client = boto3.client('emr', region_name='us-east-1')
+
+        hook = EmrHook(aws_conn_id='aws_default', emr_conn_id='emr_default')
+        # AmiVersion is really old and almost no one will use it anymore, but
+        # it's one of the "optional" request params that moto supports - it's
+        # coverage of EMR isn't 100% it turns out.
+        cluster = hook.create_job_flow({'Name': 'test_cluster',
+                                        'ReleaseLabel': '',
+                                        'AmiVersion': '3.2'})
+
+        cluster = client.describe_cluster(ClusterId=cluster['JobFlowId'])['Cluster']
+
+        # The AmiVersion comes back as {Requested,Running}AmiVersion fields.
+        self.assertEqual(cluster['RequestedAmiVersion'], '3.2')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-3197
 
### Description

- [x] Allow passing any params to the CreateJobFlow API, so that we don't have
to stay up to date with AWS api changes.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
