### PR TITLE
Adding better json return

### DIFF
--- a/airflow/api/common/experimental/get_dag_runs.py
+++ b/airflow/api/common/experimental/get_dag_runs.py
@@ -53,3 +53,16 @@ def get_dag_runs(dag_id, state=None):
         })
 
     return dag_runs
+
+def format_dag_run(run):
+    return {
+            'id': run.id,
+            'run_id': run.run_id,
+            'state': run.state,
+            'dag_id': run.dag_id,
+            'execution_date': run.execution_date.isoformat(),
+            'start_date': ((run.start_date or '') and
+                           run.start_date.isoformat()),
+            'dag_run_url': url_for('airflow.graph', dag_id=run.dag_id,
+                                   execution_date=run.execution_date)
+        }

--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -26,6 +26,7 @@ from airflow.api.common.experimental import pool as pool_api
 from airflow.api.common.experimental import trigger_dag as trigger
 from airflow.api.common.experimental.get_task import get_task
 from airflow.api.common.experimental.get_task_instance import get_task_instance
+from airflow.api.common.experimental.get_dag_runs import format_dag_run
 from airflow.exceptions import AirflowException
 from airflow.utils import timezone
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -51,6 +52,10 @@ def trigger_dag(dag_id):
     run_id = None
     if 'run_id' in data:
         run_id = data['run_id']
+
+    detailed_output = None
+    if 'detailed_output' in data:
+        detailed_output = data['detailed_output']
 
     conf = None
     if 'conf' in data:
@@ -84,8 +89,11 @@ def trigger_dag(dag_id):
 
     if getattr(g, 'user', None):
         _log.info("User {} created {}".format(g.user, dr))
-
-    response = jsonify(message="Created {}".format(dr))
+    if detailed_output :
+        dr = format_dag_run(dr)
+        response = jsonify(**dr)
+    else:
+        response = jsonify(message="Created {}".format(dr))
     return response
 
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3437) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Scenario -> Developer wants to trigger DAG_RUN through API

Issue -> Current rest API "/api/experimental/dags/<dag_id>dag_runs"returns message like below, which makes difficult for developer to figure out execution date/run_id and execution date/run_id extract logic has to be written  

{ "message": "Created <DagRun example_bash_operator @ 2018-12-03 11:16:36+00:00: manual__2018-12-03T11:16:36+00:00, externally triggered: True>" }
Improvement Suggestion -> rest API "/api/experimental/dags/<dag_id>dag_runs" should return json representing dag_run object , something like below

 

{ "dag_id": "example_bash_operator", "dag_run_url": "/admin/airflow/graph?execution_date=2018-12-03+11%3A11%3A18%2B00%3A00&dag_id=example_bash_operator", "execution_date": "2018-12-03T11:11:18+00:00", "id": 142, "run_id": "manual__2018-12-03T11:11:18+00:00", "start_date": "2018-12-03T11:11:18.267197+00:00", "state": "running" }
\

With the Json returned as shown above , picking dag_run details becomes easy.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `flake8`
