### PR TITLE
[AIRFLOW-3560] Add DayOfWeek Sensor

### DIFF
--- a/airflow/contrib/sensors/weekday_sensor.py
+++ b/airflow/contrib/sensors/weekday_sensor.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import calendar
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
+from airflow.utils import timezone
+from airflow.utils.decorators import apply_defaults
+
+
+class DayOfWeekSensor(BaseSensorOperator):
+    """
+    Waits until the first specified day of the week. For example, if the execution
+    day of the task is '2018-12-22' (Saturday) and you pass '5', the task will wait
+    until next Friday (Week Day: 5)
+
+    :param week_day_number: Day of the week as an integer, where Monday is 1 and
+        Sunday is 7 (ISO Week Numbering)
+    :type week_day_number: int
+    :param use_task_execution_day: If ``True``, uses task's execution day to compare
+        with week_day_number. Execution Date is Useful for backfilling.
+        If ``False``, uses system's day of the week. Useful when you
+        don't want to run anything on weekdays on the system.
+    :type use_task_execution_day: bool
+    """
+
+    @apply_defaults
+    def __init__(self, week_day_number,
+                 use_task_execution_day=False,
+                 *args, **kwargs):
+        super(DayOfWeekSensor, self).__init__(*args, **kwargs)
+        self.week_day_number = week_day_number
+        self.use_task_execution_day = use_task_execution_day
+
+    def poke(self, context):
+        if self.week_day_number > 7:
+            raise ValueError(
+                'Invalid value ({}) for week_day_number! '
+                'Valid value: 1 <= week_day_number <= 7'.format(self.week_day_number))
+        self.log.info('Poking until weekday is %s, Today is %s',
+                      calendar.day_name[self.week_day_number - 1],
+                      calendar.day_name[timezone.utcnow().isoweekday() - 1])
+        if self.use_task_execution_day:
+            return context['execution_date'].isoweekday() == self.week_day_number
+        else:
+            return timezone.utcnow().isoweekday() == self.week_day_number
+
+
+class WeekEndSensor(BaseSensorOperator):
+    """
+    Waits until this weekend. For example, if today is Monday, the task will wait
+    until this weekend (Saturday or Sunday)
+
+    :param use_task_execution_day: If ``True``, uses task's execution day to compare.
+        Useful for backfilling.
+        If ``False``, uses system's day of the week. Useful when you
+        don't want to run anything on weekdays on the system.
+    :type use_task_execution_day: bool
+    """
+
+    @apply_defaults
+    def __init__(self, use_task_execution_day=False, *args, **kwargs):
+        super(WeekEndSensor, self).__init__(*args, **kwargs)
+        self.use_task_execution_day = use_task_execution_day
+
+    def poke(self, context):
+        self.log.info('Poking until weekend. Today is %s',
+                      calendar.day_name[timezone.utcnow().isoweekday() - 1])
+        if self.use_task_execution_day:
+            return context['execution_date'].isoweekday() > 5
+        else:
+            return timezone.utcnow().isoweekday() > 5

--- a/airflow/contrib/sensors/weekday_sensor.py
+++ b/airflow/contrib/sensors/weekday_sensor.py
@@ -30,9 +30,9 @@ class DayOfWeekSensor(BaseSensorOperator):
     until next Friday.
 
     :param week_day: Day of the week (full name). Example: "MONDAY"
-    :type week_day_number: str
+    :type week_day: str
     :param use_task_execution_day: If ``True``, uses task's execution day to compare
-        with week_day_number. Execution Date is Useful for backfilling.
+        with week_day. Execution Date is Useful for backfilling.
         If ``False``, uses system's day of the week. Useful when you
         don't want to run anything on weekdays on the system.
     :type use_task_execution_day: bool

--- a/airflow/contrib/sensors/weekday_sensor.py
+++ b/airflow/contrib/sensors/weekday_sensor.py
@@ -17,10 +17,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import six
+from airflow.contrib.utils.weekday import WeekDay
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils import timezone
 from airflow.utils.decorators import apply_defaults
-from airflow.contrib.utils.weekday import WeekDay
 
 
 class DayOfWeekSensor(BaseSensorOperator):
