### PR TITLE
[AIRFLOW-3638] Add tests for PrestoToMySqlTransfer

### DIFF
--- a/airflow/operators/presto_to_mysql.py
+++ b/airflow/operators/presto_to_mysql.py
@@ -17,8 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow.hooks.presto_hook import PrestoHook
 from airflow.hooks.mysql_hook import MySqlHook
+from airflow.hooks.presto_hook import PrestoHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
@@ -50,14 +50,13 @@ class PrestoToMySqlTransfer(BaseOperator):
     ui_color = '#a0e08c'
 
     @apply_defaults
-    def __init__(
-            self,
-            sql,
-            mysql_table,
-            presto_conn_id='presto_default',
-            mysql_conn_id='mysql_default',
-            mysql_preoperator=None,
-            *args, **kwargs):
+    def __init__(self,
+                 sql,
+                 mysql_table,
+                 presto_conn_id='presto_default',
+                 mysql_conn_id='mysql_default',
+                 mysql_preoperator=None,
+                 *args, **kwargs):
         super(PrestoToMySqlTransfer, self).__init__(*args, **kwargs)
         self.sql = sql
         self.mysql_table = mysql_table

--- a/tests/operators/test_presto_to_mysql.py
+++ b/tests/operators/test_presto_to_mysql.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from mock import patch
+
+from airflow.operators.presto_to_mysql import PrestoToMySqlTransfer
+
+
+class TestPrestoToMySqlTransfer(unittest.TestCase):
+
+    def setUp(self):
+        self.kwargs = dict(
+            sql='sql',
+            mysql_table='mysql_table',
+            task_id='test_presto_to_mysql_transfer',
+            dag=None
+        )
+
+    @patch('airflow.operators.presto_to_mysql.MySqlHook')
+    @patch('airflow.operators.presto_to_mysql.PrestoHook')
+    def test_execute(self, mock_presto_hook, mock_mysql_hook):
+        PrestoToMySqlTransfer(**self.kwargs).execute(context={})
+
+        mock_presto_hook.return_value.get_records.assert_called_once_with(self.kwargs['sql'])
+        mock_mysql_hook.return_value.insert_rows.assert_called_once_with(
+            table=self.kwargs['mysql_table'], rows=mock_presto_hook.return_value.get_records.return_value)
+
+    @patch('airflow.operators.presto_to_mysql.MySqlHook')
+    @patch('airflow.operators.presto_to_mysql.PrestoHook')
+    def test_execute_with_mysql_preoperator(self, mock_presto_hook, mock_mysql_hook):
+        self.kwargs.update(dict(mysql_preoperator='mysql_preoperator'))
+
+        PrestoToMySqlTransfer(**self.kwargs).execute(context={})
+
+        mock_presto_hook.return_value.get_records.assert_called_once_with(self.kwargs['sql'])
+        mock_mysql_hook.return_value.run.assert_called_once_with(self.kwargs['mysql_preoperator'])
+        mock_mysql_hook.return_value.insert_rows.assert_called_once_with(
+            table=self.kwargs['mysql_table'], rows=mock_presto_hook.return_value.get_records.return_value)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3638
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR mainly adds tests but it also includes:
- reformatting of the PrestoToMySqlTransfer operator

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
