### PR TITLE
[AIRFLOW-1552] Airflow Filter_by_owner not working with password_auth

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -76,6 +76,25 @@ To delete a user:
 airflow users --delete --username jondoe
 ```
 
+### User model changes
+This patch changes the `User.superuser` field from a hardcoded boolean to a `Boolean()` database column. `User.superuser` will default to `False`, which means that this privilege will have to be granted manually to any users that may require it.
+
+For example, open a Python shell and
+```python
+from airflow import models, settings
+
+session = settings.Session()
+users = session.query(models.User).all()  # [admin, regular_user]
+
+users[1].superuser  # False
+
+admin = users[0]
+admin.superuser = True
+session.add(admin)
+session.commit()
+
+```
+
 ## Airflow 1.10.1
 
 ### StatsD Metrics

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -92,7 +92,6 @@ admin = users[0]
 admin.superuser = True
 session.add(admin)
 session.commit()
-
 ```
 
 ## Airflow 1.10.1

--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -94,6 +94,9 @@ class PasswordUser(models.User):
         """Provides access to data profiling tools"""
         return True
 
+    def is_superuser(self):
+        return hasattr(self, 'user') and self.user.is_superuser()
+
 
 @login_manager.user_loader
 @provide_session
@@ -102,8 +105,8 @@ def load_user(userid, session=None):
     if not userid or userid == 'None':
         return None
 
-    user = session.query(PasswordUser).filter(PasswordUser.id == int(userid)).first()
-    return user
+    user = session.query(models.User).filter(models.User.id == int(userid)).first()
+    return PasswordUser(user)
 
 
 def authenticate(session, username, password):

--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -94,10 +94,6 @@ class PasswordUser(models.User):
         """Provides access to data profiling tools"""
         return True
 
-    def is_superuser(self):
-        """Access all the things"""
-        return True
-
 
 @login_manager.user_loader
 @provide_session
@@ -106,8 +102,8 @@ def load_user(userid, session=None):
     if not userid or userid == 'None':
         return None
 
-    user = session.query(models.User).filter(models.User.id == int(userid)).first()
-    return PasswordUser(user)
+    user = session.query(PasswordUser).filter(PasswordUser.id == int(userid)).first()
+    return user
 
 
 def authenticate(session, username, password):

--- a/airflow/migrations/versions/41f5f12752f8_add_superuser_field.py
+++ b/airflow/migrations/versions/41f5f12752f8_add_superuser_field.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""empty message
+"""add superuser field
 
 Revision ID: 41f5f12752f8
 Revises: 03bc53e68815

--- a/airflow/migrations/versions/41f5f12752f8_add_superuser_field.py
+++ b/airflow/migrations/versions/41f5f12752f8_add_superuser_field.py
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""empty message
+
+Revision ID: 41f5f12752f8
+Revises: 03bc53e68815
+Create Date: 2018-12-04 15:50:04.456875
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '41f5f12752f8'
+down_revision = '03bc53e68815'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('users', sa.Column('superuser', sa.Boolean(), default=False))
+
+
+def downgrade():
+    op.drop_column('users', 'superuser')

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -601,7 +601,7 @@ class User(Base):
     id = Column(Integer, primary_key=True)
     username = Column(String(ID_LEN), unique=True)
     email = Column(String(500))
-    superuser = False
+    superuser = Column(Boolean(), default=False)
 
     def __repr__(self):
         return self.username


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] Fix [AIRFLOW-1552](https://issues.apache.org/jira/browse/AIRFLOW-1552), Airflow filter_by_owner not working with password_auth

### Description

- [x]  Here are some details about my PR, including screenshots of any UI changes:

- `airflow.contrib.auth.backends.password_auth.load_user` would query `models.User` and cast the result to `PasswordUser` instead of querying `PasswordUser` directly. This would map the model's fields to a nested instance, e.g., `password_user_instance.user.superuser` instead of the expected `password_user_instance.superuser`.

- The `superuser` field is added to `models.User` in the form of a SQLAlchemy column, instead of a hard-coded boolean.

- The overridden `PasswordUser.is_superuser` method is removed, so the actual value in the database is referenced instead.

### Tests


### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] Passes `flake8`
