### PR TITLE
Remove invalid parameter KeepJobFlowAliveWhenNoSteps

### DIFF
--- a/airflow/contrib/example_dags/example_emr_job_flow_manual_steps.py
+++ b/airflow/contrib/example_dags/example_emr_job_flow_manual_steps.py
@@ -54,8 +54,7 @@ SPARK_TEST_STEPS = [
 ]
 
 JOB_FLOW_OVERRIDES = {
-    'Name': 'PiCalc',
-    'KeepJobFlowAliveWhenNoSteps': True
+    'Name': 'PiCalc'
 }
 
 dag = DAG(


### PR DESCRIPTION
The parameter 'KeepJobFlowAliveWhenNoSteps' in  JOB_FLOW_OVERRIDES doesn't pass boto API parameter validation, as it should be a part of 'Instances' object.

When removed - the example runs as should. 

### Code Quality

- [ ] Passes `flake8`
