### PR TITLE
[AIRFLOW-3675] Use googlapiclient for google apis

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -34,8 +34,8 @@ from airflow import AirflowException
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 from airflow.hooks.dbapi_hook import DbApiHook
 from airflow.utils.log.logging_mixin import LoggingMixin
-from apiclient.discovery import HttpError, build
-from googleapiclient import errors
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 from pandas_gbq.gbq import \
     _check_google_client_version as gbq_check_google_client_version
 from pandas_gbq import read_gbq
@@ -136,7 +136,7 @@ class BigQueryHook(GoogleCloudBaseHook, DbApiHook, LoggingMixin):
                 projectId=project_id, datasetId=dataset_id,
                 tableId=table_id).execute()
             return True
-        except errors.HttpError as e:
+        except HttpError as e:
             if e.resp['status'] == '404':
                 return False
             raise

--- a/airflow/contrib/hooks/datastore_hook.py
+++ b/airflow/contrib/hooks/datastore_hook.py
@@ -19,7 +19,7 @@
 #
 
 import time
-from apiclient.discovery import build
+from googleapiclient.discovery import build
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 
 

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -37,22 +37,24 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
     A base hook for Google cloud-related hooks. Google cloud has a shared REST
     API client that is built in the same way no matter which service you use.
     This class helps construct and authorize the credentials needed to then
-    call apiclient.discovery.build() to actually discover and build a client
+    call googleapiclient.discovery.build() to actually discover and build a client
     for a Google cloud service.
 
     The class also contains some miscellaneous helper functions.
 
     All hook derived from this base hook use the 'Google Cloud Platform' connection
-    type. Two ways of authentication are supported:
+    type. Three ways of authentication are supported:
 
     Default credentials: Only the 'Project Id' is required. You'll need to
     have set up default credentials, such as by the
     ``GOOGLE_APPLICATION_DEFAULT`` environment variable or from the metadata
     server on Google Compute Engine.
 
-    JSON key file: Specify 'Project Id', 'Key Path' and 'Scope'.
+    JSON key file: Specify 'Project Id', 'Keyfile Path' and 'Scope'.
 
     Legacy P12 key files are not supported.
+
+    JSON data provided in the UI: Specify 'Keyfile JSON'.
     """
 
     def __init__(self, gcp_conn_id='google_cloud_default', delegate_to=None):

--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -23,7 +23,7 @@ import subprocess
 import time
 import uuid
 
-from apiclient.discovery import build
+from googleapiclient.discovery import build
 
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin

--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -20,7 +20,7 @@
 import time
 import uuid
 
-from apiclient.discovery import build
+from googleapiclient.discovery import build
 from zope.deprecation import deprecation
 
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook

--- a/airflow/contrib/hooks/gcp_kms_hook.py
+++ b/airflow/contrib/hooks/gcp_kms_hook.py
@@ -22,7 +22,7 @@ import base64
 
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 
-from apiclient.discovery import build
+from googleapiclient.discovery import build
 
 
 def _b64encode(s):
@@ -48,7 +48,7 @@ class GoogleCloudKMSHook(GoogleCloudBaseHook):
         """
         Returns a KMS service object.
 
-        :rtype: apiclient.discovery.Resource
+        :rtype: googleapiclient.discovery.Resource
         """
         http_authorized = self._authorize()
         return build(

--- a/airflow/contrib/hooks/gcp_mlengine_hook.py
+++ b/airflow/contrib/hooks/gcp_mlengine_hook.py
@@ -15,8 +15,8 @@
 # limitations under the License.
 import random
 import time
-from apiclient import errors
-from apiclient.discovery import build
+from googleapiclient.errors import HttpError
+from googleapiclient.discovery import build
 
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -37,7 +37,7 @@ def _poll_with_exponential_delay(request, max_n, is_done_func, is_error_func):
                 return response
             else:
                 time.sleep((2**i) + (random.randint(0, 1000) / 1000))
-        except errors.HttpError as e:
+        except HttpError as e:
             if e.resp.status != 429:
                 log.info('Something went wrong. Not retrying: %s', format(e))
                 raise
@@ -96,7 +96,7 @@ class MLEngineHook(GoogleCloudBaseHook):
 
         try:
             request.execute()
-        except errors.HttpError as e:
+        except HttpError as e:
             # 409 means there is an existing job with the same job ID.
             if e.resp.status == 409:
                 if use_existing_job_fn is not None:
@@ -126,14 +126,14 @@ class MLEngineHook(GoogleCloudBaseHook):
         :rtype: dict
 
         Raises:
-            apiclient.errors.HttpError: if HTTP error is returned from server
+            googleapiclient.errors.HttpError: if HTTP error is returned from server
         """
         job_name = 'projects/{}/jobs/{}'.format(project_id, job_id)
         request = self._mlengine.projects().jobs().get(name=job_name)
         while True:
             try:
                 return request.execute()
