### PR TITLE
[AIRFLOW-3268] Cannot pass SSL dictionary to mysql connection via URL

### DIFF
--- a/airflow/hooks/mysql_hook.py
+++ b/airflow/hooks/mysql_hook.py
@@ -19,6 +19,8 @@
 
 import MySQLdb
 import MySQLdb.cursors
+import json
+import six
 
 from airflow.hooks.dbapi_hook import DbApiHook
 
@@ -88,7 +90,13 @@ class MySqlHook(DbApiHook):
                 conn_config["cursorclass"] = MySQLdb.cursors.SSDictCursor
         local_infile = conn.extra_dejson.get('local_infile', False)
         if conn.extra_dejson.get('ssl', False):
-            conn_config['ssl'] = conn.extra_dejson['ssl']
+            # SSL parameter for MySQL has to be a dictionary and in case
+            # of extra/dejson we can get string if extra is passed via
+            # URL parameters
+            dejson_ssl = conn.extra_dejson['ssl']
+            if isinstance(dejson_ssl, six.string_types):
+                dejson_ssl = json.loads(dejson_ssl)
+            conn_config['ssl'] = dejson_ssl
         if conn.extra_dejson.get('unix_socket'):
             conn_config['unix_socket'] = conn.extra_dejson['unix_socket']
         if local_infile:

--- a/docs/howto/manage-connections.rst
+++ b/docs/howto/manage-connections.rst
@@ -133,8 +133,9 @@ Scopes (comma separated)
         Scopes are ignored when using application default credentials. See
         issue `AIRFLOW-2522
         <https://issues.apache.org/jira/browse/AIRFLOW-2522>`_.
+
 MySQL
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~
 The MySQL connect type allows to connect with MySQL database.
 
 Configuring the Connection
@@ -152,7 +153,61 @@ Password (required)
     Specify the password to connect.    
     
 Extra (optional)
-    Specify the charset. Example: {"charset": "utf8"}
-    
+    Specify the extra parameters (as json dictionary) that can be used in mysql
+    connection. The following parameters are supported:
+
+    * **charset**: specify charset of the connection
+    * **cursor**: one of "sscursor", "dictcursor, "ssdictcursor" - specifies cursor class to be
+      used
+    * **local_infile**: controls MySQL's LOCAL capability (permitting local data loading by
+      clients). See `MySQLdb docs <https://mysqlclient.readthedocs.io/user_guide.html>`_
+      for details.
+    * **unix_socket**: UNIX socket used instead of the default socket
+    * **ssl**: Dictionary of SSL parameters that control connecting using SSL (those
+      parameters are server specific and should contain "ca", "cert", "key", "capath",
+      "cipher" parameters. See
+      `MySQLdb docs <https://mysqlclient.readthedocs.io/user_guide.html>`_ for details.
+      Note that in order to be useful in URL notation, this parameter might also be
+      a string where the SSL dictionary is a string-encoded JSON dictionary.
+
+    Example "extras" field:
+
+    .. code-block:: json
+
+       {
+          "charset": "utf8",
+          "cursorclass": "sscursor",
+          "local_infile": true,
+          "unix_socket": "/var/socket",
+          "ssl": {
+            "cert": "/tmp/client-cert.pem",
+            "ca": "/tmp/server-ca.pem'",
+            "key": "/tmp/client-key.pem"
+          }
+       }
+
+    or
+
+    .. code-block:: json
+
+       {
+          "charset": "utf8",
+          "cursorclass": "sscursor",
+          "local_infile": true,
+          "unix_socket": "/var/socket",
+          "ssl": "{\"cert\": \"/tmp/client-cert.pem\", \"ca\": \"/tmp/server-ca.pem\", \"key\": \"/tmp/client-key.pem\"}"
+       }
+
+    When specifying the connection as URI (in AIRFLOW_CONN_* variable) you should specify it
+    following the standard syntax of DB connections, where extras as passed as parameters
+    of the URI (note that all components of the URI should be URL-encoded).
+
+    For example:
+
+    .. code-block:: bash
+
+       mysql://mysql_user:XXXXXXXXXXXX@1.1.1.1:3306/mysqldb?ssl=%7B%22cert%22%3A+%22%2Ftmp%2Fclient-cert.pem%22%2C+%22ca%22%3A+%22%2Ftmp%2Fserver-ca.pem%22%2C+%22key%22%3A+%22%2Ftmp%2Fclient-key.pem%22%7D
+
     .. note::
-        If encounter UnicodeDecodeError while working with MySQL connection check the charset defined is matched to the database charset.
+        If encounter UnicodeDecodeError while working with MySQL connection check
+        the charset defined is matched to the database charset.

--- a/tests/hooks/test_mysql_hook.py
+++ b/tests/hooks/test_mysql_hook.py
@@ -27,6 +27,12 @@ import MySQLdb.cursors
 from airflow import models
 from airflow.hooks.mysql_hook import MySqlHook
 
+SSL_DICT = {
+    'cert': '/tmp/client-cert.pem',
+    'ca': '/tmp/server-ca.pem',
+    'key': '/tmp/client-key.pem'
+}
+
 
 class TestMySqlHookConn(unittest.TestCase):
 
@@ -100,6 +106,24 @@ class TestMySqlHookConn(unittest.TestCase):
         args, kwargs = mock_connect.call_args
         self.assertEqual(args, ())
         self.assertEqual(kwargs['unix_socket'], '/tmp/socket')
+
+    @mock.patch('airflow.hooks.mysql_hook.MySQLdb.connect')
+    def test_get_conn_ssl_as_dictionary(self, mock_connect):
+        self.connection.extra = json.dumps({'ssl': SSL_DICT})
+        self.db_hook.get_conn()
+        mock_connect.assert_called_once()
+        args, kwargs = mock_connect.call_args
+        self.assertEqual(args, ())
+        self.assertEqual(kwargs['ssl'], SSL_DICT)
+
+    @mock.patch('airflow.hooks.mysql_hook.MySQLdb.connect')
+    def test_get_conn_ssl_as_string(self, mock_connect):
+        self.connection.extra = json.dumps({'ssl': json.dumps(SSL_DICT)})
+        self.db_hook.get_conn()
+        mock_connect.assert_called_once()
+        args, kwargs = mock_connect.call_args
+        self.assertEqual(args, ())
+        self.assertEqual(kwargs['ssl'], SSL_DICT)
 
 
 class TestMySqlHook(unittest.TestCase):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3268

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
It is impossible to pass 'ssl' dictionary to MySql hook as an extrai
param via URL connection. While there is a code to pass the 'ssl'
extra query parameter, MySqldb requires this parameter to be
dictionary. When you want to create a connection via URL,
you can at most have ?ssl= url-encoded string rather than
dictionary and this is how it is passed (as string). What happens
then in MySqldb, is that all SSL parameters are ignored
and MySQL establishes a non-SSL connection silently.

This is fixed by detecting if 'ssl' is a string and converting
it to json dictionary in such case.

### Tests

- [x] My PR adds the following unit tests
TestMySqlHookConn:
   test_get_conn_ssl_as_dictionary
   test_get_conn_ssl_as_string

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
No new functionality

### Code Quality

- [x] Passes `flake8`
