### PR TITLE
[AIRFLOW-3622] Add ability to pass hive_conf to HiveToMysqlTransfer

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -902,7 +902,7 @@ class HiveServer2Hook(BaseHook):
 
         self.log.info("Done. Loaded a total of %s rows.", i)
 
-    def get_records(self, hql, schema='default'):
+    def get_records(self, hql, schema='default', hive_conf=None):
         """
         Get a set of records from a Hive query.
 
@@ -911,7 +911,7 @@ class HiveServer2Hook(BaseHook):
         >>> len(hh.get_records(sql))
         100
         """
-        return self.get_results(hql, schema=schema)['data']
+        return self.get_results(hql, schema=schema, hive_conf=hive_conf)['data']
 
     def get_pandas_df(self, hql, schema='default'):
         """

--- a/tests/operators/test_hive_to_mysql.py
+++ b/tests/operators/test_hive_to_mysql.py
@@ -92,3 +92,18 @@ class TestHiveToMySqlTransfer(unittest.TestCase):
             tmp_file=mock_tmp_file.return_value.name
         )
         mock_tmp_file.return_value.close.assert_called_once_with()
+
+    @patch('airflow.operators.hive_to_mysql.MySqlHook')
+    @patch('airflow.operators.hive_to_mysql.HiveServer2Hook')
+    def test_execute_with_hive_conf(self, mock_hive_hook, mock_mysql_hook):
+        context = {}
+        self.kwargs.update(dict(hive_conf={'mapreduce.job.queuename': 'fake_queue'}))
+
+        HiveToMySqlTransfer(**self.kwargs).execute(context=context)
+
+        hive_conf = context_to_airflow_vars(context)
+        hive_conf.update(self.kwargs['hive_conf'])
+        mock_hive_hook.return_value.get_records.assert_called_once_with(
+            self.kwargs['sql'],
+            hive_conf=hive_conf
+        )


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following Airflow Jira issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-3622

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Right now we cannot overwrite Hive Yarn queue because `hive_conf` is not passed to `HiveToMySqlTransfer`

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`

### Reviewers

@KevinYang21 @feluelle @feng-tao 