### PR TITLE
[AIRFLOW-3601] add location support to BigQuery operators

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -287,6 +287,9 @@ class BigQueryBaseCursor(LoggingMixin):
             }
         }
 
+        if self.location:
+            table_resource['location'] = self.location
+
         if schema_fields:
             table_resource['schema'] = {'fields': schema_fields}
 
@@ -501,6 +504,12 @@ class BigQueryBaseCursor(LoggingMixin):
 
         if labels:
             table_resource['labels'] = labels
+
+        if self.location:
+            table_resource['location'] = self.location
+
+        self.log.info('inserting an external table: %s, body = %s',
+                      external_project_dataset_table, table_resource)
 
         try:
             self.service.tables().insert(
@@ -1372,6 +1381,8 @@ class BigQueryBaseCursor(LoggingMixin):
             optional_params['pageToken'] = page_token
         if start_index:
             optional_params['startIndex'] = start_index
+        if self.location:
+            optional_params['location'] = self.location
         return (self.service.tabledata().list(
             projectId=self.project_id,
             datasetId=dataset_id,
@@ -1571,6 +1582,9 @@ class BigQueryBaseCursor(LoggingMixin):
                 _api_resource_configs_duplication_check(
                     param_name, param,
                     dataset_reference['datasetReference'], 'dataset_reference')
+
+        if self.location:
+            dataset_reference['location'] = self.location
 
         dataset_id = dataset_reference.get("datasetReference").get("datasetId")
         dataset_project_id = dataset_reference.get("datasetReference").get(

--- a/airflow/contrib/operators/bigquery_get_data.py
+++ b/airflow/contrib/operators/bigquery_get_data.py
@@ -66,6 +66,10 @@ class BigQueryGetDataOperator(BaseOperator):
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
     :type delegate_to: str
+    :param location: The geographic location of the job. Required except for
+        US and EU. See details at
+        https://cloud.google.com/bigquery/docs/locations#specifying_your_location
+    :type location: str
     """
     template_fields = ('dataset_id', 'table_id', 'max_results')
     ui_color = '#e4f0e8'
@@ -78,6 +82,7 @@ class BigQueryGetDataOperator(BaseOperator):
                  selected_fields=None,
                  bigquery_conn_id='bigquery_default',
                  delegate_to=None,
+                 location=None,
                  *args,
                  **kwargs):
         super(BigQueryGetDataOperator, self).__init__(*args, **kwargs)
@@ -87,6 +92,7 @@ class BigQueryGetDataOperator(BaseOperator):
         self.selected_fields = selected_fields
         self.bigquery_conn_id = bigquery_conn_id
         self.delegate_to = delegate_to
+        self.location = location
 
     def execute(self, context):
         self.log.info('Fetching Data from:')
@@ -94,7 +100,8 @@ class BigQueryGetDataOperator(BaseOperator):
                       self.dataset_id, self.table_id, self.max_results)
 
         hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
-                            delegate_to=self.delegate_to)
+                            delegate_to=self.delegate_to,
+                            location=self.location)
 
         conn = hook.get_conn()
         cursor = conn.cursor()

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -282,7 +282,10 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
                 google_cloud_storage_conn_id='airflow-service-account'
             )
     :type labels: dict
-
+    :param location: The geographic location of the job. Required except for
+        US and EU. See details at
+        https://cloud.google.com/bigquery/docs/locations#specifying_your_location
+    :type location: str
     """
     template_fields = ('dataset_id', 'table_id', 'project_id',
                        'gcs_schema_object', 'labels')
@@ -300,6 +303,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
                  google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
                  labels=None,
+                 location=None,
                  *args, **kwargs):
 
         super(BigQueryCreateEmptyTableOperator, self).__init__(*args, **kwargs)
@@ -314,10 +318,12 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         self.delegate_to = delegate_to
         self.time_partitioning = {} if time_partitioning is None else time_partitioning
         self.labels = labels
+        self.location = location
 
     def execute(self, context):
         bq_hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
-                               delegate_to=self.delegate_to)
+                               delegate_to=self.delegate_to,
+                               location=self.location)
 
         if not self.schema_fields and self.gcs_schema_object:
 
@@ -416,6 +422,10 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
     :type src_fmt_configs: dict
     :param labels: a dictionary containing labels for the table, passed to BigQuery
     :type labels: dict
+    :param location: The geographic location of the job. Required except for
+        US and EU. See details at
+        https://cloud.google.com/bigquery/docs/locations#specifying_your_location
+    :type location: str
     """
     template_fields = ('bucket', 'source_objects',
                        'schema_object', 'destination_project_dataset_table', 'labels')
@@ -441,6 +451,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
                  delegate_to=None,
                  src_fmt_configs=None,
                  labels=None,
+                 location=None,
                  *args, **kwargs):
 
         super(BigQueryCreateExternalTableOperator, self).__init__(*args, **kwargs)
@@ -468,10 +479,12 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
 
         self.src_fmt_configs = src_fmt_configs if src_fmt_configs is not None else dict()
         self.labels = labels
+        self.location = location
 
     def execute(self, context):
         bq_hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
-                               delegate_to=self.delegate_to)
+                               delegate_to=self.delegate_to,
+                               location=self.location)
 
         if not self.schema_fields and self.schema_object \
                 and self.source_format != 'DATASTORE_BACKUP':
@@ -584,6 +597,10 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
                                     task_id='newDatasetCreator',
                                     dag=dag)
 
+    :param location: The geographic location of the job. Required except for
+        US and EU. See details at
+        https://cloud.google.com/bigquery/docs/locations#specifying_your_location
+    :type location: str
     """
 
     template_fields = ('dataset_id', 'project_id')
@@ -596,12 +613,14 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
                  dataset_reference=None,
                  bigquery_conn_id='bigquery_default',
                  delegate_to=None,
+                 location=None,
                  *args, **kwargs):
         self.dataset_id = dataset_id
         self.project_id = project_id
         self.bigquery_conn_id = bigquery_conn_id
         self.dataset_reference = dataset_reference if dataset_reference else {}
         self.delegate_to = delegate_to
