### PR TITLE
[AIRFLOW-3277] Correctly observe DST transitions for cron

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3540,7 +3540,7 @@ class DAG(BaseDag, LoggingMixin):
         using_start_date = using_start_date or min([t.start_date for t in self.tasks])
         using_end_date = using_end_date or timezone.utcnow()
 
-        # next run date for a subdag isn't relevant (s  chedule_interval for subdags
+        # next run date for a subdag isn't relevant (schedule_interval for subdags
         # is ignored) so we use the dag run's start date in the case of a subdag
         next_run_date = (self.normalize_schedule(using_start_date)
                          if not self.is_subdag else using_start_date)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3277
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

`following_schedule` converts to naive time by using the
local time zone. In case of a DST transition, say 3AM -> 2AM
("summer time to winter time") we generate date times that
could overlap with earlier schedules. Therefore a DAG that
should run every 5 minutes will not do so if it has already
seen the schedule.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

added

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [X] Passes `flake8`

cc @ashb 
