### PR TITLE
[AIRFLOW-722] Add celery queue sensor

### DIFF
--- a/airflow/contrib/sensors/celery_queue_sensor.py
+++ b/airflow/contrib/sensors/celery_queue_sensor.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import absolute_import
+
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
+from airflow.utils.decorators import apply_defaults
+
+from celery.app import control
+
+
+class CeleryQueueSensor(BaseSensorOperator):
+    """
+    Waits for a Celery queue to be empty. By default, in order to be considered
+    empty, the queue must not have any tasks in the ``reserved``, ``scheduled``
+    or ``active`` states.
+
+    :param celery_queue: The name of the Celery queue to wait for.
+    :type celery_queue: str
+    :param target_task_id: Task id for checking
+    :type target_task_id: str
+    """
+    @apply_defaults
+    def __init__(
+            self,
+            celery_queue,
+            target_task_id=None,
+            *args,
+            **kwargs):
+
+        super(CeleryQueueSensor, self).__init__(*args, **kwargs)
+        self.celery_queue = celery_queue
+        self.target_task_id = target_task_id
+
+    def _check_task_id(self, context):
+        """
+        Gets the returned Celery result from the Airflow task
+        ID provided to the sensor, and returns True if the
+        celery result has been finished execution.
+
+        :param context: Airflow's execution context
+        :type context: dict
+        :return: True if task has been executed, otherwise False
+        :rtype: bool
+        """
+        ti = context['ti']
+        celery_result = ti.xcom_pull(task_ids=self.target_task_id)
+        return celery_result.ready()
+
+    def poke(self, context):
+
+        if self.target_task_id:
+            return self._check_task_id(context)
+
+        inspect_result = control.Inspect()
+        reserved = inspect_result.reserved()
+        scheduled = inspect_result.scheduled()
+        active = inspect_result.active()
+
+        try:
+            reserved = len(reserved[self.celery_queue])
+            scheduled = len(scheduled[self.celery_queue])
+            active = len(active[self.celery_queue])
+
+            self.log.info(
+                'Checking if celery queue %s is empty.', self.celery_queue
+            )
+
+            return reserved == 0 and scheduled == 0 and active == 0
+        except KeyError:
+            raise KeyError(
+                'Could not locate Celery queue {0}'.format(
+                    self.celery_queue
+                )
+            )

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -242,6 +242,7 @@ Sensors
 .. autoclass:: airflow.contrib.sensors.bigquery_sensor.BigQueryTableSensor
 .. autoclass:: airflow.contrib.sensors.cassandra_record_sensor.CassandraRecordSensor
 .. autoclass:: airflow.contrib.sensors.cassandra_table_sensor.CassandraTableSensor
+.. autoclass:: airflow.contrib.sensors.celery_queue_sensor.CeleryQueueSensor
 .. autoclass:: airflow.contrib.sensors.datadog_sensor.DatadogSensor
 .. autoclass:: airflow.contrib.sensors.emr_base_sensor.EmrBaseSensor
 .. autoclass:: airflow.contrib.sensors.emr_job_flow_sensor.EmrJobFlowSensor

--- a/tests/contrib/sensors/test_celery_queue_sensor.py
+++ b/tests/contrib/sensors/test_celery_queue_sensor.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import absolute_import
+
+import unittest
+from mock import patch
+
+from airflow.contrib.sensors.celery_queue_sensor import CeleryQueueSensor
+
+
+class TestCeleryQueueSensor(unittest.TestCase):
+
+    def setUp(self):
+        class TestCeleryqueueSensor(CeleryQueueSensor):
+
+            def _check_task_id(self, context):
+                return True
+
+        self.sensor = TestCeleryqueueSensor
+
+    @patch('celery.app.control.Inspect')
+    def test_poke_success(self, mock_inspect):
+        mock_inspect_result = mock_inspect.return_value
+        # test success
+        mock_inspect_result.reserved.return_value = {
+            'test_queue': []
+        }
+
+        mock_inspect_result.scheduled.return_value = {
+            'test_queue': []
+        }
+
+        mock_inspect_result.active.return_value = {
+            'test_queue': []
+        }
+        test_sensor = self.sensor(celery_queue='test_queue',
+                                  task_id='test-task')
+        self.assertTrue(test_sensor.poke(None))
+
+    @patch('celery.app.control.Inspect')
+    def test_poke_fail(self, mock_inspect):
+        mock_inspect_result = mock_inspect.return_value
+        # test success
+        mock_inspect_result.reserved.return_value = {
+            'test_queue': []
+        }
+
+        mock_inspect_result.scheduled.return_value = {
+            'test_queue': []
+        }
+
+        mock_inspect_result.active.return_value = {
+            'test_queue': ['task']
+        }
+        test_sensor = self.sensor(celery_queue='test_queue',
+                                  task_id='test-task')
+        self.assertFalse(test_sensor.poke(None))
+
+    @patch('celery.app.control.Inspect')
+    def test_poke_success_with_taskid(self, mock_inspect):
+        test_sensor = self.sensor(celery_queue='test_queue',
+                                  task_id='test-task',
+                                  af_task_id='target-task')
+        self.assertTrue(test_sensor.poke(None))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-722
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The pr is based on https://github.com/apache/airflow/pull/1964 which get stale recently. It is very useful to have a sensor check whether the celery queue is empty or not.

I add unit tests.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
