### PR TITLE
[AIRFLOW-2508] Handle non string types in Operators templatized fields

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -47,7 +47,6 @@ import zipfile
 import jinja2
 import json
 import logging
-import numbers
 import os
 import pendulum
 import pickle
@@ -2643,18 +2642,12 @@ class BaseOperator(LoggingMixin):
             result = jinja_env.from_string(content).render(**context)
         elif isinstance(content, (list, tuple)):
             result = [rt(attr, e, context) for e in content]
-        elif isinstance(content, numbers.Number):
-            result = content
         elif isinstance(content, dict):
             result = {
                 k: rt("{}[{}]".format(attr, k), v, context)
                 for k, v in list(content.items())}
         else:
-            param_type = type(content)
-            msg = (
-                "Type '{param_type}' used for parameter '{attr}' is "
-                "not supported for templating").format(**locals())
-            raise AirflowException(msg)
+            result = content
         return result
 
     def render_template(self, attr, content, context):

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -2635,7 +2635,7 @@ class BaseOperator(LoggingMixin):
         Renders a template from a field. If the field is a string, it will
         simply render the string and return the result. If it is a collection or
         nested set of collections, it will traverse the structure and render
-        all strings in it.
+        all elements in it. If the field has another type, it will return it as it is.
         """
         rt = self.render_template
         if isinstance(content, six.string_types):

--- a/setup.py
+++ b/setup.py
@@ -243,6 +243,7 @@ devel = [
     'nose-timer',
     'parameterized',
     'paramiko',
+    'pyhamcrest',
     'pysftp',
     'pywinrm',
     'qds-sdk>=1.9.6',

--- a/setup.py
+++ b/setup.py
@@ -243,7 +243,6 @@ devel = [
     'nose-timer',
     'parameterized',
     'paramiko',
-    'pyhamcrest',
     'pysftp',
     'pywinrm',
     'qds-sdk>=1.9.6',

--- a/tests/models.py
+++ b/tests/models.py
@@ -418,8 +418,10 @@ class DagTest(unittest.TestCase):
         with dag:
             task = DummyOperator(task_id='op1')
 
-        result = task.render_template('', ['{{ foo }}_1', '{{ foo }}_2'], {'foo': 'bar'})
-        self.assertListEqual(result, ['bar_1', 'bar_2'])
+        self.assertListEqual(
+            task.render_template('', ['{{ foo }}_1', '{{ foo }}_2'], {'foo': 'bar'}),
+            ['bar_1', 'bar_2']
+        )
 
     def test_render_template_tuple_field(self):
         """Tests if render_template from a tuple field works"""
@@ -430,9 +432,11 @@ class DagTest(unittest.TestCase):
         with dag:
             task = DummyOperator(task_id='op1')
 
-        result = task.render_template('', ('{{ foo }}_1', '{{ foo }}_2'), {'foo': 'bar'})
         # tuple is replaced by a list
-        self.assertListEqual(result, ['bar_1', 'bar_2'])
+        self.assertListEqual(
+            task.render_template('', ('{{ foo }}_1', '{{ foo }}_2'), {'foo': 'bar'}),
+            ['bar_1', 'bar_2']
+        )
 
     def test_render_template_dict_field(self):
         """Tests if render_template from a dict field works"""
@@ -443,8 +447,10 @@ class DagTest(unittest.TestCase):
         with dag:
             task = DummyOperator(task_id='op1')
 
-        result = task.render_template('', {'key1': '{{ foo }}_1', 'key2': '{{ foo }}_2'}, {'foo': 'bar'})
-        self.assertDictEqual(result, {'key1': 'bar_1', 'key2': 'bar_2'})
+        self.assertDictEqual(
+            task.render_template('', {'key1': '{{ foo }}_1', 'key2': '{{ foo }}_2'}, {'foo': 'bar'}),
+            {'key1': 'bar_1', 'key2': 'bar_2'}
+        )
 
     def test_render_template_dict_field_with_templated_keys(self):
         """Tests if render_template from a dict field works as expected:
@@ -456,8 +462,10 @@ class DagTest(unittest.TestCase):
         with dag:
             task = DummyOperator(task_id='op1')
 
-        result = task.render_template('', {'key_{{ foo }}_1': 1, 'key_2': '{{ foo }}_2'}, {'foo': 'bar'})
-        self.assertDictEqual(result, {'key_{{ foo }}_1': 1, 'key_2': 'bar_2'})
+        self.assertDictEqual(
+            task.render_template('', {'key_{{ foo }}_1': 1, 'key_2': '{{ foo }}_2'}, {'foo': 'bar'}),
+            {'key_{{ foo }}_1': 1, 'key_2': 'bar_2'}
+        )
 
     def test_render_template_date_field(self):
         """Tests if render_template from a date field works"""

