### PR TITLE
[AIRFLOW-3694] Add README.md to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 FROM python:3.6-slim
-COPY setup.* /opt/airflow/
-COPY airflow /opt/airflow/airflow
+
+COPY . /opt/airflow/
 
 ARG AIRFLOW_HOME=/usr/local/airflow
 ARG AIRFLOW_DEPS="all"


### PR DESCRIPTION
The README.md is being read by setup.py and needs to be added to the Dockerfile as well.

Bug introduced in: https://github.com/apache/airflow/pull/4503

```
Obtaining file:///opt/airflow
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/opt/airflow/setup.py", line 38, in <module>
        with io.open('README.md', encoding='utf-8') as f:
    FileNotFoundError: [Errno 2] No such file or directory: 'README.md'
```

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
