### PR TITLE
AIRFLOW-3149 Support dataproc cluster deletion on ERROR

### DIFF
--- a/airflow/gcp/hooks/dataproc.py
+++ b/airflow/gcp/hooks/dataproc.py
@@ -565,7 +565,7 @@ class DataProcHook(GoogleCloudBaseHook):
             jobId=job_id
         )
 
-    def _get_final_cluster_state(self, project_id, region, cluster_name, logger):
+    def get_final_cluster_state(self, project_id, region, cluster_name, logger):
         while True:
             state = DataProcHook.get_cluster_state(self.get_conn(), project_id, region, cluster_name)
             if state is None:

--- a/airflow/gcp/hooks/dataproc.py
+++ b/airflow/gcp/hooks/dataproc.py
@@ -567,7 +567,7 @@ class DataProcHook(GoogleCloudBaseHook):
 
     def _get_final_cluster_state(self, project_id, region, cluster_name, logger):
         while True:
-            state = DataProcHook._get_cluster_state(self.get_conn(), project_id, region, cluster_name)
+            state = DataProcHook.get_cluster_state(self.get_conn(), project_id, region, cluster_name)
             if state is None:
                 logger.info("No state for cluster '%s'", cluster_name)
                 time.sleep(15)
@@ -576,23 +576,23 @@ class DataProcHook(GoogleCloudBaseHook):
                 return state
 
     @staticmethod
-    def _get_cluster_state(service, project_id, region, cluster_name):
-        cluster = DataProcHook._get_cluster(service, project_id, region, cluster_name)
+    def get_cluster_state(service, project_id, region, cluster_name):
+        cluster = DataProcHook.find_cluster(service, project_id, region, cluster_name)
         if cluster and 'status' in cluster:
             return cluster['status']['state']
         else:
             return None
 
     @staticmethod
-    def _get_cluster(service, project_id, region, cluster_name):
-        cluster_list = DataProcHook._get_cluster_list_for_project(service, project_id, region)
+    def find_cluster(service, project_id, region, cluster_name):
+        cluster_list = DataProcHook.get_cluster_list_for_project(service, project_id, region)
         cluster = [c for c in cluster_list if c['clusterName'] == cluster_name]
         if cluster:
             return cluster[0]
         return None
 
     @staticmethod
