### PR TITLE
[AIRFLOW-3580] Adds tests for HiveToMySqlTransfer

### DIFF
--- a/tests/operators/test_hive_to_mysql.py
+++ b/tests/operators/test_hive_to_mysql.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from mock import patch, PropertyMock
+
+from airflow.operators.hive_to_mysql import HiveToMySqlTransfer
+from airflow.utils.operator_helpers import context_to_airflow_vars
+
+
+class TestHiveToMySqlTransfer(unittest.TestCase):
+
+    def setUp(self):
+        self.kwargs = dict(
+            sql='sql',
+            mysql_table='table',
+            hiveserver2_conn_id='hiveserver2_default',
+            mysql_conn_id='mysql_default',
+            task_id='test_hive_to_mysql',
+            dag=None
+        )
+
+    @patch('airflow.operators.hive_to_mysql.MySqlHook')
+    @patch('airflow.operators.hive_to_mysql.HiveServer2Hook')
+    def test_execute(self, mock_hive_hook, mock_mysql_hook):
+        HiveToMySqlTransfer(**self.kwargs).execute(context={})
+
+        mock_hive_hook.assert_called_once_with(hiveserver2_conn_id=self.kwargs['hiveserver2_conn_id'])
+        mock_hive_hook.return_value.get_records.assert_called_once_with(self.kwargs['sql'])
+        mock_mysql_hook.assert_called_once_with(mysql_conn_id=self.kwargs['mysql_conn_id'])
+        mock_mysql_hook.return_value.insert_rows.assert_called_once_with(
+            table=self.kwargs['mysql_table'],
+            rows=mock_hive_hook.return_value.get_records.return_value
+        )
+
+    @patch('airflow.operators.hive_to_mysql.MySqlHook')
+    @patch('airflow.operators.hive_to_mysql.HiveServer2Hook')
+    def test_execute_mysql_preoperator(self, mock_hive_hook, mock_mysql_hook):
+        self.kwargs.update(dict(mysql_preoperator='preoperator'))
+
+        HiveToMySqlTransfer(**self.kwargs).execute(context={})
+
+        mock_mysql_hook.return_value.run.assert_called_once_with(self.kwargs['mysql_preoperator'])
+
+    @patch('airflow.operators.hive_to_mysql.MySqlHook')
+    @patch('airflow.operators.hive_to_mysql.HiveServer2Hook')
+    def test_execute_with_mysql_postoperator(self, mock_hive_hook, mock_mysql_hook):
+        self.kwargs.update(dict(mysql_postoperator='postoperator'))
+
+        HiveToMySqlTransfer(**self.kwargs).execute(context={})
+
+        mock_mysql_hook.return_value.run.assert_called_once_with(self.kwargs['mysql_postoperator'])
+
+    @patch('airflow.operators.hive_to_mysql.MySqlHook')
+    @patch('airflow.operators.hive_to_mysql.NamedTemporaryFile')
+    @patch('airflow.operators.hive_to_mysql.HiveServer2Hook')
+    def test_execute_bulk_load(self, mock_hive_hook, mock_tmp_file, mock_mysql_hook):
+        type(mock_tmp_file).name = PropertyMock(return_value='tmp_file')
+        context = {}
+        self.kwargs.update(dict(bulk_load=True))
+
+        HiveToMySqlTransfer(**self.kwargs).execute(context=context)
+
+        mock_tmp_file.assert_called_once_with()
+        mock_hive_hook.return_value.to_csv.assert_called_once_with(
+            self.kwargs['sql'],
+            mock_tmp_file.return_value.name,
+            delimiter='\t',
+            lineterminator='\n',
+            output_header=False,
+            hive_conf=context_to_airflow_vars(context)
+        )
+        mock_mysql_hook.return_value.bulk_load.assert_called_once_with(
+            table=self.kwargs['mysql_table'],
+            tmp_file=mock_tmp_file.return_value.name
+        )
+        mock_tmp_file.return_value.close.assert_called_once_with()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3580
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR:
- adds tests for the `HiveToMySqlTransfer` operator
- refactors the tested class `HiveToMySqlTransfer`

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

It adds tests for all features:
* general transfer
* transfer with mysql pre-operator
* transfer with mysql post-operator
* transfer via bulk load

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
