### PR TITLE
[AIRFLOW-3504] Extend/refine the functionality of "/health" endpoint

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -465,6 +465,11 @@ dag_dir_list_interval = 300
 # How often should stats be printed to the logs
 print_stats_interval = 30
 
+# If the last scheduler heartbeat happened more than scheduler_health_check_threshold ago (in seconds),
+# scheduler is considered unhealthy.
+# This is used by the health check in the "/health" endpoint
+scheduler_health_check_threshold = 30
+
 child_process_log_directory = {AIRFLOW_HOME}/logs/scheduler
 
 # Local task jobs periodically heartbeat to the DB. If the job has

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -112,6 +112,7 @@ docker_image_slave = test/docker-airflow
 [scheduler]
 job_heartbeat_sec = 1
 scheduler_heartbeat_sec = 5
+scheduler_health_check_threshold = 30
 authenticate = true
 max_threads = 2
 catchup_by_default = True

--- a/airflow/www/blueprints.py
+++ b/airflow/www/blueprints.py
@@ -17,10 +17,16 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+from datetime import timedelta
 from flask import (
-    url_for, Markup, Blueprint, redirect,
+    url_for, Blueprint, redirect,
 )
-import markdown
+from sqlalchemy import func
+
+from airflow import configuration as conf
+from airflow import jobs, settings
+from airflow.utils import timezone
+from airflow.www import utils as wwwutils
 
 routes = Blueprint('routes', __name__)
 
@@ -32,6 +38,35 @@ def index():
 
 @routes.route('/health')
 def health():
-    """ We can add an array of tests here to check the server's health """
-    content = Markup(markdown.markdown("The server is healthy!"))
-    return content
+    """
+    An endpoint helping check the health status of the Airflow instance,
+    including metadatabase and scheduler.
+    """
+    session = settings.Session()
+    BJ = jobs.BaseJob
+    payload = {}
+    scheduler_health_check_threshold = timedelta(seconds=conf.getint('scheduler',
+                                                                     'scheduler_health_check_threshold'
+                                                                     ))
+
+    latest_scheduler_heartbeat = None
+    payload['metadatabase'] = {'status': 'healthy'}
+    try:
+        latest_scheduler_heartbeat = session.query(func.max(BJ.latest_heartbeat)). \
+            filter(BJ.state == 'running', BJ.job_type == 'SchedulerJob'). \
+            scalar()
+    except Exception:
+        payload['metadatabase']['status'] = 'unhealthy'
+
+    if not latest_scheduler_heartbeat:
+        scheduler_status = 'unhealthy'
+    else:
+        if timezone.utcnow() - latest_scheduler_heartbeat <= scheduler_health_check_threshold:
+            scheduler_status = 'healthy'
+        else:
+            scheduler_status = 'unhealthy'
+
+    payload['scheduler'] = {'status': scheduler_status,
+                            'latest_scheduler_heartbeat': str(latest_scheduler_heartbeat)}
+
+    return wwwutils.json_response(payload)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -381,7 +381,6 @@ class Airflow(BaseView):
     @expose('/chart_data')
     @data_profiling_required
     @wwwutils.gzipped
-    # @cache.cached(timeout=3600, key_prefix=wwwutils.make_cache_key)
     def chart_data(self):
         from airflow import macros
         import pandas as pd

--- a/airflow/www_rbac/blueprints.py
+++ b/airflow/www_rbac/blueprints.py
@@ -17,8 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from flask import Markup, Blueprint, redirect
-import markdown
+from flask import Blueprint, redirect
 
 routes = Blueprint('routes', __name__)
 
@@ -26,10 +25,3 @@ routes = Blueprint('routes', __name__)
 @routes.route('/')
 def index():
     return redirect('/home')
-
-
-@routes.route('/health')
-def health():
-    """ We can add an array of tests here to check the server's health """
-    content = Markup(markdown.markdown("The server is healthy!"))
-    return content

--- a/docs/howto/check-health.rst
+++ b/docs/howto/check-health.rst
@@ -1,0 +1,47 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Checking Airflow Health Status
+==============================
+
+To check the health status of your Airflow instance, you can simply access the endpoint
+``"/health"``. It will return a JSON object in which a high-level glance is provided.
+
+.. code-block:: JSON
+
+  {
+    "metadatabase":{
+      "status":"healthy"
+    },
+    "scheduler":{
+      "status":"healthy",
+      "latest_scheduler_heartbeat":"2018-12-26 17:15:11+00:00"
+    }
+  }
+
+* The ``status`` of each component can be either "healthy" or "unhealthy".
+
+    * The status of ``metadatabase`` is depending on whether a valid connection can be initiated
+      with the database backend of Airflow.
+    * The status of ``scheduler`` is depending on when the latest scheduler heartbeat happened. If the latest
+      scheduler heartbeat happened 30 seconds (default value) earlier than the current time, scheduler component is
+      considered unhealthy. You can also specify this threshold value by changing
+      ``scheduler_health_check_threshold`` in ``scheduler`` section of the ``airflow.cfg`` file.
+
+* The response code of ``"/health"`` endpoint is not used to label the health status of the
+  application (it would always be 200). Hence please be reminded not to use the response code here
+  for health-check purpose.

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -40,4 +40,5 @@ configuring an Airflow environment.
     run-with-systemd
     run-with-upstart
     use-test-config
+    check-health
 

--- a/tests/www_rbac/test_views.py
+++ b/tests/www_rbac/test_views.py
@@ -29,6 +29,7 @@ import tempfile
 import unittest
 import urllib
 
