### PR TITLE
[WIP][AIRFLOW-1823] added possibility to send execution date with millisec…

### DIFF
--- a/airflow/www_rbac/api/experimental/endpoints.py
+++ b/airflow/www_rbac/api/experimental/endpoints.py
@@ -168,18 +168,21 @@ def task_instance_info(dag_id, execution_date, task_id):
     """
     Returns a JSON with a task instance's public instance variables.
     The format for the exec_date is expected to be
-    "YYYY-mm-DDTHH:MM:SS", for example: "2016-11-16T11:34:15". This will
+    "YYYY-mm-DDTHH:MM:SS", for example: "2016-11-16T11:34:15" or
+    "YYYY-mm-DDTHH:MM:SS.f", for example: "2016-11-16T11:34:15.680399". This will
     of course need to have been encoded for URL in the request.
     """
 
     # Convert string datetime into actual datetime
     try:
-        execution_date = timezone.parse(execution_date)
+        execution_date = datetime.strptime(
+            execution_date, '%Y-%m-%dT%H:%M:%S.%f' if '.' in execution_date
+            else '%Y-%m-%dT%H:%M:%S')
     except ValueError:
         error_message = (
             'Given execution date, {}, could not be identified '
-            'as a date. Example date format: 2015-11-16T14:34:15+00:00'
-            .format(execution_date))
+            'as a date. Example date format: 2015-11-16T14:34:15 or '
+            '2015-11-16T14:34:15.680399'.format(execution_date))
         _log.info(error_message)
         response = jsonify({'error': error_message})
         response.status_code = 400
@@ -209,17 +212,21 @@ def dag_run_status(dag_id, execution_date):
     """
     Returns a JSON with a dag_run's public instance variables.
     The format for the exec_date is expected to be
-    "YYYY-mm-DDTHH:MM:SS", for example: "2016-11-16T11:34:15". This will
+    "YYYY-mm-DDTHH:MM:SS", for example: "2016-11-16T11:34:15" or
+    "YYYY-mm-DDTHH:MM:SS.f", for example: "2016-11-16T11:34:15.680399". This will
     of course need to have been encoded for URL in the request.
     """
 
     # Convert string datetime into actual datetime
     try:
-        execution_date = timezone.parse(execution_date)
+        execution_date = datetime.strptime(
+            execution_date, '%Y-%m-%dT%H:%M:%S.%f' if '.' in execution_date
+            else '%Y-%m-%dT%H:%M:%S')
     except ValueError:
         error_message = (
             'Given execution date, {}, could not be identified '
-            'as a date. Example date format: 2015-11-16T14:34:15+00:00'.format(
+            'as a date. Example date format: 2015-11-16T14:34:15+00:00 or '
+            '2015-11-16T14:34:15.680399'.format(
                 execution_date))
         _log.info(error_message)
         response = jsonify({'error': error_message})


### PR DESCRIPTION
…onds to task_instance_info REST API endpoint

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-1823\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-1823
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

added compatibility with UI triggered DAGs
checked: 

<img width="400" alt="screen shot 2018-11-25 at 23 19 59" src="https://user-images.githubusercontent.com/15959809/48984139-260a2980-f109-11e8-95cb-31b8bc1998d1.png">


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
