### PR TITLE
[AIRFLOW-3241] Remove Invalid template ext in GCS Sensors

### DIFF
--- a/airflow/contrib/sensors/gcs_sensor.py
+++ b/airflow/contrib/sensors/gcs_sensor.py
@@ -24,20 +24,19 @@ from airflow.utils.decorators import apply_defaults
 class GoogleCloudStorageObjectSensor(BaseSensorOperator):
     """
     Checks for the existence of a file in Google Cloud Storage.
-    Create a new GoogleCloudStorageObjectSensor.
 
-        :param bucket: The Google cloud storage bucket where the object is.
-        :type bucket: str
-        :param object: The name of the object to check in the Google cloud
-            storage bucket.
-        :type object: str
-        :param google_cloud_storage_conn_id: The connection ID to use when
-            connecting to Google cloud storage.
-        :type google_cloud_storage_conn_id: str
-        :param delegate_to: The account to impersonate, if any.
-            For this to work, the service account making the request must have
-            domain-wide delegation enabled.
-        :type delegate_to: str
+    :param bucket: The Google cloud storage bucket where the object is.
+    :type bucket: str
+    :param object: The name of the object to check in the Google cloud
+        storage bucket.
+    :type object: str
+    :param google_cloud_conn_id: The connection ID to use when
+        connecting to Google cloud storage.
+    :type google_cloud_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
     """
     template_fields = ('bucket', 'object')
     ui_color = '#f0eee4'
@@ -76,27 +75,25 @@ def ts_function(context):
 class GoogleCloudStorageObjectUpdatedSensor(BaseSensorOperator):
     """
     Checks if an object is updated in Google Cloud Storage.
-    Create a new GoogleCloudStorageObjectUpdatedSensor.
 
-        :param bucket: The Google cloud storage bucket where the object is.
-        :type bucket: str
-        :param object: The name of the object to download in the Google cloud
-            storage bucket.
-        :type object: str
-        :param ts_func: Callback for defining the update condition. The default callback
-            returns execution_date + schedule_interval. The callback takes the context
-            as parameter.
-        :type ts_func: function
-        :param google_cloud_storage_conn_id: The connection ID to use when
-            connecting to Google cloud storage.
-        :type google_cloud_storage_conn_id: str
-        :param delegate_to: The account to impersonate, if any.
-            For this to work, the service account making the request must have domain-wide
-            delegation enabled.
-        :type delegate_to: str
+    :param bucket: The Google cloud storage bucket where the object is.
+    :type bucket: str
+    :param object: The name of the object to download in the Google cloud
+        storage bucket.
+    :type object: str
+    :param ts_func: Callback for defining the update condition. The default callback
+        returns execution_date + schedule_interval. The callback takes the context
+        as parameter.
+    :type ts_func: function
+    :param google_cloud_conn_id: The connection ID to use when
+        connecting to Google cloud storage.
+    :type google_cloud_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have domain-wide
+        delegation enabled.
+    :type delegate_to: str
     """
     template_fields = ('bucket', 'object')
-    template_ext = ('.sql',)
     ui_color = '#f0eee4'
 
     @apply_defaults
@@ -126,20 +123,19 @@ class GoogleCloudStorageObjectUpdatedSensor(BaseSensorOperator):
 class GoogleCloudStoragePrefixSensor(BaseSensorOperator):
     """
     Checks for the existence of a files at prefix in Google Cloud Storage bucket.
-    Create a new GoogleCloudStorageObjectSensor.
 
-        :param bucket: The Google cloud storage bucket where the object is.
-        :type bucket: str
-        :param prefix: The name of the prefix to check in the Google cloud
-            storage bucket.
-        :type prefix: str
-        :param google_cloud_storage_conn_id: The connection ID to use when
-            connecting to Google cloud storage.
-        :type google_cloud_storage_conn_id: str
-        :param delegate_to: The account to impersonate, if any.
-            For this to work, the service account making the request must have
-            domain-wide delegation enabled.
-        :type delegate_to: str
+    :param bucket: The Google cloud storage bucket where the object is.
+    :type bucket: str
+    :param prefix: The name of the prefix to check in the Google cloud
+        storage bucket.
+    :type prefix: str
+    :param google_cloud_conn_id: The connection ID to use when
+        connecting to Google cloud storage.
+    :type google_cloud_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
     """
     template_fields = ('bucket', 'prefix')
     ui_color = '#f0eee4'


### PR DESCRIPTION
- Remove `template_ext = ('.sql',)`
- Fix Docstrings (Incorrect connection name and indentation)

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3241

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

- It uses `google_cloud_storage_conn_id` instead of `google_cloud_conn_id`
- Docstrings have unncessary indentation which causes the docs to not parse it
- The GCS sensor also contains an incorrect template extension

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
