### PR TITLE
[AIRFLOW-3383] Rotate fernet keys.

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -173,6 +173,13 @@ class Connection(Base, LoggingMixin):
         return synonym('_extra',
                        descriptor=property(cls.get_extra, cls.set_extra))
 
+    def rotate_fernet_key(self):
+        fernet = get_fernet()
+        if self._password and self.is_encrypted:
+            self._password = fernet.rotate(self._password.encode('utf-8')).decode()
+        if self._extra and self.is_extra_encrypted:
+            self._extra = fernet.rotate(self._extra.encode('utf-8')).decode()
+
     def get_hook(self):
         try:
             if self.conn_type == 'mysql':

--- a/docs/howto/secure-connections.rst
+++ b/docs/howto/secure-connections.rst
@@ -48,3 +48,18 @@ variable over the value in ``airflow.cfg``:
 
 4. Restart Airflow webserver.
 5. For existing connections (the ones that you had defined before installing ``airflow[crypto]`` and creating a Fernet key), you need to open each connection in the connection admin UI, re-type the password, and save it.
+
+Rotating encryption keys
+========================
+
+Once connection credentials and variables have been encrypted using a fernet
+key, changing the key will cause decryption of existing credentials to fail. To
+rotate the fernet key without invalidating existing encrypted values, prepend
+the new key to the ``fernet_key`` setting, run
+``airflow rotate_fernet_key``, and then drop the original key from
+``fernet_keys``:
+
+1. Set ``fernet_key`` to ``new_fernet_key,old_fernet_key``.
+2. Run ``airflow rotate_fernet_key`` to reencrypt existing credentials
+with the new fernet key.
+3. Set ``fernet_key`` to ``new_fernet_key``.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3383
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

As far as I can tell, it's not straightforward to rotate the fernet key for encrypted passwords and extras. A user would have to generate a new key, restart airflow, and manually re-enter each value to be encrypted via the web interface. It should be possible to specify multiple fernet keys at once, and to easily re-encrypt values with a new key. The cryptography package provides a MultiFernet class with a rotate method that handles this use case, so I wrote up a patch that uses MultiFernet to support multiple keys and rotation via the command line.

With this approach, we can rotate keys by adding a new key at the start of the FERNET_KEYS config variable, then running the rotate_credentials command from the command line. If the approach makes sense, I'll write up some documentation.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
