### PR TITLE
[AIRFLOW-3610] Add region param for EMR jobflow creation

### DIFF
--- a/airflow/contrib/hooks/emr_hook.py
+++ b/airflow/contrib/hooks/emr_hook.py
@@ -27,12 +27,13 @@ class EmrHook(AwsHook):
     create_job_flow method.
     """
 
-    def __init__(self, emr_conn_id=None, *args, **kwargs):
+    def __init__(self, emr_conn_id=None, region_name=None, *args, **kwargs):
         self.emr_conn_id = emr_conn_id
+        self.region_name = region_name
         super(EmrHook, self).__init__(*args, **kwargs)
 
     def get_conn(self):
-        self.conn = self.get_client_type('emr')
+        self.conn = self.get_client_type('emr', self.region_name)
         return self.conn
 
     def create_job_flow(self, job_flow_overrides):

--- a/airflow/contrib/operators/emr_create_job_flow_operator.py
+++ b/airflow/contrib/operators/emr_create_job_flow_operator.py
@@ -46,6 +46,7 @@ class EmrCreateJobFlowOperator(BaseOperator):
             aws_conn_id='s3_default',
             emr_conn_id='emr_default',
             job_flow_overrides=None,
+            region_name=None,
             *args, **kwargs):
         super(EmrCreateJobFlowOperator, self).__init__(*args, **kwargs)
         self.aws_conn_id = aws_conn_id
@@ -53,9 +54,10 @@ class EmrCreateJobFlowOperator(BaseOperator):
         if job_flow_overrides is None:
             job_flow_overrides = {}
         self.job_flow_overrides = job_flow_overrides
+        self.region_name = region_name
 
     def execute(self, context):
-        emr = EmrHook(aws_conn_id=self.aws_conn_id, emr_conn_id=self.emr_conn_id)
+        emr = EmrHook(aws_conn_id=self.aws_conn_id, emr_conn_id=self.emr_conn_id, region_name=self.region_name)
 
         self.log.info(
             'Creating JobFlow using aws-conn-id: %s, emr-conn-id: %s',

--- a/tests/contrib/hooks/test_emr_hook.py
+++ b/tests/contrib/hooks/test_emr_hook.py
@@ -38,7 +38,7 @@ class TestEmrHook(unittest.TestCase):
 
     @mock_emr
     def test_get_conn_returns_a_boto3_connection(self):
-        hook = EmrHook(aws_conn_id='aws_default')
+        hook = EmrHook(aws_conn_id='aws_default', region_name='ap-southeast-2')
         self.assertIsNotNone(hook.get_conn().list_clusters())
 
     @mock_emr

--- a/tests/contrib/operators/test_emr_create_job_flow_operator.py
+++ b/tests/contrib/operators/test_emr_create_job_flow_operator.py
@@ -71,12 +71,14 @@ class TestEmrCreateJobFlowOperator(unittest.TestCase):
             aws_conn_id='aws_default',
             emr_conn_id='emr_default',
             job_flow_overrides=self._config,
+            region_name='ap-southeast-2',
             dag=DAG('test_dag_id', default_args=args)
         )
 
     def test_init(self):
         self.assertEqual(self.operator.aws_conn_id, 'aws_default')
         self.assertEqual(self.operator.emr_conn_id, 'emr_default')
+        self.assertEqual(self.operator.region_name, 'ap-southeast-2')
 
     def test_render_template(self):
         ti = TaskInstance(self.operator, DEFAULT_DATE)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3610

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
This PR is to allow setting the AWS region in the `EmrCreateJobFlowOperator` so that we can create an EMR job flow in any region.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Amending [test](https://github.com/danabananarama/incubator-airflow/blob/c451cedc3b760059c04293b25772c42db7917f10/tests/contrib/operators/test_emr_create_job_flow_operator.py#L81), did not add new test for functionality as it's essentially just persisting a new init param. Let me know if a new test needs to be added!

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X] Passes `flake8`
