### PR TITLE
[AIRFLOW-3265] Support for "unix_socket" extra for MySQL hook

### DIFF
--- a/airflow/hooks/mysql_hook.py
+++ b/airflow/hooks/mysql_hook.py
@@ -89,6 +89,8 @@ class MySqlHook(DbApiHook):
         local_infile = conn.extra_dejson.get('local_infile', False)
         if conn.extra_dejson.get('ssl', False):
             conn_config['ssl'] = conn.extra_dejson['ssl']
+        if conn.extra_dejson.get('unix_socket'):
+            conn_config['unix_socket'] = conn.extra_dejson['unix_socket']
         if local_infile:
             conn_config["local_infile"] = 1
         conn = MySQLdb.connect(**conn_config)

--- a/tests/hooks/test_mysql_hook.py
+++ b/tests/hooks/test_mysql_hook.py
@@ -92,6 +92,15 @@ class TestMySqlHookConn(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertEqual(kwargs['local_infile'], 1)
 
+    @mock.patch('airflow.hooks.mysql_hook.MySQLdb.connect')
+    def test_get_con_unix_socket(self, mock_connect):
+        self.connection.extra = json.dumps({'unix_socket': "/tmp/socket"})
+        self.db_hook.get_conn()
+        mock_connect.assert_called_once()
+        args, kwargs = mock_connect.call_args
+        self.assertEqual(args, ())
+        self.assertEqual(kwargs['unix_socket'], '/tmp/socket')
+
 
 class TestMySqlHook(unittest.TestCase):
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3265

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Added support for unix_socket extra for MySQL

MySQL hook does not support "unix_socket" extra - which allows
to specify different location of linux socket than the default one.
This is a blocker for tools like cloud-sql-proxy that
creates sockets in an arbitrary place.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

TestMySqlHookConn.test_get_con_unix_socket

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
No new functionality (at least no documentation to update)

### Code Quality

- [x] Passes `flake8`
