### PR TITLE
[AIRFLOW-3634] Fix GCP Spanner Test

### DIFF
--- a/airflow/contrib/operators/gcp_spanner_operator.py
+++ b/airflow/contrib/operators/gcp_spanner_operator.py
@@ -326,10 +326,11 @@ class CloudSpannerInstanceDatabaseUpdateOperator(BaseOperator):
         if not self._hook.get_database(self.project_id,
                                        self.instance_id,
                                        self.database_id):
-            raise AirflowException("The Cloud Spanner database "
-                                   "'%s' in project '%s' and instance '%s' is missing."
-                                   " Create the database first before you can update it.",
-                                   self.database_id, self.project_id, self.instance_id)
+            raise AirflowException("The Cloud Spanner database '{}' in project '{}' and "
+                                   "instance '{}' is missing. Create the database first "
+                                   "before you can update it.".format(self.database_id,
+                                                                      self.project_id,
+                                                                      self.instance_id))
         else:
             return self._hook.update_database(project_id=self.project_id,
                                               instance_id=self.instance_id,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3634


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Fix the following failing test:

```
======================================================================
25) FAIL: test_database_update_ex_if_database_not_exist (tests.contrib.operators.test_gcp_spanner_operator.CloudSpannerTest)
----------------------------------------------------------------------
   Traceback (most recent call last):
    .tox/py27-backend_mysql/lib/python2.7/site-packages/mock/mock.py line 1305 in patched
      return func(*args, **keywargs)
    tests/contrib/operators/test_gcp_spanner_operator.py line 354 in test_database_update_ex_if_database_not_exist
      "instance 'instance-id' is missing", str(err))
   AssertionError: "The Cloud Spanner database 'db1' in project 'project-id' and instance 'instance-id' is missing" not found in '("The Cloud Spanner database \'%s\' in project \'%s\' and instance \'%s\' is missing. Create the database first before you can update it.", \'db1\', \'project-id\', \'instance-id\')'
```

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
