### PR TITLE
[AIRFLOW-1381] Specify host temporary directory

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -72,6 +72,9 @@ class DockerOperator(BaseOperator):
     :param mem_limit: Maximum amount of memory the container can use.
         Either a float value, which represents the limit in bytes,
         or a string like ``128m`` or ``1g``.
+    :param host_tmp_dir: Specify the location of the temporary directory on the host which will
+        be mapped to tmp_dir. If not provided defaults to using the standard system temp directory.
+    :type host_tmp_dir: str
     :type mem_limit: float or str
     :param network_mode: Network mode for the container.
     :type network_mode: str
@@ -125,6 +128,7 @@ class DockerOperator(BaseOperator):
             docker_url='unix://var/run/docker.sock',
             environment=None,
             force_pull=False,
+            host_tmp_dir=None,
             mem_limit=None,
             network_mode=None,
             tls_ca_cert=None,
@@ -156,6 +160,7 @@ class DockerOperator(BaseOperator):
         self.docker_url = docker_url
         self.environment = environment or {}
         self.force_pull = force_pull
+        self.host_tmp_dir = host_tmp_dir
         self.image = image
         self.mem_limit = mem_limit
         self.network_mode = network_mode
@@ -205,7 +210,7 @@ class DockerOperator(BaseOperator):
                 if 'status' in output:
                     self.log.info("%s", output['status'])
 
-        with TemporaryDirectory(prefix='airflowtmp') as host_tmp_dir:
+        with TemporaryDirectory(prefix='airflowtmp', dir=self.host_tmp_dir) as host_tmp_dir:
             self.environment['AIRFLOW_TMP_DIR'] = self.tmp_dir
             self.volumes.append('{0}:{1}'.format(host_tmp_dir, self.tmp_dir))
 

--- a/tests/operators/test_docker_operator.py
+++ b/tests/operators/test_docker_operator.py
@@ -57,6 +57,7 @@ class DockerOperatorTestCase(unittest.TestCase):
 
         operator = DockerOperator(api_version='1.19', command='env', environment={'UNIT': 'TEST'},
                                   image='ubuntu:latest', network_mode='bridge', owner='unittest',
+                                  host_tmp_dir='/host/airflow',
                                   task_id='unittest', volumes=['/host/path:/container/path'],
                                   working_dir='/container/path', shm_size=1000)
         operator.execute(None)
@@ -83,6 +84,7 @@ class DockerOperatorTestCase(unittest.TestCase):
                                                           auto_remove=False,
                                                           dns=None,
                                                           dns_search=None)
+        mkdtemp_mock.assert_called_with(dir='/host/airflow', prefix='airflowtmp', suffix='')
         client_mock.images.assert_called_with(name='ubuntu:latest')
         client_mock.logs.assert_called_with(container='some_id', stream=True)
         client_mock.pull.assert_called_with('ubuntu:latest', stream=True)


### PR DESCRIPTION
Allow user to specify temporary directory to use on the host machine;
default settings will cause an error on OS X due to the standard
temporary directory not being shared to Docker.

This is updated PR for https://github.com/apache/incubator-airflow/pull/2418

Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!
JIRA

My PR addresses the following Airflow JIRA issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR" https://issues.apache.org/jira/browse/AIRFLOW-1381

Description

    Here are some details about my PR, including screenshots of any UI changes:

DockerOperator currently uses the standard TemporaryDirectory helper, which calls the standard libary. On OS X the default directory cannot be shared to Docker containers. This PR allows the host temporary directory to be specified by the user.
Tests

    My PR adds the following unit tests OR does not need testing for this extremely good reason:

Added a test into docker_operator to ensure that mkdtemp is called correctly.
Commits

My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "How to write a good git commit message":

    Subject is separated from body by a blank line
    Subject is limited to 50 characters
    Subject does not end with a period
    Subject uses the imperative mood ("add", not "adding")
    Body wraps at 72 characters
    Body explains "what" and "why", not "how"
