### PR TITLE
[AIRFLOW-3412] Fix kubernetes executor to delete pods after termination

### DIFF
--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -347,7 +347,8 @@ class AirflowKubernetesScheduler(LoggingMixin):
             pod_id=self._create_pod_id(dag_id, task_id),
             dag_id=dag_id, task_id=task_id,
             execution_date=self._datetime_to_label_safe_datestring(execution_date),
-            airflow_command=command, kube_executor_config=kube_executor_config
+            airflow_command=command, kube_executor_config=kube_executor_config,
+            try_number=str(try_number)
         )
         # the watcher will monitor pods, so we do not block.
         self.launcher.run_pod_async(pod)

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -187,7 +187,7 @@ class WorkerConfiguration(LoggingMixin):
         return volumes, volume_mounts
 
     def make_pod(self, namespace, worker_uuid, pod_id, dag_id, task_id, execution_date,
-                 airflow_command, kube_executor_config):
+                 airflow_command, kube_executor_config, try_number):
         volumes, volume_mounts = self.init_volumes_and_mounts()
         volumes += kube_executor_config.volumes
         volume_mounts += kube_executor_config.volume_mounts
@@ -215,7 +215,8 @@ class WorkerConfiguration(LoggingMixin):
                 'airflow-worker': worker_uuid,
                 'dag_id': dag_id,
                 'task_id': task_id,
-                'execution_date': execution_date
+                'execution_date': execution_date,
+                'try_number': try_number
             },
             envs=self._get_environment(),
             secrets=self._get_secrets(),


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3412
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
  - We need to pass 'try_number' parameter during the pod creation in kubernetes_executor.py, otherwise '_labels_to_key' function will always raise KeyError, making self.result_queue empty. 
  - As a result '_change_state' function in kubernetes_executor.py will never be called and pods will keep hanging after termination even if other pod deletion conditions are met.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - Not sure how to write one for this particular case, maybe someone will help?

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
