### PR TITLE
[AIRFLOW-XXX] Fix/complete example code in plugins.rst

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -134,6 +134,7 @@ definitions in Airflow.
     from flask import Blueprint
     from flask_admin import BaseView, expose
     from flask_admin.base import MenuLink
+    from flask_appbuilder import BaseView as AppBuilderBaseView
 
     # Importing base classes that we need to derive
     from airflow.hooks.base_hook import BaseHook
@@ -183,6 +184,8 @@ definitions in Airflow.
 
     # Creating a flask appbuilder BaseView
     class TestAppBuilderBaseView(AppBuilderBaseView):
+        default_view = "test"
+
         @expose("/")
         def test(self):
             return self.render("test_plugin/test.html", content="Hello galaxy!")


### PR DESCRIPTION
### Jira

Pure doc change

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**Fix-1:**
How `AppBuilderBaseView` should be imported was not included in the example code of `plugins.rst`. This may confuse users (in the whole codebase, the only location in which this was mentioned is `tests/plugins/test_plugin.py`. Normal users of Airflow may not get to know it).

**Fix-2:**
To add Plugin View for RBAC UI, we need to specify `default_view` in the class of `appbuilder_views`. If we don't specify it, the webserver process will fail (tested in runtime) (reference-1: https://github.com/apache/incubator-airflow/blob/master/tests/plugins/test_plugin.py#L74, reference-2: https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/baseviews.py#L76).

### Test

I added `[ci skip]` to skip CI test, given this is just doc change.