### PR TITLE
[AIRFLOW-3505] replace 'dags_in_docker' with 'dags_in_image'

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -607,7 +607,7 @@ airflow_configmap =
 
 # For docker image already contains DAGs, this is set to `True`, and the worker will search for dags in dags_folder,
 # otherwise use git sync or dags volumn chaim to mount DAGs
-dags_in_docker = FALSE
+dags_in_image = FALSE
 
 # For either git sync or volume mounted DAGs, the worker will look in this subpath for DAGs
 dags_volume_subpath =

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -139,7 +139,7 @@ class KubeConfig:
 
         # NOTE: user can build the dags into the docker image directly,
         # this will set to True if so
-        self.dags_in_docker = conf.get(self.kubernetes_section, 'dags_in_docker')
+        self.dags_in_image = conf.get(self.kubernetes_section, 'dags_in_image')
 
         # NOTE: `git_repo` and `git_branch` must be specified together as a pair
         # The http URL of the git repository to clone from
@@ -208,12 +208,12 @@ class KubeConfig:
         self._validate()
 
     def _validate(self):
-        if not self.dags_volume_claim and not self.dags_in_docker \
+        if not self.dags_volume_claim and not self.dags_in_image \
                 and (not self.git_repo or not self.git_branch):
             raise AirflowConfigException(
                 'In kubernetes mode the following must be set in the `kubernetes` '
                 'config section: `dags_volume_claim` or `git_repo and git_branch` '
-                'or `dags_in_docker`')
+                'or `dags_in_image`')
 
 
 class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin, object):

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -38,7 +38,7 @@ class WorkerConfiguration(LoggingMixin):
     def _get_init_containers(self, volume_mounts):
         """When using git to retrieve the DAGs, use the GitSync Init Container"""
         # If we're using volume claims to mount the dags, no init container is needed
-        if self.kube_config.dags_volume_claim or self.kube_config.dags_in_docker:
+        if self.kube_config.dags_volume_claim or self.kube_config.dags_in_image:
             return []
 
         # Otherwise, define a git-sync init container
@@ -134,7 +134,7 @@ class WorkerConfiguration(LoggingMixin):
             )
         ]
 
-        if not self.kube_config.dags_in_docker:
+        if not self.kube_config.dags_in_image:
             volumes.append(
                 _construct_volume(
                     dags_volume_name,
@@ -153,7 +153,7 @@ class WorkerConfiguration(LoggingMixin):
             logs_volume_mount
         ]
 
-        if not self.kube_config.dags_in_docker:
+        if not self.kube_config.dags_in_image:
             dag_volume_mount_path = ""
 
             if self.kube_config.dags_volume_claim:

--- a/scripts/ci/kubernetes/kube/configmaps.yaml
+++ b/scripts/ci/kubernetes/kube/configmaps.yaml
@@ -178,7 +178,7 @@ data:
     worker_container_image_pull_policy = IfNotPresent
     worker_dags_folder = /tmp/dags
     delete_worker_pods = True
-    dags_in_docker = False
+    dags_in_image = False
     git_repo = https://github.com/apache/incubator-airflow.git
     git_branch = master
     git_subpath = airflow/example_dags/


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3505
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:


As kubernetes is moving away from docker to OCI, it will be more correct to use the 'dags_in_image' name to be more container system agnostic

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
