### PR TITLE
[AIRFLOW-3414] Fix reload_module in DagFileProcessorAgent

### DIFF
--- a/airflow/logging_config.py
+++ b/airflow/logging_config.py
@@ -57,9 +57,9 @@ def configure_logging():
                 .format(logging_class_path, err)
             )
     else:
-        from airflow.config_templates.airflow_local_settings import (
-            DEFAULT_LOGGING_CONFIG as logging_config
-        )
+        logging_class_path = 'airflow.config_templates.' \
+                             'airflow_local_settings.DEFAULT_LOGGING_CONFIG'
+        logging_config = import_string(logging_class_path)
         log.debug('Unable to load custom logging, using default config instead')
 
     try:
@@ -73,7 +73,7 @@ def configure_logging():
 
     validate_logging_config(logging_config)
 
-    return logging_config
+    return logging_class_path
 
 
 def validate_logging_config(logging_config):

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -261,7 +261,7 @@ try:
 except Exception:
     pass
 
-configure_logging()
+logging_class_path = configure_logging()
 configure_vars()
 configure_adapters()
 # The webservers import this file from models.py with the default settings.

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -34,6 +34,7 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from collections import namedtuple
 from datetime import timedelta
+from importlib import import_module
 
 import psutil
 from six.moves import range, reload_module
@@ -45,6 +46,7 @@ import airflow.models
 from airflow import configuration as conf
 from airflow.dag.base_dag import BaseDag, BaseDagBag
 from airflow.exceptions import AirflowException
+from airflow.settings import logging_class_path
 from airflow.utils import timezone
 from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -539,7 +541,9 @@ class DagFileProcessorAgent(LoggingMixin):
             # e.g. RotatingFileHandler. And it can cause connection corruption if we
             # do not recreate the SQLA connection pool.
             os.environ['CONFIG_PROCESSOR_MANAGER_LOGGER'] = 'True'
-            reload_module(airflow.config_templates.airflow_local_settings)
+            # Replicating the behavior of how logging module was loaded
+            # in logging_config.py
+            reload_module(import_module(logging_class_path.rsplit('.', 1)[0]))
             reload_module(airflow.settings)
             del os.environ['CONFIG_PROCESSOR_MANAGER_LOGGER']
             processor_manager = DagFileProcessorManager(dag_directory,


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3414) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3414

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
`six.moves.reload_module` will throw exception if the module it is trying to reload has not been loaded yet. This will be the case if we loaded custom logging class and then try to reload the default logging module. This change will make sure we always load the already loaded logging module.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests/utils/test_dag_processing.py

Note that the unit test covers the case where we loaded BOTH default logging module and are trying to reload custom logging module but not the case where default logging module is not loaded. This is because the test env already has the default logging module loaded and it would be risky to modify the loaded module list. The case is instead covered in local tests( using custom logging and the cluster is healthy).

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
