### PR TITLE
[AIRFLOW-3382] Fix incorrect docstring in DatastoreHook

### DIFF
--- a/airflow/contrib/hooks/datastore_hook.py
+++ b/airflow/contrib/hooks/datastore_hook.py
@@ -41,7 +41,7 @@ class DatastoreHook(GoogleCloudBaseHook):
 
     def get_conn(self, version='v1'):
         """
-        Returns a Google Cloud Storage service object.
+        Returns a Google Cloud Datastore service object.
         """
         http_authorized = self._authorize()
         return build(


### PR DESCRIPTION
Correct docstring in DatastoreHook

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-3382](https://issues.apache.org/jira/browse/AIRFLOW-3382) issues and references them in the PR title. 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
    Changed 'Google Cloud Storage' to "Google Cloud Datastore" in DatastoreHook

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    No tests for this
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
