### PR TITLE
[AIRFLOW-3576] Remove unnecessray arg 'root' for /delete in dag.html

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -101,7 +101,7 @@
         </a>
       </li>
       <li>
-        <a href="{{ url_for("airflow.delete", dag_id=dag.dag_id, root=root) }}"
+        <a href="{{ url_for("airflow.delete", dag_id=dag.dag_id) }}"
         onclick="return confirmDeleteDag('{{ dag.safe_dag_id }}')">
         <span class="glyphicon glyphicon-remove-circle" style="color:red" aria-hidden="true"></span>
         Delete

--- a/airflow/www_rbac/templates/airflow/dag.html
+++ b/airflow/www_rbac/templates/airflow/dag.html
@@ -101,7 +101,7 @@
         </a>
       </li>
       <li>
-        <a href="{{ url_for('Airflow.delete', dag_id=dag.dag_id, root=root) }}"
+        <a href="{{ url_for('Airflow.delete', dag_id=dag.dag_id) }}"
         onclick="return confirmDeleteDag('{{ dag.safe_dag_id }}')">
         <span class="glyphicon glyphicon-remove-circle" style="color:red" aria-hidden="true"></span>
         Delete


### PR DESCRIPTION

### Jira

https://issues.apache.org/jira/browse/AIRFLOW-3576

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In `airflow/www/templates/airflow/dag.html` or `airflow/www_rbac/templates/airflow/dag.html`, in line `<a href="{{ url_for("airflow.delete", dag_id=dag.dag_id, root=root) }}"`, `root` is not necessary, given it's not used anywhere in the `'/delete'` method in either `airflow/www/views.py` or `airflow/www_rbac/views.py`.

**Please correct me if I'm incorrect about this or missed anything.**
