### PR TITLE
[AIRFLOW-3172] Fix error creation dag link

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -111,8 +111,7 @@ def dag_link(v, c, m, p):
     dag_id = bleach.clean(m.dag_id)
     url = url_for(
         'airflow.graph',
-        dag_id=dag_id,
-        execution_date=m.execution_date)
+        dag_id=dag_id)
     return Markup(
         '<a href="{}">{}</a>'.format(url, dag_id))
 


### PR DESCRIPTION
The "dag_link" is used in the views for DagModel and DagRun.
DagModel does not have attribute execute_date, which causes an error 500.

I think it's just a typo GH-2801

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3172

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Now, on page `/admin/dagrun/`, the link in column `Dag Id` without GET param `execute_date`

### Tests

- [x] Does not need testing for this extremely good reason:

DagModelView use ModelView without overrides

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
