### PR TITLE
[AIRFLOW-3595] Add tests for Hive2SambaOperator

### DIFF
--- a/airflow/operators/hive_to_samba_operator.py
+++ b/airflow/operators/hive_to_samba_operator.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import tempfile
+from tempfile import NamedTemporaryFile
 
 from airflow.hooks.hive_hooks import HiveServer2Hook
 from airflow.hooks.samba_hook import SambaHook
@@ -33,35 +33,35 @@ class Hive2SambaOperator(BaseOperator):
 
     :param hql: the hql to be exported. (templated)
     :type hql: str
-    :param hiveserver2_conn_id: reference to the hiveserver2 service
-    :type hiveserver2_conn_id: str
+    :param destination_filepath: the file path to where the file will be pushed onto samba
+    :type destination_filepath: str
     :param samba_conn_id: reference to the samba destination
     :type samba_conn_id: str
+    :param hiveserver2_conn_id: reference to the hiveserver2 service
+    :type hiveserver2_conn_id: str
     """
 
     template_fields = ('hql', 'destination_filepath')
     template_ext = ('.hql', '.sql',)
 
     @apply_defaults
-    def __init__(
-            self, hql,
-            destination_filepath,
-            samba_conn_id='samba_default',
-            hiveserver2_conn_id='hiveserver2_default',
-            *args, **kwargs):
+    def __init__(self,
+                 hql,
+                 destination_filepath,
+                 samba_conn_id='samba_default',
+                 hiveserver2_conn_id='hiveserver2_default',
+                 *args, **kwargs):
         super(Hive2SambaOperator, self).__init__(*args, **kwargs)
-
         self.hiveserver2_conn_id = hiveserver2_conn_id
         self.samba_conn_id = samba_conn_id
         self.destination_filepath = destination_filepath
         self.hql = hql.strip().rstrip(';')
 
     def execute(self, context):
-        samba = SambaHook(samba_conn_id=self.samba_conn_id)
-        hive = HiveServer2Hook(hiveserver2_conn_id=self.hiveserver2_conn_id)
-        tmpfile = tempfile.NamedTemporaryFile()
-        self.log.info("Fetching file from Hive")
-        hive.to_csv(hql=self.hql, csv_filepath=tmpfile.name,
-                    hive_conf=context_to_airflow_vars(context))
-        self.log.info("Pushing to samba")
-        samba.push_from_local(self.destination_filepath, tmpfile.name)
+        with NamedTemporaryFile() as tmp_file:
+            self.log.info("Fetching file from Hive")
+            hive = HiveServer2Hook(hiveserver2_conn_id=self.hiveserver2_conn_id)
+            hive.to_csv(hql=self.hql, csv_filepath=tmp_file.name, hive_conf=context_to_airflow_vars(context))
+            self.log.info("Pushing to samba")
+            samba = SambaHook(samba_conn_id=self.samba_conn_id)
+            samba.push_from_local(self.destination_filepath, tmp_file.name)

--- a/tests/operators/test_hive_to_samba_operator.py
+++ b/tests/operators/test_hive_to_samba_operator.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from mock import patch, PropertyMock, Mock
+
+from airflow.operators.hive_to_samba_operator import Hive2SambaOperator
+from airflow.utils.operator_helpers import context_to_airflow_vars
+
+
+class TestHive2SambaOperator(unittest.TestCase):
+
+    def setUp(self):
+        self.kwargs = dict(
+            hql='hql',
+            destination_filepath='destination_filepath',
+            samba_conn_id='samba_default',
+            hiveserver2_conn_id='hiveserver2_default',
+            task_id='test_hive_to_samba_operator',
+            dag=None
+        )
+
+    @patch('airflow.operators.hive_to_samba_operator.SambaHook')
+    @patch('airflow.operators.hive_to_samba_operator.HiveServer2Hook')
+    @patch('airflow.operators.hive_to_samba_operator.NamedTemporaryFile')
+    def test_execute(self, mock_tmp_file, mock_hive_hook, mock_samba_hook):
+        type(mock_tmp_file).name = PropertyMock(return_value='tmp_file')
+        mock_tmp_file.return_value.__enter__ = Mock(return_value=mock_tmp_file)
+        context = {}
+
+        Hive2SambaOperator(**self.kwargs).execute(context)
+
+        mock_hive_hook.assert_called_once_with(hiveserver2_conn_id=self.kwargs['hiveserver2_conn_id'])
+        mock_hive_hook.return_value.to_csv.assert_called_once_with(
+            hql=self.kwargs['hql'],
+            csv_filepath=mock_tmp_file.name,
+            hive_conf=context_to_airflow_vars(context))
+        mock_samba_hook.assert_called_once_with(samba_conn_id=self.kwargs['samba_conn_id'])
+        mock_samba_hook.return_value.push_from_local.assert_called_once_with(
+            self.kwargs['destination_filepath'], mock_tmp_file.name)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3595
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

- adds missing doc parameter destination_filepath
- adds missing file close for tmp file (through ContextManager Usage)
- refactoring

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
