### PR TITLE
[AIRFLOW-3719] Handle StopIteration in CloudWatch logs retrieval

### DIFF
--- a/airflow/contrib/hooks/sagemaker_hook.py
+++ b/airflow/contrib/hooks/sagemaker_hook.py
@@ -304,7 +304,15 @@ class SageMakerHook(AwsHook):
         positions = positions or {s: Position(timestamp=0, skip=0) for s in streams}
         event_iters = [self.log_stream(log_group, s, positions[s].timestamp, positions[s].skip)
                        for s in streams]
-        events = [next(s) if s else None for s in event_iters]
+        events = []
+        for s in event_iters:
+            if not s:
+                events.append(None)
+                continue
+            try:
+                events.append(next(s))
+            except StopIteration:
+                events.append(None)
 
         while any(events):
             i = argmin(events, lambda x: x['timestamp'] if x else 9999999999)

--- a/tests/contrib/hooks/test_sagemaker_hook.py
+++ b/tests/contrib/hooks/test_sagemaker_hook.py
@@ -256,6 +256,14 @@ class TestSageMakerHook(unittest.TestCase):
     def setUp(self):
         configuration.load_test_config()
 
+    @mock.patch.object(SageMakerHook, 'log_stream')
+    def test_multi_stream_iter(self, mock_log_stream):
+        event = {'timestamp': 1}
+        mock_log_stream.side_effect = [iter([event]), iter([]), None]
+        hook = SageMakerHook()
+        event_iter = hook.multi_stream_iter('log', [None, None, None])
+        self.assertEqual(next(event_iter), (0, event))
+
     @mock.patch.object(S3Hook, 'create_bucket')
     @mock.patch.object(S3Hook, 'load_file')
     def test_configure_s3_resources(self, mock_load_file, mock_create_bucket):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-3719

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Update codes to handle StopIteration during CloudWatch logs retrieval. The unhandled StopIteration will generate warning in python <= 3.6 and raise error in python 3.7.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
