### PR TITLE
[AIRFLOW-3681] All GCP operators have now optional GCP Project ID

### DIFF
--- a/airflow/contrib/example_dags/example_gcp_compute.py
+++ b/airflow/contrib/example_dags/example_gcp_compute.py
@@ -68,12 +68,13 @@ with models.DAG(
     )
     # [END howto_operator_gce_start]
     # Duplicate start for idempotence testing
+    # [START howto_operator_gce_start_no_project_id]
     gce_instance_start2 = GceInstanceStartOperator(
-        project_id=GCP_PROJECT_ID,
         zone=GCE_ZONE,
         resource_id=GCE_INSTANCE,
         task_id='gcp_compute_start_task2'
     )
+    # [END howto_operator_gce_start_no_project_id]
     # [START howto_operator_gce_stop]
     gce_instance_stop = GceInstanceStopOperator(
         project_id=GCP_PROJECT_ID,
@@ -83,12 +84,13 @@ with models.DAG(
     )
     # [END howto_operator_gce_stop]
     # Duplicate stop for idempotence testing
+    # [START howto_operator_gce_stop_no_project_id]
     gce_instance_stop2 = GceInstanceStopOperator(
-        project_id=GCP_PROJECT_ID,
         zone=GCE_ZONE,
         resource_id=GCE_INSTANCE,
         task_id='gcp_compute_stop_task2'
     )
+    # [END howto_operator_gce_stop_no_project_id]
     # [START howto_operator_gce_set_machine_type]
     gce_set_machine_type = GceSetMachineTypeOperator(
         project_id=GCP_PROJECT_ID,
@@ -99,13 +101,14 @@ with models.DAG(
     )
     # [END howto_operator_gce_set_machine_type]
     # Duplicate set machine type for idempotence testing
+    # [START howto_operator_gce_set_machine_type_no_project_id]
     gce_set_machine_type2 = GceSetMachineTypeOperator(
-        project_id=GCP_PROJECT_ID,
         zone=GCE_ZONE,
         resource_id=GCE_INSTANCE,
         body=SET_MACHINE_TYPE_BODY,
         task_id='gcp_compute_set_machine_type2'
     )
+    # [END howto_operator_gce_set_machine_type_no_project_id]
 
     gce_instance_start >> gce_instance_start2 >> gce_instance_stop >> \
         gce_instance_stop2 >> gce_set_machine_type >> gce_set_machine_type2

--- a/airflow/contrib/example_dags/example_gcp_compute_igm.py
+++ b/airflow/contrib/example_dags/example_gcp_compute_igm.py
@@ -109,12 +109,13 @@ with models.DAG(
     )
     # [END howto_operator_gce_igm_copy_template]
     # Added to check for idempotence
+    # [START howto_operator_gce_igm_copy_template_no_project_id]
     gce_instance_template_copy2 = GceInstanceTemplateCopyOperator(
-        project_id=GCP_PROJECT_ID,
         resource_id=GCE_TEMPLATE_NAME,
         body_patch=GCE_INSTANCE_TEMPLATE_BODY_UPDATE,
         task_id='gcp_compute_igm_copy_template_task_2'
     )
+    # [END howto_operator_gce_igm_copy_template_no_project_id]
     # [START howto_operator_gce_igm_update_template]
     gce_instance_group_manager_update_template = \
         GceInstanceGroupManagerUpdateTemplateOperator(
@@ -128,15 +129,16 @@ with models.DAG(
         )
     # [END howto_operator_gce_igm_update_template]
     # Added to check for idempotence (and without UPDATE_POLICY)
+    # [START howto_operator_gce_igm_update_template_no_project_id]
     gce_instance_group_manager_update_template2 = \
         GceInstanceGroupManagerUpdateTemplateOperator(
-            project_id=GCP_PROJECT_ID,
             resource_id=GCE_INSTANCE_GROUP_MANAGER_NAME,
             zone=GCE_ZONE,
             source_template=SOURCE_TEMPLATE_URL,
             destination_template=DESTINATION_TEMPLATE_URL,
             task_id='gcp_compute_igm_group_manager_update_template_2'
         )
+    # [END howto_operator_gce_igm_update_template_no_project_id]
     gce_instance_template_copy >> gce_instance_template_copy2 >> \
         gce_instance_group_manager_update_template >> \
         gce_instance_group_manager_update_template2

--- a/airflow/contrib/example_dags/example_gcp_function.py
+++ b/airflow/contrib/example_dags/example_gcp_function.py
@@ -116,10 +116,18 @@ with models.DAG(
         validate_body=GCP_VALIDATE_BODY
     )
     # [END howto_operator_gcf_deploy]
+    # [START howto_operator_gcf_deploy_no_project_id]
+    deploy2_task = GcfFunctionDeployOperator(
+        task_id="gcf_deploy2_task",
+        location=GCP_LOCATION,
+        body=body,
+        validate_body=GCP_VALIDATE_BODY
+    )
+    # [END howto_operator_gcf_deploy_no_project_id]
     # [START howto_operator_gcf_delete]
     delete_task = GcfFunctionDeleteOperator(
         task_id="gcf_delete_task",
         name=FUNCTION_NAME
     )
     # [END howto_operator_gcf_delete]
-    deploy_task >> delete_task
+    deploy_task >> deploy2_task >> delete_task

--- a/airflow/contrib/example_dags/example_gcp_spanner.py
+++ b/airflow/contrib/example_dags/example_gcp_spanner.py
@@ -77,17 +77,14 @@ with models.DAG(
         display_name=GCP_SPANNER_DISPLAY_NAME,
         task_id='spanner_instance_create_task'
     )
-    # [END howto_operator_spanner_deploy]
-
-    # Update
     spanner_instance_update_task = CloudSpannerInstanceDeployOperator(
-        project_id=GCP_PROJECT_ID,
         instance_id=GCP_SPANNER_INSTANCE_ID,
         configuration_name=GCP_SPANNER_CONFIG_NAME,
         node_count=int(GCP_SPANNER_NODE_COUNT) + 1,
         display_name=GCP_SPANNER_DISPLAY_NAME + '_updated',
         task_id='spanner_instance_update_task'
     )
+    # [END howto_operator_spanner_deploy]
 
     # [START howto_operator_spanner_database_deploy]
     spanner_database_deploy_task = CloudSpannerInstanceDatabaseDeployOperator(
@@ -99,6 +96,15 @@ with models.DAG(
             "CREATE TABLE my_table2 (id INT64, name STRING(MAX)) PRIMARY KEY (id)",
         ],
         task_id='spanner_database_deploy_task'
+    )
+    spanner_database_deploy_task2 = CloudSpannerInstanceDatabaseDeployOperator(
+        instance_id=GCP_SPANNER_INSTANCE_ID,
+        database_id=GCP_SPANNER_DATABASE_ID,
+        ddl_statements=[
+            "CREATE TABLE my_table1 (id INT64, name STRING(MAX)) PRIMARY KEY (id)",
+            "CREATE TABLE my_table2 (id INT64, name STRING(MAX)) PRIMARY KEY (id)",
+        ],
+        task_id='spanner_database_deploy_task2'
     )
     # [END howto_operator_spanner_database_deploy]
 
@@ -126,7 +132,6 @@ with models.DAG(
         task_id='spanner_database_update_idempotent1_task'
     )
     spanner_database_update_idempotent2_task = CloudSpannerInstanceDatabaseUpdateOperator(
-        project_id=GCP_PROJECT_ID,
         instance_id=GCP_SPANNER_INSTANCE_ID,
         database_id=GCP_SPANNER_DATABASE_ID,
         operation_id=OPERATION_ID,
@@ -143,17 +148,15 @@ with models.DAG(
         instance_id=GCP_SPANNER_INSTANCE_ID,
         database_id=GCP_SPANNER_DATABASE_ID,
         query=["DELETE FROM my_table2 WHERE true"],
-        task_id='spanner_instance_query'
+        task_id='spanner_instance_query_task'
     )
-    # [END howto_operator_spanner_query]
-
-    spanner_instance_query2_task = CloudSpannerInstanceDatabaseQueryOperator(
-        project_id=GCP_PROJECT_ID,
+    spanner_instance_query_task2 = CloudSpannerInstanceDatabaseQueryOperator(
         instance_id=GCP_SPANNER_INSTANCE_ID,
         database_id=GCP_SPANNER_DATABASE_ID,
-        query="example_gcp_spanner.sql",
-        task_id='spanner_instance_query2'
+        query=["DELETE FROM my_table2 WHERE true"],
+        task_id='spanner_instance_query_task2'
     )
+    # [END howto_operator_spanner_query]
 
     # [START howto_operator_spanner_database_delete]
     spanner_database_delete_task = CloudSpannerInstanceDatabaseDeleteOperator(
@@ -161,6 +164,11 @@ with models.DAG(
         instance_id=GCP_SPANNER_INSTANCE_ID,
         database_id=GCP_SPANNER_DATABASE_ID,
         task_id='spanner_database_delete_task'
+    )
+    spanner_database_delete_task2 = CloudSpannerInstanceDatabaseDeleteOperator(
+        instance_id=GCP_SPANNER_INSTANCE_ID,
+        database_id=GCP_SPANNER_DATABASE_ID,
+        task_id='spanner_database_delete_task2'
     )
     # [END howto_operator_spanner_database_delete]
 
@@ -170,15 +178,22 @@ with models.DAG(
         instance_id=GCP_SPANNER_INSTANCE_ID,
         task_id='spanner_instance_delete_task'
     )
+    spanner_instance_delete_task2 = CloudSpannerInstanceDeleteOperator(
+        instance_id=GCP_SPANNER_INSTANCE_ID,
+        task_id='spanner_instance_delete_task2'
+    )
     # [END howto_operator_spanner_delete]
 
     spanner_instance_create_task \
         >> spanner_instance_update_task \
         >> spanner_database_deploy_task \
+        >> spanner_database_deploy_task2 \
         >> spanner_database_update_task \
         >> spanner_database_update_idempotent1_task \
         >> spanner_database_update_idempotent2_task \
         >> spanner_instance_query_task \
-        >> spanner_instance_query2_task \
+        >> spanner_instance_query_task2 \
         >> spanner_database_delete_task \
-        >> spanner_instance_delete_task
+        >> spanner_database_delete_task2 \
+        >> spanner_instance_delete_task \
+        >> spanner_instance_delete_task2

--- a/airflow/contrib/example_dags/example_gcp_sql_query.py
+++ b/airflow/contrib/example_dags/example_gcp_sql_query.py
@@ -239,6 +239,21 @@ os.environ['AIRFLOW_CONN_PUBLIC_MYSQL_TCP_SSL'] = \
     "sslkey={client_key_file}&" \
     "sslrootcert={server_ca_file}".format(**mysql_kwargs)
 
+# Special case: MySQL: connect directly via TCP (SSL) and with fixed Cloud Sql
+# Proxy binary path AND with missing project_id
+
+os.environ['AIRFLOW_CONN_PUBLIC_MYSQL_TCP_SSL_NO_PROJECT_ID'] = \
+    "gcpcloudsql://{user}:{password}@{public_ip}:{public_port}/{database}?" \
+    "database_type=mysql&" \
+    "location={location}&" \
+    "instance={instance}&" \
+    "use_proxy=False&" \
+    "use_ssl=True&" \
+    "sslcert={client_cert_file}&" \
+    "sslkey={client_key_file}&" \
+    "sslrootcert={server_ca_file}".format(**mysql_kwargs)
+
+
 # [END howto_operator_cloudsql_query_connections]
 
 # [START howto_operator_cloudsql_query_operators]
@@ -251,7 +266,8 @@ connection_names = [
     "proxy_mysql_tcp",
     "proxy_mysql_socket",
     "public_mysql_tcp",
-    "public_mysql_tcp_ssl"
+    "public_mysql_tcp_ssl",
+    "public_mysql_tcp_ssl_no_project_id"
 ]
 
 tasks = []

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -18,6 +18,7 @@
 # under the License.
 #
 import json
+import functools
 
 import httplib2
 import google.auth
@@ -144,7 +145,7 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
         key_path, etc. They get formatted as shown below.
         """
         long_f = 'extra__google_cloud_platform__{}'.format(f)
-        if long_f in self.extras:
+        if hasattr(self, 'extras') and long_f in self.extras:
             return self.extras[long_f]
         else:
             return default
@@ -152,3 +153,43 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
     @property
     def project_id(self):
         return self._get_field('project')
+
+    def fallback_to_default_project_id(func):
+        """
+        Decorator that provides fallback for Google Cloud Platform project id. If
+        the project is None it will be replaced with the project_id from the
+        service account the Hook is authenticated with. Project id can be specified
+        either via project_id kwarg or via first parameter in positional args.
+
+        :param func: function to wrap
+        :return: result of the function call
+        """
+        @functools.wraps(func)
+        def inner_wrapper(self, *args, **kwargs):
+            if len(args) > 0:
+                raise AirflowException(
+                    "Use keyword arguments when initializing method with the "
+                    "'fallback_to_default_project_id' decorator")
+            if 'project_id' in kwargs:
+                kwargs['project_id'] = self._get_project_id(kwargs['project_id'])
+            else:
+                kwargs['project_id'] = self._get_project_id(None)
+            if not kwargs['project_id']:
+                raise AirflowException("The project id must be passed either as "
+                                       "keyword project_id parameter or as project_id extra "
+                                       "in GCP connection definition. Both are not set!")
+            return func(self, *args, **kwargs)
+        return inner_wrapper
+
+    fallback_to_default_project_id = staticmethod(fallback_to_default_project_id)
+
+    def _get_project_id(self, project_id):
+        """
+        In case project_id is None, overrides it with default project_id from
+        the service account that is authorized.
+
+        :param project_id: project id to
+        :type project_id: str
+        :return: the project_id specified or default project id if project_id is None
+        """
+        return project_id if project_id else self.project_id

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -569,7 +569,6 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
             )
 
     def insert_bucket_acl(self, bucket, entity, role, user_project):
-        # type: (str, str, str, str) -> None
         """
         Creates a new ACL entry on the specified bucket.
         See: https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls/insert
@@ -608,7 +607,6 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
 
     def insert_object_acl(self, bucket, object_name, entity, role, generation,
                           user_project):
-        # type: (str, str, str, str, str, str) -> None
         """
         Creates a new ACL entry on the specified object.
         See: https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls/insert

--- a/airflow/contrib/operators/gcp_bigtable_operator.py
+++ b/airflow/contrib/operators/gcp_bigtable_operator.py
@@ -44,14 +44,13 @@ class BigtableValidationMixin(object):
 class BigtableInstanceCreateOperator(BaseOperator, BigtableValidationMixin):
     """
     Creates a new Cloud Bigtable instance.
-    If the Cloud Bigtable instance with the given ID exists, the operator does not compare its configuration
+    If the Cloud Bigtable instance with the given ID exists, the operator does not
+    compare its configuration
     and immediately succeeds. No changes are made to the existing instance.
 
     For more details about instance creation have a look at the reference:
     https://googleapis.github.io/google-cloud-python/latest/bigtable/instance.html#google.cloud.bigtable.instance.Instance.create
 
-    :type project_id: str
-    :param project_id: The ID of the GCP project.
     :type instance_id: str
     :param instance_id: The ID of the Cloud Bigtable instance to create.
     :type main_cluster_id: str
@@ -59,6 +58,9 @@ class BigtableInstanceCreateOperator(BaseOperator, BigtableValidationMixin):
     :type main_cluster_zone: str
     :param main_cluster_zone: The zone for main cluster
         See https://cloud.google.com/bigtable/docs/locations for more details.
+    :type project_id: str
+    :param project_id: Optional, the ID of the GCP project.  If set to None or missing,
+            the default project_id from the GCP connection is used.
     :type replica_cluster_id: str
     :param replica_cluster_id: (optional) The ID for replica cluster for the new instance.
     :type replica_cluster_zone: str
@@ -66,9 +68,11 @@ class BigtableInstanceCreateOperator(BaseOperator, BigtableValidationMixin):
     :type instance_type: IntEnum
     :param instance_type: (optional) The type of the instance.
     :type instance_display_name: str
-    :param instance_display_name: (optional) Human-readable name of the instance. Defaults to ``instance_id``.
+    :param instance_display_name: (optional) Human-readable name of the instance. Defaults
+        to ``instance_id``.
     :type instance_labels: dict
-    :param instance_labels: (optional) Dictionary of labels to associate with the instance.
+    :param instance_labels: (optional) Dictionary of labels to associate
+        with the instance.
     :type cluster_nodes: int
     :param cluster_nodes: (optional) Number of nodes for cluster.
     :type cluster_storage_type: IntEnum
@@ -78,15 +82,17 @@ class BigtableInstanceCreateOperator(BaseOperator, BigtableValidationMixin):
                     If None is not specified, Operator will wait indefinitely.
     """
 
-    REQUIRED_ATTRIBUTES = ('project_id', 'instance_id', 'main_cluster_id', 'main_cluster_zone')
-    template_fields = ['project_id', 'instance_id', 'main_cluster_id', 'main_cluster_zone']
+    REQUIRED_ATTRIBUTES = ('instance_id', 'main_cluster_id',
+                           'main_cluster_zone')
+    template_fields = ['project_id', 'instance_id', 'main_cluster_id',
+                       'main_cluster_zone']
 
     @apply_defaults
     def __init__(self,
-                 project_id,
                  instance_id,
                  main_cluster_id,
                  main_cluster_zone,
+                 project_id=None,
                  replica_cluster_id=None,
                  replica_cluster_zone=None,
                  instance_display_name=None,
@@ -113,28 +119,31 @@ class BigtableInstanceCreateOperator(BaseOperator, BigtableValidationMixin):
         super(BigtableInstanceCreateOperator, self).__init__(*args, **kwargs)
 
     def execute(self, context):
-        instance = self.hook.get_instance(self.project_id, self.instance_id)
+        instance = self.hook.get_instance(project_id=self.project_id,
+                                          instance_id=self.instance_id)
         if instance:
-            # Based on Instance.__eq__ instance with the same ID and client is considered as equal.
+            # Based on Instance.__eq__ instance with the same ID and client is
+            # considered as equal.
             self.log.info(
-                "The instance '%s' already exists in this project. Consider it as created",
+                "The instance '%s' already exists in this project. "
+                "Consider it as created",
                 self.instance_id
             )
             return
         try:
             self.hook.create_instance(
-                self.project_id,
-                self.instance_id,
-                self.main_cluster_id,
-                self.main_cluster_zone,
-                self.replica_cluster_id,
-                self.replica_cluster_zone,
-                self.instance_display_name,
-                self.instance_type,
-                self.instance_labels,
-                self.cluster_nodes,
-                self.cluster_storage_type,
-                self.timeout,
+                project_id=self.project_id,
+                instance_id=self.instance_id,
+                main_cluster_id=self.main_cluster_id,
+                main_cluster_zone=self.main_cluster_zone,
+                replica_cluster_id=self.replica_cluster_id,
+                replica_cluster_zone=self.replica_cluster_zone,
+                instance_display_name=self.instance_display_name,
+                instance_type=self.instance_type,
+                instance_labels=self.instance_labels,
+                cluster_nodes=self.cluster_nodes,
+                cluster_storage_type=self.cluster_storage_type,
+                timeout=self.timeout,
             )
         except google.api_core.exceptions.GoogleAPICallError as e:
             self.log.error('An error occurred. Exiting.')
@@ -148,18 +157,19 @@ class BigtableInstanceDeleteOperator(BaseOperator, BigtableValidationMixin):
     For more details about deleting instance have a look at the reference:
     https://googleapis.github.io/google-cloud-python/latest/bigtable/instance.html#google.cloud.bigtable.instance.Instance.delete
 
-    :type project_id: str
-    :param project_id: The ID of the GCP project.
     :type instance_id: str
     :param instance_id: The ID of the Cloud Bigtable instance to delete.
+    :param project_id: Optional, the ID of the GCP project.  If set to None or missing,
+            the default project_id from the GCP connection is used.
+    :type project_id: str
     """
-    REQUIRED_ATTRIBUTES = ('project_id', 'instance_id')
+    REQUIRED_ATTRIBUTES = ('instance_id',)
     template_fields = ['project_id', 'instance_id']
 
     @apply_defaults
     def __init__(self,
-                 project_id,
                  instance_id,
+                 project_id=None,
                  *args, **kwargs):
         self.project_id = project_id
         self.instance_id = instance_id
@@ -169,10 +179,12 @@ class BigtableInstanceDeleteOperator(BaseOperator, BigtableValidationMixin):
 
     def execute(self, context):
         try:
-            self.hook.delete_instance(self.project_id, self.instance_id)
+            self.hook.delete_instance(project_id=self.project_id,
+                                      instance_id=self.instance_id)
         except google.api_core.exceptions.NotFound:
             self.log.info(
-                "The instance '%s' does not exist in project '%s'. Consider it as deleted",
+                "The instance '%s' does not exist in project '%s'. "
+                "Consider it as deleted",
                 self.instance_id, self.project_id
             )
         except google.api_core.exceptions.GoogleAPICallError as e:
@@ -187,27 +199,30 @@ class BigtableTableCreateOperator(BaseOperator, BigtableValidationMixin):
     For more details about creating table have a look at the reference:
     https://googleapis.github.io/google-cloud-python/latest/bigtable/table.html#google.cloud.bigtable.table.Table.create
 
-    :type project_id: str
-    :param project_id: The ID of the GCP project.
     :type instance_id: str
-    :param instance_id: The ID of the Cloud Bigtable instance that will hold the new table.
+    :param instance_id: The ID of the Cloud Bigtable instance that will
+        hold the new table.
     :type table_id: str
     :param table_id: The ID of the table to be created.
+    :type project_id: str
+    :param project_id: Optional, the ID of the GCP project. If set to None or missing,
+            the default project_id from the GCP connection is used.
     :type initial_split_keys: list
-    :param initial_split_keys: (Optional) list of row keys in bytes that will be used to initially split
-                                the table into several tablets.
+    :param initial_split_keys: (Optional) list of row keys in bytes that will be used to
+        initially split the table into several tablets.
     :type column_families: dict
     :param column_families: (Optional) A map columns to create.
-                            The key is the column_id str and the value is a GarbageCollectionRule
+                            The key is the column_id str and the value is a
+                            GarbageCollectionRule
     """
-    REQUIRED_ATTRIBUTES = ('project_id', 'instance_id', 'table_id')
+    REQUIRED_ATTRIBUTES = ('instance_id', 'table_id')
     template_fields = ['project_id', 'instance_id', 'table_id']
 
     @apply_defaults
     def __init__(self,
-                 project_id,
                  instance_id,
                  table_id,
+                 project_id=None,
                  initial_split_keys=None,
                  column_families=None,
                  *args, **kwargs):
@@ -222,41 +237,50 @@ class BigtableTableCreateOperator(BaseOperator, BigtableValidationMixin):
         super(BigtableTableCreateOperator, self).__init__(*args, **kwargs)
 
     def _compare_column_families(self):
-        table_column_families = self.hook.get_column_families_for_table(self.instance, self.table_id)
+        table_column_families = self.hook.get_column_families_for_table(self.instance,
+                                                                        self.table_id)
         if set(table_column_families.keys()) != set(self.column_families.keys()):
-            self.log.error("Table '%s' has different set of Column Families", self.table_id)
+            self.log.error("Table '%s' has different set of Column Families",
+                           self.table_id)
             self.log.error("Expected: %s", self.column_families.keys())
             self.log.error("Actual: %s", table_column_families.keys())
             return False
 
         for key in table_column_families.keys():
-            # There is difference in structure between local Column Families and remote ones
-            # Local `self.column_families` is dict with column_id as key and GarbageCollectionRule as value.
+            # There is difference in structure between local Column Families
+            # and remote ones
+            # Local `self.column_families` is dict with column_id as key
+            # and GarbageCollectionRule as value.
             # Remote `table_column_families` is list of ColumnFamily objects.
             # For more information about ColumnFamily please refer to the documentation:
             # https://googleapis.github.io/google-cloud-python/latest/bigtable/column-family.html#google.cloud.bigtable.column_family.ColumnFamily
             if table_column_families[key].gc_rule != self.column_families[key]:
-                self.log.error("Column Family '%s' differs for table '%s'.", key, self.table_id)
+                self.log.error("Column Family '%s' differs for table '%s'.", key,
+                               self.table_id)
                 return False
         return True
 
     def execute(self, context):
-        self.instance = self.hook.get_instance(self.project_id, self.instance_id)
+        self.instance = self.hook.get_instance(project_id=self.project_id,
+                                               instance_id=self.instance_id)
         if not self.instance:
-            raise AirflowException("Dependency: instance '{}' does not exist in project '{}'.".format(
-                self.instance_id, self.project_id))
+            raise AirflowException(
+                "Dependency: instance '{}' does not exist in project '{}'.".
+                format(self.instance_id, self.project_id))
         try:
             self.hook.create_table(
-                self.instance,
-                self.table_id,
-                self.initial_split_keys,
-                self.column_families
+                instance=self.instance,
+                table_id=self.table_id,
+                initial_split_keys=self.initial_split_keys,
+                column_families=self.column_families
             )
         except google.api_core.exceptions.AlreadyExists:
             if not self._compare_column_families():
                 raise AirflowException(
-                    "Table '{}' already exists with different Column Families.".format(self.table_id))
-            self.log.info("The table '%s' already exists. Consider it as created", self.table_id)
+                    "Table '{}' already exists with different Column Families.".
+                    format(self.table_id))
+            self.log.info("The table '%s' already exists. Consider it as created",
+                          self.table_id)
 
 
 class BigtableTableDeleteOperator(BaseOperator, BigtableValidationMixin):
@@ -266,21 +290,24 @@ class BigtableTableDeleteOperator(BaseOperator, BigtableValidationMixin):
     For more details about deleting table have a look at the reference:
     https://googleapis.github.io/google-cloud-python/latest/bigtable/table.html#google.cloud.bigtable.table.Table.delete
 
-    :type project_id: str
-    :param project_id: The ID of the GCP project.
     :type instance_id: str
     :param instance_id: The ID of the Cloud Bigtable instance.
     :type table_id: str
     :param table_id: The ID of the table to be deleted.
+    :type project_id: str
+    :param project_id: Optional, the ID of the GCP project. If set to None or missing,
+            the default project_id from the GCP connection is used.
+    :type app_profile_id: str
+    :parm app_profile_id: Application profile.
     """
-    REQUIRED_ATTRIBUTES = ('project_id', 'instance_id', 'table_id')
+    REQUIRED_ATTRIBUTES = ('instance_id', 'table_id')
     template_fields = ['project_id', 'instance_id', 'table_id']
 
     @apply_defaults
     def __init__(self,
-                 project_id,
                  instance_id,
                  table_id,
+                 project_id=None,
                  app_profile_id=None,
                  *args, **kwargs):
         self.project_id = project_id
@@ -292,19 +319,22 @@ class BigtableTableDeleteOperator(BaseOperator, BigtableValidationMixin):
         super(BigtableTableDeleteOperator, self).__init__(*args, **kwargs)
 
     def execute(self, context):
-        instance = self.hook.get_instance(self.project_id, self.instance_id)
+        instance = self.hook.get_instance(project_id=self.project_id,
+                                          instance_id=self.instance_id)
         if not instance:
-            raise AirflowException("Dependency: instance '{}' does not exist.".format(self.instance_id))
+            raise AirflowException("Dependency: instance '{}' does not exist.".format(
+                self.instance_id))
 
         try:
             self.hook.delete_table(
-                self.project_id,
-                self.instance_id,
-                self.table_id,
+                project_id=self.project_id,
+                instance_id=self.instance_id,
+                table_id=self.table_id,
             )
         except google.api_core.exceptions.NotFound:
             # It's OK if table doesn't exists.
-            self.log.info("The table '%s' no longer exists. Consider it as deleted", self.table_id)
+            self.log.info("The table '%s' no longer exists. Consider it as deleted",
+                          self.table_id)
         except google.api_core.exceptions.GoogleAPICallError as e:
             self.log.error('An error occurred. Exiting.')
             raise e
@@ -314,27 +344,28 @@ class BigtableClusterUpdateOperator(BaseOperator, BigtableValidationMixin):
     """
     Updates a Cloud Bigtable cluster.
 
-    For more details about updating a Cloud Bigtable cluster, have a look at the reference:
+    For more details about updating a Cloud Bigtable cluster,
+    have a look at the reference:
     https://googleapis.github.io/google-cloud-python/latest/bigtable/cluster.html#google.cloud.bigtable.cluster.Cluster.update
 
-    :type project_id: str
-    :param project_id: The ID of the GCP project.
     :type instance_id: str
     :param instance_id: The ID of the Cloud Bigtable instance.
     :type cluster_id: str
     :param cluster_id: The ID of the Cloud Bigtable cluster to update.
     :type nodes: int
     :param nodes: The desired number of nodes for the Cloud Bigtable cluster.
+    :type project_id: str
+    :param project_id: Optional, the ID of the GCP project.
     """
-    REQUIRED_ATTRIBUTES = ('project_id', 'instance_id', 'cluster_id', 'nodes')
+    REQUIRED_ATTRIBUTES = ('instance_id', 'cluster_id', 'nodes')
     template_fields = ['project_id', 'instance_id', 'cluster_id', 'nodes']
 
     @apply_defaults
     def __init__(self,
-                 project_id,
                  instance_id,
                  cluster_id,
                  nodes,
+                 project_id=None,
                  *args, **kwargs):
         self.project_id = project_id
         self.instance_id = instance_id
@@ -345,21 +376,22 @@ class BigtableClusterUpdateOperator(BaseOperator, BigtableValidationMixin):
         super(BigtableClusterUpdateOperator, self).__init__(*args, **kwargs)
 
     def execute(self, context):
-        instance = self.hook.get_instance(self.project_id, self.instance_id)
+        instance = self.hook.get_instance(project_id=self.project_id,
+                                          instance_id=self.instance_id)
         if not instance:
-            raise AirflowException("Dependency: instance '{}' does not exist.".format(self.instance_id))
+            raise AirflowException("Dependency: instance '{}' does not exist.".format(
+                self.instance_id))
 
         try:
             self.hook.update_cluster(
-                instance,
-                self.cluster_id,
-                self.nodes
+                instance=instance,
+                cluster_id=self.cluster_id,
+                nodes=self.nodes
             )
         except google.api_core.exceptions.NotFound:
-            raise AirflowException("Dependency: cluster '{}' does not exist for instance '{}'.".format(
-                self.cluster_id,
-                self.instance_id
-            ))
+            raise AirflowException(
+                "Dependency: cluster '{}' does not exist for instance '{}'.".
+                format(self.cluster_id, self.instance_id))
         except google.api_core.exceptions.GoogleAPICallError as e:
             self.log.error('An error occurred. Exiting.')
             raise e
@@ -373,21 +405,21 @@ class BigtableTableWaitForReplicationSensor(BaseSensorOperator, BigtableValidati
     For more details about cluster states for a table, have a look at the reference:
     https://googleapis.github.io/google-cloud-python/latest/bigtable/table.html#google.cloud.bigtable.table.Table.get_cluster_states
 
-    :type project_id: str
-    :param project_id: The ID of the GCP project.
     :type instance_id: str
     :param instance_id: The ID of the Cloud Bigtable instance.
     :type table_id: str
     :param table_id: The ID of the table to check replication status.
+    :type project_id: str
+    :param project_id: Optional, the ID of the GCP project.
     """
-    REQUIRED_ATTRIBUTES = ('project_id', 'instance_id', 'table_id')
+    REQUIRED_ATTRIBUTES = ('instance_id', 'table_id')
     template_fields = ['project_id', 'instance_id', 'table_id']
 
     @apply_defaults
     def __init__(self,
-                 project_id,
                  instance_id,
                  table_id,
+                 project_id=None,
                  *args, **kwargs):
         self.project_id = project_id
         self.instance_id = instance_id
@@ -397,16 +429,19 @@ class BigtableTableWaitForReplicationSensor(BaseSensorOperator, BigtableValidati
         super(BigtableTableWaitForReplicationSensor, self).__init__(*args, **kwargs)
 
     def poke(self, context):
-        instance = self.hook.get_instance(self.project_id, self.instance_id)
+        instance = self.hook.get_instance(project_id=self.project_id,
+                                          instance_id=self.instance_id)
         if not instance:
             self.log.info("Dependency: instance '%s' does not exist.", self.instance_id)
             return False
 
         try:
-            cluster_states = self.hook.get_cluster_states_for_table(instance, self.table_id)
+            cluster_states = self.hook.get_cluster_states_for_table(instance=instance,
+                                                                    table_id=self.table_id)
         except google.api_core.exceptions.NotFound:
             self.log.info(
-                "Dependency: table '%s' does not exist in instance '%s'.", self.table_id, self.instance_id)
+                "Dependency: table '%s' does not exist in instance '%s'.",
+                self.table_id, self.instance_id)
             return False
 
         ready_state = ClusterState(enums.Table.ClusterState.ReplicationState.READY)
@@ -414,7 +449,8 @@ class BigtableTableWaitForReplicationSensor(BaseSensorOperator, BigtableValidati
         is_table_replicated = True
         for cluster_id in cluster_states.keys():
             if cluster_states[cluster_id] != ready_state:
-                self.log.info("Table '%s' is not yet replicated on cluster '%s'.", self.table_id, cluster_id)
+                self.log.info("Table '%s' is not yet replicated on cluster '%s'.",
+                              self.table_id, cluster_id)
                 is_table_replicated = False
 
         if not is_table_replicated:

--- a/airflow/contrib/operators/gcp_sql_operator.py
+++ b/airflow/contrib/operators/gcp_sql_operator.py
@@ -23,6 +23,7 @@ from airflow.contrib.hooks.gcp_sql_hook import CloudSqlHook, CloudSqlDatabaseHoo
 from airflow.contrib.utils.gcp_field_validator import GcpBodyFieldValidator
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
+from airflow.hooks.base_hook import BaseHook
 
 SETTINGS = 'settings'
 SETTINGS_VERSION = 'settingsVersion'
@@ -136,10 +137,11 @@ class CloudSqlBaseOperator(BaseOperator):
     """
     Abstract base operator for Google Cloud SQL operators to inherit from.
 
-    :param project_id: Project ID of the Google Cloud Platform project to operate it.
-    :type project_id: str
     :param instance: Cloud SQL instance ID. This does not include the project ID.
     :type instance: str
+    :param project_id: Optional, Google Cloud Platform Project ID.  f set to None or missing,
+            the default project_id from the GCP connection is used.
+    :type project_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
     :param api_version: API version used (e.g. v1beta4).
@@ -147,8 +149,8 @@ class CloudSqlBaseOperator(BaseOperator):
     """
     @apply_defaults
     def __init__(self,
-                 project_id,
                  instance,
+                 project_id=None,
                  gcp_conn_id='google_cloud_default',
                  api_version='v1beta4',
                  *args, **kwargs):
@@ -162,14 +164,15 @@ class CloudSqlBaseOperator(BaseOperator):
         super(CloudSqlBaseOperator, self).__init__(*args, **kwargs)
 
     def _validate_inputs(self):
-        if not self.project_id:
+        if self.project_id == '':
             raise AirflowException("The required parameter 'project_id' is empty")
         if not self.instance:
-            raise AirflowException("The required parameter 'instance' is empty")
+            raise AirflowException("The required parameter 'instance' is empty or None")
 
     def _check_if_instance_exists(self, instance):
         try:
-            return self._hook.get_instance(self.project_id, instance)
+            return self._hook.get_instance(project_id=self.project_id,
+                                           instance=instance)
         except HttpError as e:
             status = e.resp.status
             if status == 404:
@@ -178,7 +181,10 @@ class CloudSqlBaseOperator(BaseOperator):
 
     def _check_if_db_exists(self, db_name):
         try:
-            return self._hook.get_database(self.project_id, self.instance, db_name)
+            return self._hook.get_database(
+                project_id=self.project_id,
+                instance=self.instance,
+                database=db_name)
         except HttpError as e:
             status = e.resp.status
             if status == 404:
@@ -199,15 +205,15 @@ class CloudSqlInstanceCreateOperator(CloudSqlBaseOperator):
     If an instance with the same name exists, no action will be taken and
     the operator will succeed.
 
-    :param project_id: Project ID of the project to which the newly created Cloud SQL
-        instances should belong.
-    :type project_id: str
     :param body: Body required by the Cloud SQL insert API, as described in
         https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/insert
         #request-body
     :type body: dict
     :param instance: Cloud SQL instance ID. This does not include the project ID.
     :type instance: str
+    :param project_id: Optional, Google Cloud Platform Project ID. If set to None or missing,
+            the default project_id from the GCP connection is used.
+    :type project_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
     :param api_version: API version used (e.g. v1beta4).
@@ -221,9 +227,9 @@ class CloudSqlInstanceCreateOperator(CloudSqlBaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 project_id,
                  body,
                  instance,
+                 project_id=None,
                  gcp_conn_id='google_cloud_default',
                  api_version='v1beta4',
                  validate_body=True,
@@ -247,12 +253,15 @@ class CloudSqlInstanceCreateOperator(CloudSqlBaseOperator):
     def execute(self, context):
         self._validate_body_fields()
         if not self._check_if_instance_exists(self.instance):
-            self._hook.create_instance(self.project_id, self.body)
+            self._hook.create_instance(
+                project_id=self.project_id,
+                body=self.body)
         else:
             self.log.info("Cloud SQL instance with ID {} already exists. "
                           "Aborting create.".format(self.instance))
 
-        instance_resource = self._hook.get_instance(self.project_id, self.instance)
+        instance_resource = self._hook.get_instance(project_id=self.project_id,
+                                                    instance=self.instance)
         service_account_email = instance_resource["serviceAccountEmailAddress"]
         task_instance = context['task_instance']
         task_instance.xcom_push(key="service_account_email", value=service_account_email)
@@ -269,13 +278,14 @@ class CloudSqlInstancePatchOperator(CloudSqlBaseOperator):
     to the rules of patch semantics.
     https://cloud.google.com/sql/docs/mysql/admin-api/how-tos/performance#patch
 
-    :param project_id: Project ID of the project that contains the instance.
-    :type project_id: str
     :param body: Body required by the Cloud SQL patch API, as described in
         https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/patch#request-body
     :type body: dict
     :param instance: Cloud SQL instance ID. This does not include the project ID.
     :type instance: str
+    :param project_id: Optional, Google Cloud Platform Project ID.  If set to None or missing,
+            the default project_id from the GCP connection is used.
+    :type project_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
     :param api_version: API version used (e.g. v1beta4).
@@ -287,9 +297,9 @@ class CloudSqlInstancePatchOperator(CloudSqlBaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 project_id,
                  body,
                  instance,
+                 project_id=None,
                  gcp_conn_id='google_cloud_default',
                  api_version='v1beta4',
                  *args, **kwargs):
@@ -309,17 +319,21 @@ class CloudSqlInstancePatchOperator(CloudSqlBaseOperator):
                                    'Please specify another instance to patch.'
                                    .format(self.instance))
         else:
-            return self._hook.patch_instance(self.project_id, self.body, self.instance)
+            return self._hook.patch_instance(
+                project_id=self.project_id,
+                body=self.body,
+                instance=self.instance)
 
 
 class CloudSqlInstanceDeleteOperator(CloudSqlBaseOperator):
     """
     Deletes a Cloud SQL instance.
 
-    :param project_id: Project ID of the project that contains the instance to be deleted.
-    :type project_id: str
     :param instance: Cloud SQL instance ID. This does not include the project ID.
     :type instance: str
+    :param project_id: Optional, Google Cloud Platform Project ID. If set to None or missing,
+            the default project_id from the GCP connection is used.
+    :type project_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
     :param api_version: API version used (e.g. v1beta4).
@@ -331,8 +345,8 @@ class CloudSqlInstanceDeleteOperator(CloudSqlBaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 project_id,
                  instance,
+                 project_id=None,
                  gcp_conn_id='google_cloud_default',
                  api_version='v1beta4',
                  *args, **kwargs):
@@ -346,20 +360,23 @@ class CloudSqlInstanceDeleteOperator(CloudSqlBaseOperator):
                   .format(self.instance))
             return True
         else:
-            return self._hook.delete_instance(self.project_id, self.instance)
+            return self._hook.delete_instance(
+                project_id=self.project_id,
+                instance=self.instance)
 
 
 class CloudSqlInstanceDatabaseCreateOperator(CloudSqlBaseOperator):
     """
     Creates a new database inside a Cloud SQL instance.
 
-    :param project_id: Project ID of the project that contains the instance.
-    :type project_id: str
     :param instance: Database instance ID. This does not include the project ID.
     :type instance: str
     :param body: The request body, as described in
         https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/databases/insert#request-body
     :type body: dict
+    :param project_id: Optional, Google Cloud Platform Project ID. If set to None or missing,
+            the default project_id from the GCP connection is used.
+    :type project_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
     :param api_version: API version used (e.g. v1beta4).
@@ -373,9 +390,9 @@ class CloudSqlInstanceDatabaseCreateOperator(CloudSqlBaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 project_id,
                  instance,
                  body,
+                 project_id=None,
                  gcp_conn_id='google_cloud_default',
                  api_version='v1beta4',
                  validate_body=True,
@@ -410,7 +427,9 @@ class CloudSqlInstanceDatabaseCreateOperator(CloudSqlBaseOperator):
                           .format(self.instance, database))
             return True
         else:
-            return self._hook.create_database(self.project_id, self.instance, self.body)
+            return self._hook.create_database(project_id=self.project_id,
+                                              instance=self.instance,
+                                              body=self.body)
 
 
 class CloudSqlInstanceDatabasePatchOperator(CloudSqlBaseOperator):
@@ -419,8 +438,6 @@ class CloudSqlInstanceDatabasePatchOperator(CloudSqlBaseOperator):
     instance using patch semantics.
     See: https://cloud.google.com/sql/docs/mysql/admin-api/how-tos/performance#patch
 
-    :param project_id: Project ID of the project that contains the instance.
-    :type project_id: str
     :param instance: Database instance ID. This does not include the project ID.
     :type instance: str
     :param database: Name of the database to be updated in the instance.
@@ -428,6 +445,8 @@ class CloudSqlInstanceDatabasePatchOperator(CloudSqlBaseOperator):
     :param body: The request body, as described in
         https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/databases/patch#request-body
     :type body: dict
+    :param project_id: Optional, Google Cloud Platform Project ID.
+    :type project_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
     :param api_version: API version used (e.g. v1beta4).
@@ -442,10 +461,10 @@ class CloudSqlInstanceDatabasePatchOperator(CloudSqlBaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 project_id,
                  instance,
                  database,
                  body,
+                 project_id=None,
                  gcp_conn_id='google_cloud_default',
                  api_version='v1beta4',
                  validate_body=True,
@@ -477,20 +496,24 @@ class CloudSqlInstanceDatabasePatchOperator(CloudSqlBaseOperator):
                                    "Please specify another database to patch."
                                    .format(self.instance, self.database))
         else:
-            return self._hook.patch_database(self.project_id, self.instance,
-                                             self.database, self.body)
+            return self._hook.patch_database(
+                project_id=self.project_id,
+                instance=self.instance,
+                database=self.database,
+                body=self.body)
 
 
 class CloudSqlInstanceDatabaseDeleteOperator(CloudSqlBaseOperator):
     """
     Deletes a database from a Cloud SQL instance.
 
-    :param project_id: Project ID of the project that contains the instance.
-    :type project_id: str
     :param instance: Database instance ID. This does not include the project ID.
     :type instance: str
     :param database: Name of the database to be deleted in the instance.
     :type database: str
+    :param project_id: Optional, Google Cloud Platform Project ID. If set to None or missing,
+            the default project_id from the GCP connection is used.
+    :type project_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
     :param api_version: API version used (e.g. v1beta4).
@@ -503,9 +526,9 @@ class CloudSqlInstanceDatabaseDeleteOperator(CloudSqlBaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 project_id,
                  instance,
                  database,
+                 project_id=None,
                  gcp_conn_id='google_cloud_default',
                  api_version='v1beta4',
                  *args, **kwargs):
@@ -526,8 +549,10 @@ class CloudSqlInstanceDatabaseDeleteOperator(CloudSqlBaseOperator):
                   .format(self.instance, self.database))
             return True
         else:
-            return self._hook.delete_database(self.project_id, self.instance,
-                                              self.database)
+            return self._hook.delete_database(
+                project_id=self.project_id,
+                instance=self.instance,
+                database=self.database)
 
 
 class CloudSqlInstanceExportOperator(CloudSqlBaseOperator):
@@ -538,14 +563,14 @@ class CloudSqlInstanceExportOperator(CloudSqlBaseOperator):
     Note: This operator is idempotent. If executed multiple times with the same
     export file URI, the export file in GCS will simply be overridden.
 
-    :param project_id: Project ID of the project that contains the instance to be
-        exported.
-    :type project_id: str
     :param instance: Cloud SQL instance ID. This does not include the project ID.
     :type instance: str
     :param body: The request body, as described in
         https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/export#request-body
     :type body: dict
+    :param project_id: Optional, Google Cloud Platform Project ID. If set to None or missing,
+            the default project_id from the GCP connection is used.
+    :type project_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
     :param api_version: API version used (e.g. v1beta4).
@@ -559,9 +584,9 @@ class CloudSqlInstanceExportOperator(CloudSqlBaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 project_id,
                  instance,
                  body,
+                 project_id=None,
                  gcp_conn_id='google_cloud_default',
                  api_version='v1beta4',
                  validate_body=True,
@@ -584,7 +609,10 @@ class CloudSqlInstanceExportOperator(CloudSqlBaseOperator):
 
     def execute(self, context):
         self._validate_body_fields()
-        return self._hook.export_instance(self.project_id, self.instance, self.body)
+        return self._hook.export_instance(
+            project_id=self.project_id,
+            instance=self.instance,
+            body=self.body)
 
 
 class CloudSqlInstanceImportOperator(CloudSqlBaseOperator):
@@ -607,13 +635,14 @@ class CloudSqlInstanceImportOperator(CloudSqlBaseOperator):
     If the import file was generated in a different way, idempotence is not guaranteed.
     It has to be ensured on the SQL file level.
 
-    :param project_id: Project ID of the project that contains the instance.
-    :type project_id: str
     :param instance: Cloud SQL instance ID. This does not include the project ID.
     :type instance: str
     :param body: The request body, as described in
         https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/export#request-body
     :type body: dict
+    :param project_id: Optional, Google Cloud Platform Project ID. If set to None or missing,
+            the default project_id from the GCP connection is used.
+    :type project_id: str
     :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
     :type gcp_conn_id: str
     :param api_version: API version used (e.g. v1beta4).
@@ -627,9 +656,9 @@ class CloudSqlInstanceImportOperator(CloudSqlBaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 project_id,
                  instance,
                  body,
+                 project_id=None,
                  gcp_conn_id='google_cloud_default',
                  api_version='v1beta4',
                  validate_body=True,
@@ -652,7 +681,10 @@ class CloudSqlInstanceImportOperator(CloudSqlBaseOperator):
 
     def execute(self, context):
         self._validate_body_fields()
-        return self._hook.import_instance(self.project_id, self.instance, self.body)
+        return self._hook.import_instance(
+            project_id=self.project_id,
+            instance=self.instance,
+            body=self.body)
 
 
 class CloudSqlQueryOperator(BaseOperator):
@@ -699,8 +731,11 @@ class CloudSqlQueryOperator(BaseOperator):
         self.gcp_cloudsql_conn_id = gcp_cloudsql_conn_id
         self.autocommit = autocommit
         self.parameters = parameters
+        self.gcp_connection = BaseHook.get_connection(self.gcp_conn_id)
         self.cloudsql_db_hook = CloudSqlDatabaseHook(
-            gcp_cloudsql_conn_id=gcp_cloudsql_conn_id)
+            gcp_cloudsql_conn_id=gcp_cloudsql_conn_id,
+            default_gcp_project_id=self.gcp_connection.extra_dejson.get(
+                'extra__google_cloud_platform__project'))
         self.cloud_sql_proxy_runner = None
         self.database_hook = None
 
@@ -708,6 +743,7 @@ class CloudSqlQueryOperator(BaseOperator):
         self.cloudsql_db_hook.validate_ssl_certs()
         self.cloudsql_db_hook.create_connection()
         try:
+            self.cloudsql_db_hook.validate_socket_path_length()
             self.database_hook = self.cloudsql_db_hook.get_database_hook()
             try:
                 try:

--- a/docs/howto/operator.rst
+++ b/docs/howto/operator.rst
@@ -144,11 +144,23 @@ The following examples of OS environment variables used to pass arguments to the
 Using the operator
 """"""""""""""""""
 
+The code to create the operator:
+
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_compute.py
     :language: python
     :dedent: 4
     :start-after: [START howto_operator_gce_start]
     :end-before: [END howto_operator_gce_start]
+
+You can also create the operator without project id - project id will be retrieved
+from the GCP connection id used:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_compute.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gce_start_no_project_id]
+    :end-before: [END howto_operator_gce_start_no_project_id]
+
 
 Templating
 """"""""""
@@ -187,11 +199,22 @@ The following examples of OS environment variables used to pass arguments to the
 Using the operator
 """"""""""""""""""
 
+The code to create the operator:
+
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_compute.py
     :language: python
     :dedent: 4
     :start-after: [START howto_operator_gce_stop]
     :end-before: [END howto_operator_gce_stop]
+
+You can also create the operator without project id - project id will be retrieved
+from the GCP connection used:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_compute.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gce_stop_no_project_id]
+    :end-before: [END howto_operator_gce_stop_no_project_id]
 
 Templating
 """"""""""
@@ -236,11 +259,22 @@ The following examples of OS environment variables used to pass arguments to the
 Using the operator
 """"""""""""""""""
 
+The code to create the operator:
+
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_compute.py
     :language: python
     :dedent: 4
     :start-after: [START howto_operator_gce_set_machine_type]
     :end-before: [END howto_operator_gce_set_machine_type]
+
+You can also create the operator without project id - project id will be retrieved
+from the GCP connection used:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_compute.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gce_set_machine_type_no_project_id]
+    :end-before: [END howto_operator_gce_set_machine_type_no_project_id]
 
 Templating
 """"""""""
@@ -285,11 +319,22 @@ The following examples of OS environment variables used to pass arguments to the
 Using the operator
 """"""""""""""""""
 
+The code to create the operator:
+
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_compute_igm.py
     :language: python
     :dedent: 4
     :start-after: [START howto_operator_gce_igm_copy_template]
     :end-before: [END howto_operator_gce_igm_copy_template]
+
+You can also create the operator without project id - project id will be retrieved
+from the GCP connection used:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_compute_igm.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gce_igm_copy_template_no_project_id]
+    :end-before: [END howto_operator_gce_igm_copy_template_no_project_id]
 
 Templating
 """"""""""
@@ -332,11 +377,23 @@ The following examples of OS environment variables used to pass arguments to the
 Using the operator
 """"""""""""""""""
 
+The code to create the operator:
+
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_compute_igm.py
     :language: python
     :dedent: 4
     :start-after: [START howto_operator_gce_igm_update_template]
     :end-before: [END howto_operator_gce_igm_update_template]
+
+You can also create the operator without project id - project id will be retrieved
+from the GCP connection used:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_compute_igm.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gce_igm_update_template_no_project_id]
+    :end-before: [END howto_operator_gce_igm_update_template_no_project_id]
+
 
 Templating
 """"""""""
@@ -387,12 +444,14 @@ and immediately succeeds. No changes are made to the existing instance.
 Using the operator
 """"""""""""""""""
 
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
+
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_bigtable_operators.py
     :language: python
     :dedent: 4
     :start-after: [START howto_operator_gcp_bigtable_instance_create]
     :end-before: [END howto_operator_gcp_bigtable_instance_create]
-
 
 BigtableInstanceDeleteOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -402,6 +461,9 @@ to delete a Google Cloud Bigtable instance.
 
 Using the operator
 """"""""""""""""""
+
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
 
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_bigtable_operators.py
     :language: python
@@ -418,12 +480,14 @@ to modify number of nodes in a Cloud Bigtable cluster.
 Using the operator
 """"""""""""""""""
 
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
+
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_bigtable_operators.py
     :language: python
     :dedent: 4
     :start-after: [START howto_operator_gcp_bigtable_cluster_update]
     :end-before: [END howto_operator_gcp_bigtable_cluster_update]
-
 
 BigtableTableCreateOperator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -437,6 +501,9 @@ error message.
 
 Using the operator
 """"""""""""""""""
+
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
 
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_bigtable_operators.py
     :language: python
@@ -462,6 +529,9 @@ to delete a table in Google Cloud Bigtable.
 Using the operator
 """"""""""""""""""
 
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
+
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_bigtable_operators.py
     :language: python
     :dedent: 4
@@ -470,6 +540,9 @@ Using the operator
 
 BigtableTableWaitForReplicationSensor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
 
 Use the :class:`~airflow.contrib.operators.gcp_bigtable_operator.BigtableTableWaitForReplicationSensor`
 to wait for the table to replicate fully.
@@ -487,8 +560,6 @@ Using the operator
     :dedent: 4
     :start-after: [START howto_operator_gcp_bigtable_table_wait_for_replication]
     :end-before: [END howto_operator_gcp_bigtable_table_wait_for_replication]
-
-
 
 Google Cloud Functions Operators
 --------------------------------
@@ -609,6 +680,15 @@ The code to create the operator:
     :start-after: [START howto_operator_gcf_deploy]
     :end-before: [END howto_operator_gcf_deploy]
 
+You can also create the operator without project id - project id will be retrieved
+from the GCP connection used:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_function.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcf_deploy_no_project_id]
+    :end-before: [END howto_operator_gcf_deploy_no_project_id]
+
 Templating
 """"""""""
 
@@ -684,6 +764,9 @@ Some arguments in the example DAG are taken from environment variables.
 Using the operator
 """"""""""""""""""
 
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
+
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_spanner.py
     :language: python
     :dedent: 4
@@ -729,6 +812,9 @@ Some arguments in the example DAG are taken from environment variables.
 
 Using the operator
 """"""""""""""""""
+
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
 
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_spanner.py
     :language: python
@@ -779,11 +865,20 @@ Some arguments in the example DAG are taken from environment variables.
 Using the operator
 """"""""""""""""""
 
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
+
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_spanner.py
     :language: python
     :dedent: 4
     :start-after: [START howto_operator_spanner_database_update]
     :end-before: [END howto_operator_spanner_database_update]
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_spanner.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_spanner_database_update_idempotent]
+    :end-before: [END howto_operator_spanner_database_update_idempotent]
 
 Templating
 """"""""""
@@ -820,6 +915,9 @@ Some arguments in the example DAG are taken from environment variables.
 
 Using the operator
 """"""""""""""""""
+
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
 
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_spanner.py
     :language: python
@@ -863,6 +961,9 @@ Some arguments in the example DAG are taken from environment variables:
 
 Using the operator
 """"""""""""""""""
+
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
 
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_spanner.py
     :language: python
@@ -908,6 +1009,9 @@ Some arguments in the example DAG are taken from environment variables:
 
 Using the operator
 """"""""""""""""""
+
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
 
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
     :language: python
@@ -958,6 +1062,9 @@ Some arguments in the example DAG are taken from environment variables:
 Using the operator
 """"""""""""""""""
 
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
+
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
     :language: python
     :dedent: 4
@@ -1001,6 +1108,9 @@ Some arguments in the example DAG are taken from environment variables:
 
 Using the operator
 """"""""""""""""""
+
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
 
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
     :language: python
@@ -1050,6 +1160,9 @@ Some arguments in the example DAG are taken from OS environment variables:
 
 Using the operator
 """"""""""""""""""
+
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
 
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
     :language: python
@@ -1110,6 +1223,9 @@ Example body defining the export operation:
 
 Using the operator
 """"""""""""""""""
+
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
 
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
     :language: python
@@ -1205,6 +1321,9 @@ Example body defining the import operation:
 Using the operator
 """"""""""""""""""
 
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
+
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
     :language: python
     :dedent: 4
@@ -1277,6 +1396,9 @@ Example body defining the instance:
 Using the operator
 """"""""""""""""""
 
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
+
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
     :language: python
     :dedent: 4
@@ -1331,6 +1453,9 @@ Example body defining the instance:
 
 Using the operator
 """"""""""""""""""
+
+You can create the operator with or without project id. If project id is missing
+it will be retrieved from the GCP connection used. Both variants are shown:
 
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
     :language: python

--- a/tests/contrib/hooks/test_gcp_bigtable_hook.py
+++ b/tests/contrib/hooks/test_gcp_bigtable_hook.py
@@ -1,0 +1,372 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import google
+
+import unittest
+
+from google.cloud.bigtable import Client
+from google.cloud.bigtable.instance import Instance
+
+from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id, \
+    mock_base_gcp_hook_default_project_id, GCP_PROJECT_ID_HOOK_UNIT_TEST
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+from airflow import AirflowException
+from airflow.contrib.hooks.gcp_bigtable_hook import BigtableHook
+
+CBT_INSTANCE = 'instance'
+CBT_CLUSTER = 'cluster'
+CBT_ZONE = 'zone'
+CBT_TABLE = 'table'
+
+
+class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
+
+    def setUp(self):
+        with mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+                        new=mock_base_gcp_hook_no_default_project_id):
+            self.bigtable_hook_no_default_project_id = BigtableHook(gcp_conn_id='test')
+
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_get_instance_missing_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        with self.assertRaises(AirflowException) as cm:
+            self.bigtable_hook_no_default_project_id.get_instance(instance_id=CBT_INSTANCE)
+        instance_exists_method.assert_not_called()
+        instance_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_get_instance_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        res = self.bigtable_hook_no_default_project_id.get_instance(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            instance_id=CBT_INSTANCE)
+        instance_method.assert_called_once_with('instance')
+        instance_exists_method.assert_called_once_with()
+        get_client.assert_called_once_with(project_id='example-project')
+        self.assertIsNotNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_delete_instance_missing_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        delete_method = instance_method.return_value.delete
+        instance_exists_method.return_value = True
+        with self.assertRaises(AirflowException) as cm:
+            self.bigtable_hook_no_default_project_id.delete_instance(instance_id=CBT_INSTANCE)
+        instance_exists_method.assert_not_called()
+        instance_method.assert_not_called()
+        delete_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_delete_instance_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        delete_method = instance_method.return_value.delete
+        res = self.bigtable_hook_no_default_project_id.delete_instance(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST, instance_id=CBT_INSTANCE)
+        instance_method.assert_called_once_with('instance')
+        instance_exists_method.assert_called_once_with()
+        delete_method.assert_called_once_with()
+        get_client.assert_called_once_with(project_id='example-project')
+        self.assertIsNone(res)
+
+    @mock.patch('google.cloud.bigtable.instance.Instance.create')
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_create_instance_missing_project_id(self, get_client, instance_create):
+        operation = mock.Mock()
+        operation.result_return_value = Instance(instance_id=CBT_INSTANCE, client=get_client)
+        instance_create.return_value = operation
+        with self.assertRaises(AirflowException) as cm:
+            self.bigtable_hook_no_default_project_id.create_instance(
+                instance_id=CBT_INSTANCE,
+                main_cluster_id=CBT_CLUSTER,
+                main_cluster_zone=CBT_ZONE)
+        get_client.assert_not_called()
+        instance_create.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+
+    @mock.patch('google.cloud.bigtable.instance.Instance.create')
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_create_instance_overridden_project_id(self, get_client, instance_create):
+        operation = mock.Mock()
+        operation.result_return_value = Instance(instance_id=CBT_INSTANCE, client=get_client)
+        instance_create.return_value = operation
+        res = self.bigtable_hook_no_default_project_id.create_instance(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            instance_id=CBT_INSTANCE,
+            main_cluster_id=CBT_CLUSTER,
+            main_cluster_zone=CBT_ZONE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_create.assert_called_once_with(clusters=mock.ANY)
+        self.assertEquals(res.instance_id, 'instance')
+
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_delete_table_missing_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        table_delete_method = instance_method.return_value.table.return_value.delete
+        instance_exists_method.return_value = True
+        with self.assertRaises(AirflowException) as cm:
+            self.bigtable_hook_no_default_project_id.delete_table(
+                instance_id=CBT_INSTANCE,
+                table_id=CBT_TABLE)
+        get_client.assert_not_called()
+        instance_exists_method.assert_not_called()
+        table_delete_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_delete_table_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        table_delete_method = instance_method.return_value.table.return_value.delete
+        instance_exists_method.return_value = True
+        self.bigtable_hook_no_default_project_id.delete_table(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            instance_id=CBT_INSTANCE,
+            table_id=CBT_TABLE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_exists_method.assert_called_once_with()
+        table_delete_method.assert_called_once_with()
+
+
+class TestBigtableHookDefaultProjectId(unittest.TestCase):
+
+    def setUp(self):
+        with mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+                        new=mock_base_gcp_hook_default_project_id):
+            self.bigtable_hook_default_project_id = BigtableHook(gcp_conn_id='test')
+
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_get_instance(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        res = self.bigtable_hook_default_project_id.get_instance(
+            instance_id=CBT_INSTANCE)
+        instance_method.assert_called_once_with('instance')
+        instance_exists_method.assert_called_once_with()
+        get_client.assert_called_once_with(project_id='example-project')
+        self.assertIsNotNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_get_instance_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        res = self.bigtable_hook_default_project_id.get_instance(
+            project_id='new-project',
+            instance_id=CBT_INSTANCE)
+        instance_method.assert_called_once_with('instance')
+        instance_exists_method.assert_called_once_with()
+        get_client.assert_called_once_with(project_id='new-project')
+        self.assertIsNotNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_get_instance_no_instance(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = False
+        res = self.bigtable_hook_default_project_id.get_instance(
+            instance_id=CBT_INSTANCE)
+        instance_method.assert_called_once_with('instance')
+        instance_exists_method.assert_called_once_with()
+        get_client.assert_called_once_with(project_id='example-project')
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_delete_instance(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        delete_method = instance_method.return_value.delete
+        res = self.bigtable_hook_default_project_id.delete_instance(
+            instance_id=CBT_INSTANCE)
+        instance_method.assert_called_once_with('instance')
+        instance_exists_method.assert_called_once_with()
+        delete_method.assert_called_once_with()
+        get_client.assert_called_once_with(project_id='example-project')
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_delete_instance_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        delete_method = instance_method.return_value.delete
+        res = self.bigtable_hook_default_project_id.delete_instance(
+            project_id='new-project', instance_id=CBT_INSTANCE)
+        instance_method.assert_called_once_with('instance')
+        instance_exists_method.assert_called_once_with()
+        delete_method.assert_called_once_with()
+        get_client.assert_called_once_with(project_id='new-project')
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_delete_instance_no_instance(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = False
+        delete_method = instance_method.return_value.delete
+        self.bigtable_hook_default_project_id.delete_instance(
+            instance_id=CBT_INSTANCE)
+        instance_method.assert_called_once_with('instance')
+        instance_exists_method.assert_called_once_with()
+        delete_method.assert_not_called()
+        get_client.assert_called_once_with(project_id='example-project')
+
+    @mock.patch('google.cloud.bigtable.instance.Instance.create')
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_create_instance(self, get_client, instance_create):
+        operation = mock.Mock()
+        operation.result_return_value = Instance(instance_id=CBT_INSTANCE, client=get_client)
+        instance_create.return_value = operation
+        res = self.bigtable_hook_default_project_id.create_instance(
+            instance_id=CBT_INSTANCE,
+            main_cluster_id=CBT_CLUSTER,
+            main_cluster_zone=CBT_ZONE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_create.assert_called_once_with(clusters=mock.ANY)
+        self.assertEquals(res.instance_id, 'instance')
+
+    @mock.patch('google.cloud.bigtable.instance.Instance.create')
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_create_instance_overridden_project_id(self, get_client, instance_create):
+        operation = mock.Mock()
+        operation.result_return_value = Instance(instance_id=CBT_INSTANCE, client=get_client)
+        instance_create.return_value = operation
+        res = self.bigtable_hook_default_project_id.create_instance(
+            project_id='new-project',
+            instance_id=CBT_INSTANCE,
+            main_cluster_id=CBT_CLUSTER,
+            main_cluster_zone=CBT_ZONE)
+        get_client.assert_called_once_with(project_id='new-project')
+        instance_create.assert_called_once_with(clusters=mock.ANY)
+        self.assertEquals(res.instance_id, 'instance')
+
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_delete_table(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        table_delete_method = instance_method.return_value.table.return_value.delete
+        instance_exists_method.return_value = True
+        self.bigtable_hook_default_project_id.delete_table(
+            instance_id=CBT_INSTANCE,
+            table_id=CBT_TABLE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_exists_method.assert_called_once_with()
+        table_delete_method.assert_called_once_with()
+
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_delete_table_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        table_delete_method = instance_method.return_value.table.return_value.delete
+        instance_exists_method.return_value = True
+        self.bigtable_hook_default_project_id.delete_table(
+            project_id='new-project',
+            instance_id=CBT_INSTANCE,
+            table_id=CBT_TABLE)
+        get_client.assert_called_once_with(project_id='new-project')
+        instance_exists_method.assert_called_once_with()
+        table_delete_method.assert_called_once_with()
+
+    @mock.patch('google.cloud.bigtable.table.Table.create')
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_create_table(self, get_client, create):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        client = mock.Mock(Client)
+        instance = google.cloud.bigtable.instance.Instance(
+            instance_id=CBT_INSTANCE,
+            client=client)
+        self.bigtable_hook_default_project_id.create_table(
+            instance=instance,
+            table_id=CBT_TABLE)
+        get_client.assert_not_called()
+        create.assert_called_once_with([], {})
+
+    @mock.patch('google.cloud.bigtable.cluster.Cluster.update')
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_update_cluster(self, get_client, update):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        client = mock.Mock(Client)
+        instance = google.cloud.bigtable.instance.Instance(
+            instance_id=CBT_INSTANCE,
+            client=client)
+        self.bigtable_hook_default_project_id.update_cluster(
+            instance=instance,
+            cluster_id=CBT_CLUSTER,
+            nodes=4)
+        get_client.assert_not_called()
+        update.assert_called_once_with()
+
+    @mock.patch('google.cloud.bigtable.table.Table.list_column_families')
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_list_column_families(self, get_client, list_column_families):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        client = mock.Mock(Client)
+        get_client.return_value = client
+        instance = google.cloud.bigtable.instance.Instance(
+            instance_id=CBT_INSTANCE,
+            client=client)
+        self.bigtable_hook_default_project_id.get_column_families_for_table(
+            instance=instance, table_id=CBT_TABLE)
+        get_client.assert_not_called()
+        list_column_families.assert_called_once_with()
+
+    @mock.patch('google.cloud.bigtable.table.Table.get_cluster_states')
+    @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
+    def test_get_cluster_states(self, get_client, get_cluster_states):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        client = mock.Mock(Client)
+        instance = google.cloud.bigtable.instance.Instance(
+            instance_id=CBT_INSTANCE,
+            client=client)
+        self.bigtable_hook_default_project_id.get_cluster_states_for_table(
+            instance=instance, table_id=CBT_TABLE)
+        get_client.assert_not_called()
+        get_cluster_states.assert_called_once_with()

--- a/tests/contrib/hooks/test_gcp_compute_hook.py
+++ b/tests/contrib/hooks/test_gcp_compute_hook.py
@@ -1,0 +1,576 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id, \
+    mock_base_gcp_hook_default_project_id, GCP_PROJECT_ID_HOOK_UNIT_TEST
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+from airflow import AirflowException
+from airflow.contrib.hooks.gcp_compute_hook import GceHook
+
+GCE_ZONE = 'zone'
+GCE_INSTANCE = 'instance'
+GCE_INSTANCE_TEMPLATE = 'instance-template'
+GCE_REQUEST_ID = 'request_id'
+GCE_INSTANCE_GROUP_MANAGER = 'instance_group_manager'
+
+
+class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
+
+    def setUp(self):
+        with mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+                        new=mock_base_gcp_hook_no_default_project_id):
+            self.gce_hook_no_project_id = GceHook(gcp_conn_id='test')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_start_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        start_method = get_conn.return_value.instances.return_value.start
+        execute_method = start_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook_no_project_id.start_instance(
+            project_id='example-project',
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE)
+        self.assertIsNone(res)
+        start_method.assert_called_once_with(instance='instance', project='example-project', zone='zone')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
+                                                               operation_name='operation_id',
+                                                               zone='zone')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_start_instance_no_project_id(self, wait_for_operation_to_complete, get_conn):
+        start_method = get_conn.return_value.instances.return_value.start
+        execute_method = start_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.gce_hook_no_project_id.start_instance(
+                zone=GCE_ZONE,
+                resource_id=GCE_INSTANCE)
+        start_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_stop_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        stop_method = get_conn.return_value.instances.return_value.stop
+        execute_method = stop_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook_no_project_id.stop_instance(
+            project_id='example-project',
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE)
+        self.assertIsNone(res)
+        stop_method.assert_called_once_with(instance='instance', project='example-project', zone='zone')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
+                                                               operation_name='operation_id',
+                                                               zone='zone')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_stop_instance_no_project_id(self, wait_for_operation_to_complete, get_conn):
+        stop_method = get_conn.return_value.instances.return_value.stop
+        execute_method = stop_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.gce_hook_no_project_id.stop_instance(
+                zone=GCE_ZONE,
+                resource_id=GCE_INSTANCE)
+        stop_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_set_machine_type_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        set_machine_type_method = get_conn.return_value.instances.return_value.setMachineType
+        execute_method = set_machine_type_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook_no_project_id.set_machine_type(
+            body={},
+            project_id='example-project',
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE)
+        self.assertIsNone(res)
+        set_machine_type_method.assert_called_once_with(body={}, instance='instance',
+                                                        project='example-project', zone='zone')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
+                                                               operation_name='operation_id',
+                                                               zone='zone')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_set_machine_type_no_project_id(self, wait_for_operation_to_complete, get_conn):
+        set_machine_type_method = get_conn.return_value.instances.return_value.setMachineType
+        execute_method = set_machine_type_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.gce_hook_no_project_id.set_machine_type(
+                body={},
+                zone=GCE_ZONE,
+                resource_id=GCE_INSTANCE)
+        set_machine_type_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_get_instance_template_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.instanceTemplates.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook_no_project_id.get_instance_template(
+            resource_id=GCE_INSTANCE_TEMPLATE,
+            project_id='example-project'
+        )
+        self.assertIsNotNone(res)
+        get_method.assert_called_once_with(instanceTemplate='instance-template', project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_get_instance_template_no_project_id(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.instanceTemplates.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.gce_hook_no_project_id.get_instance_template(
+                resource_id=GCE_INSTANCE_TEMPLATE
+            )
+        get_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_insert_instance_template_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        insert_method = get_conn.return_value.instanceTemplates.return_value.insert
+        execute_method = insert_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook_no_project_id.insert_instance_template(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            body={},
+            request_id=GCE_REQUEST_ID
+        )
+        self.assertIsNone(res)
+        insert_method.assert_called_once_with(body={}, project='example-project', requestId='request_id')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
+                                                               operation_name='operation_id')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_insert_instance_template_no_project_id(self, wait_for_operation_to_complete, get_conn):
+        insert_method = get_conn.return_value.instanceTemplates.return_value.insert
+        execute_method = insert_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.gce_hook_no_project_id.insert_instance_template(
+                body={},
+                request_id=GCE_REQUEST_ID
+            )
+        insert_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_get_instance_group_manager_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.instanceGroupManagers.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook_no_project_id.get_instance_group_manager(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE_GROUP_MANAGER
+        )
+        self.assertIsNotNone(res)
+        get_method.assert_called_once_with(instanceGroupManager='instance_group_manager',
+                                           project='example-project',
+                                           zone='zone')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_get_instance_group_manager_no_project_id(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.instanceGroupManagers.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.gce_hook_no_project_id.get_instance_group_manager(
+                zone=GCE_ZONE,
+                resource_id=GCE_INSTANCE_GROUP_MANAGER
+            )
+        get_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_patch_instance_group_manager_overridden_project_id(self,
+                                                                wait_for_operation_to_complete, get_conn):
+        patch_method = get_conn.return_value.instanceGroupManagers.return_value.patch
+        execute_method = patch_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook_no_project_id.patch_instance_group_manager(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE_GROUP_MANAGER,
+            body={},
+            request_id=GCE_REQUEST_ID
+        )
+        self.assertIsNone(res)
+        patch_method.assert_called_once_with(
+            body={},
+            instanceGroupManager='instance_group_manager',
+            project='example-project',
+            requestId='request_id',
+            zone='zone'
+        )
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(operation_name='operation_id',
+                                                               project_id='example-project',
+                                                               zone='zone')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_patch_instance_group_manager_no_project_id(self, wait_for_operation_to_complete, get_conn):
+        patch_method = get_conn.return_value.instanceGroupManagers.return_value.patch
+        execute_method = patch_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.gce_hook_no_project_id.patch_instance_group_manager(
+                zone=GCE_ZONE,
+                resource_id=GCE_INSTANCE_GROUP_MANAGER,
+                body={},
+                request_id=GCE_REQUEST_ID
+            )
+        patch_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+
+class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
+    def setUp(self):
+        with mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+                        new=mock_base_gcp_hook_default_project_id):
+            self.gce_hook = GceHook(gcp_conn_id='test')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_start_instance(self, wait_for_operation_to_complete, get_conn):
+        start_method = get_conn.return_value.instances.return_value.start
+        execute_method = start_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook.start_instance(
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE)
+        self.assertIsNone(res)
+        start_method.assert_called_once_with(instance='instance', project='example-project', zone='zone')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
+                                                               operation_name='operation_id',
+                                                               zone='zone')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_start_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        start_method = get_conn.return_value.instances.return_value.start
+        execute_method = start_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook.start_instance(
+            project_id='new-project',
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE)
+        self.assertIsNone(res)
+        start_method.assert_called_once_with(instance='instance', project='new-project', zone='zone')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='new-project',
+                                                               operation_name='operation_id',
+                                                               zone='zone')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_stop_instance(self, wait_for_operation_to_complete, get_conn):
+        stop_method = get_conn.return_value.instances.return_value.stop
+        execute_method = stop_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook.stop_instance(
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE)
+        self.assertIsNone(res)
+        stop_method.assert_called_once_with(instance='instance', project='example-project', zone='zone')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
+                                                               operation_name='operation_id',
+                                                               zone='zone')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_stop_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        stop_method = get_conn.return_value.instances.return_value.stop
+        execute_method = stop_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook.stop_instance(
+            project_id='new-project',
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE)
+        self.assertIsNone(res)
+        stop_method.assert_called_once_with(instance='instance', project='new-project', zone='zone')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='new-project',
+                                                               operation_name='operation_id',
+                                                               zone='zone')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_set_machine_type_instance(self, wait_for_operation_to_complete, get_conn):
+        execute_method = get_conn.return_value.instances.return_value.setMachineType.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook.set_machine_type(
+            body={},
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE)
+        self.assertIsNone(res)
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
+                                                               operation_name='operation_id',
+                                                               zone='zone')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_set_machine_type_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        execute_method = get_conn.return_value.instances.return_value.setMachineType.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook.set_machine_type(
+            project_id='new-project',
+            body={},
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE)
+        self.assertIsNone(res)
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='new-project',
+                                                               operation_name='operation_id',
+                                                               zone='zone')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_get_instance_template(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.instanceTemplates.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook.get_instance_template(
+            resource_id=GCE_INSTANCE_TEMPLATE)
+        self.assertIsNotNone(res)
+        get_method.assert_called_once_with(instanceTemplate='instance-template', project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_get_instance_template_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.instanceTemplates.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook.get_instance_template(
+            project_id='new-project',
+            resource_id=GCE_INSTANCE_TEMPLATE)
+        self.assertIsNotNone(res)
+        get_method.assert_called_once_with(instanceTemplate='instance-template', project='new-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_insert_instance_template(self, wait_for_operation_to_complete, get_conn):
+        insert_method = get_conn.return_value.instanceTemplates.return_value.insert
+        execute_method = insert_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook.insert_instance_template(
+            body={},
+            request_id=GCE_REQUEST_ID
+        )
+        self.assertIsNone(res)
+        insert_method.assert_called_once_with(body={}, project='example-project', requestId='request_id')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
+                                                               operation_name='operation_id')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_insert_instance_template_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        insert_method = get_conn.return_value.instanceTemplates.return_value.insert
+        execute_method = insert_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook.insert_instance_template(
+            project_id='new-project',
+            body={},
+            request_id=GCE_REQUEST_ID
+        )
+        self.assertIsNone(res)
+        insert_method.assert_called_once_with(body={}, project='new-project', requestId='request_id')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='new-project',
+                                                               operation_name='operation_id')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_get_instance_group_manager(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.instanceGroupManagers.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook.get_instance_group_manager(
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE_GROUP_MANAGER
+        )
+        self.assertIsNotNone(res)
+        get_method.assert_called_once_with(instanceGroupManager='instance_group_manager',
+                                           project='example-project',
+                                           zone='zone')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_get_instance_group_manager_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.instanceGroupManagers.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook.get_instance_group_manager(
+            project_id='new-project',
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE_GROUP_MANAGER
+        )
+        self.assertIsNotNone(res)
+        get_method.assert_called_once_with(instanceGroupManager='instance_group_manager',
+                                           project='new-project',
+                                           zone='zone')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_patch_instance_group_manager(self, wait_for_operation_to_complete, get_conn):
+        patch_method = get_conn.return_value.instanceGroupManagers.return_value.patch
+        execute_method = patch_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook.patch_instance_group_manager(
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE_GROUP_MANAGER,
+            body={},
+            request_id=GCE_REQUEST_ID
+        )
+        self.assertIsNone(res)
+        patch_method.assert_called_once_with(
+            body={},
+            instanceGroupManager='instance_group_manager',
+            project='example-project',
+            requestId='request_id',
+            zone='zone'
+        )
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(operation_name='operation_id',
+                                                               project_id='example-project',
+                                                               zone='zone')
+
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')
+    def test_patch_instance_group_manager_overridden_project_id(self,
+                                                                wait_for_operation_to_complete,
+                                                                get_conn):
+        patch_method = get_conn.return_value.instanceGroupManagers.return_value.patch
+        execute_method = patch_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gce_hook.patch_instance_group_manager(
+            project_id='new-project',
+            zone=GCE_ZONE,
+            resource_id=GCE_INSTANCE_GROUP_MANAGER,
+            body={},
+            request_id=GCE_REQUEST_ID
+        )
+        self.assertIsNone(res)
+        patch_method.assert_called_once_with(
+            body={},
+            instanceGroupManager='instance_group_manager',
+            project='new-project',
+            requestId='request_id',
+            zone='zone'
+        )
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(operation_name='operation_id',
+                                                               project_id='new-project',
+                                                               zone='zone')

--- a/tests/contrib/hooks/test_gcp_dataproc_hook.py
+++ b/tests/contrib/hooks/test_gcp_dataproc_hook.py
@@ -21,6 +21,7 @@
 import unittest
 from airflow.contrib.hooks.gcp_dataproc_hook import _DataProcJob
 from airflow.contrib.hooks.gcp_dataproc_hook import DataProcHook
+from tests.contrib.utils.base_gcp_mock import GCP_PROJECT_ID_HOOK_UNIT_TEST
 
 try:
     from unittest import mock
@@ -31,7 +32,6 @@ except ImportError:
         mock = None
 
 JOB = 'test-job'
-GCP_PROJECT_ID = 'test-project-id'
 GCP_REGION = 'global'
 TASK_ID = 'test-task-id'
 
@@ -53,8 +53,8 @@ class DataProcHookTest(unittest.TestCase):
     def test_submit(self, job_mock):
         with mock.patch(DATAPROC_STRING.format('DataProcHook.get_conn',
                                                return_value=None)):
-            self.dataproc_hook.submit(GCP_PROJECT_ID, JOB)
-            job_mock.assert_called_once_with(mock.ANY, GCP_PROJECT_ID, JOB, GCP_REGION,
+            self.dataproc_hook.submit(GCP_PROJECT_ID_HOOK_UNIT_TEST, JOB)
+            job_mock.assert_called_once_with(mock.ANY, GCP_PROJECT_ID_HOOK_UNIT_TEST, JOB, GCP_REGION,
                                              job_error_states=mock.ANY)
 
 

--- a/tests/contrib/hooks/test_gcp_function_hook.py
+++ b/tests/contrib/hooks/test_gcp_function_hook.py
@@ -1,0 +1,276 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow import AirflowException
+from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id, \
+    mock_base_gcp_hook_default_project_id, GCP_PROJECT_ID_HOOK_UNIT_TEST, get_open_mock
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+from airflow.contrib.hooks.gcp_function_hook import GcfHook
+
+GCF_LOCATION = 'location'
+GCF_FUNCTION = 'function'
+
+
+class TestFunctionHookNoDefaultProjectId(unittest.TestCase):
+
+    def setUp(self):
+        with mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+                        new=mock_base_gcp_hook_no_default_project_id):
+            self.gcf_function_hook_no_project_id = GcfHook(gcp_conn_id='test', api_version='v1')
+
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook._wait_for_operation_to_complete')
+    def test_create_new_function_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+        create_method = get_conn.return_value.projects.return_value.locations. \
+            return_value.functions.return_value.create
+        execute_method = create_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.gcf_function_hook_no_project_id.create_new_function(
+                location=GCF_LOCATION,
+                body={}
+            )
+        create_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook._wait_for_operation_to_complete')
+    def test_create_new_function_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        create_method = get_conn.return_value.projects.return_value.locations. \
+            return_value.functions.return_value.create
+        execute_method = create_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gcf_function_hook_no_project_id.create_new_function(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            location=GCF_LOCATION,
+            body={}
+        )
+        self.assertIsNone(res)
+        create_method.assert_called_once_with(body={},
+                                              location='projects/example-project/locations/location')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(operation_name='operation_id')
+
+    @mock.patch('requests.put')
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook.get_conn')
+    def test_upload_function_zip_missing_project_id(self, get_conn, requests_put):
+        m = mock.mock_open()
+        with mock.patch('builtins.open', m):
+            generate_upload_url_method = get_conn.return_value.projects.return_value.locations. \
+                return_value.functions.return_value.generateUploadUrl
+            execute_method = generate_upload_url_method.return_value.execute
+            execute_method.return_value = {"uploadUrl": "http://uploadHere"}
+            requests_put.return_value = None
+            with self.assertRaises(AirflowException) as cm:
+                self.gcf_function_hook_no_project_id.upload_function_zip(
+                    location=GCF_LOCATION,
+                    zip_path="/tmp/path.zip"
+                )
+                generate_upload_url_method.assert_not_called()
+                execute_method.assert_not_called()
+                m.assert_not_called()
+                err = cm.exception
+                self.assertIn("The project id must be passed", str(err))
+
+    @mock.patch('requests.put')
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook.get_conn')
+    def test_upload_function_zip_overridden_project_id(self, get_conn, requests_put):
+        m, open_module = get_open_mock()
+        with mock.patch('{}.open'.format(open_module), m):
+            generate_upload_url_method = get_conn.return_value.projects.return_value.locations. \
+                return_value.functions.return_value.generateUploadUrl
+            execute_method = generate_upload_url_method.return_value.execute
+            execute_method.return_value = {"uploadUrl": "http://uploadHere"}
+            requests_put.return_value = None
+            res = self.gcf_function_hook_no_project_id.upload_function_zip(
+                project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+                location=GCF_LOCATION,
+                zip_path="/tmp/path.zip"
+            )
+            self.assertEquals("http://uploadHere", res)
+            generate_upload_url_method.assert_called_with(
+                parent='projects/example-project/locations/location')
+            execute_method.assert_called_once_with(num_retries=5)
+            requests_put.assert_called_once_with(
+                data=mock.ANY,
+                headers={'Content-type': 'application/zip',
+                         'x-goog-content-length-range': '0,104857600'},
+                url='http://uploadHere'
+            )
+
+
+class TestFunctionHookDefaultProjectId(unittest.TestCase):
+    def setUp(self):
+        with mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+                        new=mock_base_gcp_hook_default_project_id):
+            self.gcf_function_hook = GcfHook(gcp_conn_id='test', api_version='v1')
+
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook._wait_for_operation_to_complete')
+    def test_create_new_function(self, wait_for_operation_to_complete, get_conn):
+        create_method = get_conn.return_value.projects.return_value.locations.\
+            return_value.functions.return_value.create
+        execute_method = create_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gcf_function_hook.create_new_function(
+            location=GCF_LOCATION,
+            body={}
+        )
+        self.assertIsNone(res)
+        create_method.assert_called_once_with(body={},
+                                              location='projects/example-project/locations/location')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(operation_name='operation_id')
+
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook._wait_for_operation_to_complete')
+    def test_create_new_function_override_project_id(self, wait_for_operation_to_complete, get_conn):
+        create_method = get_conn.return_value.projects.return_value.locations. \
+            return_value.functions.return_value.create
+        execute_method = create_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gcf_function_hook.create_new_function(
+            project_id='new-project',
+            location=GCF_LOCATION,
+            body={}
+        )
+        self.assertIsNone(res)
+        create_method.assert_called_once_with(body={},
+                                              location='projects/new-project/locations/location')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(operation_name='operation_id')
+
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook.get_conn')
+    def test_get_function(self, get_conn):
+        get_method = get_conn.return_value.projects.return_value.locations. \
+            return_value.functions.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "function"}
+        res = self.gcf_function_hook.get_function(
+            name=GCF_FUNCTION
+        )
+        self.assertIsNotNone(res)
+        self.assertEquals('function', res['name'])
+        get_method.assert_called_once_with(name='function')
+        execute_method.assert_called_once_with(num_retries=5)
+
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook._wait_for_operation_to_complete')
+    def test_delete_function(self, wait_for_operation_to_complete, get_conn):
+        delete_method = get_conn.return_value.projects.return_value.locations. \
+            return_value.functions.return_value.delete
+        execute_method = delete_method.return_value.execute
+        wait_for_operation_to_complete.return_value = None
+        execute_method.return_value = {"name": "operation_id"}
+        res = self.gcf_function_hook.delete_function(
+            name=GCF_FUNCTION
+        )
+        self.assertIsNone(res)
+        delete_method.assert_called_once_with(name='function')
+        execute_method.assert_called_once_with(num_retries=5)
+
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook._wait_for_operation_to_complete')
+    def test_update_function(self, wait_for_operation_to_complete, get_conn):
+        patch_method = get_conn.return_value.projects.return_value.locations. \
+            return_value.functions.return_value.patch
+        execute_method = patch_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.gcf_function_hook.update_function(
+            update_mask=['a', 'b', 'c'],
+            name=GCF_FUNCTION,
+            body={}
+        )
+        self.assertIsNone(res)
+        patch_method.assert_called_once_with(
+            body={},
+            name='function',
+            updateMask='a,b,c'
+        )
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(operation_name='operation_id')
+
+    @mock.patch('requests.put')
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook.get_conn')
+    def test_upload_function_zip(self, get_conn, requests_put):
+        m, open_module = get_open_mock()
+        with mock.patch('{}.open'.format(open_module), m):
+            generate_upload_url_method = get_conn.return_value.projects.return_value.locations. \
+                return_value.functions.return_value.generateUploadUrl
+            execute_method = generate_upload_url_method.return_value.execute
+            execute_method.return_value = {"uploadUrl": "http://uploadHere"}
+            requests_put.return_value = None
+            res = self.gcf_function_hook.upload_function_zip(
+                location=GCF_LOCATION,
+                zip_path="/tmp/path.zip"
+            )
+            self.assertEquals("http://uploadHere", res)
+            generate_upload_url_method.assert_called_with(
+                parent='projects/example-project/locations/location')
+            execute_method.assert_called_once_with(num_retries=5)
+            requests_put.assert_called_once_with(
+                data=mock.ANY,
+                headers={'Content-type': 'application/zip',
+                         'x-goog-content-length-range': '0,104857600'},
+                url='http://uploadHere'
+            )
+
+    @mock.patch('requests.put')
+    @mock.patch('airflow.contrib.hooks.gcp_function_hook.GcfHook.get_conn')
+    def test_upload_function_zip_overridden_project_id(self, get_conn, requests_put):
+        m, open_module = get_open_mock()
+        with mock.patch('{}.open'.format(open_module), m):
+            generate_upload_url_method = get_conn.return_value.projects.return_value.locations. \
+                return_value.functions.return_value.generateUploadUrl
+            execute_method = generate_upload_url_method.return_value.execute
+            execute_method.return_value = {"uploadUrl": "http://uploadHere"}
+            requests_put.return_value = None
+            res = self.gcf_function_hook.upload_function_zip(
+                project_id='new-project',
+                location=GCF_LOCATION,
+                zip_path="/tmp/path.zip"
+            )
+            self.assertEquals("http://uploadHere", res)
+            generate_upload_url_method.assert_called_with(
+                parent='projects/new-project/locations/location')
+            execute_method.assert_called_once_with(num_retries=5)
+            requests_put.assert_called_once_with(
+                data=mock.ANY,
+                headers={'Content-type': 'application/zip',
+                         'x-goog-content-length-range': '0,104857600'},
+                url='http://uploadHere'
+            )

--- a/tests/contrib/hooks/test_gcp_spanner_hook.py
+++ b/tests/contrib/hooks/test_gcp_spanner_hook.py
@@ -1,0 +1,730 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow import AirflowException
+from airflow.contrib.hooks.gcp_spanner_hook import CloudSpannerHook
+from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id, \
+    GCP_PROJECT_ID_HOOK_UNIT_TEST, mock_base_gcp_hook_default_project_id
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+SPANNER_INSTANCE = 'instance'
+SPANNER_CONFIGURATION = 'configuration'
+SPANNER_DATABASE = 'database-name'
+
+
+class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
+
+    def setUp(self):
+        with mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+                        new=mock_base_gcp_hook_default_project_id):
+            self.spanner_hook_default_project_id = CloudSpannerHook(gcp_conn_id='test')
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_get_existing_instance(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        res = self.spanner_hook_default_project_id.get_instance(instance_id=SPANNER_INSTANCE,
+                                                                project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        self.assertIsNotNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_get_existing_instance_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        res = self.spanner_hook_default_project_id.get_instance(instance_id=SPANNER_INSTANCE,
+                                                                project_id='new-project')
+        get_client.assert_called_once_with(project_id='new-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        self.assertIsNotNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_create_instance(self, get_client):
+        instance_method = get_client.return_value.instance
+        create_method = instance_method.return_value.create
+        create_method.return_value = False
+        res = self.spanner_hook_default_project_id.create_instance(
+            instance_id=SPANNER_INSTANCE,
+            configuration_name=SPANNER_CONFIGURATION,
+            node_count=1,
+            display_name=SPANNER_DATABASE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(
+            instance_id='instance',
+            configuration_name='configuration',
+            display_name='database-name',
+            node_count=1)
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_create_instance_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        create_method = instance_method.return_value.create
+        create_method.return_value = False
+        res = self.spanner_hook_default_project_id.create_instance(
+            project_id='new-project',
+            instance_id=SPANNER_INSTANCE,
+            configuration_name=SPANNER_CONFIGURATION,
+            node_count=1,
+            display_name=SPANNER_DATABASE)
+        get_client.assert_called_once_with(project_id='new-project')
+        instance_method.assert_called_once_with(
+            instance_id='instance',
+            configuration_name='configuration',
+            display_name='database-name',
+            node_count=1)
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_update_instance(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        update_method = instance_method.return_value.update
+        update_method.return_value = False
+        res = self.spanner_hook_default_project_id.update_instance(
+            instance_id=SPANNER_INSTANCE,
+            configuration_name=SPANNER_CONFIGURATION,
+            node_count=2,
+            display_name=SPANNER_DATABASE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(
+            instance_id='instance', configuration_name='configuration', display_name='database-name',
+            node_count=2)
+        update_method.assert_called_with()
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_update_instance_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        update_method = instance_method.return_value.update
+        update_method.return_value = False
+        res = self.spanner_hook_default_project_id.update_instance(
+            project_id='new-project',
+            instance_id=SPANNER_INSTANCE,
+            configuration_name=SPANNER_CONFIGURATION,
+            node_count=2,
+            display_name=SPANNER_DATABASE)
+        get_client.assert_called_once_with(project_id='new-project')
+        instance_method.assert_called_once_with(
+            instance_id='instance', configuration_name='configuration', display_name='database-name',
+            node_count=2)
+        update_method.assert_called_with()
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_delete_instance(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        delete_method = instance_method.return_value.delete
+        delete_method.return_value = False
+        res = self.spanner_hook_default_project_id.delete_instance(
+            instance_id=SPANNER_INSTANCE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(
+            'instance')
+        delete_method.assert_called_with()
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_delete_instance_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        delete_method = instance_method.return_value.delete
+        delete_method.return_value = False
+        res = self.spanner_hook_default_project_id.delete_instance(
+            project_id='new-project',
+            instance_id=SPANNER_INSTANCE)
+        get_client.assert_called_once_with(project_id='new-project')
+        instance_method.assert_called_once_with(
+            'instance')
+        delete_method.assert_called_with()
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_get_database(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_exists_method = instance_method.return_value.exists
+        database_exists_method.return_value = True
+        res = self.spanner_hook_default_project_id.get_database(
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name')
+        database_exists_method.assert_called_with()
+        self.assertIsNotNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_get_database_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_exists_method = instance_method.return_value.exists
+        database_exists_method.return_value = True
+        res = self.spanner_hook_default_project_id.get_database(
+            project_id='new-project',
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE)
+        get_client.assert_called_once_with(project_id='new-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name')
+        database_exists_method.assert_called_with()
+        self.assertIsNotNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_create_database(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_create_method = database_method.return_value.create
+        res = self.spanner_hook_default_project_id.create_database(
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE,
+            ddl_statements=[])
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name', ddl_statements=[])
+        database_create_method.assert_called_with()
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_create_database_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_create_method = database_method.return_value.create
+        res = self.spanner_hook_default_project_id.create_database(
+            project_id='new-project',
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE,
+            ddl_statements=[])
+        get_client.assert_called_once_with(project_id='new-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name', ddl_statements=[])
+        database_create_method.assert_called_with()
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_update_database(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_update_ddl_method = database_method.return_value.update_ddl
+        res = self.spanner_hook_default_project_id.update_database(
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE,
+            ddl_statements=[])
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name')
+        database_update_ddl_method.assert_called_with(ddl_statements=[], operation_id=None)
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_update_database_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_update_ddl_method = database_method.return_value.update_ddl
+        res = self.spanner_hook_default_project_id.update_database(
+            project_id='new-project',
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE,
+            ddl_statements=[])
+        get_client.assert_called_once_with(project_id='new-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name')
+        database_update_ddl_method.assert_called_with(ddl_statements=[], operation_id=None)
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_delete_database(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_drop_method = database_method.return_value.drop
+        database_exists_method = database_method.return_value.exists
+        database_exists_method.return_value = True
+        res = self.spanner_hook_default_project_id.delete_database(
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name')
+        database_exists_method.assert_called_with()
+        database_drop_method.assert_called_with()
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_delete_database_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_drop_method = database_method.return_value.drop
+        database_exists_method = database_method.return_value.exists
+        database_exists_method.return_value = True
+        res = self.spanner_hook_default_project_id.delete_database(
+            project_id='new-project',
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE)
+        get_client.assert_called_once_with(project_id='new-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name')
+        database_exists_method.assert_called_with()
+        database_drop_method.assert_called_with()
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_execute_dml(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        run_in_transaction_method = database_method.return_value.run_in_transaction
+        res = self.spanner_hook_default_project_id.execute_dml(
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE,
+            queries='')
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name')
+        run_in_transaction_method.assert_called_with(mock.ANY)
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_execute_dml_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        run_in_transaction_method = database_method.return_value.run_in_transaction
+        res = self.spanner_hook_default_project_id.execute_dml(
+            project_id='new-project',
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE,
+            queries='')
+        get_client.assert_called_once_with(project_id='new-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name')
+        run_in_transaction_method.assert_called_with(mock.ANY)
+        self.assertIsNone(res)
+
+
+class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
+
+    def setUp(self):
+        with mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+                        new=mock_base_gcp_hook_no_default_project_id):
+            self.spanner_hook_no_default_project_id = CloudSpannerHook(gcp_conn_id='test')
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_get_existing_instance_missing_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        with self.assertRaises(AirflowException) as cm:
+            self.spanner_hook_no_default_project_id.get_instance(instance_id=SPANNER_INSTANCE)
+        get_client.assert_not_called()
+        instance_method.assert_not_called()
+        instance_exists_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_get_existing_instance_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        res = self.spanner_hook_no_default_project_id.get_instance(instance_id=SPANNER_INSTANCE,
+                                                                   project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        self.assertIsNotNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_get_non_existing_instance(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = False
+        res = self.spanner_hook_no_default_project_id.get_instance(instance_id=SPANNER_INSTANCE,
+                                                                   project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_create_instance_missing_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        create_method = instance_method.return_value.create
+        create_method.return_value = False
+        with self.assertRaises(AirflowException) as cm:
+            self.spanner_hook_no_default_project_id.create_instance(
+                instance_id=SPANNER_INSTANCE,
+                configuration_name=SPANNER_CONFIGURATION,
+                node_count=1,
+                display_name=SPANNER_DATABASE)
+            get_client.assert_called_once_with(project_id='example-project')
+        get_client.assert_not_called()
+        instance_method.assert_not_called()
+        create_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_create_instance_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        create_method = instance_method.return_value.create
+        create_method.return_value = False
+        res = self.spanner_hook_no_default_project_id.create_instance(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            instance_id=SPANNER_INSTANCE,
+            configuration_name=SPANNER_CONFIGURATION,
+            node_count=1,
+            display_name=SPANNER_DATABASE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(
+            instance_id='instance',
+            configuration_name='configuration',
+            display_name='database-name',
+            node_count=1)
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_update_instance_missing_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        update_method = instance_method.return_value.update
+        update_method.return_value = False
+        with self.assertRaises(AirflowException) as cm:
+            self.spanner_hook_no_default_project_id.update_instance(
+                instance_id=SPANNER_INSTANCE,
+                configuration_name=SPANNER_CONFIGURATION,
+                node_count=2,
+                display_name=SPANNER_DATABASE)
+        get_client.assert_not_called()
+        instance_method.assert_not_called()
+        update_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_update_instance_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        update_method = instance_method.return_value.update
+        update_method.return_value = False
+        res = self.spanner_hook_no_default_project_id.update_instance(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            instance_id=SPANNER_INSTANCE,
+            configuration_name=SPANNER_CONFIGURATION,
+            node_count=2,
+            display_name=SPANNER_DATABASE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(
+            instance_id='instance', configuration_name='configuration', display_name='database-name',
+            node_count=2)
+        update_method.assert_called_with()
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_delete_instance_missing_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        delete_method = instance_method.return_value.delete
+        delete_method.return_value = False
+        with self.assertRaises(AirflowException) as cm:
+            self.spanner_hook_no_default_project_id.delete_instance(
+                instance_id=SPANNER_INSTANCE)
+        get_client.assert_not_called()
+        instance_method.assert_not_called()
+        delete_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_delete_instance_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        delete_method = instance_method.return_value.delete
+        delete_method.return_value = False
+        res = self.spanner_hook_no_default_project_id.delete_instance(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            instance_id=SPANNER_INSTANCE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(
+            'instance')
+        delete_method.assert_called_with()
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_get_database_missing_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_exists_method = instance_method.return_value.exists
+        database_exists_method.return_value = True
+        with self.assertRaises(AirflowException) as cm:
+            self.spanner_hook_no_default_project_id.get_database(
+                instance_id=SPANNER_INSTANCE,
+                database_id=SPANNER_DATABASE)
+        get_client.assert_not_called()
+        instance_method.assert_not_called()
+        database_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_get_database_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_exists_method = instance_method.return_value.exists
+        database_exists_method.return_value = True
+        res = self.spanner_hook_no_default_project_id.get_database(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name')
+        database_exists_method.assert_called_with()
+        self.assertIsNotNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_create_database_missing_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_create_method = database_method.return_value.create
+        with self.assertRaises(AirflowException) as cm:
+            self.spanner_hook_no_default_project_id.create_database(
+                instance_id=SPANNER_INSTANCE,
+                database_id=SPANNER_DATABASE,
+                ddl_statements=[])
+        get_client.assert_not_called()
+        instance_method.assert_not_called()
+        database_method.assert_not_called()
+        database_create_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_create_database_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_create_method = database_method.return_value.create
+        res = self.spanner_hook_no_default_project_id.create_database(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE,
+            ddl_statements=[])
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name', ddl_statements=[])
+        database_create_method.assert_called_with()
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_update_database_missing_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_update_method = database_method.return_value.update
+        with self.assertRaises(AirflowException) as cm:
+            self.spanner_hook_no_default_project_id.update_database(
+                instance_id=SPANNER_INSTANCE,
+                database_id=SPANNER_DATABASE,
+                ddl_statements=[])
+        get_client.assert_not_called()
+        instance_method.assert_not_called()
+        database_method.assert_not_called()
+        database_update_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_update_database_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_update_ddl_method = database_method.return_value.update_ddl
+        res = self.spanner_hook_no_default_project_id.update_database(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE,
+            ddl_statements=[])
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name')
+        database_update_ddl_method.assert_called_with(ddl_statements=[], operation_id=None)
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_update_database_overridden_project_id_and_operation(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_update_ddl_method = database_method.return_value.update_ddl
+        res = self.spanner_hook_no_default_project_id.update_database(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE,
+            operation_id="operation",
+            ddl_statements=[])
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name')
+        database_update_ddl_method.assert_called_with(ddl_statements=[], operation_id="operation")
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_delete_database_missing_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_drop_method = database_method.return_value.drop
+        database_exists_method = database_method.return_value.exists
+        database_exists_method.return_value = True
+        with self.assertRaises(AirflowException) as cm:
+            self.spanner_hook_no_default_project_id.delete_database(
+                instance_id=SPANNER_INSTANCE,
+                database_id=SPANNER_DATABASE)
+        get_client.assert_not_called()
+        instance_method.assert_not_called()
+        database_method.assert_not_called()
+        database_exists_method.assert_not_called()
+        database_drop_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_delete_database_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_drop_method = database_method.return_value.drop
+        database_exists_method = database_method.return_value.exists
+        database_exists_method.return_value = True
+        res = self.spanner_hook_no_default_project_id.delete_database(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name')
+        database_exists_method.assert_called_with()
+        database_drop_method.assert_called_with()
+        self.assertIsNone(res)
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_delete_database_missing_database(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        database_drop_method = database_method.return_value.drop
+        database_exists_method = database_method.return_value.exists
+        database_exists_method.return_value = False
+        self.spanner_hook_no_default_project_id.delete_database(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE)
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name')
+        database_exists_method.assert_called_with()
+        database_drop_method.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_execute_dml_missing_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        run_in_transaction_method = database_method.return_value.run_in_transaction
+        with self.assertRaises(AirflowException) as cm:
+            self.spanner_hook_no_default_project_id.execute_dml(
+                instance_id=SPANNER_INSTANCE,
+                database_id=SPANNER_DATABASE,
+                queries='')
+        get_client.assert_not_called()
+        instance_method.assert_not_called()
+        database_method.assert_not_called()
+        run_in_transaction_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_spanner_hook.CloudSpannerHook._get_client')
+    def test_execute_dml_overridden_project_id(self, get_client):
+        instance_method = get_client.return_value.instance
+        instance_exists_method = instance_method.return_value.exists
+        instance_exists_method.return_value = True
+        database_method = instance_method.return_value.database
+        run_in_transaction_method = database_method.return_value.run_in_transaction
+        res = self.spanner_hook_no_default_project_id.execute_dml(
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE,
+            queries='')
+        get_client.assert_called_once_with(project_id='example-project')
+        instance_method.assert_called_once_with(instance_id='instance')
+        database_method.assert_called_with(database_id='database-name')
+        run_in_transaction_method.assert_called_with(mock.ANY)
+        self.assertIsNone(res)

--- a/tests/contrib/hooks/test_gcp_sql_hook.py
+++ b/tests/contrib/hooks/test_gcp_sql_hook.py
@@ -16,13 +16,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import json
 import unittest
 
 from googleapiclient.errors import HttpError
 
-from airflow.contrib.hooks.gcp_sql_hook import CloudSqlHook
+from airflow.contrib.hooks.gcp_sql_hook import CloudSqlHook, CloudSqlDatabaseHook
 from airflow.exceptions import AirflowException
+from airflow.models.connection import Connection
+from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id, \
+    mock_base_gcp_hook_no_default_project_id
+
+from parameterized import parameterized
 
 try:
     from unittest import mock
@@ -33,31 +38,971 @@ except ImportError:
         mock = None
 
 
-class TestGcpSqlHook(unittest.TestCase):
-    def test_instance_import_ex(self):
-        # Mocking __init__ with an empty anonymous function
-        with mock.patch.object(CloudSqlHook, "__init__", lambda x, y, z: None):
-            hook = CloudSqlHook(None, None)
-            # Simulating HttpError inside import_instance
-            hook.get_conn = mock.Mock(
-                side_effect=HttpError(resp={'status': '400'},
-                                      content='Error content'.encode('utf-8'))
-            )
-            with self.assertRaises(AirflowException) as cm:
-                hook.import_instance(None, None, None)
-            err = cm.exception
-            self.assertIn("Importing instance ", str(err))
+class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
 
-    def test_instance_export_ex(self):
-        # Mocking __init__ with an empty anonymous function
-        with mock.patch.object(CloudSqlHook, "__init__", lambda x, y, z: None):
-            hook = CloudSqlHook(None, None)
-            # Simulating HttpError inside export_instance
-            hook.get_conn = mock.Mock(
-                side_effect=HttpError(resp={'status': '400'},
-                                      content='Error content'.encode('utf-8'))
-            )
+    def setUp(self):
+        with mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+                        new=mock_base_gcp_hook_default_project_id):
+            self.cloudsql_hook = CloudSqlHook(api_version='v1', gcp_conn_id='test')
+
+    def test_instance_import_exception(self):
+        self.cloudsql_hook.get_conn = mock.Mock(
+            side_effect=HttpError(resp={'status': '400'},
+                                  content='Error content'.encode('utf-8'))
+        )
+        with self.assertRaises(AirflowException) as cm:
+            self.cloudsql_hook.import_instance(
+                instance='instance',
+                body={})
+        err = cm.exception
+        self.assertIn("Importing instance ", str(err))
+
+    def test_instance_export_exception(self):
+        self.cloudsql_hook.get_conn = mock.Mock(
+            side_effect=HttpError(resp={'status': '400'},
+                                  content='Error content'.encode('utf-8'))
+        )
+        with self.assertRaises(AirflowException) as cm:
+            self.cloudsql_hook.export_instance(
+                instance='instance',
+                body={})
+        err = cm.exception
+        self.assertIn("Exporting instance ", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_instance_import(self, wait_for_operation_to_complete, get_conn):
+        import_method = get_conn.return_value.instances.return_value.import_
+        execute_method = import_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.import_instance(
+            instance='instance',
+            body={})
+        self.assertIsNone(res)
+        import_method.assert_called_once_with(body={}, instance='instance', project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
+                                                               operation_name='operation_id')
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_instance_import_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        import_method = get_conn.return_value.instances.return_value.import_
+        execute_method = import_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.import_instance(
+            project_id='new-project',
+            instance='instance',
+            body={})
+        self.assertIsNone(res)
+        import_method.assert_called_once_with(body={}, instance='instance', project='new-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='new-project',
+                                                               operation_name='operation_id')
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_instance_export(self, wait_for_operation_to_complete, get_conn):
+        export_method = get_conn.return_value.instances.return_value.export
+        execute_method = export_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.export_instance(
+            instance='instance',
+            body={})
+        self.assertIsNone(res)
+        export_method.assert_called_once_with(body={}, instance='instance', project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
+                                                               operation_name='operation_id')
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_instance_export_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        export_method = get_conn.return_value.instances.return_value.export
+        execute_method = export_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.export_instance(
+            project_id='new-project',
+            instance='instance',
+            body={})
+        self.assertIsNone(res)
+        export_method.assert_called_once_with(body={}, instance='instance', project='new-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='new-project',
+                                                               operation_name='operation_id')
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_get_instance(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.instances.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "instance"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.get_instance(
+            instance='instance')
+        self.assertIsNotNone(res)
+        self.assertEquals('instance', res['name'])
+        get_method.assert_called_once_with(instance='instance', project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_get_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.instances.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "instance"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.get_instance(
+            project_id='new-project',
+            instance='instance')
+        self.assertIsNotNone(res)
+        self.assertEquals('instance', res['name'])
+        get_method.assert_called_once_with(instance='instance', project='new-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_create_instance(self, wait_for_operation_to_complete, get_conn):
+        insert_method = get_conn.return_value.instances.return_value.insert
+        execute_method = insert_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.create_instance(
+            body={})
+        self.assertIsNone(res)
+        insert_method.assert_called_once_with(body={}, project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='example-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_create_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        insert_method = get_conn.return_value.instances.return_value.insert
+        execute_method = insert_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.create_instance(
+            project_id='new-project',
+            body={})
+        self.assertIsNone(res)
+        insert_method.assert_called_once_with(body={}, project='new-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='new-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_patch_instance(self, wait_for_operation_to_complete, get_conn):
+        patch_method = get_conn.return_value.instances.return_value.patch
+        execute_method = patch_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.patch_instance(
+            instance='instance',
+            body={})
+        self.assertIsNone(res)
+        patch_method.assert_called_once_with(body={}, instance='instance', project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='example-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_patch_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        patch_method = get_conn.return_value.instances.return_value.patch
+        execute_method = patch_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.patch_instance(
+            project_id='new-project',
+            instance='instance',
+            body={})
+        self.assertIsNone(res)
+        patch_method.assert_called_once_with(body={}, instance='instance', project='new-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='new-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_delete_instance(self, wait_for_operation_to_complete, get_conn):
+        delete_method = get_conn.return_value.instances.return_value.delete
+        execute_method = delete_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.delete_instance(
+            instance='instance')
+        self.assertIsNone(res)
+        delete_method.assert_called_once_with(instance='instance', project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='example-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_delete_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        delete_method = get_conn.return_value.instances.return_value.delete
+        execute_method = delete_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.delete_instance(
+            project_id='new-project',
+            instance='instance')
+        self.assertIsNone(res)
+        delete_method.assert_called_once_with(instance='instance', project='new-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='new-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_get_database(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.databases.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "database"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.get_database(
+            database='database',
+            instance='instance')
+        self.assertIsNotNone(res)
+        self.assertEquals('database', res['name'])
+        get_method.assert_called_once_with(instance='instance',
+                                           database='database',
+                                           project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_get_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.databases.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "database"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.get_database(
+            project_id='new-project',
+            database='database',
+            instance='instance')
+        self.assertIsNotNone(res)
+        self.assertEquals('database', res['name'])
+        get_method.assert_called_once_with(instance='instance',
+                                           database='database',
+                                           project='new-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_create_database(self, wait_for_operation_to_complete, get_conn):
+        insert_method = get_conn.return_value.databases.return_value.insert
+        execute_method = insert_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.create_database(
+            instance='instance',
+            body={})
+        self.assertIsNone(res)
+        insert_method.assert_called_once_with(body={}, instance='instance', project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='example-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_create_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        insert_method = get_conn.return_value.databases.return_value.insert
+        execute_method = insert_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.create_database(
+            project_id='new-project',
+            instance='instance',
+            body={})
+        self.assertIsNone(res)
+        insert_method.assert_called_once_with(body={}, instance='instance', project='new-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='new-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_patch_database(self, wait_for_operation_to_complete, get_conn):
+        patch_method = get_conn.return_value.databases.return_value.patch
+        execute_method = patch_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.patch_database(
+            instance='instance',
+            database='database',
+            body={})
+        self.assertIsNone(res)
+        patch_method.assert_called_once_with(body={},
+                                             database='database',
+                                             instance='instance',
+                                             project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='example-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_patch_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        patch_method = get_conn.return_value.databases.return_value.patch
+        execute_method = patch_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.patch_database(
+            project_id='new-project',
+            instance='instance',
+            database='database',
+            body={})
+        self.assertIsNone(res)
+        patch_method.assert_called_once_with(body={},
+                                             database='database',
+                                             instance='instance',
+                                             project='new-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='new-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_delete_database(self, wait_for_operation_to_complete, get_conn):
+        delete_method = get_conn.return_value.databases.return_value.delete
+        execute_method = delete_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.delete_database(
+            instance='instance',
+            database='database')
+        self.assertIsNone(res)
+        delete_method.assert_called_once_with(database='database',
+                                              instance='instance',
+                                              project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='example-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_delete_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        delete_method = get_conn.return_value.databases.return_value.delete
+        execute_method = delete_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook.delete_database(
+            project_id='new-project',
+            instance='instance',
+            database='database')
+        self.assertIsNone(res)
+        delete_method.assert_called_once_with(database='database',
+                                              instance='instance',
+                                              project='new-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='new-project'
+        )
+
+
+class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
+    def setUp(self):
+        with mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+                        new=mock_base_gcp_hook_no_default_project_id):
+            self.cloudsql_hook_no_default_project_id = CloudSqlHook(api_version='v1', gcp_conn_id='test')
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_instance_import_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        import_method = get_conn.return_value.instances.return_value.import_
+        execute_method = import_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook_no_default_project_id.import_instance(
+            project_id='example-project',
+            instance='instance',
+            body={})
+        self.assertIsNone(res)
+        import_method.assert_called_once_with(body={}, instance='instance', project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
+                                                               operation_name='operation_id')
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_instance_import_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+        import_method = get_conn.return_value.instances.return_value.import_
+        execute_method = import_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.cloudsql_hook_no_default_project_id.import_instance(
+                instance='instance',
+                body={})
+        import_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_instance_export_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        export_method = get_conn.return_value.instances.return_value.export
+        execute_method = export_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook_no_default_project_id.export_instance(
+            project_id='example-project',
+            instance='instance',
+            body={})
+        self.assertIsNone(res)
+        export_method.assert_called_once_with(body={}, instance='instance', project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
+                                                               operation_name='operation_id')
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_instance_export_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+        export_method = get_conn.return_value.instances.return_value.export
+        execute_method = export_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.cloudsql_hook_no_default_project_id.export_instance(
+                instance='instance',
+                body={})
+        export_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_get_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.instances.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "instance"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook_no_default_project_id.get_instance(
+            project_id='example-project',
+            instance='instance')
+        self.assertIsNotNone(res)
+        self.assertEquals('instance', res['name'])
+        get_method.assert_called_once_with(instance='instance', project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_get_instance_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.instances.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "instance"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.cloudsql_hook_no_default_project_id.get_instance(
+                instance='instance')
+        get_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_create_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        insert_method = get_conn.return_value.instances.return_value.insert
+        execute_method = insert_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook_no_default_project_id.create_instance(
+            project_id='example-project',
+            body={})
+        self.assertIsNone(res)
+        insert_method.assert_called_once_with(body={}, project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='example-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_create_instance_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+        insert_method = get_conn.return_value.instances.return_value.insert
+        execute_method = insert_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.cloudsql_hook_no_default_project_id.create_instance(
+                body={})
+        insert_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_patch_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        patch_method = get_conn.return_value.instances.return_value.patch
+        execute_method = patch_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook_no_default_project_id.patch_instance(
+            project_id='example-project',
+            instance='instance',
+            body={})
+        self.assertIsNone(res)
+        patch_method.assert_called_once_with(body={}, instance='instance', project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='example-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_patch_instance_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+        patch_method = get_conn.return_value.instances.return_value.patch
+        execute_method = patch_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.cloudsql_hook_no_default_project_id.patch_instance(
+                instance='instance',
+                body={})
+        patch_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_delete_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        delete_method = get_conn.return_value.instances.return_value.delete
+        execute_method = delete_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook_no_default_project_id.delete_instance(
+            project_id='example-project',
+            instance='instance')
+        self.assertIsNone(res)
+        delete_method.assert_called_once_with(instance='instance', project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='example-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_delete_instance_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+        delete_method = get_conn.return_value.instances.return_value.delete
+        execute_method = delete_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.cloudsql_hook_no_default_project_id.delete_instance(
+                instance='instance')
+        delete_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_get_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.databases.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "database"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook_no_default_project_id.get_database(
+            project_id='example-project',
+            database='database',
+            instance='instance')
+        self.assertIsNotNone(res)
+        self.assertEquals('database', res['name'])
+        get_method.assert_called_once_with(instance='instance',
+                                           database='database',
+                                           project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_get_database_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+        get_method = get_conn.return_value.databases.return_value.get
+        execute_method = get_method.return_value.execute
+        execute_method.return_value = {"name": "database"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.cloudsql_hook_no_default_project_id.get_database(
+                database='database',
+                instance='instance')
+        get_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_create_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        insert_method = get_conn.return_value.databases.return_value.insert
+        execute_method = insert_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook_no_default_project_id.create_database(
+            project_id='example-project',
+            instance='instance',
+            body={})
+        self.assertIsNone(res)
+        insert_method.assert_called_once_with(body={}, instance='instance', project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='example-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_create_database_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+        insert_method = get_conn.return_value.databases.return_value.insert
+        execute_method = insert_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.cloudsql_hook_no_default_project_id.create_database(
+                instance='instance',
+                body={})
+        insert_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_patch_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        patch_method = get_conn.return_value.databases.return_value.patch
+        execute_method = patch_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook_no_default_project_id.patch_database(
+            project_id='example-project',
+            instance='instance',
+            database='database',
+            body={})
+        self.assertIsNone(res)
+        patch_method.assert_called_once_with(body={},
+                                             database='database',
+                                             instance='instance',
+                                             project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='example-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_patch_database_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+        patch_method = get_conn.return_value.databases.return_value.patch
+        execute_method = patch_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.cloudsql_hook_no_default_project_id.patch_database(
+                instance='instance',
+                database='database',
+                body={})
+        patch_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_delete_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+        delete_method = get_conn.return_value.databases.return_value.delete
+        execute_method = delete_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        res = self.cloudsql_hook_no_default_project_id.delete_database(
+            project_id='example-project',
+            instance='instance',
+            database='database')
+        self.assertIsNone(res)
+        delete_method.assert_called_once_with(database='database',
+                                              instance='instance',
+                                              project='example-project')
+        execute_method.assert_called_once_with(num_retries=5)
+        wait_for_operation_to_complete.assert_called_once_with(
+            operation_name='operation_id', project_id='example-project'
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook._wait_for_operation_to_complete')
+    def test_delete_database_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+        delete_method = get_conn.return_value.databases.return_value.delete
+        execute_method = delete_method.return_value.execute
+        execute_method.return_value = {"name": "operation_id"}
+        wait_for_operation_to_complete.return_value = None
+        with self.assertRaises(AirflowException) as cm:
+            self.cloudsql_hook_no_default_project_id.delete_database(
+                instance='instance',
+                database='database')
+        delete_method.assert_not_called()
+        execute_method.assert_not_called()
+        err = cm.exception
+        self.assertIn("The project id must be passed", str(err))
+        wait_for_operation_to_complete.assert_not_called()
+
+
+class TestCloudsqlDatabaseHook(unittest.TestCase):
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook.get_connection')
+    def test_cloudsql_database_hook_validate_ssl_certs_no_ssl(self, get_connection):
+        connection = Connection()
+        connection.set_extra(json.dumps({
+            "location": "test",
+            "instance": "instance",
+            "database_type": "postgres"
+        }))
+        get_connection.return_value = connection
+        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+                                    default_gcp_project_id='google_connection')
+        hook.validate_ssl_certs()
+
+    @parameterized.expand([
+        [{}],
+        [{"sslcert": "cert_file.pem"}],
+        [{"sslkey": "cert_key.pem"}],
+        [{"sslrootcert": "root_cert_file.pem"}],
+        [{"sslcert": "cert_file.pem", "sslkey": "cert_key.pem"}],
+        [{"sslrootcert": "root_cert_file.pem", "sslkey": "cert_key.pem"}],
+        [{"sslrootcert": "root_cert_file.pem", "sslcert": "cert_file.pem"}],
+    ])
+    @mock.patch('os.path.isfile')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook.get_connection')
+    def test_cloudsql_database_hook_validate_ssl_certs_missing_cert_params(
+            self, cert_dict, get_connection, mock_is_file):
+        mock_is_file.side_effects = True
+        connection = Connection()
+        extras = {
+            "location": "test",
+            "instance": "instance",
+            "database_type": "postgres",
+            "use_ssl": "True"
+        }
+        extras.update(cert_dict)
+        connection.set_extra(json.dumps(extras))
+
+        get_connection.return_value = connection
+        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+                                    default_gcp_project_id='google_connection')
+        with self.assertRaises(AirflowException) as cm:
+            hook.validate_ssl_certs()
+        err = cm.exception
+        self.assertIn("SSL connections requires", str(err))
+
+    @mock.patch('os.path.isfile')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook.get_connection')
+    def test_cloudsql_database_hook_validate_ssl_certs_with_ssl(self, get_connection, mock_is_file):
+        connection = Connection()
+        mock_is_file.return_value = True
+        connection.set_extra(json.dumps({
+            "location": "test",
+            "instance": "instance",
+            "database_type": "postgres",
+            "use_ssl": "True",
+            "sslcert": "cert_file.pem",
+            "sslrootcert": "rootcert_file.pem",
+            "sslkey": "key_file.pem",
+        }))
+        get_connection.return_value = connection
+        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+                                    default_gcp_project_id='google_connection')
+        hook.validate_ssl_certs()
+
+    @mock.patch('os.path.isfile')
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook.get_connection')
+    def test_cloudsql_database_hook_validate_ssl_certs_with_ssl_files_not_readable(
+            self, get_connection, mock_is_file):
+        connection = Connection()
+        mock_is_file.return_value = False
+        connection.set_extra(json.dumps({
+            "location": "test",
+            "instance": "instance",
+            "database_type": "postgres",
+            "use_ssl": "True",
+            "sslcert": "cert_file.pem",
+            "sslrootcert": "rootcert_file.pem",
+            "sslkey": "key_file.pem",
+        }))
+        get_connection.return_value = connection
+        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+                                    default_gcp_project_id='google_connection')
+        with self.assertRaises(AirflowException) as cm:
+            hook.validate_ssl_certs()
+        err = cm.exception
+        self.assertIn("must be a readable file", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook.get_connection')
+    def test_cloudsql_database_hook_validate_socket_path_length_too_long(self, get_connection):
+        connection = Connection()
+        connection.set_extra(json.dumps({
+            "location": "test",
+            "instance": "very_long_instance_name_that_will_be_too_long_to_build_socket_length",
+            "database_type": "postgres",
+            "use_proxy": "True",
+            "use_tcp": "False"
+        }))
+        get_connection.return_value = connection
+        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+                                    default_gcp_project_id='google_connection')
+        with self.assertRaises(AirflowException) as cm:
+            hook.validate_socket_path_length()
+        err = cm.exception
+        self.assertIn("The UNIX socket path length cannot exceed", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook.get_connection')
+    def test_cloudsql_database_hook_validate_socket_path_length_not_too_long(self, get_connection):
+        connection = Connection()
+        connection.set_extra(json.dumps({
+            "location": "test",
+            "instance": "short_instance_name",
+            "database_type": "postgres",
+            "use_proxy": "True",
+            "use_tcp": "False"
+        }))
+        get_connection.return_value = connection
+        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+                                    default_gcp_project_id='google_connection')
+        hook.validate_socket_path_length()
+
+    @parameterized.expand([
+        ["http://:password@host:80/database"],
+        ["http://user:@host:80/database"],
+        ["http://user:password@/database"],
+        ["http://user:password@host:80/"],
+        ["http://user:password@/"],
+        ["http://host:80/database"],
+        ["http://host:80/"],
+    ])
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook.get_connection')
+    def test_cloudsql_database_hook_create_connection_missing_fields(self, uri, get_connection):
+        connection = Connection()
+        connection.parse_from_uri(uri)
+        params = {
+            "location": "test",
+            "instance": "instance",
+            "database_type": "postgres",
+            'use_proxy': "True",
+            'use_tcp': "False"
+        }
+        connection.set_extra(json.dumps(params))
+        get_connection.return_value = connection
+        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+                                    default_gcp_project_id='google_connection')
+        with self.assertRaises(AirflowException) as cm:
+            hook.create_connection()
+        err = cm.exception
+        self.assertIn("needs to be set in connection", str(err))
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook.get_connection')
+    def test_cloudsql_database_hook_create_delete_connection(self, get_connection):
+        connection = Connection()
+        connection.parse_from_uri("http://user:password@host:80/database")
+        connection.set_extra(json.dumps({
+            "location": "test",
+            "instance": "instance",
+            "database_type": "postgres"
+        }))
+        get_connection.return_value = connection
+        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+                                    default_gcp_project_id='google_connection')
+        hook.create_connection()
+        self.assertIsNotNone(hook.retrieve_connection())
+        hook.delete_connection()
+        self.assertIsNone(hook.retrieve_connection())
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook.get_connection')
+    def test_cloudsql_database_hook_get_sqlproxy_runner_no_proxy(self, get_connection):
+        connection = Connection()
+        connection.parse_from_uri("http://user:password@host:80/database")
+        connection.set_extra(json.dumps({
+            "location": "test",
+            "instance": "instance",
+            "database_type": "postgres",
+        }))
+        get_connection.return_value = connection
+        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+                                    default_gcp_project_id='google_connection')
+        hook.create_connection()
+        try:
             with self.assertRaises(AirflowException) as cm:
-                hook.export_instance(None, None, None)
+                hook.get_sqlproxy_runner()
             err = cm.exception
-            self.assertIn("Exporting instance ", str(err))
+            self.assertIn('Proxy runner can only be retrieved in case of use_proxy = True', str(err))
+        finally:
+            hook.delete_connection()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook.get_connection')
+    def test_cloudsql_database_hook_get_sqlproxy_runner(self, get_connection):
+        connection = Connection()
+        connection.parse_from_uri("http://user:password@host:80/database")
+        connection.set_extra(json.dumps({
+            "location": "test",
+            "instance": "instance",
+            "database_type": "postgres",
+            'use_proxy': "True",
+            'use_tcp': "False"
+        }))
+        get_connection.return_value = connection
+        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+                                    default_gcp_project_id='google_connection')
+        hook.create_connection()
+        try:
+            proxy_runner = hook.get_sqlproxy_runner()
+            self.assertIsNotNone(proxy_runner)
+        finally:
+            hook.delete_connection()
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook.get_connection')
+    def test_cloudsql_database_hook_get_database_hook(self, get_connection):
+        connection = Connection()
+        connection.parse_from_uri("http://user:password@host:80/database")
+        connection.set_extra(json.dumps({
+            "location": "test",
+            "instance": "instance",
+            "database_type": "postgres",
+        }))
+        get_connection.return_value = connection
+        hook = CloudSqlDatabaseHook(gcp_cloudsql_conn_id='cloudsql_connection',
+                                    default_gcp_project_id='google_connection')
+        hook.create_connection()
+        try:
+            db_hook = hook.get_database_hook()
+            self.assertIsNotNone(db_hook)
+        finally:
+            hook.delete_connection()

--- a/tests/contrib/utils/base_gcp_mock.py
+++ b/tests/contrib/utils/base_gcp_mock.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import sys
+
+import mock
+
+GCP_PROJECT_ID_HOOK_UNIT_TEST = 'example-project'
+
+
+def mock_base_gcp_hook_default_project_id(self, gcp_conn_id, delegate_to=None):
+    self.extras = {
+        'extra__google_cloud_platform__project': GCP_PROJECT_ID_HOOK_UNIT_TEST
+    }
+    self._conn = gcp_conn_id
+    self.delegate_to = delegate_to
+
+
+def mock_base_gcp_hook_no_default_project_id(self, gcp_conn_id, delegate_to=None):
+    self.extras = {
+    }
+    self._conn = gcp_conn_id
+    self.delegate_to = delegate_to
+
+
+def get_open_mock():
+    m = mock.mock_open()
+    if sys.version_info[0] == 2:
+        open_module = '__builtin__'
+    else:
+        open_module = 'builtins'
+    return m, open_module

--- a/tests/contrib/utils/base_gcp_system_test_case.py
+++ b/tests/contrib/utils/base_gcp_system_test_case.py
@@ -40,7 +40,7 @@ ENV_FILE_RETRIEVER = os.path.join(AIRFLOW_PARENT_FOLDER,
 
 
 # Retrieve environment variables from parent directory retriever - it should be
-# in the path ${AIRFLOW_SOOURCE_DIR}/../../get_system_test_environment_variables.py
+# in the path ${AIRFLOW_SOURCE_DIR}/../../get_system_test_environment_variables.py
 # and it should print all the variables in form of key=value to the stdout
 class RetrieveVariables:
     @staticmethod
@@ -243,6 +243,7 @@ You can create the database via these commands:
             # and move them back after reset
             self._store_dags_to_temporary_directory()
             try:
+                db_utils.upgradedb()
                 db_utils.resetdb(settings.RBAC)
             finally:
                 self._restore_dags_from_temporary_directory()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3681

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The service account/connection to GCP can have an optional default
project id assigned. The project id can be specified explicitly
if we wish to override it, but when not specified (i.e. set to None)
the default one should be used instead.

This solution uses centralised decorator in order to have a common
place where retrieval logic is implemented for all operators.
Project_id is an important parameter of all GCP calls, therefore
in hooks it is left as always first positional parameter and it
has no default value. This has the added value that you have to
explicitly provide a value = None if you want to use default
project id.

On the other hand in operators, project_id is optional as in this
case you usually want to operate on default connection and project.

### Tests

- [x] My PR adds the following unit test cases:

* BigtableInstanceCreateTest.test_create_instance_that_exists_empty_project_id
* BigtableInstanceCreateTest.test_updating_cluster_but_instance_does_not_exists_empty_project_id
* BigtableInstanceCreateTest.test_updating_cluster_that_does_not_exists_empty_project_id
* BigtableInstanceDeleteTest.test_delete_execute_empty_project_id
* BigtableInstanceDeleteTest.test_deleting_instance_that_doesnt_exists_empty_project_id
* BigtableTableDeleteTest.test_deleting_table_that_doesnt_exists_empty_project_id
* BigtableTableCreateTest.test_creating_table_that_exists_empty_project_id
* GceInstanceStartTest.test_start_should_not_throw_ex_when_project_id_None
* GceInstanceStopTest.test_stop_should_not_throw_ex_when_project_id_none
* GceInstanceSetMachineTypeTest.test_set_machine_type_should_not_throw_ex_when_project_id_none
* GceInstanceGroupManagerUpdateTest.test_successful_instance_group_update_missing_project_id
* GceInstanceTemplateCopyTest.test_successful_copy_template_missing_project_id
* GcfFunctionDeployTest.test_empty_project_id_is_ok
* CloudSpannerTest.test_instance_create_missing_project_id
* CloudSpannerTest.test_instance_update_missing_project_id
* CloudSpannerTest.test_instance_query_missing_project_id
* CloudSpannerTest.test_database_update_missing_project_id
* CloudSpannerTest.test_database_delete_missing_project_id
* CloudSqlQueryValidationTest.test_create_operator_with_correct_parameters_project_id_missing
* CloudSqlTest.test_instance_create_missing_project_id
* CloudSqlTest.test_instance_patch_missing_project_id
* CloudSqlTest.test_instance_delete_missing_project_id
* CloudSqlTest.test_instance_db_create_missing_project_id
* CloudSqlTest.test_instance_db_patch_missing_project_id
* CloudSqlTest.test_instance_db_delete_missing_project_id
* CloudSqlTest.test_instance_export_missing_project_id
* CloudSqlTest.test_instance_import_missing_project_id

System tests updated with cases with project_id not set:
* example_gcp_sql_query.py
* example_gcp_spanner.sql
* example_gcp_sql.py
* example_gcp_spanner.py
* example_gcp_compute_igm.py
* example_gcp_compute.py
* example_gcp_bigtable_operators.py

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
Documentation is updated. Example dags now include examples with and without project_id

### Code Quality

- [x] Passes `flake8`
