### PR TITLE
[AIRFLOW-3618] - Fix models.connection.Connection get_hook function

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -175,67 +175,67 @@ class Connection(Base, LoggingMixin):
 
     def get_hook(self):
         try:
-            if self.conn_type == 'mysql':
+            if self.conn_type.lower() == 'mysql':
                 from airflow.hooks.mysql_hook import MySqlHook
                 return MySqlHook(mysql_conn_id=self.conn_id)
-            elif self.conn_type == 'google_cloud_platform':
+            elif self.conn_type.lower() == 'google_cloud_platform':
                 from airflow.contrib.hooks.bigquery_hook import BigQueryHook
                 return BigQueryHook(bigquery_conn_id=self.conn_id)
-            elif self.conn_type == 'postgres':
+            elif self.conn_type.lower() == 'postgres':
                 from airflow.hooks.postgres_hook import PostgresHook
                 return PostgresHook(postgres_conn_id=self.conn_id)
-            elif self.conn_type == 'hive_cli':
+            elif self.conn_type.lower() == 'hive_cli':
                 from airflow.hooks.hive_hooks import HiveCliHook
                 return HiveCliHook(hive_cli_conn_id=self.conn_id)
-            elif self.conn_type == 'presto':
+            elif self.conn_type.lower() == 'presto':
                 from airflow.hooks.presto_hook import PrestoHook
                 return PrestoHook(presto_conn_id=self.conn_id)
-            elif self.conn_type == 'hiveserver2':
+            elif self.conn_type.lower() == 'hiveserver2':
                 from airflow.hooks.hive_hooks import HiveServer2Hook
                 return HiveServer2Hook(hiveserver2_conn_id=self.conn_id)
-            elif self.conn_type == 'sqlite':
+            elif self.conn_type.lower() == 'sqlite':
                 from airflow.hooks.sqlite_hook import SqliteHook
                 return SqliteHook(sqlite_conn_id=self.conn_id)
-            elif self.conn_type == 'jdbc':
+            elif self.conn_type.lower() == 'jdbc':
                 from airflow.hooks.jdbc_hook import JdbcHook
                 return JdbcHook(jdbc_conn_id=self.conn_id)
-            elif self.conn_type == 'mssql':
+            elif self.conn_type.lower() == 'mssql':
                 from airflow.hooks.mssql_hook import MsSqlHook
                 return MsSqlHook(mssql_conn_id=self.conn_id)
-            elif self.conn_type == 'oracle':
+            elif self.conn_type.lower() == 'oracle':
                 from airflow.hooks.oracle_hook import OracleHook
                 return OracleHook(oracle_conn_id=self.conn_id)
-            elif self.conn_type == 'vertica':
+            elif self.conn_type.lower() == 'vertica':
                 from airflow.contrib.hooks.vertica_hook import VerticaHook
                 return VerticaHook(vertica_conn_id=self.conn_id)
-            elif self.conn_type == 'cloudant':
+            elif self.conn_type.lower() == 'cloudant':
                 from airflow.contrib.hooks.cloudant_hook import CloudantHook
                 return CloudantHook(cloudant_conn_id=self.conn_id)
-            elif self.conn_type == 'jira':
+            elif self.conn_type.lower() == 'jira':
                 from airflow.contrib.hooks.jira_hook import JiraHook
                 return JiraHook(jira_conn_id=self.conn_id)
-            elif self.conn_type == 'redis':
+            elif self.conn_type.lower() == 'redis':
                 from airflow.contrib.hooks.redis_hook import RedisHook
                 return RedisHook(redis_conn_id=self.conn_id)
-            elif self.conn_type == 'wasb':
+            elif self.conn_type.lower() == 'wasb':
                 from airflow.contrib.hooks.wasb_hook import WasbHook
                 return WasbHook(wasb_conn_id=self.conn_id)
-            elif self.conn_type == 'docker':
+            elif self.conn_type.lower() == 'docker':
                 from airflow.hooks.docker_hook import DockerHook
                 return DockerHook(docker_conn_id=self.conn_id)
-            elif self.conn_type == 'azure_data_lake':
+            elif self.conn_type.lower() == 'azure_data_lake':
                 from airflow.contrib.hooks.azure_data_lake_hook import AzureDataLakeHook
                 return AzureDataLakeHook(azure_data_lake_conn_id=self.conn_id)
-            elif self.conn_type == 'azure_cosmos':
+            elif self.conn_type.lower() == 'azure_cosmos':
                 from airflow.contrib.hooks.azure_cosmos_hook import AzureCosmosDBHook
                 return AzureCosmosDBHook(azure_cosmos_conn_id=self.conn_id)
-            elif self.conn_type == 'cassandra':
+            elif self.conn_type.lower() == 'cassandra':
                 from airflow.contrib.hooks.cassandra_hook import CassandraHook
                 return CassandraHook(cassandra_conn_id=self.conn_id)
-            elif self.conn_type == 'mongo':
+            elif self.conn_type.lower() == 'mongo':
                 from airflow.contrib.hooks.mongo_hook import MongoHook
                 return MongoHook(conn_id=self.conn_id)
-            elif self.conn_type == 'gcpcloudsql':
+            elif self.conn_type.lower() == 'gcpcloudsql':
                 from airflow.contrib.hooks.gcp_sql_hook import CloudSqlDatabaseHook
                 return CloudSqlDatabaseHook(gcp_cloudsql_conn_id=self.conn_id)
         except Exception:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-3618

### Description

- [x] The airflow.models.connection.Connection class function get_hook did not work as expected. The `conn_type` was not guaranteed to be lower case, and the get_hook function expected all lowercase type names. By updating the code so that the conditionals used `self.conn_type.lower()` instead of just `self.conn_type`, we can now make sure that the conditionals match the expected. 

For example:
```
>>> import airflow
>>> from airflow.hooks.base_hook import BaseHook
>>> airflow.__version__
'1.10.1'
>>> conn = BaseHook.get_connection('test_local_mysql')
[2019-01-02 11:36:15,530] {base_hook.py:83} INFO - Using connection to: localhost
>>> conn.conn_type
'MySQL'
>>> type(conn.get_hook())
<class 'NoneType'>
>>> conn.conn_type = conn.conn_type.lower()
>>> conn.conn_type
'mysql'
>>> type(conn.get_hook())
<class 'airflow.hooks.mysql_hook.MySqlHook'>
```

### Tests

- [x] Does not need tests as it is updating existing functionality which should already have test associated.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] No new documentation is needed as the change is a bug fix which does not change the expected functionality of the function `Connection.get_hook`.

### Code Quality

- [x] Passes `flake8`