@@ -29,8 +30,41 @@ class DayOfWeekSensor(BaseSensorOperator):
     day of the task is '2018-12-22' (Saturday) and you pass 'FRIDAY', the task will wait
     until next Friday.
 
-    :param week_day: Day of the week (full name). Example: "MONDAY"
-    :type week_day: str
+    **Example** (with single day): ::
+
+        weekend_check = DayOfWeekSensor(
+            task_id='weekend_check',
+            week_day='Saturday',
+            use_task_execution_day=True,
+            dag=dag)
+
+    **Example** (with multiple day using set): ::
+
+        weekend_check = DayOfWeekSensor(
+            task_id='weekend_check',
+            week_day={'Saturday', 'Sunday'},
+            use_task_execution_day=True,
+            dag=dag)
+
+    **Example** (with :class:`~airflow.contrib.utils.weekday.WeekDay` enum): ::
+
+        # import WeekDay Enum
+        from airflow.contrib.utils.weekday import WeekDay
+
+        weekend_check = DayOfWeekSensor(
+            task_id='weekend_check',
+            week_day={WeekDay.Saturday, WeekDay.Sunday},
+            use_task_execution_day=True,
+            dag=dag)
+
+    :param week_day: Day of the week to check (full name). Optionally, a set
+        of days can also be provided using a set.
+        Example values:
+            * ``"MONDAY"``,
+            * ``{"Saturday", "Sunday"}``
+            * ``{WeekDay.TUESDAY}``
+            * ``{WeekDay.Saturday, WeekDay.Sunday}``
+    :type week_day: set or str or WeekDay
     :param use_task_execution_day: If ``True``, uses task's execution day to compare
         with week_day. Execution Date is Useful for backfilling.
         If ``False``, uses system's day of the week. Useful when you
@@ -45,39 +79,25 @@ class DayOfWeekSensor(BaseSensorOperator):
         super(DayOfWeekSensor, self).__init__(*args, **kwargs)
         self.week_day = week_day
         self.use_task_execution_day = use_task_execution_day
-        self._week_day_num = WeekDay.get_weekday_number(week_day_str=self.week_day)
+        if isinstance(self.week_day, six.string_types):
+            self._week_day_num = {WeekDay.get_weekday_number(week_day_str=self.week_day)}
+        elif isinstance(self.week_day, WeekDay):
+            self._week_day_num = {self.week_day}
+        elif isinstance(self.week_day, set):
+            if all(isinstance(day, six.string_types) for day in self.week_day):
+                self._week_day_num = {WeekDay.get_weekday_number(day) for day in week_day}
+            elif all(isinstance(day, WeekDay) for day in self.week_day):
+                self._week_day_num = self.week_day
+        else:
+            raise TypeError(
+                'Unsupported Type for week_day parameter: {}. It should be one of str'
+                ', set or Weekday enum type'.format(type(week_day)))
 
     def poke(self, context):
