### PR TITLE
[AIRFLOW-3591] Fix start date, end date, duration for rescheduled tasks

### DIFF
--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -183,6 +183,8 @@ class BaseSensorTest(unittest.TestCase):
             if ti.task_id == SENSOR_OP:
                 # verify task is re-scheduled, i.e. state set to NONE
                 self.assertEquals(ti.state, State.UP_FOR_RESCHEDULE)
+                # verify task start date is the initial one
+                self.assertEquals(ti.start_date, date1)
                 # verify one row in task_reschedule table
                 task_reschedules = TaskReschedule.find_for_task_instance(ti)
                 self.assertEquals(len(task_reschedules), 1)
@@ -202,6 +204,8 @@ class BaseSensorTest(unittest.TestCase):
             if ti.task_id == SENSOR_OP:
                 # verify task is re-scheduled, i.e. state set to NONE
                 self.assertEquals(ti.state, State.UP_FOR_RESCHEDULE)
+                # verify task start date is the initial one
+                self.assertEquals(ti.start_date, date1)
                 # verify two rows in task_reschedule table
                 task_reschedules = TaskReschedule.find_for_task_instance(ti)
                 self.assertEquals(len(task_reschedules), 2)
@@ -220,6 +224,8 @@ class BaseSensorTest(unittest.TestCase):
         for ti in tis:
             if ti.task_id == SENSOR_OP:
                 self.assertEquals(ti.state, State.SUCCESS)
+                # verify task start date is the initial one
+                self.assertEquals(ti.start_date, date1)
             if ti.task_id == DUMMY_OP:
                 self.assertEquals(ti.state, State.NONE)
 


### PR DESCRIPTION
### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3591

### Description

- [X] Here are some details about my PR:
  - Use first start date when running a rescheduled task, this also fixes the duration. Use actual start date to record reschedule requests.
  - Simplify gantt view code now that start date and duration are correct in `task_instance` table

### Tests

- [X] My PR adds test

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X] Passes `flake8`