--- a/tests/models.py
+++ b/tests/models.py
@@ -36,9 +36,6 @@ from tempfile import NamedTemporaryFile, mkdtemp
 
 import pendulum
 import six
-from hamcrest import contains, instance_of
-from hamcrest.core import assert_that
-from hamcrest.core.core import is_
 from mock import ANY, Mock, mock_open, patch
 from parameterized import parameterized
 from freezegun import freeze_time
@@ -422,8 +419,7 @@ class DagTest(unittest.TestCase):
             task = DummyOperator(task_id='op1')
 
         result = task.render_template('', ['{{ foo }}_1', '{{ foo }}_2'], dict(foo='bar'))
-        assert_that(result, is_(instance_of(list)))
-        assert_that(result, contains('bar_1', 'bar_2'))
+        self.assertListEqual(result, ['bar_1', 'bar_2'])
 
     def test_render_template_tuple_field(self):
         """Tests if render_template from a tuple field works"""
@@ -436,8 +432,7 @@ class DagTest(unittest.TestCase):
 
         result = task.render_template('', ('{{ foo }}_1', '{{ foo }}_2'), dict(foo='bar'))
         # tuple is replaced by a list
-        assert_that(result, is_(instance_of(list)))
-        assert_that(result, contains('bar_1', 'bar_2'))
+        self.assertListEqual(result, ['bar_1', 'bar_2'])
 
     def test_render_template_dict_field(self):
         """Tests if render_template from a dict field works"""
@@ -449,7 +444,7 @@ class DagTest(unittest.TestCase):
             task = DummyOperator(task_id='op1')
 
         result = task.render_template('', {'key1': '{{ foo }}_1', 'key2': '{{ foo }}_2'}, dict(foo='bar'))
-        assert_that(result, is_({'key1': 'bar_1', 'key2': 'bar_2'}))
+        self.assertDictEqual(result, {'key1': 'bar_1', 'key2': 'bar_2'})
 
     def test_render_template_dict_field_with_templated_keys(self):
         """Tests if render_template from a dict field works as expected:
@@ -462,7 +457,7 @@ class DagTest(unittest.TestCase):
             task = DummyOperator(task_id='op1')
 
         result = task.render_template('', {'key_{{ foo }}_1': 1, 'key_2': '{{ foo }}_2'}, dict(foo='bar'))
-        assert_that(result, is_({'key_{{ foo }}_1': 1, 'key_2': 'bar_2'}))
+        self.assertDictEqual(result, {'key_{{ foo }}_1': 1, 'key_2': 'bar_2'})
 
     def test_render_template_date_field(self):
         """Tests if render_template from a date field works"""
@@ -473,9 +468,10 @@ class DagTest(unittest.TestCase):
         with dag:
             task = DummyOperator(task_id='op1')
 
-        assert_that(
+        self.assertEqual(
             task.render_template('', datetime.date(2018, 12, 6), dict(foo='bar')),
-            is_(datetime.date(2018, 12, 6)))
+            datetime.date(2018, 12, 6)
+        )
 
     def test_render_template_datetime_field(self):
         """Tests if render_template from a datetime field works"""
@@ -486,9 +482,10 @@ class DagTest(unittest.TestCase):
         with dag:
             task = DummyOperator(task_id='op1')
 
-        assert_that(
+        self.assertEqual(
             task.render_template('', datetime.datetime(2018, 12, 6, 10, 55), dict(foo='bar')),
-            is_(datetime.datetime(2018, 12, 6, 10, 55)))
+            datetime.datetime(2018, 12, 6, 10, 55)
+        )
 
     def test_render_template_UUID_field(self):
         """Tests if render_template from a UUID field works"""
@@ -500,7 +497,10 @@ class DagTest(unittest.TestCase):
             task = DummyOperator(task_id='op1')
 
         random_uuid = uuid.uuid4()
-        assert_that(task.render_template('', random_uuid, dict(foo='bar')), is_(random_uuid))
+        self.assertIs(
+            task.render_template('', random_uuid, dict(foo='bar')),
+            random_uuid
+        )
 
     def test_render_template_object_field(self):
         """Tests if render_template from an object field works"""
@@ -512,7 +512,10 @@ class DagTest(unittest.TestCase):
             task = DummyOperator(task_id='op1')
 
         test_object = object()
-        assert_that(task.render_template('', test_object, dict(foo='bar')), is_(test_object))
+        self.assertIs(
+            task.render_template('', test_object, dict(foo='bar')),
+            test_object
+        )
 
     def test_render_template_field_macro(self):
         """ Tests if render_template from a field works,

--- a/tests/models.py
+++ b/tests/models.py
@@ -418,7 +418,7 @@ class DagTest(unittest.TestCase):
         with dag:
             task = DummyOperator(task_id='op1')
 
