### PR TITLE
[AIRFLOW-XXX] Pin version of MarkupSafe to fix "TestAirflowBaseViews" CI failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -329,6 +329,7 @@ def do_setup():
             'unicodecsv>=0.14.1',
             'werkzeug>=0.14.1, <0.15.0',
             'zope.deprecation>=4.0, <5.0',
+            'MarkupSafe==1.0',
         ],
         setup_requires=[
             'docutils>=0.14, <1.0',


### PR DESCRIPTION
MarkupSafe is a dependency of jinja2.

Its latest release (1.1.0) time matches with the time from which we start to have weird error (mainly `TestAirflowBaseViews`).

Try to pin it to see if it fix the CI.