### PR TITLE
[AIRFLOW-3262] Add param to log response when using SimpleHttpOperator

### DIFF
--- a/airflow/operators/http_operator.py
+++ b/airflow/operators/http_operator.py
@@ -46,6 +46,10 @@ class SimpleHttpOperator(BaseOperator):
         'requests' documentation (options to modify timeout, ssl, etc.)
     :type extra_options: A dictionary of options, where key is string and value
         depends on the option that's being modified.
+    :param xcom_push: Push the response to Xcom (default: False)
+    :type xcom_push: bool
+    :param log_response: Log the response (default: False)
+    :type log_response: bool
     """
 
     template_fields = ('endpoint', 'data',)
@@ -61,7 +65,9 @@ class SimpleHttpOperator(BaseOperator):
                  response_check=None,
                  extra_options=None,
                  xcom_push=False,
-                 http_conn_id='http_default', *args, **kwargs):
+                 http_conn_id='http_default',
+                 log_response=False,
+                 *args, **kwargs):
         """
         If xcom_push is True, response of an HTTP request will also
         be pushed to an XCom.
@@ -75,6 +81,7 @@ class SimpleHttpOperator(BaseOperator):
         self.response_check = response_check
         self.extra_options = extra_options or {}
         self.xcom_push_flag = xcom_push
+        self.log_response = log_response
 
     def execute(self, context):
         http = HttpHook(self.method, http_conn_id=self.http_conn_id)
@@ -90,3 +97,5 @@ class SimpleHttpOperator(BaseOperator):
                 raise AirflowException("Response check returned False.")
         if self.xcom_push_flag:
             return response.text
+        if self.log_response:
+            self.log.info(response.text)

--- a/tests/operators/test_http_operator.py
+++ b/tests/operators/test_http_operator.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import unittest
+
+from mock import patch
+from airflow.operators.http_operator import SimpleHttpOperator
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+
+class AnyStringWith(str):
+    """
+    Helper class to check if a substring is a part of a string
+    """
+    def __eq__(self, other):
+        return self in other
+
+
+class SimpleHttpOpTests(unittest.TestCase):
+    def setUp(self):
+        # Creating a local Http connection to Airflow Webserver
+        os.environ['AIRFLOW_CONN_HTTP_LOCAL'] = 'http://localhost:8080'
+
+    def test_response_in_logs(self):
+        """
+        Test that when using SimpleHttpOperator with 'GET' on localhost:8080,
+        the log contains 'Airflow' in it
+        """
+        operator = SimpleHttpOperator(
+            task_id='test_HTTP_op',
+            method='GET',
+            endpoint='/',
+            http_conn_id='HTTP_LOCAL',
+            log_response=True,
+        )
+
+        with patch.object(operator.log, 'info') as mock_info:
+            operator.execute(None)
+            mock_info.assert_called_with(AnyStringWith('Airflow'))

--- a/tests/operators/test_http_operator.py
+++ b/tests/operators/test_http_operator.py
@@ -43,21 +43,21 @@ class AnyStringWith(str):
 class SimpleHttpOpTests(unittest.TestCase):
     def setUp(self):
         # Creating a local Http connection to Airflow Webserver
-        os.environ['AIRFLOW_CONN_HTTP_LOCAL'] = 'http://localhost:8080'
+        os.environ['AIRFLOW_CONN_HTTP_GOOGLE'] = 'http://www.google.com'
 
     def test_response_in_logs(self):
         """
         Test that when using SimpleHttpOperator with 'GET' on localhost:8080,
-        the log contains 'Airflow' in it
+        the log contains 'Google' in it
         """
         operator = SimpleHttpOperator(
             task_id='test_HTTP_op',
             method='GET',
             endpoint='/',
-            http_conn_id='HTTP_LOCAL',
+            http_conn_id='HTTP_GOOGLE',
             log_response=True,
         )
 
         with patch.object(operator.log, 'info') as mock_info:
             operator.execute(None)
-            mock_info.assert_called_with(AnyStringWith('Airflow'))
+            mock_info.assert_called_with(AnyStringWith('Google'))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3262

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When you use SimpleHttpOperator for things like ElasticSearch, you want to get the response in the logs as well. Currently, the only workaround is to use `xcom_push` and push the content to xcom and in the next task get the response.



### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- `SimpleHttpOpTests.test_response_in_logs`: Test that when using SimpleHttpOperator with 'GET' on localhost:8080, the log contains 'Airflow' in it
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
