### PR TITLE
[AIRFLOW-3678] Fixes 'airflow resetdb' for initialized Postgres DB

### DIFF
--- a/airflow/migrations/versions/1b38cef5b76e_add_dagrun.py
+++ b/airflow/migrations/versions/1b38cef5b76e_add_dagrun.py
@@ -29,6 +29,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
+from sqlalchemy.engine.reflection import Inspector
+
 revision = '1b38cef5b76e'
 down_revision = '502898887f84'
 branch_labels = None
@@ -36,16 +38,20 @@ depends_on = None
 
 
 def upgrade():
-    op.create_table('dag_run',
-                    sa.Column('id', sa.Integer(), nullable=False),
-                    sa.Column('dag_id', sa.String(length=250), nullable=True),
-                    sa.Column('execution_date', sa.DateTime(), nullable=True),
-                    sa.Column('state', sa.String(length=50), nullable=True),
-                    sa.Column('run_id', sa.String(length=250), nullable=True),
-                    sa.Column('external_trigger', sa.Boolean(), nullable=True),
-                    sa.PrimaryKeyConstraint('id'),
-                    sa.UniqueConstraint('dag_id', 'execution_date'),
-                    sa.UniqueConstraint('dag_id', 'run_id'))
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+    tables = inspector.get_table_names()
+    if 'dag_run' not in tables:
+        op.create_table('dag_run',
+                        sa.Column('id', sa.Integer(), nullable=False),
+                        sa.Column('dag_id', sa.String(length=250), nullable=True),
+                        sa.Column('execution_date', sa.DateTime(), nullable=True),
+                        sa.Column('state', sa.String(length=50), nullable=True),
+                        sa.Column('run_id', sa.String(length=250), nullable=True),
+                        sa.Column('external_trigger', sa.Boolean(), nullable=True),
+                        sa.PrimaryKeyConstraint('id'),
+                        sa.UniqueConstraint('dag_id', 'execution_date'),
+                        sa.UniqueConstraint('dag_id', 'run_id'))
 
 
 def downgrade():

--- a/airflow/migrations/versions/33ae817a1ff4_add_kubernetes_resource_checkpointing.py
+++ b/airflow/migrations/versions/33ae817a1ff4_add_kubernetes_resource_checkpointing.py
@@ -29,6 +29,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
+from sqlalchemy.engine.reflection import Inspector
+
 revision = '33ae817a1ff4'
 down_revision = 'd2ae31099d61'
 branch_labels = None
@@ -50,10 +52,14 @@ def upgrade():
     if conn.dialect.name not in ('mssql'):
         columns_and_constraints.append(sa.CheckConstraint("one_row_id", name="kube_resource_version_one_row_id"))
 
-    table = op.create_table(
-        RESOURCE_TABLE,
-        *columns_and_constraints
-    )
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+    tables = inspector.get_table_names()
+    if RESOURCE_TABLE not in tables:
+        table = op.create_table(
+            RESOURCE_TABLE,
+            *columns_and_constraints
+        )
 
     op.bulk_insert(table, [
         {"resource_version": ""}

--- a/airflow/migrations/versions/64de9cddf6c9_add_task_fails_journal_table.py
+++ b/airflow/migrations/versions/64de9cddf6c9_add_task_fails_journal_table.py
@@ -27,6 +27,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
+from sqlalchemy.engine.reflection import Inspector
+
 revision = '64de9cddf6c9'
 down_revision = '211e584da130'
 branch_labels = None
@@ -34,17 +36,22 @@ depends_on = None
 
 
 def upgrade():
-    op.create_table(
-        'task_fail',
-        sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('task_id', sa.String(length=250), nullable=False),
-        sa.Column('dag_id', sa.String(length=250), nullable=False),
-        sa.Column('execution_date', sa.DateTime(), nullable=False),
-        sa.Column('start_date', sa.DateTime(), nullable=True),
-        sa.Column('end_date', sa.DateTime(), nullable=True),
-        sa.Column('duration', sa.Integer(), nullable=True),
-        sa.PrimaryKeyConstraint('id'),
-    )
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+    tables = inspector.get_table_names()
+
+    if 'task_fail' not in tables:
+        op.create_table(
+            'task_fail',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('task_id', sa.String(length=250), nullable=False),
+            sa.Column('dag_id', sa.String(length=250), nullable=False),
+            sa.Column('execution_date', sa.DateTime(), nullable=False),
+            sa.Column('start_date', sa.DateTime(), nullable=True),
+            sa.Column('end_date', sa.DateTime(), nullable=True),
+            sa.Column('duration', sa.Integer(), nullable=True),
+            sa.PrimaryKeyConstraint('id'),
+        )
 
 
 def downgrade():

--- a/airflow/migrations/versions/86770d1215c0_add_kubernetes_scheduler_uniqueness.py
+++ b/airflow/migrations/versions/86770d1215c0_add_kubernetes_scheduler_uniqueness.py
@@ -29,6 +29,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
+from sqlalchemy.engine.reflection import Inspector
+
 revision = '86770d1215c0'
 down_revision = '27c6a30d7c24'
 branch_labels = None
@@ -50,10 +52,14 @@ def upgrade():
     if conn.dialect.name not in ('mssql'):
         columns_and_constraints.append(sa.CheckConstraint("one_row_id", name="kube_worker_one_row_id"))
 
-    table = op.create_table(
-        RESOURCE_TABLE,
-        *columns_and_constraints
-    )
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+    tables = inspector.get_table_names()
+    if RESOURCE_TABLE not in tables:
+        table = op.create_table(
+            RESOURCE_TABLE,
+            *columns_and_constraints
+        )
 
     op.bulk_insert(table, [
         {"worker_uuid": ""}

--- a/airflow/migrations/versions/f2ca10b85618_add_dag_stats_table.py
+++ b/airflow/migrations/versions/f2ca10b85618_add_dag_stats_table.py
@@ -25,6 +25,7 @@ Create Date: 2016-07-20 15:08:28.247537
 """
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.engine.reflection import Inspector
 
 # revision identifiers, used by Alembic.
 revision = 'f2ca10b85618'
@@ -34,12 +35,16 @@ depends_on = None
 
 
 def upgrade():
-    op.create_table('dag_stats',
-                    sa.Column('dag_id', sa.String(length=250), nullable=False),
-                    sa.Column('state', sa.String(length=50), nullable=False),
-                    sa.Column('count', sa.Integer(), nullable=False, default=0),
-                    sa.Column('dirty', sa.Boolean(), nullable=False, default=False),
-                    sa.PrimaryKeyConstraint('dag_id', 'state'))
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+    tables = inspector.get_table_names()
+    if 'dag_stats' not in tables:
+        op.create_table('dag_stats',
+                        sa.Column('dag_id', sa.String(length=250), nullable=False),
+                        sa.Column('state', sa.String(length=50), nullable=False),
+                        sa.Column('count', sa.Integer(), nullable=False, default=0),
+                        sa.Column('dirty', sa.Boolean(), nullable=False, default=False),
+                        sa.PrimaryKeyConstraint('dag_id', 'state'))
 
 
 def downgrade():


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3678

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

There is a missing check for existence of dag_stats table in
Alembic migration script which causes the 'airflow resetdb'
command to fail when it is run on already initialized postgres
Database.

### Tests

- [x] MPR  does not need testing for this extremely good reason:
It's hard to test multiple resets on existing Postgres database during unit tests.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
No new functionality.

### Code Quality

- [x] Passes `flake8`
