### PR TITLE
[AIRFLOW-3216] HiveServer2Hook need a password with LDAP authentication

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -787,7 +787,7 @@ class HiveServer2Hook(BaseHook):
             auth=auth_mechanism,
             kerberos_service_name=kerberos_service_name,
             username=db.login or username,
-            password=db.password or password,
+            password=db.password,
             database=schema or db.schema or 'default')
 
     def _get_results(self, hql, schema='default', fetch_size=None, hive_conf=None):

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -787,6 +787,7 @@ class HiveServer2Hook(BaseHook):
             auth=auth_mechanism,
             kerberos_service_name=kerberos_service_name,
             username=db.login or username,
+            password=db.password or password,
             database=schema or db.schema or 'default')
 
     def _get_results(self, hql, schema='default', fetch_size=None, hive_conf=None):

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -403,6 +403,18 @@ class TestHiveServer2Hook(unittest.TestCase):
         hook = HiveServer2Hook()
         hook.get_conn()
 
+    def test_get_conn_with_password(self):
+        from airflow.hooks.base_hook import CONN_ENV_PREFIX
+        conn_id = "conn_with_password"
+        conn_env = CONN_ENV_PREFIX + conn_id.upper()
+        conn_value = os.getenv(conn_env)
+        os.putenv(conn_env, "http://conn_id@conn_pass:address.com:port")
+
+        hook = HiveServer2Hook(hiveserver2_conn_id=conn_id)
+        self.assertEqual(hook.get_conn().password, 'conn_pass')
+
+        os.putenv(conn_env, conn_value)
+
     def test_get_records(self):
         hook = HiveServer2Hook()
         query = "SELECT * FROM {}".format(self.table)


### PR DESCRIPTION
### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-3216

### Description

- [x] To use HiveServer2Hook under LDAP environment, authentication information should be passed to `pyhive` while creating a connection. It missed.

### Tests

- [x] This change is quite simple and I've tested it in my own environment with LDAP

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
