### PR TITLE
AIRFLOW-3316 be sure to initialize schema_fields variable

### DIFF
--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -208,6 +208,8 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
             elif self.schema_object is None and self.autodetect is False:
                 raise ValueError('At least one of `schema_fields`, `schema_object`, '
                                  'or `autodetect` must be passed.')
+            else:
+                schema_fields = None
 
         else:
             schema_fields = self.schema_fields


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3316/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3316

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
The execute method of the GoogleCloudStorageToBigQueryOperator will in certain situations fail to initialize a varaible called `schema_fields`, which it later references.  See the Jira issue for more details.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
It's a simple one-line fix which is very easy to reason about.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X] Passes `flake8`
