### PR TITLE
[AIRFLOW-3233] Fix deletion of DAGs in the UI

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -191,11 +191,11 @@
                 </a>
 
                 <!-- Delete -->
-                <a href="{{ url_for('airflow.delete', dag_id=dag.dag_id) }}"
-                  onclick="return confirmDeleteDag('{{ dag.safe_dag_id }}')">
+                <!-- Use dag_id instead of dag.dag_id, because the DAG might not exist in the webserver's DagBag -->
+                <a href="{{ url_for('airflow.delete', dag_id=dag_id) }}"
+                  onclick="return confirmDeleteDag('{{ dag_id }}')">
                    <span class="glyphicon glyphicon-remove-circle" style="color:red" aria-hidden="true" data-original-title="Delete Dag"></span>
                 </a>
-
                 </td>
             </tr>
         {% endfor %}

--- a/airflow/www_rbac/templates/airflow/dags.html
+++ b/airflow/www_rbac/templates/airflow/dags.html
@@ -192,9 +192,10 @@
                 </a>
 
                 <!-- Delete -->
-                <a href="{{ url_for('Airflow.delete', dag_id=dag.dag_id) }}"
-                   onclick="return confirmDeleteDag('{{ dag.safe_dag_id }}')">
-                  <span class="glyphicon glyphicon-remove-circle" style="color:red" aria-hidden="true" data-original-title="Delete Dag"></span>
+                <!-- Use dag_id instead of dag.dag_id, because the DAG might not exist in the webserver's DagBag -->
+                <a href="{{ url_for('Airflow.delete', dag_id=dag_id) }}"
+                  onclick="return confirmDeleteDag('{{ dag_id }}')">
+                   <span class="glyphicon glyphicon-remove-circle" style="color:red" aria-hidden="true" data-original-title="Delete Dag"></span>
                 </a>
                 </td>
             </tr>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3233) issues and references them in the PR title.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Currently deleting DAGs that exist on the scheduler but not the webserver is not possible because the DAG id in the deletion URL comes from the webserver DAG object.
e.g. http://localhost:8080/delete?dag_id= instead of http://localhost:8080/delete?dag_id=example_kubernetes_executor

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
UI Fix, tested both RBAC and regular.

### Commits
- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [X] Passes `flake8`
