### PR TITLE
[AIRFLOW-2641]  Fix MySqlToHiveTransfer to handle MySQL DECIMAL correctly

### DIFF
--- a/airflow/operators/mysql_to_hive.py
+++ b/airflow/operators/mysql_to_hive.py
@@ -101,6 +101,7 @@ class MySqlToHiveTransfer(BaseOperator):
         d = {
             t.BIT: 'INT',
             t.DECIMAL: 'DOUBLE',
+            t.NEWDECIMAL: 'DOUBLE',
             t.DOUBLE: 'DOUBLE',
             t.FLOAT: 'DOUBLE',
             t.INT24: 'INT',
@@ -122,7 +123,8 @@ class MySqlToHiveTransfer(BaseOperator):
         cursor = conn.cursor()
         cursor.execute(self.sql)
         with NamedTemporaryFile("wb") as f:
-            csv_writer = csv.writer(f, delimiter=self.delimiter, encoding="utf-8")
+            csv_writer = csv.writer(f, delimiter=self.delimiter,
+                                    encoding="utf-8")
             field_dict = OrderedDict()
             for field in cursor.description:
                 field_dict[field[0]] = self.type_map(field[1])


### PR DESCRIPTION
### Jira

- [V] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-2641) 

### Description

MySQLdb has also FIELD_TYPE.NEWDECIMAL 
adding support for it in the operator
https://github.com/farcepest/MySQLdb1/blob/master/MySQLdb/converters.py#L158

Also fix flake8 errors

### Code Quality

- [V ] Passes `flake8`
