### PR TITLE
[AIRFLOW-XXX] Speed up RBAC view tests

### DIFF
--- a/tests/www_rbac/test_views.py
+++ b/tests/www_rbac/test_views.py
@@ -46,13 +46,16 @@ from airflow.www_rbac import app as application
 
 
 class TestBase(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         conf.load_test_config()
-        self.app, self.appbuilder = application.create_app(session=Session, testing=True)
-        self.app.config['WTF_CSRF_ENABLED'] = False
-        self.client = self.app.test_client()
+        cls.app, cls.appbuilder = application.create_app(session=Session, testing=True)
+        cls.app.config['WTF_CSRF_ENABLED'] = False
         settings.configure_orm()
-        self.session = Session
+        cls.session = Session
+
+    def setUp(self):
+        self.client = self.app.test_client()
         self.login()
 
     def login(self):


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### Jira

- [x] No jira needed I think?

### Description

- [x] Not re-creating the FAB app ones per test functions took the run time of
the TestAirflowBaseViews from 223s down to 53s on my laptop, _and_ made
it only print the deprecation warning (fixed in another PR already open)
once instead of 10+ times.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
