### PR TITLE
docs: Remove quotes from domain in Google Oauth

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -333,7 +333,7 @@ login, separated with a comma, to only members of those domains.
     client_id = google_client_id
     client_secret = google_client_secret
     oauth_callback_route = /oauth2callback
-    domain = "example1.com,example2.com"
+    domain = example1.com,example2.com
 
 To use Google authentication, you must install Airflow with the `google_auth` extras group:
 


### PR DESCRIPTION
The documentation example that uses quotes around the `domain` in Google Oauth authentication currently doesn't work. 

Using `domain` with quotes around domains results in "You don't seem to have access. Please contact your administrator" when logging in. 

Removing the quotes results in the ability to login with the `domain`. 

Also mentioned in this Stackoverflow: https://stackoverflow.com/a/52528091/10638329