### PR TITLE
AIRFLOW-3437 Adding better json

### DIFF
--- a/airflow/api/common/experimental/get_dag_runs.py
+++ b/airflow/api/common/experimental/get_dag_runs.py
@@ -40,16 +40,18 @@ def get_dag_runs(dag_id, state=None):
     dag_runs = list()
     state = state.lower() if state else None
     for run in DagRun.find(dag_id=dag_id, state=state):
-        dag_runs.append({
-            'id': run.id,
+        dag_runs.append(format_dag_run(run))
+    return dag_runs
+
+
+def format_dag_run(run):
+    return {'id': run.id,
             'run_id': run.run_id,
             'state': run.state,
             'dag_id': run.dag_id,
             'execution_date': run.execution_date.isoformat(),
             'start_date': ((run.start_date or '') and
                            run.start_date.isoformat()),
-            'dag_run_url': url_for('Airflow.graph', dag_id=run.dag_id,
+            'dag_run_url': url_for('airflow.graph', dag_id=run.dag_id,
                                    execution_date=run.execution_date)
-        })
-
-    return dag_runs
+            }

--- a/airflow/api/common/experimental/get_dag_runs.py
+++ b/airflow/api/common/experimental/get_dag_runs.py
@@ -52,6 +52,6 @@ def format_dag_run(run):
             'execution_date': run.execution_date.isoformat(),
             'start_date': ((run.start_date or '') and
                            run.start_date.isoformat()),
-            'dag_run_url': url_for('airflow.graph', dag_id=run.dag_id,
+            'dag_run_url': url_for('Airflow.graph', dag_id=run.dag_id,
                                    execution_date=run.execution_date)
             }

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -94,6 +94,23 @@ class TestApiExperimental(unittest.TestCase):
         )
         self.assertEqual(404, response.status_code)
 
+    def test_trigger_dag_detailed_output(self):
+        url_template = '/api/experimental/dags/{}/dag_runs'
+        response = self.app.post(
+            url_template.format('example_bash_operator'),
+            data=json.dumps({'run_id': 'my_run' + utcnow().isoformat(),
+                             'detailed_output': 1}),
+            content_type="application/json"
+        )
+        data = json.loads(response.data)
+        self.assertEqual(200, response.status_code)
+        self.assertIn('id', data)
+        self.assertIn('run_id', data)
+        self.assertIn('dag_id', data)
+        self.assertIn('execution_date', data)
+        self.assertIn('start_date', data)
+        self.assertIn('dag_run_url', data)
+
     def test_delete_dag(self):
         url_template = '/api/experimental/dags/{}'
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3437) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3437


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Current rest API "/api/experimental/dags/<dag_id>dag_runs"returns message like below, which makes difficult for developer to figure out execution date/run_id and execution date/run_id extract logic has to be written  

{ "message": "Created <DagRun example_bash_operator @ 2018-12-03 11:16:36+00:00: manual__2018-12-03T11:16:36+00:00, externally triggered: True>" 
### Tests

- [x] My PR adds the following unit tests :

- test_trigger_dag_detailed_output 

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
