### PR TITLE
[AIRFLOW-3410] Add feature to allow Host Key Change for SSH Op

### DIFF
--- a/airflow/www/static/connection_form.js
+++ b/airflow/www/static/connection_form.js
@@ -61,6 +61,12 @@
             'password': 'Auth Token',
           }
         },
+        ssh: {
+          hidden_fields: ['schema'],
+          relabeling: {
+            'login': 'Username',
+          }
+        },
       }
       function connTypeChange(connectionType) {
         $("div.form-group").removeClass("hide");

--- a/airflow/www_rbac/static/js/connection_form.js
+++ b/airflow/www_rbac/static/js/connection_form.js
@@ -53,6 +53,12 @@ $(document).ready(function () {
         'password': 'Auth Token',
       }
     },
+    ssh: {
+      hidden_fields: ['schema'],
+      relabeling: {
+        'login': 'Username',
+      }
+    },
   };
 
   function connTypeChange(connectionType) {

--- a/docs/howto/manage-connections.rst
+++ b/docs/howto/manage-connections.rst
@@ -216,7 +216,7 @@ Extra (optional)
        }
 
     When specifying the connection as URI (in AIRFLOW_CONN_* variable) you should specify it
-    following the standard syntax of DB connections, where extras as passed as parameters
+    following the standard syntax of DB connections, where extras are passed as parameters
     of the URI (note that all components of the URI should be URL-encoded).
 
     For example:
@@ -248,7 +248,7 @@ Password (required)
     Specify the password to connect.
 
 Extra (optional)
-    Specify the extra parameters (as json dictionary) that can be used in mysql
+    Specify the extra parameters (as json dictionary) that can be used in postgres
     connection. The following parameters out of the standard python parameters
     are supported:
 
@@ -278,12 +278,12 @@ Extra (optional)
        {
           "sslmode": "verify-ca",
           "sslcert": "/tmp/client-cert.pem",
-          "sslca": "/tmp/server-ca.pem'",
+          "sslca": "/tmp/server-ca.pem",
           "sslkey": "/tmp/client-key.pem"
        }
 
     When specifying the connection as URI (in AIRFLOW_CONN_* variable) you should specify it
-    following the standard syntax of DB connections, where extras as passed as parameters
+    following the standard syntax of DB connections, where extras are passed as parameters
     of the URI (note that all components of the URI should be URL-encoded).
 
     For example:
@@ -321,7 +321,7 @@ Password (required)
     Specify the password to connect.
 
 Extra (optional)
-    Specify the extra parameters (as json dictionary) that can be used in mysql
+    Specify the extra parameters (as json dictionary) that can be used in gcpcloudsql
     connection.
 
     Details of all the parameters supported in extra field can be found in
@@ -341,7 +341,7 @@ Extra (optional)
        }
 
     When specifying the connection as URI (in AIRFLOW_CONN_* variable) you should specify it
-    following the standard syntax of DB connections, where extras as passed as parameters
+    following the standard syntax of DB connections, where extras are passed as parameters
     of the URI (note that all components of the URI should be URL-encoded).
 
     For example:
@@ -350,3 +350,51 @@ Extra (optional)
 
         gcpcloudsql://user:XXXXXXXXX@1.1.1.1:3306/mydb?database_type=mysql&project_id=example-project&location=europe-west1&instance=testinstance&use_proxy=True&sql_proxy_use_tcp=False
 
