### PR TITLE
[AIRFLOW-3270] Allow passwordless-binding for LDAP auth backend

### DIFF
--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -57,6 +57,12 @@ class LdapException(Exception):
 def get_ldap_connection(dn=None, password=None):
     tls_configuration = None
     use_ssl = False
+
+    if dn == "":
+        dn = None
+    if password == "":
+        password = None
+
     try:
         cacert = configuration.conf.get("ldap", "cacert")
         tls_configuration = Tls(validate=ssl.CERT_REQUIRED, ca_certs_file=cacert)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-3270

### Description

- [x] Because the bind password came from the config parser it was impossible
to set it as None, it would come through as `""`, which is not the same
(to the ldap3 lib) as not providing a password.
### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: no tests -hard to test, but tested by author of Jira ticket.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