-        self.log.info('Poking until weekday is %s, Today is %s',
-                      WeekDay(self._week_day_num).name,
+        self.log.info('Poking until weekday is in %s, Today is %s',
+                      self.week_day,
                       WeekDay(timezone.utcnow().isoweekday()).name)
         if self.use_task_execution_day:
-            return context['execution_date'].isoweekday() == self._week_day_num
+            return context['execution_date'].isoweekday() in self._week_day_num
         else:
-            return timezone.utcnow().isoweekday() == self._week_day_num
-
-
-class WeekEndSensor(BaseSensorOperator):
-    """
-    Waits until this weekend. For example, if today is Monday, the task will wait
-    until this weekend (Saturday or Sunday)
-
-    :param use_task_execution_day: If ``True``, uses task's execution day to compare.
-        Useful for backfilling.
-        If ``False``, uses system's day of the week. Useful when you
-        don't want to run anything on weekdays on the system.
-    :type use_task_execution_day: bool
-    """
-
-    @apply_defaults
-    def __init__(self, use_task_execution_day=False, *args, **kwargs):
-        super(WeekEndSensor, self).__init__(*args, **kwargs)
-        self.use_task_execution_day = use_task_execution_day
-
-    def poke(self, context):
-        self.log.info('Poking until weekend. Today is %s',
-                      WeekDay(timezone.utcnow().isoweekday()).name)
-        if self.use_task_execution_day:
-            return context['execution_date'].isoweekday() > 5
-        else:
-            return timezone.utcnow().isoweekday() > 5
+            return timezone.utcnow().isoweekday() in self._week_day_num

--- a/airflow/contrib/sensors/weekday_sensor.py
+++ b/airflow/contrib/sensors/weekday_sensor.py
@@ -17,21 +17,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import calendar
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils import timezone
 from airflow.utils.decorators import apply_defaults
+from airflow.contrib.utils.weekday import WeekDay
 
 
 class DayOfWeekSensor(BaseSensorOperator):
     """
     Waits until the first specified day of the week. For example, if the execution
-    day of the task is '2018-12-22' (Saturday) and you pass '5', the task will wait
-    until next Friday (Week Day: 5)
+    day of the task is '2018-12-22' (Saturday) and you pass 'FRIDAY', the task will wait
+    until next Friday.
 
-    :param week_day_number: Day of the week as an integer, where Monday is 1 and
-        Sunday is 7 (ISO Week Numbering)
-    :type week_day_number: int
+    :param week_day: Day of the week (full name). Example: "MONDAY"
+    :type week_day_number: str
     :param use_task_execution_day: If ``True``, uses task's execution day to compare
         with week_day_number. Execution Date is Useful for backfilling.
         If ``False``, uses system's day of the week. Useful when you
@@ -40,25 +39,22 @@ class DayOfWeekSensor(BaseSensorOperator):
     """
 
     @apply_defaults
-    def __init__(self, week_day_number,
+    def __init__(self, week_day,
                  use_task_execution_day=False,
                  *args, **kwargs):
         super(DayOfWeekSensor, self).__init__(*args, **kwargs)
-        self.week_day_number = week_day_number
+        self.week_day = week_day
         self.use_task_execution_day = use_task_execution_day
+        self._week_day_num = WeekDay.get_weekday_number(week_day_str=self.week_day)
 
     def poke(self, context):
-        if self.week_day_number > 7:
-            raise ValueError(
-                'Invalid value ({}) for week_day_number! '
-                'Valid value: 1 <= week_day_number <= 7'.format(self.week_day_number))
         self.log.info('Poking until weekday is %s, Today is %s',
-                      calendar.day_name[self.week_day_number - 1],
-                      calendar.day_name[timezone.utcnow().isoweekday() - 1])
+                      WeekDay(self._week_day_num).name,
+                      WeekDay(timezone.utcnow().isoweekday()).name)
         if self.use_task_execution_day:
-            return context['execution_date'].isoweekday() == self.week_day_number
+            return context['execution_date'].isoweekday() == self._week_day_num
         else:
-            return timezone.utcnow().isoweekday() == self.week_day_number
+            return timezone.utcnow().isoweekday() == self._week_day_num
 
 
 class WeekEndSensor(BaseSensorOperator):
@@ -80,7 +76,7 @@ class WeekEndSensor(BaseSensorOperator):
 
     def poke(self, context):
         self.log.info('Poking until weekend. Today is %s',
-                      calendar.day_name[timezone.utcnow().isoweekday() - 1])
+                      WeekDay(timezone.utcnow().isoweekday()).name)
         if self.use_task_execution_day:
             return context['execution_date'].isoweekday() > 5
         else:

