### PR TITLE
[AIRFLOW-3469] Move KnownEvent out of models.py

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -4344,27 +4344,6 @@ class KnownEventType(Base):
         return self.know_event_type
 
 
-class KnownEvent(Base):
-    __tablename__ = "known_event"
-
-    id = Column(Integer, primary_key=True)
-    label = Column(String(200))
-    start_date = Column(UtcDateTime)
-    end_date = Column(UtcDateTime)
-    user_id = Column(Integer(), ForeignKey('users.id'),)
-    known_event_type_id = Column(Integer(), ForeignKey('known_event_type.id'),)
-    reported_by = relationship(
-        "User", cascade=False, cascade_backrefs=False, backref='known_events')
-    event_type = relationship(
-        "KnownEventType",
-        cascade=False,
-        cascade_backrefs=False, backref='known_events')
-    description = Column(Text)
-
-    def __repr__(self):
-        return self.label
-
-
 class Variable(Base, LoggingMixin):
     __tablename__ = "variable"
 

--- a/airflow/models/knownevent.py
+++ b/airflow/models/knownevent.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from sqlalchemy import Column, Integer, String, ForeignKey, Text
+from sqlalchemy.orm import relationship
+
+from airflow.models.base import Base
+from airflow.utils.sqlalchemy import UtcDateTime
+
+
+class KnownEvent(Base):
+    __tablename__ = "known_event"
+
+    id = Column(Integer, primary_key=True)
+    label = Column(String(200))
+    start_date = Column(UtcDateTime)
+    end_date = Column(UtcDateTime)
+    user_id = Column(Integer(), ForeignKey('users.id'),)
+    known_event_type_id = Column(Integer(), ForeignKey('known_event_type.id'),)
+    reported_by = relationship(
+        "User", cascade=False, cascade_backrefs=False, backref='known_events')
+    event_type = relationship(
+        "KnownEventType",
+        cascade=False,
+        cascade_backrefs=False, backref='known_events')
+    description = Column(Text)
+
+    def __repr__(self):
+        return self.label

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -31,6 +31,7 @@ import airflow
 from airflow import configuration as conf
 from airflow import models, LoggingMixin
 from airflow.models.connection import Connection
+from airflow.models.knownevent import KnownEvent
 from airflow.settings import Session
 
 from airflow.www.blueprints import routes
@@ -90,7 +91,7 @@ def create_app(config=None, testing=False):
             av(vs.ChartModelView(
                 models.Chart, Session, name="Charts", category="Data Profiling"))
         av(vs.KnownEventView(
-            models.KnownEvent,
+            KnownEvent,
             Session, name="Known Events", category="Data Profiling"))
         av(vs.SlaMissModelView(
             models.SlaMiss,

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -34,6 +34,7 @@ from werkzeug.test import Client
 from airflow import models, configuration
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.models import DAG, DagRun, TaskInstance
+from airflow.models.knownevent import KnownEvent
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.settings import Session
 from airflow.utils.timezone import datetime
@@ -177,7 +178,7 @@ class TestKnownEventView(unittest.TestCase):
     def setUpClass(cls):
         super(TestKnownEventView, cls).setUpClass()
         session = Session()
-        session.query(models.KnownEvent).delete()
+        session.query(KnownEvent).delete()
         session.query(models.User).delete()
         session.commit()
         user = models.User(username='airflow')
@@ -203,7 +204,7 @@ class TestKnownEventView(unittest.TestCase):
         }
 
     def tearDown(self):
-        self.session.query(models.KnownEvent).delete()
+        self.session.query(KnownEvent).delete()
         self.session.commit()
         self.session.close()
         super(TestKnownEventView, self).tearDown()
@@ -223,7 +224,7 @@ class TestKnownEventView(unittest.TestCase):
             follow_redirects=True,
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.session.query(models.KnownEvent).count(), 1)
+        self.assertEqual(self.session.query(KnownEvent).count(), 1)
 
     def test_create_known_event_with_end_data_earlier_than_start_date(self):
         self.known_event['end_date'] = '2017-06-05 11:00:00'
@@ -236,7 +237,7 @@ class TestKnownEventView(unittest.TestCase):
             'Field must be greater than or equal to Start Date.',
             response.data.decode('utf-8'),
         )
-        self.assertEqual(self.session.query(models.KnownEvent).count(), 0)
+        self.assertEqual(self.session.query(KnownEvent).count(), 0)
 
 
 class TestPoolModelView(unittest.TestCase):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3469
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Move the KnownEvent class to a separate file as part of [the big models.py refactor](https://issues.apache.org/jira/issues/?jql=text%20~%20%22Refactor%3A%20Move%20out%20of%20models.py%22%20AND%20reporter%20in%20(Fokko)) (/airflow/models/knownevent.py).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
