### PR TITLE
[AIRFLOW-3628] Add smtp_mime_from

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -342,7 +342,7 @@ smtp_ssl = False
 # smtp_password = airflow
 smtp_port = 25
 smtp_mail_from = airflow@example.com
-
+smtp_mime_from = airflow
 
 [celery]
 # This section only applies if you are using the CeleryExecutor in

--- a/airflow/utils/email.py
+++ b/airflow/utils/email.py
@@ -65,12 +65,13 @@ def send_email_smtp(to, subject, html_content, files=None,
     >>> send_email('test@example.com', 'foo', '<b>Foo</b> bar', ['/dev/null'], dryrun=True)
     """
     smtp_mail_from = configuration.conf.get('smtp', 'SMTP_MAIL_FROM')
+    smtp_mime_from = configuration.conf.get('smtp', 'SMTP_MIME_FROM')
 
     to = get_email_address_list(to)
 
     msg = MIMEMultipart(mime_subtype)
     msg['Subject'] = subject
-    msg['From'] = smtp_mail_from
+    msg['From'] = smtp_mime_from or smtp_mail_from
     msg['To'] = ", ".join(to)
     recipients = to
     if cc:

--- a/tests/core.py
+++ b/tests/core.py
@@ -2640,7 +2640,9 @@ class EmailSmtpTest(unittest.TestCase):
         self.assertEqual(['to'], call_args[1])
         msg = call_args[2]
         self.assertEqual('subject', msg['Subject'])
-        self.assertEqual(configuration.conf.get('smtp', 'SMTP_MAIL_FROM'), msg['From'])
+        self.assertEqual(
+            configuration.conf.get('smtp', 'SMTP_MIME_FROM') or configuration.conf.get('smtp', 'SMTP_MAIL_FROM'),
+            msg['From'])
         self.assertEqual(2, len(msg.get_payload()))
         filename = u'attachment; filename="' + os.path.basename(attachment.name) + '"'
         self.assertEqual(filename, msg.get_payload()[-1].get(u'Content-Disposition'))
@@ -2668,7 +2670,9 @@ class EmailSmtpTest(unittest.TestCase):
         self.assertEqual(['to', 'cc', 'bcc'], call_args[1])
         msg = call_args[2]
         self.assertEqual('subject', msg['Subject'])
-        self.assertEqual(configuration.conf.get('smtp', 'SMTP_MAIL_FROM'), msg['From'])
+        self.assertEqual(
+            configuration.conf.get('smtp', 'SMTP_MIME_FROM') or configuration.conf.get('smtp', 'SMTP_MAIL_FROM'),
+            msg['From'])
         self.assertEqual(2, len(msg.get_payload()))
         self.assertEqual(u'attachment; filename="' + os.path.basename(attachment.name) + '"',
                          msg.get_payload()[-1].get(u'Content-Disposition'))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3628
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
In airflow alert email, the value of the from field is the source email address, but sometimes we want to show the receiver where the alert is really from. For example, the email was sent from no-reply@example.com, but we want to show the receiver it was from "airflow", so that it is easy to distinguish it from other messages. With this PR, we just need to set "smtp_mime_from = "airflow" in airflow.cfg.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
