### PR TITLE
[AIRFLOW-520] Fix Version Info in Flask UI

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -37,7 +37,6 @@ import bleach
 import markdown
 import nvd3
 import pendulum
-import pkg_resources
 import sqlalchemy as sqla
 from flask import (
     abort, jsonify, redirect, url_for, request, Markup, Response,
@@ -3052,7 +3051,7 @@ class VersionView(wwwutils.SuperUserMixin, BaseView):
     def version(self):
         # Look at the version from setup.py
         try:
-            airflow_version = pkg_resources.require("apache-airflow")[0].version
+            airflow_version = airflow.__version__
         except Exception as e:
             airflow_version = None
             logging.error(e)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-520

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
![image](https://user-images.githubusercontent.com/8811558/47261096-53d3d100-d4c0-11e8-94dc-8d9ba4ce2647.png)

That is because of the following issue:
```
>>> import pkg_resources
>>> airflow_version = pkg_resources.require("apache-airflow")[0].version
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/kaxil/.virtualenvs/airflow_stable_pip/lib/python2.7/site-packages/pkg_resources/__init__.py", line 892, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/Users/kaxil/.virtualenvs/airflow_stable_pip/lib/python2.7/site-packages/pkg_resources/__init__.py", line 783, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (Flask-Login 0.2.11 (/Users/kaxil/.virtualenvs/airflow_stable_pip/lib/python2.7/site-packages), Requirement.parse('Flask-Login<0.5,>=0.3'), set(['flask-appbuilder']))
```

This also brings it in line with RBAC FAB UI.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
