### PR TITLE
[AIRFLOW-502] BashOperator success/failure conditions not documented

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -52,7 +52,8 @@ class BashOperator(BaseOperator):
     
     On execution of the operator the task will up for retry when exception is raised.
     However if a command exists with non-zero value Airflow will not recognize
-    it as failure unless explicitly specified in the beggining of the script.
+    it as failure unless the whole shell exits with a failure. The easiest way of 
+    achieving this is to prefix the command with ``set -e;`` 
     Example:
         bash_command = "python3 script.py '{{ next_execution_date }}'"
         when executing command exit(1) the task will be marked as success.

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -57,8 +57,6 @@ class BashOperator(BaseOperator):
              when executing command exit(1) the task will be marked as success.
              bash_command = "set -e; python3 script.py '{{ next_execution_date }}'"
              when executing command  exit(1) the task will be marked as up for retry.
-    
-    
     """
     template_fields = ('bash_command', 'env')
     template_ext = ('.sh', '.bash',)

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -49,6 +49,16 @@ class BashOperator(BaseOperator):
     :type env: dict
     :param output_encoding: Output encoding of bash command
     :type output_encoding: str
+    
+    On execution of the operator the task will up for retry when exception is raised.
+    However if a command exists with non-zero value Airflow will not recognize
+    it as failure unless explicitly specified in the beggining of the script.
+    Example: bash_command = """python3 script.py '{{ next_execution_date }}' """
+             when executing command exit(1) the task will be marked as success.
+             bash_command = """python3 script.py '{{ next_execution_date }}' || exit 1 """
+             when executing command  exit(1) the task will be marked as up for retry.
+    
+    
     """
     template_fields = ('bash_command', 'env')
     template_ext = ('.sh', '.bash',)

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -58,7 +58,7 @@ class BashOperator(BaseOperator):
         bash_command = "python3 script.py '{{ next_execution_date }}'"
         when executing command exit(1) the task will be marked as success.
         bash_command = "set -e; python3 script.py '{{ next_execution_date }}'"
-        when executing command  exit(1) the task will be marked as up for retry.
+        when executing command ``exit(1)`` the task will be marked as up for retry.
     """
     template_fields = ('bash_command', 'env')
     template_ext = ('.sh', '.bash',)

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -53,10 +53,11 @@ class BashOperator(BaseOperator):
     On execution of the operator the task will up for retry when exception is raised.
     However if a command exists with non-zero value Airflow will not recognize
     it as failure unless explicitly specified in the beggining of the script.
-    Example: bash_command = "python3 script.py '{{ next_execution_date }}'"
-             when executing command exit(1) the task will be marked as success.
-             bash_command = "set -e; python3 script.py '{{ next_execution_date }}'"
-             when executing command  exit(1) the task will be marked as up for retry.
+    Example:
+        bash_command = "python3 script.py '{{ next_execution_date }}'"
+        when executing command exit(1) the task will be marked as success.
+        bash_command = "set -e; python3 script.py '{{ next_execution_date }}'"
+        when executing command  exit(1) the task will be marked as up for retry.
     """
     template_fields = ('bash_command', 'env')
     template_ext = ('.sh', '.bash',)

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -51,7 +51,7 @@ class BashOperator(BaseOperator):
     :type output_encoding: str
     
     On execution of the operator the task will up for retry when exception is raised.
-    However if a command exists with non-zero value Airflow will not recognize
+    However if a sub-command exists with non-zero value Airflow will not recognize
     it as failure unless the whole shell exits with a failure. The easiest way of 
     achieving this is to prefix the command with ``set -e;`` 
     Example:

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -53,9 +53,9 @@ class BashOperator(BaseOperator):
     On execution of the operator the task will up for retry when exception is raised.
     However if a command exists with non-zero value Airflow will not recognize
     it as failure unless explicitly specified in the beggining of the script.
-    Example: bash_command = python3 script.py '{{ next_execution_date }}'
+    Example: bash_command = "python3 script.py '{{ next_execution_date }}'"
              when executing command exit(1) the task will be marked as success.
-             bash_command = python3 script.py '{{ next_execution_date }}' || exit 1
+             bash_command = "set -e; python3 script.py '{{ next_execution_date }}'"
              when executing command  exit(1) the task will be marked as up for retry.
     
     

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -53,9 +53,9 @@ class BashOperator(BaseOperator):
     On execution of the operator the task will up for retry when exception is raised.
     However if a command exists with non-zero value Airflow will not recognize
     it as failure unless explicitly specified in the beggining of the script.
-    Example: bash_command = """python3 script.py '{{ next_execution_date }}' """
+    Example: bash_command = python3 script.py '{{ next_execution_date }}'
              when executing command exit(1) the task will be marked as success.
-             bash_command = """python3 script.py '{{ next_execution_date }}' || exit 1 """
+             bash_command = python3 script.py '{{ next_execution_date }}' || exit 1
              when executing command  exit(1) the task will be marked as up for retry.
     
     


### PR DESCRIPTION
elaborate about exit commands when working with the operator


### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-502) 
### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
Add documentation based on request from ticket 502 and based on stack-overflow question: https://stackoverflow.com/questions/52355179/how-to-exit-with-error-from-script-to-airflow
