### PR TITLE
[AIRFLOW-3537] Add task_definition as templated parameter in AWS ECS Operator

### DIFF
--- a/airflow/contrib/operators/ecs_operator.py
+++ b/airflow/contrib/operators/ecs_operator.py
@@ -30,7 +30,7 @@ class ECSOperator(BaseOperator):
     """
     Execute a task on AWS EC2 Container Service
 
-    :param task_definition: the task definition name on EC2 Container Service
+    :param task_definition: the task definition name on EC2 Container Service (templated)
     :type task_definition: str
     :param cluster: the cluster name on EC2 Container Service
     :type cluster: str
@@ -60,7 +60,7 @@ class ECSOperator(BaseOperator):
     ui_color = '#f0ede4'
     client = None
     arn = None
-    template_fields = ('overrides',)
+    template_fields = ('task_definition', 'overrides',)
 
     @apply_defaults
     def __init__(self, task_definition, cluster, overrides,

--- a/tests/contrib/operators/test_ecs_operator.py
+++ b/tests/contrib/operators/test_ecs_operator.py
@@ -95,7 +95,7 @@ class TestECSOperator(unittest.TestCase):
         self.aws_hook_mock.assert_called_once_with(aws_conn_id=None)
 
     def test_template_fields_overrides(self):
-        self.assertEqual(self.ecs.template_fields, ('overrides',))
+        self.assertEqual(self.ecs.template_fields, ('task_definition', 'overrides',))
 
     @mock.patch.object(ECSOperator, '_wait_for_task_ended')
     @mock.patch.object(ECSOperator, '_check_success_task')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3537
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When using the AWS ECS Operator, I'd like to pass the task_definition as a template. Because I decide the task_definition dynamically by another operator, and get the task_definition from XCom.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Updated existing test case to check for new field.


### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
