### PR TITLE
[AIRFLOW-3587] Remove unnecessary condition checks in dag_stats & task_stats

### DIFF
--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -297,16 +297,15 @@ class Airflow(AirflowBaseView):
                 filter_dag_ids = [dag_id for dag_id, in session.query(models.DagModel.dag_id)]
 
             for dag_id in filter_dag_ids:
-                if 'all_dags' in filter_dag_ids or dag_id in filter_dag_ids:
-                    payload[dag_id] = []
-                    for state in State.dag_states:
-                        count = data.get(dag_id, {}).get(state, 0)
-                        payload[dag_id].append({
-                            'state': state,
-                            'count': count,
-                            'dag_id': dag_id,
-                            'color': State.color(state)
-                        })
+                payload[dag_id] = []
+                for state in State.dag_states:
+                    count = data.get(dag_id, {}).get(state, 0)
+                    payload[dag_id].append({
+                        'state': state,
+                        'count': count,
+                        'dag_id': dag_id,
+                        'color': State.color(state)
+                    })
         return wwwutils.json_response(payload)
 
     @expose('/task_stats')
@@ -373,16 +372,15 @@ class Airflow(AirflowBaseView):
         if 'all_dags' in filter_dag_ids:
             filter_dag_ids = [dag_id for dag_id, in session.query(models.DagModel.dag_id)]
         for dag_id in filter_dag_ids:
-            if 'all_dags' in filter_dag_ids or dag_id in filter_dag_ids:
-                payload[dag_id] = []
-                for state in State.task_states:
-                    count = data.get(dag_id, {}).get(state, 0)
-                    payload[dag_id].append({
-                        'state': state,
-                        'count': count,
-                        'dag_id': dag_id,
-                        'color': State.color(state)
-                    })
+            payload[dag_id] = []
+            for state in State.task_states:
+                count = data.get(dag_id, {}).get(state, 0)
+                payload[dag_id].append({
+                    'state': state,
+                    'count': count,
+                    'dag_id': dag_id,
+                    'color': State.color(state)
+                })
         return wwwutils.json_response(payload)
 
     @expose('/code')


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3587


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

These two condition checks (introduced in 
https://github.com/apache/incubator-airflow/pull/4368) will always pass, and are not necessary.

**Reasoning:**

- if `"all_dags" in filter_dag_ids == True`, `filter_dag_ids` will be updated into a list of all DAG IDs (no `"all_dags"` inside)
- if `"all_dags" in filter_dag_ids == False`, `filter_dag_ids` will not be touched. It will still be a set of DAG IDs, or empty set.

In either case,
- there is no point to check whether `"all_dags"` is in `filter_dag_ids`, because for sure it will not.
- then what's the point to check `dag_id in filter_dag_ids` in a `for loop` of `for dag_id in filter_dag_ids`?

### Code Quality

- [x] Passes `flake8`