### PR TITLE
[AIRFLOW-XXX] Fix display of SageMaker operators/hook docs

### DIFF
--- a/airflow/contrib/hooks/sagemaker_hook.py
+++ b/airflow/contrib/hooks/sagemaker_hook.py
@@ -160,7 +160,7 @@ class SageMakerHook(AwsHook):
 
         :param config: config of SageMaker operation
         :type config: dict
-        :return: dict
+        :rtype: dict
         """
         s3_operations = config.pop('S3Operations', None)
 
@@ -182,8 +182,8 @@ class SageMakerHook(AwsHook):
         Check if an S3 URL exists
 
         :param s3url: S3 url
-        :type s3url:str
-        :return: bool
+        :type s3url: str
+        :rtype: bool
         """
         bucket, key = S3Hook.parse_s3_url(s3url)
         if not self.s3_hook.check_for_bucket(bucket_name=bucket):
@@ -226,7 +226,7 @@ class SageMakerHook(AwsHook):
         """
         Establish an AWS connection for SageMaker
 
-        :return: a boto3 SageMaker client
+        :rtype: :py:class:`SageMaker.Client`
         """
         return self.get_client_type('sagemaker')
 
@@ -234,7 +234,7 @@ class SageMakerHook(AwsHook):
         """
         Establish an AWS connection for retrieving logs during training
 
-        :return: a boto3 CloudWatchLog client
+        :rtype: :py:class:`CloudWatchLog.Client`
         """
         config = botocore.config.Config(retries={'max_attempts': 15})
         return self.get_client_type('logs', config=config)
@@ -253,10 +253,11 @@ class SageMakerHook(AwsHook):
         :param skip: The number of log entries to skip at the start (default: 0).
             This is for when there are multiple entries at the same timestamp.
         :type skip: int
