### PR TITLE
[AIRFLOW-3302] Small CSS fixes

### DIFF
--- a/airflow/www/templates/admin/master.html
+++ b/airflow/www/templates/admin/master.html
@@ -89,7 +89,7 @@
         <ul class="nav navbar-nav navbar-right">
             <li><a id="clock"></a></li>
             {% if current_user.is_authenticated %}
-              <li><a href="{{ url_for('airflow.logout') }}"><span data-toggle="tooltip" data-placement="left" title="Logout" class="glyphicon glyphicon-log-out"></span></a></li>
+              <li class="never_active"><a href="{{ url_for('airflow.logout') }}"><span data-toggle="tooltip" data-placement="left" title="Logout" class="glyphicon glyphicon-log-out"></span></a></li>
             {% endif %}
         </ul>
           <ul class="nav navbar-nav navbar-right">

--- a/airflow/www/templates/airflow/login.html
+++ b/airflow/www/templates/airflow/login.html
@@ -1,13 +1,13 @@
-{# 
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,7 @@
     <div class="row">
         <div class="col-sm-6 col-md-4 col-md-offset-4">
             <h1 class="text-center login-title">Sign in to Airflow</h1>
-            <div class="account-wall">
+            <div class="text-center account-wall">
                 <img src="{{ url_for("static", filename="pin_100.png") }}" />
                 <form class="form-signin" method="post" action="{{ url_for('airflow.login') }}">
                     <input type="text" class="form-control" placeholder="Username" name="username" required autofocus>


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-3302

### Description

- [x] 2 small CSS fixes
   - Don't highlight logout button when viewing *Log* tab of a task run
   - Align Airflow logo to the center of the login page

Before:
<img width="993" alt="screen shot 2018-11-07 at 2 05 48 pm" src="https://user-images.githubusercontent.com/2018407/48119889-863e4600-e296-11e8-9afd-4369d4342cef.png">

After:
<img width="990" alt="screen shot 2018-11-07 at 2 06 15 pm" src="https://user-images.githubusercontent.com/2018407/48119901-8f2f1780-e296-11e8-84be-6577183c87e2.png">

Before:
<img width="991" alt="screen shot 2018-11-07 at 2 04 52 pm" src="https://user-images.githubusercontent.com/2018407/48119917-99511600-e296-11e8-9a40-d7be3b6a0c2d.png">

After:
<img width="988" alt="screen shot 2018-11-07 at 2 05 16 pm" src="https://user-images.githubusercontent.com/2018407/48119922-9d7d3380-e296-11e8-85ad-12961efe0df7.png">


### Tests

- [x] Tested manually

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
