### PR TITLE
[AIRFLOW-3582] Adds tests for HiveStatsCollectionOperator

### DIFF
--- a/airflow/operators/hive_stats_operator.py
+++ b/airflow/operators/hive_stats_operator.py
@@ -17,14 +17,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import json
 from builtins import zip
 from collections import OrderedDict
-import json
 
 from airflow.exceptions import AirflowException
+from airflow.hooks.hive_hooks import HiveMetastoreHook
 from airflow.hooks.mysql_hook import MySqlHook
 from airflow.hooks.presto_hook import PrestoHook
-from airflow.hooks.hive_hooks import HiveMetastoreHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
@@ -64,19 +64,17 @@ class HiveStatsCollectionOperator(BaseOperator):
     ui_color = '#aff7a6'
 
     @apply_defaults
-    def __init__(
-            self,
-            table,
-            partition,
-            extra_exprs=None,
-            col_blacklist=None,
-            assignment_func=None,
-            metastore_conn_id='metastore_default',
-            presto_conn_id='presto_default',
-            mysql_conn_id='airflow_db',
-            *args, **kwargs):
+    def __init__(self,
+                 table,
+                 partition,
+                 extra_exprs=None,
+                 col_blacklist=None,
+                 assignment_func=None,
+                 metastore_conn_id='metastore_default',
+                 presto_conn_id='presto_default',
+                 mysql_conn_id='airflow_db',
+                 *args, **kwargs):
         super(HiveStatsCollectionOperator, self).__init__(*args, **kwargs)
-
         self.table = table
         self.partition = partition
         self.extra_exprs = extra_exprs or {}
@@ -92,7 +90,7 @@ class HiveStatsCollectionOperator(BaseOperator):
         if col in self.col_blacklist:
             return {}
         d = {(col, 'non_null'): "COUNT({col})"}
-        if col_type in ['double', 'int', 'bigint', 'float', 'double']:
+        if col_type in ['double', 'int', 'bigint', 'float']:
             d[(col, 'sum')] = 'SUM({col})'
             d[(col, 'min')] = 'MIN({col})'
             d[(col, 'max')] = 'MAX({col})'
@@ -129,8 +127,7 @@ class HiveStatsCollectionOperator(BaseOperator):
             v + " AS " + k[0] + '__' + k[1]
             for k, v in exprs.items()])
 
-        where_clause = [
-            "{0} = '{1}'".format(k, v) for k, v in self.partition.items()]
+        where_clause = ["{} = '{}'".format(k, v) for k, v in self.partition.items()]
         where_clause = " AND\n        ".join(where_clause)
         sql = """
         SELECT
@@ -140,9 +137,9 @@ class HiveStatsCollectionOperator(BaseOperator):
             {where_clause};
         """.format(**locals())
 
-        hook = PrestoHook(presto_conn_id=self.presto_conn_id)
+        presto = PrestoHook(presto_conn_id=self.presto_conn_id)
         self.log.info('Executing SQL check: %s', sql)
-        row = hook.get_first(hql=sql)
+        row = presto.get_first(hql=sql)
         self.log.info("Record: %s", row)
         if not row:
             raise AirflowException("The query returned None")
@@ -170,10 +167,8 @@ class HiveStatsCollectionOperator(BaseOperator):
             mysql.run(sql)
 
         self.log.info("Pivoting and loading cells into the Airflow db")
