### PR TITLE
[AIRFLOW-3062] Add QDS dependency in readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -30,3 +30,4 @@ python:
         - sendgrid
         - ssh
         - slack
+        - qds


### PR DESCRIPTION
### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues 
  - https://issues.apache.org/jira/browse/AIRFLOW-3062

### Description

- [ ] Readthedocs not showing QDS integrations related info due to a missing dependency 

### Tests

- [ ] Just adding a dependency 

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] Not applicable 

### Code Quality

- [ ] Passes `flake8`
