### PR TITLE
[AIRFLOW-3551] Improve BashOperator Test Coverage

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -20,10 +20,9 @@
 
 import os
 import signal
+from builtins import bytes
 from subprocess import Popen, STDOUT, PIPE
 from tempfile import gettempdir, NamedTemporaryFile
-
-from builtins import bytes
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -66,13 +65,12 @@ class BashOperator(BaseOperator):
     ui_color = '#f0ede4'
 
     @apply_defaults
-    def __init__(
-            self,
-            bash_command,
-            xcom_push=False,
-            env=None,
-            output_encoding='utf-8',
-            *args, **kwargs):
+    def __init__(self,
+                 bash_command,
+                 xcom_push=False,
+                 env=None,
+                 output_encoding='utf-8',
+                 *args, **kwargs):
 
         super(BashOperator, self).__init__(*args, **kwargs)
         self.bash_command = bash_command
@@ -85,14 +83,14 @@ class BashOperator(BaseOperator):
         Execute the bash command in a temporary directory
         which will be cleaned afterwards
         """
-        self.log.info("Tmp dir root location: \n %s", gettempdir())
+        self.log.info('Tmp dir root location: \n %s', gettempdir())
 
         # Prepare env for child process.
         if self.env is None:
             self.env = os.environ.copy()
-        airflow_context_vars = context_to_airflow_vars(context,
-                                                       in_env_var_format=True)
-        self.log.info("Exporting the following env vars:\n" +
+
+        airflow_context_vars = context_to_airflow_vars(context, in_env_var_format=True)
+        self.log.info('Exporting the following env vars:\n' +
                       '\n'.join(["{}={}".format(k, v)
                                  for k, v in
                                  airflow_context_vars.items()]))
@@ -101,16 +99,11 @@ class BashOperator(BaseOperator):
         self.lineage_data = self.bash_command
 
         with TemporaryDirectory(prefix='airflowtmp') as tmp_dir:
-            with NamedTemporaryFile(dir=tmp_dir, prefix=self.task_id) as f:
-
-                f.write(bytes(self.bash_command, 'utf_8'))
-                f.flush()
-                fname = f.name
-                script_location = os.path.abspath(fname)
-                self.log.info(
-                    "Temporary script location: %s",
-                    script_location
-                )
+            with NamedTemporaryFile(dir=tmp_dir, prefix=self.task_id) as tmp_file:
+                tmp_file.write(bytes(self.bash_command, 'utf_8'))
+                tmp_file.flush()
+                script_location = os.path.abspath(tmp_file.name)
+                self.log.info('Temporary script location: %s', script_location)
 
                 def pre_exec():
                     # Restore default signal disposition and invoke setsid
@@ -119,32 +112,33 @@ class BashOperator(BaseOperator):
                             signal.signal(getattr(signal, sig), signal.SIG_DFL)
                     os.setsid()
 
-                self.log.info("Running command: %s", self.bash_command)
-                sp = Popen(
-                    ['bash', fname],
-                    stdout=PIPE, stderr=STDOUT,
-                    cwd=tmp_dir, env=self.env,
+                self.log.info('Running command: %s', self.bash_command)
+                sub_process = Popen(
+                    ['bash', tmp_file.name],
+                    stdout=PIPE,
+                    stderr=STDOUT,
+                    cwd=tmp_dir,
+                    env=self.env,
                     preexec_fn=pre_exec)
 
-                self.sp = sp
+                self.sub_process = sub_process
 
-                self.log.info("Output:")
+                self.log.info('Output:')
                 line = ''
-                for line in iter(sp.stdout.readline, b''):
-                    line = line.decode(self.output_encoding).rstrip()
+                for raw_line in iter(sub_process.stdout.readline, b''):
+                    line = raw_line.decode(self.output_encoding).rstrip()
                     self.log.info(line)
-                sp.wait()
-                self.log.info(
-                    "Command exited with return code %s",
-                    sp.returncode
-                )
 
-                if sp.returncode:
-                    raise AirflowException("Bash command failed")
+                sub_process.wait()
+
+                self.log.info('Command exited with return code %s', sub_process.returncode)
+
+                if sub_process.returncode:
+                    raise AirflowException('Bash command failed')
 
         if self.xcom_push_flag:
             return line
 
     def on_kill(self):
         self.log.info('Sending SIGTERM signal to bash process group')
-        os.killpg(os.getpgid(self.sp.pid), signal.SIGTERM)
+        os.killpg(os.getpgid(self.sub_process.pid), signal.SIGTERM)

--- a/tests/operators/test_bash_operator.py
+++ b/tests/operators/test_bash_operator.py
@@ -15,6 +15,7 @@
 import os
 import unittest
 from datetime import datetime, timedelta
+from tempfile import NamedTemporaryFile
 
 from airflow import DAG
 from airflow.models import State
@@ -26,7 +27,8 @@ END_DATE = datetime(2016, 1, 2, tzinfo=timezone.utc)
 INTERVAL = timedelta(hours=12)
 
 
-class BashOperatorTestCase(unittest.TestCase):
+class BashOperatorTest(unittest.TestCase):
+
     def test_echo_env_variables(self):
         """
         Test that env variables are exported correctly to the
