### PR TITLE
[AIRFLOW-3246] Make hmsclient import optional

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -27,7 +27,6 @@ import time
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile
 
-import hmsclient
 import six
 import unicodecsv as csv
 from past.builtins import basestring
@@ -496,6 +495,7 @@ class HiveMetastoreHook(BaseHook):
         """
         Returns a Hive thrift client.
         """
+        import hmsclient
         from thrift.transport import TSocket, TTransport
         from thrift.protocol import TBinaryProtocol
         ms = self.metastore_conn


### PR DESCRIPTION
### Jira

- Jira issue: [AIRFLOW-3246](https://issues.apache.org/jira/browse/AIRFLOW-3246)

### Description

Currently to use anything from hive_hooks.py you must have hmsclient installed, which is inconsistent: thrift imports are made inside the `get_metastore_client` method, and hnsclient is imported outside (and it does thrift imports internally).

### Tests

Not sure if tests needed for this change.

### Documentation

### Code Quality
