### PR TITLE
[AIRFLOW-3375] Support returning multiple tasks with BranchPythonOperator

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -500,8 +500,8 @@ that happened in an upstream task. One way to do this is by using the
 ``BranchPythonOperator``.
 
 The ``BranchPythonOperator`` is much like the PythonOperator except that it
-expects a python_callable that returns a task_id. The task_id returned
-is followed, and all of the other paths are skipped.
+expects a python_callable that returns a task_id (or list of task_ids). The
+task_id returned is followed, and all of the other paths are skipped.
 The task_id returned by the Python function has to be referencing a task
 directly downstream from the BranchPythonOperator task.
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

https://issues.apache.org/jira/browse/AIRFLOW-3375

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds support to the BranchPythonOperator for handling a list of tasks, so multiple branches can be returned. A single task_id string is still supported.

This is now possible with this PR:
![image](https://user-images.githubusercontent.com/6249654/48800846-3a19e980-ed0b-11e8-89d0-29ceba2ce2fb.png)

By returning a list of task ids:
```BranchPythonOperator(task_id='your_dag', dag=dag, python_callable=lambda: ['branch_1', 'branch_2'])```

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added `test_branch_list_without_dag_run` test to BranchOperatorTest.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

Added new functionality in parentheses.

### Code Quality

- [x] Passes `flake8`
