### PR TITLE
[AIRFLOW-3323] Support HTTP basic authentication for Airflow Flower

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1276,6 +1276,10 @@ def flower(args):
     if args.url_prefix:
         url_prefix = '--url-prefix=' + args.url_prefix
 
+    basic_auth = ''
+    if args.basic_auth:
+        basic_auth = '--basic_auth=' + args.basic_auth
+
     flower_conf = ''
     if args.flower_conf:
         flower_conf = '--conf=' + args.flower_conf
@@ -1297,7 +1301,7 @@ def flower(args):
 
         with ctx:
             os.execvp("flower", ['flower', '-b',
-                                 broka, address, port, api, flower_conf, url_prefix])
+                                 broka, address, port, api, flower_conf, url_prefix, basic_auth])
 
         stdout.close()
         stderr.close()
@@ -1306,7 +1310,7 @@ def flower(args):
         signal.signal(signal.SIGTERM, sigint_handler)
 
         os.execvp("flower", ['flower', '-b',
-                             broka, address, port, api, flower_conf, url_prefix])
+                             broka, address, port, api, flower_conf, url_prefix, basic_auth])
 
 
 @cli_utils.action_logging
@@ -1823,6 +1827,12 @@ class CLIFactory(object):
             ("-u", "--url_prefix"),
             default=conf.get('celery', 'FLOWER_URL_PREFIX'),
             help="URL prefix for Flower"),
+        'flower_basic_auth': Arg(
+            ("-ba", "--basic_auth"),
+            default=conf.get('celery', 'FLOWER_BASIC_AUTH'),
+            help=("Securing Flower with Basic Authentication. "
+                  "Accepts user:password pairs separated by a comma. "
+                  "Example: flower_basic_auth = user1:password1,user2:password2")),
         'task_params': Arg(
             ("-tp", "--task_params"),
             help="Sends a JSON params dict to the task"),
@@ -2070,7 +2080,7 @@ class CLIFactory(object):
             'func': flower,
             'help': "Start a Celery Flower",
             'args': ('flower_hostname', 'flower_port', 'flower_conf', 'flower_url_prefix',
-                     'broker_api', 'pid', 'daemon', 'stdout', 'stderr', 'log_file'),
+                     'flower_basic_auth', 'broker_api', 'pid', 'daemon', 'stdout', 'stderr', 'log_file'),
         }, {
             'func': version,
             'help': "Show the version",

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -392,6 +392,11 @@ flower_url_prefix =
 # This defines the port that Celery Flower runs on
 flower_port = 5555
 
+# Securing Flower with Basic Authentication
+# Accepts user:password pairs separated by a comma
+# Example: flower_basic_auth = user1:password1,user2:password2
+flower_basic_auth =
+
 # Default queue that tasks get assigned to and that worker listen on.
 default_queue = default
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -402,3 +402,22 @@ not set.
 
     [core]
     default_impersonation = airflow
+
+
+Flower Authentication
+---------------------
+
+Basic authentication for Celery Flower is supported.
+
+You can specify the details either as an optional argument in the Flower process launching
+command, or as a configuration item in your ``airflow.cfg``. For both cases, please provide
+`user:password` pairs separated by a comma.
+
+.. code-block:: bash
+
+    airflow flower --basic_auth=user1:password1,user2:password2
+
+.. code-block:: bash
+
+    [celery]
+    flower_basic_auth = user1:password1,user2:password2

--- a/scripts/ci/kubernetes/kube/configmaps.yaml
+++ b/scripts/ci/kubernetes/kube/configmaps.yaml
@@ -253,6 +253,11 @@ data:
     # This defines the port that Celery Flower runs on
     flower_port = 5555
 
+    # Securing Flower with Basic Authentication
+    # Accepts user:password pairs separated by a comma
+    # Example: flower_basic_auth = user1:password1,user2:password2
+    flower_basic_auth =
+
     # Default queue that tasks get assigned to and that worker listen on.
     default_queue = default
 


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3323


### Description

The current `airflow flower` doesn't come with any authentication. This may make essential information exposed to in an untrusted environment.

Currently Flower itself supports
- HTTP Basic Authentication
- Google OAuth 2.0
- GitHub OAuth

Given Flower is not really the most essential component of Airflow, we don't have to support all its authentication methods. But may be good to at least support **`Basic Authentication`**.

Ref:
https://flower.readthedocs.io/en/latest/auth.html

### Documentation

`docs/security.rst` & docstring in `airflow/bin/cli.py` are updated accordingly.

### Code Quality

- [x] Passes `flake8`

### Screenshots

#### 1. Asking for ID/password
<img width="1125" alt="screen shot 2018-11-09 at 5 31 32 pm" src="https://user-images.githubusercontent.com/11539188/48256289-1cff3400-e44a-11e8-9112-5f1277c65a84.png">

#### 2. Failed authentication
<img width="973" alt="screen shot 2018-11-09 at 5 31 42 pm" src="https://user-images.githubusercontent.com/11539188/48256297-238dab80-e44a-11e8-8b32-1487b49d1f24.png">

