### PR TITLE
[AIRFLOW-2524] Add SageMaker doc to AWS integration section

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -401,9 +401,9 @@ AwsFirehoseHook
 Amazon SageMaker
 ''''''''''''''''
 
-For more instructions on using Amazon SageMaker in Airflow, please see `here`_.
+For more instructions on using Amazon SageMaker in Airflow, please see `the SageMaker Python SDK README`_.
 
-.. _here: https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/workflow/README.rst
+.. _the SageMaker Python SDK README: https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/workflow/README.rst
 
 - :ref:`SageMakerHook` : Interact with Amazon SageMaker.
 - :ref:`SageMakerTrainingOperator` : Create a SageMaker training job.
@@ -425,7 +425,7 @@ SageMakerHook
 SageMakerTrainingOperator
 """""""""""""""""""""""""
 
-.. autoclass:: airflow.operators.sagemaker_training_operator.SageMakerTrainingOperator
+.. autoclass:: airflow.contrib.operators.sagemaker_training_operator.SageMakerTrainingOperator
 
 .. _SageMakerTuningOperator:
 
@@ -453,14 +453,14 @@ SageMakerTransformOperator
 SageMakerEndpointConfigOperator
 """""""""""""""""""""""""""""""
 
-.. autoclass:: airflow.operators.sagemaker_endpoint_config_operator.SageMakerEndpointConfigOperator
+.. autoclass:: airflow.contrib.operators.sagemaker_endpoint_config_operator.SageMakerEndpointConfigOperator
 
 .. _SageMakerEndpointOperator:
 
 SageMakerEndpointOperator
 """""""""""""""""""""""""
 
-.. autoclass:: airflow.operators.sagemaker_endpoint_operator.SageMakerEndpointOperator
+.. autoclass:: airflow.contrib.operators.sagemaker_endpoint_operator.SageMakerEndpointOperator
 
 .. _Databricks:
 

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -398,6 +398,70 @@ AwsFirehoseHook
 
 .. autoclass:: airflow.contrib.hooks.aws_firehose_hook.AwsFirehoseHook
 
+Amazon SageMaker
+''''''''''''''''
+
+For more instructions on using Amazon SageMaker in Airflow, please see `here`_.
+
+.. _here: https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/workflow/README.rst
+
+- :ref:`SageMakerHook` : Interact with Amazon SageMaker.
+- :ref:`SageMakerTrainingOperator` : Create a SageMaker training job.
+- :ref:`SageMakerTuningOperator` : Create a SageMaker tuning job.
+- :ref:`SageMakerModelOperator` : Create a SageMaker model.
+- :ref:`SageMakerTransformOperator` : Create a SageMaker transform job.
+- :ref:`SageMakerEndpointConfigOperator` : Create a SageMaker endpoint config.
+- :ref:`SageMakerEndpointOperator` : Create a SageMaker endpoint.
+
+.. _SageMakerHook:
+
+SageMakerHook
+"""""""""""""
+
+.. autoclass:: airflow.contrib.hooks.sagemaker_hook.SageMakerHook
+
+.. _SageMakerTrainingOperator:
+
+SageMakerTrainingOperator
+"""""""""""""""""""""""""
+
+.. autoclass:: airflow.operators.sagemaker_training_operator.SageMakerTrainingOperator
+
+.. _SageMakerTuningOperator:
+
+SageMakerTuningOperator
+"""""""""""""""""""""""
+
+.. autoclass:: airflow.contrib.operators.sagemaker_tuning_operator.SageMakerTuningOperator
+
+.. _SageMakerModelOperator:
+
+SageMakerModelOperator
+""""""""""""""""""""""
+
+.. autoclass:: airflow.contrib.operators.sagemaker_model_operator.SageMakerModelOperator
+
+.. _SageMakerTransformOperator:
+
+SageMakerTransformOperator
+""""""""""""""""""""""""""
+
+.. autoclass:: airflow.contrib.operators.sagemaker_transform_operator.SageMakerTransformOperator
+
+.. _SageMakerEndpointConfigOperator:
+
+SageMakerEndpointConfigOperator
+"""""""""""""""""""""""""""""""
+
+.. autoclass:: airflow.operators.sagemaker_endpoint_config_operator.SageMakerEndpointConfigOperator
+
+.. _SageMakerEndpointOperator:
+
+SageMakerEndpointOperator
+"""""""""""""""""""""""""
+
+.. autoclass:: airflow.operators.sagemaker_endpoint_operator.SageMakerEndpointOperator
+
 .. _Databricks:
 
 Databricks


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Add SageMaker doc to AWS integration section

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [x] Passes `flake8`
