### PR TITLE
[AIRFLOW-3235] Add list function in AzureDataLakeHook

### DIFF
--- a/airflow/contrib/hooks/azure_data_lake_hook.py
+++ b/airflow/contrib/hooks/azure_data_lake_hook.py
@@ -139,3 +139,15 @@ class AzureDataLakeHook(BaseHook):
                                   overwrite=overwrite,
                                   buffersize=buffersize,
                                   blocksize=blocksize)
+
+    def list(self, path):
+        """
+        List files in Azure Data Lake Storage
+
+        :param path: full path/globstring to use to list files in ADLS
+        :type path: str
+        """
+        if "*" in path:
+            return self.connection.glob(path)
+        else:
+            return self.connection.walk(path)

--- a/tests/contrib/hooks/test_azure_data_lake_hook.py
+++ b/tests/contrib/hooks/test_azure_data_lake_hook.py
@@ -100,6 +100,24 @@ class TestAzureDataLakeHook(unittest.TestCase):
                                                 nthreads=64, overwrite=True,
                                                 buffersize=4194304, blocksize=4194304)
 
+    @mock.patch('airflow.contrib.hooks.azure_data_lake_hook.core.AzureDLFileSystem',
+                autospec=True)
+    @mock.patch('airflow.contrib.hooks.azure_data_lake_hook.lib', autospec=True)
+    def test_list_glob(self, mock_lib, mock_fs):
+        from airflow.contrib.hooks.azure_data_lake_hook import AzureDataLakeHook
+        hook = AzureDataLakeHook(azure_data_lake_conn_id='adl_test_key')
+        hook.list('file_path/*')
+        mock_fs.return_value.glob.assert_called_with('file_path/*')
+
+    @mock.patch('airflow.contrib.hooks.azure_data_lake_hook.core.AzureDLFileSystem',
+                autospec=True)
+    @mock.patch('airflow.contrib.hooks.azure_data_lake_hook.lib', autospec=True)
+    def test_list_walk(self, mock_lib, mock_fs):
+        from airflow.contrib.hooks.azure_data_lake_hook import AzureDataLakeHook
+        hook = AzureDataLakeHook(azure_data_lake_conn_id='adl_test_key')
+        hook.list('file_path/some_folder/')
+        mock_fs.return_value.walk.assert_called_with('file_path/some_folder/')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3235) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3235
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- This PR adds a list function that returns a list of objects at some specified Azure Data Lake Storage path, something other similar Hooks for S3 and GCS have. It will be useful for Operators developed that leverage this Hook. 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
test_list_glob
test_list_walk

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
