### PR TITLE
[AIRFLOW-3630] Cleanup of generated connection is done also on exception

### DIFF
--- a/airflow/contrib/hooks/gcp_sql_hook.py
+++ b/airflow/contrib/hooks/gcp_sql_hook.py
@@ -748,6 +748,8 @@ class CloudSqlDatabaseHook(BaseHook):
             raise AirflowException("Cloud SQL Proxy does not support SSL connections."
                                    " SSL is not needed as Cloud SQL Proxy "
                                    "provides encryption on its own")
+
+    def validate_ssl_certs(self):
         if self.use_ssl:
             self._check_ssl_file(self.sslcert, "sslcert")
             self._check_ssl_file(self.sslkey, "sslkey")
@@ -913,8 +915,9 @@ class CloudSqlDatabaseHook(BaseHook):
         Clean up database hook after it was used.
         """
         if self.database_type == 'postgres':
-            for output in self.db_hook.conn.notices:
-                self.log.info(output)
+            if self.db_hook.conn and self.db_hook.conn.notices:
+                for output in self.db_hook.conn.notices:
+                    self.log.info(output)
 
     def reserve_free_tcp_port(self):
         """


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3630

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When there is an error during Cloud SQL Query, there was a cleanup in post_execute_method. This cleanup is supposed to delete the connection, however it turns out that post_execute is not executed when execute() method throws an error (it was bad assumption). 

The connection is now closed in finally clause in execute.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   - CloudSqlQueryValidationTest.test_cloudsql_hook_delete_connection_on_exception 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  No documentation needed.

### Code Quality

- [x] Passes `flake8`
