### PR TITLE
 [AIRFLOW-3348] update run statistics on dag refresh

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1877,6 +1877,8 @@ class Airflow(BaseView):
             session.merge(orm_dag)
         session.commit()
 
+        models.DagStat.update([dag_id], session=session, dirty_only=False)
+
         dagbag.get_dag(dag_id)
         flash("DAG [{}] is now fresh as a daisy".format(dag_id))
         return redirect(request.referrer)

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -1627,6 +1627,8 @@ class Airflow(AirflowBaseView):
         # sync dag permission
         appbuilder.sm.sync_perm_for_dag(dag_id)
 
+        models.DagStat.update([dag_id])
+
         dagbag.get_dag(dag_id)
         flash("DAG [{}] is now fresh as a daisy".format(dag_id))
         return redirect(request.referrer)

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -1627,7 +1627,7 @@ class Airflow(AirflowBaseView):
         # sync dag permission
         appbuilder.sm.sync_perm_for_dag(dag_id)
 
-        models.DagStat.update([dag_id])
+        models.DagStat.update([dag_id], session=session, dirty_only=False)
 
         dagbag.get_dag(dag_id)
         flash("DAG [{}] is now fresh as a daisy".format(dag_id))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira]
  - https://issues.apache.org/jira/browse/AIRFLOW-3348

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

In some cases dag run statistics may become outdated, for example, when dag run is deleted.

As the view from which dag runs are deleted permits to delete runs from multiple dags in a single transaction, this seems to be the most reasonable place to update run statistics

### Tests

- [X] My PR does not need testing for this extremely good reason:
 Covered by existing test for `/refresh`

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [X] Passes `flake8`
