### PR TITLE
[AIRFLOW-3625] Add Redis Cluster support

### DIFF
--- a/airflow/contrib/hooks/redis_cluster_hook.py
+++ b/airflow/contrib/hooks/redis_cluster_hook.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from rediscluster import StrictRedisCluster
+from airflow.exceptions import AirflowException
+from airflow.hooks.base_hook import BaseHook
+from airflow.utils.log.logging_mixin import LoggingMixin
+
+
+class RedisClusterHook(BaseHook, LoggingMixin):
+    """
+    Hook to interact with Redis Cluster
+
+    Note: If the Redis Cluster is launched in AWS Elasticache,
+    the hook must be initialized with skip_full_coverage_check=True option.
+    This is because AWS disallowed the CONFIG command in the Redis Cluster.
+    """
+    def __init__(self, redis_cluster_conn_id='redis_cluster_default',
+                 skip_full_coverage_check=False, **kwargs):
+        """
+        Prepares hook to connect to a Redis Cluster.
+
+        :param redis_cluster_conn_id: the name of the connection that has the
+            parameters we need to connect to Redis Cluster.
+        :type redis_cluster_conn_id: str
+        :param skip_full_coverage_check: If True, the hook will skip the check
+            of 'cluster-require-full-coverage' config, useful for clusters
+            without the CONFIG command.
+        :type skip_full_coverage_check: bool
+        :param kwargs: optional arguments to pass to `StrictRedisCluster()`.
+        :type kwargs: object
+        """
+        self.redis_cluster_conn_id = redis_cluster_conn_id
+        self.client = None
+        conn = self.get_connection(self.redis_cluster_conn_id)
+        self.startup_nodes = conn.extra_dejson.get('startup_nodes', [])
+        if conn.host and conn.port:
+            self.startup_nodes.append({
+                "host": conn.host,
+                "port": int(conn.port)
+            })
+        self.skip_full_coverage_check = skip_full_coverage_check
+        self.kwargs = kwargs
+
+        self.log.info(
+            '''Connection "{conn}":
+            \tstartup_nodes: {startup_nodes}
+            '''.format(
+                conn=self.redis_cluster_conn_id,
+                startup_nodes=self.startup_nodes
+            )
+        )
+
+    def get_conn(self):
+        """
+        Returns a StrictRedisCluster connection.
+        """
+        if not self.client:
+            self.log.info(
+                'generating StrictRedisCluster client for conn_id "%s" with startup_nodes = %s',
+                self.redis_cluster_conn_id, self.startup_nodes
+            )
+            try:
+                self.client = StrictRedisCluster(
+                    startup_nodes=self.startup_nodes,
+                    skip_full_coverage_check=self.skip_full_coverage_check,
+                    **self.kwargs
+                )
+            except Exception as general_error:
+                raise AirflowException(
+                    'Failed to create StrictRedisCluster client, error: {error}'.format(
+                        error=str(general_error)
+                    )
+                )
+
+        return self.client

--- a/airflow/contrib/sensors/redis_cluster_key_sensor.py
+++ b/airflow/contrib/sensors/redis_cluster_key_sensor.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from airflow.contrib.hooks.redis_cluster_hook import RedisClusterHook
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class RedisClusterKeySensor(BaseSensorOperator):
+    """
+    Checks for the existence of a key in a Redis Cluster
+    """
+    template_fields = ('key',)
+    ui_color = '#d8766c'
+
+    @apply_defaults
+    def __init__(self, key, redis_cluster_conn_id, *args, **kwargs):
+        """
+        Creates a new RedisClusterKeySensor
+
+        :param key: the key to monitor its existence.
+        :type key: str
+        :param redis_cluster_conn_id: the name of the connection that has the
+            parameters we need to connect to Redis Cluster.
+        :type redis_cluster_conn_id: str
+        """
+        super(RedisClusterKeySensor, self).__init__(*args, **kwargs)
+        self.redis_cluster_conn_id = redis_cluster_conn_id
+        self.key = key
+
+    def poke(self, context):
+        self.log.info('Sensor checks for existence of key: %s', self.key)
+        return RedisClusterHook(self.redis_cluster_conn_id).get_conn().exists(self.key)

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -77,6 +77,7 @@ class Connection(Base, LoggingMixin):
         ('mesos_framework-id', 'Mesos Framework ID'),
         ('jira', 'JIRA',),
         ('redis', 'Redis',),