--- a/airflow/contrib/utils/weekday.py
+++ b/airflow/contrib/utils/weekday.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import enum
+
+
+@enum.unique
+class WeekDay(enum.IntEnum):
+    """
+    Python Enum containing Days of the Week
+    """
+    MONDAY = 1
+    TUESDAY = 2
+    WEDNESDAY = 3
+    THURSDAY = 4
+    FRIDAY = 5
+    SATURDAY = 6
+    SUNDAY = 7
+
+    @classmethod
+    def get_weekday_number(cls, week_day_str):
+        """
+        Return the ISO Week Day Number for a Week Day
+
+        :param week_day_str: Full Name of the Week Day. Example: "Sunday"
+        :type week_day_str: str
+        :return: ISO Week Day Number corresponding to the provided Weedkay
+        """
+        sanitized_week_day_str = week_day_str.upper()
+
+        if sanitized_week_day_str not in cls.__members__:
+            raise AttributeError(
+                'Invalid Week Day passed: "{}"'.format(week_day_str)
+            )
+
+        return cls[sanitized_week_day_str]

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -266,6 +266,8 @@ Sensors
 .. autoclass:: airflow.contrib.sensors.sagemaker_tuning_sensor.SageMakerTuningSensor
 .. autoclass:: airflow.contrib.sensors.sftp_sensor.SFTPSensor
 .. autoclass:: airflow.contrib.sensors.wasb_sensor.WasbBlobSensor
+.. autoclass:: airflow.contrib.sensors.weekday_sensor.DayOfWeekSensor
+.. autoclass:: airflow.contrib.sensors.weekday_sensor.WeekEndSensor
 
 .. _macros:
 

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -267,7 +267,6 @@ Sensors
 .. autoclass:: airflow.contrib.sensors.sftp_sensor.SFTPSensor
 .. autoclass:: airflow.contrib.sensors.wasb_sensor.WasbBlobSensor
 .. autoclass:: airflow.contrib.sensors.weekday_sensor.DayOfWeekSensor
-.. autoclass:: airflow.contrib.sensors.weekday_sensor.WeekEndSensor
 
 .. _macros:
 

--- a/tests/contrib/sensors/test_weekday_sensor.py
+++ b/tests/contrib/sensors/test_weekday_sensor.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+
+from airflow import DAG, configuration
+from airflow.contrib.sensors.weekday_sensor import DayOfWeekSensor, WeekEndSensor
+from airflow.exceptions import AirflowSensorTimeout
+from airflow.models import DagBag
+from airflow.utils.timezone import datetime
+
+
+DEFAULT_DATE = datetime(2018, 12, 10)
+WEEKDAY_DATE = datetime(2018, 12, 20)
+WEEKEND_DATE = datetime(2018, 12, 22)
+TEST_DAG_ID = 'weekday_sensor_dag'
+DEV_NULL = '/dev/null'
+
+
+class DayOfWeekSensorTests(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+        self.dagbag = DagBag(
+            dag_folder=DEV_NULL,
+            include_examples=True
+        )
+        self.args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE
+        }
+        dag = DAG(TEST_DAG_ID, default_args=self.args)
+        self.dag = dag
+
+    def test_weekday_sensor_true(self):
+        t = DayOfWeekSensor(
+            task_id='weekday_sensor_check_true',
+            week_day_number=4,
+            use_task_execution_day=True,
+            dag=self.dag)
+        t.run(start_date=WEEKDAY_DATE, end_date=WEEKDAY_DATE, ignore_ti_state=True)
+
+    def test_weekday_sensor_false(self):
+        t = DayOfWeekSensor(
+            task_id='weekday_sensor_check_false',
+            poke_interval=1,
+            timeout=2,
+            week_day_number=2,
+            use_task_execution_day=True,
+            dag=self.dag)
+        with self.assertRaises(AirflowSensorTimeout):
+            t.run(start_date=WEEKDAY_DATE, end_date=WEEKDAY_DATE, ignore_ti_state=True)
+
+    def test_invalid_weekday_number(self):
+        week_day_number = 8
+        t = DayOfWeekSensor(
+            task_id='weekday_sensor_invalid_weekday_num',
+            week_day_number=week_day_number,
+            use_task_execution_day=True,
+            dag=self.dag)
+        with self.assertRaisesRegexp(ValueError, 'Invalid value'):
+            t.run(start_date=WEEKDAY_DATE, end_date=WEEKDAY_DATE, ignore_ti_state=True)
+
+
+class WeekEndSensorTests(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+        self.dagbag = DagBag(
+            dag_folder=DEV_NULL,
+            include_examples=False
+        )
+        self.args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE
+        }
+        dag = DAG(TEST_DAG_ID, default_args=self.args)
+        self.dag = dag
+
+    def test_weekend_sensor_true(self):
+        t = WeekEndSensor(
+            task_id='weekend_sensor_check_true',
+            use_task_execution_day=True,
+            dag=self.dag)
+        t.run(start_date=WEEKEND_DATE, end_date=WEEKEND_DATE, ignore_ti_state=True)
+
+    def test_weekend_sensor_false(self):
+        t = WeekEndSensor(
+            task_id='weekend_sensor_check_false',
+            poke_interval=1,
+            timeout=2,
+            use_task_execution_day=True,
+            dag=self.dag)
+        with self.assertRaises(AirflowSensorTimeout):
+            t.run(start_date=WEEKDAY_DATE, end_date=WEEKDAY_DATE, ignore_ti_state=True)