-        rows = [
-            (self.ds, self.dttm, self.table, part_json) +
-            (r[0][0], r[0][1], r[1])
-            for r in zip(exprs, row)]
+        rows = [(self.ds, self.dttm, self.table, part_json) + (r[0][0], r[0][1], r[1])
+                for r in zip(exprs, row)]
         mysql.insert_rows(
             table='hive_stats',
             rows=rows,

--- a/tests/operators/test_hive_stats_operator.py
+++ b/tests/operators/test_hive_stats_operator.py
@@ -1,0 +1,286 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from collections import OrderedDict
+
+from mock import patch
+
+from airflow import AirflowException
+from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator
+
+
+class _FakeCol:
+    def __init__(self, col_name, col_type):
+        self.name = col_name
+        self.type = col_type
+
+
+fake_col = _FakeCol('col', 'string')
+
+
+class TestHiveStatsCollectionOperator(unittest.TestCase):
+
+    def setUp(self):
+        self.kwargs = dict(
+            table='table',
+            partition=dict(col='col', value='value'),
+            metastore_conn_id='metastore_conn_id',
+            presto_conn_id='presto_conn_id',
+            mysql_conn_id='mysql_conn_id',
+            task_id='test_hive_stats_collection_operator',
+            dag=None
+        )
+
+    def test_get_default_exprs(self):
+        col = 'col'
+
+        default_exprs = HiveStatsCollectionOperator(**self.kwargs).get_default_exprs(col, None)
+
+        self.assertEqual(default_exprs, {
+            (col, 'non_null'): 'COUNT({})'.format(col)
+        })
+
+    def test_get_default_exprs_blacklist(self):
+        col = 'blacklisted_col'
+        self.kwargs.update(dict(col_blacklist=[col]))
+
+        default_exprs = HiveStatsCollectionOperator(**self.kwargs).get_default_exprs(col, None)
+
+        self.assertEqual(default_exprs, {})
+
+    def test_get_default_exprs_number(self):
+        col = 'col'
+        for col_type in ['double', 'int', 'bigint', 'float']:
+            default_exprs = HiveStatsCollectionOperator(**self.kwargs).get_default_exprs(col, col_type)
+
+            self.assertEqual(default_exprs, {
+                (col, 'avg'): 'AVG({})'.format(col),
+                (col, 'max'): 'MAX({})'.format(col),
+                (col, 'min'): 'MIN({})'.format(col),
+                (col, 'non_null'): 'COUNT({})'.format(col),
+                (col, 'sum'): 'SUM({})'.format(col)
+            })
+
+    def test_get_default_exprs_boolean(self):
+        col = 'col'
+        col_type = 'boolean'
+
+        default_exprs = HiveStatsCollectionOperator(**self.kwargs).get_default_exprs(col, col_type)
+
+        self.assertEqual(default_exprs, {
+            (col, 'false'): 'SUM(CASE WHEN NOT {} THEN 1 ELSE 0 END)'.format(col),
+            (col, 'non_null'): 'COUNT({})'.format(col),
+            (col, 'true'): 'SUM(CASE WHEN {} THEN 1 ELSE 0 END)'.format(col)
+        })
+
+    def test_get_default_exprs_string(self):
+        col = 'col'
+        col_type = 'string'
+
+        default_exprs = HiveStatsCollectionOperator(**self.kwargs).get_default_exprs(col, col_type)
+
+        self.assertEqual(default_exprs, {
+            (col, 'approx_distinct'): 'APPROX_DISTINCT({})'.format(col),
+            (col, 'len'): 'SUM(CAST(LENGTH({}) AS BIGINT))'.format(col),
+            (col, 'non_null'): 'COUNT({})'.format(col)
+        })
+
+    @patch('airflow.operators.hive_stats_operator.json.dumps')
+    @patch('airflow.operators.hive_stats_operator.MySqlHook')
+    @patch('airflow.operators.hive_stats_operator.PrestoHook')
+    @patch('airflow.operators.hive_stats_operator.HiveMetastoreHook')
+    def test_execute(self, mock_hive_metastore_hook, mock_presto_hook, mock_mysql_hook, mock_json_dumps):
+        mock_hive_metastore_hook.return_value.get_table.return_value.sd.cols = [fake_col]
+        mock_mysql_hook.return_value.get_records.return_value = False
+
+        hive_stats_collection_operator = HiveStatsCollectionOperator(**self.kwargs)
+        hive_stats_collection_operator.execute(context={})
+
+        mock_hive_metastore_hook.assert_called_once_with(
+            metastore_conn_id=hive_stats_collection_operator.metastore_conn_id)
+        mock_hive_metastore_hook.return_value.get_table.assert_called_once_with(
+            table_name=hive_stats_collection_operator.table)
+        mock_presto_hook.assert_called_once_with(presto_conn_id=hive_stats_collection_operator.presto_conn_id)
+        mock_mysql_hook.assert_called_once_with(hive_stats_collection_operator.mysql_conn_id)
+        mock_json_dumps.assert_called_once_with(hive_stats_collection_operator.partition, sort_keys=True)
+        field_types = {
+            col.name: col.type for col in mock_hive_metastore_hook.return_value.get_table.return_value.sd.cols
+        }
+        exprs = {
+            ('', 'count'): 'COUNT(*)'
+        }
+        for col, col_type in list(field_types.items()):
+            exprs.update(hive_stats_collection_operator.get_default_exprs(col, col_type))
+        exprs = OrderedDict(exprs)
+        rows = [(hive_stats_collection_operator.ds,
+                 hive_stats_collection_operator.dttm,
+                 hive_stats_collection_operator.table,
+                 mock_json_dumps.return_value) +
+                (r[0][0], r[0][1], r[1])
+                for r in zip(exprs, mock_presto_hook.return_value.get_first.return_value)]
+        mock_mysql_hook.return_value.insert_rows.assert_called_once_with(
+            table='hive_stats',
+            rows=rows,
+            target_fields=[
+                'ds',
+                'dttm',
+                'table_name',
+                'partition_repr',
+                'col',
+                'metric',
+                'value',
+            ]
+        )
+
+    @patch('airflow.operators.hive_stats_operator.json.dumps')
+    @patch('airflow.operators.hive_stats_operator.MySqlHook')
+    @patch('airflow.operators.hive_stats_operator.PrestoHook')
+    @patch('airflow.operators.hive_stats_operator.HiveMetastoreHook')
+    def test_execute_with_assignment_func(self,
+                                          mock_hive_metastore_hook,
+                                          mock_presto_hook,
+                                          mock_mysql_hook,
+                                          mock_json_dumps):
+        def assignment_func(col, col_type):
+            return {
+                (col, 'test'): 'TEST({})'.format(col)
+            }
+
+        self.kwargs.update(dict(assignment_func=assignment_func))
+        mock_hive_metastore_hook.return_value.get_table.return_value.sd.cols = [fake_col]
+        mock_mysql_hook.return_value.get_records.return_value = False
+
+        hive_stats_collection_operator = HiveStatsCollectionOperator(**self.kwargs)
+        hive_stats_collection_operator.execute(context={})
+
+        field_types = {
+            col.name: col.type for col in mock_hive_metastore_hook.return_value.get_table.return_value.sd.cols
+        }
+        exprs = {
+            ('', 'count'): 'COUNT(*)'
+        }
+        for col, col_type in list(field_types.items()):
+            exprs.update(hive_stats_collection_operator.assignment_func(col, col_type))
+        exprs = OrderedDict(exprs)
+        rows = [(hive_stats_collection_operator.ds,
+                 hive_stats_collection_operator.dttm,
+                 hive_stats_collection_operator.table,
+                 mock_json_dumps.return_value) +
+                (r[0][0], r[0][1], r[1])
+                for r in zip(exprs, mock_presto_hook.return_value.get_first.return_value)]
+        mock_mysql_hook.return_value.insert_rows.assert_called_once_with(
+            table='hive_stats',
+            rows=rows,
+            target_fields=[
+                'ds',
+                'dttm',
+                'table_name',
+                'partition_repr',
+                'col',
+                'metric',
+                'value',
+            ]
+        )
+
+    @patch('airflow.operators.hive_stats_operator.json.dumps')
+    @patch('airflow.operators.hive_stats_operator.MySqlHook')
+    @patch('airflow.operators.hive_stats_operator.PrestoHook')
+    @patch('airflow.operators.hive_stats_operator.HiveMetastoreHook')
+    def test_execute_with_assignment_func_no_return_value(self,
+                                                          mock_hive_metastore_hook,
+                                                          mock_presto_hook,
+                                                          mock_mysql_hook,
+                                                          mock_json_dumps):
+        def assignment_func(col, col_type):
+            pass
+
+        self.kwargs.update(dict(assignment_func=assignment_func))
+        mock_hive_metastore_hook.return_value.get_table.return_value.sd.cols = [fake_col]
+        mock_mysql_hook.return_value.get_records.return_value = False
+
+        hive_stats_collection_operator = HiveStatsCollectionOperator(**self.kwargs)
+        hive_stats_collection_operator.execute(context={})
+
+        field_types = {
+            col.name: col.type for col in mock_hive_metastore_hook.return_value.get_table.return_value.sd.cols
+        }
+        exprs = {
+            ('', 'count'): 'COUNT(*)'
+        }
+        for col, col_type in list(field_types.items()):
+            exprs.update(hive_stats_collection_operator.get_default_exprs(col, col_type))
+        exprs = OrderedDict(exprs)
+        rows = [(hive_stats_collection_operator.ds,
+                 hive_stats_collection_operator.dttm,
+                 hive_stats_collection_operator.table,
+                 mock_json_dumps.return_value) +
+                (r[0][0], r[0][1], r[1])
+                for r in zip(exprs, mock_presto_hook.return_value.get_first.return_value)]
+        mock_mysql_hook.return_value.insert_rows.assert_called_once_with(
+            table='hive_stats',
+            rows=rows,
+            target_fields=[
+                'ds',
+                'dttm',
+                'table_name',
+                'partition_repr',
+                'col',
+                'metric',
+                'value',
+            ]
+        )
+
+    @patch('airflow.operators.hive_stats_operator.MySqlHook')
+    @patch('airflow.operators.hive_stats_operator.PrestoHook')
+    @patch('airflow.operators.hive_stats_operator.HiveMetastoreHook')
+    def test_execute_no_query_results(self, mock_hive_metastore_hook, mock_presto_hook, mock_mysql_hook):
+        mock_hive_metastore_hook.return_value.get_table.return_value.sd.cols = [fake_col]
+        mock_mysql_hook.return_value.get_records.return_value = False
+        mock_presto_hook.return_value.get_first.return_value = None
+
+        self.assertRaises(AirflowException, HiveStatsCollectionOperator(**self.kwargs).execute, context={})
+
+    @patch('airflow.operators.hive_stats_operator.json.dumps')
+    @patch('airflow.operators.hive_stats_operator.MySqlHook')
+    @patch('airflow.operators.hive_stats_operator.PrestoHook')
+    @patch('airflow.operators.hive_stats_operator.HiveMetastoreHook')
+    def test_execute_delete_previous_runs_rows(self,
+                                               mock_hive_metastore_hook,
+                                               mock_presto_hook,
+                                               mock_mysql_hook,
+                                               mock_json_dumps):
+        mock_hive_metastore_hook.return_value.get_table.return_value.sd.cols = [fake_col]
+        mock_mysql_hook.return_value.get_records.return_value = True
+
+        hive_stats_collection_operator = HiveStatsCollectionOperator(**self.kwargs)
+        hive_stats_collection_operator.execute(context={})
+
+        sql = """
+            DELETE FROM hive_stats
+            WHERE
+                table_name='{}' AND
+                partition_repr='{}' AND
+                dttm='{}';
+            """.format(
+            hive_stats_collection_operator.table,
+            mock_json_dumps.return_value,
+            hive_stats_collection_operator.dttm
+        )
+        mock_mysql_hook.return_value.run.assert_called_once_with(sql)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3582
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

- adds tests for hive_stats_operator
- removes duplicated entry in list used in get_default_exprs
- refactoring

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