+        self.location = location
 
         self.log.info('Dataset id: %s', self.dataset_id)
         self.log.info('Project id: %s', self.project_id)
@@ -610,7 +629,8 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
 
     def execute(self, context):
         bq_hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
-                               delegate_to=self.delegate_to)
+                               delegate_to=self.delegate_to,
+                               location=self.location)
 
         conn = bq_hook.get_conn()
         cursor = conn.cursor()

--- a/airflow/contrib/operators/bigquery_to_bigquery.py
+++ b/airflow/contrib/operators/bigquery_to_bigquery.py
@@ -52,6 +52,10 @@ class BigQueryToBigQueryOperator(BaseOperator):
     :param labels: a dictionary containing labels for the job/query,
         passed to BigQuery
     :type labels: dict
+    :param location: The geographic location of the job. Required except for
+        US and EU. See details at
+        https://cloud.google.com/bigquery/docs/locations#specifying_your_location
+    :type location: str
     """
     template_fields = ('source_project_dataset_tables',
                        'destination_project_dataset_table', 'labels')
@@ -67,6 +71,7 @@ class BigQueryToBigQueryOperator(BaseOperator):
                  bigquery_conn_id='bigquery_default',
                  delegate_to=None,
                  labels=None,
+                 location=None,
                  *args,
                  **kwargs):
         super(BigQueryToBigQueryOperator, self).__init__(*args, **kwargs)
@@ -77,6 +82,7 @@ class BigQueryToBigQueryOperator(BaseOperator):
         self.bigquery_conn_id = bigquery_conn_id
         self.delegate_to = delegate_to
         self.labels = labels
+        self.location = location
 
     def execute(self, context):
         self.log.info(
@@ -84,7 +90,8 @@ class BigQueryToBigQueryOperator(BaseOperator):
             self.source_project_dataset_tables, self.destination_project_dataset_table
         )
         hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
-                            delegate_to=self.delegate_to)
+                            delegate_to=self.delegate_to,
+                            location=self.location)
         conn = hook.get_conn()
         cursor = conn.cursor()
         cursor.run_copy(

--- a/airflow/contrib/operators/bigquery_to_gcs.py
+++ b/airflow/contrib/operators/bigquery_to_gcs.py
@@ -57,6 +57,10 @@ class BigQueryToCloudStorageOperator(BaseOperator):
     :param labels: a dictionary containing labels for the job/query,
         passed to BigQuery
     :type labels: dict
+    :param location: The geographic location of the job. Required except for
+        US and EU. See details at
+        https://cloud.google.com/bigquery/docs/locations#specifying_your_location
+    :type location: str
     """
     template_fields = ('source_project_dataset_table',
                        'destination_cloud_storage_uris', 'labels')
