### PR TITLE
[AIRFLOW-3546] Fix typos in jobs.py logs

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1213,7 +1213,7 @@ class SchedulerJob(BaseJob):
         task_instance_str = "\n\t".join(
             ["{}".format(x) for x in executable_tis])
         self.log.info(
-            "Setting the follow tasks to queued state:\n\t%s", task_instance_str)
+            "Setting the following tasks to queued state:\n\t%s", task_instance_str)
         # so these dont expire on commit
         for ti in executable_tis:
             copy_dag_id = ti.dag_id
@@ -1408,7 +1408,7 @@ class SchedulerJob(BaseJob):
                 ["{}".format(x) for x in tis_to_set_to_scheduled])
 
             session.commit()
-            self.log.info("Set the follow tasks to scheduled state:\n\t{}"
+            self.log.info("Set the following tasks to scheduled state:\n\t{}"
                           .format(task_instance_str))
 
     def _process_dags(self, dagbag, dags, tis_out):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3546) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3546
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x ] Here are some details about my PR, including screenshots of any UI changes:
Scheduler logs the following:
```
...INFO - Setting the follow tasks to queued state:
```
this PR changes `follow` to `following`

### Tests

- [ x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This is a trivial change which doesn't need tests

### Commits

- [x ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x ] Passes `flake8`
