### PR TITLE
[AIRFLOW-3522] Add support for sending Slack attachments

### DIFF
--- a/airflow/contrib/hooks/slack_webhook_hook.py
+++ b/airflow/contrib/hooks/slack_webhook_hook.py
@@ -38,7 +38,8 @@ class SlackWebhookHook(HttpHook):
     :type webhook_token: str
     :param message: The message you want to send on Slack
     :type message: str
-    :param attachments: The attachments you want to send on Slack
+    :param attachments: The attachments to send on Slack. Should be a list of
+                        dictionaries representing Slack attachments.
     :type attachments: list
     :param channel: The channel the message should be posted to
     :type channel: str

--- a/airflow/contrib/hooks/slack_webhook_hook.py
+++ b/airflow/contrib/hooks/slack_webhook_hook.py
@@ -38,6 +38,8 @@ class SlackWebhookHook(HttpHook):
     :type webhook_token: str
     :param message: The message you want to send on Slack
     :type message: str
+    :param attachments: The attachments you want to send on Slack
+    :type attachments: list
     :param channel: The channel the message should be posted to
     :type channel: str
     :param username: The username to post to slack with
@@ -54,6 +56,7 @@ class SlackWebhookHook(HttpHook):
                  http_conn_id=None,
                  webhook_token=None,
                  message="",
+                 attachments=None,
                  channel=None,
                  username=None,
                  icon_emoji=None,
@@ -66,6 +69,7 @@ class SlackWebhookHook(HttpHook):
         self.http_conn_id = http_conn_id
         self.webhook_token = self._get_token(webhook_token, http_conn_id)
         self.message = message
+        self.attachments = attachments
         self.channel = channel
         self.username = username
         self.icon_emoji = icon_emoji
@@ -105,8 +109,9 @@ class SlackWebhookHook(HttpHook):
             cmd['icon_emoji'] = self.icon_emoji
         if self.link_names:
             cmd['link_names'] = 1
+        if self.attachments:
+            cmd['attachments'] = self.attachments
 
-        # there should always be a message to post ;-)
         cmd['text'] = self.message
         return json.dumps(cmd)
 

--- a/airflow/contrib/operators/slack_webhook_operator.py
+++ b/airflow/contrib/operators/slack_webhook_operator.py
@@ -37,6 +37,8 @@ class SlackWebhookOperator(SimpleHttpOperator):
     :type webhook_token: str
     :param message: The message you want to send on Slack
     :type message: str
+    :param attachments: The attachments you want to send on Slack
+    :type attachments: list
     :param channel: The channel the message should be posted to
     :type channel: str
     :param username: The username to post to slack with
@@ -55,6 +57,7 @@ class SlackWebhookOperator(SimpleHttpOperator):
                  http_conn_id=None,
                  webhook_token=None,
                  message="",
+                 attachments="",
                  channel=None,
                  username=None,
                  icon_emoji=None,
@@ -68,6 +71,7 @@ class SlackWebhookOperator(SimpleHttpOperator):
         self.http_conn_id = http_conn_id
         self.webhook_token = webhook_token
         self.message = message
+        self.attachments = attachments
         self.channel = channel
         self.username = username
         self.icon_emoji = icon_emoji
@@ -83,6 +87,7 @@ class SlackWebhookOperator(SimpleHttpOperator):
             self.http_conn_id,
             self.webhook_token,
             self.message,
+            self.attachments,
             self.channel,
             self.username,
             self.icon_emoji,

--- a/airflow/contrib/operators/slack_webhook_operator.py
+++ b/airflow/contrib/operators/slack_webhook_operator.py
@@ -37,7 +37,8 @@ class SlackWebhookOperator(SimpleHttpOperator):
     :type webhook_token: str
     :param message: The message you want to send on Slack
     :type message: str
-    :param attachments: The attachments you want to send on Slack
+    :param attachments: The attachments to send on Slack. Should be a list of
+                        dictionaries representing Slack attachments.
     :type attachments: list
     :param channel: The channel the message should be posted to
     :type channel: str
@@ -57,7 +58,7 @@ class SlackWebhookOperator(SimpleHttpOperator):
                  http_conn_id=None,
                  webhook_token=None,
                  message="",
-                 attachments="",
+                 attachments=None,
                  channel=None,
                  username=None,
                  icon_emoji=None,

--- a/tests/contrib/hooks/test_slack_webhook_hook.py
+++ b/tests/contrib/hooks/test_slack_webhook_hook.py
@@ -32,18 +32,21 @@ class TestSlackWebhookHook(unittest.TestCase):
         'http_conn_id': 'slack-webhook-default',
         'webhook_token': 'manual_token',
         'message': 'Awesome message to put on Slack',
+        'attachments': [{'fallback': 'Required plain-text summary'}],
         'channel': '#general',
         'username': 'SlackMcSlackFace',
         'icon_emoji': ':hankey:',
         'link_names': True,
         'proxy': 'https://my-horrible-proxy.proxyist.com:8080'
     }
-    expected_message_dict = {'channel': _config['channel'],
-                             'username': _config['username'],
-                             'icon_emoji': _config['icon_emoji'],
-                             'link_names': 1,
-                             'text': _config['message']
-                             }
+    expected_message_dict = {
+        'channel': _config['channel'],
+        'username': _config['username'],
+        'icon_emoji': _config['icon_emoji'],
+        'link_names': 1,
+        'attachments': _config['attachments'],
+        'text': _config['message']
+    }
     expected_message = json.dumps(expected_message_dict)
 
     def setUp(self):

--- a/tests/contrib/operators/test_slack_webhook_operator.py
+++ b/tests/contrib/operators/test_slack_webhook_operator.py
@@ -33,6 +33,7 @@ class TestSlackWebhookOperator(unittest.TestCase):
         'http_conn_id': 'slack-webhook-default',
         'webhook_token': 'manual_token',
         'message': 'your message here',
+        'attachments': [{'fallback': 'Required plain-text summary'}],
         'channel': '#general',
         'username': 'SlackMcSlackFace',
         'icon_emoji': ':hankey',
@@ -59,6 +60,7 @@ class TestSlackWebhookOperator(unittest.TestCase):
         self.assertEqual(self._config['http_conn_id'], operator.http_conn_id)
         self.assertEqual(self._config['webhook_token'], operator.webhook_token)
         self.assertEqual(self._config['message'], operator.message)
+        self.assertEqual(self._config['attachments'], operator.attachments)
         self.assertEqual(self._config['channel'], operator.channel)
         self.assertEqual(self._config['username'], operator.username)
         self.assertEqual(self._config['icon_emoji'], operator.icon_emoji)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/AIRFLOW-3522) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3522
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Adding support for sending Slack attachments with messages via the SlackWebhookOperator. This will allow customized messages to be sent with interactive content. 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - Modified test_slack_webhook_hook.py
  - Modified test_slack_webhook_operator.py

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
