### PR TITLE
[AIRFLOW-3318] BigQueryHook check if dataset exists

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1527,8 +1527,7 @@ class BigQueryBaseCursor(LoggingMixin):
         :type dataset_id: str
         """
         try:
-            service = self.get_service()
-            service.datasets().get(
+            self.service.datasets().get(
                 projectId=project_id, datasetId=dataset_id).execute()
             return True
         except errors.HttpError as e:

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1515,6 +1515,27 @@ class BigQueryBaseCursor(LoggingMixin):
 
         return datasets_list
 
+    def dataset_exists(self, project_id, dataset_id):
+        """
+        Checks for the existence of a dataset in Google BigQuery.
+
+        :param project_id: The Google cloud project in which to look for the
+            dataset. The connection supplied to the hook must provide access to
+            the specified project.
+        :type project_id: str
+        :param dataset_id: The name of the dataset to check the existence of.
+        :type dataset_id: str
+        """
+        try:
+            service = self.get_service()
+            service.datasets().get(
+                projectId=project_id, datasetId=dataset_id).execute()
+            return True
+        except errors.HttpError as e:
+            if e.resp['status'] == '404':
+                return False
+            raise
+
 
 class BigQueryCursor(BigQueryBaseCursor):
     """


### PR DESCRIPTION
Add a function to BigQueryHook to check the existence of a dataset. 
Return True if the dataset exists.
Return False if 404 error received.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-3318](https://issues.apache.org/jira/browse/AIRFLOW-3318) issues and references them in the PR title. 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
To check the existence of a dataset in BigQuery, existing BigQueryHook only supports either 1) using get_datasets_list() to get all the datasets and then searching the target dataset from the list; or 2) using get_dataset().

However, with get_dataset(), it raises AirflowException whenever an HttpError received. So it has no capabilities to determine if the dataset exists or not.

To solve this issue, I've added a function to return a boolean value representing the existence of the dataset.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests.contrib.hooks.test_bigquery_hook:TestDatasetsOperations.test_check_dataset_exists
tests.contrib.hooks.test_bigquery_hook:TestDatasetsOperations.test_check_dataset_exists_not_exist

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
