### PR TITLE
[AIRFLOW-3700] Change the lowest allowed version of "requests" to address security vulnerabilities

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ crypto = ['cryptography>=0.9.3']
 dask = [
     'distributed>=1.17.1, <2'
 ]
-databricks = ['requests>=2.5.1, <3']
+databricks = ['requests>=2.20.0, <3']
 datadog = ['datadog>=0.14.0']
 doc = [
     'mock',
@@ -314,7 +314,7 @@ def do_setup():
             'python-daemon>=2.1.1, <2.2',
             'python-dateutil>=2.3, <3',
             'python-nvd3==0.15.0',
-            'requests>=2.5.1, <3',
+            'requests>=2.20.0, <3',
             'setproctitle>=1.1.8, <2',
             'sqlalchemy>=1.1.15, <1.3.0',
             'tabulate>=0.7.5, <=0.8.2',


### PR DESCRIPTION
JIRA Ticket: https://issues.apache.org/jira/browse/AIRFLOW-3700

Accordingly to https://nvd.nist.gov/vuln/detail/CVE-2018-18074, the Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.

It's recommended to have `requests>=2.20.0`.

**This will not break anything given what we had was  `['requests>=2.5.1, <3']`. If it's a new installation, it will install the latest version. This change is mainly for users who already have `requests<=2.19.1` installed. We should force them to upgrade.**