@@ -74,6 +78,7 @@ class BigQueryToCloudStorageOperator(BaseOperator):
                  bigquery_conn_id='bigquery_default',
                  delegate_to=None,
                  labels=None,
+                 location=None,
                  *args,
                  **kwargs):
         super(BigQueryToCloudStorageOperator, self).__init__(*args, **kwargs)
@@ -86,13 +91,15 @@ class BigQueryToCloudStorageOperator(BaseOperator):
         self.bigquery_conn_id = bigquery_conn_id
         self.delegate_to = delegate_to
         self.labels = labels
+        self.location = location
 
     def execute(self, context):
         self.log.info('Executing extract of %s into: %s',
                       self.source_project_dataset_table,
                       self.destination_cloud_storage_uris)
         hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
-                            delegate_to=self.delegate_to)
+                            delegate_to=self.delegate_to,
+                            location=self.location)
         conn = hook.get_conn()
         cursor = conn.cursor()
         cursor.run_extract(

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -123,7 +123,11 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         by one or more columns. This is only available in conjunction with
         time_partitioning. The order of columns given determines the sort order.
         Not applicable for external tables.
-    :type cluster_fields: list[str]
+    :type cluster_fields: list of str
+    :param location: The geographic location of the job. Required except for
+        US and EU. See details at
+        https://cloud.google.com/bigquery/docs/locations#specifying_your_location
+    :type location: str
     """
     template_fields = ('bucket', 'source_objects',
                        'schema_object', 'destination_project_dataset_table')
@@ -158,6 +162,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                  time_partitioning=None,
                  cluster_fields=None,
                  autodetect=False,
+                 location=None,
                  *args, **kwargs):
 
         super(GoogleCloudStorageToBigQueryOperator, self).__init__(*args, **kwargs)
@@ -197,10 +202,12 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         self.time_partitioning = time_partitioning
         self.cluster_fields = cluster_fields
         self.autodetect = autodetect
+        self.location = location
 
     def execute(self, context):
         bq_hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
-                               delegate_to=self.delegate_to)
+                               delegate_to=self.delegate_to,
+                               location=self.location)
 
         if not self.schema_fields:
             if self.schema_object and self.source_format != 'DATASTORE_BACKUP':

--- a/airflow/contrib/sensors/bigquery_sensor.py
+++ b/airflow/contrib/sensors/bigquery_sensor.py
@@ -41,6 +41,10 @@ class BigQueryTableSensor(BaseSensorOperator):
         For this to work, the service account making the request must
         have domain-wide delegation enabled.
     :type delegate_to: str
+    :param location: The geographic location of the job. Required except for
+        US and EU. See details at
+        https://cloud.google.com/bigquery/docs/locations#specifying_your_location
+    :type location: str
     """
     template_fields = ('project_id', 'dataset_id', 'table_id',)
     ui_color = '#f0eee4'
@@ -52,6 +56,7 @@ class BigQueryTableSensor(BaseSensorOperator):
                  table_id,
                  bigquery_conn_id='bigquery_default_conn',
                  delegate_to=None,
+                 location=None,
                  *args, **kwargs):
 
         super(BigQueryTableSensor, self).__init__(*args, **kwargs)
@@ -60,11 +65,13 @@ class BigQueryTableSensor(BaseSensorOperator):
         self.table_id = table_id
         self.bigquery_conn_id = bigquery_conn_id
         self.delegate_to = delegate_to
+        self.location = location
 
     def poke(self, context):
         table_uri = '{0}:{1}.{2}'.format(self.project_id, self.dataset_id, self.table_id)
         self.log.info('Sensor checks existence of table: %s', table_uri)
         hook = BigQueryHook(
             bigquery_conn_id=self.bigquery_conn_id,
-            delegate_to=self.delegate_to)
+            delegate_to=self.delegate_to,
+            location=self.location)
         return hook.table_exists(self.project_id, self.dataset_id, self.table_id)

