### PR TITLE
[AIRFLOW-3271] Airflow RBAC Permissions modification via UI do not persist

### DIFF
--- a/airflow/www_rbac/security.py
+++ b/airflow/www_rbac/security.py
@@ -181,13 +181,17 @@ class AirflowSecurityManager(SecurityManager):
         if not role:
             role = self.add_role(role_name)
 
-        role_pvms = []
-        for pvm in pvms:
-            if pvm.view_menu.name in role_vms and pvm.permission.name in role_perms:
-                role_pvms.append(pvm)
-        role.permissions = list(set(role_pvms))
-        self.get_session.merge(role)
-        self.get_session.commit()
+        if (len(role.permissions) == 0):
+            logging.info('Initializing permissions for role:%s in the database.', role_name)
+            role_pvms = []
+            for pvm in pvms:
+                if pvm.view_menu.name in role_vms and pvm.permission.name in role_perms:
+                    role_pvms.append(pvm)
+            role.permissions = list(set(role_pvms))
+            self.get_session.merge(role)
+            self.get_session.commit()
+        else:
+            logging.info('Existing permissions for the role:%s within the database will persist.', role_name)
 
     def get_user_roles(self, user=None):
         """

--- a/airflow/www_rbac/security.py
+++ b/airflow/www_rbac/security.py
@@ -181,7 +181,7 @@ class AirflowSecurityManager(SecurityManager):
         if not role:
             role = self.add_role(role_name)
 
-        if (len(role.permissions) == 0):
+        if len(role.permissions) == 0:
             logging.info('Initializing permissions for role:%s in the database.', role_name)
             role_pvms = []
             for pvm in pvms:

--- a/airflow/www_rbac/security.py
+++ b/airflow/www_rbac/security.py
@@ -192,10 +192,6 @@ class AirflowSecurityManager(SecurityManager):
             self.get_session.commit()
         else:
             logging.info('Existing permissions for the role:%s within the database will persist.', role_name)
-            for pvm in pvms:
-                if pvm not in role.permissions:
-                    if pvm.view_menu.name in role_vms and pvm.permission.name in role_perms:
-                        role.permissions.append(pvm)
 
     def get_user_roles(self, user=None):
         """

--- a/airflow/www_rbac/security.py
+++ b/airflow/www_rbac/security.py
@@ -192,6 +192,10 @@ class AirflowSecurityManager(SecurityManager):
             self.get_session.commit()
         else:
             logging.info('Existing permissions for the role:%s within the database will persist.', role_name)
+            for pvm in pvms:
+                if pvm not in role.permissions and pvm.view_menu.name in role_vms and pvm.permission.name in role_perms:
+                    role.permissions.append(pvm)
+
 
     def get_user_roles(self, user=None):
         """

--- a/airflow/www_rbac/security.py
+++ b/airflow/www_rbac/security.py
@@ -193,9 +193,9 @@ class AirflowSecurityManager(SecurityManager):
         else:
             logging.info('Existing permissions for the role:%s within the database will persist.', role_name)
             for pvm in pvms:
-                if pvm not in role.permissions and pvm.view_menu.name in role_vms and pvm.permission.name in role_perms:
-                    role.permissions.append(pvm)
-
+                if pvm not in role.permissions:
+                    if pvm.view_menu.name in role_vms and pvm.permission.name in role_perms:
+                        role.permissions.append(pvm)
 
     def get_user_roles(self, user=None):
         """

--- a/tests/www_rbac/test_security.py
+++ b/tests/www_rbac/test_security.py
@@ -107,6 +107,20 @@ class TestSecurity(unittest.TestCase):
         self.assertIsNotNone(role)
         self.assertEqual(len(role_perms), len(role.permissions))
 
+    def test_update_and_verify_permission_role(self):
+        self.security_manager.init_role('User', [], [])
+        role = self.security_manager.find_role('User')
+
+        perm = self.security_manager.\
+            find_permission_view_menu('can_edit', 'RoleModelView')
+        self.security_manager.add_permission_role(role,perm)
+        role_perms_len = len(role.permissions)
+
+        self.security_manager.init_role('User', [], [])
+        new_role_perms_len = len(role.permissions)
+
+        self.assertEqual(role_perms_len, new_role_perms_len)
+
     def test_get_user_roles(self):
         user = mock.MagicMock()
         user.is_anonymous = False

--- a/tests/www_rbac/test_security.py
+++ b/tests/www_rbac/test_security.py
@@ -113,7 +113,7 @@ class TestSecurity(unittest.TestCase):
 
         perm = self.security_manager.\
             find_permission_view_menu('can_edit', 'RoleModelView')
-        self.security_manager.add_permission_role(role,perm)
+        self.security_manager.add_permission_role(role, perm)
         role_perms_len = len(role.permissions)
 
         self.security_manager.init_role('User', [], [])

--- a/tests/www_rbac/test_security.py
+++ b/tests/www_rbac/test_security.py
@@ -108,15 +108,16 @@ class TestSecurity(unittest.TestCase):
         self.assertEqual(len(role_perms), len(role.permissions))
 
     def test_update_and_verify_permission_role(self):
-        self.security_manager.init_role('User', [], [])
-        role = self.security_manager.find_role('User')
+        role_name = 'Test_Role'
+        self.security_manager.init_role(role_name, [], [])
+        role = self.security_manager.find_role(role_name)
 
         perm = self.security_manager.\
             find_permission_view_menu('can_edit', 'RoleModelView')
         self.security_manager.add_permission_role(role, perm)
         role_perms_len = len(role.permissions)
 
-        self.security_manager.init_role('User', [], [])
+        self.security_manager.init_role(role_name, [], [])
         new_role_perms_len = len(role.permissions)
 
         self.assertEqual(role_perms_len, new_role_perms_len)

--- a/tests/www_rbac/test_views.py
+++ b/tests/www_rbac/test_views.py
@@ -962,6 +962,9 @@ class TestDagACLView(TestBase):
         all_dag_role = self.appbuilder.sm.find_role('all_dag_role')
         self.appbuilder.sm.add_permission_role(all_dag_role, perm_on_all_dag)
 
+        role_user = self.appbuilder.sm.find_role('User')
+        self.appbuilder.sm.add_permission_role(role_user, perm_on_all_dag)
+
         read_only_perm_on_dag = self.appbuilder.sm.\
             find_permission_view_menu('can_dag_read', 'example_bash_operator')
         dag_read_only_role = self.appbuilder.sm.find_role('dag_acl_read_only')


### PR DESCRIPTION
Fix is added to not reset the database whenever a new process comes up (or init_roles is called). Otherwise Airflow RBAC permissions that are modified, do not persist for long

"test_update_and_verify_permission_role" test has been added.

Make sure you have checked _all_ steps below.

Jira
- [x] My PR addresses the following AIRFLOW-3271 issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  -https://issues.apache.org/jira/browse/AIRFLOW-3271

Description
- [x] Here are some details about my PR, including screenshots of any UI changes: My PR adds a fix to make Airflow RBAC permission changes to the database persist. The RBAC permission will only be reset in the very beginning and later when init_role is called, it will keep the existing permission as is and will not reset it. Previously, when any change is made to the RBAC permissions, those changes used to get reset when init_roles is called (for every new process creation). Because of which, any new RBAC permission added via UI used to be missing in the database after sometime. 

### Tests

- [x] My PR adds the following unit tests:
        test_update_and_verify_permission_role

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
        No new functionality

### Code Quality

- [x] Passes `flake8`
