### PR TITLE
AIRFLOW-3508: add slugify env to build.sh script

### DIFF
--- a/scripts/ci/kubernetes/docker/build.sh
+++ b/scripts/ci/kubernetes/docker/build.sh
@@ -17,8 +17,12 @@
 #  specific language governing permissions and limitations      *
 #  under the License.                                           *
 
-# python-slugify - install and use text-unidecode because of the existing https://github.com/areski/python-nvd3 dependency
-export SLUGIFY_USES_TEXT_UNIDECODE=yes
+# python-slugify - install and use text-unidecode because of the existing python-nvd3 dependency
+# set SLUGIFY_USES_TEXT_UNIDECODE variable needed for installation
+if [ -z "$SLUGIFY_USES_TEXT_UNIDECODE" ]
+then
+        export SLUGIFY_USES_TEXT_UNIDECODE=yes
+fi
 
 IMAGE=${1:-airflow}
 TAG=${2:-latest}

--- a/scripts/ci/kubernetes/docker/build.sh
+++ b/scripts/ci/kubernetes/docker/build.sh
@@ -17,6 +17,9 @@
 #  specific language governing permissions and limitations      *
 #  under the License.                                           *
 
+# python-slugify - install and use text-unidecode because of the existing https://github.com/areski/python-nvd3 dependency
+export SLUGIFY_USES_TEXT_UNIDECODE=yes
+
 IMAGE=${1:-airflow}
 TAG=${2:-latest}
 DIRNAME=$(cd "$(dirname "$0")"; pwd)


### PR DESCRIPTION
See AIRFLOW-3508 Jira ticket
docker build script fails because of the existing areski/python-nvd3 dependency.
incubator-airflow/scripts/ci/kubernetes/docker/build.sh fails to start setup because of the existing areski/python-nvd3 dependency that requires python-slugify which installs unidecode (GPL) for its decoding needs. 

The 
python setup.py sdist -q 
fails with the following error:
"By default one of Airflow's dependencies installs a GPL dependency (unidecode). To avoid this..."
Many experience the same issue, so its better to avoid it by adding SLUGIFY_USES_TEXT_UNIDECODE=yes env to install and use text-unidecode