### PR TITLE
[AIRFLOW-3490] BigQueryHook's Ability to Patch Table/View

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -506,6 +506,8 @@ class BigQueryBaseCursor(LoggingMixin):
         Schema changes can only be applied to tables, not views.
         To patch a view, 'view' kwarg is required to parse in.
 
+        Reference: https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/patch
+
         :param project_id: The project containing the table/view to be patched.
         :type project_id: str
         :param dataset_id: The dataset containing the table/view to be patched.

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -496,9 +496,9 @@ class BigQueryBaseCursor(LoggingMixin):
             )
 
     def patch_table(self,
-                    project_id,
                     dataset_id,
                     table_id,
+                    project_id=None,
                     description=None,
                     expiration_time=None,
                     external_data_configuration=None,
@@ -514,12 +514,12 @@ class BigQueryBaseCursor(LoggingMixin):
 
         Reference: https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/patch
 
-        :param project_id: The project containing the table to be patched.
-        :type project_id: str
         :param dataset_id: The dataset containing the table to be patched.
         :type dataset_id: str
         :param table_id: The Name of the table to be patched.
         :type table_id: str
+        :param project_id: The project containing the table to be patched.
+        :type project_id: str
         :param description: [Optional] A user-friendly description of this table.
         :type description: str
         :param expiration_time: [Optional] The time when this table expires,

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -516,7 +516,7 @@ class BigQueryBaseCursor(LoggingMixin):
 
         :param project_id: The project containing the table to be patched.
         :type project_id: str
-        :param dataset_id: The dataset containing the tableto be patched.
+        :param dataset_id: The dataset containing the table to be patched.
         :type dataset_id: str
         :param table_id: The Name of the table to be patched.
         :type table_id: str

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -499,21 +499,39 @@ class BigQueryBaseCursor(LoggingMixin):
                     project_id,
                     dataset_id,
                     table_id,
+                    description=None,
+                    expiration_time=None,
+                    external_data_configuration=None,
+                    friendly_name=None,
+                    labels=None,
                     schema=None,
-                    view=None):
+                    time_partitioning=None,
+                    view=None,
+                    require_partition_filter=None):
         """
-        Patch information in an existing table/view.
-        Schema changes can only be applied to tables, not views.
-        To patch a view, 'view' kwarg is required to parse in.
+        Patch information in an existing table.
+        It only updates fileds that are provided in the request object.
 
         Reference: https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/patch
 
-        :param project_id: The project containing the table/view to be patched.
+        :param project_id: The project containing the table to be patched.
         :type project_id: str
-        :param dataset_id: The dataset containing the table/view to be patched.
+        :param dataset_id: The dataset containing the tableto be patched.
         :type dataset_id: str
-        :param table_id: The Name of the table/view to be patched.
+        :param table_id: The Name of the table to be patched.
         :type table_id: str
+        :param description: [Optional] A user-friendly description of this table.
+        :type description: str
+        :param expiration_time: [Optional] The time when this table expires,
+            in milliseconds since the epoch.
+        :type expiration_time: int
+        :param external_data_configuration: [Optional] A dictionary containing
+            properties of a table stored outside of BigQuery.
+        :type external_data_configuration: dict
+        :param friendly_name: [Optional] A descriptive name for this table.
+        :type friendly_name: str
+        :param labels: [Optional] A dictionary containing labels associated with this table.
+        :type labels: dict
         :param schema: [Optional] If set, the schema field list as defined here:
             https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.load.schema
             The supported schema modifications and unsupported schema modification are listed here:
@@ -525,6 +543,9 @@ class BigQueryBaseCursor(LoggingMixin):
             schema=[{"name": "emp_name", "type": "STRING", "mode": "REQUIRED"},
                            {"name": "salary", "type": "INTEGER", "mode": "NULLABLE"}]
 
+        :param time_partitioning: [Optional] A dictionary containing time-based partitioning
+             definition for the table.
+        :type time_partitioning: dict
         :param view: [Optional] A dictionary containing definition for the view.
             If set, it will patch a view instead of a table:
             https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#view
@@ -537,17 +558,34 @@ class BigQueryBaseCursor(LoggingMixin):
                 "useLegacySql": False
             }
 
+        :param require_partition_filter: [Optional] If true, queries over the this table require a
+            partition filter. If false, queries over the table
+        :type require_partition_filter: bool
+
         """
 
         project_id = project_id if project_id is not None else self.project_id
 
         table_resource = {}
 
