### PR TITLE
[AIRFLOW-3416] Fixes Python 3 compatibility with CloudSqlQueryOperator

### DIFF
--- a/airflow/contrib/example_dags/example_gcp_sql_query.py
+++ b/airflow/contrib/example_dags/example_gcp_sql_query.py
@@ -188,7 +188,7 @@ os.environ['AIRFLOW_CONN_PROXY_MYSQL_TCP'] = \
 # MySQL: connect via proxy over UNIX socket using pre-downloaded Cloud Sql Proxy binary
 try:
     sql_proxy_binary_path = subprocess.check_output(
-        ['which', 'cloud_sql_proxy']).rstrip()
+        ['which', 'cloud_sql_proxy']).decode('utf-8').rstrip()
 except subprocess.CalledProcessError:
     sql_proxy_binary_path = "/tmp/anyhow_download_cloud_sql_proxy"
 

--- a/airflow/contrib/hooks/gcp_sql_hook.py
+++ b/airflow/contrib/hooks/gcp_sql_hook.py
@@ -463,7 +463,7 @@ class CloudSqlProxyRunner(LoggingMixin):
             self.log.info("The pid of cloud_sql_proxy: {}".format(
                 self.sql_proxy_process.pid))
             while True:
-                line = self.sql_proxy_process.stderr.readline()
+                line = self.sql_proxy_process.stderr.readline().decode('utf-8')
                 return_code = self.sql_proxy_process.poll()
                 if line == '' and return_code is not None:
                     self.sql_proxy_process = None
@@ -522,7 +522,7 @@ class CloudSqlProxyRunner(LoggingMixin):
         command_to_run = [self.sql_proxy_path]
         command_to_run.extend(['--version'])
         command_to_run.extend(self._get_credential_parameters())
-        result = subprocess.check_output(command_to_run)
+        result = subprocess.check_output(command_to_run).decode('utf-8')
         pattern = re.compile("^.*[V|v]ersion ([^;]*);.*$")
         m = pattern.match(result)
         if m:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3416

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Added several missing decodes on reading output from running
subprocess (cloud_sql_proxy). This fixes Python3 compatibility.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

The problem with testing this issue is that it really needs integration testing level with GCP - something that I proposed in https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-4+Support+for+Integration+Tests and we have a working proof of concept  using Cloud Build and our own GCP project (we will soon share it with community to see what they think about) so this problem has been actually detected using our automated integration testing and then fixed and tested in python 3.5 and python 3.6 environment. Here are some results of those tests:

Tests succeeding in Python 2.7 but failing on both 3.5 and 3.6:
https://storage.googleapis.com/polidea-airflow-builds/944c09c7-fbb5-4ae4-b069-7c2590cd1e7e/index.html

Tests succeeding in all 3 environments after adding decodes:
https://storage.googleapis.com/polidea-airflow-builds/5843e2a9-f086-448d-bdc3-14646ebb7f5d/index.html

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
No new functionality.

### Code Quality

- [x] Passes `flake8`
