### PR TITLE
[AIRFLOW-3521] Fetch more than 50 items in `airflow-jira compare` script

### DIFF
--- a/dev/airflow-jira
+++ b/dev/airflow-jira
@@ -65,9 +65,22 @@ GIT_LOG_FORMAT = '%x1f'.join(GIT_LOG_FORMAT) + '%x1e'
 def get_jiras_for_version(version):
     asf_jira = jira.client.JIRA({'server': JIRA_API_BASE})
 
-    return asf_jira.search_issues(
-        'PROJECT={} and fixVersion={}'.format(PROJECT, version)
-    )
+    start_at = 0
+    page_size = 50
+    while True:
+        results = asf_jira.search_issues(
+            'PROJECT={} and fixVersion={}'.format(PROJECT, version),
+            maxResults=page_size,
+            startAt=start_at,
+        )
+
+        for r in results:
+            yield r
+
+        if len(results) < page_size:
+            break
+
+        start_at += page_size
 
 
 def get_merged_issues(version):


### PR DESCRIPTION


[ci-skip]

Make sure you have checked _all_ steps below.

### Jira

- [x] No jira

### Description

- [x] This script is useful (though not fool-proof if a PR addresses multiple
Jira tickets) for comparing what issues are marked as fixed in a release
vs what PRs are actually on the (current) branch.

Usage:

    git co v1-10-test
    ./dev/airflow-jira compare 1.10.2

Prior to this change only the first 50 issues would come back, which for
1.10.1 wasn't enough as we ended up with over 100 issues targeting that
branch.
### Tests

- [x] no tests

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
