### PR TITLE
[AIRFLOW-XXX] Don't publish md5 sigs as part of release

### DIFF
--- a/dev/sign.sh
+++ b/dev/sign.sh
@@ -26,4 +26,3 @@ NAME=${1}
 
 gpg --armor --output ${NAME}.asc --detach-sig ${NAME}
 gpg --print-md SHA512 ${NAME} > ${NAME}.sha512
-gpg --print-md MD5 ${NAME} > ${NAME}.md5


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] No Jira

### Description

- [x] Apache recommend against publishing MD5 files now as they are relatively
easy to collide and shouldn't be trusted anymore

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
