### PR TITLE
[AIRFLOW-3547] Fixed Jinja templating in SparkSubmitOperator

### DIFF
--- a/airflow/contrib/operators/spark_submit_operator.py
+++ b/airflow/contrib/operators/spark_submit_operator.py
@@ -84,8 +84,9 @@ class SparkSubmitOperator(BaseOperator):
                          Some distros may use spark2-submit.
     :type spark_binary: string
     """
-    template_fields = ('_application', '_conf', '_files', '_py_files', '_jars', '_driver_classpath', '_packages',
-                       '_exclude_packages', '_keytab', '_principal', '_name', '_application_args', '_env_vars')
+    template_fields = ('_application', '_conf', '_files', '_py_files', '_jars', '_driver_classpath',
+                       '_packages', '_exclude_packages', '_keytab', '_principal', '_name',
+                       '_application_args', '_env_vars')
     ui_color = WEB_COLORS['LIGHTORANGE']
 
     @apply_defaults

--- a/airflow/contrib/operators/spark_submit_operator.py
+++ b/airflow/contrib/operators/spark_submit_operator.py
@@ -29,31 +29,30 @@ class SparkSubmitOperator(BaseOperator):
     It requires that the "spark-submit" binary is in the PATH or the spark-home is set
     in the extra on the connection.
 
-    :param application: The application that submitted as a job, either jar or
-        py file. (templated)
+    :param application: The application that submitted as a job, either jar or py file. (templated)
     :type application: str
-    :param conf: Arbitrary Spark configuration properties
+    :param conf: Arbitrary Spark configuration properties (templated)
     :type conf: dict
     :param conn_id: The connection id as configured in Airflow administration. When an
                     invalid connection_id is supplied, it will default to yarn.
     :type conn_id: str
     :param files: Upload additional files to the executor running the job, separated by a
                   comma. Files will be placed in the working directory of each executor.
-                  For example, serialized objects.
+                  For example, serialized objects. (templated)
     :type files: str
-    :param py_files: Additional python files used by the job, can be .zip, .egg or .py.
+    :param py_files: Additional python files used by the job, can be .zip, .egg or .py. (templated)
     :type py_files: str
-    :param jars: Submit additional jars to upload and place them in executor classpath.
-    :param driver_classpath: Additional, driver-specific, classpath settings.
-    :type driver_classpath: str
+    :param jars: Submit additional jars to upload and place them in executor classpath. (templated)
     :type jars: str
+    :param driver_classpath: Additional, driver-specific, classpath settings. (templated)
+    :type driver_classpath: str
     :param java_class: the main class of the Java application
     :type java_class: str
     :param packages: Comma-separated list of maven coordinates of jars to include on the
                      driver and executor classpaths. (templated)
     :type packages: str
     :param exclude_packages: Comma-separated list of maven coordinates of jars to exclude
-                             while resolving the dependencies provided in 'packages'
+                             while resolving the dependencies provided in 'packages' (templated)
     :type exclude_packages: str
     :param repositories: Comma-separated list of additional remote repositories to search
                          for the maven coordinates given with 'packages'
@@ -61,25 +60,23 @@ class SparkSubmitOperator(BaseOperator):
     :param total_executor_cores: (Standalone & Mesos only) Total cores for all executors
                                  (Default: all the available cores on the worker)
     :type total_executor_cores: int
-    :param executor_cores: (Standalone & YARN only) Number of cores per executor
-                           (Default: 2)
+    :param executor_cores: (Standalone & YARN only) Number of cores per executor (Default: 2)
     :type executor_cores: int
     :param executor_memory: Memory per executor (e.g. 1000M, 2G) (Default: 1G)
     :type executor_memory: str
     :param driver_memory: Memory allocated to the driver (e.g. 1000M, 2G) (Default: 1G)
     :type driver_memory: str
-    :param keytab: Full path to the file that contains the keytab
+    :param keytab: Full path to the file that contains the keytab (templated)
     :type keytab: str
-    :param principal: The name of the kerberos principal used for keytab
+    :param principal: The name of the kerberos principal used for keytab (templated)
     :type principal: str
     :param name: Name of the job (default airflow-spark). (templated)
     :type name: str
     :param num_executors: Number of executors to launch
     :type num_executors: int
-    :param application_args: Arguments for the application being submitted
+    :param application_args: Arguments for the application being submitted (templated)
     :type application_args: list
-    :param env_vars: Environment variables for spark-submit. It
-                     supports yarn and k8s mode too.
+    :param env_vars: Environment variables for spark-submit. It supports yarn and k8s mode too. (templated)
     :type env_vars: dict
     :param verbose: Whether to pass the verbose flag to spark-submit process for debugging
     :type verbose: bool
@@ -87,7 +84,8 @@ class SparkSubmitOperator(BaseOperator):
                          Some distros may use spark2-submit.
     :type spark_binary: string
     """
-    template_fields = ('_name', '_application_args', '_packages')
+    template_fields = ('_application', '_conf', '_files', '_py_files', '_jars', '_driver_classpath', '_packages',
+                       '_exclude_packages', '_keytab', '_principal', '_name', '_application_args', '_env_vars')
     ui_color = WEB_COLORS['LIGHTORANGE']
 
     @apply_defaults


### PR DESCRIPTION
### Jira

- [X] My PR addresses [AIRFLOW-3547](https://jira.apache.org/jira/browse/AIRFLOW-3547)

### Description

- This is a minor change to allow Jinja templating in parameters where it makes sense for SparkSubmitOperator.

### Tests

- Probably not needed as it simply adds templating support to a few more parameters. 

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X] Passes `flake8`
