### PR TITLE
[AIRFLOW-2082] Resolve a bug in adding password_auth to API as auth method

### DIFF
--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -48,6 +48,9 @@ log = LoggingMixin().log
 PY3 = version_info[0] == 3
 
 
+client_auth = None
+
+
 class AuthenticationError(Exception):
     pass
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-2082) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2082
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
  - The current docs indicate that password authentication can be added to the experimental REST API by adding `auth_backend = airflow.contrib.auth.backends.password_auth` to the api config. This fails with `AttributeError: module 'airflow.contrib.auth.backends.password_auth' has no attribute 'client_auth'`. This PR follows the suggestion in the JIRA ticket to simply add `client_auth = None`

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

If there are existing tests around config, would be nice to add this in there. I took a quick look and didn't see any. 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
