### PR TITLE
[AIRFLOW-3650] Skip running on mysql for the flaky test

### DIFF
--- a/tests/www_rbac/test_views.py
+++ b/tests/www_rbac/test_views.py
@@ -1462,6 +1462,8 @@ class TestTriggerDag(TestBase):
         self.assertIn('/trigger?dag_id=example_bash_operator', resp.data.decode('utf-8'))
         self.assertIn("return confirmDeleteDag('example_bash_operator')", resp.data.decode('utf-8'))
 
+    @unittest.skipIf('mysql' in conf.conf.get('core', 'sql_alchemy_conn'),
+                     "flaky when run on mysql")
     def test_trigger_dag_button(self):
 
         test_dag_id = "example_bash_operator"


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-3650\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3650
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-3650\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
test_trigger_dag_button seems to be failing pretty consistent for MySQL ORM. 

I think the issue is not on the actual test, but on mysqlclient. The session can't get the latest data from  from ORM after finish running this line(https://github.com/apache/airflow/blob/master/tests/www_rbac/test_views.py#L1473). But I try different mysqlclient version which doesn't work. To unblock, I would suggest we skip MySQL orm for this test.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
