### PR TITLE
[AIRFLOW-XXX] Minor fix of docs/scheduler.rst

### DIFF
--- a/docs/scheduler.rst
+++ b/docs/scheduler.rst
@@ -23,7 +23,7 @@ start date, at the END of the period.
 
 The scheduler starts an instance of the executor specified in the your
 ``airflow.cfg``. If it happens to be the ``LocalExecutor``, tasks will be
-executed as subprocesses; in the case of ``CeleryExecutor`` and
+executed as subprocesses; in the case of ``CeleryExecutor``, ``DaskExecutor``, and
 ``MesosExecutor``, tasks are executed remotely.
 
 To start a scheduler, simply run the command:


### PR DESCRIPTION
### Jira
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

DaskExecutor is not mentioned in docs/scheduler.rst, while it's listed as one of the main executors in `airflow/config_templates/default_airflow.cfg`.
