### PR TITLE
[AIRFLOW-3218] add support for poking a whole DAG

### DIFF
--- a/airflow/sensors/external_task_sensor.py
+++ b/airflow/sensors/external_task_sensor.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow.models import TaskInstance
+from airflow.models import TaskInstance, DagRun
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.db import provide_session
 from airflow.utils.decorators import apply_defaults
@@ -26,18 +26,18 @@ from airflow.utils.state import State
 
 class ExternalTaskSensor(BaseSensorOperator):
     """
-    Waits for a task to complete in a different DAG
+    Waits for a different DAG or a task in in a different DAG to complete
 
     :param external_dag_id: The dag_id that contains the task you want to
         wait for
     :type external_dag_id: str
     :param external_task_id: The task_id that contains the task you want to
-        wait for
+        wait for. If ``None`` the sensor waits for the DAG
     :type external_task_id: str
     :param allowed_states: list of allowed states, default is ``['success']``
     :type allowed_states: list
     :param execution_delta: time difference with the previous execution to
-        look at, the default is the same execution_date as the current task.
+        look at, the default is the same execution_date as the current task or DAG.
         For yesterday, use [positive!] datetime.timedelta(days=1). Either
         execution_delta or execution_date_fn can be passed to
         ExternalTaskSensor, but not both.
@@ -89,13 +89,23 @@ class ExternalTaskSensor(BaseSensorOperator):
             '{self.external_dag_id}.'
             '{self.external_task_id} on '
             '{} ... '.format(serialized_dttm_filter, **locals()))
-        TI = TaskInstance
 
-        count = session.query(TI).filter(
-            TI.dag_id == self.external_dag_id,
-            TI.task_id == self.external_task_id,
-            TI.state.in_(self.allowed_states),
-            TI.execution_date.in_(dttm_filter),
-        ).count()
+        if self.external_task_id:
+            TI = TaskInstance
+
+            count = session.query(TI).filter(
+                TI.dag_id == self.external_dag_id,
+                TI.task_id == self.external_task_id,
+                TI.state.in_(self.allowed_states),
+                TI.execution_date.in_(dttm_filter),
+            ).count()
+        else:
+            DR = DagRun
+            count = session.query(DR).filter(
+                DR.dag_id == self.external_dag_id,
+                DR.state.in_(self.allowed_states),
+                DR.execution_date.in_(dttm_filter),
+            ).count()
+
         session.commit()
         return count == len(dttm_filter)

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -161,7 +161,7 @@ exit 0
                 TI.state == State.FAILED,
                 TI.execution_date == DEFAULT_DATE + timedelta(seconds=1)).all()
             if len(failed_tis) == 1 and \
-                failed_tis[0].task_id == 'task_external_with_failure':
+               failed_tis[0].task_id == 'task_external_with_failure':
                 pass
             else:
                 raise e

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -79,11 +79,13 @@ class ExternalTaskSensorTests(unittest.TestCase):
         other_dag = DAG(
             'other_dag',
             default_args=self.args,
-            start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE,
             schedule_interval='@once')
-        d = DummyOperator(dag=other_dag, task_id='dummy')
-        d.run()
+        other_dag.create_dagrun(
+            run_id='test',
+            start_date=DEFAULT_DATE,
+            execution_date=DEFAULT_DATE,
+            state=State.SUCCESS)
         t = ExternalTaskSensor(
             task_id='test_external_dag_sensor_check',
             external_dag_id='other_dag',

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -75,6 +75,20 @@ class ExternalTaskSensorTests(unittest.TestCase):
             ignore_ti_state=True
         )
 
+    def test_external_dag_sensor(self):
+        self.test_time_sensor()
+        t = ExternalTaskSensor(
+            task_id='test_external_task_sensor_check',
+            external_dag_id=TEST_DAG_ID,
+            external_task_id=None,
+            dag=self.dag
+        )
+        t.run(
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
+            ignore_ti_state=True
+        )
+
     def test_templated_sensor(self):
         dag = DAG(TEST_DAG_ID, self.args)
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following 
  - https://issues.apache.org/jira/browse/AIRFLOW-3218

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Currently external task sensor requires a specific task to finish. This change adds support for DAG level checks, if task ID is not provided

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

``test_external_dag_sensor``

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [X] Passes `flake8`