+        if description is not None:
+            table_resource['description'] = description
+        if expiration_time is not None:
+            table_resource['expirationTime'] = expiration_time
+        if external_data_configuration:
+            table_resource['externalDataConfiguration'] = external_data_configuration
+        if friendly_name is not None:
+            table_resource['friendlyName'] = friendly_name
+        if labels:
+            table_resource['labels'] = labels
         if schema:
             table_resource['schema'] = {'fields': schema}
-
+        if time_partitioning:
+            table_resource['timePartitioning'] = time_partitioning
         if view:
             table_resource['view'] = view
+        if require_partition_filter is not None:
+            table_resource['requirePartitionFilter'] = require_partition_filter
 
         self.log.info('Patching Table %s:%s.%s',
                       project_id, dataset_id, table_id)

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -408,7 +408,6 @@ class TestBigQueryBaseCursor(unittest.TestCase):
                 "fields": schema_patched
             }
         }
-
         method.assert_called_once_with(
             projectId=project_id,
             datasetId=dataset_id,
@@ -433,7 +432,6 @@ class TestBigQueryBaseCursor(unittest.TestCase):
         body = {
             "view": view_patched
         }
-        
         method.assert_called_once_with(
             projectId=project_id,
             datasetId=dataset_id,

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -387,6 +387,59 @@ class TestBigQueryBaseCursor(unittest.TestCase):
         }
         method.assert_called_once_with(projectId=project_id, datasetId=dataset_id, body=body)
 
+    @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')
+    def test_patch_table(self, run_with_config):
+        project_id = 'bq-project'
+        dataset_id = 'bq_dataset'
+        table_id = 'bq_table'
+        schema_patched = [
+            {"name": "id", "type": "STRING", "mode": "REQUIRED"},
+            {"name": "name", "type": "STRING", "mode": "NULLABLE"},
+            {"name": "balance", "type": "FLOAT", "mode": "NULLABLE"},
+            {"name": "new_field", "type": "STRING", "mode": "NULLABLE"}
+        ]
+
+        mock_service = mock.Mock()
+        method = (mock_service.tables.return_value.patch)
+        cursor = hook.BigQueryBaseCursor(mock_service, project_id)
+        cursor.patch_table(project_id, dataset_id, table_id, schema=schema_patched)
+        body = {
+            "schema": {
+                "fields": schema_patched
+            }
+        }
+
+        method.assert_called_once_with(
+            projectId=project_id,
+            datasetId=dataset_id,
+            tableId=table_id,
+            body=body
+        )
+
+    @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')
+    def test_patch_view(self, run_with_config):
+        project_id = 'bq-project'
+        dataset_id = 'bq_dataset'
+        view_id = 'bq_view'
+        view_patched = {
+            "query": "SELECT * FROM `test-project-id.test_dataset_id.test_table_prefix*` LIMIT 500",
+            "useLegacySql": False
+        }
+
+        mock_service = mock.Mock()
+        method = (mock_service.tables.return_value.patch)
+        cursor = hook.BigQueryBaseCursor(mock_service, project_id)
+        cursor.patch_table(project_id, dataset_id, view_id, view=view_patched)
+        body = {
+            "view": view_patched
+        }
+        method.assert_called_once_with(
+            projectId=project_id,
+            datasetId=dataset_id,
+            tableId=view_id,
+            body=body
+        )
+
 
 class TestBigQueryCursor(unittest.TestCase):
     @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -433,6 +433,7 @@ class TestBigQueryBaseCursor(unittest.TestCase):
         body = {
             "view": view_patched
         }
+        
         method.assert_called_once_with(
             projectId=project_id,
             datasetId=dataset_id,

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -392,21 +392,45 @@ class TestBigQueryBaseCursor(unittest.TestCase):
         project_id = 'bq-project'
         dataset_id = 'bq_dataset'
         table_id = 'bq_table'
+
+        description_patched = 'Test description.'
+        expiration_time_patched = 2524608000000
+        friendly_name_patched = 'Test friendly name.'
+        labels_patched = {'label1': 'test1', 'label2': 'test2'}
         schema_patched = [
-            {"name": "id", "type": "STRING", "mode": "REQUIRED"},
-            {"name": "name", "type": "STRING", "mode": "NULLABLE"},
-            {"name": "balance", "type": "FLOAT", "mode": "NULLABLE"},
-            {"name": "new_field", "type": "STRING", "mode": "NULLABLE"}
+            {'name': 'id', 'type': 'STRING', 'mode': 'REQUIRED'},
+            {'name': 'name', 'type': 'STRING', 'mode': 'NULLABLE'},
+            {'name': 'balance', 'type': 'FLOAT', 'mode': 'NULLABLE'},
+            {'name': 'new_field', 'type': 'STRING', 'mode': 'NULLABLE'}
         ]
+        time_partitioning_patched = {
+            'expirationMs': 10000000
+        }
+        require_partition_filter_patched = True
 
         mock_service = mock.Mock()
         method = (mock_service.tables.return_value.patch)
         cursor = hook.BigQueryBaseCursor(mock_service, project_id)
-        cursor.patch_table(project_id, dataset_id, table_id, schema=schema_patched)
+        cursor.patch_table(
+            project_id, dataset_id, table_id,
+            description=description_patched,
+            expiration_time=expiration_time_patched,
+            friendly_name=friendly_name_patched,
+            labels=labels_patched, schema=schema_patched,
+            time_partitioning=time_partitioning_patched,
+            require_partition_filter=require_partition_filter_patched
+        )
+
         body = {
+            "description": description_patched,
+            "expirationTime": expiration_time_patched,
+            "friendlyName": friendly_name_patched,
+            "labels": labels_patched,
             "schema": {
                 "fields": schema_patched
-            }
+            },
+            "timePartitioning": time_partitioning_patched,
+            "requirePartitionFilter": require_partition_filter_patched
         }
         method.assert_called_once_with(
             projectId=project_id,
@@ -421,8 +445,8 @@ class TestBigQueryBaseCursor(unittest.TestCase):
         dataset_id = 'bq_dataset'
         view_id = 'bq_view'
         view_patched = {
-            "query": "SELECT * FROM `test-project-id.test_dataset_id.test_table_prefix*` LIMIT 500",
-            "useLegacySql": False
+            'query': "SELECT * FROM `test-project-id.test_dataset_id.test_table_prefix*` LIMIT 500",
+            'useLegacySql': False
         }
 
         mock_service = mock.Mock()
@@ -430,7 +454,7 @@ class TestBigQueryBaseCursor(unittest.TestCase):
         cursor = hook.BigQueryBaseCursor(mock_service, project_id)
         cursor.patch_table(project_id, dataset_id, view_id, view=view_patched)
         body = {
-            "view": view_patched
+            'view': view_patched
         }
         method.assert_called_once_with(
             projectId=project_id,

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -412,7 +412,7 @@ class TestBigQueryBaseCursor(unittest.TestCase):
         method = (mock_service.tables.return_value.patch)
         cursor = hook.BigQueryBaseCursor(mock_service, project_id)
         cursor.patch_table(
-            project_id, dataset_id, table_id,
+            dataset_id, table_id, project_id,
             description=description_patched,
             expiration_time=expiration_time_patched,
             friendly_name=friendly_name_patched,
@@ -452,7 +452,7 @@ class TestBigQueryBaseCursor(unittest.TestCase):
         mock_service = mock.Mock()
         method = (mock_service.tables.return_value.patch)
         cursor = hook.BigQueryBaseCursor(mock_service, project_id)
-        cursor.patch_table(project_id, dataset_id, view_id, view=view_patched)
+        cursor.patch_table(dataset_id, view_id, project_id, view=view_patched)
         body = {
             'view': view_patched
         }


### PR DESCRIPTION
Add patch_table() to BQHook, and its unit tests

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-3490](https://issues.apache.org/jira/browse/AIRFLOW-3490) issues and references them in the PR title. 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Add patch_table() to BigQueryBaseCursor in BigQueryHook so that it has ability to patch tables and patch views.


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests.contrib.hooks.test_bigquery_hook:TestBigQueryBaseCursor.test_patch_table
tests.contrib.hooks.test_bigquery_hook:TestBigQueryBaseCursor.test_patch_view

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
