### PR TITLE
[AIRFLOW-3627] Improve queries performance in /task_stats in views.py by ~20%

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -590,21 +590,24 @@ class Airflow(BaseView):
         dag_ids = session.query(Dag.dag_id)
 
         LastDagRun = (
-            session.query(DagRun.dag_id, sqla.func.max(DagRun.execution_date).label('execution_date'))
-                .join(Dag, Dag.dag_id == DagRun.dag_id)
-                .filter(DagRun.state != State.RUNNING)
-                .filter(Dag.is_active == True)  # noqa: E712
-                .filter(Dag.is_subdag == False)  # noqa: E712
-                .group_by(DagRun.dag_id)
-                .subquery('last_dag_run')
+            session.query(
+                DagRun.dag_id,
+                sqla.func.max(DagRun.execution_date).label('execution_date')
+            )
+            .join(Dag, Dag.dag_id == DagRun.dag_id)
+            .filter(DagRun.state != State.RUNNING,
+                    Dag.is_active,
+                    Dag.is_subdag == False)  # noqa: E712
+            .group_by(DagRun.dag_id)
+            .subquery('last_dag_run')
         )
         RunningDagRun = (
             session.query(DagRun.dag_id, DagRun.execution_date)
-                .join(Dag, Dag.dag_id == DagRun.dag_id)
-                .filter(DagRun.state == State.RUNNING)
-                .filter(Dag.is_active == True)  # noqa: E712
-                .filter(Dag.is_subdag == False)  # noqa: E712
-                .subquery('running_dag_run')
+            .join(Dag, Dag.dag_id == DagRun.dag_id)
+            .filter(DagRun.state == State.RUNNING,
+                    Dag.is_active,
+                    Dag.is_subdag == False)  # noqa: E712
+            .subquery('running_dag_run')
         )
 
         # Select all task_instances from active dag_runs.

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -333,19 +333,18 @@ class Airflow(AirflowBaseView):
 
         LastDagRun = (
             session.query(
-                        DagRun.dag_id,
-                        sqla.func.max(DagRun.execution_date).label('execution_date'))
-                   .join(Dag, Dag.dag_id == DagRun.dag_id)
-                   .filter(DagRun.state != State.RUNNING)
-                   .filter(Dag.is_active == True)  # noqa
-                   .group_by(DagRun.dag_id)
-                   .subquery('last_dag_run')
+                DagRun.dag_id,
+                sqla.func.max(DagRun.execution_date).label('execution_date')
+            )
+            .join(Dag, Dag.dag_id == DagRun.dag_id)
+            .filter(DagRun.state != State.RUNNING, Dag.is_active)
+            .group_by(DagRun.dag_id)
+            .subquery('last_dag_run')
         )
         RunningDagRun = (
             session.query(DagRun.dag_id, DagRun.execution_date)
                    .join(Dag, Dag.dag_id == DagRun.dag_id)
-                   .filter(DagRun.state == State.RUNNING)
-                   .filter(Dag.is_active == True)  # noqa
+                   .filter(DagRun.state == State.RUNNING, Dag.is_active)
                    .subquery('running_dag_run')
         )
 
@@ -1391,7 +1390,7 @@ class Airflow(AirflowBaseView):
         TF = models.TaskFail
         ti_fails = (
             session.query(TF)
-                   .filter(TF.dag_id == dag.dag_id,  # noqa
+                   .filter(TF.dag_id == dag.dag_id,
                            TF.execution_date >= min_date,
                            TF.execution_date <= base_date,
                            TF.task_id.in_([t.task_id for t in dag.tasks]))


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3627

### Description

`/task_stats` is used quite frequently. Every time the main page is loaded, it will be called. But actually the performance of it can be improved significantly by minor changes.

1. In the sqlalchemy `.filter()` statement, no need to explicitly add `==True`. The value itself is already Boolean. Doing another explicit comparison is adding heavy overhead. This change helps improve query performance significantly

2. We can merge the multiple `.filter()`s (https://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.query.Query.filter).

**After these changes, the query time can be reduced by ~20%** (_the absolute value of the time reduced is not big, given the query itself is quite simple_).

#### Benchmarking

```python
from airflow.settings import Session
from airflow import models
from datetime import datetime

def test0():
    s.query(DM).filter(DM.is_active == True).filter(DM.dag_id == 'tutorial')

def test1():
    s.query(DM).filter(DM.is_active).filter(DM.dag_id == 'tutorial')

def test2():
    s.query(DM).filter(DM.is_active, DM.dag_id == 'tutorial')

if __name__ == '__main__':

    import timeit

    s = Session()
    DM = models.DagModel
    n = 300000

    print(s.query(DM).filter(DM.is_paused == True).count() == s.query(DM).filter(DM.is_paused).count())

    print(timeit.timeit("test0()", number=n, setup="from __main__ import test0"))
    print(timeit.timeit("test1()", number=n, setup="from __main__ import test1"))
    print(timeit.timeit("test2()", number=n, setup="from __main__ import test2"))

    print("\n --- Run Tests in Reverse Order --- \n")

    print(timeit.timeit("test2()", number=n, setup="from __main__ import test2"))
    print(timeit.timeit("test1()", number=n, setup="from __main__ import test1"))
    print(timeit.timeit("test0()", number=n, setup="from __main__ import test0"))
```

Result:
```
True

94.96372179000173
65.610312083998
65.09665720800695

 --- Run Tests in Reverse Order ---

61.59604939300334
65.70635982099338
83.37481481899158
```
### Code Quality

- [x] Passes `flake8`