### PR TITLE
[AIRFLOW-2799] Fix filtering UI objects by datetime

### DIFF
--- a/airflow/utils/timezone.py
+++ b/airflow/utils/timezone.py
@@ -164,9 +164,9 @@ def datetime(*args, **kwargs):
     return dt.datetime(*args, **kwargs)
 
 
-def parse(string):
+def parse(string, timezone=None):
     """
     Parse a time string and return an aware datetime
     :param string: time string
     """
-    return pendulum.parse(string, tz=TIMEZONE)
+    return pendulum.parse(string, tz=timezone or TIMEZONE)

--- a/airflow/www_rbac/utils.py
+++ b/airflow/www_rbac/utils.py
@@ -37,7 +37,10 @@ from past.builtins import basestring
 from pygments import highlight, lexers
 from pygments.formatters import HtmlFormatter
 from flask import request, Response, Markup, url_for
-from airflow import configuration
+from flask_appbuilder.models.sqla.interface import SQLAInterface
+import flask_appbuilder.models.sqla.filters as fab_sqlafilters
+import sqlalchemy as sqla
+from airflow import configuration, settings
 from airflow.models import BaseOperator
 from airflow.operators.subdag_operator import SubDagOperator
 from airflow.utils import timezone
@@ -378,3 +381,69 @@ def get_chart_height(dag):
     charts, that is charts that take up space based on the size of the components within.
     """
     return 600 + len(dag.tasks) * 10
+
+
+class UtcAwareFilterMixin(object):
+    def apply(self, query, value):
+        value = timezone.parse(value, timezone=timezone.utc)
+
+        return super(UtcAwareFilterMixin, self).apply(query, value)
+
+
+class UtcAwareFilterEqual(UtcAwareFilterMixin, fab_sqlafilters.FilterEqual):
+    pass
+
+
+class UtcAwareFilterGreater(UtcAwareFilterMixin, fab_sqlafilters.FilterGreater):
+    pass
+
+
+class UtcAwareFilterSmaller(UtcAwareFilterMixin, fab_sqlafilters.FilterSmaller):
+    pass
+
+
+class UtcAwareFilterNotEqual(UtcAwareFilterMixin, fab_sqlafilters.FilterNotEqual):
+    pass
+
+
+class UtcAwareFilterConverter(fab_sqlafilters.SQLAFilterConverter):
+
+    conversion_table = (
+        (('is_utcdatetime', [UtcAwareFilterEqual,
+                             UtcAwareFilterGreater,
+                             UtcAwareFilterSmaller,
+                             UtcAwareFilterNotEqual]),) +
+        fab_sqlafilters.SQLAFilterConverter.conversion_table
+    )
+
+
+class CustomSQLAInterface(SQLAInterface):
+    """
+    FAB does not know how to handle columns with leading underscores because
+    they are not supported by WTForm. This hack will remove the leading
+    '_' from the key to lookup the column names.
+
+    """
+    def __init__(self, obj):
+        super(CustomSQLAInterface, self).__init__(obj)
+
+        self.session = settings.Session()
+
+        def clean_column_names():
+            if self.list_properties:
+                self.list_properties = dict(
+                    (k.lstrip('_'), v) for k, v in self.list_properties.items())
+            if self.list_columns:
+                self.list_columns = dict(
+                    (k.lstrip('_'), v) for k, v in self.list_columns.items())
+
+        clean_column_names()
+
+    def is_utcdatetime(self, col_name):
+        from airflow.utils.sqlalchemy import UtcDateTime
+        obj = self.list_columns[col_name].type
+        return isinstance(obj, UtcDateTime) or \
+            isinstance(obj, sqla.types.TypeDecorator) and \
+            isinstance(obj.impl, UtcDateTime)
+
+    filter_converter_class = UtcAwareFilterConverter

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -41,7 +41,6 @@ from flask._compat import PY2
 from flask_appbuilder import BaseView, ModelView, expose, has_access
 from flask_appbuilder.actions import action
 from flask_appbuilder.models.sqla.filters import BaseFilter
-from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import lazy_gettext
 from past.builtins import unicode
 from pygments import highlight, lexers
@@ -1839,27 +1838,7 @@ class AirflowModelView(ModelView):
     list_widget = AirflowModelListWidget
     page_size = PAGE_SIZE
 
-    class CustomSQLAInterface(SQLAInterface):
-        """
-        FAB does not know how to handle columns with leading underscores because
-        they are not supported by WTForm. This hack will remove the leading
-        '_' from the key to lookup the column names.
-
-        """
-        def __init__(self, obj):
-            super(AirflowModelView.CustomSQLAInterface, self).__init__(obj)
-
-            self.session = settings.Session()
-
-            def clean_column_names():
-                if self.list_properties:
-                    self.list_properties = dict(
-                        (k.lstrip('_'), v) for k, v in self.list_properties.items())
-                if self.list_columns:
-                    self.list_columns = dict(
-                        (k.lstrip('_'), v) for k, v in self.list_columns.items())
-
-            clean_column_names()
+    CustomSQLAInterface = wwwutils.CustomSQLAInterface
 
 
 class SlaMissModelView(AirflowModelView):

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -770,5 +770,23 @@ class TestGanttView(unittest.TestCase):
         self.tester.test_with_base_date_and_num_runs_and_execution_date_within()
 
 
+class TestTaskInstanceView(unittest.TestCase):
+    TI_ENDPOINT = '/admin/taskinstance/?flt2_execution_date_greater_than={}'
+
+    def setUp(self):
+        super(TestTaskInstanceView, self).setUp()
+        configuration.load_test_config()
+        app = application.create_app(testing=True)
+        app.config['WTF_CSRF_METHODS'] = []
+        self.app = app.test_client()
+
+    def test_start_date_filter(self):
+        resp = self.app.get(self.TI_ENDPOINT.format('2018-10-09+22:44:31'))
+        # We aren't checking the logic of the date filter itself (that is built
+        # in to flask-admin) but simply that our UTC conversion was run - i.e. it
+        # doesn't blow up!
+        self.assertEqual(resp.status_code, 200)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/www_rbac/test_views.py
+++ b/tests/www_rbac/test_views.py
@@ -1375,5 +1375,18 @@ class TestDagACLView(TestBase):
         self.check_content_in_response('"metadata":', resp)
 
 
+class TestTaskInstanceView(TestBase):
+    TI_ENDPOINT = '/taskinstance/list/?_flt_0_execution_date={}'
+
+    def test_start_date_filter(self):
+        resp = self.client.get(self.TI_ENDPOINT.format(
+            self.percent_encode('2018-10-09 22:44:31')))
+        # We aren't checking the logic of the date filter itself (that is built
+        # in to FAB) but simply that our UTC conversion was run - i.e. it
+        # doesn't blow up!
+        self.check_content_in_response('List Task Instance', resp)
+        pass
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-2799

### Description

- [x] Our conversion to Timezone-aware date times in 1.10 missed this case -
any filter on a date time would blow up with `naive datetime is
disallowed` - this makes our datetime filters timezone aware now (they
respect the default_timezone, and they accept timezones in input even
though the UI won't let you craft those.)

### Tests

- [x] added a simple test to www.test_views and www_rbac.test_views

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
