### PR TITLE
[AIRFLOW-XXX] Remove duplicated line in changelog

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,7 +11,6 @@ AIRFLOW 1.10.0, 2018-08-03
 [AIRFLOW-2710] Clarify fernet key value in documentation
 [AIRFLOW-2606] Fix DB schema and SQLAlchemy model
 [AIRFLOW-2646] Fix setup.py not to install snakebite on Python3
-[AIRFLOW-2512][AIRFLOW-2522] Use google-auth instead of oauth2client
 [AIRFLOW-2604] Add index to task_fail
 [AIRFLOW-2650] Mark SchedulerJob as succeed when hitting Ctrl-c
 [AIRFLOW-2678] Fix db schema unit test to remove checking fab models


### PR DESCRIPTION
I accidentally found duplicated line in changelog 😃  ([L14](https://github.com/apache/incubator-airflow/blob/abc9ebb973ade4d39780af293ff70217074300d0/CHANGELOG.txt#L14) / [L48](https://github.com/apache/incubator-airflow/blob/abc9ebb973ade4d39780af293ff70217074300d0/CHANGELOG.txt#L48))

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
