### PR TITLE
Fix for scheduler infinite loop when evaluating non-UTC DAGs after DST

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3206,6 +3206,10 @@ class DAG(BaseDag, LoggingMixin):
         else:
             self.timezone = settings.TIMEZONE
 
+        # drop utc offsets of start_date so we can operate on both sides of DST
+        if self.timezone:
+            self.timezone = pendulum.timezone(self.timezone.name)
+
         self.start_date = timezone.convert_to_utc(start_date)
         self.end_date = timezone.convert_to_utc(end_date)
 


### PR DESCRIPTION
…ing than their start state

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow-1710](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-1710\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-1710
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [X ] Here are some details about my PR, including screenshots of any UI changes:

This fixes the infinite loop in the AF jobs scheduler scanning a DAG with a start date in Daylight Savings Time while evaluating a potential run date in Standard Time.

The infinite loop Airflow gets trapped in is below:

`while next_run_date <= last_run.execution_date:
    next_run_date = dag.following_schedule(next_run_date)`

dag.following_schedule is not incrementing as expected. It instead starts to repeating values that dag.following_schedule has already returned.

This is caused by an interaction between a pendulum instance timezone having a DST offset this is 'illegal' for the evaluated next run date.

IE, If I call following_schedule with a dag.timezone that has a DST offset of -5, but on the date being evaluated the value should be -6, the function stops incrementing and repeats ranges of values.

The fix is to simply drop the dst offset from dag.timezone.  dag.following_schedule will then increment normally, it fixes the infinite loop.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I need help with my PR

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `flake8`
