### PR TITLE
AIRFLOW-3567 Show an error in case logs can't be fetched from S3

### DIFF
--- a/airflow/utils/log/s3_task_handler.py
+++ b/airflow/utils/log/s3_task_handler.py
@@ -123,8 +123,9 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         """
         try:
             return self.hook.get_key(remote_log_location) is not None
-        except Exception:
-            pass
+        except Exception as e:
+            self.log.error('Error listing logs at {}: {}'.format(
+                remote_log_location, e))
         return False
 
     def s3_read(self, remote_log_location, return_error=False):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

This PR relates to:
  - https://issues.apache.org/jira/browse/AIRFLOW-3567

### Description

- This change allows actually seeing what's wrong in the S3 logging configuration

### Tests

- No tests required

### Commits

- Show an error in case logs can't be fetched from S3

### Documentation

- No documentation needed

### Code Quality

- Passes `flake8`