### PR TITLE
[AIRFLOW-689] Okta Authentication

### DIFF
--- a/airflow/contrib/auth/backends/okta_auth.py
+++ b/airflow/contrib/auth/backends/okta_auth.py
@@ -1,0 +1,119 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import unicode_literals
+
+import okta
+import flask_login
+from flask_login import login_required, current_user, logout_user  # noqa: F401
+from flask import flash
+from wtforms import (Form, PasswordField, StringField)
+from wtforms.validators import InputRequired
+
+from flask import url_for, redirect, session
+
+from airflow import models
+from airflow import configuration
+
+login_manager = flask_login.LoginManager()
+login_manager.login_view = 'airflow.login'  # Calls login() below
+login_manager.login_message = 'Login using your Okta creds'
+
+
+class OktaUser(object):
+    def __init__(self, user):
+        self.user = models.User(id=user['id'], username=user['username'], email=user['email'], superuser=True)
+
+    @property
+    def is_active(self):
+        '''Required by flask_login'''
+        return True
+
+    @property
+    def is_authenticated(self):
+        '''Required by flask_login'''
+        return True
+
+    @property
+    def is_anonymous(self):
+        '''Required by flask_login'''
+        return False
+
+    def data_profiling(self):
+        '''Provides access to data profiling tools'''
+        return True
+
+    def is_superuser(self):
+        '''Access all the things'''
+        return True
+
+    def get_id(self):
+        '''Returns the current user id as required by flask_login'''
+        return self.user.get_id()
+
+    @property
+    def username(self):
+        return self.user.username
+
+
+@login_manager.user_loader
+def load_user(userid):
+    return OktaUser(session[userid])
+
+
+def login(self, request):
+    if current_user.is_authenticated:
+        flash("You are already logged in")
+        return redirect(url_for('admin.index'))
+
+    username = None
+    password = None
+
+    form = LoginForm(request.form)
+
+    if request.method == 'POST' and form.validate():
+        username = request.form.get("username")
+        password = request.form.get("password")
+
+    if not username or not password:
+        return self.render('airflow/login.html',
+                           title="Airflow - Login",
+                           form=form)
+
+    try:
+        url = configuration.get("okta", "url")
+        key = configuration.get("okta", "api_key")
+
+        # Authenticate user
+        usersClient = okta.AuthClient(url, key)
+        res = usersClient.authenticate(username, password)
+
+        # User authenticated, store in session and proceed to log them in
+        user = dict()
+        user['id'] = res.sessionToken
+        user['email'] = username
+        user['username'] = username
+
+        flask_login.login_user(OktaUser(user))
+        session[user['id']] = user
+
+        return redirect(request.args.get("next") or url_for("admin.index"))
+
+    except Exception as e:
+        flash("Incorrect username or password")
+        return self.render('airflow/login.html',
+                           title="Airflow - Login",
+                           form=form)
+
+
+class LoginForm(Form):
+    username = StringField('Username', [InputRequired()])
+    password = PasswordField('Password', [InputRequired()])


### PR DESCRIPTION
Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:

https://issues.apache.org/jira/browse/AIRFLOW-689

### Description

- [ ] Ability to use Okta's api based authentication mechanism

### Tests

- Install Okta SDK with pip onto your airflow instance
- Add in your Okta API key and organization URL (usually your_org.okta.com) in the config
- Replace backend with okta_auth in the config
- Log in

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `flake8`
