### PR TITLE
[AIRFLOW-3211] Reattach to GCP Dataproc jobs upon Airflow restart 

### DIFF
--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -65,11 +65,11 @@ class _DataProcJob(LoggingMixin):
         # The full set of possible states is here:
         # https://cloud.google.com/dataproc/docs/reference/rest/v1beta2/projects.regions.jobs#State
         recoverable_states = frozenset([
-                'PENDING',
-                'SETUP_DONE',
-                'RUNNING',
-                'DONE',
-            ])
+            'PENDING',
+            'SETUP_DONE',
+            'RUNNING',
+            'DONE',
+        ])
 
         found_match = False
         for job_on_cluster in jobs_on_cluster:
@@ -81,7 +81,7 @@ class _DataProcJob(LoggingMixin):
                 self.job_id = self.job['reference']['jobId']
                 found_match = True
 
-                # We can stop looking once we find a matching job in a recoverable state
+                # We can stop looking once we find a matching job in a recoverable state.
                 if self.job['status']['state'] in recoverable_states:
                     break
 
@@ -94,13 +94,13 @@ class _DataProcJob(LoggingMixin):
     gcloud --project %s dataproc jobs delete %s --region %s
 """
             self.log.info(
-                    message,
-                    self.job_id,
-                    str(self.job['status']['state']),
-                    self.project_id,
-                    self.job_id,
-                    self.region,
-                    )
+                message,
+                self.job_id,
+                str(self.job['status']['state']),
+                self.project_id,
+                self.job_id,
+                self.region,
+            )
 
             return
 
@@ -277,6 +277,7 @@ class _DataProcOperation(LoggingMixin):
 
 class DataProcHook(GoogleCloudBaseHook):
     """Hook for Google Cloud Dataproc APIs."""
+
     def __init__(self,
                  gcp_conn_id='google_cloud_default',
                  delegate_to=None,

--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -34,12 +34,82 @@ class _DataProcJob(LoggingMixin):
         self.project_id = project_id
         self.region = region
         self.num_retries = num_retries
+        self.job_error_states = job_error_states
+
+        # Check if the job to submit is already running on the cluster.
+        # If so, don't resubmit the job.
+        try:
+            cluster_name = job['job']['placement']['clusterName']
+        except KeyError:
+            self.log.error('Job to submit is incorrectly configured.')
+            raise
+
+        jobs_on_cluster_response = dataproc_api.projects().regions().jobs().list(
+            projectId=self.project_id,
+            region=self.region,
+            clusterName=cluster_name).execute()
+
+        UUID_LENGTH = 9
+        jobs_on_cluster = jobs_on_cluster_response.get('jobs', [])
+        try:
+            task_id_to_submit = job['job']['reference']['jobId'][:-UUID_LENGTH]
+        except KeyError:
+            self.log.error('Job to submit is incorrectly configured.')
+            raise
+
+        # There is a small set of states that we will accept as sufficient
+        # for attaching the new task instance to the old Dataproc job.  We
+        # generally err on the side of _not_ attaching, unless the prior
+        # job is in a known-good state. For example, we don't attach to an
+        # ERRORed job because we want Airflow to be able to retry the job.
+        # The full set of possible states is here:
+        # https://cloud.google.com/dataproc/docs/reference/rest/v1beta2/projects.regions.jobs#State
+        recoverable_states = frozenset([
+                'PENDING',
+                'SETUP_DONE',
+                'RUNNING',
+                'DONE',
+            ])
+
+        found_match = False
+        for job_on_cluster in jobs_on_cluster:
+            job_on_cluster_id = job_on_cluster['reference']['jobId']
+            job_on_cluster_task_id = job_on_cluster_id[:-UUID_LENGTH]
+            if task_id_to_submit == job_on_cluster_task_id:
+
+                self.job = job_on_cluster
+                self.job_id = self.job['reference']['jobId']
+                found_match = True
+
+                # We can stop looking once we find a matching job in a recoverable state
+                if self.job['status']['state'] in recoverable_states:
+                    break
+
+        if found_match and self.job['status']['state'] in recoverable_states:
+            message = """
+    Reattaching to previously-started DataProc job %s (in state %s).
+    If this is not the desired behavior (ie if you would like to re-run this job),
+    please delete the previous instance of the job by running:
+
+    gcloud --project %s dataproc jobs delete %s --region %s
+"""
+            self.log.info(
+                    message,
+                    self.job_id,
+                    str(self.job['status']['state']),
+                    self.project_id,
+                    self.job_id,
+                    self.region,
+                    )
+
+            return
+
         self.job = dataproc_api.projects().regions().jobs().submit(
             projectId=self.project_id,
             region=self.region,
             body=job).execute(num_retries=self.num_retries)
         self.job_id = self.job['reference']['jobId']
-        self.job_error_states = job_error_states
+
         self.log.info(
             'DataProc job %s is %s',
             self.job_id, str(self.job['status']['state'])

--- a/tests/contrib/hooks/test_gcp_dataproc_hook.py
+++ b/tests/contrib/hooks/test_gcp_dataproc_hook.py
@@ -69,63 +69,67 @@ class DataProcJobTest(unittest.TestCase):
         mock_job_on_cluster = {'reference': {'jobId': '{}_{}'.format(TASK_ID, self.UUID)},
                                'status': {'state': 'RUNNING'}}
 
-        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value.execute.return_value = {
-            'jobs': [mock_job_on_cluster]}
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value. \
+            execute.return_value = {'jobs': [mock_job_on_cluster]}
 
         _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
 
-        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit.assert_not_called()
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
+            .assert_not_called()
 
     def test_keep_looking_for_recoverable_job_even_if_errored_job_exists_on_cluster(self):
-        # Keep looking for a job to reattach to even if the first matching job found is in an irrecoverable state
+        # Keep looking for a job to reattach to even if the first matching job found is in an irrecoverable
+        #  state
         mock_job_on_cluster_running = {'reference': {'jobId': '{}_{}'.format(TASK_ID, self.UUID)},
                                        'status': {'state': 'RUNNING'}}
 
         mock_job_on_cluster_error = {'reference': {'jobId': '{}_{}'.format(TASK_ID, self.UUID)},
                                      'status': {'state': 'ERROR'}}
 
-        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value.execute.return_value = {
-            'jobs': [mock_job_on_cluster_error, mock_job_on_cluster_running]}
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value\
+            .execute.return_value = {'jobs': [mock_job_on_cluster_error, mock_job_on_cluster_running]}
 
         _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
 
-        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit.assert_not_called()
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
+            .assert_not_called()
 
     def test_submit_job_if_different_job_running_on_cluster(self):
-        # If there are jobs running on the cluster, but none of them have the same task ID as the job we're about to submit, then submit the job.
+        # If there are jobs running on the cluster, but none of them have the same task ID as the job we're
+        #  about to submit, then submit the job.
         mock_job_on_cluster = {'reference': {'jobId': 'a-different-job-id_{}'.format(self.UUID)},
                                'status': {'state': 'RUNNING'}}
 
-        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value.execute.return_value = {
-            'jobs': [mock_job_on_cluster]}
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value\
+            .execute.return_value = {'jobs': [mock_job_on_cluster]}
 
         _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
 
-        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit.assert_called_once_with(
-            projectId=PROJECT_ID, region=REGION, body=self.JOB_TO_SUBMIT)
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
+            .assert_called_once_with(projectId=PROJECT_ID, region=REGION, body=self.JOB_TO_SUBMIT)
 
     def test_submit_job_if_no_jobs_running_on_cluster(self):
         # If there are no other jobs already running on the cluster, then submit the job.
-        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value.execute.return_value = {
-            'jobs': []}
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value\
+            .execute.return_value = {'jobs': []}
 
         _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
 
-        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit.assert_called_once_with(
-            projectId=PROJECT_ID, region=REGION, body=self.JOB_TO_SUBMIT)
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
+            .assert_called_once_with(projectId=PROJECT_ID, region=REGION, body=self.JOB_TO_SUBMIT)
 
     def test_submit_job_if_same_job_errored_on_cluster(self):
         # If a job with the same task ID finished with error on the cluster, then resubmit the job for retry.
         mock_job_on_cluster = {'reference': {'jobId': '{}_{}'.format(TASK_ID, self.UUID)},
                                'status': {'state': 'ERROR'}}
 
-        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value.execute.return_value = {
-            'jobs': [mock_job_on_cluster]}
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value\
+            .execute.return_value = {'jobs': [mock_job_on_cluster]}
 
         _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
 
-        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit.assert_called_once_with(
-            projectId=PROJECT_ID, region=REGION, body=self.JOB_TO_SUBMIT)
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
+            .assert_called_once_with(projectId=PROJECT_ID, region=REGION, body=self.JOB_TO_SUBMIT)
 
     @mock.patch(DATAPROC_STRING.format('_DataProcJob.__init__'), return_value=None)
     def test_raise_error_default_job_error_states(self, mock_init):

--- a/tests/contrib/hooks/test_gcp_dataproc_hook.py
+++ b/tests/contrib/hooks/test_gcp_dataproc_hook.py
@@ -72,7 +72,9 @@ class DataProcJobTest(unittest.TestCase):
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value. \
             execute.return_value = {'jobs': [mock_job_on_cluster]}
 
-        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST, job=self.JOB_TO_SUBMIT)
+        _DataProcJob(dataproc_api=self.mock_dataproc,
+                     project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+                     job=self.JOB_TO_SUBMIT)
 
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
             .assert_not_called()
@@ -89,7 +91,9 @@ class DataProcJobTest(unittest.TestCase):
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value\
             .execute.return_value = {'jobs': [mock_job_on_cluster_error, mock_job_on_cluster_running]}
 
-        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST, job=self.JOB_TO_SUBMIT)
+        _DataProcJob(dataproc_api=self.mock_dataproc,
+                     project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+                     job=self.JOB_TO_SUBMIT)
 
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
             .assert_not_called()
@@ -103,20 +107,28 @@ class DataProcJobTest(unittest.TestCase):
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value\
             .execute.return_value = {'jobs': [mock_job_on_cluster]}
 
-        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST, job=self.JOB_TO_SUBMIT)
+        _DataProcJob(dataproc_api=self.mock_dataproc,
+                     project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+                     job=self.JOB_TO_SUBMIT)
 
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
-            .assert_called_once_with(projectId=GCP_PROJECT_ID_HOOK_UNIT_TEST, region=GCP_REGION, body=self.JOB_TO_SUBMIT)
+            .assert_called_once_with(projectId=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+                                     region=GCP_REGION,
+                                     body=self.JOB_TO_SUBMIT)
 
     def test_submit_job_if_no_jobs_running_on_cluster(self):
         # If there are no other jobs already running on the cluster, then submit the job.
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value\
             .execute.return_value = {'jobs': []}
 
-        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST, job=self.JOB_TO_SUBMIT)
+        _DataProcJob(dataproc_api=self.mock_dataproc,
+                     project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+                     job=self.JOB_TO_SUBMIT)
 
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
-            .assert_called_once_with(projectId=GCP_PROJECT_ID_HOOK_UNIT_TEST, region=GCP_REGION, body=self.JOB_TO_SUBMIT)
+            .assert_called_once_with(projectId=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+                                     region=GCP_REGION,
+                                     body=self.JOB_TO_SUBMIT)
 
     def test_submit_job_if_same_job_errored_on_cluster(self):
         # If a job with the same task ID finished with error on the cluster, then resubmit the job for retry.
@@ -126,10 +138,14 @@ class DataProcJobTest(unittest.TestCase):
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value\
             .execute.return_value = {'jobs': [mock_job_on_cluster]}
 
-        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST, job=self.JOB_TO_SUBMIT)
+        _DataProcJob(dataproc_api=self.mock_dataproc,
+                     project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+                     job=self.JOB_TO_SUBMIT)
 
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
-            .assert_called_once_with(projectId=GCP_PROJECT_ID_HOOK_UNIT_TEST, region=GCP_REGION, body=self.JOB_TO_SUBMIT)
+            .assert_called_once_with(projectId=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+                                     region=GCP_REGION,
+                                     body=self.JOB_TO_SUBMIT)
 
     @mock.patch(DATAPROC_STRING.format('_DataProcJob.__init__'), return_value=None)
     def test_raise_error_default_job_error_states(self, mock_init):

--- a/tests/contrib/hooks/test_gcp_dataproc_hook.py
+++ b/tests/contrib/hooks/test_gcp_dataproc_hook.py
@@ -72,7 +72,7 @@ class DataProcJobTest(unittest.TestCase):
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value. \
             execute.return_value = {'jobs': [mock_job_on_cluster]}
 
-        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
+        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST, job=self.JOB_TO_SUBMIT)
 
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
             .assert_not_called()
@@ -89,7 +89,7 @@ class DataProcJobTest(unittest.TestCase):
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value\
             .execute.return_value = {'jobs': [mock_job_on_cluster_error, mock_job_on_cluster_running]}
 
-        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
+        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST, job=self.JOB_TO_SUBMIT)
 
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
             .assert_not_called()
@@ -103,20 +103,20 @@ class DataProcJobTest(unittest.TestCase):
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value\
             .execute.return_value = {'jobs': [mock_job_on_cluster]}
 
-        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
+        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST, job=self.JOB_TO_SUBMIT)
 
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
-            .assert_called_once_with(projectId=PROJECT_ID, region=REGION, body=self.JOB_TO_SUBMIT)
+            .assert_called_once_with(projectId=GCP_PROJECT_ID_HOOK_UNIT_TEST, region=GCP_REGION, body=self.JOB_TO_SUBMIT)
 
     def test_submit_job_if_no_jobs_running_on_cluster(self):
         # If there are no other jobs already running on the cluster, then submit the job.
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value\
             .execute.return_value = {'jobs': []}
 
-        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
+        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST, job=self.JOB_TO_SUBMIT)
 
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
-            .assert_called_once_with(projectId=PROJECT_ID, region=REGION, body=self.JOB_TO_SUBMIT)
+            .assert_called_once_with(projectId=GCP_PROJECT_ID_HOOK_UNIT_TEST, region=GCP_REGION, body=self.JOB_TO_SUBMIT)
 
     def test_submit_job_if_same_job_errored_on_cluster(self):
         # If a job with the same task ID finished with error on the cluster, then resubmit the job for retry.
@@ -126,10 +126,10 @@ class DataProcJobTest(unittest.TestCase):
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value\
             .execute.return_value = {'jobs': [mock_job_on_cluster]}
 
-        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
+        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST, job=self.JOB_TO_SUBMIT)
 
         self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit\
-            .assert_called_once_with(projectId=PROJECT_ID, region=REGION, body=self.JOB_TO_SUBMIT)
+            .assert_called_once_with(projectId=GCP_PROJECT_ID_HOOK_UNIT_TEST, region=GCP_REGION, body=self.JOB_TO_SUBMIT)
 
     @mock.patch(DATAPROC_STRING.format('_DataProcJob.__init__'), return_value=None)
     def test_raise_error_default_job_error_states(self, mock_init):

--- a/tests/contrib/hooks/test_gcp_dataproc_hook.py
+++ b/tests/contrib/hooks/test_gcp_dataproc_hook.py
@@ -19,6 +19,8 @@
 #
 
 import unittest
+from mock import MagicMock
+
 from airflow.contrib.hooks.gcp_dataproc_hook import _DataProcJob
 from airflow.contrib.hooks.gcp_dataproc_hook import DataProcHook
 from tests.contrib.utils.base_gcp_mock import GCP_PROJECT_ID_HOOK_UNIT_TEST
@@ -52,6 +54,79 @@ class DataProcHookTest(unittest.TestCase):
 
 
 class DataProcJobTest(unittest.TestCase):
+    UUID = '12345678'
+    JOB_TO_SUBMIT = {
+        'job':
+            {'placement': {'clusterName': 'test-cluster-name'},
+             'reference': {'jobId': '{}_{}'.format(TASK_ID, UUID)}}
+    }
+
+    def setUp(self):
+        self.mock_dataproc = MagicMock()
+
+    def test_do_not_resubmit_job_if_same_job_running_on_cluster(self):
+        # If a job with the same task ID is already running on the cluster, don't resubmit the job.
+        mock_job_on_cluster = {'reference': {'jobId': '{}_{}'.format(TASK_ID, self.UUID)},
+                               'status': {'state': 'RUNNING'}}
+
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value.execute.return_value = {
+            'jobs': [mock_job_on_cluster]}
+
+        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
+
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit.assert_not_called()
+
+    def test_keep_looking_for_recoverable_job_even_if_errored_job_exists_on_cluster(self):
+        # Keep looking for a job to reattach to even if the first matching job found is in an irrecoverable state
+        mock_job_on_cluster_running = {'reference': {'jobId': '{}_{}'.format(TASK_ID, self.UUID)},
+                                       'status': {'state': 'RUNNING'}}
+
+        mock_job_on_cluster_error = {'reference': {'jobId': '{}_{}'.format(TASK_ID, self.UUID)},
+                                     'status': {'state': 'ERROR'}}
+
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value.execute.return_value = {
+            'jobs': [mock_job_on_cluster_error, mock_job_on_cluster_running]}
+
+        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
+
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit.assert_not_called()
+
+    def test_submit_job_if_different_job_running_on_cluster(self):
+        # If there are jobs running on the cluster, but none of them have the same task ID as the job we're about to submit, then submit the job.
+        mock_job_on_cluster = {'reference': {'jobId': 'a-different-job-id_{}'.format(self.UUID)},
+                               'status': {'state': 'RUNNING'}}
+
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value.execute.return_value = {
+            'jobs': [mock_job_on_cluster]}
+
+        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
+
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit.assert_called_once_with(
+            projectId=PROJECT_ID, region=REGION, body=self.JOB_TO_SUBMIT)
+
+    def test_submit_job_if_no_jobs_running_on_cluster(self):
+        # If there are no other jobs already running on the cluster, then submit the job.
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value.execute.return_value = {
+            'jobs': []}
+
+        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
+
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit.assert_called_once_with(
+            projectId=PROJECT_ID, region=REGION, body=self.JOB_TO_SUBMIT)
+
+    def test_submit_job_if_same_job_errored_on_cluster(self):
+        # If a job with the same task ID finished with error on the cluster, then resubmit the job for retry.
+        mock_job_on_cluster = {'reference': {'jobId': '{}_{}'.format(TASK_ID, self.UUID)},
+                               'status': {'state': 'ERROR'}}
+
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.list.return_value.execute.return_value = {
+            'jobs': [mock_job_on_cluster]}
+
+        _DataProcJob(dataproc_api=self.mock_dataproc, project_id=PROJECT_ID, job=self.JOB_TO_SUBMIT)
+
+        self.mock_dataproc.projects.return_value.regions.return_value.jobs.return_value.submit.assert_called_once_with(
+            projectId=PROJECT_ID, region=REGION, body=self.JOB_TO_SUBMIT)
+
     @mock.patch(DATAPROC_STRING.format('_DataProcJob.__init__'), return_value=None)
     def test_raise_error_default_job_error_states(self, mock_init):
         job = _DataProcJob()


### PR DESCRIPTION
This change allows Airflow to reattach to existing Dataproc jobs upon scheduler restart. Previously, if the Airflow scheduler restarts while it's running a job on GCP Dataproc, it'll lose track of that job, mark the task as failed, and eventually retry. However, the jobs may still be running on Dataproc and maybe even finish successfully. So when Airflow retries and reruns the job, the same job will run twice. This can result in issues like delayed workflows, increased costs, and duplicate data.

The fix also helps in cases where the task fails for some other reason: for example, sometimes the Dataproc service is unavailable, and the Airflow task will fail because it can't check the status of the job, but the job is actually still running correctly.

We've been using this solution successfully at Etsy for the past 6 months. 

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-3211

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

My change has Airflow query the Dataproc API before submitting a job to see if the job is already running on the cluster. If a job with a matching task ID is already running on the cluster AND is in a recoverable state (like RUNNING or DONE), then Airflow will reattach itself to the existing job on Dataproc instead of resubmitting a new job to the cluster. If the job on the cluster is in an irrecoverable state like ERROR, Airflow will resubmit the job.

To see this change in action:

Setup:
1. Set up a GCP Project with the Dataproc API enabled
2. Install Airflow.
3. In the box that's running Airflow, `pip install google-api-python-client oauth2client`
4. Start the Airflow webserver. In the Airflow UI, Go to Admin->Connections, edit the `google_cloud_default` connection, and fill in the Project Id field with your project ID.

To reproduce:

1. Install this DAG in the Airflow instance: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/b80895ed88ba86fce223df27a48bf481007ca708/composer/workflows/quickstart.py Set up the Airflow variables as instructed at the top of the file.
2. Start the Airflow scheduler and webserver if they're not running already. Kick off a run of the above DAG through the Airflow UI. Wait for the cluster to spin up and the job to start running on Dataproc.
3. While the job's running, kill the scheduler. Wait 5 seconds or so, and then start it back up.
4. Airflow will retry the task and reattach to the existing task already on Dataproc. Look at the Airflow logs to observe "Reattaching to previously-started DataProc job run_dataproc_... (in state RUNNING)." Click on the cluster in Dataproc to observe that only the single job is running; a duplicate job has not been submitted.
5. Observe that, when the job finishes, Airflow detects the completion successfully and runs the downstream cluster delete operation.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added the following tests to `tests/contrib/hooks/test_gcp_dataproc_hook.py`:

When submitting a new job to Dataproc:
- If a job with the same task ID is already running on the cluster, don't resubmit the job.
- If the first matching job found on the cluster is in an irrecoverable state, keep looking for a job in a recoverable state to reattach to on the cluster. This ensures that Airflow will prioritize recoverable jobs when looking for jobs to reattach to on the cluster.
- If there are jobs running on the cluster, but none of them have the same task ID as the job we're about to submit, then submit the new job.
- If there are no other jobs already running on the cluster, then submit the job.
- If a job with the same task ID finished with error on the cluster, then resubmit the job for retry.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
