### PR TITLE
[AIRFLOW-3492] Addition of Unique ID required in every Airflow Task Log for debugging purpose

### DIFF
--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -21,6 +21,7 @@ import os
 
 from airflow import configuration as conf
 from airflow.utils.file import mkdirs
+import uuid
 
 # TODO: Logging format and level should be configured
 # in this file instead of from airflow.cfg. Currently
@@ -64,7 +65,7 @@ DEFAULT_LOGGING_CONFIG = {
     'disable_existing_loggers': False,
     'formatters': {
         'airflow': {
-            'format': LOG_FORMAT,
+            'format': LOG_FORMAT + ' [' + str(uuid.uuid1()) + ']',
         },
     },
     'handlers': {


### PR DESCRIPTION
Currently we are using Airflow as our main orchestrator and in turn we need all the Airflow logs at one place. In the current system, all of task logs of a particular DAG are forwarded to Splunk. Due to security reason, Airflow UI is not accessible to all the clients. So, we don't have any way to co-relate all the logs of a particular task in a DAG while searching in Splunk. 

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-3492](https://issues.apache.org/jira/browse/AIRFLOW-3492) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-3492

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
