### PR TITLE
[AIRFLOW-3531] Fix test for GCS to GCS Transfer Hook

### DIFF
--- a/tests/contrib/hooks/test_gcp_transfer_hook.py
+++ b/tests/contrib/hooks/test_gcp_transfer_hook.py
@@ -54,7 +54,10 @@ class TestGCPTransferServiceHook(unittest.TestCase):
             'gcsDataSink': {'bucketName': 'test-gcs-bucket'}
         }
         self.transfer_hook.create_transfer_job(
-            'test-project', 'test-description', None, transfer_spec)
+            project_id='test-project',
+            description='test-description',
+            schedule=None,
+            transfer_spec=transfer_spec)
         mock_create.assert_called_once_with(body={
             'status': 'ENABLED',
             'projectId': 'test-project',
@@ -90,7 +93,10 @@ class TestGCPTransferServiceHook(unittest.TestCase):
             'gcsDataSink': {'bucketName': 'test-gcs-bucket'}
         }
         self.transfer_hook.create_transfer_job(
-            'test-project', 'test-description', schedule, transfer_spec)
+            project_id='test-project',
+            description='test-description',
+            schedule=schedule,
+            transfer_spec=transfer_spec)
         mock_create.assert_called_once_with(body={
             'status': 'ENABLED',
             'projectId': 'test-project',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3531


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
(#4331) broke the CI because of incorrect test

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