+        ('redis_cluster', 'Redis Cluster',),
         ('wasb', 'Azure Blob Storage'),
         ('databricks', 'Databricks',),
         ('aws', 'Amazon Web Services',),
@@ -226,6 +227,9 @@ class Connection(Base, LoggingMixin):
         elif self.conn_type == 'redis':
             from airflow.contrib.hooks.redis_hook import RedisHook
             return RedisHook(redis_conn_id=self.conn_id)
+        elif self.conn_type == 'redis_cluster':
+            from airflow.contrib.hooks.redis_cluster_hook import RedisClusterHook
+            return RedisClusterHook(redis_cluster_conn_id=self.conn_id)
         elif self.conn_type == 'wasb':
             from airflow.contrib.hooks.wasb_hook import WasbHook
             return WasbHook(wasb_conn_id=self.conn_id)

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -209,6 +209,18 @@ def initdb():
             extra='{"db": 0}'))
     merge_conn(
         Connection(
+            conn_id='redis_cluster_default', conn_type='redis_cluster',
+            extra='''
+                {   "startup_nodes": [
+                        {
+                            "host": "redis-cluster",
+                            "port": 7000
+                        }
+                    ]
+                }
+            '''))
+    merge_conn(
+        Connection(
             conn_id='sqoop_default', conn_type='sqoop',
             host='rmdbs', extra=''))
     merge_conn(

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -112,6 +112,8 @@ Here's the list of the subpackages and what they enable:
 +---------------------+---------------------------------------------------+----------------------------------------------------------------------+
 | redis               | ``pip install apache-airflow[redis]``             | Redis hooks and sensors                                              |
 +---------------------+---------------------------------------------------+----------------------------------------------------------------------+
+| redis_cluster       | ``pip install apache-airflow[redis_cluster]``     | Redis Cluster hooks and sensors                                      |
++---------------------+---------------------------------------------------+----------------------------------------------------------------------+
 | samba               | ``pip install apache-airflow[samba]``             | :class:`airflow.operators.hive_to_samba_operator.Hive2SambaOperator` |
 +---------------------+---------------------------------------------------+----------------------------------------------------------------------+
 | slack               | ``pip install apache-airflow[slack]``             | :class:`airflow.operators.slack_operator.SlackAPIOperator`           |

--- a/scripts/ci/docker-compose.yml
+++ b/scripts/ci/docker-compose.yml
@@ -49,6 +49,10 @@ services:
     image: redis:5.0.1
     restart: always
 
+  redis-cluster:
+    image: grokzen/redis-cluster:5.0.1
+    restart: always
+
   openldap:
     image: osixia/openldap:1.2.0
     restart: always
@@ -91,6 +95,7 @@ services:
       - cassandra
       - rabbitmq
       - redis
+      - redis-cluster
       - openldap
       - krb5-kdc-server
     volumes:

--- a/setup.py
+++ b/setup.py
@@ -212,6 +212,7 @@ postgres = ['psycopg2>=2.7.4']
 qds = ['qds-sdk>=1.10.4']
 rabbitmq = ['librabbitmq>=1.6.1']
 redis = ['redis>=2.10.5,<3.0.0']
+redis_cluster = ['redis-py-cluster>=1.3.0,<2.0.0']
 salesforce = ['simple-salesforce>=0.72']
 samba = ['pysmbclient>=0.1.3']
 segment = ['analytics-python>=1.2.9']
@@ -258,7 +259,7 @@ if not PY3:
 devel_minreq = devel + kubernetes + mysql + doc + password + cgroups
 devel_hadoop = devel_minreq + hive + hdfs + webhdfs + kerberos
 devel_all = (sendgrid + devel + all_dbs + doc + samba + slack + crypto + oracle +
-             docker + ssh + kubernetes + celery + redis + gcp_api +
+             docker + ssh + kubernetes + celery + redis + redis_cluster + gcp_api +
              datadog + zendesk + jdbc + ldap + kerberos + password + webhdfs + jenkins +
              druid + pinot + segment + snowflake + elasticsearch +
              atlas + azure + aws)
@@ -371,6 +372,7 @@ def do_setup():
             'qds': qds,
             'rabbitmq': rabbitmq,
             'redis': redis,
+            'redis_cluster': redis_cluster,
             'salesforce': salesforce,
             'samba': samba,
             'sendgrid': sendgrid,

--- a/tests/contrib/hooks/test_redis_cluster_hook.py
+++ b/tests/contrib/hooks/test_redis_cluster_hook.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import unittest
+from airflow import configuration
+from airflow.contrib.hooks.redis_cluster_hook import RedisClusterHook
+
+
+class TestRedisClusterHook(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+
+    def test_get_conn(self):
+        hook = RedisClusterHook(redis_cluster_conn_id='redis_cluster_default')
+        self.assertEqual(hook.client, None)
+        self.assertEqual(hook.skip_full_coverage_check, False)
+
+        self.assertEqual(
+            hook.startup_nodes,
+            [{'host': 'redis-cluster', 'port': 7000}],
+            'startup_nodes is correctly initialized.'
+        )
+        self.assertIs(hook.get_conn(), hook.get_conn(), 'Connection initialized only if None.')
+
+    def test_real_ping(self):
+        hook = RedisClusterHook(redis_cluster_conn_id='redis_cluster_default')
+        redis_cluster = hook.get_conn()
+
+        pong = redis_cluster.ping()
+        self.assertTrue(all(pong.values()), 'Connection to Redis Cluster with PING works.')
+
+    def test_real_get_and_set(self):
+        hook = RedisClusterHook(
+            redis_cluster_conn_id='redis_cluster_default',
+            skip_full_coverage_check=True
+        )
+        redis_cluster = hook.get_conn()
+
+        self.assertTrue(
+            redis_cluster.set('test_key', 'test_value'),
+            'Connection to Redis Cluster with SET works.'
+        )
+        self.assertEqual(
+            redis_cluster.get('test_key'),
+            b'test_value',
+            'Connection to Redis Cluster with GET works.'
+        )
+        self.assertEqual(
+            redis_cluster.delete('test_key'),
+            1,
+            'Connection to Redis Cluster with DELETE works.'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/contrib/sensors/test_redis_cluster_sensor.py
+++ b/tests/contrib/sensors/test_redis_cluster_sensor.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import unittest
+from airflow import DAG
+from airflow import configuration
+from airflow.contrib.hooks.redis_cluster_hook import RedisClusterHook
+from airflow.contrib.sensors.redis_cluster_key_sensor import RedisClusterKeySensor
+from airflow.utils import timezone
+
+DEFAULT_DATE = timezone.datetime(2017, 1, 1)
+
+
+class TestRedisClusterSensor(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+        args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE
+        }
+
+        self.dag = DAG('test_dag_id', default_args=args)
+        self.sensor = RedisClusterKeySensor(
+            task_id='test_task',
+            redis_cluster_conn_id='redis_cluster_default',
+            dag=self.dag,
+            key='test_key'
+        )
+
+    def test_poke(self):
+        hook = RedisClusterHook(
+            redis_cluster_conn_id='redis_cluster_default',
+            skip_full_coverage_check=True
+        )
+        redis_cluster = hook.get_conn()
+        redis_cluster.set('test_key', 'test_value')
+        self.assertTrue(self.sensor.poke(None), "Key exists on first call.")
+        redis_cluster.delete('test_key')
+        self.assertFalse(self.sensor.poke(None), "Key does NOT exists on second call.")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3625
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
- This PR added a new operator and a sensor for Redis Cluster mode, since the existing `RedisHook` is incompatible with Redis Cluster
- In `setup.py`, added extra option for `redis_cluster`
- Added connection type `redis_cluster`

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- Test the instance variables in `RedisClusterHook`
- Test the correctness of getting and setting value in `RedisClusterHook`
- Test the correctness of `RedisClusterKeySensor`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
