### PR TITLE
[AIRFLOW-3423] Fix unauthenticated access for mongo hook

### DIFF
--- a/airflow/contrib/hooks/mongo_hook.py
+++ b/airflow/contrib/hooks/mongo_hook.py
@@ -56,11 +56,11 @@ class MongoHook(BaseHook):
         uri = 'mongodb://{creds}{host}{port}/{database}'.format(
             creds='{}:{}@'.format(
                 conn.login, conn.password
-            ) if conn.login is not None else '',
+            ) if conn.login != '' else '',
 
             host=conn.host,
             port='' if conn.port is None else ':{}'.format(conn.port),
-            database='' if conn.schema is None else conn.schema
+            database=conn.schema
         )
 
         # Mongo Connection Options dict that is unpacked when passed to MongoClient

--- a/airflow/contrib/hooks/mongo_hook.py
+++ b/airflow/contrib/hooks/mongo_hook.py
@@ -56,7 +56,7 @@ class MongoHook(BaseHook):
         uri = 'mongodb://{creds}{host}{port}/{database}'.format(
             creds='{}:{}@'.format(
                 conn.login, conn.password
-            ) if conn.login != '' else '',
+            ) if conn.login else '',
 
             host=conn.host,
             port='' if conn.port is None else ':{}'.format(conn.port),


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira]
  - https://issues.apache.org/jira/browse/AIRFLOW-3423
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Empty login and schema are returned by Airflow as empty strings, not as `None`. As a result incorrect URL is generated, causing authentication to fail.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Should fall under existing mongo hook testcases

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [X] Passes `flake8`
