### PR TITLE
[AIRFLOW-2192] Allow non-latin1 usernames with MySQL back-end

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -86,6 +86,9 @@ executor = SequentialExecutor
 # their website
 sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/airflow.db
 
+# The encoding for the databases
+sql_engine_encoding = utf-8
+
 # If SqlAlchemy should pool database connections.
 sql_alchemy_pool_enabled = True
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -2121,6 +2121,11 @@ class PasswordUserTest(unittest.TestCase):
         self.password_user.password = "secure_password"
         self.assertTrue(self.password_user.authenticate("secure_password"))
 
+    def test_password_unicode_user_authenticate(self):
+        self.password_user.username = u"🐼"  # This is a panda
+        self.password_user.password = "secure_password"
+        self.assertTrue(self.password_user.authenticate("secure_password"))
+
     def test_password_authenticate_session(self):
         from airflow.contrib.auth.backends.password_auth import PasswordUser
         self.password_user.password = 'test_password'


### PR DESCRIPTION
Allow non-latin1 usernames by adding a SQL_ENGINE_ENCODING param and default to UTF-8

Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-2192\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2192
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-2192\], code changes always need a Jira issue.

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:

Allow non-latin1 usernames by adding a SQL_ENGINE_ENCODING param and default to UTF-8

### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
WIP PR, tests after manual validation
Adds a test for unicode username, also covered by existing tests.

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ X ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ X ] Passes `flake8`
