### PR TITLE
[AIRFLOW-3398] Google Cloud Spanner instance database query operator

### DIFF
--- a/airflow/contrib/example_dags/example_gcp_spanner.sql
+++ b/airflow/contrib/example_dags/example_gcp_spanner.sql
@@ -1,0 +1,3 @@
+INSERT my_table2 (id, name) VALUES (7, 'Seven');
+INSERT my_table2 (id, name)
+    VALUES (8, 'Eight');

--- a/airflow/contrib/hooks/gcp_spanner_hook.py
+++ b/airflow/contrib/hooks/gcp_spanner_hook.py
@@ -16,12 +16,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from google.longrunning.operations_grpc_pb2 import Operation  # noqa: F401
-from typing import Optional, Callable  # noqa: F401
-
 from google.api_core.exceptions import GoogleAPICallError
 from google.cloud.spanner_v1.client import Client
+from google.cloud.spanner_v1.database import Database
 from google.cloud.spanner_v1.instance import Instance  # noqa: F401
+from google.longrunning.operations_grpc_pb2 import Operation  # noqa: F401
+from typing import Optional, Callable  # noqa: F401
 
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 
@@ -181,3 +181,28 @@ class CloudSpannerHook(GoogleCloudBaseHook):
         except GoogleAPICallError as e:
             self.log.error('An error occurred: %s. Aborting.', e.message)
             raise e
+
+    def execute_dml(self, project_id, instance_id, database_id, queries):
+        # type: (str, str, str, str) -> None
+        """
+        Executes an arbitrary DML query (INSERT, UPDATE, DELETE).
+
+        :param project_id: The ID of the project which owns the instances, tables and data.
+        :type project_id: str
+        :param instance_id: The ID of the instance.
+        :type instance_id: str
+        :param database_id: The ID of the database.
+        :type database_id: str
+        :param queries: The queries to be executed.
+        :type queries: str
+        """
+        client = self.get_client(project_id)
+        instance = client.instance(instance_id)
+        database = Database(database_id, instance)
+        database.run_in_transaction(lambda transaction:
+                                    self._execute_sql_in_transaction(transaction, queries))
+
+    @staticmethod
+    def _execute_sql_in_transaction(transaction, queries):
+        for sql in queries:
+            transaction.execute_update(sql)

--- a/docs/howto/operator.rst
+++ b/docs/howto/operator.rst
@@ -545,6 +545,48 @@ See `Google Cloud Functions API documentation
 Google Cloud Sql Operators
 --------------------------
 
+CloudSpannerInstanceDatabaseQueryOperator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Executes an arbitrary DML query (INSERT, UPDATE, DELETE).
+
+For parameter definition take a look at
+:class:`~airflow.contrib.operators.gcp_spanner_operator.CloudSpannerInstanceDatabaseQueryOperator`.
+
+Arguments
+"""""""""
+
+Some arguments in the example DAG are taken from environment variables:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_spanner.py
+    :language: python
+    :start-after: [START howto_operator_spanner_arguments]
+    :end-before: [END howto_operator_spanner_arguments]
+
+Using the operator
+""""""""""""""""""
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_spanner.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_spanner_query]
+    :end-before: [END howto_operator_spanner_query]
+
+Templating
+""""""""""
+
+.. literalinclude:: ../../airflow/contrib/operators/gcp_spanner_operator.py
+  :language: python
+  :dedent: 4
+  :start-after: [START gcp_spanner_query_template_fields]
+  :end-before: [END gcp_spanner_query_template_fields]
+
+More information
+""""""""""""""""
+
+See Google Cloud Spanner API documentation for `the DML syntax
+<https://cloud.google.com/spanner/docs/dml-syntax>`_.
+
 CloudSpannerInstanceDeployOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -642,9 +642,18 @@ Cloud Spanner
 Cloud Spanner Operators
 """""""""""""""""""""""
 
+- :ref:`CloudSpannerInstanceDatabaseQueryOperator` : executes an arbitrary DML query
+  (INSERT, UPDATE, DELETE).
 - :ref:`CloudSpannerInstanceDeployOperator` : creates a new Cloud Spanner instance or,
   if an instance with the same name exists, updates it.
 - :ref:`CloudSpannerInstanceDeleteOperator` : deletes a Cloud Spanner instance.
+
+.. _CloudSpannerInstanceDatabaseQueryOperator:
+
+CloudSpannerInstanceDatabaseQueryOperator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: airflow.contrib.operators.gcp_spanner_operator.CloudSpannerInstanceDatabaseQueryOperator
 
 .. _CloudSpannerInstanceDeployOperator:
 


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3398) issues and references them in the PR title.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Created an operator to enable executing arbitrary DML query (INSERT, UPDATE, DELETE) in a Transaction in Cloud Spanner:
`CloudSpannerInstanceDatabaseQueryOperator`

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

`test_gcp_spanner_operator.py`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
