### PR TITLE
[AIRFLOW-3397] Fix integrety error in rbac AirflowSecurityManager

### DIFF
--- a/airflow/www_rbac/security.py
+++ b/airflow/www_rbac/security.py
@@ -395,8 +395,8 @@ class AirflowSecurityManager(SecurityManager):
             existing_perm_view_by_user = self.get_session.query(ab_perm_view_role)\
                 .filter(ab_perm_view_role.columns.role_id == role.id)
 
-            existing_perms_views = set([role.permission_view_id
-                                        for role in existing_perm_view_by_user])
+            existing_perms_views = set([pv.permission_view_id
+                                        for pv in existing_perm_view_by_user])
             missing_perm_views = all_perm_views - existing_perms_views
 
             for perm_view_id in missing_perm_views:


### PR DESCRIPTION
This was caused by the variable `role` being shadowed in a loop statement.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3397

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR fixes a bug in rbac AirflowSecurityManager where a variable was shadowed by a loop variable.

### Tests

- [x] My PR does not need testing for this extremely good reason:

No significant changes were made, only a variable name was changed to fix a shadowing bug.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
