### PR TITLE
[AIRFLOW-3670] Add stages to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ env:
     - SLUGIFY_USES_TEXT_UNIDECODE=yes
     - TRAVIS_CACHE=$HOME/.travis_cache/
   matrix:
-    - TOX_ENV=flake8
     - TOX_ENV=py27-backend_mysql-env_docker
     - TOX_ENV=py27-backend_sqlite-env_docker
     - TOX_ENV=py27-backend_postgres-env_docker
@@ -35,6 +34,16 @@ env:
     - TOX_ENV=py27-backend_postgres-env_kubernetes KUBERNETES_VERSION=v1.9.0
     - TOX_ENV=py35-backend_postgres-env_kubernetes KUBERNETES_VERSION=v1.10.0 PYTHON_VERSION=3
 
+stages:
+  - flake8
+  - test
+
+jobs:
+  include:
+    - stage: flake8
+      name: Flake8
+      script: docker-compose --log-level ERROR -f scripts/ci/docker-compose.yml run airflow-testing /app/scripts/ci/run-ci.sh
+      env: TOX_ENV=flake8
 cache:
   directories:
     - $HOME/.wheelhouse/


### PR DESCRIPTION
Allow travis to fail the entire build quickly, if the flake8 build fails

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-3670

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
 This makes no changes to the application code, and is designed to improve the development ccle by reducing the cycle time from test start to notification that test has failed

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No tests as this is a config for the test running. An example of the fast fail can be seen here https://travis-ci.org/drewsonne/airflow/builds/478054124

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