-            except errors.HttpError as e:
+            except HttpError as e:
                 if e.resp.status == 429:
                     # polling after 30 seconds when quota failure occurs
                     time.sleep(30)
@@ -149,7 +149,7 @@ class MLEngineHook(GoogleCloudBaseHook):
         a terminal state.
 
         Raises:
-            apiclient.errors.HttpError: if HTTP error is returned when getting
+            googleapiclient.errors.HttpError: if HTTP error is returned when getting
             the job
         """
         if interval <= 0:
@@ -193,7 +193,7 @@ class MLEngineHook(GoogleCloudBaseHook):
             response = request.execute()
             self.log.info('Successfully set version: %s to default', response)
             return response
-        except errors.HttpError as e:
+        except HttpError as e:
             self.log.error('Something went wrong: %s', e)
             raise
 
@@ -264,7 +264,7 @@ class MLEngineHook(GoogleCloudBaseHook):
         request = self._mlengine.projects().models().get(name=full_model_name)
         try:
             return request.execute()
-        except errors.HttpError as e:
+        except HttpError as e:
             if e.resp.status == 404:
                 self.log.error('Model was not found: %s', e)
                 return None

--- a/airflow/contrib/hooks/gcp_sql_hook.py
+++ b/airflow/contrib/hooks/gcp_sql_hook.py
@@ -30,7 +30,7 @@ import subprocess
 import time
 import uuid
 from os.path import isfile
-from googleapiclient import errors
+from googleapiclient.errors import HttpError
 from subprocess import Popen, PIPE
 from six.moves.urllib.parse import quote_plus
 
@@ -284,7 +284,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
             ).execute(num_retries=NUM_RETRIES)
             operation_name = response["name"]
             return self._wait_for_operation_to_complete(project_id, operation_name)
-        except errors.HttpError as ex:
+        except HttpError as ex:
             raise AirflowException(
                 'Exporting instance {} failed: {}'.format(instance_id, ex.content)
             )
@@ -313,7 +313,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
             ).execute(num_retries=NUM_RETRIES)
             operation_name = response["name"]
             return self._wait_for_operation_to_complete(project_id, operation_name)
-        except errors.HttpError as ex:
+        except HttpError as ex:
             raise AirflowException(
                 'Importing instance {} failed: {}'.format(instance_id, ex.content)
             )

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -17,9 +17,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from apiclient.discovery import build
-from apiclient.http import MediaFileUpload
-from googleapiclient import errors
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+from googleapiclient.errors import HttpError
 
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 from airflow.exceptions import AirflowException
@@ -91,7 +91,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                       destinationObject=destination_object, body='') \
                 .execute()
             return True
-        except errors.HttpError as ex:
+        except HttpError as ex:
             if ex.resp['status'] == '404':
                 return False
             raise
@@ -144,7 +144,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                     .execute()
                 self.log.info('Rewrite request #%s: %s', request_count, result)
             return True
-        except errors.HttpError as ex:
+        except HttpError as ex:
             if ex.resp['status'] == '404':
                 return False
             raise
@@ -239,7 +239,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                     .insert(bucket=bucket, name=object, media_body=media) \
                     .execute(num_retries=num_retries)
 
-        except errors.HttpError as ex:
+        except HttpError as ex:
             if ex.resp['status'] == '404':
                 return False
             raise
@@ -268,7 +268,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                 .get(bucket=bucket, object=object) \
                 .execute()
             return True
-        except errors.HttpError as ex:
+        except HttpError as ex:
             if ex.resp['status'] == '404':
                 return False
             raise
@@ -306,7 +306,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                 if updated > ts:
                     return True
 
-        except errors.HttpError as ex:
+        except HttpError as ex:
             if ex.resp['status'] != '404':
                 raise
 
@@ -333,7 +333,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                 .delete(bucket=bucket, object=object, generation=generation) \
                 .execute()
             return True
-        except errors.HttpError as ex:
+        except HttpError as ex:
             if ex.resp['status'] == '404':
                 return False
             raise
@@ -418,7 +418,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                 return size
             else:
                 raise ValueError('Object is not a file')
-        except errors.HttpError as ex:
+        except HttpError as ex:
             if ex.resp['status'] == '404':
                 raise ValueError('Object Not Found')
 
@@ -445,7 +445,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
             self.log.info('The crc32c checksum of %s is %s', object, crc32c)
             return crc32c
 
-        except errors.HttpError as ex:
+        except HttpError as ex:
             if ex.resp['status'] == '404':
                 raise ValueError('Object Not Found')
 
@@ -472,7 +472,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
             self.log.info('The md5Hash of %s is %s', object, md5hash)
             return md5hash
 
-        except errors.HttpError as ex:
+        except HttpError as ex:
             if ex.resp['status'] == '404':
                 raise ValueError('Object Not Found')
 
@@ -563,7 +563,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
 
             return response['id']
 
-        except errors.HttpError as ex:
+        except HttpError as ex:
             raise AirflowException(
                 'Bucket creation failed. Error was: {}'.format(ex.content)
             )
@@ -601,7 +601,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
             ).execute()
             if response:
                 self.log.info('A new ACL entry created in bucket: %s', bucket)
-        except errors.HttpError as ex:
+        except HttpError as ex:
             raise AirflowException(
                 'Bucket ACL entry creation failed. Error was: {}'.format(ex.content)
             )
@@ -651,7 +651,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
             if response:
                 self.log.info('A new ACL entry created for object: %s in bucket: %s',
                               object_name, bucket)
-        except errors.HttpError as ex:
+        except HttpError as ex:
             raise AirflowException(
                 'Object ACL entry creation failed. Error was: {}'.format(ex.content)
             )

--- a/airflow/contrib/operators/mlengine_operator.py
+++ b/airflow/contrib/operators/mlengine_operator.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 import re
 
-from apiclient import errors
+from googleapiclient.errors import HttpError
 
 from airflow.contrib.hooks.gcp_mlengine_hook import MLEngineHook
 from airflow.exceptions import AirflowException
@@ -264,7 +264,7 @@ class MLEngineBatchPredictionOperator(BaseOperator):
         try:
             finished_prediction_job = hook.create_job(
                 self._project_id, prediction_request, check_existing_job)
-        except errors.HttpError:
+        except HttpError:
             raise
 
         if finished_prediction_job['state'] != 'SUCCEEDED':
@@ -614,7 +614,7 @@ class MLEngineTrainingOperator(BaseOperator):
         try:
             finished_training_job = hook.create_job(
                 self._project_id, training_request, check_existing_job)
-        except errors.HttpError:
+        except HttpError:
             raise
 
         if finished_training_job['state'] != 'SUCCEEDED':

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,9 +36,10 @@ import sys
 import mock
 
 MOCK_MODULES = [
-    'apiclient',
-    'apiclient.discovery',
-    'apiclient.http',
+    'googleapiclient',
+    'googleapiclient.errors',
+    'googleapiclient.discovery',
+    'googleapiclient.http',
     'mesos',
     'mesos.interface',
     'mesos.native',

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -22,7 +22,7 @@ import unittest
 
 from google.auth.exceptions import GoogleAuthError
 import mock
-from apiclient.errors import HttpError
+from googleapiclient.errors import HttpError
 
 from airflow.contrib.hooks import bigquery_hook as hook
 from airflow.contrib.hooks.bigquery_hook import _cleanse_time_partitioning, \

--- a/tests/contrib/hooks/test_gcp_mlengine_hook.py
+++ b/tests/contrib/hooks/test_gcp_mlengine_hook.py
@@ -25,9 +25,9 @@ except ImportError:  # python 3
     from urllib.parse import urlparse, parse_qsl
 
 from airflow.contrib.hooks import gcp_mlengine_hook as hook
-from apiclient import errors
-from apiclient.discovery import build_from_document
-from apiclient.http import HttpMockSequence
+from googleapiclient.errors import HttpError
+from googleapiclient.discovery import build_from_document
+from googleapiclient.http import HttpMockSequence
 from google.auth.exceptions import GoogleAuthError
 import requests
 
@@ -392,7 +392,7 @@ class TestMLEngineHook(unittest.TestCase):
                 self,
                 responses=responses,
                 expected_requests=expected_requests) as cml_hook:
-            with self.assertRaises(errors.HttpError):
+            with self.assertRaises(HttpError):
                 cml_hook.create_job(
                     project_id=project, job=my_job,
                     use_existing_job_fn=check_input)

--- a/tests/contrib/hooks/test_gcp_pubsub_hook.py
+++ b/tests/contrib/hooks/test_gcp_pubsub_hook.py
@@ -23,7 +23,7 @@ from __future__ import unicode_literals
 from base64 import b64encode as b64e
 import unittest
 
-from apiclient.errors import HttpError
+from googleapiclient.errors import HttpError
 
 from airflow.contrib.hooks.gcp_pubsub_hook import PubSubException, PubSubHook
 

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -23,7 +23,7 @@ import os
 
 from airflow.contrib.hooks import gcs_hook
 from airflow.exceptions import AirflowException
-from apiclient.errors import HttpError
+from googleapiclient.errors import HttpError
 
 try:
     from unittest import mock

--- a/tests/contrib/operators/test_mlengine_operator.py
+++ b/tests/contrib/operators/test_mlengine_operator.py
@@ -22,7 +22,7 @@ import datetime
 import unittest
 
 import httplib2
-from apiclient import errors
+from googleapiclient.errors import HttpError
 from mock import ANY, patch
 
 from airflow import DAG, configuration
@@ -85,7 +85,7 @@ class MLEngineBatchPredictionOperatorTest(unittest.TestCase):
             success_message['predictionInput'] = input_with_model
 
             hook_instance = mock_hook.return_value
-            hook_instance.get_job.side_effect = errors.HttpError(
+            hook_instance.get_job.side_effect = HttpError(
                 resp=httplib2.Response({
                     'status': 404
                 }), content=b'some bytes')
@@ -123,7 +123,7 @@ class MLEngineBatchPredictionOperatorTest(unittest.TestCase):
             success_message['predictionInput'] = input_with_version
 
             hook_instance = mock_hook.return_value
-            hook_instance.get_job.side_effect = errors.HttpError(
+            hook_instance.get_job.side_effect = HttpError(
                 resp=httplib2.Response({
                     'status': 404
                 }), content=b'some bytes')
@@ -161,7 +161,7 @@ class MLEngineBatchPredictionOperatorTest(unittest.TestCase):
             success_message['predictionInput'] = input_with_uri
 
             hook_instance = mock_hook.return_value
-            hook_instance.get_job.side_effect = errors.HttpError(
+            hook_instance.get_job.side_effect = HttpError(
                 resp=httplib2.Response({
                     'status': 404
                 }), content=b'some bytes')
@@ -238,13 +238,13 @@ class MLEngineBatchPredictionOperatorTest(unittest.TestCase):
                 'projects/experimental/models/test_model'
 
             hook_instance = mock_hook.return_value
-            hook_instance.create_job.side_effect = errors.HttpError(
+            hook_instance.create_job.side_effect = HttpError(
                 resp=httplib2.Response({
                     'status': http_error_code
                 }),
                 content=b'Forbidden')
 
-            with self.assertRaises(errors.HttpError) as context:
+            with self.assertRaises(HttpError) as context:
                 prediction_task = MLEngineBatchPredictionOperator(
                     job_id='test_prediction',
                     project_id='test-project',
@@ -356,13 +356,13 @@ class MLEngineTrainingOperatorTest(unittest.TestCase):
         with patch('airflow.contrib.operators.mlengine_operator.MLEngineHook') \
                 as mock_hook:
             hook_instance = mock_hook.return_value
-            hook_instance.create_job.side_effect = errors.HttpError(
+            hook_instance.create_job.side_effect = HttpError(
                 resp=httplib2.Response({
                     'status': http_error_code
                 }),
                 content=b'Forbidden')
 
-            with self.assertRaises(errors.HttpError) as context:
+            with self.assertRaises(HttpError) as context:
                 training_op = MLEngineTrainingOperator(
                     **self.TRAINING_DEFAULT_ARGS)
                 training_op.execute(None)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3675

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The deprecated apiclient package name is used in a number of places.

This commit changes it to googleapiclient and modifies the right
packages to be used instead.

### Tests

- [x] My PR  does not need extra testing for this extremely good reason - just running the old tests should be enough to verify it :).

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

No public API changes/documentation needed

### Code Quality

- [x] Passes `flake8`
