### PR TITLE
[AIRFLOW-3408] Remove outdated info from Systemd Instructions

### DIFF
--- a/docs/howto/run-with-systemd.rst
+++ b/docs/howto/run-with-systemd.rst
@@ -27,6 +27,5 @@ have been tested on Redhat based systems. You can copy those to
 based system) you probably need to adjust the unit files.
 
 Environment configuration is picked up from ``/etc/sysconfig/airflow``.
-An example file is supplied. Make sure to specify the ``SCHEDULER_RUNS``
-variable in this file when you run the scheduler. You
+An example file is supplied. You
 can also define here, for example, ``AIRFLOW_HOME`` or ``AIRFLOW_CONFIG``.

--- a/scripts/systemd/README
+++ b/scripts/systemd/README
@@ -6,6 +6,6 @@ You can then start the different servers by using systemctl start <service>. Ena
  systemctl enable <service>.
 
 By default the environment configuration points to /etc/sysconfig/airflow . You can copy the "airflow" file in this
-directory and adjust it to your liking. Make sure to specify the SCHEDULER_RUNS variable.
+directory and adjust it to your liking.
 
 With some minor changes they probably work on other systemd systems.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3408


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
AIRFLOW-1698 was solved in code, but the documentation drifted. This PR remove instructions about using `SCHEDULER_RUNS`


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
n/a

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
