### PR TITLE
[AIRFLOW-1196][AIRFLOW-2399] Add templated field in TriggerDagRunOperator

### DIFF
--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -35,7 +35,7 @@ class TriggerDagRunOperator(BaseOperator):
     """
     Triggers a DAG run for a specified ``dag_id``
 
-    :param trigger_dag_id: the dag_id to trigger
+    :param trigger_dag_id: the dag_id to trigger (templated)
     :type trigger_dag_id: str
     :param python_callable: a reference to a python function that will be
         called while passing it the ``context`` object and a placeholder

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -50,7 +50,7 @@ class TriggerDagRunOperator(BaseOperator):
     :param execution_date: Execution date for the dag
     :type execution_date: datetime.datetime
     """
-    template_fields = tuple()
+    template_fields = ('trigger_dag_id',)
     template_ext = tuple()
     ui_color = '#ffefeb'
 


### PR DESCRIPTION
Make trigger_dag_id a templated field of TriggerDagRunOperator

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-1196
  - https://issues.apache.org/jira/browse/AIRFLOW-2399


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Make `trigger_dag_id` a templated field of `TriggerDagRunOperator`

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
n/a

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
