### PR TITLE
[AIRFLOW-3360] Make the DAGs search respect other querystring parameters

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -215,9 +215,9 @@
 
     </div>
     {% if not hide_paused %}
-    <a href="{{ url_for('admin.index') }}?showPaused=False">Hide Paused DAGs</a>
+    <a href="{{ url_for('admin.index', showPaused=False, search=request.args.get('search', None)) }}">Hide Paused DAGs</a>
     {% else %}
-    <a href="{{ url_for('admin.index') }}?showPaused=True">Show Paused DAGs</a>
+    <a href="{{ url_for('admin.index', showPaused=True, search=request.args.get('search', None)) }}">Show Paused DAGs</a>
     {% endif %}
   </div>
 {% endblock %}
@@ -233,11 +233,32 @@
       const DAGS_INDEX = "{{ url_for('admin.index') }}";
       const ENTER_KEY_CODE = 13;
 
+      function createOrAppendToQueryString(parameter, value) {
+        var query_string_parameters = {};
+        if (typeof window.location.search !== "undefined") {
+          window.location.search.substr(1).split('&').forEach(function (query_string_parameter) {
+            query_string_parameter_delimeted = query_string_parameter.split('=');
+            query_string_key = query_string_parameter_delimeted.shift();
+            query_string_value = query_string_parameter_delimeted.join('=');
+            query_string_parameters[query_string_key] = query_string_value
+          });
+        }
+        if (window.location.search == "") {
+          query_string_parameters = {};
+        }
+        query_string_parameters[parameter] = encodeURI(value);
+        var query_string = Object.keys(query_string_parameters).map(function(key) {
+          return key + "=" + query_string_parameters[key];
+        }).join("&");
+        return query_string
+      }
+
       $('#dag_query').on('keypress', function (e) {
         // check for key press on ENTER (key code 13) to trigger the search
         if (e.which === ENTER_KEY_CODE) {
-          search_query = $('#dag_query').val();
-          window.location = DAGS_INDEX + "?search="+ encodeURI(search_query);
+          var search_query = $('#dag_query').val();
+          var query_string = createOrAppendToQueryString("search", encodeURI(search_query));
+          window.location = DAGS_INDEX + "?" + query_string;
           e.preventDefault();
         }
       });
@@ -283,7 +304,8 @@
         afterSelect: function(value) {
           search_query = value.trim()
           if (search_query) {
-            window.location = DAGS_INDEX + "?search="+ encodeURI(search_query);
+            var query_string = createOrAppendToQueryString("search", encodeURI(search_query));
+            window.location = DAGS_INDEX + "?" + query_string;
           }
         }
       });

--- a/airflow/www_rbac/templates/airflow/dags.html
+++ b/airflow/www_rbac/templates/airflow/dags.html
@@ -216,9 +216,9 @@
 
     </div>
     {% if not hide_paused %}
-    <a href="{{ url_for('Airflow.index') }}?showPaused=False">Hide Paused DAGs</a>
+    <a href="{{ url_for('Airflow.index', showPaused=False, search=request.args.get('search', None)) }}">Hide Paused DAGs</a>
     {% else %}
-    <a href="{{ url_for('Airflow.index') }}?showPaused=True">Show Paused DAGs</a>
+    <a href="{{ url_for('Airflow.index', showPaused=True, search=request.args.get('search', None)) }}">Show Paused DAGs</a>
     {% endif %}
   </div>
 {% endblock %}
@@ -235,11 +235,32 @@
       const DAGS_INDEX = "{{ url_for('Airflow.index') }}";
       const ENTER_KEY_CODE = 13;
 
+      function createOrAppendToQueryString(parameter, value) {
+        var query_string_parameters = {};
+        if (typeof window.location.search !== "undefined") {
+          window.location.search.substr(1).split('&').forEach(function (query_string_parameter) {
+            query_string_parameter_delimeted = query_string_parameter.split('=');
+            query_string_key = query_string_parameter_delimeted.shift();
+            query_string_value = query_string_parameter_delimeted.join('=');
+            query_string_parameters[query_string_key] = query_string_value
+          });
+        }
+        if (window.location.search == "") {
+          query_string_parameters = {};
+        }
+        query_string_parameters[parameter] = encodeURI(value);
+        var query_string = Object.keys(query_string_parameters).map(function(key) {
+          return key + "=" + query_string_parameters[key];
+        }).join("&");
+        return query_string
+      }
+
       $('#dag_query').on('keypress', function (e) {
         // check for key press on ENTER (key code 13) to trigger the search
         if (e.which === ENTER_KEY_CODE) {
           search_query = $('#dag_query').val();
-          window.location = DAGS_INDEX + "?search="+ encodeURI(search_query);
+          var query_string = createOrAppendToQueryString("search", encodeURI(search_query));
+          window.location = DAGS_INDEX + "?" + query_string;
           e.preventDefault();
         }
       });
@@ -285,7 +306,8 @@
         afterSelect: function(value) {
           search_query = value.trim()
           if (search_query) {
-            window.location = DAGS_INDEX + "?search="+ encodeURI(search_query);
+            var query_string = createOrAppendToQueryString("search", encodeURI(search_query));
+            window.location = DAGS_INDEX + "?" + query_string;
           }
         }
       });


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Search will append to the query string rather than replacing it. Allows users to decide whether they want to search for hidden DAGs.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No existing tests around the DAGs template.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
