### PR TITLE
[AIRFLOW-3603] QuboleOperator: Remove SQLCommand from SparkCmd Doc 

### DIFF
--- a/airflow/contrib/operators/qubole_operator.py
+++ b/airflow/contrib/operators/qubole_operator.py
@@ -67,12 +67,12 @@ class QuboleOperator(BaseOperator):
             :parameters: any extra args which need to be passed to script (only when
                 script_location is supplied
         sparkcmd:
-            :program: the complete Spark Program in Scala, SQL, Command, R, or Python
+            :program: the complete Spark Program in Scala, R, or Python
             :cmdline: spark-submit command line, all required information must be specify
                 in cmdline itself.
             :sql: inline sql query
             :script_location: s3 location containing query statement
-            :language: language of the program, Scala, SQL, Command, R, or Python
+            :language: language of the program, Scala, R, or Python
             :app_id: ID of an Spark job server app
             :arguments: spark-submit command line arguments
             :user_program_arguments: arguments that the user program takes in


### PR DESCRIPTION

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3603) issues and references them in the PR [AIRFLOW-3603]QuboleOperator: remove SQLCommand from SparkCmd Doc 
  - https://issues.apache.org/jira/browse/AIRFLOW-3603

### Description

- [ ] The SparkCmd doesn't support SQL for prog and language arguments, this is to reflect it in the documentation.


### Tests

- [ ] Change in documentation, no tests needed.

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue.

### Documentation

- [ ] Change in documentation only

### Code Quality

- [ ] Passes `flake8`
