### PR TITLE
[AIRFLOW-3451] Add UI button to refresh all dags

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -184,6 +184,9 @@
         {% endfor %}
         </tbody>
     </table>
+    <a href="{{ url_for('Airflow.refresh_all') }}">
+      <span class="glyphicon glyphicon-refresh" aria-hidden="true" data-original-title="Refresh All DAGs"></span> Refresh All DAGs
+    </a>
     <div class="row">
       <div class="col-sm-12" style="text-align:right;">
         <div class="dataTables_info" id="dags_info" role="status" aria-live="polite" style="padding-top: 0px;">Showing {{num_dag_from}} to {{num_dag_to}} of {{num_of_all_dags}} entries</div>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3451
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-3451\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
       Added a button on the main dags page that calls `refresh_all` dags endpoint that is exposed in the webserver.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
       I didn't add in any more backend functionality
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
