### PR TITLE
[AIRFLOW-3259] Fix internal server error when displaying charts

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -488,7 +488,7 @@ class Airflow(BaseView):
                 else:
                     # User provides columns (x, y, metric1, metric2, ...)
                     df.index = df[df.columns[0]]
-                    df = df.sort(df.columns[0])
+                    df = df.sort_values(by=df.columns[0])
                     del df[df.columns[0]]
                     for col in df.columns:
                         df[col] = df[col].astype(np.float)


### PR DESCRIPTION
This is caused by the fact that the function 'sort' is no longer a part of Dataframe in pandas and is still used in the code base. It has ever since been replaced by 'sort_values'. Replacing the function gets the chart display back to its normal behavior.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3259/) issues and references them in the PR title. For example, "\[AIRFLOW-3259\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3259
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**Problem**
When you try to create a chart and display metrics you get an internal server error.

**Cause**
A dependency issue: the function "sort" was deprecated and is no longer a part of pandas Dataframe and thus it creates a problem when creating charts in airflow.

**Solution**
The sort function needs to replaced by sort_values instead (See code below)
`# Replace this `
`df = df.sort(df.columns[0]) `
`# By this `
`df = df.sort_values(by=df.columns[0])`
In views.py

**Result**
The data is loaded and the chart displayed   

### Tests

- [x] My PR does not need testing for this extremely good reason:
My code doesn't change the behavior of the code, but rather modifies a no longer existing function (in pandas) with its new substitute.

### Commits

- [x] My commit all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] Passes `flake8`
