### PR TITLE
[AIRFLOW-3605] Load plugins from entry_points

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -220,3 +220,56 @@ Note on role based views
 Airflow 1.10 introduced role based views using FlaskAppBuilder. You can configure which UI is used by setting
 rbac = True. To support plugin views and links for both versions of the UI and maintain backwards compatibility,
 the fields appbuilder_views and appbuilder_menu_items were added to the AirflowTestPlugin class.
+
+
+Plugins as Python packages
+--------------------------
+
+It is possible to load plugins via `setuptools' entrypoint<https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata>`_ mechanism. To do this link
+your plugin using an entrypoint in your package. If the package is installed, airflow
+will automatically load the registered plugins from the entrypoint list.
+
+_Note_: Neither the entrypoint name (eg, `my_plugin`) nor the name of the
+plugin class will contribute towards the module and class name of the plugin
+itself. The structure is determined by
+`airflow.plugins_manager.AirflowPlugin.name` and the class name of the plugin
+component with the pattern `airflow.{component}.{name}.{component_class_name}`.
+
+.. code-block:: python
+
+    # my_package/my_plugin.py
+    from airflow.plugins_manager import AirflowPlugin
+    from airflow.models import BaseOperator
+    from airflow.hooks.base_hook import BaseHook
+
+    class MyOperator(BaseOperator):
+      pass
+
+    class MyHook(BaseHook):
+      pass
+
+    class MyAirflowPlugin(AirflowPlugin):
+      name = 'my_namespace'
+      operators = [MyOperator]
+      hooks = [MyHook]
+
+
+.. code-block:: python
+
+    from setuptools import setup
+
+    setup(
+        name="my-package",
+        ...
+        entry_points = {
+            'airflow.plugins': [
+                'my_plugin = my_package.my_plugin:MyAirflowPlugin'
+            ]
+        }
+    )
+
+::
+
+This will create a hook, and an operator accessible at:
+ - `airflow.hooks.my_namespace.MyHook`
+ - `airflow.operators.my_namespace.MyOperator`

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -117,3 +117,15 @@ class AirflowTestPlugin(AirflowPlugin):
     menu_links = [ml]
     appbuilder_views = [v_appbuilder_package]
     appbuilder_menu_items = [appbuilder_mitem]
+
+
+class MockPluginA(AirflowPlugin):
+    name = 'plugin-a'
+
+
+class MockPluginB(AirflowPlugin):
+    name = 'plugin-b'
+
+
+class MockPluginC(AirflowPlugin):
+    name = 'plugin-c'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-3605

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Added logic to load AirflowPlugins from the [entry_points](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#id16). Rather than moving files on the OS, this allows plugins to be installed and distributed via `pip`. 

Also added a callback to execute business logic from the plugin when the plugin is loaded.

### Tests

- [x] My PR adds the following unit tests:
 - `plugins_manager.PluginsEntrypointLoad`
 - `plugins_manager.PluginsTestValidator`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

~I haven't written the documentation yet, as I wanted to see if there was an appetite for this kind of loading of plugins.~

### Code Quality

- [x] Passes `flake8`
