### PR TITLE
added role, schema and warehouse

### DIFF
--- a/airflow/contrib/hooks/snowflake_hook.py
+++ b/airflow/contrib/hooks/snowflake_hook.py
@@ -39,6 +39,8 @@ class SnowflakeHook(DbApiHook):
         self.account = kwargs.pop("account", None)
         self.warehouse = kwargs.pop("warehouse", None)
         self.database = kwargs.pop("database", None)
+        self.role = kwargs.pop("role", None)
+        self.schema=kwargs.pop("schema", None)
 
     def _get_conn_params(self):
         """
@@ -49,14 +51,18 @@ class SnowflakeHook(DbApiHook):
         account = conn.extra_dejson.get('account', None)
         warehouse = conn.extra_dejson.get('warehouse', None)
         database = conn.extra_dejson.get('database', None)
+        role = conn.extra_dejson.get('role', None)
+        schema = conn.extra_dejson.get('schema',None)
 
         conn_config = {
             "user": conn.login,
             "password": conn.password or '',
-            "schema": conn.schema or '',
+            "schema": conn.schema or schema or '',
             "database": self.database or database or '',
             "account": self.account or account or '',
-            "warehouse": self.warehouse or warehouse or ''
+            "warehouse": self.warehouse or warehouse or '',
+            "role": self.role or role or ''
+
         }
         return conn_config
 
@@ -66,7 +72,7 @@ class SnowflakeHook(DbApiHook):
         """
         conn_config = self._get_conn_params()
         uri = 'snowflake://{user}:{password}@{account}/{database}/'
-        uri += '{schema}?warehouse={warehouse}'
+        uri += '?schema={schema}&warehouse={warehouse}&role={role}'
         return uri.format(
             **conn_config)
 

--- a/airflow/contrib/operators/snowflake_operator.py
+++ b/airflow/contrib/operators/snowflake_operator.py
@@ -26,16 +26,16 @@ class SnowflakeOperator(BaseOperator):
     Executes sql code in a Snowflake database
 
     :param snowflake_conn_id: reference to specific snowflake connection id
-    :type snowflake_conn_id: str
+    :type snowflake_conn_id: string
     :param sql: the sql code to be executed. (templated)
     :type sql: Can receive a str representing a sql statement,
         a list of str (sql statements), or reference to a template file.
         Template reference are recognized by str ending in '.sql'
     :param warehouse: name of warehouse which overwrite defined
         one in connection
-    :type warehouse: str
+    :type warehouse: string
     :param database: name of database which overwrite defined one in connection
-    :type database: str
+    :type database: string
     """
 
     template_fields = ('sql',)
@@ -45,7 +45,7 @@ class SnowflakeOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self, sql, snowflake_conn_id='snowflake_default', parameters=None,
-            autocommit=True, warehouse=None, database=None, *args, **kwargs):
+            autocommit=True, warehouse=None, database=None, role=None, schema=None, *args, **kwargs):
         super(SnowflakeOperator, self).__init__(*args, **kwargs)
         self.snowflake_conn_id = snowflake_conn_id
         self.sql = sql
@@ -53,10 +53,12 @@ class SnowflakeOperator(BaseOperator):
         self.parameters = parameters
         self.warehouse = warehouse
         self.database = database
+        self.role = role
+        self.schema = schema
 
     def get_hook(self):
         return SnowflakeHook(snowflake_conn_id=self.snowflake_conn_id,
-                             warehouse=self.warehouse, database=self.database)
+                             warehouse=self.warehouse, database=self.database, role=self.role, schema=self.schema)
 
     def execute(self, context):
         self.log.info('Executing: %s', self.sql)


### PR DESCRIPTION
added addition connection params - current hook does not allow for connecting with correct role ie security.  current  hook requires full qualification of database.schema.table_name in query - we should have the ability to have per schema/database connections in Airflow

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