-    def _get_cluster_list_for_project(service, project_id, region):
+    def get_cluster_list_for_project(service, project_id, region):
         result = service.projects().regions().clusters().list(
             projectId=project_id,
             region=region
@@ -600,7 +600,7 @@ class DataProcHook(GoogleCloudBaseHook):
         return result.get('clusters', [])
 
     @staticmethod
-    def _execute_dataproc_diagnose(service, project_id, region, cluster_name):
+    def execute_dataproc_diagnose(service, project_id, region, cluster_name):
         response = service.projects().regions().clusters().diagnose(
             projectId=project_id,
             region=region,
@@ -611,7 +611,7 @@ class DataProcHook(GoogleCloudBaseHook):
         return operation_name
 
     @staticmethod
-    def _execute_delete(service, project_id, region, cluster_name):
+    def execute_delete(service, project_id, region, cluster_name):
         response = service.projects().regions().clusters().delete(
             projectId=project_id,
             region=region,
@@ -622,7 +622,7 @@ class DataProcHook(GoogleCloudBaseHook):
 
     @staticmethod
     # Return the response object when done
-    def _wait_for_operation_done(service, operation_name):
+    def wait_for_operation_done(service, operation_name):
         while True:
             response = service.projects().regions().operations().get(
                 name=operation_name
@@ -633,9 +633,9 @@ class DataProcHook(GoogleCloudBaseHook):
             time.sleep(15)
 
     @staticmethod
-    def _wait_for_operation_done_or_error(service, operation_name):
+    def wait_for_operation_done_or_error(service, operation_name):
 
-        response = DataProcHook._wait_for_operation_done(service, operation_name)
+        response = DataProcHook.wait_for_operation_done(service, operation_name)
         if response.get('done'):
             if 'error' in response:
                 raise AirflowException(str(response['error']))

--- a/airflow/gcp/operators/dataproc.py
+++ b/airflow/gcp/operators/dataproc.py
@@ -480,7 +480,7 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
                 'Cluster %s already exists... Checking status...',
                 self.cluster_name
             )
-            existing_status = self.hook._get_final_cluster_state(service, self.project_id,
+            existing_status = self.hook._get_final_cluster_state(self.project_id,
                                                                  self.region, self.cluster_name, self.log)
 
             if existing_status == 'RUNNING':

--- a/airflow/gcp/operators/dataproc.py
+++ b/airflow/gcp/operators/dataproc.py
@@ -276,8 +276,36 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
             )
         ), "num_workers == 0 means single node mode - no preemptibles allowed"
 
+    def _cluster_ready(self, state, service):
+        if state == 'RUNNING':
+            return True
+        if state == 'DELETING':
+            raise Exception('Tried to create a cluster but it\'s in DELETING, something went wrong.')
+        if state == 'ERROR':
+            cluster = DataProcHook._get_cluster(service, self.project_id, self.region, self.cluster_name)
+            try:
+                error_details = cluster['status']['details']
+            except KeyError:
+                error_details = 'Unknown error in cluster creation, ' \
+                                'check Google Cloud console for details.'
+
+            self.log.info('Dataproc cluster creation resulted in an ERROR state running diagnostics')
+            self.log.info(error_details)
+            diagnose_operation_name = \
+                DataProcHook._execute_dataproc_diagnose(service, self.project_id,
+                                                        self.region, self.cluster_name)
+            diagnose_result = DataProcHook._wait_for_operation_done(service, diagnose_operation_name)
+            if diagnose_result.get('response') and diagnose_result.get('response').get('outputUri'):
+                outputUri = diagnose_result.get('response').get('outputUri')
+                self.log.info('Diagnostic information for ERROR cluster available at [%s]', outputUri)
+            else:
+                self.log.info('Diagnostic information could not be retrieved!')
+
+            raise Exception(error_details)
+        return False
+
     def _get_init_action_timeout(self):
-        match = re.match(r"^(\d+)(s|m)$", self.init_action_timeout)
+        match = re.match(r"^(\d+)([sm])$", self.init_action_timeout)
         if match:
             if match.group(2) == "s":
                 return self.init_action_timeout
@@ -445,11 +473,51 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
 
         return cluster_data
 
+    def _usable_existing_cluster_present(self, service):
+        existing_cluster = DataProcHook._get_cluster(service, self.project_id, self.region, self.cluster_name)
+        if existing_cluster:
+            self.log.info(
+                'Cluster %s already exists... Checking status...',
+                self.cluster_name
+            )
+            existing_status = self.hook._get_final_cluster_state(service, self.project_id,
+                                                                 self.region, self.cluster_name, self.log)
+
+            if existing_status == 'RUNNING':
+                self.log.info('Cluster exists and is already running. Using it.')
+                return True
+
+            elif existing_status == 'DELETING':
+                while DataProcHook._get_cluster(service, self.project_id, self.region, self.cluster_name) \
+                    and DataProcHook._get_cluster_state(service, self.project_id,
+                                                        self.region, self.cluster_name) == 'DELETING':
+                    self.log.info('Existing cluster is deleting, waiting for it to finish')
+                    time.sleep(15)
+
+            elif existing_status == 'ERROR':
+                self.log.info('Existing cluster in ERROR state, deleting it first')
+
+                operation_name = DataProcHook._execute_delete(service, self.project_id,
+                                                              self.region, self.cluster_name)
+                self.log.info("Cluster delete operation name: %s", operation_name)
+                DataProcHook._wait_for_operation_done_or_error(service, operation_name)
+
+        return False
+
     def start(self):
         """
         Create a new cluster on Google Cloud Dataproc.
         """
         self.log.info('Creating cluster: %s', self.cluster_name)
+        hook = DataProcHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to
+        )
+        service = hook.get_conn()
+
+        if self._usable_existing_cluster_present(service):
+            return True
+
         cluster_data = self._build_cluster_data()
 
         return (
@@ -542,7 +610,7 @@ class DataprocClusterScaleOperator(DataprocOperationBaseOperator):
 
     @staticmethod
     def _get_graceful_decommission_timeout(timeout):
-        match = re.match(r"^(\d+)(s|m|h|d)$", timeout)
+        match = re.match(r"^(\d+)([smdh])$", timeout)
         if match:
             if match.group(2) == "s":
                 return timeout

--- a/airflow/gcp/operators/dataproc.py
+++ b/airflow/gcp/operators/dataproc.py
@@ -480,8 +480,8 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
                 'Cluster %s already exists... Checking status...',
                 self.cluster_name
             )
-            existing_status = self.hook._get_final_cluster_state(self.project_id,
-                                                                 self.region, self.cluster_name, self.log)
+            existing_status = self.hook.get_final_cluster_state(self.project_id,
+                                                                self.region, self.cluster_name, self.log)
 
             if existing_status == 'RUNNING':
                 self.log.info('Cluster exists and is already running. Using it.')

--- a/tests/gcp/operators/test_dataproc.py
+++ b/tests/gcp/operators/test_dataproc.py
@@ -399,10 +399,12 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
         self.operation = {'name': 'operation', 'done': True}
         self.mock_execute = Mock()
         self.mock_execute.execute.return_value = self.operation
-        # Clusters should be iterable
-        self.mock_clusters = [Mock()]
-        for m in self.mock_clusters:
-            m.create.return_value = self.mock_execute
+        self.mock_list = Mock()
+        self.mock_list_execute = {}
+        self.mock_list.execute.return_value = self.mock_list_execute
+        self.mock_clusters = Mock()
+        self.mock_clusters.create.return_value = self.mock_execute
+        self.mock_clusters.list.return_value = self.mock_list
         self.mock_regions = Mock()
         self.mock_regions.clusters.return_value = self.mock_clusters
         self.mock_projects = Mock()

--- a/tests/gcp/operators/test_dataproc.py
+++ b/tests/gcp/operators/test_dataproc.py
@@ -534,7 +534,7 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
         self.mock_execute = Mock()
         self.mock_execute.execute.return_value = self.operation
         self.mock_list = Mock()
-        self.mock_list_execute = {'clusters':[{'clusterName': CLUSTER_NAME,'status': {'state':'ERROR'}}]}
+        self.mock_list_execute = {'clusters': [{'clusterName': CLUSTER_NAME, 'status': {'state': 'ERROR'}}]}
         self.mock_list.execute.return_value = self.mock_list_execute
         self.mock_clusters = Mock()
         self.mock_clusters.create.return_value = self.mock_execute

--- a/tests/gcp/operators/test_dataproc.py
+++ b/tests/gcp/operators/test_dataproc.py
@@ -699,7 +699,7 @@ class TestDataprocClusterDeleteOperator(unittest.TestCase):
                 projectId=GCP_PROJECT_ID,
                 clusterName=CLUSTER_NAME,
                 requestId=mock.ANY)
