### PR TITLE
[AIRFLOW-3340] Placeholder support in connections form

### DIFF
--- a/airflow/www/static/connection_form.js
+++ b/airflow/www/static/connection_form.js
@@ -59,6 +59,9 @@
           relabeling: {
             'host': 'API Endpoint',
             'password': 'Auth Token',
+          },
+          placeholders: {
+            'host': 'https://<env>.qubole.com/api'
           }
         },
         ssh: {
@@ -81,6 +84,8 @@
         $("label[orig_text]").each(function(){
             $(this).text($(this).attr("orig_text"));
         });
+        $(".form-control").each(function(){$(this).attr('placeholder', '')});
+
         if (config[connectionType] != undefined){
           $.each(config[connectionType].hidden_fields, function(i, field){
             $("#" + field).parent().parent().addClass('hide')
@@ -89,6 +94,9 @@
             lbl = $("label[for='" + k + "']")
             lbl.attr("orig_text", lbl.text());
             $("label[for='" + k + "']").text(v);
+          });
+          $.each(config[connectionType].placeholders, function(k, v){
+            $("#" + k).attr('placeholder', v);
           });
         }
       }

--- a/airflow/www_rbac/static/js/connection_form.js
+++ b/airflow/www_rbac/static/js/connection_form.js
@@ -51,6 +51,9 @@ $(document).ready(function () {
       relabeling: {
         'host': 'API Endpoint',
         'password': 'Auth Token',
+      },
+      placeholders: {
+        'host': 'https://<env>.qubole.com/api'
       }
     },
     ssh: {
@@ -72,6 +75,8 @@ $(document).ready(function () {
     $("label[orig_text]").each(function () {
       $(this).text($(this).attr("orig_text"));
     });
+    $(".form-control").each(function(){$(this).attr('placeholder', '')});
+
     if (config[connectionType] != undefined) {
       $.each(config[connectionType].hidden_fields, function (i, field) {
         $("#" + field).parent().parent().addClass('hide')
@@ -80,6 +85,9 @@ $(document).ready(function () {
         lbl = $("label[for='" + k + "']");
         lbl.attr("orig_text", lbl.text());
         $("label[for='" + k + "']").text(v);
+      });
+      $.each(config[connectionType].placeholders, function(k, v){
+        $("#" + k).attr('placeholder', v);
       });
     }
   }


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues
  - https://issues.apache.org/jira/browse/AIRFLOW-3340

### Description

- [x] Placeholder are very useful when setting up new connections. Adding the capability to provide custom placeholders in Connections form.

![placeholder](https://user-images.githubusercontent.com/2018407/48485724-a7c3a280-e83f-11e8-8269-4e5be6f4d9c1.gif)


### Tests

- [x] Small UI change, which I've tested manually 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] NA

### Code Quality

- [x] Passes `flake8`
