### PR TITLE
[AIRFLOW-3404] Add Amazon SES support

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -28,6 +28,7 @@ python:
         - s3
         - salesforce
         - sendgrid
+        - ses
         - ssh
         - slack
         - qds

--- a/airflow/contrib/utils/ses.py
+++ b/airflow/contrib/utils/ses.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+import os
+import boto3
+
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import formatdate
+
+from airflow import configuration
+
+
+def send_email(to, subject, html_content, files=None, dryrun=False, cc=None,
+               bcc=None, mime_subtype='mixed', sandbox_mode=False, **kwargs):
+    """
+    Send an email with html content using Amazon SES.
+
+    To use this plugin:
+    0. include ses subpackage as part of your Airflow installation, e.g.,
+    pip install apache-airflow[ses]
+    1. update [email] backend in airflow.cfg, i.e.,
+    [email]
+    email_backend = airflow.contrib.utils.ses.send_email
+    2. configure SES specific setting in airflow.cfg, e.g.:
+    [ses]
+    aws_region = eu-west-1
+    mail_from = airflow@example.com
+    """
+    mail_from = configuration.get('ses', 'MAIL_FROM') or configuration.get('smtp', 'SMTP_MAIL_FROM')
+    to = get_email_address_list(to)
+
+    msg = MIMEMultipart(mime_subtype)
+    msg['Subject'] = subject
+    msg['From'] = mail_from
+    msg['To'] = ", ".join(to)
+    if cc:
+        cc = get_email_address_list(cc)
+        msg['CC'] = ", ".join(cc)
+    if bcc:
+        logging.warning('bcc recipients are not supported')
+
+    msg['Date'] = formatdate(localtime=True)
+    mime_text = MIMEText(html_content, 'html')
+    msg.attach(mime_text)
+
+    for file_name in files or []:
+        basename = os.path.basename(file_name)
+        with open(file_name, "rb") as f:
+            msg.attach(MIMEApplication(
+                f.read(),
+                Content_Disposition='attachment; filename="{}"'.format(basename),
+                Name=basename
+            ))
+
+    if not dryrun:
+        aws_region = configuration.get('ses', 'REGION')
+        data = msg.as_string()
+        ses = boto3.client('ses', region_name=aws_region)
+        ses.send_raw_email(RawMessage={'Data': data})
+
+
+def get_email_address_list(address_string):
+    if isinstance(address_string, str):
+        if ',' in address_string:
+            return address_string.split(',')
+        elif ';' in address_string:
+            return address_string.split(';')
+        else:
+            return [address_string]
+    else:
+        return address_string

--- a/setup.py
+++ b/setup.py
@@ -225,6 +225,7 @@ salesforce = ['simple-salesforce>=0.72']
 samba = ['pysmbclient>=0.1.3']
 segment = ['analytics-python>=1.2.9']
 sendgrid = ['sendgrid>=5.2.0']
+ses = ['boto3']
 slack = ['slackclient>=1.0.0']
 mongo = ['pymongo>=3.6.0']
 snowflake = ['snowflake-connector-python>=1.5.2',
@@ -269,7 +270,7 @@ devel_all = (sendgrid + devel + all_dbs + doc + samba + s3 + slack + crypto + or
              docker + ssh + kubernetes + celery + azure_blob_storage + redis + gcp_api +
              datadog + zendesk + jdbc + ldap + kerberos + password + webhdfs + jenkins +
              druid + pinot + segment + snowflake + elasticsearch + azure_data_lake +
-             atlas)
+             atlas + ses)
 
 # Snakebite & Google Cloud Dataflow are not Python 3 compatible :'(
 if PY3:
@@ -382,6 +383,7 @@ def do_setup():
             'salesforce': salesforce,
             'samba': samba,
             'sendgrid': sendgrid,
+            'ses': ses,
             'segment': segment,
             'slack': slack,
             'snowflake': snowflake,

--- a/tests/contrib/utils/test_ses.py
+++ b/tests/contrib/utils/test_ses.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import os
+import unittest
+
+from airflow import configuration
+from airflow.contrib.utils.ses import send_email
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import formatdate
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+
+class SendEmailSesTest(unittest.TestCase):
+    # Unit test for ses.send_email()
+    def setUp(self):
+        configuration.set('smtp', 'SMTP_MAIL_FROM', 'foo@bar.com')
+
+        self.to = ['foo@foo.com', 'bar@bar.com']
+        self.subject = 'ses-send-email unit test'
+        self.html_content = '<b>Foo</b> bar'
+        self.cc = ['foo-cc@foo.com', 'bar-cc@bar.com']
+        self.bcc = ['foo-bcc@foo.com', 'bar-bcc@bar.com']
+
+        self.expected_message = MIMEMultipart('mixed')
+        self.expected_message['Subject'] = 'ses-send-email unit test'
+        self.expected_message['From'] = 'foo@bar.com'
+        self.expected_message['To'] = 'foo@foo.com, bar@bar.com'
+        self.expected_message['Cc'] = 'foo-cc@foo.com, bar-cc@bar.com'
+        self.expected_message['Bcc'] = 'foo-bcc@foo.com, bar-bcc@bar.com'
+        self.expected_message['Date'] = formatdate(localtime=True)
+        self.expected_message.attach(MIMEText(self.html_content, 'html'))
+
+    @mock.patch('airflow.contrib.utils.ses._ses_send_raw_email')
+    def test_send_email_ses_correct_message(self, mock_send):
+        send_email(self.to,
+                   self.subject,
+                   self.html_content,
+                   cc=self.cc,
+                   bcc=self.bcc)
+        # TODO fix test: failing because the MIME boundary is randomly generated
+        mock_send.assert_called_with(self.expected_message)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3404
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Similarly to `sendgrid.py`, `ses.py` defines an e-mail backend using Amazon SES.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
I don't know how to test this code, and would appreciate any support in that direction

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
