### PR TITLE
[AIRFLOW-3698] Add documentation for AWS Connection

### DIFF
--- a/docs/howto/manage-connections.rst
+++ b/docs/howto/manage-connections.rst
@@ -162,6 +162,11 @@ Authenticating to AWS
 
 Authentication may be performed using any of the `boto3 options <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials>`_. Alternatively, one can pass credentials in as a Connection initialisation parameter.
 
+Default Connection IDs
+''''''''''''''''''''''
+
+The default connection ID is ``aws_default``.
+
 Configuring the Connection
 ''''''''''''''''''''''''''
 

--- a/docs/howto/manage-connections.rst
+++ b/docs/howto/manage-connections.rst
@@ -28,7 +28,7 @@ will author will reference the 'conn_id' of the Connection objects.
 Connections can be created and managed using either the UI or environment
 variables.
 
-See the :ref:`Connenctions Concepts <concepts-connections>` documentation for
+See the :ref:`Connections Concepts <concepts-connections>` documentation for
 more information.
 
 Creating a Connection with the UI
@@ -151,6 +151,47 @@ Scopes (comma separated)
         issue `AIRFLOW-2522
         <https://issues.apache.org/jira/browse/AIRFLOW-2522>`_.
 
+Amazon Web Services
+~~~~~~~~~~~~~~~~~~~
+
+The Amazon Web Services connection type enables the :ref:`AWS Integrations
+<AWS>`.
+
+Authenticating to AWS
+'''''''''''''''''''''
+
+Authentication may be performed using any of the `boto3 options <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials>`_. Alternatively, one can pass credentials in as a Connection initialisation parameter.
+
+Configuring the Connection
+''''''''''''''''''''''''''
+
+Login (optional)
+    Specify the AWS access key ID.
+
+Password (optional)
+    Specify the AWS secret access key.
+
+Extra (optional)
+    Specify the extra parameters (as json dictionary) that can be used in ssh
+    connection. The following parameters are supported:
+
+    * **aws_access_key_id**: AWS access key ID of the connection. To use this, the `aws_secret_access_key` parameter must also be passed in.
+    * **aws_secret_access_key**: AWS secret access key of the connection
+    * **aws_account_id**: AWS account ID for the connection
+    * **aws_iam_role**: AWS IAM role for the connection
+    * **external_id**: AWS external ID for the connection
+    * **region_name**: AWS region for the connection
+    * **role_arn**: AWS role ARN for the connection
+
+    Example "extras" field:
+
+    .. code-block:: json
+
+       {
+          "aws_iam_role": "aws_iam_role_name",
+          "region_name": "ap-southeast-2"
+       }
+
 MySQL
 ~~~~~
 The MySQL connection type provides connection to a MySQL database.
@@ -165,10 +206,10 @@ Schema (optional)
 
 Login (required)
     Specify the user name to connect.
-    
+
 Password (required)
-    Specify the password to connect.    
-    
+    Specify the password to connect.
+
 Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in MySQL
     connection. The following parameters are supported:

--- a/docs/howto/manage-connections.rst
+++ b/docs/howto/manage-connections.rst
@@ -162,6 +162,8 @@ Authenticating to AWS
 
 Authentication may be performed using any of the `boto3 options <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials>`_. Alternatively, one can pass credentials in as a Connection initialisation parameter.
 
+To use IAM instance profile, create an "empty" connection (i.e. one with no Login or Password specified).
+
 Default Connection IDs
 ''''''''''''''''''''''
 
@@ -177,14 +179,13 @@ Password (optional)
     Specify the AWS secret access key.
 
 Extra (optional)
-    Specify the extra parameters (as json dictionary) that can be used in ssh
+    Specify the extra parameters (as json dictionary) that can be used in AWS
     connection. The following parameters are supported:
 
-    * **aws_access_key_id**: AWS access key ID of the connection. To use this, the `aws_secret_access_key` parameter must also be passed in.
-    * **aws_secret_access_key**: AWS secret access key of the connection
     * **aws_account_id**: AWS account ID for the connection
     * **aws_iam_role**: AWS IAM role for the connection
     * **external_id**: AWS external ID for the connection
+    * **host**: Endpoint URL for the connection
     * **region_name**: AWS region for the connection
     * **role_arn**: AWS role ARN for the connection
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3698

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
~This PR is to allow setting the AWS region in the `EmrJobFlowSensor` so that we can sense EMR job flow completion in any region.~
The AWS region setting functionality is available via the `extra` param in the Connection class, so adding a section in the docs to describe this

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
~Amending [test](https://github.com/danabananarama/incubator-airflow/blob/d51a5e48a6ec015e365fdc754fbbe9875747dfc9/tests/contrib/sensors/test_emr_job_flow_sensor.py), did not add new test for functionality as it's essentially just persisting a new init param. Let me know if a new test needs to be added!~
Doc change only

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
