### PR TITLE
[AIRFLOW-3578] Fix Type Error for BigQueryOperator

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -23,6 +23,7 @@ implementation for BigQuery.
 """
 
 import time
+import six
 from builtins import range
 from copy import deepcopy
 from six import iteritems
@@ -640,8 +641,8 @@ class BigQueryBaseCursor(LoggingMixin):
             cluster_fields = {'fields': cluster_fields}
 
         query_param_list = [
-            (sql, 'query', None, str),
-            (priority, 'priority', 'INTERACTIVE', str),
+            (sql, 'query', None, six.string_types),
+            (priority, 'priority', 'INTERACTIVE', six.string_types),
             (use_legacy_sql, 'useLegacySql', self.use_legacy_sql, bool),
             (query_params, 'queryParameters', None, dict),
             (udf_config, 'userDefinedFunctionResources', None, list),

--- a/tests/contrib/operators/test_bigquery_operator.py
+++ b/tests/contrib/operators/test_bigquery_operator.py
@@ -17,12 +17,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import os
 import unittest
+from datetime import datetime
+
+import six
+
+from airflow import configuration, models
+from airflow.models import TaskInstance, DAG
 
 from airflow.contrib.operators.bigquery_operator import \
     BigQueryCreateExternalTableOperator, BigQueryCreateEmptyTableOperator, \
     BigQueryDeleteDatasetOperator, BigQueryCreateEmptyDatasetOperator, \
     BigQueryOperator
+from airflow.settings import Session
 
 try:
     from unittest import mock
@@ -39,6 +47,8 @@ TEST_TABLE_ID = 'test-table-id'
 TEST_GCS_BUCKET = 'test-bucket'
 TEST_GCS_DATA = ['dir1/*.csv']
 TEST_SOURCE_FORMAT = 'CSV'
+DEFAULT_DATE = datetime(2015, 1, 1)
+TEST_DAG_ID = 'test-bigquery-operators'
 
 
 class BigQueryCreateEmptyTableOperatorTest(unittest.TestCase):
@@ -147,6 +157,22 @@ class BigQueryCreateEmptyDatasetOperatorTest(unittest.TestCase):
 
 
 class BigQueryOperatorTest(unittest.TestCase):
+    def setUp(self):
+        configuration.conf.load_test_config()
+        self.dagbag = models.DagBag(
+            dag_folder='/dev/null', include_examples=True)
+        self.args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
+        self.dag = DAG(TEST_DAG_ID, default_args=self.args)
+
+    def tearDown(self):
+        session = Session()
+        session.query(models.TaskInstance).filter_by(
+            dag_id=TEST_DAG_ID).delete()
+        session.query(models.TaskFail).filter_by(
+            dag_id=TEST_DAG_ID).delete()
+        session.commit()
+        session.close()
+
     @mock.patch('airflow.contrib.operators.bigquery_operator.BigQueryHook')
     def test_execute(self, mock_hook):
         operator = BigQueryOperator(
@@ -197,9 +223,11 @@ class BigQueryOperatorTest(unittest.TestCase):
 
     @mock.patch('airflow.contrib.operators.bigquery_operator.BigQueryHook')
     def test_bigquery_operator_defaults(self, mock_hook):
+
         operator = BigQueryOperator(
             task_id=TASK_ID,
             sql='Select * from test_table',
+            dag=self.dag, default_args=self.args
         )
 
         operator.execute(None)
@@ -225,3 +253,8 @@ class BigQueryOperatorTest(unittest.TestCase):
                 api_resource_configs=None,
                 cluster_fields=None,
             )
+
+        self.assertTrue(isinstance(operator.sql, six.string_types))
+        ti = TaskInstance(task=operator, execution_date=DEFAULT_DATE)
+        ti.render_templates()
+        self.assertTrue(isinstance(ti.task.sql, six.string_types))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-3578


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The error is because it just checks for `str` type and not `unicode` but as **`sql` is a templated field it returns unicode and not str**

**Error**:
```
[2018-12-27 13:33:08,756] {__init__.py:1548} ERROR - query argument must have a type <type 'str'> not <type 'unicode'>
Traceback (most recent call last):
  File "/Users/kaxil/Documents/GitHub/incubator-airflow/airflow/models/__init__.py", line 1431, in _run_raw_task
    result = task_copy.execute(context=context)
  File "/Users/kaxil/Documents/GitHub/incubator-airflow/airflow/contrib/operators/bigquery_operator.py", line 176, in execute
    cluster_fields=self.cluster_fields,
  File "/Users/kaxil/Documents/GitHub/incubator-airflow/airflow/contrib/hooks/bigquery_hook.py", line 677, in run_query
    param_type)
  File "/Users/kaxil/Documents/GitHub/incubator-airflow/airflow/contrib/hooks/bigquery_hook.py", line 1903, in _validate_value
    key, expected_type, type(value)))
TypeError: query argument must have a type <type 'str'> not <type 'unicode'>
```

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added tests

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
