### PR TITLE
[AIRFLOW-3624] Add masterType parameter to MLEngineTrainingOperator

### DIFF
--- a/airflow/contrib/operators/mlengine_operator.py
+++ b/airflow/contrib/operators/mlengine_operator.py
@@ -473,6 +473,10 @@ class MLEngineTrainingOperator(BaseOperator):
     :param scale_tier: Resource tier for MLEngine training job. (templated)
     :type scale_tier: str
 
+    :param master_type: Cloud ML Engine machine name.
+        Must be set when scale_tier is CUSTOM. (templated)
+    :type master_type: str
+
     :param runtime_version: The Google Cloud ML runtime version to use for
         training. (templated)
     :type runtime_version: str
@@ -507,6 +511,7 @@ class MLEngineTrainingOperator(BaseOperator):
         '_training_args',
         '_region',
         '_scale_tier',
+        '_master_type',
         '_runtime_version',
         '_python_version',
         '_job_dir'
@@ -521,6 +526,7 @@ class MLEngineTrainingOperator(BaseOperator):
                  training_args,
                  region,
                  scale_tier=None,
+                 master_type=None,
                  runtime_version=None,
                  python_version=None,
                  job_dir=None,
@@ -537,6 +543,7 @@ class MLEngineTrainingOperator(BaseOperator):
         self._training_args = training_args
         self._region = region
         self._scale_tier = scale_tier
+        self._master_type = master_type
         self._runtime_version = runtime_version
         self._python_version = python_version
         self._job_dir = job_dir
@@ -560,6 +567,9 @@ class MLEngineTrainingOperator(BaseOperator):
                 'packages is required.')
         if not self._region:
             raise AirflowException('Google Compute Engine region is required.')
+        if self._scale_tier is not None and self._scale_tier.upper() == "CUSTOM" and not self._master_type:
+            raise AirflowException(
+                'master_type must be set when scale_tier is CUSTOM')
 
     def execute(self, context):
         job_id = _normalize_mlengine_job_id(self._job_id)
@@ -582,6 +592,9 @@ class MLEngineTrainingOperator(BaseOperator):
 
         if self._job_dir:
             training_request['trainingInput']['jobDir'] = self._job_dir
+
+        if self._scale_tier is not None and self._scale_tier.upper() == "CUSTOM":
+            training_request['trainingInput']['masterType'] = self._master_type
 
         if self._mode == 'DRY_RUN':
             self.log.info('In dry_run mode.')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

Ref to document https://cloud.google.com/ml-engine/docs/tensorflow/machine-types

> When the scale_tier is set to CUSTOM, user should specify masterType
> The CUSTOM tier is not a set tier, but rather enables you to use your own cluster specification. When you use this tier, set values to configure your processing cluster according to these guidelines:
> 
> * You must set TrainingInput.masterType to specify the type of machine to use for your master node. This is the only required setting. See the machine types described below.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
