### PR TITLE
[AIRFLOW-3583] Fix AirflowException import

### DIFF
--- a/airflow/contrib/hooks/wasb_hook.py
+++ b/airflow/contrib/hooks/wasb_hook.py
@@ -18,7 +18,7 @@
 # under the License.
 #
 
-from airflow import AirflowException
+from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 
 from azure.storage.blob import BlockBlobService


### PR DESCRIPTION
Looks like the class path changed and broke wasb_hook

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [AIRFLOW-3583](https://issues.apache.org/jira/browse/AIRFLOW-3583)

### Description

- [X] Simple fix for AirflowException import

### Tests

- [X] No tests needed :)

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [X] Passes `flake8`
