### PR TITLE
[AIRFLOW-3308] Fix plugins import

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -79,3 +79,16 @@ class AirflowViewPlugin(BaseView):
 class AirflowMacroPlugin(object):
     def __init__(self, namespace):
         self.namespace = namespace
+
+
+from airflow import operators  # noqa: E402
+from airflow import sensors  # noqa: E402
+from airflow import hooks  # noqa: E402
+from airflow import executors  # noqa: E402
+from airflow import macros  # noqa: E402
+
+operators._integrate_plugins()
+sensors._integrate_plugins()  # noqa: E402
+hooks._integrate_plugins()
+executors._integrate_plugins()
+macros._integrate_plugins()

--- a/airflow/operators/__init__.py
+++ b/airflow/operators/__init__.py
@@ -16,3 +16,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+
+def _integrate_plugins():
+    """Integrate plugins to the context"""
+    import sys
+    from airflow.plugins_manager import operators_modules
+    for operators_module in operators_modules:
+        sys.modules[operators_module.__name__] = operators_module
+        globals()[operators_module._name] = operators_module

--- a/airflow/sensors/__init__.py
+++ b/airflow/sensors/__init__.py
@@ -17,3 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
+
+def _integrate_plugins():
+    """Integrate plugins to the context"""
+    import sys
+    from airflow.plugins_manager import sensors_modules
+    for sensors_module in sensors_modules:
+        sys.modules[sensors_module.__name__] = sensors_module
+        globals()[sensors_module._name] = sensors_module


### PR DESCRIPTION
Revert #3906 partially.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3308
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Plugins import is broken after #3906 . This PR is to revert `airflow.__init__`

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
