### PR TITLE
[AIRFLOW-3664] Fix interpreter errors in test_python_operator.py

### DIFF
--- a/tests/operators/test_python_operator.py
+++ b/tests/operators/test_python_operator.py
@@ -225,7 +225,7 @@ class BranchOperatorTest(unittest.TestCase):
             elif ti.task_id == 'branch_2':
                 self.assertEquals(ti.state, State.SKIPPED)
             else:
-                raise
+                raise Exception
 
     def test_branch_list_without_dag_run(self):
         """This checks if the BranchPythonOperator supports branching off to a list of tasks."""
@@ -258,7 +258,7 @@ class BranchOperatorTest(unittest.TestCase):
             if ti.task_id in expected:
                 self.assertEquals(ti.state, expected[ti.task_id])
             else:
-                raise
+                raise Exception
 
     def test_with_dag_run(self):
         self.branch_op = BranchPythonOperator(task_id='make_choice',
@@ -287,7 +287,7 @@ class BranchOperatorTest(unittest.TestCase):
             elif ti.task_id == 'branch_2':
                 self.assertEquals(ti.state, State.SKIPPED)
             else:
-                raise
+                raise Exception
 
 
 class ShortCircuitOperatorTest(unittest.TestCase):
@@ -345,11 +345,11 @@ class ShortCircuitOperatorTest(unittest.TestCase):
                 self.assertEquals(ti.state, State.SUCCESS)
             elif ti.task_id == 'upstream':
                 # should not exist
-                raise
+                raise Exception
             elif ti.task_id == 'branch_1' or ti.task_id == 'branch_2':
                 self.assertEquals(ti.state, State.SKIPPED)
             else:
-                raise
+                raise Exception
 
         value = True
         dag.clear()
@@ -360,11 +360,11 @@ class ShortCircuitOperatorTest(unittest.TestCase):
                 self.assertEquals(ti.state, State.SUCCESS)
             elif ti.task_id == 'upstream':
                 # should not exist
-                raise
+                raise Exception
             elif ti.task_id == 'branch_1' or ti.task_id == 'branch_2':
                 self.assertEquals(ti.state, State.NONE)
             else:
-                raise
+                raise Exception
 
         session.close()
 
@@ -408,7 +408,7 @@ class ShortCircuitOperatorTest(unittest.TestCase):
             elif ti.task_id == 'branch_1' or ti.task_id == 'branch_2':
                 self.assertEquals(ti.state, State.SKIPPED)
             else:
-                raise
+                raise Exception
 
         value = True
         dag.clear()
@@ -426,4 +426,4 @@ class ShortCircuitOperatorTest(unittest.TestCase):
             elif ti.task_id == 'branch_1' or ti.task_id == 'branch_2':
                 self.assertEquals(ti.state, State.NONE)
             else:
-                raise
+                raise Exception


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3664

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

There are interpreter errors with 'raise' without Exception and not in except clause in test_python_operator. This commit fixes it.

### Tests

- [x] My PR does not need testing for this extremely good reason - it's just test code itself :).

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
