### PR TITLE
[AIRFLOW-3301] Update DockerOperator unit test for PR #3977 to fix CI failure

### DIFF
--- a/tests/operators/test_docker_operator.py
+++ b/tests/operators/test_docker_operator.py
@@ -80,6 +80,7 @@ class DockerOperatorTestCase(unittest.TestCase):
                                                           shm_size=1000,
                                                           cpu_shares=1024,
                                                           mem_limit=None,
+                                                          auto_remove=False,
                                                           dns=None,
                                                           dns_search=None)
         client_mock.images.assert_called_with(name='ubuntu:latest')


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3301

### Description

In PR https://github.com/apache/incubator-airflow/pull/3977, new argument `auto_remove` was added  but test was NOT updated accordingly, and it results in CI failure.