### PR TITLE
[AIRFLOW-3222] Remove bql keyword from BigQueryOperator

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -480,7 +480,6 @@ class BigQueryBaseCursor(LoggingMixin):
             )
 
     def run_query(self,
-                  bql=None,
                   sql=None,
                   destination_dataset_table=None,
                   write_disposition='WRITE_EMPTY',
@@ -506,9 +505,6 @@ class BigQueryBaseCursor(LoggingMixin):
 
         For more details about these parameters.
 
-        :param bql: (Deprecated. Use `sql` parameter instead) The BigQuery SQL
-            to execute.
-        :type bql: str
         :param sql: The BigQuery SQL to execute.
         :type sql: str
         :param destination_dataset_table: The dotted <dataset>.<table>
@@ -582,19 +578,6 @@ class BigQueryBaseCursor(LoggingMixin):
         else:
             _validate_value("api_resource_configs['query']",
                             configuration['query'], dict)
-
-        sql = bql if sql is None else sql
-
-        # TODO remove `bql` in Airflow 2.0 - Jira: [AIRFLOW-2513]
-        if bql:
-            import warnings
-            warnings.warn('Deprecated parameter `bql` used in '
-                          '`BigQueryBaseCursor.run_query` '
-                          'Use `sql` parameter instead to pass the sql to be '
-                          'executed. `bql` parameter is deprecated and '
-                          'will be removed in a future version of '
-                          'Airflow.',
-                          category=DeprecationWarning)
 
         if sql is None and not configuration['query'].get('query', None):
             raise TypeError('`BigQueryBaseCursor.run_query` '

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -29,11 +29,6 @@ class BigQueryOperator(BaseOperator):
     """
     Executes BigQuery SQL queries in a specific BigQuery database
 
-    :param bql: (Deprecated. Use `sql` parameter instead) the sql code to be
-        executed (templated)
-    :type bql: Can receive a str representing a sql statement,
-        a list of str (sql statements), or reference to a template file.
-        Template reference are recognized by str ending in '.sql'.
     :param sql: the sql code to be executed (templated)
     :type sql: Can receive a str representing a sql statement,
         a list of str (sql statements), or reference to a template file.
@@ -104,13 +99,12 @@ class BigQueryOperator(BaseOperator):
     :type cluster_fields: list of str
     """
 
-    template_fields = ('bql', 'sql', 'destination_dataset_table', 'labels')
+    template_fields = ('sql', 'destination_dataset_table', 'labels')
     template_ext = ('.sql', )
     ui_color = '#e4f0e8'
 
     @apply_defaults
     def __init__(self,
-                 bql=None,
                  sql=None,
                  destination_dataset_table=False,
                  write_disposition='WRITE_EMPTY',
@@ -133,8 +127,7 @@ class BigQueryOperator(BaseOperator):
                  *args,
                  **kwargs):
         super(BigQueryOperator, self).__init__(*args, **kwargs)
-        self.bql = bql
-        self.sql = sql if sql else bql
+        self.sql = sql
         self.destination_dataset_table = destination_dataset_table
         self.write_disposition = write_disposition
         self.create_disposition = create_disposition
@@ -156,16 +149,6 @@ class BigQueryOperator(BaseOperator):
         if api_resource_configs is None:
             self.api_resource_configs = {}
         self.cluster_fields = cluster_fields
-
-        # TODO remove `bql` in Airflow 2.0
-        if self.bql:
-            import warnings
-            warnings.warn('Deprecated parameter `bql` used in Task id: {}. '
-                          'Use `sql` parameter instead to pass the sql to be '
-                          'executed. `bql` parameter is deprecated and '
-                          'will be removed in a future version of '
-                          'Airflow.'.format(self.task_id),
-                          category=DeprecationWarning)
 
         if self.sql is None:
             raise TypeError('{} missing 1 required positional '

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -19,7 +19,6 @@
 #
 
 import unittest
-import warnings
 
 from google.auth.exceptions import GoogleAuthError
 import mock
@@ -207,16 +206,6 @@ def mock_job_cancel(projectId, jobId):
 
 
 class TestBigQueryBaseCursor(unittest.TestCase):
-    def test_bql_deprecation_warning(self):
-        with warnings.catch_warnings(record=True) as w:
-            hook.BigQueryBaseCursor("test", "test").run_query(
-                bql='select * from test_table'
-            )
-            yield
-        self.assertIn(
-            'Deprecated parameter `bql`',
-            w[0].message.args[0])
-
     def test_invalid_schema_update_options(self):
         with self.assertRaises(Exception) as context:
             hook.BigQueryBaseCursor("test", "test").run_load(
@@ -226,16 +215,6 @@ class TestBigQueryBaseCursor(unittest.TestCase):
                 schema_update_options=["THIS IS NOT VALID"]
             )
         self.assertIn("THIS IS NOT VALID", str(context.exception))
-
-    def test_nobql_nosql_param_error(self):
-        with self.assertRaises(TypeError) as context:
-            hook.BigQueryBaseCursor("test", "test").run_query(
-                sql=None,
-                bql=None
-            )
-        self.assertIn(
-            'missing 1 required positional',
-            str(context.exception))
 
     def test_invalid_schema_update_and_write_disposition(self):
         with self.assertRaises(Exception) as context:

--- a/tests/contrib/operators/test_bigquery_operator.py
+++ b/tests/contrib/operators/test_bigquery_operator.py
@@ -18,11 +18,9 @@
 # under the License.
 
 import unittest
-import warnings
 
 from airflow.contrib.operators.bigquery_operator import \
-    BigQueryCreateExternalTableOperator, \
-    BigQueryOperator, BigQueryCreateEmptyTableOperator, \
+    BigQueryCreateExternalTableOperator, BigQueryCreateEmptyTableOperator, \
     BigQueryDeleteDatasetOperator, BigQueryCreateEmptyDatasetOperator
 
 try:
@@ -40,18 +38,6 @@ TEST_TABLE_ID = 'test-table-id'
 TEST_GCS_BUCKET = 'test-bucket'
 TEST_GCS_DATA = ['dir1/*.csv']
 TEST_SOURCE_FORMAT = 'CSV'
-
-
-class BigQueryOperatorTest(unittest.TestCase):
-    def test_bql_deprecation_warning(self):
-        with warnings.catch_warnings(record=True) as w:
-            BigQueryOperator(
-                task_id='test_deprecation_warning_for_bql',
-                bql='select * from test_table'
-            )
-        self.assertIn(
-            'Deprecated parameter `bql`',
-            w[0].message.args[0])
 
 
 class BigQueryCreateEmptyTableOperatorTest(unittest.TestCase):


### PR DESCRIPTION
Will be removed in Apache Airflow 2.0

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-3222\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3222
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-3222\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `flake8`
