### PR TITLE
[AIRFLOW-3395] Add REST API endpoints to the docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,10 +24,74 @@ available at /api/experimental/. Please note that we expect the endpoint definit
 Endpoints
 ---------
 
-This is a place holder until the swagger definitions are active
+.. http:post:: /api/experimental/dags/<DAG_ID>/dag_runs
 
-* /api/experimental/dags/<DAG_ID>/tasks/<TASK_ID> returns info for a task (GET).
-* /api/experimental/dags/<DAG_ID>/dag_runs creates a dag_run for a given dag id (POST).
+
+  Creates a dag_run for a given dag id.
+
+
+  **Trigger DAG with config, example:**
+
+  .. code-block:: bash
+
+    curl -X POST \
+      http://localhost:8080/api/experimental/dags/<DAG_ID>/dag_runs \
+      -H 'Cache-Control: no-cache' \
+      -H 'Content-Type: application/json' \
+      -d '{"conf":"{\"key\":\"value\"}"}'
+
+
+.. http:get:: /api/experimental/dags/<DAG_ID>/dag_runs
+
+  Returns a list of Dag Runs for a specific DAG ID.
+
+.. http:get:: /api/experimental/dags/<string:dag_id>/dag_runs/<string:execution_date>
+
+  Returns a JSON with a dag_run's public instance variables. The format for the <string:execution_date> is expected to be "YYYY-mm-DDTHH:MM:SS", for example: "2016-11-16T11:34:15".
+
+
+.. http:get:: /api/experimental/test
+
+  To check REST API server correct work. Return status 'OK'.
+
+
+.. http:get:: /api/experimental/dags/<DAG_ID>/tasks/<TASK_ID>
+
+  Returns info for a task.
+
+
+.. http:get:: /api/experimental/dags/<DAG_ID>/dag_runs/<string:execution_date>/tasks/<TASK_ID>
+
+  Returns a JSON with a task instance's public instance variables. The format for the <string:execution_date> is expected to be "YYYY-mm-DDTHH:MM:SS", for example: "2016-11-16T11:34:15".
+
+
+.. http:get:: /api/experimental/dags/<DAG_ID>/paused/<string:paused>
+
+  '<string:paused>' must be a 'true' to pause a DAG and 'false' to unpause.
+
+
+.. http:get:: /api/experimental/latest_runs
+
+  Returns the latest DagRun for each DAG formatted for the UI.
+
+
+.. http:get:: /api/experimental/pools
+
+  Get all pools.
+
+
+.. http:get:: /api/experimental/pools/<string:name>
+
+  Get pool by a given name.
+
+.. http:post:: /api/experimental/pools
+
+  Create a pool.
+
+.. http:delete:: /api/experimental/pools/<string:name>
+
+  Delete pool.
+
 
 CLI
 -----

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,6 +76,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
     'sphinxarg.ext',
+    'sphinxcontrib.httpdomain'
 ]
 
 autodoc_default_flags = ['show-inheritance', 'members']

--- a/setup.py
+++ b/setup.py
@@ -172,6 +172,7 @@ doc = [
     'sphinx>=1.2.3',
     'sphinx-argparse>=0.1.13',
     'sphinx-rtd-theme>=0.1.6',
+    'sphinxcontrib-httpdomain>=1.7.0',
     'Sphinx-PyPI-upload>=0.2.1'
 ]
 docker = ['docker~=3.0']


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-3395\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3395
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

I don't see any task about start using swagger or something else, so I added temporary doc for informing about existed endpoints

I also try to use flask autodoc https://sphinxcontrib-httpdomain.readthedocs.io/en/stable/#module-sphinxcontrib.autohttp.flask but has an issue relative to defining flask app, I believe need to do some refactor to use flask app, so I just used simple httpdomain sphinx.

Added info about REST API endpoints in doc 
result doc preview: 
<img width="400" alt="screen shot 2018-11-25 at 21 10 37" src="https://user-images.githubusercontent.com/15959809/48982716-3addc180-f0f7-11e8-8113-7667873ba110.png">
<img width="400" alt="screen shot 2018-11-25 at 21 10 43" src="https://user-images.githubusercontent.com/15959809/48982717-3b765800-f0f7-11e8-8550-c7afe7612cb6.png">

if try to use autofunction, for example, will be problems such as: 

''' File "/Users/jvolkova/.virtualenvs/airflow_tutorial/lib/python2.7/site-packages/airflow/www_rbac/api/experimental/endpoints.py", line 38, in <module>
    requires_authentication = airflow.api.api_auth.requires_authentication
AttributeError: 'NoneType' object has no attribute 'requires_authentication'
''' so need to refactor 'endpoints.py' to avoid those issues, but I don't want to do it right now, because as I remember we plan do something with REST API
### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
