### PR TITLE
[AIRFLOW-3692] Remove ENV variables to avoid GPL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ There are three ways to setup an Apache Airflow development environment.
 
   ```
   # Start docker in your Airflow directory
-  docker run -t -i -v `pwd`:/airflow/ -w /airflow/ -e SLUGIFY_USES_TEXT_UNIDECODE=yes python:3 bash
+  docker run -t -i -v `pwd`:/airflow/ -w /airflow/ python:3 bash
 
   # Install Airflow with all the required dependencies,
   # including the devel which will provide the development tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ ARG APT_DEPS="$buildDeps libsasl2-dev freetds-bin build-essential default-libmys
 
 WORKDIR /opt/airflow
 RUN set -x \
-    && export SLUGIFY_USES_TEXT_UNIDECODE=yes \
     && apt update \
     && if [ -n "${APT_DEPS}" ]; then apt install -y $APT_DEPS; fi \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install --no-cache-dir ${PYTHON_DEPS}; fi \

--- a/INSTALL
+++ b/INSTALL
@@ -14,14 +14,6 @@ java -jar apache-rat.jar -E ./.rat-excludes -d .
 python -m my_env
 source my_env/bin/activate
 
-# [required] by default one of Apache Airflow's dependencies pulls in a GPL
-# library. Airflow will not install (and upgrade) without an explicit choice.
-#
-# To make sure not to install the GPL dependency:
-#   export SLUGIFY_USES_TEXT_UNIDECODE=yes
-# In case you do not mind:
-#   export AIRFLOW_GPL_UNIDECODE=yes
-
 # [required] building and installing
 # by pip (preferred)
 pip install .

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,12 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+#### SLUGIFY_USES_TEXT_UNIDECODE or AIRFLOW_GPL_UNIDECODE no longer required
+
+It is no longer required to set one of the environment variables to avoid
+a GPL dependency. Airflow will now always use text-unidecode if unidecode
+was not installed before.
+
 #### Remove run_duration
 
 We should not use the `run_duration` option anymore. This used to be for restarting the scheduler from time to time, but right now the scheduler is getting more stable and therefore using this setting is considered bad and might cause an inconsistent state.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,17 +33,6 @@ You can also install Airflow with support for extra features like ``s3`` or ``po
 
     pip install apache-airflow[postgres,s3]
 
-.. note:: GPL dependency
-
-    One of the dependencies of Apache Airflow by default pulls in a GPL library ('unidecode').
-    
-    If you are not concerned about the GPL dependency, export the following environment variable prior to installing airflow: ``export AIRFLOW_GPL_UNIDECODE=yes``.
-    
-    In case this is a concern you can force a non GPL library by issuing
-    ``export SLUGIFY_USES_TEXT_UNIDECODE=yes`` and then proceed with the normal installation.
-    Please note that this needs to be specified at every upgrade. Also note that if `unidecode`
-    is already present on the system the dependency will still be used.
-
 Extra Packages
 ''''''''''''''
 

--- a/scripts/ci/docker-compose.yml
+++ b/scripts/ci/docker-compose.yml
@@ -71,7 +71,6 @@ services:
     environment:
       - USER=airflow
       - ADDITIONAL_PATH=~/.local/bin
-      - SLUGIFY_USES_TEXT_UNIDECODE=yes
       - TOX_ENV
       - PYTHON_VERSION
       - CI

--- a/scripts/ci/kubernetes/docker/Dockerfile
+++ b/scripts/ci/kubernetes/docker/Dockerfile
@@ -17,8 +17,6 @@
 
 FROM ubuntu:16.04
 
-ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
-
 # install deps
 RUN apt-get update -y && apt-get install -y \
         wget \

--- a/scripts/ci/kubernetes/docker/build.sh
+++ b/scripts/ci/kubernetes/docker/build.sh
@@ -41,7 +41,7 @@ else
 fi
 
 cd $AIRFLOW_ROOT
-docker run -ti --rm -e SLUGIFY_USES_TEXT_UNIDECODE -v ${AIRFLOW_ROOT}:/airflow \
+docker run -ti --rm -v ${AIRFLOW_ROOT}:/airflow \
     -w /airflow ${PYTHON_DOCKER_IMAGE} ./scripts/ci/kubernetes/docker/compile.sh \
 
 sudo rm -rf ${AIRFLOW_ROOT}/airflow/www_rbac/node_modules

--- a/setup.py
+++ b/setup.py
@@ -35,24 +35,6 @@ version = imp.load_source(
 PY3 = sys.version_info[0] == 3
 
 
-# See LEGAL-362
-def verify_gpl_dependency():
-    # The Read the Docs build environment [1] does a pip install of Airflow which cannot
-    # be overridden with custom environment variables, so we detect the READTHEDOCS env
-    # var they provide to set the env var that avoids the GPL dependency on install when
-    # building the docs site.
-    # [1]: http://docs.readthedocs.io/en/latest/builds.html#build-environment
-    if os.getenv("READTHEDOCS") == "True":
-        os.environ["SLUGIFY_USES_TEXT_UNIDECODE"] = "yes"
-
-    if not os.getenv("AIRFLOW_GPL_UNIDECODE") and not os.getenv("SLUGIFY_USES_TEXT_UNIDECODE") == "yes":
-        raise RuntimeError("By default one of Airflow's dependencies installs a GPL "
-                           "dependency (unidecode). To avoid this dependency set "
-                           "SLUGIFY_USES_TEXT_UNIDECODE=yes in your environment when you "
-                           "install or upgrade Airflow. To force installing the GPL "
-                           "version set AIRFLOW_GPL_UNIDECODE")
-
-
 class Tox(TestCommand):
     user_options = [('tox-args=', None, "Arguments to pass to tox")]
 
@@ -286,7 +268,6 @@ else:
 
 
 def do_setup():
-    verify_gpl_dependency()
     write_version()
     setup(
         name='apache-airflow',
@@ -332,6 +313,7 @@ def do_setup():
             'sqlalchemy>=1.1.15, <1.3.0',
             'tabulate>=0.7.5, <=0.8.2',
             'tenacity==4.8.0',
+            'text-unidecode==1.2',  # Avoid GPL dependency, pip uses reverse order(!)
             'thrift>=0.9.2',
             'tzlocal>=1.4',
             'unicodecsv>=0.14.1',


### PR DESCRIPTION
Python-slugify 2.0.1 has a cleaner way to avoid the GPL
dependency. This removes the need for the ENV hacks.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3692
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

@kaxil @Fokko @ashb 