### PR TITLE
[AIRFLOW-3554] Remove contrib folder from code cov omit list

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -18,7 +18,6 @@
 
 [report]
 omit =
-    *contrib*
     tests/*
     scripts/*
     dev/*


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3554
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently the `contrib` folder is not being processed by codecov.
That means that contributors won't see a code coverage of their implemented code in this folder.
To generally improve code/test coverage for this project I would recommend to enable coverage for the `contrib` folder, too.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
