### PR TITLE
[AIRFLOW-3434] Allows creating intermediate folders in SFTPOperator

### DIFF
--- a/airflow/contrib/operators/sftp_operator.py
+++ b/airflow/contrib/operators/sftp_operator.py
@@ -16,6 +16,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import os
+
 from airflow.contrib.hooks.ssh_hook import SSHHook
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -48,9 +50,28 @@ class SFTPOperator(BaseOperator):
     :param remote_filepath: remote file path to get or put. (templated)
     :type remote_filepath: str
     :param operation: specify operation 'get' or 'put', defaults to put
-    :type get: bool
+    :type operation: str
     :param confirm: specify if the SFTP operation should be confirmed, defaults to True
     :type confirm: bool
+    :param create_intermediate_dirs: create missing intermediate directories when
+        copying from remote to local and vice-versa. Default is False.
+
+        Example: The following task would copy ``file.txt`` to the remote host
+        at ``/tmp/tmp1/tmp2/`` while creating ``tmp``,``tmp1`` and ``tmp2`` if they
+        don't exist. If the parameter is not passed it would error as the directory
+        does not exist. ::
+
+            put_file = SFTPOperator(
+                task_id="test_sftp",
+                ssh_conn="ssh_default",
+                local_filepath="/tmp/file.txt",
+                remote_filepath="/tmp/tmp1/tmp2/file.txt",
+                operation="put",
+                create_intermediate_dirs=True,
+                dag=dag
+            )
+
+    :type create_intermediate_dirs: bool
     """
     template_fields = ('local_filepath', 'remote_filepath', 'remote_host')
 
@@ -63,6 +84,7 @@ class SFTPOperator(BaseOperator):
                  remote_filepath=None,
                  operation=SFTPOperation.PUT,
                  confirm=True,
+                 create_intermediate_dirs=False,
                  *args,
                  **kwargs):
         super(SFTPOperator, self).__init__(*args, **kwargs)
@@ -73,6 +95,7 @@ class SFTPOperator(BaseOperator):
         self.remote_filepath = remote_filepath
         self.operation = operation
         self.confirm = confirm
+        self.create_intermediate_dirs = create_intermediate_dirs
         if not (self.operation.lower() == SFTPOperation.GET or
                 self.operation.lower() == SFTPOperation.PUT):
             raise TypeError("unsupported operation value {0}, expected {1} or {2}"
@@ -101,11 +124,25 @@ class SFTPOperator(BaseOperator):
             with self.ssh_hook.get_conn() as ssh_client:
                 sftp_client = ssh_client.open_sftp()
                 if self.operation.lower() == SFTPOperation.GET:
+                    local_folder = os.path.dirname(self.local_filepath)
+                    if self.create_intermediate_dirs:
+                        # Create Intermediate Directories if it doesn't exist
+                        try:
+                            os.makedirs(local_folder)
+                        except OSError:
+                            if not os.path.isdir(local_folder):
+                                raise
                     file_msg = "from {0} to {1}".format(self.remote_filepath,
                                                         self.local_filepath)
                     self.log.debug("Starting to transfer %s", file_msg)
                     sftp_client.get(self.remote_filepath, self.local_filepath)
                 else:
+                    remote_folder = os.path.dirname(self.remote_filepath)
+                    if self.create_intermediate_dirs:
+                        _make_intermediate_dirs(
+                            sftp_client=sftp_client,
+                            remote_directory=remote_folder,
+                        )
                     file_msg = "from {0} to {1}".format(self.local_filepath,
                                                         self.remote_filepath)
                     self.log.debug("Starting to transfer file %s", file_msg)
@@ -118,3 +155,26 @@ class SFTPOperator(BaseOperator):
                                    .format(file_msg, str(e)))
 
         return None
+
+
+def _make_intermediate_dirs(sftp_client, remote_directory):
+    """
+    Create all the intermediate directories in a remote host
+
+    :param sftp_client: A Paramiko SFTP client.
+    :param remote_directory: Absolute Path of the directory containing the file
+    :return:
+    """
+    if remote_directory == '/':
+        sftp_client.chdir('/')
+        return
+    if remote_directory == '':
+        return
+    try:
+        sftp_client.chdir(remote_directory)
+    except IOError:
+        dirname, basename = os.path.split(remote_directory.rstrip('/'))
+        _make_intermediate_dirs(sftp_client, dirname)
+        sftp_client.mkdir(basename)
+        sftp_client.chdir(basename)
+        return


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3434

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR adds the feature to create the intermediate directories when copying to/from the remote host.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- `test_file_transfer_no_intermediate_dir_error_put`
- `test_file_transfer_with_intermediate_dir_error_put`
- `test_file_transfer_no_intermediate_dir_error_get`
- `test_file_transfer_with_intermediate_dir_error_get`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
