### PR TITLE
[AIRFLOW-3288] Add SNS integration

### DIFF
--- a/airflow/contrib/hooks/aws_sns_hook.py
+++ b/airflow/contrib/hooks/aws_sns_hook.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+
+from airflow.contrib.hooks.aws_hook import AwsHook
+
+
+class AwsSnsHook(AwsHook):
+    """
+    Interact with Amazon Simple Notification Service.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(AwsSnsHook, self).__init__(*args, **kwargs)
+
+    def get_conn(self):
+        """
+        Get an SNS connection
+        """
+        self.conn = self.get_client_type('sns')
+        return self.conn
+
+    def publish_to_target(self, target_arn, message):
+        """
+        Publish a message to a topic or an endpoint.
+
+        :param target_arn: either a TopicArn or an EndpointArn
+        :type target_arn: str
+        :param message: the default message you want to send
+        :param message: str
+        """
+
+        conn = self.get_conn()
+
+        messages = {
+            'default': message
+        }
+
+        return conn.publish(
+            TargetArn=target_arn,
+            Message=json.dumps(messages),
+            MessageStructure='json'
+        )

--- a/airflow/contrib/operators/sns_publish_operator.py
+++ b/airflow/contrib/operators/sns_publish_operator.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.contrib.hooks.aws_sns_hook import AwsSnsHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class SnsPublishOperator(BaseOperator):
+    """
+    Publish a message to Amazon SNS.
+
+    :param aws_conn_id: aws connection to use
+    :type aws_conn_id: str
+    :param target_arn: either a TopicArn or an EndpointArn
+    :type target_arn: str
+    :param message: the default message you want to send (templated)
+    :type message: str
+    """
+    template_fields = ['message']
+    template_ext = ()
+
+    @apply_defaults
+    def __init__(
+            self,
+            target_arn,
+            message,
+            aws_conn_id='aws_default',
+            *args, **kwargs):
+        super(SnsPublishOperator, self).__init__(*args, **kwargs)
+        self.target_arn = target_arn
+        self.message = message
+        self.aws_conn_id = aws_conn_id
+
+    def execute(self, context):
+        sns = AwsSnsHook(aws_conn_id=self.aws_conn_id)
+
+        self.log.info(
+            'Sending SNS notification to {} using {}:\n{}'.format(
+                self.target_arn,
+                self.aws_conn_id,
+                self.message
+            )
+        )
+
+        return sns.publish_to_target(
+            target_arn=self.target_arn,
+            message=self.message
+        )

--- a/tests/contrib/hooks/test_aws_sns_hook.py
+++ b/tests/contrib/hooks/test_aws_sns_hook.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+
+from airflow.contrib.hooks.aws_sns_hook import AwsSnsHook
+
+try:
+    from moto import mock_sns
+except ImportError:
+    mock_sns = None
+
+
+@unittest.skipIf(mock_sns is None, 'moto package not present')
+class TestAwsLambdaHook(unittest.TestCase):
+
+    @mock_sns
+    def test_get_conn_returns_a_boto3_connection(self):
+        hook = AwsSnsHook(aws_conn_id='aws_default')
+        self.assertIsNotNone(hook.get_conn())
+
+    @mock_sns
+    def test_publish_to_target(self):
+        hook = AwsSnsHook(aws_conn_id='aws_default')
+
+        message = "Hello world"
+        topic_name = "test-topic"
+        target = hook.get_conn().create_topic(Name=topic_name).get('TopicArn')
+
+        response = hook.publish_to_target(target, message)
+
+        self.assertTrue('MessageId' in response)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/contrib/operators/test_sns_publish_operator.py
+++ b/tests/contrib/operators/test_sns_publish_operator.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import mock
+import unittest
+
+from airflow.contrib.operators.sns_publish_operator import SnsPublishOperator
+
+TASK_ID = "sns_publish_job"
+AWS_CONN_ID = "custom_aws_conn"
+TARGET_ARN = "arn:aws:sns:eu-central-1:1234567890:test-topic"
+MESSAGE = "Message to send"
+
+
+class TestSnsPublishOperator(unittest.TestCase):
+
+    def test_init(self):
+        # Given / When
+        operator = SnsPublishOperator(
+            task_id=TASK_ID,
+            aws_conn_id=AWS_CONN_ID,
+            target_arn=TARGET_ARN,
+            message=MESSAGE
+        )
+
+        # Then
+        self.assertEqual(TASK_ID, operator.task_id)
+        self.assertEqual(AWS_CONN_ID, operator.aws_conn_id)
+        self.assertEqual(TARGET_ARN, operator.target_arn)
+        self.assertEqual(MESSAGE, operator.message)
+
+    @mock.patch('airflow.contrib.operators.sns_publish_operator.AwsSnsHook')
+    def test_execute(self, mock_hook):
+        # Given
+        hook_response = {'MessageId': 'foobar'}
+
+        hook_instance = mock_hook.return_value
+        hook_instance.publish_to_target.return_value = hook_response
+
+        operator = SnsPublishOperator(
+            task_id=TASK_ID,
+            aws_conn_id=AWS_CONN_ID,
+            target_arn=TARGET_ARN,
+            message=MESSAGE
+        )
+
+        # When
+        result = operator.execute(None)
+
+        # Then
+        self.assertEqual(hook_response, result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://jira.apache.org/jira/browse/AIRFLOW-3288

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Adds a hook and a basic operator for publishing **Amazon SNS** messages. 

Our project is currently using an identical plugin for integrating SQS into our Airflow pipelines, but it could be used for other purposes as well (e-mail, sms, lambda function invocation etc.).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

The hook and the operator have independent unit tests. 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

Classes and methods should be documented.

### Code Quality

- [x] Passes `flake8`