-            hook.wait.assert_called_once_with(self.operation)
+            hook.wait.assert_called_with(self.operation)
 
     def test_render_template(self):
         task = DataprocClusterDeleteOperator(

--- a/tests/gcp/operators/test_dataproc.py
+++ b/tests/gcp/operators/test_dataproc.py
@@ -546,8 +546,8 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
         self.mock_conn = Mock()
         self.mock_conn.projects.return_value = self.mock_projects
 
-        with patch(HOOK) as MockHook:
-            hook = MockHook()
+        with patch(HOOK) as mock_hook:
+            hook = mock_hook()
             hook.get_conn.return_value = self.mock_conn
             hook.wait.return_value = None
             hook._get_final_cluster_state.return_value = "ERROR"

--- a/tests/gcp/operators/test_dataproc.py
+++ b/tests/gcp/operators/test_dataproc.py
@@ -399,7 +399,8 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
         self.operation = {'name': 'operation', 'done': True}
         self.mock_execute = Mock()
         self.mock_execute.execute.return_value = self.operation
-        self.mock_clusters = Mock()
+        # Clusters should be iterable
+        self.mock_clusters = [Mock()]
         self.mock_clusters.create.return_value = self.mock_execute
         self.mock_regions = Mock()
         self.mock_regions.clusters.return_value = self.mock_clusters

--- a/tests/gcp/operators/test_dataproc.py
+++ b/tests/gcp/operators/test_dataproc.py
@@ -834,7 +834,7 @@ class TestDataProcHadoopOperator(unittest.TestCase):
             schedule_interval='@daily')
 
     @mock.patch(
-        'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
+        'airflow.gcp.hooks.dataproc.DataProcHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID
     )
