### PR TITLE
[AIRFLOW-3468] Move KnownEventType out of models.py

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -4334,16 +4334,6 @@ class Chart(Base):
         return self.label
 
 
-class KnownEventType(Base):
-    __tablename__ = "known_event_type"
-
-    id = Column(Integer, primary_key=True)
-    know_event_type = Column(String(200))
-
-    def __repr__(self):
-        return self.know_event_type
-
-
 class KnownEvent(Base):
     __tablename__ = "known_event"
 

--- a/airflow/models/known_event_type.py
+++ b/airflow/models/known_event_type.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from sqlalchemy import Integer, Column, String
+
+from airflow.models.base import Base
+
+
+class KnownEventType(Base):
+    __tablename__ = "known_event_type"
+
+    id = Column(Integer, primary_key=True)
+    know_event_type = Column(String(200))
+
+    def __repr__(self):
+        return self.know_event_type

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -28,6 +28,7 @@ import os
 import contextlib
 
 from airflow import settings
+from airflow.models.known_event_type import KnownEventType
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 log = LoggingMixin().log
@@ -291,7 +292,7 @@ def initdb(rbac=False):
             host='cassandra', port=9042))
 
     # Known event types
-    KET = models.KnownEventType
+    KET = KnownEventType
     if not session.query(KET).filter(KET.know_event_type == 'Holiday').first():
         session.add(KET(know_event_type='Holiday'))
     if not session.query(KET).filter(KET.know_event_type == 'Outage').first():


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3468
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Move the KnownEventType class to a separate file as part of [the big models.py refactor](https://issues.apache.org/jira/issues/?jql=text%20~%20%22Refactor%3A%20Move%20out%20of%20models.py%22%20AND%20reporter%20in%20(Fokko)) (/airflow/models/knowneventtype.py).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