+SSH
+~~~
+The SSH connection type provides connection to use :class:`~airflow.contrib.hooks.ssh_hook.SSHHook` to run commands on a remote server using :class:`~airflow.contrib.operators.ssh_operator.SSHOperator` or transfer file from/to the remote server using :class:`~airflow.contrib.operators.ssh_operator.SFTPOperator`.
+
+Configuring the Connection
+''''''''''''''''''''''''''
+Host (required)
+    The Remote host to connect.
+
+Username (optional)
+    The Username to connect to the remote_host.
+
+Password (optional)
+    Specify the password of the username to connect to the remote_host.
+
+Port (optional)
+    Port of remote host to connect. Default is 22.
+
+Extra (optional)
+    Specify the extra parameters (as json dictionary) that can be used in ssh
+    connection. The following parameters out of the standard python parameters
+    are supported:
+
+    * **timeout** - An optional timeout (in seconds) for the TCP connect. Default is ``10``.
+    * **compress** - ``true`` to ask the remote client/server to compress traffic; `false` to refuse compression. Default is ``true``.
+    * **no_host_key_check** - Set to ``false`` to restrict connecting to hosts with no entries in ``~/.ssh/known_hosts`` (Hosts file). This provides maximum protection against trojan horse attacks, but can be troublesome when the ``/etc/ssh/ssh_known_hosts`` file is poorly maintained or connections to new hosts are frequently made. This option forces the user to manually add all new hosts. Default is ``true``, ssh will automatically add new host keys to the user known hosts files.
+    * **allow_host_key_change** - Set to ``true`` if you want to allow connecting to hosts that has host key changed or when you get 'REMOTE HOST IDENTIFICATION HAS CHANGED' error.  This wont protect against Man-In-The-Middle attacks. Other possible solution is to remove the host entry from ``~/.ssh/known_hosts`` file. Default is ``false``.
+
+    Example "extras" field:
+
+    .. code-block:: json
+
+       {
+          "timeout": "10",
+          "compress": "false",
+          "no_host_key_check": "true",
+          "allow_host_key_change": "false"
+       }
+
+    When specifying the connection as URI (in AIRFLOW_CONN_* variable) you should specify it
+    following the standard syntax of connections, where extras are passed as parameters
+    of the URI (note that all components of the URI should be URL-encoded).
+
+    For example:
+
+    .. code-block:: bash
+
+        ssh://user:pass@localhost:22?timeout=10&compress=false&no_host_key_check=false&allow_host_key_change=true

--- a/docs/howto/manage-connections.rst
+++ b/docs/howto/manage-connections.rst
@@ -385,7 +385,7 @@ Extra (optional)
        {
           "timeout": "10",
           "compress": "false",
-          "no_host_key_check": "true",
+          "no_host_key_check": "false",
           "allow_host_key_change": "false"
        }
 

--- a/tests/contrib/hooks/test_ssh_hook.py
+++ b/tests/contrib/hooks/test_ssh_hook.py
@@ -132,15 +132,18 @@ class SSHHookTest(unittest.TestCase):
 
     def test_conn_with_extra_parameters(self):
         db.merge_conn(
-            models.Connection(conn_id='ssh_with_extra',
-                              host='localhost',
-                              conn_type='ssh',
-                              extra='{"compress" : true, "no_host_key_check" : "true"}'
-                              )
+            models.Connection(
+                conn_id='ssh_with_extra',
+                host='localhost',
+                conn_type='ssh',
+                extra='{"compress" : true, "no_host_key_check" : "true", '
+                      '"allow_host_key_change": false}'
+            )
         )
         ssh_hook = SSHHook(ssh_conn_id='ssh_with_extra')
         self.assertEqual(ssh_hook.compress, True)
         self.assertEqual(ssh_hook.no_host_key_check, True)
+        self.assertEqual(ssh_hook.allow_host_key_change, False)
 
     def test_ssh_connection(self):
         hook = SSHHook(ssh_conn_id='ssh_default')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-3410


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR adds a feature to allow connecting to host (that already has an entry in Known Host file with different key) that has a new IP. Currently, it fails with `Remote Identification Changed`.

I have also added documentation on adding extras field to SSH Connection

![image](https://user-images.githubusercontent.com/8811558/49120570-1293c580-f2a5-11e8-8e0b-ea60e6de7959.png)

![image](https://user-images.githubusercontent.com/8811558/49120697-aebdcc80-f2a5-11e8-855b-2acb5f238204.png)


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