--- a/tests/contrib/sensors/test_weekday_sensor.py
+++ b/tests/contrib/sensors/test_weekday_sensor.py
@@ -52,7 +52,7 @@ class DayOfWeekSensorTests(unittest.TestCase):
     def test_weekday_sensor_true(self):
         t = DayOfWeekSensor(
             task_id='weekday_sensor_check_true',
-            week_day_number=4,
+            week_day='Thursday',
             use_task_execution_day=True,
             dag=self.dag)
         t.run(start_date=WEEKDAY_DATE, end_date=WEEKDAY_DATE, ignore_ti_state=True)
@@ -62,21 +62,22 @@ class DayOfWeekSensorTests(unittest.TestCase):
             task_id='weekday_sensor_check_false',
             poke_interval=1,
             timeout=2,
-            week_day_number=2,
+            week_day='Tuesday',
             use_task_execution_day=True,
             dag=self.dag)
         with self.assertRaises(AirflowSensorTimeout):
             t.run(start_date=WEEKDAY_DATE, end_date=WEEKDAY_DATE, ignore_ti_state=True)
 
     def test_invalid_weekday_number(self):
-        week_day_number = 8
-        t = DayOfWeekSensor(
-            task_id='weekday_sensor_invalid_weekday_num',
-            week_day_number=week_day_number,
-            use_task_execution_day=True,
-            dag=self.dag)
-        with self.assertRaisesRegexp(ValueError, 'Invalid value'):
-            t.run(start_date=WEEKDAY_DATE, end_date=WEEKDAY_DATE, ignore_ti_state=True)
+        invalid_week_day = 'Thsday'
+        with self.assertRaisesRegexp(AttributeError,
+                                     'Invalid Week Day passed: "{}"'.format(
+                                         invalid_week_day)):
+            DayOfWeekSensor(
+                task_id='weekday_sensor_invalid_weekday_num',
+                week_day=invalid_week_day,
+                use_task_execution_day=True,
+                dag=self.dag)
 
 
 class WeekEndSensorTests(unittest.TestCase):

--- a/tests/contrib/utils/test_weekday.py
+++ b/tests/contrib/utils/test_weekday.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest
+
+from enum import Enum
+
+from airflow.contrib.utils.weekday import WeekDay
+
+
+class WeekDayTest(unittest.TestCase):
+    def test_weekday_enum_length(self):
+        self.assertEqual(len(WeekDay), 7)
+
+    def test_weekday_name_value(self):
+        weekdays = "MONDAY TUESDAY WEDNESDAY THURSDAY FRIDAY SATURDAY SUNDAY"
+        weekdays = weekdays.split()
+        for i, weekday in enumerate(weekdays, start=1):
+            e = WeekDay(i)
+            self.assertEqual(e, i)
+            self.assertEqual(int(e), i)
+            self.assertEqual(e.name, weekday)
+            self.assertTrue(e in WeekDay)
+            self.assertTrue(0 < e < 8)
+            self.assertTrue(type(e) is WeekDay)
+            self.assertTrue(isinstance(e, int))
+            self.assertTrue(isinstance(e, Enum))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3560


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
One of the use-cases we had is we wanted to run certain tasks only on Weekends or certain days of the weeks. Along the way, I have seen more people requiring the same.


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
* `DayOfWeekSensorTests`
* `WeekEndSensorTests`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
