### PR TITLE
[AIRFLOW-3626] Fixed zipped Dag trigger

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -92,7 +92,7 @@ from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 
 from airflow.ti_deps.dep_context import DepContext, QUEUE_DEPS, RUN_DEPS
 from airflow.utils import timezone
-from airflow.utils.dag_processing import list_py_file_paths
+from airflow.utils.dag_processing import list_py_file_paths, correct_maybe_zipped_fileloc
 from airflow.utils.dates import cron_presets, date_range as utils_date_range
 from airflow.utils.db import provide_session
 from airflow.utils.decorators import apply_defaults
@@ -542,6 +542,7 @@ class DagBag(BaseDagBag, LoggingMixin):
         stats = []
         FileLoadStat = namedtuple(
             'FileLoadStat', "file duration dag_num task_num dags")
+        dag_folder = correct_maybe_zipped_fileloc(dag_folder)
         for filepath in list_py_file_paths(dag_folder, include_examples):
             try:
                 ts = timezone.utcnow()

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -275,6 +275,20 @@ class SimpleDagBag(BaseDagBag):
         return self.dag_id_to_simple_dag[dag_id]
 
 
+def correct_maybe_zipped_fileloc(fileloc):
+    """
+    If the path contains a folder with a .zip suffix, then
+    the folder is treated as a zip archive and path to zip is returned.
+    """
+
+    _, archive, filename = re.search(
+        r'((.*\.zip){})?(.*)'.format(re.escape(os.sep)), fileloc).groups()
+    if archive and zipfile.is_zipfile(archive):
+        return archive                                           
+    else:
+        return fileloc
+
+
 def list_py_file_paths(directory, safe_mode=True,
                        include_examples=conf.getboolean('core', 'LOAD_EXAMPLES')):
     """

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -284,7 +284,7 @@ def correct_maybe_zipped_fileloc(fileloc):
     _, archive, filename = re.search(
         r'((.*\.zip){})?(.*)'.format(re.escape(os.sep)), fileloc).groups()
     if archive and zipfile.is_zipfile(archive):
-        return archive                                           
+        return archive
     else:
         return fileloc
 


### PR DESCRIPTION
Fixed zipped Dag trigger for Web and Api

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3626

### Description

- [x] Added utility function similar to open_maybe_zipped to handle cases where fileloc can be a zipped python file. e.g. ~/airflow/dags/example.zip/example.py
### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`