+from datetime import timedelta
 from flask._compat import PY2
 from urllib.parse import quote_plus
 from werkzeug.test import Client
@@ -36,6 +37,7 @@ from werkzeug.test import Client
 from airflow import configuration as conf
 from airflow import models, settings
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
+from airflow.jobs import BaseJob
 from airflow.models import DAG, DagRun, TaskInstance
 from airflow.models.connection import Connection
 from airflow.operators.dummy_operator import DummyOperator
@@ -322,8 +324,66 @@ class TestAirflowBaseViews(TestBase):
         self.check_content_in_response('DAGs', resp)
 
     def test_health(self):
-        resp = self.client.get('health', follow_redirects=True)
-        self.check_content_in_response('The server is healthy!', resp)
+
+        # case-1: healthy scheduler status
+        last_scheduler_heartbeat_for_testing_1 = timezone.utcnow()
+        self.session.add(BaseJob(job_type='SchedulerJob',
+                                 state='running',
+                                 latest_heartbeat=last_scheduler_heartbeat_for_testing_1))
+        self.session.commit()
+
+        resp_json = json.loads(self.client.get('health', follow_redirects=True).data.decode('utf-8'))
+
+        self.assertEqual('healthy', resp_json['metadatabase']['status'])
+        self.assertEqual('healthy', resp_json['scheduler']['status'])
+        self.assertEqual(str(last_scheduler_heartbeat_for_testing_1),
+                         resp_json['scheduler']['latest_scheduler_heartbeat'])
+
+        self.session.query(BaseJob).\
+            filter(BaseJob.job_type == 'SchedulerJob',
+                   BaseJob.state == 'running',
+                   BaseJob.latest_heartbeat == last_scheduler_heartbeat_for_testing_1).\
+            delete()
+        self.session.commit()
+
+        # case-2: unhealthy scheduler status - scenario 1 (SchedulerJob is running too slowly)
+        last_scheduler_heartbeat_for_testing_2 = timezone.utcnow() - timedelta(minutes=1)
+        (self.session
+             .query(BaseJob)
+             .filter(BaseJob.job_type == 'SchedulerJob')
+             .update({'latest_heartbeat': last_scheduler_heartbeat_for_testing_2 - timedelta(seconds=1)}))
+        self.session.add(BaseJob(job_type='SchedulerJob',
+                                 state='running',
+                                 latest_heartbeat=last_scheduler_heartbeat_for_testing_2))
+        self.session.commit()
+
+        resp_json = json.loads(self.client.get('health', follow_redirects=True).data.decode('utf-8'))
+
+        self.assertEqual('healthy', resp_json['metadatabase']['status'])
+        self.assertEqual('unhealthy', resp_json['scheduler']['status'])
+        self.assertEqual(str(last_scheduler_heartbeat_for_testing_2),
+                         resp_json['scheduler']['latest_scheduler_heartbeat'])
+
+        self.session.query(BaseJob).\
+            filter(BaseJob.job_type == 'SchedulerJob',
+                   BaseJob.state == 'running',
+                   BaseJob.latest_heartbeat == last_scheduler_heartbeat_for_testing_2).\
+            delete()
+        self.session.commit()
+
+        # case-3: unhealthy scheduler status - scenario 2 (no running SchedulerJob)
+        self.session.query(BaseJob).\
+            filter(BaseJob.job_type == 'SchedulerJob',
+                   BaseJob.state == 'running').\
+            delete()
+        self.session.commit()
+
+        resp_json = json.loads(self.client.get('health', follow_redirects=True).data.decode('utf-8'))
+
+        self.assertEqual('healthy', resp_json['metadatabase']['status'])
+        self.assertEqual('unhealthy', resp_json['scheduler']['status'])
+        self.assertEqual('None',
+                         resp_json['scheduler']['latest_scheduler_heartbeat'])
 
     def test_home(self):
         resp = self.client.get('home', follow_redirects=True)


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3504


### Description

**=== UPDATED BASED ON THE LATEST COMMIT ===**

#### The Issue That This PR Tried to Address

For both www/ and www_rbac/, there is "/health" endpoint, which is supposed to help users know the "health" condition of the Airflow application.

But the functionality of it at this moment is very limited. It can only help check if the webserver is running, but actually the "health" of the application may be bad even though this endpoint returns "The server is healthy!" (scheduler may be down, database backend may be disconnected, etc)

#### What Have Been Done in This PR

Extend the functionality of "`/health`" endpoint:

1. Check if database backend can be connected;
2. Check the latest scheduler heartbeat.

This is done for both `/www` and `/www_rbac`. Tests are added accordingly as well.

Note that no authentication is required to access "`/health`" endpoint (no sensitive information will be exposed through it).

(Deleted an unnecessary line in `airflow/www/views.py` as well)

#### How Final Result Looks Like

The "`/health`" endpoint will return a JSON like

```
  {
    "metadatabase":{
      "status":"healthy"
    },
    "scheduler":{
      "status":"healthy",
      "latest_scheduler_heartbeat":"2018-12-26 17:15:11+00:00"
    }
  }
```

(Currently it simply returns "`The server is healthy!`", which is not very useful, and can't really check the health condition of the application)

#### Others

**No authentication is required to access this `/health` endpoint. This is a conscious decision.**

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Changed tests below accordingly:
- `tests/core.py` (for /www)
- `tests/www_rbac/test_views.py` (for /www_rbac)

### Code Quality

- [x] Passes `flake8`
