### PR TITLE
[AIRFLOW-3325] Fix UI Page DAGs-column 'Recent Tasks' display issue

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -402,7 +402,7 @@
             states = json[dag_id];
             g = d3.select('svg#task-run-' + dag_id)
               .attr('height', diameter + (stroke_width_hover * 2))
-              .attr('width', '240px')
+              .attr('width', '270px')
               .selectAll("g")
               .data(states)
               .enter()

--- a/airflow/www_rbac/templates/airflow/dags.html
+++ b/airflow/www_rbac/templates/airflow/dags.html
@@ -402,7 +402,7 @@
             states = json[dag_id];
             g = d3.select('svg#task-run-' + dag_id)
               .attr('height', diameter + (stroke_width_hover * 2))
-              .attr('width', '240px')
+              .attr('width', '270px')
               .selectAll("g")
               .data(states)
               .enter()


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3325

### Description

A new task state "Skipped" was added in https://github.com/apache/incubator-airflow/pull/4059, while UI was not updated accordingly.

This makes the last circle in column "Recent Tasks" not displayed completely (zoom in/out the page doesn't help).

This is affecting both **master branch** and **1.10.1b1**.

**Update**: Both `www/` and `www_rabac/` are affected.

### Screenshot

#### Version 1.10.1b1 - Before Fix
<img width="1279" alt="screen shot 2018-11-10 at 11 01 43 am" src="https://user-images.githubusercontent.com/11539188/48298576-8f2f5180-e4fa-11e8-8f62-4bf572585227.png">

#### Version 1.10.1b1 - After Fix
<img width="1280" alt="after fix" src="https://user-images.githubusercontent.com/11539188/48298580-98202300-e4fa-11e8-9369-6a6ba5a85db1.png">

#### Version 1.10.0
<img width="960" alt="screen shot 2018-11-10 at 11 09 19 am" src="https://user-images.githubusercontent.com/11539188/48298589-bab23c00-e4fa-11e8-8988-c3bfda891b02.png">


