### PR TITLE
[AIRFLOW-3298] Return None if user not found in session.

### DIFF
--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -271,6 +271,9 @@ def load_user(userid, session=None):
         return None
 
     user = session.query(models.User).filter(models.User.id == int(userid)).first()
+    if not user:
+        return None
+
     return LdapUser(user)
 
 


### PR DESCRIPTION
* It is possible for the browser to have a user-id stored, but the user to be absent from the session (database backend).
* This was encountered in a setup where, during development, a new database is instantiated for each branch, per developer

### Jira

- [x] AIRFLOW-3298

### Description

- [x] [AIRFLOW-3298] Return None if user not found in session. 
  * It is possible for the browser to have a user-id stored, but the user to be absent from the session (database backend). 
  * This was encountered in a setup where, during development, a new database is instantiated for each branch, per developer

### Tests

- [ ] I have no idea how to test this.  Anyone have any tips or suggestions?

### Commits

- [x] Good commit message

### Documentation

- [x] No new functionality.  No new docs.

### Code Quality

- [x] Passes `flake8`
