### PR TITLE
[AIRFLOW-3202] add missing documentation for AWS hooks/operator

### DIFF
--- a/docs/code.rst
+++ b/docs/code.rst
@@ -378,6 +378,7 @@ Community contributed hooks
 .. autoclass:: airflow.contrib.hooks.aws_dynamodb_hook.AwsDynamoDBHook
 .. autoclass:: airflow.contrib.hooks.aws_hook.AwsHook
 .. autoclass:: airflow.contrib.hooks.aws_lambda_hook.AwsLambdaHook
+.. autoclass:: airflow.contrib.hooks.aws_firehose_hook.AwsFirehoseHook
 .. autoclass:: airflow.contrib.hooks.azure_data_lake_hook.AzureDataLakeHook
 .. autoclass:: airflow.contrib.hooks.azure_fileshare_hook.AzureFileShareHook
 .. autoclass:: airflow.contrib.hooks.bigquery_hook.BigQueryHook

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -313,6 +313,49 @@ S3ToRedshiftTransfer
 
 .. autoclass:: airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer
 
+AWS DynamoDB
+''''''''
+
+- :ref:`HiveToDynamoDBTransferOperator` :  Moves data from Hive to DynamoDB.
+- :ref:`AwsDynamoDBHook` : Interact with AWS DynamoDB.
+
+.. _HiveToDynamoDBTransferOperator:
+
+HiveToDynamoDBTransferOperator
+"""""""""""""""""""
+
+.. autoclass:: airflow.contrib.operators.hive_to_dynamodb.HiveToDynamoDBTransferOperator
+
+.. _AwsDynamoDBHook:
+
+AwsDynamoDBHook
+"""""""
+
+.. autoclass:: airflow.contrib.hooks.aws_dynamodb_hook.AwsDynamoDBHook
+
+AWS Lambda
+''''''''
+
+- :ref:`AwsLambdaHook` : Interact with AWS Lambda.
+
+.. _AwsLambdaHook:
+
+AwsLambdaHook
+"""""""
+
+.. autoclass:: airflow.contrib.hooks.aws_lambda_hook.AwsLambdaHook
+
+AWS Kinesis
+''''''''
+
+- :ref:`AwsFirehoseHook` : Interact with AWS Kinesis Firehose.
+
+.. _AwsFirehoseHook:
+
+AwsFirehoseHook
+"""""""
+
+.. autoclass:: airflow.contrib.hooks.aws_firehose_hook.AwsFirehoseHook
 
 .. _Databricks:
 

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -314,7 +314,7 @@ S3ToRedshiftTransfer
 .. autoclass:: airflow.operators.s3_to_redshift_operator.S3ToRedshiftTransfer
 
 AWS DynamoDB
-''''''''
+''''''''''''
 
 - :ref:`HiveToDynamoDBTransferOperator` :  Moves data from Hive to DynamoDB.
 - :ref:`AwsDynamoDBHook` : Interact with AWS DynamoDB.
@@ -322,38 +322,38 @@ AWS DynamoDB
 .. _HiveToDynamoDBTransferOperator:
 
 HiveToDynamoDBTransferOperator
-"""""""""""""""""""
+""""""""""""""""""""""""""""""
 
 .. autoclass:: airflow.contrib.operators.hive_to_dynamodb.HiveToDynamoDBTransferOperator
 
 .. _AwsDynamoDBHook:
 
 AwsDynamoDBHook
-"""""""
+"""""""""""""""
 
 .. autoclass:: airflow.contrib.hooks.aws_dynamodb_hook.AwsDynamoDBHook
 
 AWS Lambda
-''''''''
+''''''''''
 
 - :ref:`AwsLambdaHook` : Interact with AWS Lambda.
 
 .. _AwsLambdaHook:
 
 AwsLambdaHook
-"""""""
+"""""""""""""
 
 .. autoclass:: airflow.contrib.hooks.aws_lambda_hook.AwsLambdaHook
 
 AWS Kinesis
-''''''''
+'''''''''''
 
 - :ref:`AwsFirehoseHook` : Interact with AWS Kinesis Firehose.
 
 .. _AwsFirehoseHook:
 
 AwsFirehoseHook
-"""""""
+"""""""""""""""
 
 .. autoclass:: airflow.contrib.hooks.aws_firehose_hook.AwsFirehoseHook
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3202
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `flake8`