--- a/tests/contrib/operators/test_bigquery_get_data.py
+++ b/tests/contrib/operators/test_bigquery_get_data.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from datetime import datetime
+
+from airflow.contrib.operators.bigquery_get_data import BigQueryGetDataOperator
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+TASK_ID = 'test-bq-create-table-operator'
+TEST_DATASET = 'test-dataset'
+TEST_GCP_PROJECT_ID = 'test-project'
+TEST_TABLE_ID = 'test-table-id'
+TEST_GCS_BUCKET = 'test-bucket'
+TEST_GCS_DATA = ['dir1/*.csv']
+TEST_SOURCE_FORMAT = 'CSV'
+DEFAULT_DATE = datetime(2015, 1, 1)
+TEST_DAG_ID = 'test-bigquery-operators'
+TEST_LOCATION = 'ap-northeast-1'
+TEST_MAX_RESULT = 100
+TEST_SELECTED_FIELDS = 'a'
+
+
+class BigQueryGetDataOperatorTest(unittest.TestCase):
+
+    @mock.patch('airflow.contrib.operators.bigquery_operator.BigQueryHook')
+    def test_execute(self, mock_hook):
+        operator = BigQueryGetDataOperator(task_id=TASK_ID,
+                                           dataset_id=TEST_DATASET,
+                                           project_id=TEST_GCP_PROJECT_ID,
+                                           table_id=TEST_TABLE_ID,
+                                           max_results=TEST_MAX_RESULT,
+                                           selected_fields=TEST_SELECTED_FIELDS,
+                                           location=TEST_LOCATION)
+
+        operator.execute(None)
+        mock_hook.return_value \
+            .get_conn() \
+            .cursor() \
+            .get_tabledata \
+            .assert_called_once_with(
+                dataset_id=TEST_DATASET,
+                table_id=TEST_TABLE_ID,
+                max_results=TEST_MAX_RESULT,
+                selected_fields=TEST_SELECTED_FIELDS
+            )


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3601
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
  - location support for BigQueryHook was merged by the PR 4324 https://github.com/apache/incubator-airflow/pull/4324
  - To support BigQuery datasets in other than US and EU, the following operators needs to be updated:
    - `bigquery_get_data.py`
      - `BigQueryGetDataOperator`
    - `bigquery_operator.py`
      - `BigQueryOperator`
      - `BigQueryCreateEmptyTableOperator`
      - `BigQueryCreateExternalTableOperator`
      - `BigQueryDeleteDatasetOperator`
      - `BigQueryCreateEmptyDatasetOperator`
    - `bigquery_to_bigquery.py`
      - `BigQueryToBigQueryOperator`
    - `bigquery_to_gcs.py`
      - `BigQueryToCloudStorageOperator`
    - `gcs_to_bq.py`
    - `bigquery_sensor.py`
  - The following operators does not require location since it does not use location internally 
    - `bigquery_check_operator.py`
      - `BigQueryCheckOperator`
    - `bigquery_operator.py`
      - `BigQueryDeleteDatasetOperator`: see [doc](https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/delete)
    - `bigquery_table_delete_operator.py`
      - `BigQueryTableDeleteOperator`: see [doc](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/delete)

### Tests

- [x] My PR adds the unit tests to check location support:
    - `bigquery_get_data.py`
       - `BigQueryGetDataOperator`
         -  `test_bigquery_hook.py`: `TestBigQueryBaseCursor test_get_tabledata`
         - `test_bigquery_get_data.py`: `BigQueryGetDataOperatorTest test_execute`
    - `bigquery_operator.py`
        - `BigQueryOperator`
          - `test_bigquery_hook.py`:  https://github.com/apache/incubator-airflow/pull/4324 added test for location support of the hook.
          - `test_bigquery_operator.py`: `BigQueryOperatorTest test_bigquery_operator_location`
        - `BigQueryCreateEmptyTableOperator`
          - `test_bigquery_hook.py`: `TestBigQueryBaseCursor test_create_empty_table_with_location`. A table insert request can have location in its request body ([doc](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#resource)).
          - `test_bigquery_operator.py`: `BigQueryCreateEmptyTableOperatorTest test_execute`
        - `BigQueryCreateExternalTableOperator`
          - `test_bigquery_hook.py`: `TestBigQueryExternalTableSourceFormat test_table_location` A table insert request can have location in its request body ([doc](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#resource)).
          - `test_bigquery_operator.py`:  `BigQueryCreateExternalTableOperatorTest test_execute`
        - `BigQueryCreateEmptyDatasetOperator`
          - `test_bigquery_hook.py`: `TestDatasetsOperations test_create_empty_dataset` 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
