### PR TITLE
[AIRFLOW-3636] Fix a test introduced in #4425

### DIFF
--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -402,7 +402,7 @@ class TestLogView(unittest.TestCase):
 
         content_disposition = response.headers.get('Content-Disposition')
         self.assertTrue(content_disposition.startswith('attachment'))
-        self.assertTrue(content_disposition.endswith(expected_filename))
+        self.assertTrue(expected_filename in content_disposition)
         self.assertEqual(200, response.status_code)
         self.assertIn('Log for testing.', response.data.decode('utf-8'))
 

--- a/tests/www_rbac/test_views.py
+++ b/tests/www_rbac/test_views.py
@@ -566,7 +566,7 @@ class TestLogView(TestBase):
                                   quote_plus(self.DEFAULT_DATE.isoformat()),
                                   try_number,
                                   json.dumps({}))
-        response = self.app.get(url)
+        response = self.client.get(url)
         expected_filename = '{}/{}/{}/{}.log'.format(self.DAG_ID,
                                                      self.TASK_ID,
                                                      self.DEFAULT_DATE.isoformat(),
@@ -574,7 +574,7 @@ class TestLogView(TestBase):
 
         content_disposition = response.headers.get('Content-Disposition')
         self.assertTrue(content_disposition.startswith('attachment'))
-        self.assertTrue(content_disposition.endswith(expected_filename))
+        self.assertTrue(expected_filename in content_disposition)
         self.assertEqual(200, response.status_code)
         self.assertIn('Log for testing.', response.data.decode('utf-8'))
 


### PR DESCRIPTION
Fix a broken test, introduced in https://github.com/apache/airflow/pull/4425 

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3636
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
