### PR TITLE
[AIRFLOW-3314] Changed auto inlets feature to work as described

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -76,6 +76,7 @@ from croniter import (
 )
 import six
 
+import airflow.lineage
 from airflow import settings, utils
 from airflow.executors import GetDefaultExecutor, LocalExecutor
 from airflow import configuration
@@ -84,7 +85,6 @@ from airflow.exceptions import (
     AirflowRescheduleException
 )
 from airflow.dag.base_dag import BaseDag, BaseDagBag
-from airflow.lineage import apply_lineage, prepare_lineage
 from airflow.models.dagpickle import DagPickle
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
 from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
@@ -2556,7 +2556,7 @@ class BaseOperator(LoggingMixin):
                 self.get_flat_relative_ids(upstream=upstream))
         )
 
-    @prepare_lineage
+    @airflow.lineage.prepare_lineage
     def pre_execute(self, context):
         """
         This hook is triggered right before self.execute() is called.
@@ -2572,7 +2572,7 @@ class BaseOperator(LoggingMixin):
         """
         raise NotImplementedError()
 
-    @apply_lineage
+    @airflow.lineage.apply_lineage
     def post_execute(self, context, result=None):
         """
         This hook is triggered right after self.execute() is called.

--- a/tests/lineage/test_lineage.py
+++ b/tests/lineage/test_lineage.py
@@ -115,3 +115,243 @@ class TestLineage(unittest.TestCase):
         post(op5, ctx5)
         self.assertEqual(send_mock.call_count, 1)
         send_mock.reset_mock()
+
+    @mock.patch("airflow.lineage._get_backend")
+    def test_lineage_auto_simple_skipping(self, _get_backend):
+        # Tests the ability for the auto feature to skip non state affecting operators
+        # DAG diagram:
+        #  1--->2--->3--->4
+
+        backend = mock.Mock()
+        send_mock = mock.Mock()
+        backend.send_lineage = send_mock
+
+        _get_backend.return_value = backend
+
+        dag = DAG(
+            dag_id='test_prepare_lineage_auto_simple_skipping',
+            start_date=DEFAULT_DATE
+        )
+
+        f1 = File("/tmp/does_not_exist_1")
+
+        with dag:
+            op1 = DummyOperator(task_id='leave1',
+                                outlets={"datasets": [f1, ]})
+            op2 = DummyOperator(task_id='upstream_level_1')
+            op3 = DummyOperator(task_id='upstream_level_2')
+            op4 = DummyOperator(task_id='upstream_level_3', inlets={"auto": True})
+
+            op1.set_downstream(op2)
+            op2.set_downstream(op3)
+            op3.set_downstream(op4)
+
+        ctx1 = {"ti": TI(task=op1, execution_date=DEFAULT_DATE)}
+        ctx2 = {"ti": TI(task=op2, execution_date=DEFAULT_DATE)}
+        ctx3 = {"ti": TI(task=op3, execution_date=DEFAULT_DATE)}
+        ctx4 = {"ti": TI(task=op4, execution_date=DEFAULT_DATE)}
+
+        func = mock.Mock()
+        func.__name__ = 'foo'
+
+        # prepare with manual inlets and outlets
+        prep = prepare_lineage(func)
+        prep(op1, ctx1)
+
+        self.assertEqual(len(op1.inlets), 0)
+
+        self.assertEqual(len(op1.outlets), 1)
+        self.assertEqual(op1.outlets[0], f1)
+
+        # post process with no backend
+        post = apply_lineage(func)
+        post(op1, ctx1)
+        send_mock.reset_mock()
+
+        prep(op2, ctx2)
+        self.assertEqual(len(op2.inlets), 0)
+        post(op2, ctx2)
+        self.assertEqual(send_mock.call_count, 1)
+        send_mock.reset_mock()
+
+        prep(op3, ctx3)
+        self.assertEqual(len(op3.inlets), 0)
+        post(op3, ctx3)
+        self.assertEqual(send_mock.call_count, 1)
+        send_mock.reset_mock()
+
+        prep(op4, ctx4)
+        self.assertEqual(len(op4.inlets), 1)
+        self.assertEqual(op4.inlets[0].name, f1.name)
+        post(op4, ctx4)
+        self.assertEqual(send_mock.call_count, 1)
+        send_mock.reset_mock()
+
+    @mock.patch("airflow.lineage._get_backend")
+    def test_lineage_complicated_dag(self, _get_backend):
+        # Tests the ability for the auto feature to skip non state affecting operators, while still
+        # retrieving data from multiple outlet sources. Notice how if outlets are not specified,
+        # that the auto feature continues to traverse down the dag until not input sources are found.
+
+        # DAG diagram:
+        # 1-----------+
+        #             |
+        #             ▼
+        #             4 ----------+
+        #             ▲           ▼
+        #             |           5+-------->6
+        # 2-----------+           ▲
+        #                         |
+        #                         |
+        #                         |
+        # 3-----------------------+
+
+        backend = mock.Mock()
+        send_mock = mock.Mock()
+        backend.send_lineage = send_mock
+
+        _get_backend.return_value = backend
+
+        dag = DAG(
+            dag_id='test_prepare_lineage_auto_complicated_dag',
+            start_date=DEFAULT_DATE
+        )
+
+        f1 = File("/tmp/does_not_exist_1")
+        f2 = File("/tmp/does_not_exist_2")
+        f3 = File("/tmp/does_not_exist_3")
+
+        with dag:
+            op1 = DummyOperator(task_id='leave1',
+                                outlets={"datasets": [f1, ]},
+                                inlets={"auto": True})
+            op2 = DummyOperator(task_id='leave2',
+                                outlets={"datasets": [f2, ]})
+            op3 = DummyOperator(task_id='leave3',
+                                outlets={"datasets": [f3, ]})
+            op4 = DummyOperator(task_id='upstream_level_1')
+            op5 = DummyOperator(task_id='upstream_level_2', inlets={"auto": True})
+            op6 = DummyOperator(task_id='upstream_level_3', inlets={"auto": True})
+
+            op1.set_downstream(op4)
+            op2.set_downstream(op4)
+            op3.set_downstream(op5)
+            op4.set_downstream(op5)
+            op5.set_downstream(op6)
+
+        ctx1 = {"ti": TI(task=op1, execution_date=DEFAULT_DATE)}
+        ctx2 = {"ti": TI(task=op2, execution_date=DEFAULT_DATE)}
+        ctx3 = {"ti": TI(task=op3, execution_date=DEFAULT_DATE)}
+        ctx4 = {"ti": TI(task=op4, execution_date=DEFAULT_DATE)}
+        ctx5 = {"ti": TI(task=op5, execution_date=DEFAULT_DATE)}
+        ctx6 = {"ti": TI(task=op6, execution_date=DEFAULT_DATE)}
+
+        func = mock.Mock()
+        func.__name__ = 'foo'
+
+        # prepare with manual inlets and outlets
+        prep = prepare_lineage(func)
+        prep(op1, ctx1)
+
+        self.assertEqual(len(op1.outlets), 1)
+        self.assertEqual(op1.outlets[0], f1)
+        self.assertEqual(len(op1.inlets), 0)
+
+        # post process with no backend
+        post = apply_lineage(func)
+        post(op1, ctx1)
+
+        prep(op2, ctx2)
+        self.assertEqual(len(op2.outlets), 1)
+        post(op2, ctx2)
+
+        prep(op3, ctx3)
+        self.assertEqual(len(op3.outlets), 1)
+        post(op3, ctx3)
+
+        prep(op4, ctx4)
+        self.assertEqual(len(op4.inlets), 0)
+        post(op4, ctx4)
+
+        prep(op5, ctx5)
+        self.assertEqual(len(op5.inlets), 3)
+        self.assertEqual({file.qualified_name for file in op5.inlets}, {'file:///tmp/does_not_exist_1',
+                                                                        'file:///tmp/does_not_exist_2',
+                                                                        'file:///tmp/does_not_exist_3'})
+        post(op5, ctx5)
+
+        prep(op6, ctx6)
+        self.assertEqual(len(op6.inlets), 3)
+        self.assertEqual({file.qualified_name for file in op6.inlets}, {'file:///tmp/does_not_exist_1',
+                                                                        'file:///tmp/does_not_exist_2',
+                                                                        'file:///tmp/does_not_exist_3'})
+        post(op6, ctx6)
+
+    @mock.patch("airflow.lineage._get_backend")
+    def test_lineage_auto_branching(self, _get_backend):
+        # Tests the ability for the auto feature to skip non state affecting operators
+        # DAG diagram:
+        #  1--->2---->4
+        #       ▼     ▲
+        #       3-----+
+        backend = mock.Mock()
+        send_mock = mock.Mock()
+        backend.send_lineage = send_mock
+
+        _get_backend.return_value = backend
+
+        dag = DAG(
+            dag_id='test_prepare_lineage_auto_branching',
+            start_date=DEFAULT_DATE
+        )
+
+        f1 = File("/tmp/does_not_exist_1")
+
+        with dag:
+            op1 = DummyOperator(task_id='leave1')
+            op2 = DummyOperator(task_id='branch_1', outlets={"datasets": [f1, ]})
+            op3 = DummyOperator(task_id='branch_2')
+            op4 = DummyOperator(task_id='upstream_level_2', inlets={"auto": True})
+
+            op1.set_downstream(op2)
+            op2.set_downstream(op3)
+            op2.set_downstream(op4)
+            op3.set_downstream(op4)
+
+        ctx1 = {"ti": TI(task=op1, execution_date=DEFAULT_DATE)}
+        ctx2 = {"ti": TI(task=op2, execution_date=DEFAULT_DATE)}
+        ctx3 = {"ti": TI(task=op3, execution_date=DEFAULT_DATE)}
+        ctx4 = {"ti": TI(task=op4, execution_date=DEFAULT_DATE)}
+
+        func = mock.Mock()
+        func.__name__ = 'foo'
+
+        # prepare with manual inlets and outlets
+        prep = prepare_lineage(func)
+        prep(op1, ctx1)
+
+        self.assertEqual(len(op1.inlets), 0)
+
+        # post process with no backend
+        post = apply_lineage(func)
+        post(op1, ctx1)
+        send_mock.reset_mock()
+
+        prep(op2, ctx2)
+        self.assertEqual(len(op2.inlets), 0)
+        post(op2, ctx2)
+        self.assertEqual(send_mock.call_count, 1)
+        send_mock.reset_mock()
+
+        prep(op3, ctx3)
+        self.assertEqual(len(op3.inlets), 0)
+        post(op3, ctx3)
+        self.assertEqual(send_mock.call_count, 1)
+        send_mock.reset_mock()
+
+        prep(op4, ctx4)
+        self.assertEqual(len(op4.inlets), 1)
+        self.assertEqual(op4.inlets[0].name, f1.name)
+        post(op4, ctx4)
+        self.assertEqual(send_mock.call_count, 1)
+        send_mock.reset_mock()


### PR DESCRIPTION
Currently, the automatic inlets feature is described to be able to skip
operations that produce no outlets. This changes the behaviour of the
auto inlets feature in order so that the presence of non outlet
producing operations are effectively ignored while still receiving all
outlets from upstream tasks.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3314
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Uses a tree search algorithm in order to find upstream outlets to be used as inlets. Provides expected behaviour as described in the previous documentation to receive outlets. 

@bolkedebruin, do you have any input on these changes?
### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Adds unit tests to tests/lineage/test_lineage.py
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`

Sorry if I'm breaking any guidelines, this is my first OSS pull request. 
