### PR TITLE
[AIRFLOW-3371] BigQueryHook's Ability to Create View

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -221,7 +221,8 @@ class BigQueryBaseCursor(LoggingMixin):
                            labels=None,
                            view=None):
         """
-        Creates a new, empty table in the dataset.
+        Creates a new, empty table in the dataset. 
+        To create a view, which is defined by a SQL query, parse a dictionary to 'view' kwarg
 
         :param project_id: The project to create the table into.
         :type project_id: str
@@ -246,7 +247,8 @@ class BigQueryBaseCursor(LoggingMixin):
             .. seealso::
             https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#timePartitioning
         :type time_partitioning: dict
-        :param view: [Optional] a dictionary containing definition for the view:
+        :param view: [Optional] A dictionary containing definition for the view.
+            If set, it will create a view instead of a table:
             https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#view
         :type view: dict
 

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -218,8 +218,8 @@ class BigQueryBaseCursor(LoggingMixin):
                            table_id,
                            schema_fields=None,
                            time_partitioning=None,
-                           labels=None
-                           ):
+                           labels=None,
+                           view=None):
         """
         Creates a new, empty table in the dataset.
 
@@ -246,6 +246,16 @@ class BigQueryBaseCursor(LoggingMixin):
             .. seealso::
             https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#timePartitioning
         :type time_partitioning: dict
+        :param view: [Optional] a dictionary containing definition for the view:
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#view
+        :type view: dict
+
+        **Example**: ::
+
+            view = {
+                "query": "SELECT * FROM `test-project-id.test_dataset_id.test_table_prefix*` LIMIT 1000",
+                "useLegacySql": False
+            }
 
         :return:
         """
@@ -266,6 +276,9 @@ class BigQueryBaseCursor(LoggingMixin):
 
         if labels:
             table_resource['labels'] = labels
+
+        if view:
+            table_resource['view'] = view
 
         self.log.info('Creating Table %s:%s.%s',
                       project_id, dataset_id, table_id)

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -221,7 +221,7 @@ class BigQueryBaseCursor(LoggingMixin):
                            labels=None,
                            view=None):
         """
-        Creates a new, empty table in the dataset. 
+        Creates a new, empty table in the dataset.
         To create a view, which is defined by a SQL query, parse a dictionary to 'view' kwarg
 
         :param project_id: The project to create the table into.


### PR DESCRIPTION
1) Edit create_empty_table to take in optional 'view' dict
2) Add unit tests for creating view

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-3371](https://issues.apache.org/jira/browse/AIRFLOW-3371) issues and references them in the PR title. 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
To enable BigQueryBaseCursor.create_empty_table to create view in BigQuery
Ref: https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#view

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   tests.contrib.hooks.test_bigquery_hook:TestBigQueryBaseCursor.test_create_view_fails_on_exception
   tests.contrib.hooks.test_bigquery_hook:TestBigQueryBaseCursor.test_create_view

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
