### PR TITLE
[AIRFLOW-XXX] Fix Flake8 error

### DIFF
--- a/airflow/contrib/operators/mysql_to_gcs.py
+++ b/airflow/contrib/operators/mysql_to_gcs.py
@@ -71,7 +71,7 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
     :param delegate_to: The account to impersonate, if any. For this to
         work, the service account making the request must have domain-wide
         delegation enabled.
-    :type delegate_to: str        
+    :type delegate_to: str
     """
     template_fields = ('sql', 'bucket', 'filename', 'schema_filename', 'schema')
     template_ext = ('.sql',)


### PR DESCRIPTION
This error passed PR CI (in https://github.com/apache/incubator-airflow/pull/4403) when the Flake8 test was not working from https://github.com/apache/incubator-airflow/commit/7a6acbf5b343e4a6895d1cc8af75ecc02b4fd0e8 (10 days ago) to https://github.com/apache/incubator-airflow/commit/0d5c127d720e3b602fb4322065511c5c1c046adb (today).

The Flake8 test is already fixed in https://github.com/apache/incubator-airflow/pull/4415 https://github.com/apache/incubator-airflow/commit/0d5c127d720e3b602fb4322065511c5c1c046adb, so this error arose after it was merged into master.
