### PR TITLE
[AIRFLOW-3501] k8s executor - Support loading dags from image.

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -624,6 +624,10 @@ git_user =
 git_password =
 git_subpath =
 
+# If True, use the dags that exist in the docker container instead of pulling
+# from git or a dag volume claim.
+use_container_dags =
+
 # For cloning DAGs from git repositories into volumes: https://github.com/kubernetes/git-sync
 git_sync_container_repository = gcr.io/google-containers/git-sync-amd64
 git_sync_container_tag = v2.0.5

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -150,6 +150,10 @@ class KubeConfig:
         self.git_user = conf.get(self.kubernetes_section, 'git_user')
         self.git_password = conf.get(self.kubernetes_section, 'git_password')
 
+        # If True, use the dags that exist in the docker container instead of pulling
+        # from git or a dag volume claim.
+        self.use_container_dags = conf.get(self.kubernetes_section, 'use_container_dags')
+
         # NOTE: The user may optionally use a volume claim to mount a PV containing
         # DAGs directly
         self.dags_volume_claim = conf.get(self.kubernetes_section, 'dags_volume_claim')
@@ -204,10 +208,13 @@ class KubeConfig:
         self._validate()
 
     def _validate(self):
-        if not self.dags_volume_claim and (not self.git_repo or not self.git_branch):
+        if not self.dags_volume_claim \
+                and (not self.git_repo or not self.git_branch) \
+                and not self.use_container_dags:
             raise AirflowConfigException(
                 'In kubernetes mode the following must be set in the `kubernetes` '
-                'config section: `dags_volume_claim` or `git_repo and git_branch`')
+                'config section: `dags_volume_claim` or `use_container_dags` '
+                'or `git_repo and git_branch`')
 
 
 class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin, object):

--- a/tests/contrib/executors/test_kubernetes_executor.py
+++ b/tests/contrib/executors/test_kubernetes_executor.py
@@ -109,6 +109,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         self.kube_config.airflow_dags = 'logs'
         self.kube_config.dags_volume_subpath = None
         self.kube_config.logs_volume_subpath = None
+        self.kube_config.use_container_dags = None
 
     def test_worker_configuration_no_subpaths(self):
         worker_config = WorkerConfiguration(self.kube_config)
@@ -154,6 +155,61 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         env = worker_config._get_environment()
 
         self.assertEqual(dags_folder, env['AIRFLOW__CORE__DAGS_FOLDER'])
+
+    def test_worker_pvc_dags(self):
+        # Tests persistence volume config created when `dags_volume_claim` is set
+        self.kube_config.dags_volume_claim = 'airflow-dags'
+
+        worker_config = WorkerConfiguration(self.kube_config)
+        volumes, volume_mounts = worker_config.init_volumes_and_mounts()
+
+        dag_volume = [volume for volume in volumes if volume['name'] == 'airflow-dags']
+        dag_volume_mount = [mount for mount in volume_mounts if mount['name'] == 'airflow-dags']
+
+        self.assertEqual('airflow-dags', dag_volume[0]['persistentVolumeClaim']['claimName'])
+        self.assertEqual(1, len(dag_volume_mount))
+
+    def test_worker_git_dags(self):
+        # Tests persistence volume config created when `git_repo` is set
+        self.kube_config.dags_volume_claim = None
+        self.kube_config.dags_folder = '/usr/local/airflow/dags'
+        self.kube_config.worker_dags_folder = '/usr/local/airflow/dags'
+
+        self.kube_config.git_sync_container_repository = 'gcr.io/google-containers/git-sync-amd64'
+        self.kube_config.git_sync_container_tag = 'v2.0.5'
+        self.kube_config.git_sync_container = 'gcr.io/google-containers/git-sync-amd64:v2.0.5'
+        self.kube_config.git_sync_init_container_name = 'git-sync-clone'
+        self.kube_config.git_subpath = ''
+
+        worker_config = WorkerConfiguration(self.kube_config)
+        volumes, volume_mounts = worker_config.init_volumes_and_mounts()
+
+        init_container = worker_config._get_init_containers(volume_mounts)[0]
+
+        dag_volume = [volume for volume in volumes if volume['name'] == 'airflow-dags']
+        dag_volume_mount = [mount for mount in volume_mounts if mount['name'] == 'airflow-dags']
+
+        self.assertTrue('emptyDir' in dag_volume[0])
+        self.assertEqual('/usr/local/airflow/dags/', dag_volume_mount[0]['mountPath'])
+
+        self.assertEqual('git-sync-clone', init_container['name'])
+        self.assertEqual('gcr.io/google-containers/git-sync-amd64:v2.0.5', init_container['image'])
+
+    def test_worker_container_dags(self):
+        # Tests persistence volume config created when `use_container_dags` is set
+        self.kube_config.use_container_dags = True
+
+        worker_config = WorkerConfiguration(self.kube_config)
+        volumes, volume_mounts = worker_config.init_volumes_and_mounts()
+
+        dag_volume = [volume for volume in volumes if volume['name'] == 'airflow-dags']
+        dag_volume_mount = [mount for mount in volume_mounts if mount['name'] == 'airflow-dags']
+
+        init_containers = worker_config._get_init_containers(volume_mounts)
+
+        self.assertEqual(0, len(dag_volume))
+        self.assertEqual(0, len(dag_volume_mount))
+        self.assertEqual(0, len(init_containers))
 
 
 class TestKubernetesExecutor(unittest.TestCase):


### PR DESCRIPTION
### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-3501\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3501
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-3501\], code changes always need a Jira issue.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This PR adds a new config property named `use_container_dags` to the `kubernetes` configuration section.

When this property is set to `True`, airflow will uses the dags packaged into the running docker container instead of loading them from a kubernetes volume mount or from a git init container.

Prior to this change airflow forced loading dags either from a volume claim or an init container.

The motivation for this change is to allow for an airflow image to be built and released via a CI/CD pipeline upon a new commit to a dag repository.  For example, given a new git commit to a dag repo, a CI/CD server can build an airflow docker image, run tests against the current dags, and finally push the entire bundle as a single, complete, well-known unit to kubernetes.

There's no need to worry that a git init container will fail, having to have a separate pipeline to update dags on a shared volume, etc.  And if issues arise from an update, the configuration can be easily rolled back to the prior version of the image.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X] Passes `flake8`
