### PR TITLE
[AIRFLOW-3447] Add 2 options for ts_nodash Macro

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,13 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Modification to `ts_nodash` macro
+`ts_nodash` previously contained TimeZone information alongwith execution date. For Example: `20150101T000000+0000`. This is not user-friendly for file or folder names which was a popular use case for `ts_nodash`. Hence this behavior has been changed and using `ts_nodash` will no longer contain TimeZone information, restoring the pre-1.10 behavior of this macro. And a new macro `ts_nodash_with_tz` has been added which can be used to get a string with execution date and timezone info without dashes. 
+
+Examples:
+  * `ts_nodash`: `20150101T000000`
+  * `ts_nodash_with_tz`: `20150101T000000+0000`
+
 ### New `dag_processor_manager_log_location` config option
 
 The DAG parsing manager log now by default will be log into a file, where its location is

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1869,7 +1869,8 @@ class TaskInstance(Base, LoggingMixin):
             prev_ds_nodash = prev_ds.replace('-', '')
 
         ds_nodash = ds.replace('-', '')
-        ts_nodash = ts.replace('-', '').replace(':', '')
+        ts_nodash = self.execution_date.strftime('%Y%m%dT%H%M%S')
+        ts_nodash_with_tz = ts.replace('-', '').replace(':', '')
         yesterday_ds_nodash = yesterday_ds.replace('-', '')
         tomorrow_ds_nodash = tomorrow_ds.replace('-', '')
 
@@ -1939,6 +1940,7 @@ class TaskInstance(Base, LoggingMixin):
             'ds_nodash': ds_nodash,
             'ts': ts,
             'ts_nodash': ts_nodash,
+            'ts_nodash_with_tz': ts_nodash_with_tz,
             'yesterday_ds': yesterday_ds,
             'yesterday_ds_nodash': yesterday_ds_nodash,
             'tomorrow_ds': tomorrow_ds,

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -269,7 +269,7 @@ Sensors
 .. _macros:
 
 Macros
----------
+------
 Here's a list of variables and macros that can be used in templates
 
 
@@ -284,19 +284,20 @@ Variable                            Description
 ``{{ ds }}``                        the execution date as ``YYYY-MM-DD``
 ``{{ ds_nodash }}``                 the execution date as ``YYYYMMDD``
 ``{{ prev_ds }}``                   the previous execution date as ``YYYY-MM-DD``
-                                    if ``{{ ds }}`` is ``2016-01-08`` and ``schedule_interval`` is ``@weekly``,
+                                    if ``{{ ds }}`` is ``2018-01-08`` and ``schedule_interval`` is ``@weekly``,
                                     ``{{ prev_ds }}`` will be ``2016-01-01``
 ``{{ prev_ds_nodash }}``            the previous execution date as ``YYYYMMDD`` if exists, else ``None`
 ``{{ next_ds }}``                   the next execution date as ``YYYY-MM-DD``
-                                    if ``{{ ds }}`` is ``2016-01-01`` and ``schedule_interval`` is ``@weekly``,
-                                    ``{{ next_ds }}`` will be ``2016-01-08``
+                                    if ``{{ ds }}`` is ``2018-01-01`` and ``schedule_interval`` is ``@weekly``,
+                                    ``{{ next_ds }}`` will be ``2018-01-08``
 ``{{ next_ds_nodash }}``            the next execution date as ``YYYYMMDD`` if exists, else ``None`
 ``{{ yesterday_ds }}``              the day before the execution date as ``YYYY-MM-DD``
 ``{{ yesterday_ds_nodash }}``       the day before the execution date as ``YYYYMMDD``
 ``{{ tomorrow_ds }}``               the day after the execution date as ``YYYY-MM-DD``
 ``{{ tomorrow_ds_nodash }}``        the day after the execution date as ``YYYYMMDD``
-``{{ ts }}``                        same as ``execution_date.isoformat()``
-``{{ ts_nodash }}``                 same as ``ts`` without ``-`` and ``:``
+``{{ ts }}``                        same as ``execution_date.isoformat()``. Example: ``2018-01-01T00:00:00+00:00``
+``{{ ts_nodash }}``                 same as ``ts`` without ``-``, ``:`` and TimeZone info. Example: ``20180101T000000``
+``{{ ts_nodash_with_tz }}``         same as ``ts`` without ``-`` and ``:``. Example: ``20180101T000000+0000``
 ``{{ execution_date }}``            the execution_date, (datetime.datetime)
 ``{{ prev_execution_date }}``       the previous execution date (if available) (datetime.datetime)
 ``{{ next_execution_date }}``       the next execution date (datetime.datetime)

--- a/tests/core.py
+++ b/tests/core.py
@@ -667,7 +667,8 @@ class CoreTest(unittest.TestCase):
         self.assertEquals(context['prev_ds_nodash'], '20141231')
 
         self.assertEquals(context['ts'], '2015-01-01T00:00:00+00:00')
-        self.assertEquals(context['ts_nodash'], '20150101T000000+0000')
+        self.assertEquals(context['ts_nodash'], '20150101T000000')
+        self.assertEquals(context['ts_nodash_with_tz'], '20150101T000000+0000')
 
         self.assertEquals(context['yesterday_ds'], '2014-12-31')
         self.assertEquals(context['yesterday_ds_nodash'], '20141231')


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3447


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Add Option to use `ts_nodash` and `ts_nodash_with_tz` macro so it gives any option to users to use it Filename. Previous users have been using `ts_nodash` for file and folder names.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added tests


### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
Updated the docs

### Code Quality

- [x] Passes `flake8`
