### PR TITLE
[AIRFLOW-XXX] Correct BranchPythonOperator instructions in docs

### DIFF
--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -127,8 +127,8 @@ class BranchPythonOperator(PythonOperator, SkipMixin):
 
     Note that using tasks with ``depends_on_past=True`` downstream from
     ``BranchPythonOperator`` is logically unsound as ``skipped`` status
-    will invariably lead to block tasks that depend on their past successes.
-    ``skipped`` states propagates where all directly upstream tasks are
+    will invariably lead to blocked tasks that depend on their past success.
+    ``skipped`` states propagate where any directly upstream task is
     ``skipped``.
     """
     def execute(self, context):

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -507,8 +507,8 @@ directly downstream from the BranchPythonOperator task.
 
 Note that using tasks with ``depends_on_past=True`` downstream from
 ``BranchPythonOperator`` is logically unsound as ``skipped`` status
-will invariably lead to block tasks that depend on their past successes.
-``skipped`` states propagates where all directly upstream tasks are
+will invariably lead to blocked tasks that depend on their past success.
+``skipped`` states propagate where any directly upstream task is
 ``skipped``.
 
 If you want to skip some tasks, keep in mind that you can't have an empty


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The docs incorrectly stated **all** upstream tasks must be skipped for a task to be skipped (assuming default `TriggerRule.ALL_SUCCESS`). However (with the default TriggerRule), **any** upstream task must be skipped for a task to be skipped. This PR corrects that.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
