### PR TITLE
[AIRFLOW-XXX] Fix inconsistent comment in example_python_operator.py

### DIFF
--- a/airflow/example_dags/example_python_operator.py
+++ b/airflow/example_dags/example_python_operator.py
@@ -61,7 +61,7 @@ def my_sleeping_function(random_base):
     time.sleep(random_base)
 
 
-# Generate 10 sleeping tasks, sleeping from 0 to 4 seconds respectively
+# Generate 5 sleeping tasks, sleeping from 0.0 to 0.4 seconds respectively
 for i in range(5):
     task = PythonOperator(
         task_id='sleep_for_' + str(i),


### PR DESCRIPTION
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The comment and actual code are inconsistent:
- **actual code**: the DAG is generating 5 tasks in which the processes will sleep for 0.0 to 0.4 seconds separately.
- **comment**: the comment is out-dated and claiming that 10 tasks will be created and they will sleep 0-4 seconds separately.

This is also affecting documentation https://airflow.apache.org/howto/operator.html#passing-in-arguments (the doc is referring the sample DAG code directly from https://github.com/apache/incubator-airflow/blob/master/docs/howto/operator.rst#pythonoperator)

<img width="1061" alt="screen shot 2018-12-18 at 10 06 12 pm" src="https://user-images.githubusercontent.com/11539188/50159236-32049800-0311-11e9-8c64-a6cb579181de.png">
