### PR TITLE
[AIRFLOW-3690] Fix api.common.experimental.mark_tasks.set_state for manually-triggered DAG Runs

### DIFF
--- a/airflow/api/common/experimental/mark_tasks.py
+++ b/airflow/api/common/experimental/mark_tasks.py
@@ -76,10 +76,6 @@ def set_state(task, execution_date, upstream=False, downstream=False,
     """
     assert timezone.is_localized(execution_date)
 
-    # microseconds are supported by the database, but is not handled
-    # correctly by airflow on e.g. the filesystem and in other places
-    execution_date = execution_date.replace(microsecond=0)
-
     assert task.dag is not None
     dag = task.dag
 


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3690

### Description

`set_state` function removes microsecond information from the exectution_date before
further query from the database. However, microsecond is stored in the task_instance table. So all task instances of manually-triggered DAG Runs can not be queried successfully inside the set_state function.

The result is: for all the manually-triggered DAG Runs, if users try to mark state of a task instance, it will fail because no corresponding records can be found. 

This doesn't impact any scheduled DAG Runs since the microsecond in their execution_date is 0.

