### PR TITLE
[AIRFLOW-3262] Update SimpleHttpOpTests to check Example.com

### DIFF
--- a/tests/operators/test_http_operator.py
+++ b/tests/operators/test_http_operator.py
@@ -42,22 +42,21 @@ class AnyStringWith(str):
 
 class SimpleHttpOpTests(unittest.TestCase):
     def setUp(self):
-        # Creating a local Http connection to Airflow Webserver
-        os.environ['AIRFLOW_CONN_HTTP_GOOGLE'] = 'http://www.google.com'
+        os.environ['AIRFLOW_CONN_HTTP_EXAMPLE'] = 'http://www.example.com'
 
     def test_response_in_logs(self):
         """
-        Test that when using SimpleHttpOperator with 'GET' on localhost:8080,
-        the log contains 'Google' in it
+        Test that when using SimpleHttpOperator with 'GET',
+        the log contains 'Example Domain' in it
         """
         operator = SimpleHttpOperator(
             task_id='test_HTTP_op',
             method='GET',
             endpoint='/',
-            http_conn_id='HTTP_GOOGLE',
+            http_conn_id='HTTP_EXAMPLE',
             log_response=True,
         )
 
         with patch.object(operator.log, 'info') as mock_info:
             operator.execute(None)
-            mock_info.assert_called_with(AnyStringWith('Google'))
+            mock_info.assert_called_with(AnyStringWith('Example Domain'))


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3262


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Update SimpleHttpOpTests to check Example.com instead of Google.com so that the ip doesn't get banned.

Currently, test in v1.10-test is failing

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
