### PR TITLE
[AIRFLOW-3657] Fix zendesk integration

### DIFF
--- a/airflow/hooks/zendesk_hook.py
+++ b/airflow/hooks/zendesk_hook.py
@@ -33,7 +33,8 @@ class ZendeskHook(BaseHook):
     def get_conn(self):
         conn = self.get_connection(self.__zendesk_conn_id)
         self.__url = "https://" + conn.host
-        return Zendesk(self.__url, conn.login, conn.password, True)
+        return Zendesk(zdesk_url=self.__url, zdesk_email=conn.login, zdesk_password=conn.password,
+                       zdesk_token=True)
 
     def __handle_rate_limit_exception(self, rate_limit_exception):
         """

--- a/tests/contrib/hooks/test_zendesk_hook.py
+++ b/tests/contrib/hooks/test_zendesk_hook.py
@@ -92,8 +92,8 @@ class TestZendeskHook(unittest.TestCase):
         zendesk_hook = ZendeskHook("conn_id")
         zendesk_hook.get_connection = mock.Mock(return_value=conn_mock)
         zendesk_hook.get_conn()
-        mock_zendesk.assert_called_with('https://conn_host', 'conn_login',
-                                        'conn_pass', True)
+        mock_zendesk.assert_called_with(zdesk_url='https://conn_host', zdesk_email='conn_login',
+                                        zdesk_password='conn_pass', zdesk_token=True)
 
     @mock.patch("airflow.hooks.zendesk_hook.Zendesk")
     def test_zdesk_sideloading_works_correctly(self, mock_zendesk):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3657)
  - https://issues.apache.org/jira/browse/AIRFLOW-3657

### Description

- Specifying zdesk package version in setup.py is required, as zendesk_hook uses unnamed argument and the signature of the method changed in version 2.7.0 and above

### Tests

- [X] Tests have been adjusted

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X] Passes `flake8`
