### PR TITLE
[AIRFLOW-3332] Add insert_all to allow inserting rows into BigQuery table

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1552,6 +1552,8 @@ class BigQueryBaseCursor(LoggingMixin):
         :type fail_on_error: bool
         """
 
+        dataset_project_id = project_id if project_id else self.project_id
+
         body = {
             "rows": rows,
             "ignoreUnknownValues": ignore_unknown_values,
@@ -1561,21 +1563,21 @@ class BigQueryBaseCursor(LoggingMixin):
 
         try:
             self.log.info('Inserting {} row(s) into Table {}:{}.{}'.format(
-                len(rows), project_id,
+                len(rows), dataset_project_id,
                 dataset_id, table_id))
 
             resp = self.service.tabledata().insertAll(
-                projectId=project_id, datasetId=dataset_id,
+                projectId=dataset_project_id, datasetId=dataset_id,
                 tableId=table_id, body=body
             ).execute()
 
             if 'insertErrors' not in resp:
                 self.log.info('All row(s) inserted successfully: {}:{}.{}'.format(
-                    project_id, dataset_id, table_id))
+                    dataset_project_id, dataset_id, table_id))
             else:
                 error_msg = '{} insert error(s) occured: {}:{}.{}. Details: {}'.format(
                     len(resp['insertErrors']),
-                    project_id, dataset_id, table_id, resp['insertErrors'])
+                    dataset_project_id, dataset_id, table_id, resp['insertErrors'])
                 if fail_on_error:
                     raise AirflowException(
                         'BigQuery job failed. Error was: {}'.format(error_msg)

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1515,6 +1515,77 @@ class BigQueryBaseCursor(LoggingMixin):
 
         return datasets_list
 
+    def insert_all(self, project_id, dataset_id, table_id,
+                   rows, ignore_unknown_values=False,
+                   skip_invalid_rows=False, fail_on_error=False):
+        """
+        Method to stream data into BigQuery one record at a time without needing
+        to run a load job
+
+        .. seealso::
+            For more information, see:
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/tabledata/insertAll
+
+        :param project_id: The name of the project where we have the table
+        :type project_id: str
+        :param dataset_id: The name of the dataset where we have the table
+        :type dataset_id: str
+        :param table_id: The name of the table
+        :type table_id: str
+        :param rows: the rows to insert
+        :type rows: list
+
+        **Example or rows**:
+            rows=[{"json": {"a_key": "a_value_0"}}, {"json": {"a_key": "a_value_1"}}]
+
+        :param ignore_unknown_values: [Optional] Accept rows that contain values
+            that do not match the schema. The unknown values are ignored.
+            The default value  is false, which treats unknown values as errors.
+        :type ignore_unknown_values: bool
+        :param skip_invalid_rows: [Optional] Insert all valid rows of a request,
+            even if invalid rows exist. The default value is false, which causes
+            the entire request to fail if any invalid rows exist.
+        :type skip_invalid_rows: bool
+        :param fail_on_error: [Optional] Force the task to fail if any errors occur.
+            The default value is false, which indicates the task should not fail
+            even if any insertion errors occur.
+        :type fail_on_error: bool
+        """
+
+        body = {
+            "rows": rows,
+            "ignoreUnknownValues": ignore_unknown_values,
+            "kind": "bigquery#tableDataInsertAllRequest",
+            "skipInvalidRows": skip_invalid_rows,
+        }
+
+        try:
+            self.log.info('Inserting {} row(s) into Table {}:{}.{}'.format(
+                          len(rows), project_id,
+                          dataset_id, table_id))
+
+            resp = self.service.tabledata().insertAll(
+                projectId=project_id, datasetId=dataset_id,
+                tableId=table_id, body=body
+            ).execute()
+
+            if 'insertErrors' not in resp:
+                self.log.info('All row(s) inserted successfully: {}:{}.{}'.format(
+                              project_id, dataset_id, table_id))
+            else:
+                error_msg = '{} insert error(s) occured: {}:{}.{}. Details: {}'.format(
+                              len(resp['insertErrors']),
+                              project_id, dataset_id, table_id, resp['insertErrors'])
+                if fail_on_error:
+                    raise AirflowException(
+                        'BigQuery job failed. Error was: {}'.format(error_msg)
+                    )
+                self.log.info(error_msg)
+        except HttpError as err:
+            raise AirflowException(
+                'BigQuery job failed. Error was: {}'.format(err.content)
+            )
+
 
 class BigQueryCursor(BigQueryBaseCursor):
     """

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1561,8 +1561,8 @@ class BigQueryBaseCursor(LoggingMixin):
 
         try:
             self.log.info('Inserting {} row(s) into Table {}:{}.{}'.format(
-                          len(rows), project_id,
-                          dataset_id, table_id))
+                len(rows), project_id,
+                dataset_id, table_id))
 
             resp = self.service.tabledata().insertAll(
                 projectId=project_id, datasetId=dataset_id,
@@ -1571,11 +1571,11 @@ class BigQueryBaseCursor(LoggingMixin):
 
             if 'insertErrors' not in resp:
                 self.log.info('All row(s) inserted successfully: {}:{}.{}'.format(
-                              project_id, dataset_id, table_id))
+                    project_id, dataset_id, table_id))
             else:
                 error_msg = '{} insert error(s) occured: {}:{}.{}. Details: {}'.format(
-                              len(resp['insertErrors']),
-                              project_id, dataset_id, table_id, resp['insertErrors'])
+                    len(resp['insertErrors']),
+                    project_id, dataset_id, table_id, resp['insertErrors'])
                 if fail_on_error:
                     raise AirflowException(
                         'BigQuery job failed. Error was: {}'.format(error_msg)

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -294,6 +294,56 @@ class TestBigQueryBaseCursor(unittest.TestCase):
         self.assertIsNone(_api_resource_configs_duplication_check(
             "key_one", key_one, {"key_one": True}))
 
+    @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')
+    def test_insert_all_succeed(self, run_with_config):
+        project_id = 'bq-project'
+        dataset_id = 'bq_dataset'
+        table_id = 'bq_table'
+        rows = [
+            {"json": {"a_key": "a_value_0"}}
+        ]
+        body = {
+            "rows": rows,
+            "ignoreUnknownValues": False,
+            "kind": "bigquery#tableDataInsertAllRequest",
+            "skipInvalidRows": False,
+        }
+
+        mock_service = mock.Mock()
+        method = (mock_service.tabledata.return_value.insertAll)
+        method.return_value.execute.return_value = {
+            "kind": "bigquery#tableDataInsertAllResponse"
+        }
+        cursor = hook.BigQueryBaseCursor(mock_service, 'project_id')
+        cursor.insert_all(project_id, dataset_id, table_id, rows)
+        method.assert_called_with(projectId=project_id, datasetId=dataset_id,
+                                  tableId=table_id, body=body)
+
+    @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')
+    def test_insert_all_fail(self, run_with_config):
+        project_id = 'bq-project'
+        dataset_id = 'bq_dataset'
+        table_id = 'bq_table'
+        rows = [
+            {"json": {"a_key": "a_value_0"}}
+        ]
+
+        mock_service = mock.Mock()
+        method = (mock_service.tabledata.return_value.insertAll)
+        method.return_value.execute.return_value = {
+            "kind": "bigquery#tableDataInsertAllResponse",
+            "insertErrors": [
+                {
+                    "index": 1,
+                    "errors": []
+                }
+            ]
+        }
+        cursor = hook.BigQueryBaseCursor(mock_service, 'project_id')
+        with self.assertRaises(Exception):
+            cursor.insert_all(project_id, dataset_id, table_id,
+                              rows, fail_on_error=True)
+
 
 class TestLabelsInRunJob(unittest.TestCase):
     @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')


### PR DESCRIPTION
[AIRFLOW-3332] Add insert_all to allow inserting rows into BigQuery table

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-3332](https://issues.apache.org/jira/browse/AIRFLOW-3332) issues and references them in the PR title. 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
        Add insert_all function in BigQueryHook to allow inserting one or more rows into BigQuery table 
        without needing to run a load job


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
        tests.contrib.hooks.test_bigquery_hook:TestBigQueryBaseCursor.test_insert_all_succeed
        tests.contrib.hooks.test_bigquery_hook:TestBigQueryBaseCursor.test_insert_all_fail

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
