### PR TITLE
[AIRFLOW-3506] use match_phrase to query log_id in elasticsearch

### DIFF
--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -135,7 +135,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
 
         # Offset is the unique key for sorting logs given log_id.
         s = Search(using=self.client) \
-            .query('match', log_id=log_id) \
+            .query('match_phrase', log_id=log_id) \
             .sort('offset')
 
         s = s.filter('range', offset={'gt': offset})

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -39,8 +39,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
     DAG_ID = 'dag_for_testing_file_task_handler'
     TASK_ID = 'task_for_testing_file_log_handler'
     EXECUTION_DATE = datetime(2016, 1, 1)
-    LOG_ID = 'dag_for_testing_file_task_handler-task_for_testing' \
-             '_file_log_handler-2016-01-01T00:00:00+00:00-1'
+    LOG_ID = '{dag_id}-{task_id}-2016-01-01T00:00:00+00:00-1'.format(dag_id=DAG_ID, task_id=TASK_ID)
 
     @elasticmock
     def setUp(self):
@@ -90,6 +89,31 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.assertEqual(1, len(logs))
         self.assertEqual(len(logs), len(metadatas))
         self.assertEqual(self.test_message, logs[0])
+        self.assertFalse(metadatas[0]['end_of_log'])
+        self.assertEqual(1, metadatas[0]['offset'])
+        self.assertTrue(timezone.parse(metadatas[0]['last_log_timestamp']) > ts)
+
+    def test_read_with_match_phrase_query(self):
+        simiar_log_id = '{task_id}-{dag_id}-2016-01-01T00:00:00+00:00-1'.format(
+            dag_id=TestElasticsearchTaskHandler.DAG_ID,
+            task_id=TestElasticsearchTaskHandler.TASK_ID)
+        another_test_message = 'another message'
+
+        another_body = {'message': another_test_message, 'log_id': simiar_log_id, 'offset': 1}
+        self.es.index(index=self.index_name, doc_type=self.doc_type,
+                      body=another_body, id=1)
+
+        ts = pendulum.now()
+        logs, metadatas = self.es_task_handler.read(self.ti,
+                                                    1,
+                                                    {'offset': 0,
+                                                     'last_log_timestamp': str(ts),
+                                                     'end_of_log': False})
+        self.assertEqual(1, len(logs))
+        self.assertEqual(len(logs), len(metadatas))
+        self.assertEqual(self.test_message, logs[0])
+        self.assertNotEqual(another_test_message, logs[0])
+
         self.assertFalse(metadatas[0]['end_of_log'])
         self.assertEqual(1, metadatas[0]['offset'])
         self.assertTrue(timezone.parse(metadatas[0]['last_log_timestamp']) > ts)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3506
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We have noticed that the elasticsearch_logging_backend use match to query the log_id from elasticsearch, which ends up getting more results from elasticsearch. It should use match_phrase to query the log_id as a phrase since log_id is a phrase.

![image](https://user-images.githubusercontent.com/8662365/50174807-fc7b9280-02af-11e9-9033-d0fe91aceba4.png)


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