-        result = task.render_template('', ['{{ foo }}_1', '{{ foo }}_2'], dict(foo='bar'))
+        result = task.render_template('', ['{{ foo }}_1', '{{ foo }}_2'], {'foo': 'bar'})
         self.assertListEqual(result, ['bar_1', 'bar_2'])
 
     def test_render_template_tuple_field(self):
@@ -430,7 +430,7 @@ class DagTest(unittest.TestCase):
         with dag:
             task = DummyOperator(task_id='op1')
 
-        result = task.render_template('', ('{{ foo }}_1', '{{ foo }}_2'), dict(foo='bar'))
+        result = task.render_template('', ('{{ foo }}_1', '{{ foo }}_2'), {'foo': 'bar'})
         # tuple is replaced by a list
         self.assertListEqual(result, ['bar_1', 'bar_2'])
 
@@ -443,7 +443,7 @@ class DagTest(unittest.TestCase):
         with dag:
             task = DummyOperator(task_id='op1')
 
-        result = task.render_template('', {'key1': '{{ foo }}_1', 'key2': '{{ foo }}_2'}, dict(foo='bar'))
+        result = task.render_template('', {'key1': '{{ foo }}_1', 'key2': '{{ foo }}_2'}, {'foo': 'bar'})
         self.assertDictEqual(result, {'key1': 'bar_1', 'key2': 'bar_2'})
 
     def test_render_template_dict_field_with_templated_keys(self):
@@ -456,7 +456,7 @@ class DagTest(unittest.TestCase):
         with dag:
             task = DummyOperator(task_id='op1')
 
-        result = task.render_template('', {'key_{{ foo }}_1': 1, 'key_2': '{{ foo }}_2'}, dict(foo='bar'))
+        result = task.render_template('', {'key_{{ foo }}_1': 1, 'key_2': '{{ foo }}_2'}, {'foo': 'bar'})
         self.assertDictEqual(result, {'key_{{ foo }}_1': 1, 'key_2': 'bar_2'})
 
     def test_render_template_date_field(self):
@@ -469,7 +469,7 @@ class DagTest(unittest.TestCase):
             task = DummyOperator(task_id='op1')
 
         self.assertEqual(
-            task.render_template('', datetime.date(2018, 12, 6), dict(foo='bar')),
+            task.render_template('', datetime.date(2018, 12, 6), {'foo': 'bar'}),
             datetime.date(2018, 12, 6)
         )
 
@@ -483,7 +483,7 @@ class DagTest(unittest.TestCase):
             task = DummyOperator(task_id='op1')
 
         self.assertEqual(
-            task.render_template('', datetime.datetime(2018, 12, 6, 10, 55), dict(foo='bar')),
+            task.render_template('', datetime.datetime(2018, 12, 6, 10, 55), {'foo': 'bar'}),
             datetime.datetime(2018, 12, 6, 10, 55)
         )
 
@@ -498,7 +498,7 @@ class DagTest(unittest.TestCase):
 
         random_uuid = uuid.uuid4()
         self.assertIs(
-            task.render_template('', random_uuid, dict(foo='bar')),
+            task.render_template('', random_uuid, {'foo': 'bar'}),
             random_uuid
         )
 
@@ -513,7 +513,7 @@ class DagTest(unittest.TestCase):
 
         test_object = object()
         self.assertIs(
-            task.render_template('', test_object, dict(foo='bar')),
+            task.render_template('', test_object, {'foo': 'bar'}),
             test_object
         )
 


### PR DESCRIPTION
### Jira

This PR addresses [[AIRFLOW-2508] Handle non string types in render_template_from_field](https://issues.apache.org/jira/browse/AIRFLOW-2508)

### Description

This PR changes `BaseOperator.render_template_from_field` method behavior: 
- it was previously rendering `string_types` and supporting `Number`s (and collections or dictionaries of these types); but it was raising an `AirflowException` on any other type.
- it is now supporting any other type (by returning the value as is)

### Tests

This PR adds the following unit tests on `BaseOperator.render_template_from_field` method:
- rendering a list of strings
- rendering a tuple of strings
- rendering dictionary values
- showing dictionary keys are not templatized
- returning a `date` as is
- returning a `datetime` as is
- returning a `UUID` as is
- returning an `object` as is

### Notice

**This PR adds [pyhamcrest](http://hamcrest.org/) to Airflow _test dependencies_.** This module helps writing meaningful assertions, and also provides very clear and helpful messages on test failures.

If Airflow maintainers do not want to include this test module, just let me know, and I'll rework unit tests 

### Note

This PR was made during working hours thanks to my employer: the [city of Montreal](http://ville.montreal.qc.ca)