@@ -52,10 +54,8 @@ class BashOperatorTestCase(unittest.TestCase):
             external_trigger=False,
         )
 
-        import tempfile
-        with tempfile.NamedTemporaryFile() as f:
-            fname = f.name
-            t = BashOperator(
+        with NamedTemporaryFile() as tmp_file:
+            task = BashOperator(
                 task_id='echo_env_vars',
                 dag=self.dag,
                 bash_command='echo $AIRFLOW_HOME>> {0};'
@@ -63,17 +63,17 @@ class BashOperatorTestCase(unittest.TestCase):
                              'echo $AIRFLOW_CTX_DAG_ID >> {0};'
                              'echo $AIRFLOW_CTX_TASK_ID>> {0};'
                              'echo $AIRFLOW_CTX_EXECUTION_DATE>> {0};'
-                             'echo $AIRFLOW_CTX_DAG_RUN_ID>> {0};'.format(fname)
+                             'echo $AIRFLOW_CTX_DAG_RUN_ID>> {0};'.format(tmp_file.name)
             )
 
             original_AIRFLOW_HOME = os.environ['AIRFLOW_HOME']
 
             os.environ['AIRFLOW_HOME'] = 'MY_PATH_TO_AIRFLOW_HOME'
-            t.run(DEFAULT_DATE, DEFAULT_DATE,
-                  ignore_first_depends_on_past=True, ignore_ti_state=True)
+            task.run(DEFAULT_DATE, DEFAULT_DATE,
+                     ignore_first_depends_on_past=True, ignore_ti_state=True)
 
-            with open(fname, 'r') as fr:
-                output = ''.join(fr.readlines())
+            with open(tmp_file.name, 'r') as file:
+                output = ''.join(file.readlines())
                 self.assertIn('MY_PATH_TO_AIRFLOW_HOME', output)
                 # exported in run_unit_tests.sh as part of PYTHONPATH
                 self.assertIn('tests/test_utils', output)
@@ -83,3 +83,14 @@ class BashOperatorTestCase(unittest.TestCase):
                 self.assertIn('manual__' + DEFAULT_DATE.isoformat(), output)
 
             os.environ['AIRFLOW_HOME'] = original_AIRFLOW_HOME
+
+    def test_return_value_to_xcom(self):
+        bash_operator = BashOperator(
+            bash_command='echo "stdout"',
+            xcom_push=True,
+            task_id='test_return_value_to_xcom',
+            dag=None
+        )
+        xcom_return_value = bash_operator.execute(context={})
+
+        self.assertEqual(xcom_return_value, u'stdout')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3551
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
- adds test case for xcom_push=True
- refactoring

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
