### PR TITLE
[AIRFLOW-3683] Fix formatting of error message for invalid TriggerRule

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -2317,7 +2317,7 @@ class BaseOperator(LoggingMixin):
             raise AirflowException(
                 "The trigger_rule must be one of {all_triggers},"
                 "'{d}.{t}'; received '{tr}'."
-                .format(all_triggers=TriggerRule.all_triggers,
+                .format(all_triggers=TriggerRule.all_triggers(),
                         d=dag.dag_id if dag else "", t=task_id, tr=trigger_rule))
 
         self.trigger_rule = trigger_rule


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3683/) issues and references them in the PR title. For example, "\[AIRFLOW-3683\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3683
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-3683\], code changes always need a Jira issue.

### Description

- [ X] Here are some details about my PR, including screenshots of any UI changes:
[AIRFLOW-3683] Fixed formatting of error message for invalid TriggerRule

The valid values have not been displayed in the error message.

### Tests

- [ X] My PR does not need testing for this extremely good reason:
        it was a trivial formatting issue
### Commits

- [X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X ] Passes `flake8`