### PR TITLE
[AIRFLOW-3870] Update log level and return value

### DIFF
--- a/airflow/contrib/operators/sftp_operator.py
+++ b/airflow/contrib/operators/sftp_operator.py
@@ -134,7 +134,7 @@ class SFTPOperator(BaseOperator):
                                 raise
                     file_msg = "from {0} to {1}".format(self.remote_filepath,
                                                         self.local_filepath)
-                    self.log.debug("Starting to transfer %s", file_msg)
+                    self.log.info("Starting to transfer %s", file_msg)
                     sftp_client.get(self.remote_filepath, self.local_filepath)
                 else:
                     remote_folder = os.path.dirname(self.remote_filepath)
@@ -145,7 +145,7 @@ class SFTPOperator(BaseOperator):
                         )
                     file_msg = "from {0} to {1}".format(self.local_filepath,
                                                         self.remote_filepath)
-                    self.log.debug("Starting to transfer file %s", file_msg)
+                    self.log.info("Starting to transfer file %s", file_msg)
                     sftp_client.put(self.local_filepath,
                                     self.remote_filepath,
                                     confirm=self.confirm)
@@ -154,7 +154,7 @@ class SFTPOperator(BaseOperator):
             raise AirflowException("Error while transferring {0}, error: {1}"
                                    .format(file_msg, str(e)))
 
-        return None
+        return self.local_filepath
 
 
 def _make_intermediate_dirs(sftp_client, remote_directory):


### PR DESCRIPTION
### Jira

https://issues.apache.org/jira/browse/AIRFLOW-3870

### Description

After using this operator, it's very useful to see which file is getting downloaded. Changed the debug logging to info. 

Also, return the filepath into xcom so that downstream tasks can use it.
