### PR TITLE
[AIRFLOW-3569] Add "Trigger DAG" button in DAG page

### DIFF
--- a/airflow/www_rbac/templates/airflow/dag.html
+++ b/airflow/www_rbac/templates/airflow/dag.html
@@ -95,6 +95,13 @@
         </a>
       </li>
       <li>
+        <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin="/tree?dag_id="+dag.dag_id) }}"
+          onclick="return confirmTriggerDag('{{ dag.safe_dag_id }}')">
+          <span class="glyphicon glyphicon-play-circle" aria-hidden="true"></span>
+          Trigger DAG
+        </a>
+      </li>
+      <li>
         <a href="{{ url_for('Airflow.refresh', dag_id=dag.dag_id) }}" title="Refresh">
           <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
           Refresh
@@ -328,6 +335,10 @@ function updateQueryStringParameter(uri, key, value) {
       $('#dag_id').html(dag_id);
       $('#dagModal').modal({});
       $("#dagModal").css("margin-top","0px");
+    }
+
+    function confirmTriggerDag(dag_id){
+        return confirm("Are you sure you want to run '"+dag_id+"' now?");
     }
 
     function confirmDeleteDag(dag_id){


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3569

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

#### What this PR is addressing?
Currently, the (manual) Trigger DAG button is only available at the /home page.

But I always encounter this situation: when I'm checking the tree view, or code, or graph view of a specific DAG, I may want to manually trigger another DagRun. I need to go back to the home page, search for that DAG, trigger the DagRun, then click it again to check the tree view.

It may be good if we can have the Manual Trigger DAG button in the DAG page as well, rather than only in the home page.

#### Others
1. **This PR only updated `/www_rbac`**. Given deprecating old UI (`/www`) is already in the plan (https://github.com/apache/incubator-airflow/pull/4339), updating `/www` may add extra re-basing work for https://github.com/apache/incubator-airflow/pull/4339. But kindly let me know if any committer finds it's still necessary to update `/www`. 

2. After the DagRun is triggered, users will be re-directed back to the `Tree-View` tab of the DAG that was triggered.

#### Screenshots
<img width="1280" alt="screen shot 2018-12-26 at 8 07 16 pm" src="https://user-images.githubusercontent.com/11539188/50445475-efaf0c80-0949-11e9-8677-2093dae3af9d.png">

<img width="1280" alt="screen shot 2018-12-26 at 7 52 30 pm" src="https://user-images.githubusercontent.com/11539188/50445388-6b5c8980-0949-11e9-8951-21f036492b4c.png">


