### PR TITLE
[AIRFLOW-3479] Keeps records in Log Table when delete DAG & refine related tests

### DIFF
--- a/airflow/api/common/experimental/delete_dag.py
+++ b/airflow/api/common/experimental/delete_dag.py
@@ -23,7 +23,15 @@ from airflow import models, settings
 from airflow.exceptions import DagNotFound, DagFileExists
 
 
-def delete_dag(dag_id):
+def delete_dag(dag_id, keep_records_in_log=True):
+    """
+    :param dag_id: the dag_id of the DAG to delete
+    :type dag_id: str
+    :param keep_records_in_log: whether keep records of the given dag_id
+        in the Log table in the backend database (for reasons like auditing).
+        The default value is True.
+    :type keep_records_in_log: bool
+    """
     session = settings.Session()
 
     DM = models.DagModel
@@ -41,6 +49,8 @@ def delete_dag(dag_id):
     # noinspection PyUnresolvedReferences,PyProtectedMember
     for m in models.Base._decl_class_registry.values():
         if hasattr(m, "dag_id"):
+            if keep_records_in_log and m.__name__ == 'Log':
+                continue
             cond = or_(m.dag_id == dag_id, m.dag_id.like(dag_id + ".%"))
             count += session.query(m).filter(cond).delete(synchronize_session='fetch')
 

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -332,7 +332,7 @@ function updateQueryStringParameter(uri, key, value) {
 
     function confirmDeleteDag(dag_id){
         return confirm("Are you sure you want to delete '"+dag_id+"' now?\n\
-          This option will delete ALL metadata, DAG runs, etc.\n\
+          This option will delete ALL metadata, DAG runs, etc., EXCEPT Log\n\
           This cannot be undone.");
     }
 

--- a/tests/api/common/experimental/test_delete_dag.py
+++ b/tests/api/common/experimental/test_delete_dag.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow import models
+from airflow import settings
+from airflow.api.common.experimental.delete_dag import delete_dag
+from airflow.exceptions import DagNotFound, DagFileExists
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.utils.dates import days_ago
+from airflow.utils.state import State
+
+DM = models.DagModel
+DS = models.DagStat
+DR = models.DagRun
+TI = models.TaskInstance
+LOG = models.Log
+
+
+class TestDeleteDAGCatchError(unittest.TestCase):
+
+    def setUp(self):
+        self.session = settings.Session()
+        self.dagbag = models.DagBag(include_examples=True)
+        self.dag_id = 'example_bash_operator'
+        self.dag = self.dagbag.dags[self.dag_id]
+
+    def tearDown(self):
+        self.dag.clear()
+        self.session.close()
+
+    def test_delete_dag_non_existent_dag(self):
+        with self.assertRaises(DagNotFound):
+            delete_dag("non-existent DAG")
+
+    def test_delete_dag_dag_still_in_dagbag(self):
+        models_to_check = ['DagModel', 'DagStat', 'DagRun', 'TaskInstance']
+        record_counts = {}
+
+        for model_name in models_to_check:
+            m = getattr(models, model_name)
+            record_counts[model_name] = self.session.query(m).filter(m.dag_id == self.dag_id).count()
+
+        with self.assertRaises(DagFileExists):
+            delete_dag(self.dag_id)
+
+        # No change should happen in DB
+        for model_name in models_to_check:
+            m = getattr(models, model_name)
+            self.assertEqual(
+                self.session.query(m).filter(
+                    m.dag_id == self.dag_id
+                ).count(),
+                record_counts[model_name]
+            )
+
+
+class TestDeleteDAGSuccessfulDelete(unittest.TestCase):
+
+    def setUp(self):
+        self.session = settings.Session()
+        self.key = "test_dag_id"
+
+        task = DummyOperator(task_id='dummy',
+                             dag=models.DAG(dag_id=self.key,
+                                            default_args={'start_date': days_ago(2)}),
+                             owner='airflow')
+
+        self.session.add(DM(dag_id=self.key))
+        self.session.add(DS(dag_id=self.key, state=State.SUCCESS))
+        self.session.add(DR(dag_id=self.key))
+        self.session.add(TI(task=task,
+                            execution_date=days_ago(1),
+                            state=State.SUCCESS))
+        self.session.add(LOG(dag_id=self.key, task_id=None, task_instance=None,
+                             execution_date=days_ago(1), event="varimport"))
+
+        self.session.commit()
+
+    def tearDown(self):
+        self.session.query(DM).filter(DM.dag_id == self.key).delete()
+        self.session.query(DS).filter(DS.dag_id == self.key).delete()
+        self.session.query(DR).filter(DR.dag_id == self.key).delete()
+        self.session.query(TI).filter(TI.dag_id == self.key).delete()
+        self.session.query(LOG).filter(LOG.dag_id == self.key).delete()
+        self.session.commit()
+
+        self.session.close()
+
+    def test_delete_dag_successful_delete(self):
+
+        self.assertEqual(self.session.query(DM).filter(DM.dag_id == self.key).count(), 1)
+        self.assertEqual(self.session.query(DS).filter(DS.dag_id == self.key).count(), 1)
+        self.assertEqual(self.session.query(DR).filter(DR.dag_id == self.key).count(), 1)
+        self.assertEqual(self.session.query(TI).filter(TI.dag_id == self.key).count(), 1)
+        self.assertEqual(self.session.query(LOG).filter(LOG.dag_id == self.key).count(), 1)
+
+        delete_dag(dag_id=self.key)
+
+        self.assertEqual(self.session.query(DM).filter(DM.dag_id == self.key).count(), 0)
+        self.assertEqual(self.session.query(DS).filter(DS.dag_id == self.key).count(), 0)
+        self.assertEqual(self.session.query(DR).filter(DR.dag_id == self.key).count(), 0)
+        self.assertEqual(self.session.query(TI).filter(TI.dag_id == self.key).count(), 0)
+        self.assertEqual(self.session.query(LOG).filter(LOG.dag_id == self.key).count(), 1)
+
+    def test_delete_dag_successful_delete_not_keeping_records_in_log(self):
+
+        self.assertEqual(self.session.query(DM).filter(DM.dag_id == self.key).count(), 1)
+        self.assertEqual(self.session.query(DS).filter(DS.dag_id == self.key).count(), 1)
+        self.assertEqual(self.session.query(DR).filter(DR.dag_id == self.key).count(), 1)
+        self.assertEqual(self.session.query(TI).filter(TI.dag_id == self.key).count(), 1)
+        self.assertEqual(self.session.query(LOG).filter(LOG.dag_id == self.key).count(), 1)
+
+        delete_dag(dag_id=self.key, keep_records_in_log=False)
+
+        self.assertEqual(self.session.query(DM).filter(DM.dag_id == self.key).count(), 0)
+        self.assertEqual(self.session.query(DS).filter(DS.dag_id == self.key).count(), 0)
+        self.assertEqual(self.session.query(DR).filter(DR.dag_id == self.key).count(), 0)
+        self.assertEqual(self.session.query(TI).filter(TI.dag_id == self.key).count(), 0)
+        self.assertEqual(self.session.query(LOG).filter(LOG.dag_id == self.key).count(), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION

### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3479

### Description

#### Problem This PR Tries to Address

Currently when we delete a DAG (using API or from the UI), it will delete all related records in all tables (all tables in which "dag_id" is available), including "log" table.

However, the records in "log" table should be kept (by default). This would be ideal for multiple reasons, like auditing.

#### What This PR Does

- **When we delete DAG using API**: provide one boolean parameter to let users decide if they want to keep records in Log table when they delete a DAG. Default value it True (to keep records in Log table).

- **When we delete DAG from UI**: will keep records in the Log table when delete records for a specific DAG ID (pop-up message is updated accordingly).


### Tests

Test cases are added to cover:
1. Delete a DAG which doesn't exist.
1. Delete a DAG which is still in DagBag.
1. Successfully delete a DAG + keep records in Log table.
1. Successfully delete a DAG + delete records in Log table as well.

