### PR TITLE
Fix showing config on RBAC UI when expose_config is False

### DIFF
--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -1798,11 +1798,18 @@ class ConfigurationView(AirflowBaseView):
         raw = request.args.get('raw') == "true"
         title = "Airflow Configuration"
         subtitle = conf.AIRFLOW_CONFIG
-        with open(conf.AIRFLOW_CONFIG, 'r') as f:
-            config = f.read()
-        table = [(section, key, value, source)
-                 for section, parameters in conf.as_dict(True, True).items()
-                 for key, (value, source) in parameters.items()]
+        # Don't show config when expose_config variable is False in airflow config
+        if conf.getboolean("webserver", "expose_config"):
+            with open(conf.AIRFLOW_CONFIG, 'r') as f:
+                config = f.read()
+            table = [(section, key, value, source)
+                     for section, parameters in conf.as_dict(True, True).items()
+                     for key, (value, source) in parameters.items()]
+        else:
+            config = (
+                "# Your Airflow administrator chose not to expose the "
+                "configuration, most likely for security reasons.")
+            table = None
 
         if raw:
             return Response(


### PR DESCRIPTION
RBAC UI does not respect variable `expose_config` in airflow config to show configuration.
This snippet will show config only when `expose_config` is set to `True`.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-3352\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3352

### Description

- [x] Here are some details about my PR, including screenshots of any UI 
    - This PR will control showing airflow configuration RBAC UI based on variable `expose_config` defined in airflow config
    - Please find attached screenshot for the same 
![img-20181115-wa0000](https://user-images.githubusercontent.com/12140904/48553561-f0dc2b00-e901-11e8-93b5-db2579e7434f.jpg)



### Tests

- [x] My PR  does not need testing as this is UI change.


### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] Passes `flake8`
