### PR TITLE
[AIRFLOW-3687] Add missing @apply_defaults decorators

### DIFF
--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -24,6 +24,7 @@ import time
 from airflow.exceptions import AirflowException
 from airflow.contrib.hooks.databricks_hook import DatabricksHook
 from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
 
 
 XCOM_RUN_ID_KEY = 'run_id'
@@ -218,6 +219,7 @@ class DatabricksSubmitRunOperator(BaseOperator):
     ui_color = '#1CB1C2'
     ui_fgcolor = '#fff'
 
+    @apply_defaults
     def __init__(
             self,
             json=None,
@@ -419,6 +421,7 @@ class DatabricksRunNowOperator(BaseOperator):
     ui_color = '#1CB1C2'
     ui_fgcolor = '#fff'
 
+    @apply_defaults
     def __init__(
             self,
             job_id,

--- a/airflow/contrib/operators/druid_operator.py
+++ b/airflow/contrib/operators/druid_operator.py
@@ -21,6 +21,7 @@ import json
 
 from airflow.hooks.druid_hook import DruidHook
 from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
 
 
 class DruidOperator(BaseOperator):
@@ -36,6 +37,7 @@ class DruidOperator(BaseOperator):
     template_fields = ('index_spec_str',)
     template_ext = ('.json',)
 
+    @apply_defaults
     def __init__(self, json_index_file,
                  druid_ingest_conn_id='druid_ingest_default',
                  max_ingestion_time=None,

--- a/airflow/contrib/operators/mongo_to_s3.py
+++ b/airflow/contrib/operators/mongo_to_s3.py
@@ -21,6 +21,7 @@ import json
 from airflow.contrib.hooks.mongo_hook import MongoHook
 from airflow.hooks.S3_hook import S3Hook
 from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
 from bson import json_util
 
 
@@ -39,6 +40,7 @@ class MongoToS3Operator(BaseOperator):
     template_fields = ['s3_key', 'mongo_query']
     # pylint: disable=too-many-instance-attributes
 
+    @apply_defaults
     def __init__(self,
                  mongo_conn_id,
                  s3_conn_id,

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -226,6 +226,7 @@ class PythonVirtualenvOperator(PythonOperator):
         processing templated fields, for examples ``['.sql', '.hql']``
     :type templates_exts: list(str)
     """
+    @apply_defaults
     def __init__(self, python_callable,
                  requirements=None,
                  python_version=None, use_dill=False,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3687

### Description

- [x] Adds missing decorators.

### Tests

- [x] No operator has a test that could check it. The change would have to take place globally.

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
