### PR TITLE
 [AIRFLOW-3511] Create GCP Memorystore Redis Hook

### DIFF
--- a/airflow/contrib/hooks/gcp_memorystore_hook.py
+++ b/airflow/contrib/hooks/gcp_memorystore_hook.py
@@ -1,0 +1,283 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import time
+
+from airflow import AirflowException
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from apiclient.discovery import HttpError, build
+
+NUM_RETRIES = 5
+SLEEP_TIME_IN_SECONDS = 60
+
+
+class MemorystoreHook(GoogleCloudBaseHook):
+    """
+    Interact with Google Cloud Memorystore. This hook uses the Google Cloud Platform
+    connection.
+
+    This object is not threads safe. If you want to make multiple requests
+    simultaneously, you will need to create a hook per thread.
+    """
+
+    def __init__(
+        self,
+        gcp_conn_id="google_cloud_default",
+        delegate_to=None,
+        version="v1beta1",
+    ):
+        super(MemorystoreHook, self).__init__(gcp_conn_id, delegate_to)
+        self._conn = self.get_conn(version)
+
+    def get_conn(self, version):
+        """
+        Returns a Google Cloud Memorystore service object.
+        """
+        credentials = self._get_credentials()
+        return build("redis", version, credentials=credentials, cache_discovery=False)
+
+    def list_instances(self, project_id, location_id):
+        """
+        Lists all Redis instances owned by the specified project in
+        either the specified location (region) or all locations.
+        location_id can be set to - (wildcard) to query all the regions available
+        to the project.
+
+        .. seealso::
+            For more information, see:
+            https://cloud.google.com/memorystore/docs/redis/reference/rest/v1beta1/projects.locations.instances/list
+
+        :param project_id: The ID of the project in which to query the instances
+        :type project_id: str
+        :param location_id: The name of the location
+        :type location_id: str
+        """
+
+        project_id = project_id if project_id is not None else self.project_id
+
+        self.log.info("Start requesting list of Redis instances")
+        try:
+            resp = (
+                self._conn.projects()
+                .locations()
+                .instances()
+                .list(parent="projects/{}/locations/{}".format(project_id, location_id))
+                .execute()
+            )
+
+            self.log.info("Redis instances retrieved")
+            return resp["instances"]
+        except HttpError as err:
+            raise AirflowException(
+                "BigQuery job failed. Error was: {}".format(err.content)
+            )
+
+    def create_instance(
+        self,
+        project_id,
+        location_id,
+        instance_id,
+        tier="BASIC",
+        memory_size=1,
+        wait_until_finish=False,
+    ):
+        """
+        Method to create a Cloud Memorystore Redis instance based on the specified
+        tier and memory size.
+
+        .. seealso::
+            For more information, see:
+            https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances/create
+
+        :param project_id: The ID of the project in which to create the instance
+        :type project_id: str
+        :param location_id: The name of the location
+        :type location_id: str
+        :param instance_id: The ID of the instance
+        :type instance_id: str
+        :param tier: The service tier of the instance. Defaults to use "BASIC"
+        :type tier: str
+
+        ** Available tiers **:
+        TIER_UNSPECIFIED, BASIC, STANDARD_HA
+
+        :param memory_size: Redis memory size in GiB. Defaults to use 1
+        :type memory_size: int
+        :param wait_until_finish: Waits for the operation to finish. Defaults to False
+        :type wait_until_finish: bool
+        """
+
+        project_id = project_id if project_id is not None else self.project_id
+
+        body = {
+            "name": "projects/{}/locations/{}/instances/{}".format(
+                project_id, location_id, instance_id
+            ),
+            "tier": tier,
+            "memorySizeGb": memory_size,
+        }
+
+        self.log.info("Start creating Redis instance")
+        try:
+            resp = (
+                self._conn.projects()
+                .locations()
+                .instances()
+                .create(
+                    parent="projects/{}/locations/{}".format(project_id, location_id),
+                    instanceId=instance_id,
+                    body=body,
+                )
+                .execute()
+            )
+
+            self.log.info("Redis instance is being created")
+            if wait_until_finish:
+                return self._wait_until_finish(project_id, resp["name"])
+            else:
+                return resp
+        except HttpError as err:
+            raise AirflowException(
+                "BigQuery job failed. Error was: {}".format(err.content)
+            )
+
+    def delete_instance(
+        self, project_id, location_id, instance_id, wait_until_finish=False
+    ):
+        """
+        Method to delete a specified Redis instance. Instance stops serving and data is deleted.
+
+        .. seealso::
+            For more information, see:
+            https://cloud.google.com/memorystore/docs/redis/reference/rest/v1beta1/projects.locations.instances/delete
+
+        :param project_id: The ID of the project in which to delete the instance
+        :type project_id: str
+        :param location_id: The name of the location
+        :type location_id: str
+        :param instance_id: The ID of the instance
+        :type instance_id: str
+        :param wait_until_finish: Waits for the operation to finish. Defaults to False
+        :type wait_until_finish: bool
+        """
+
+        project_id = project_id if project_id is not None else self.project_id
+
+        self.log.info("Start deleting Redis instance")
+        try:
+            resp = (
+                self._conn.projects()
+                .locations()
+                .instances()
+                .delete(
+                    name="projects/{}/locations/{}/instances/{}".format(
+                        project_id, location_id, instance_id
+                    )
+                )
+                .execute()
+            )
+
+            self.log.info("Redis instance is being deleted")
+            if wait_until_finish:
+                return self._wait_until_finish(project_id, resp["name"])
+            else:
+                return resp
+        except HttpError as err:
+            raise AirflowException(
+                "BigQuery job failed. Error was: {}".format(err.content)
+            )
+
+    def get_instance(
+        self, project_id, location_id, instance_id, wait_until_finish=False
+    ):
+        """
+        Method to get the details of a specified Redis instance.
+
+        .. seealso::
+            For more information, see:
+            https://cloud.google.com/memorystore/docs/redis/reference/rest/v1beta1/projects.locations.instances/get
+
+        :param project_id: The ID of the project in which to query the details
+                           of the specified instance
+        :type project_id: str
+        :param location_id: The name of the location
+        :type location_id: str
+        :param instance_id: The ID of the instance
+        :type instance_id: str
+        :param wait_until_finish: Waits for the operation to finish. Defaults to False
+        :type wait_until_finish: bool
+        """
+
+        project_id = project_id if project_id is not None else self.project_id
+
+        self.log.info("Start requesting Redis instance")
+        try:
+            resp = (
+                self._conn.projects()
+                .locations()
+                .instances()
+                .get(
+                    name="projects/{}/locations/{}/instances/{}".format(
+                        project_id, location_id, instance_id
+                    )
+                )
+                .execute()
+            )
+            self.log.info("Redis instance requested")
+            return resp
+        except HttpError as err:
+            raise AirflowException(
+                "BigQuery job failed. Error was: {}".format(err.content)
+            )
+
+    def _wait_until_finish(self, project_id, operation):
+        """
+        Check the status of the operation and return once the operation is done.
+
+        :param project_id: The ID of the project that holds the Redis instance
+        :type project_id: str
+        :param operation: Name of the operation
+        :type operation: str
+        """
+        while True:
+            resp = (
+                self.get_conn()
+                .projects()
+                .locations()
+                .operations()
+                .get(name=operation)
+                .execute(num_retries=NUM_RETRIES)
+            )
+
+            done = resp.get("done")
+            self.log.info(
+                "Updating status for operation name: {}. Done: {}".format(
+                    operation, done
+                )
+            )
+
+            if done:
+                error = resp.get("error")
+                if error:
+                    raise AirflowException(error.get("message"))
+                self.log.info("Operation completed.")
+                return resp
+
+            time.sleep(SLEEP_TIME_IN_SECONDS)

