### PR TITLE
[AIRFLOW-XXX] Fix/complete example code in plugins.rst

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -184,6 +184,8 @@ definitions in Airflow.
 
     # Creating a flask appbuilder BaseView
     class TestAppBuilderBaseView(AppBuilderBaseView):
+        default_view = "test"
+
         @expose("/")
         def test(self):
             return self.render("test_plugin/test.html", content="Hello galaxy!")

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -134,6 +134,7 @@ definitions in Airflow.
     from flask import Blueprint
     from flask_admin import BaseView, expose
     from flask_admin.base import MenuLink
+    from flask_appbuilder import BaseView as AppBuilderBaseView
 
     # Importing base classes that we need to derive
     from airflow.hooks.base_hook import BaseHook


### PR DESCRIPTION
### Jira

Pure doc change

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Fix-1:
How `AppBuilderBaseView` should be imported was not included in the example code of `plugins.rst`. This may confuse users (in the whole codebase, the only location in which this was mentioned is `tests/plugins/test_plugin.py`. Normal users of Airflow may not get to know it).

Fix-2:
To add Plugin View for RBAC UI, we need to specify `default_view` in the class of `appbuilder_views`. Otherwise the whole webserver process would fail (tested in runtime).

#### Reference:
reference-1 for fix-2: https://github.com/apache/incubator-airflow/blob/master/tests/plugins/test_plugin.py#L74

reference-2 for fix-2: https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/baseviews.py#L76