### PR TITLE
[AIRFLOW-3257] Pin flake8 version to avoid checks changing over time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -256,7 +256,7 @@ devel = [
     'qds-sdk>=1.9.6',
     'rednose',
     'requests_mock',
-    'flake8'
+    'flake8==3.5.0'
 ]
 
 if not PY3:

--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,6 @@ commands =
 basepython = python3
 
 deps =
-    flake8
+    flake8==3.5.0
 
 commands = flake8


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3257) issues and references them in the PR title.

### Description

- [x] Here are some details about my PR:

Flake8 3.6.0 was just released and it introduced some new checks that
didn't exist before. As a result all of our CI pipelines are now failing.

To avoid this happening in future we should pin the version of flake8
to 3.5.0 (currently this is in tox.ini, and setup.py)

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No new tests, PR only pins a dependency.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
No new functionality.

### Code Quality

- [x] Passes `flake8`
