### PR TITLE
[AIRFLOW-3688] Run only airflow-testing for flake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
   include:
     - name: Flake8
       stage: pre-test
-      script: docker-compose --log-level ERROR -f scripts/ci/docker-compose.yml run airflow-testing /app/scripts/ci/run-ci.sh
+      script: docker-compose --log-level ERROR -f scripts/ci/docker-compose.yml run --no-deps airflow-testing /app/scripts/ci/run-ci.sh
       env: TOX_ENV=flake8
     - name: Check license header
       stage: pre-test


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira
  - https://issues.apache.org/jira/browse/AIRFLOW-3688

### Description

- [x] Flake don't have external depedencies. 

### Tests

- [x] ¯\_(ツ)_/¯

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
