### PR TITLE
[AIRFLOW-3699] Speed up Flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@
 sudo: true
 dist: trusty
 language: python
+python:
+  - "3.6"
 env:
   global:
     - DOCKER_COMPOSE_VERSION=1.20.0
@@ -42,8 +44,7 @@ jobs:
   include:
     - name: Flake8
       stage: pre-test
-      script: docker-compose --log-level ERROR -f scripts/ci/docker-compose.yml run airflow-testing /app/scripts/ci/run-ci.sh
-      env: TOX_ENV=flake8
+      script: pip install flake8 && flake8
     - name: Check license header
       stage: pre-test
       script: scripts/ci/6-check-license.sh


### PR DESCRIPTION
Flake8 runs within the Docker container, which is not needed.
Running this outside Docker will dramatically speed up the
CI process.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-3699\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3699
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-3699\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
