### PR TITLE
[AIRFLOW-2939][AIRFLOW-3568] fix TypeError on GoogleCloudStorageToS3Operator / S3ToGoogleCloudStorageOperator

### DIFF
--- a/airflow/contrib/operators/gcs_to_s3.py
+++ b/airflow/contrib/operators/gcs_to_s3.py
@@ -101,7 +101,7 @@ class GoogleCloudStorageToS3Operator(GoogleCloudStorageListOperator):
             # Google Cloud Storage and not in S3
             bucket_name, _ = S3Hook.parse_s3_url(self.dest_s3_key)
             existing_files = s3_hook.list_keys(bucket_name)
-            files = set(files) - set(existing_files)
+            files = list(set(files) - set(existing_files))
 
         if files:
             hook = GoogleCloudStorageHook(

--- a/airflow/contrib/operators/s3_to_gcs_operator.py
+++ b/airflow/contrib/operators/s3_to_gcs_operator.py
@@ -152,7 +152,7 @@ class S3ToGoogleCloudStorageOperator(S3ListOperator):
                     else:
                         existing_files.append(f)
 
-            files = set(files) - set(existing_files)
+            files = list(set(files) - set(existing_files))
             if len(files) > 0:
                 self.log.info('{0} files are going to be synced: {1}.'.format(
                     len(files), files))


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2939
  - https://issues.apache.org/jira/browse/AIRFLOW-3568
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
 - A task created by GoogleCloudStorageToS3Operator or S3ToGoogleCloudStorageOperator always fail due to a type error `TypeError: 'NoneType' object is not iterable`.
 - `model.py` tries to push the return value from the operators, which is a file list as set, to xcom but xcom_push does not support set.  According to the traceback `model.py` internally uses `json.dumps(value).encode` but it does not support `set` since `set` is not JSON serializable

```
Traceback (most recent call last)
  File "/usr/local/lib/airflow/airflow/models.py", line 1637, in _run_raw_tas
    self.xcom_push(key=XCOM_RETURN_KEY, value=result
  File "/usr/local/lib/airflow/airflow/models.py", line 1983, in xcom_pus
    execution_date=execution_date or self.execution_date
  File "/usr/local/lib/airflow/airflow/utils/db.py", line 74, in wrappe
    return func(*args, **kwargs
  File "/usr/local/lib/airflow/airflow/models.py", line 4531, in se
    value = json.dumps(value).encode('UTF-8'
  File "/usr/local/lib/python3.6/json/__init__.py", line 231, in dump
    return _default_encoder.encode(obj
  File "/usr/local/lib/python3.6/json/encoder.py", line 199, in encod
    chunks = self.iterencode(o, _one_shot=True
  File "/usr/local/lib/python3.6/json/encoder.py", line 257, in iterencod
    return _iterencode(o, 0
  File "/usr/local/lib/python3.6/json/encoder.py", line 180, in defaul
    o.__class__.__name__
TypeError: Object of type 'set' is not JSON serializabl
```

### Tests

- [x] These operators has unit tests so my PR does not add new unit tests:
 - test_gcs_to_s3_operator.py
 - test_s3_list_operator.py

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
