### PR TITLE
[AIRFLOW-3311] Allow pod operator to keep failed pods

### DIFF
--- a/airflow/contrib/example_dags/example_kubernetes_operator.py
+++ b/airflow/contrib/example_dags/example_kubernetes_operator.py
@@ -58,6 +58,7 @@ try:
         get_logs=True,
         dag=dag,
         is_delete_operator_pod=False,
+        keep_failed_pod=False,
         tolerations=tolerations
     )
 

--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -102,6 +102,7 @@ Kubernetes Operator
                               task_id="task",
                               affinity=affinity,
                               is_delete_operator_pod=True,
+                              keep_failed_pod=True,
                               hostnetwork=False,
                               tolerations=tolerations
                               )

--- a/tests/contrib/minikube/test_kubernetes_pod_operator.py
+++ b/tests/contrib/minikube/test_kubernetes_pod_operator.py
@@ -111,6 +111,21 @@ class KubernetesPodOperatorTest(unittest.TestCase):
         )
         k.execute(None)
 
+    def test_keep_failed_pod(self):
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["exit 1"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            is_delete_operator_pod=True,
+            keep_failed_pod=True
+        )
+        with self.assertRaises(AirflowException):
+            k.execute(None)
+
     @staticmethod
     def test_pod_hostnetwork():
         k = KubernetesPodOperator(


### PR DESCRIPTION
### Jira

- [ ✔] My PR addresses the following [AIRFLOW-3311] 
`Allow pod operator to keep failed pods`
`https://issues.apache.org/jira/browse/AIRFLOW-3311`

### Description

- [✔ ] Here are some details about my PR, including screenshots of any UI changes:

Extends `AIRFLOW-2854` to enable keeping of pods with non-zero exit codes for log inspection in kubernetes clusters.

### Tests

- [✔ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`tests/contrib/minikube/test_kubernetes_pod_operator.py`:
`test_keep_failed_pod(self)`

### Commits

- [✔ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"

### Documentation

- [✔ ] In case of new functionality, my PR adds documentation that describes how to use it.
`docs/kubernetes.rst` updated
`kubernetes_pod_operator` docstring updated
`example_kubernetes_operator` updated

### Code Quality

- [✔ ] Passes `flake8`
