### PR TITLE
[AIRFLOW-3250] Fix for Redis Hook for not authorised connection calls

### DIFF
--- a/airflow/contrib/sensors/redis_key_sensor.py
+++ b/airflow/contrib/sensors/redis_key_sensor.py
@@ -23,25 +23,17 @@ from airflow.utils.decorators import apply_defaults
 
 class RedisKeySensor(BaseSensorOperator):
     """
-    Checks for the existence of a key in a Redis database
+    Checks for the existence of a key in a Redis
     """
     template_fields = ('key',)
     ui_color = '#f0eee4'
 
     @apply_defaults
     def __init__(self, key, redis_conn_id, *args, **kwargs):
-        """
-        Create a new RedisKeySensor
-
-        :param key: The key to be monitored
-        :type key: str
-        :param redis_conn_id: The connection ID to use when connecting to Redis DB.
-        :type redis_conn_id: str
-        """
         super(RedisKeySensor, self).__init__(*args, **kwargs)
         self.redis_conn_id = redis_conn_id
         self.key = key
 
     def poke(self, context):
-        self.log.info('Sensor check existence of key: %s', self.key)
-        return RedisHook(self.redis_conn_id).key_exists(self.key)
+        self.log.info('Sensor checks for existence of key: %s', self.key)
+        return RedisHook(self.redis_conn_id).get_conn().exists(self.key)

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -208,7 +208,7 @@ def initdb(rbac=False):
     merge_conn(
         models.Connection(
             conn_id='redis_default', conn_type='redis',
-            host='localhost', port=6379,
+            host='redis', port=6379,
             extra='{"db": 0}'))
     merge_conn(
         models.Connection(

--- a/scripts/ci/docker-compose.yml
+++ b/scripts/ci/docker-compose.yml
@@ -45,6 +45,10 @@ services:
     image: rabbitmq:3.7
     restart: always
 
+  redis:
+    image: redis:5.0.1
+    restart: always
+
   openldap:
     image: osixia/openldap:1.2.0
     restart: always
@@ -87,6 +91,7 @@ services:
       - mongo
       - cassandra
       - rabbitmq
+      - redis
       - openldap
       - krb5-kdc-server
     volumes:


### PR DESCRIPTION
Password stay None value and not None (str) in case there is no password set through webadmin interfaces.
This is fix for connections for Redis that not expect autorisation from clients. 
Fixes originally  implemented: https://issues.apache.org/jira/browse/AIRFLOW-999

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/AIRFLOW-3250) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-3250

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

This functionality is trivial further description is NOT needed.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

/tests/contrib/hooks/test_redis_hook.py
/tests/contrib/sensors/test_redis_sensor.py

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

This functionality is trivial and documentation is NOT needed.

### Code Quality

- [X] Passes `flake8`
