### PR TITLE
[AIRFLOW-XXX] - Fix missing type in docstring of MySqlToGoogleCloudStorageOperator

### DIFF
--- a/airflow/contrib/operators/mysql_to_gcs.py
+++ b/airflow/contrib/operators/mysql_to_gcs.py
@@ -71,6 +71,7 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
     :param delegate_to: The account to impersonate, if any. For this to
         work, the service account making the request must have domain-wide
         delegation enabled.
+    :type delegate_to: str        
     """
     template_fields = ('sql', 'bucket', 'filename', 'schema_filename', 'schema')
     template_ext = ('.sql',)


### PR DESCRIPTION
Add missing type of delegate_to