-        :return:A CloudWatch log event with the following key-value pairs:
-            'timestamp' (int): The time in milliseconds of the event.
-            'message' (str): The log event data.
-            'ingestionTime' (int): The time in milliseconds the event was ingested.
+        :rtype: dict
+        :return: | A CloudWatch log event with the following key-value pairs:
+                 |   'timestamp' (int): The time in milliseconds of the event.
+                 |   'message' (str): The log event data.
+                 |   'ingestionTime' (int): The time in milliseconds the event was ingested.
         """
 
         next_token = None

--- a/airflow/contrib/operators/sagemaker_endpoint_config_operator.py
+++ b/airflow/contrib/operators/sagemaker_endpoint_config_operator.py
@@ -31,12 +31,11 @@ class SageMakerEndpointConfigOperator(SageMakerBaseOperator):
 
     :param config: The configuration necessary to create an endpoint config.
 
-        For details of the configuration parameter, See:
-        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.create_endpoint_config
+        For details of the configuration parameter see :py:meth:`SageMaker.Client.create_endpoint_config`
     :type config: dict
     :param aws_conn_id: The AWS connection ID to use.
     :type aws_conn_id: str
-    """  # noqa: E501
+    """
 
     integer_fields = [
         ['ProductionVariants', 'InitialInstanceCount']

--- a/airflow/contrib/operators/sagemaker_endpoint_operator.py
+++ b/airflow/contrib/operators/sagemaker_endpoint_operator.py
@@ -33,43 +33,42 @@ class SageMakerEndpointOperator(SageMakerBaseOperator):
     :param config:
         The configuration necessary to create an endpoint.
 
-        If you need to create a SageMaker endpoint based on an existed SageMaker model and an existed SageMaker
-        endpoint config,
+        If you need to create a SageMaker endpoint based on an existed
+        SageMaker model and an existed SageMaker endpoint config::
 
             config = endpoint_configuration;
 
-        If you need to create all of SageMaker model, SageMaker endpoint-config and SageMaker endpoint,
+        If you need to create all of SageMaker model, SageMaker endpoint-config and SageMaker endpoint::
 
             config = {
                 'Model': model_configuration,
-
                 'EndpointConfig': endpoint_config_configuration,
-
                 'Endpoint': endpoint_configuration
             }
 
-        For details of the configuration parameter of model_configuration, See:
-        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.create_model
+        For details of the configuration parameter of model_configuration see
+        :py:meth:`SageMaker.Client.create_model`
 
-        For details of the configuration parameter of endpoint_config_configuration, See:
-        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.create_endpoint_config
+        For details of the configuration parameter of endpoint_config_configuration see
+        :py:meth:`SageMaker.Client.create_endpoint_config`
 
-        For details of the configuration parameter of endpoint_configuration, See:
-        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.create_endpoint
+        For details of the configuration parameter of endpoint_configuration see
+        :py:meth:`SageMaker.Client.create_endpoint`
+
     :type config: dict
     :param aws_conn_id: The AWS connection ID to use.
     :type aws_conn_id: str
     :param wait_for_completion: Whether the operator should wait until the endpoint creation finishes.
     :type wait_for_completion: bool
-    :param check_interval: If wait is set to True, this is the time interval, in seconds, that this operation waits
-        before polling the status of the endpoint creation.
+    :param check_interval: If wait is set to True, this is the time interval, in seconds, that this operation
+        waits before polling the status of the endpoint creation.
     :type check_interval: int
-    :param max_ingestion_time: If wait is set to True, this operation fails if the endpoint creation doesn't finish
-        within max_ingestion_time seconds. If you set this parameter to None it never times out.
+    :param max_ingestion_time: If wait is set to True, this operation fails if the endpoint creation doesn't
+        finish within max_ingestion_time seconds. If you set this parameter to None it never times out.
     :type max_ingestion_time: int
     :param operation: Whether to create an endpoint or update an endpoint. Must be either 'create or 'update'.
     :type operation: str
-    """  # noqa: E501
+    """
 
     @apply_defaults
     def __init__(self,

--- a/airflow/contrib/operators/sagemaker_model_operator.py
+++ b/airflow/contrib/operators/sagemaker_model_operator.py
@@ -32,12 +32,11 @@ class SageMakerModelOperator(SageMakerBaseOperator):
 
     :param config: The configuration necessary to create a model.
 
-        For details of the configuration parameter, See:
-        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.create_model
+        For details of the configuration parameter see :py:meth:`SageMaker.Client.create_model`
     :type config: dict
     :param aws_conn_id: The AWS connection ID to use.
     :type aws_conn_id: str
-    """  # noqa: E501
+    """
 
     @apply_defaults
     def __init__(self,

--- a/airflow/contrib/operators/sagemaker_training_operator.py
+++ b/airflow/contrib/operators/sagemaker_training_operator.py
@@ -31,8 +31,7 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
 
     :param config: The configuration necessary to start a training job (templated).
 
-        For details of the configuration parameter, See:
-        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.create_training_job
+        For details of the configuration parameter see :py:meth:`SageMaker.Client.create_training_job`
     :type config: dict
     :param aws_conn_id: The AWS connection ID to use.
     :type aws_conn_id: str
@@ -48,7 +47,7 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
         doesn't finish within max_ingestion_time seconds. If you set this parameter to None,
         the operation does not timeout.
     :type max_ingestion_time: int
-    """  # noqa: E501
+    """
 
     integer_fields = [
         ['ResourceConfig', 'InstanceCount'],

--- a/airflow/contrib/operators/sagemaker_transform_operator.py
+++ b/airflow/contrib/operators/sagemaker_transform_operator.py
@@ -31,23 +31,22 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
 
     :param config: The configuration necessary to start a transform job (templated).
 
-        If you need to create a SageMaker transform job based on an existed SageMaker model,
+        If you need to create a SageMaker transform job based on an existed SageMaker model::
 
-            config = transform_config;
+            config = transform_config
 
-        If you need to create both SageMaker model and SageMaker Transform job,
+        If you need to create both SageMaker model and SageMaker Transform job::
 
             config = {
                 'Model': model_config,
-
                 'Transform': transform_config
             }
 
-        For details of the configuration parameter of transform_config, See:
-        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.create_transform_job
+        For details of the configuration parameter of transform_config see
+        :py:meth:`SageMaker.Client.create_transform_job`
 
         For details of the configuration parameter of model_config, See:
-        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.create_model
+        :py:meth:`SageMaker.Client.create_model`
 
     :type config: dict
     :param aws_conn_id: The AWS connection ID to use.
@@ -61,7 +60,7 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
         if the transform job doesn't finish within max_ingestion_time seconds. If you
         set this parameter to None, the operation does not timeout.
     :type max_ingestion_time: int
-    """  # noqa: E501
+    """
 
     @apply_defaults
     def __init__(self,

--- a/airflow/contrib/operators/sagemaker_tuning_operator.py
+++ b/airflow/contrib/operators/sagemaker_tuning_operator.py
@@ -31,8 +31,8 @@ class SageMakerTuningOperator(SageMakerBaseOperator):
 
     :param config: The configuration necessary to start a tuning job (templated).
 
-        For details of the configuration parameter, See:
-        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.create_hyper_parameter_tuning_job
+        For details of the configuration parameter see
+        :py:meth:`SageMaker.Client.create_hyper_parameter_tuning_job`
     :type config: dict
     :param aws_conn_id: The AWS connection ID to use.
     :type aws_conn_id: str
@@ -45,7 +45,7 @@ class SageMakerTuningOperator(SageMakerBaseOperator):
         if the tuning job doesn't finish within max_ingestion_time seconds. If you
         set this parameter to None, the operation does not timeout.
     :type max_ingestion_time: int
-    """  # noqa: E501
+    """
 
     integer_fields = [
         ['HyperParameterTuningJobConfig', 'ResourceLimits', 'MaxNumberOfTrainingJobs'],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,8 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
     'sphinxarg.ext',
-    'sphinxcontrib.httpdomain'
+    'sphinxcontrib.httpdomain',
+    'sphinx.ext.intersphinx',
 ]
 
 autodoc_default_flags = ['show-inheritance', 'members']
@@ -146,6 +147,10 @@ pygments_style = 'sphinx'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 #keep_warnings = False
 
+
+intersphinx_mapping = {
+    'boto3': ('https://boto3.amazonaws.com/v1/documentation/api/latest', None),
+}
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

There were a number of minor formatting glitches that meant these didn't
display 100% right once written to HTML. I use "intersphinx" ext to link directly to the boto3 class-names by name, rather than URL.

**Before**
![screen shot 2018-12-01 at 23 30 57](https://user-images.githubusercontent.com/34150/49334053-5c412080-f5c3-11e8-9c9b-78a181158f64.png)

**After**
![screen shot 2018-12-01 at 23 30 31](https://user-images.githubusercontent.com/34150/49334054-63682e80-f5c3-11e8-9c4d-352cfbea1d13.png)


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
