### PR TITLE
[AIRFLOW-1191] Simplify override of spark submit command

### DIFF
--- a/airflow/contrib/hooks/spark_submit_hook.py
+++ b/airflow/contrib/hooks/spark_submit_hook.py
@@ -85,6 +85,9 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     :type env_vars: dict
     :param verbose: Whether to pass the verbose flag to spark-submit process for debugging
     :type verbose: bool
+    :param spark_binary: The command to use for spark submit.
+                         Some distros may use spark2-submit.
+    :type spark_binary: string
     """
     def __init__(self,
                  conf=None,
@@ -107,7 +110,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                  num_executors=None,
                  application_args=None,
                  env_vars=None,
-                 verbose=False):
+                 verbose=False,
+                 spark_binary="spark-submit"):
         self._conf = conf
         self._conn_id = conn_id
         self._files = files
@@ -132,6 +136,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         self._submit_sp = None
         self._yarn_application_id = None
         self._kubernetes_driver_pod = None
+        self._spark_binary = spark_binary
 
         self._connection = self._resolve_connection()
         self._is_yarn = 'yarn' in self._connection['master']
@@ -161,7 +166,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                      'queue': None,
                      'deploy_mode': None,
                      'spark_home': None,
-                     'spark_binary': 'spark-submit',
+                     'spark_binary': self._spark_binary,
                      'namespace': 'default'}
 
         try:
@@ -178,7 +183,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             conn_data['queue'] = extra.get('queue', None)
             conn_data['deploy_mode'] = extra.get('deploy-mode', None)
             conn_data['spark_home'] = extra.get('spark-home', None)
-            conn_data['spark_binary'] = extra.get('spark-binary', 'spark-submit')
+            conn_data['spark_binary'] = extra.get('spark-binary', "spark-submit")
             conn_data['namespace'] = extra.get('namespace', 'default')
         except AirflowException:
             self.log.debug(

--- a/airflow/contrib/operators/spark_submit_operator.py
+++ b/airflow/contrib/operators/spark_submit_operator.py
@@ -83,6 +83,9 @@ class SparkSubmitOperator(BaseOperator):
     :type env_vars: dict
     :param verbose: Whether to pass the verbose flag to spark-submit process for debugging
     :type verbose: bool
+    :param spark_binary: The command to use for spark submit.
+                         Some distros may use spark2-submit.
+    :type spark_binary: string
     """
     template_fields = ('_name', '_application_args', '_packages')
     ui_color = WEB_COLORS['LIGHTORANGE']
@@ -111,6 +114,7 @@ class SparkSubmitOperator(BaseOperator):
                  application_args=None,
                  env_vars=None,
                  verbose=False,
+                 spark_binary="spark-submit",
                  *args,
                  **kwargs):
         super(SparkSubmitOperator, self).__init__(*args, **kwargs)
@@ -135,6 +139,7 @@ class SparkSubmitOperator(BaseOperator):
         self._application_args = application_args
         self._env_vars = env_vars
         self._verbose = verbose
+        self._spark_binary = spark_binary
         self._hook = None
         self._conn_id = conn_id
 
@@ -163,7 +168,8 @@ class SparkSubmitOperator(BaseOperator):
             num_executors=self._num_executors,
             application_args=self._application_args,
             env_vars=self._env_vars,
-            verbose=self._verbose
+            verbose=self._verbose,
+            spark_binary=self._spark_binary
         )
         self._hook.submit(self._application)
 

--- a/tests/contrib/operators/test_spark_submit_operator.py
+++ b/tests/contrib/operators/test_spark_submit_operator.py
@@ -28,6 +28,7 @@ from airflow.utils import timezone
 
 from datetime import timedelta
 
+
 DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 
 
@@ -73,15 +74,17 @@ class TestSparkSubmitOperator(unittest.TestCase):
         self.dag = DAG('test_dag_id', default_args=args)
 
     def test_execute(self):
+
         # Given / When
         conn_id = 'spark_default'
         operator = SparkSubmitOperator(
             task_id='spark_submit_job',
+            spark_binary="sparky",
             dag=self.dag,
             **self._config
         )
 
-        # Then
+        # Then expected results
         expected_dict = {
             'conf': {
                 'parquet.compression': 'SNAPPY'
@@ -110,7 +113,8 @@ class TestSparkSubmitOperator(unittest.TestCase):
                 '--start', '{{ macros.ds_add(ds, -1)}}',
                 '--end', '{{ ds }}',
                 '--with-spaces', 'args should keep embdedded spaces',
-            ]
+            ],
+            "spark_binary": "sparky"
         }
 
         self.assertEqual(conn_id, operator._conn_id)
@@ -135,6 +139,7 @@ class TestSparkSubmitOperator(unittest.TestCase):
         self.assertEqual(expected_dict['java_class'], operator._java_class)
         self.assertEqual(expected_dict['driver_memory'], operator._driver_memory)
         self.assertEqual(expected_dict['application_args'], operator._application_args)
+        self.assertEqual(expected_dict['spark_binary'], operator._spark_binary)
 
     def test_render_template(self):
         # Given


### PR DESCRIPTION
This will better support distros which ship spark 1 & 2 ( and eventually 3)

Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-1191  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:

Adds a spark_binary param to the spark submit operator to allow folks to more easily configure the operator to use a different binary, as is needed for some distros of the Hadoop ecosystem which ship multiple version of Spark.

### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Updates the existing test_spark_submit_operator to check for override

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ X ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
docstring update

### Code Quality

- [ ] Passes `flake8`
