### PR TITLE
AIRFLOW-3452 removed an unused/dangerous display-none

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -28,7 +28,7 @@
 {% block body %}
   <h2>DAGs</h2>
 
-  <div id="main_content" style="display:none;">
+  <div id="main_content">
     <div class="row">
       <div class="col-sm-2">
       </div>

--- a/airflow/www_rbac/templates/airflow/dags.html
+++ b/airflow/www_rbac/templates/airflow/dags.html
@@ -28,7 +28,7 @@
 {% block content %}
   <h2>DAGs</h2>
 
-  <div id="main_content" style="display:none;">
+  <div id="main_content">
     <div class="row">
       <div class="col-sm-2">
       </div>


### PR DESCRIPTION
The `display-none` style that includes the DAGs table on the homepage could resurface as a bug if the mechanism that is currently overriding it is removed. A recent JIRA issue suggests that a user may have already encountered this issue.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [AIRFLOW-3452](https://issues.apache.org/jira/browse/AIRFLOW-3452) issues and references them in the PR title. 

### Description

- [x] I simply removed an inline CSS style that can hide DAGs on the homepage as referenced in the issue above.
- [x] [Here is the picture](https://drive.google.com/open?id=1pybh-Yi_JP4-MhaM2fADVIzAqnf-K4U_)
### Tests

- [x] This issue does affect any existing tests and does not add new functionality. 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
