### PR TITLE
[AIRFLOW-3626] Fixed zipped Dag trigger

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -39,7 +39,7 @@ from airflow.exceptions import AirflowDagCycleException
 from airflow.executors import get_default_executor
 from airflow.stats import Stats
 from airflow.utils import timezone
-from airflow.utils.dag_processing import list_py_file_paths
+from airflow.utils.dag_processing import list_py_file_paths, correct_maybe_zipped
 from airflow.utils.db import provide_session
 from airflow.utils.helpers import pprinttable
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -363,6 +363,8 @@ class DagBag(BaseDagBag, LoggingMixin):
         stats = []
         FileLoadStat = namedtuple(
             'FileLoadStat', "file duration dag_num task_num dags")
+
+        dag_folder = correct_maybe_zipped(dag_folder)
 
         for filepath in list_py_file_paths(dag_folder, safe_mode=safe_mode,
                                            include_examples=include_examples):

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -277,6 +277,20 @@ class SimpleDagBag(BaseDagBag):
         return self.dag_id_to_simple_dag[dag_id]
 
 
+def correct_maybe_zipped(fileloc):
+    """
+    If the path contains a folder with a .zip suffix, then
+    the folder is treated as a zip archive and path to zip is returned.
+    """
+
+    _, archive, filename = re.search(
+        r'((.*\.zip){})?(.*)'.format(re.escape(os.sep)), fileloc).groups()
+    if archive and zipfile.is_zipfile(archive):
+        return archive
+    else:
+        return fileloc
+
+
 def list_py_file_paths(directory, safe_mode=True,
                        include_examples=None):
     """

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -21,6 +21,7 @@ import os
 import sys
 import tempfile
 import unittest
+import mock
 from datetime import timedelta
 
 from mock import MagicMock
@@ -32,7 +33,7 @@ from airflow.jobs import LocalTaskJob as LJ
 from airflow.models import DagBag, TaskInstance as TI
 from airflow.utils import timezone
 from airflow.utils.dag_processing import (DagFileProcessorAgent, DagFileProcessorManager,
-                                          SimpleTaskInstance)
+                                          SimpleTaskInstance, correct_maybe_zipped)
 from airflow.utils.db import create_session
 from airflow.utils.state import State
 
@@ -326,3 +327,36 @@ class TestDagFileProcessorAgent(unittest.TestCase):
         manager_process.join()
 
         self.assertTrue(os.path.isfile(log_file_loc))
+
+
+class TestCorrectMaybeZipped(unittest.TestCase):
+    @mock.patch("zipfile.is_zipfile")
+    def test_correct_maybe_zipped_normal_file(self, mocked_is_zipfile):
+        path = '/path/to/some/file.txt'
+        mocked_is_zipfile.return_value = False
+
+        dag_folder = correct_maybe_zipped(path)
+
+        self.assertEqual(dag_folder, path)
+
+    @mock.patch("zipfile.is_zipfile")
+    def test_correct_maybe_zipped_normal_file_with_zip_in_name(self, mocked_is_zipfile):
+        path = '/path/to/fakearchive.zip.other/file.txt'
+        mocked_is_zipfile.return_value = False
+
+        dag_folder = correct_maybe_zipped(path)
+
+        self.assertEqual(dag_folder, path)
+
+    @mock.patch("zipfile.is_zipfile")
+    def test_correct_maybe_zipped_archive(self, mocked_is_zipfile):
+        path = '/path/to/archive.zip/deep/path/to/file.txt'
+        mocked_is_zipfile.return_value = True
+
+        dag_folder = correct_maybe_zipped(path)
+
+        assert mocked_is_zipfile.call_count == 1
+        (args, kwargs) = mocked_is_zipfile.call_args_list[0]
+        self.assertEqual('/path/to/archive.zip', args[0])
+
+        self.assertEqual(dag_folder, '/path/to/archive.zip')


### PR DESCRIPTION
Fixed zipped Dag trigger for Web and Api

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3626

### Description
- Conversion from Dagbag() to Dagbag(fileloc_of_zip) fails.
- This happened with the following commits for [api](https://github.com/apache/airflow/commit/aa17b5baf886f7e23b3a9bcf8fef45759193f1b6) and for [webserver](https://github.com/apache/airflow/commit/548f38a81e096ea25de09131affdc66d392b1ece)
- The above commits are necessary to speed up trigger of dag else it will parse all dags again.
- Hence added utility function similar to open_maybe_zipped to handle cases where fileloc can be a zipped python file. e.g. ~/airflow/dags/example.zip/example.py
### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`