--- a/airflow/contrib/hooks/gcp_memorystore_hook.py
+++ b/airflow/contrib/hooks/gcp_memorystore_hook.py
@@ -44,14 +44,14 @@ class MemorystoreHook(GoogleCloudBaseHook):
         version="v1beta1",
     ):
         super(MemorystoreHook, self).__init__(gcp_conn_id, delegate_to)
-        self._conn = self.get_conn(version)
+        self.version = version
 
-    def get_conn(self, version):
+    def get_conn(self):
         """
         Returns a Google Cloud Memorystore service object.
         """
         credentials = self._get_credentials()
-        return build("redis", version, credentials=credentials, cache_discovery=False)
+        return build("redis", self.version, credentials=credentials, cache_discovery=False)
 
     def list_instances(self, project_id, location_id):
         """
@@ -75,7 +75,7 @@ class MemorystoreHook(GoogleCloudBaseHook):
         self.log.info("Start requesting list of Redis instances")
         try:
             resp = (
-                self._conn.projects()
+                self.get_conn().projects()
                 .locations()
                 .instances()
                 .list(parent="projects/{}/locations/{}".format(project_id, location_id))
@@ -137,7 +137,7 @@ class MemorystoreHook(GoogleCloudBaseHook):
         self.log.info("Start creating Redis instance")
         try:
             resp = (
-                self._conn.projects()
+                self.get_conn().projects()
                 .locations()
                 .instances()
                 .create(
@@ -183,7 +183,7 @@ class MemorystoreHook(GoogleCloudBaseHook):
         self.log.info("Start deleting Redis instance")
         try:
             resp = (
-                self._conn.projects()
+                self.get_conn().projects()
                 .locations()
                 .instances()
                 .delete(
@@ -230,7 +230,7 @@ class MemorystoreHook(GoogleCloudBaseHook):
         self.log.info("Start requesting Redis instance")
         try:
             resp = (
-                self._conn.projects()
+                self.get_conn().projects()
                 .locations()
                 .instances()
                 .get(

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -433,6 +433,7 @@ Community contributed hooks
 .. autoclass:: airflow.contrib.hooks.gcp_container_hook.GKEClusterHook
 .. autoclass:: airflow.contrib.hooks.gcp_dataflow_hook.DataFlowHook
 .. autoclass:: airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook
+.. autoclass:: airflow.contrib.hooks.gcp_memorystore_hook.MemorystoreHook
 .. autoclass:: airflow.contrib.hooks.gcp_mlengine_hook.MLEngineHook
 .. autoclass:: airflow.contrib.hooks.gcp_pubsub_hook.PubSubHook
 .. autoclass:: airflow.contrib.hooks.gcs_hook.GoogleCloudStorageHook

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -927,6 +927,16 @@ DatastoreHook
     :members:
 
 
+Cloud Memorystore
+'''''''''''''''
+
+MemorystoreHook
+"""""""""""""
+
+.. autoclass:: airflow.contrib.hooks.gcp_memorystore_hook.MemorystoreHook
+    :members:
+
+
 Cloud ML Engine
 '''''''''''''''
 

--- a/tests/contrib/hooks/test_gcp_memorystore_hook.py
+++ b/tests/contrib/hooks/test_gcp_memorystore_hook.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+
+from airflow.contrib.hooks.gcp_memorystore_hook import MemorystoreHook
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+PROJECT_ID = "test-project-id"
+INSTANCE_ID = "test-instance_id"
+LOCATION_ID = "us-east1"
+BASE_STRING = "airflow.contrib.hooks.gcp_api_base_hook.{}"
+MEMORYSTORE_STRING = "airflow.contrib.hooks.gcp_memorystore_hook.{}"
+MEMORYSTORE_HOOK_CONN_STRING = MEMORYSTORE_STRING.format("MemorystoreHook.get_conn")
+
+
+def mock_init(self, gcp_conn_id, delegate_to=None, version=None):
+    pass
+
+
+class MemorystoreHookTest(unittest.TestCase):
+    def setUp(self):
+        with mock.patch(
+            BASE_STRING.format("GoogleCloudBaseHook.__init__"), new=mock_init
+        ):
+            self.memorystore_hook = MemorystoreHook()
+
+    @mock.patch(MEMORYSTORE_HOOK_CONN_STRING)
+    def test_list_instances(self, mock_service):
+        self.memorystore_hook.list_instances(PROJECT_ID, LOCATION_ID)
+
+        method = (
+            mock_service.return_value.projects.return_value.locations.return_value
+            .instances.return_value.list
+        )
+        method.assert_called_with(
+            parent="projects/{}/locations/{}".format(PROJECT_ID, LOCATION_ID)
+        )
+        method.return_value.execute.assert_called_with()
+
+    @mock.patch(MEMORYSTORE_HOOK_CONN_STRING)
+    def test_create_instance(self, mock_service):
+        instance_body = {
+            "name": "projects/{}/locations/{}/instances/{}".format(
+                PROJECT_ID, LOCATION_ID, INSTANCE_ID
+            ),
+            "tier": "BASIC",
+            "memorySizeGb": 1,
+        }
+        self.memorystore_hook.create_instance(PROJECT_ID, LOCATION_ID, INSTANCE_ID)
+
+        method = (
+            mock_service.return_value.projects.return_value.locations.return_value
+            .instances.return_value.create
+        )
+        method.assert_called_with(
+            parent="projects/{}/locations/{}".format(PROJECT_ID, LOCATION_ID),
+            instanceId=INSTANCE_ID,
+            body=instance_body,
+        )
+        method.return_value.execute.assert_called_with()
+
+    @mock.patch(MEMORYSTORE_HOOK_CONN_STRING)
+    def test_delete_instance(self, mock_service):
+        self.memorystore_hook.delete_instance(PROJECT_ID, LOCATION_ID, INSTANCE_ID)
+
+        method = (
+            mock_service.return_value.projects.return_value.locations.return_value
+            .instances.return_value.delete
+        )
+        method.assert_called_with(
+            name="projects/{}/locations/{}/instances/{}".format(
+                PROJECT_ID, LOCATION_ID, INSTANCE_ID
+            )
+        )
+        method.return_value.execute.assert_called_with()
+
+    @mock.patch(MEMORYSTORE_HOOK_CONN_STRING)
+    def test_get_instance(self, mock_service):
+        self.memorystore_hook.get_instance(PROJECT_ID, LOCATION_ID, INSTANCE_ID)
+
+        method = (
+            mock_service.return_value.projects.return_value.locations.return_value
+            .instances.return_value.get
+        )
+        method.assert_called_with(
+            name="projects/{}/locations/{}/instances/{}".format(
+                PROJECT_ID, LOCATION_ID, INSTANCE_ID
+            )
+        )
+        method.return_value.execute.assert_called_with()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-3511](https://issues.apache.org/jira/browse/AIRFLOW-3511) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Add a hook to connect to GCP Cloud Memorystore and perform operations such as instance creation, instance deletion, etc.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests.contrib.hooks.test_gcp_memorystore_hook

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
