### PR TITLE
[AIRFLOW-XXX] Fix incorrect statement in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,10 +106,7 @@ There are three ways to setup an Apache Airflow development environment.
 
   ```
   # Start docker in your Airflow directory
-  docker run -t -i -v `pwd`:/airflow/ -w /airflow/ -e SLUGIFY_USES_TEXT_UNIDECODE=yes python:2 bash
-
-  # Go to the Airflow directory
-  cd /airflow/
+  docker run -t -i -v `pwd`:/airflow/ -w /airflow/ -e SLUGIFY_USES_TEXT_UNIDECODE=yes python:3 bash
 
   # Install Airflow with all the required dependencies,
   # including the devel which will provide the development tools


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

Changed 2 lines in CONTRIBUTING.md.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Changed 2 lines in CONTRIBUTING.md:

1. Set Python version to 3 in instructions about using Docker for unit testing. The Python world prefers version 3 afaik, so let's promote that version. There's still a note saying both Python 2 & 3 are supported.
2. Removed incorrect `cd` statement (`pip install` must be run from `/airflow` and the `docker run` sets the working dir to `/airflow`, so it's incorrect to then go to `/airflow/airflow` inside the container).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No tests for docs.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