@@ -919,7 +919,7 @@ class TestDataProcHiveOperator(unittest.TestCase):
             schedule_interval='@daily')
 
     @mock.patch(
-        'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
+        'airflow.gcp.hooks.dataproc.DataProcHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID
     )
@@ -1004,7 +1004,7 @@ class TestDataProcPigOperator(unittest.TestCase):
             schedule_interval='@daily')
 
     @mock.patch(
-        'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
+        'airflow.gcp.hooks.dataproc.DataProcHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID
     )
@@ -1094,7 +1094,7 @@ class TestDataProcPySparkOperator(unittest.TestCase):
             schedule_interval='@daily')
 
     @mock.patch(
-        'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
+        'airflow.gcp.hooks.dataproc.DataProcHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID
     )
@@ -1182,7 +1182,7 @@ class TestDataProcSparkOperator(unittest.TestCase):
             schedule_interval='@daily')
 
     @mock.patch(
-        'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
+        'airflow.gcp.hooks.dataproc.DataProcHook.project_id',
         new_callable=PropertyMock,
         return_value=GCP_PROJECT_ID
     )

--- a/tests/gcp/operators/test_dataproc.py
+++ b/tests/gcp/operators/test_dataproc.py
@@ -530,6 +530,7 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
     def test_create_cluster_deletes_error_cluster(self):
         # Setup service.projects().regions().clusters().create()
         #              .execute()
+        # pylint:disable=attribute-defined-outside-init
         self.operation = {'name': 'operation', 'done': True}
         self.mock_execute = Mock()
         self.mock_execute.execute.return_value = self.operation
@@ -550,7 +551,7 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
             hook = mock_hook()
             hook.get_conn.return_value = self.mock_conn
             hook.wait.return_value = None
-            hook._get_final_cluster_state.return_value = "ERROR"
+            hook.get_final_cluster_state.return_value = "ERROR"
 
             dataproc_task = DataprocClusterCreateOperator(
                 task_id=TASK_ID,

--- a/tests/gcp/operators/test_dataproc.py
+++ b/tests/gcp/operators/test_dataproc.py
@@ -550,6 +550,7 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
             hook = MockHook()
             hook.get_conn.return_value = self.mock_conn
             hook.wait.return_value = None
+            hook._get_final_cluster_state.return_value = "ERROR"
 
             dataproc_task = DataprocClusterCreateOperator(
                 task_id=TASK_ID,

--- a/tests/gcp/operators/test_dataproc.py
+++ b/tests/gcp/operators/test_dataproc.py
@@ -401,7 +401,8 @@ class TestDataprocClusterCreateOperator(unittest.TestCase):
         self.mock_execute.execute.return_value = self.operation
         # Clusters should be iterable
         self.mock_clusters = [Mock()]
-        self.mock_clusters.create.return_value = self.mock_execute
+        for m in self.mock_clusters:
+            m.create.return_value = self.mock_execute
         self.mock_regions = Mock()
         self.mock_regions.clusters.return_value = self.mock_clusters
         self.mock_projects = Mock()


### PR DESCRIPTION
Sometimes a dataproc cluster creation results in a
cluster in a state of ERROR, which makes it unsuable.
Subsequent Airflow retries will fail because a cluster
already exists.  This change adds the option to delete
an ERROR cluster on creation so that subsequent attempts
might succeed.  There are also some other small cleanups.

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3149/) issues and references them in the PR title.

### Description

- [X] See commit message above

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:  

My change does not include tests, I did not see any integration tests in the code base that this could fit into.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [X] Passes `flake8`
