### PR TITLE
[AIRFLOW-839] Only log status for DockerOperator pull if the key is present

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -192,7 +192,8 @@ class DockerOperator(BaseOperator):
             self.log.info('Pulling docker image %s', self.image)
             for l in self.cli.pull(self.image, stream=True):
                 output = json.loads(l.decode('utf-8'))
-                self.log.info("%s", output['status'])
+                if 'status' in output:
+                    self.log.info("%s", output['status'])
 
         with TemporaryDirectory(prefix='airflowtmp') as host_tmp_dir:
             self.environment['AIRFLOW_TMP_DIR'] = self.tmp_dir


### PR DESCRIPTION


### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description
This addresses [AIRFLOW-839](https://issues.apache.org/jira/browse/AIRFLOW-839) wherein a job will fail on logging the status of a docker image pull and fail to provide further output.

Example:

```
{docker_operator.py:160} INFO - Downloading
[2018-10-25 02:10:44,746] {base_task_runner.py:93} INFO - Subtask: [2018-10-25 02:10:44,746] {docker_operator.py:160} INFO - Verifying Checksum
[2018-10-25 02:10:44,746] {base_task_runner.py:93} INFO - Subtask: [2018-10-25 02:10:44,746] {docker_operator.py:160} INFO - Download complete
[2018-10-25 02:10:45,034] {base_task_runner.py:93} INFO - Subtask: [2018-10-25 02:10:45,033] {models.py:1544} ERROR - 'status'
[2018-10-25 02:10:45,034] {base_task_runner.py:93} INFO - Subtask: Traceback (most recent call last):
[2018-10-25 02:10:45,035] {base_task_runner.py:93} INFO - Subtask:   File "/usr/local/lib/python2.7/dist-packages/airflow/models.py", line 1457, in _run_raw_task
[2018-10-25 02:10:45,035] {base_task_runner.py:93} INFO - Subtask:     result = task_copy.execute(context=context)
[2018-10-25 02:10:45,035] {base_task_runner.py:93} INFO - Subtask:   File "/usr/local/lib/python2.7/dist-packages/airflow/operators/docker_operator.py", line 160, in execute
[2018-10-25 02:10:45,035] {base_task_runner.py:93} INFO - Subtask:     logging.info("{}".format(output['status']))
[2018-10-25 02:10:45,035] {base_task_runner.py:93} INFO - Subtask: KeyError: 'status'
[2018-10-25 02:10:45,037] {base_task_runner.py:93} INFO - Subtask: [2018-10-25 02:10:45,037] {models.py:1571} INFO - All retries failed; marking task as FAILED
[2018-10-25 02:10:45,170] {base_task_runner.py:93} INFO - Subtask: [2018-10-25 02:10:45,170] {email.py:110} INFO - Sent an alert email to <redacted>
[2018-10-25 02:10:45,316] {base_task_runner.py:93} INFO - Subtask: [2018-10-25 02:10:45,316] {models.py:1594} ERROR - 'status'
[2018-10-25 02:10:45,316] {base_task_runner.py:93} INFO - Subtask: Traceback (most recent call last):
[2018-10-25 02:10:45,317] {base_task_runner.py:93} INFO - Subtask:   File "/usr/local/bin/airflow", line 28, in <module>
[2018-10-25 02:10:45,317] {base_task_runner.py:93} INFO - Subtask:     args.func(args)
[2018-10-25 02:10:45,317] {base_task_runner.py:93} INFO - Subtask:   File "/usr/local/lib/python2.7/dist-packages/airflow/bin/cli.py", line 438, in run
[2018-10-25 02:10:45,317] {base_task_runner.py:93} INFO - Subtask:     pool=args.pool,
[2018-10-25 02:10:45,317] {base_task_runner.py:93} INFO - Subtask:   File "/usr/local/lib/python2.7/dist-packages/airflow/utils/db.py", line 49, in wrapper
[2018-10-25 02:10:45,317] {base_task_runner.py:93} INFO - Subtask:     result = func(*args, **kwargs)
[2018-10-25 02:10:45,317] {base_task_runner.py:93} INFO - Subtask:   File "/usr/local/lib/python2.7/dist-packages/airflow/models.py", line 1457, in _run_raw_task
[2018-10-25 02:10:45,317] {base_task_runner.py:93} INFO - Subtask:     result = task_copy.execute(context=context)
[2018-10-25 02:10:45,318] {base_task_runner.py:93} INFO - Subtask:   File "/usr/local/lib/python2.7/dist-packages/airflow/operators/docker_operator.py", line 160, in execute
[2018-10-25 02:10:45,318] {base_task_runner.py:93} INFO - Subtask:     logging.info("{}".format(output['status']))
[2018-10-25 02:10:45,318] {base_task_runner.py:93} INFO - Subtask: KeyError: 'status'
[2018-10-25 02:11:08,673] {jobs.py:183} DEBUG - [heartbeat]
[2018-10-25 02:11:08,673] {jobs.py:2436} INFO - Task exited with return code 1
```

We already log the rest of the status of the pull so this wouldn't introduce a regression.

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This is just checking for the key presence prior to logging. It would be difficult to unit test this outside of a basic dictionary check which is rather meaningless.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
