### PR TITLE
[AIRFLOW-3392] Add index on dag_id in sla_miss table

### DIFF
--- a/airflow/migrations/versions/03bc53e68815_add_sm_dag_index.py
+++ b/airflow/migrations/versions/03bc53e68815_add_sm_dag_index.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""merge_heads_2
+
+Revision ID: 03bc53e68815
+Revises: 0a2a5b66e19d, bf00311e1990
+Create Date: 2018-11-24 20:21:46.605414
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '03bc53e68815'
+down_revision = ('0a2a5b66e19d', 'bf00311e1990')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('sm_dag', 'sla_miss', ['dag_id'], unique=False)
+
+
+def downgrade():
+    op.drop_index('sm_dag', table_name='sla_miss')

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -5481,6 +5481,10 @@ class SlaMiss(Base):
     description = Column(Text)
     notification_sent = Column(Boolean, default=False)
 
+    __table_args__ = (
+        Index('sm_dag', dag_id, unique=False),
+    )
+
     def __repr__(self):
         return str((
             self.dag_id, self.task_id, self.execution_date.isoformat()))


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3392) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3392

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The [select queries on sla_miss table](https://github.com/apache/incubator-airflow/blob/master/airflow/jobs.py#L669-L674) produce a great % of DB traffic and thus made the DB CPU usage unnecessarily high. It would be a low hanging fruit to add an index and reduce the load. After all such queries that are issued by the DagFileProcessor should be optimized as much as possible.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tested within Airbnb's setup. In Airbnb's setup, the # of rows scanned by this query is ~80% of all row scanned. Add such index reduced ~30% of the DB CPU usage and the cluster has been running healthy for 1 month +. Below is the CPU usage metrics.

![cpu_diff](https://user-images.githubusercontent.com/7818710/49055356-27d8f900-f1ac-11e8-8346-1458fa36fb06.png) 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
