### PR TITLE
[AIRFLOW-3655] Escape links generated in model views

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -209,7 +209,8 @@ def label_link(v, c, m, p):
 
 def pool_link(v, c, m, p):
     title = escape(m.pool)
-    url = '/admin/taskinstance/?flt1_pool_equals=' + m.pool
+
+    url = url_for('airflow.task', flt1_pool_equals=m.pool)
     return Markup("<a href='{url}'>{title}</a>".format(**locals()))
 
 
@@ -273,18 +274,22 @@ def data_profiling_required(f):
 
 
 def fused_slots(v, c, m, p):
-    url = (
-        '/admin/taskinstance/' +
-        '?flt1_pool_equals=' + m.pool +
-        '&flt2_state_equals=running')
+    url = url_for(
+        'taskinstance.index_view',
+        flt1_pool_equals=m.pool,
+        flt2_state_equals='running',
+    )
     return Markup("<a href='{0}'>{1}</a>".format(url, m.used_slots()))
 
 
 def fqueued_slots(v, c, m, p):
-    url = (
-        '/admin/taskinstance/' +
-        '?flt1_pool_equals=' + m.pool +
-        '&flt2_state_equals=queued&sort=10&desc=1')
+    url = url_for(
+        'taskinstance.index_view',
+        flt1_pool_equals=m.pool,
+        flt2_state_equals='queued',
+        sort='1',
+        desc='1'
+    )
     return Markup("<a href='{0}'>{1}</a>".format(url, m.queued_slots()))
 
 

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -36,7 +36,7 @@ import pendulum
 import sqlalchemy as sqla
 from flask import (
     redirect, request, Markup, Response, render_template,
-    make_response, flash, jsonify, escape)
+    make_response, flash, jsonify, escape, url_for)
 from flask._compat import PY2
 from flask_appbuilder import BaseView, ModelView, expose, has_access
 from flask_appbuilder.actions import action
@@ -2015,7 +2015,7 @@ class PoolModelView(AirflowModelView):
     def pool_link(attr):
         pool_id = attr.get('pool')
         if pool_id is not None:
-            url = '/taskinstance/list/?_flt_3_pool=' + str(pool_id)
+            url = url_for('TaskInstanceModelView.list', _flt_3_pool=pool_id)
             pool_id = escape(pool_id)
             return Markup("<a href='{url}'>{pool_id}</a>".format(**locals()))
         else:
@@ -2025,8 +2025,8 @@ class PoolModelView(AirflowModelView):
         pool_id = attr.get('pool')
         used_slots = attr.get('used_slots')
         if pool_id is not None and used_slots is not None:
-            url = '/taskinstance/list/?_flt_3_pool=' + str(pool_id) + \
-                  '&_flt_3_state=running'
+            url = url_for('TaskInstanceModelView.list', _flt_3_pool=pool_id, _flt_3_state='running')
+            pool_id = escape(pool_id)
             return Markup("<a href='{url}'>{used_slots}</a>".format(**locals()))
         else:
             return Markup('<span class="label label-danger">Invalid</span>')
@@ -2035,8 +2035,8 @@ class PoolModelView(AirflowModelView):
         pool_id = attr.get('pool')
         queued_slots = attr.get('queued_slots')
         if pool_id is not None and queued_slots is not None:
-            url = '/taskinstance/list/?_flt_3_pool=' + str(pool_id) + \
-                  '&_flt_3_state=queued'
+            url = url_for('TaskInstanceModelView.list', _flt_3_pool=pool_id, _flt_3_state='queued')
+            pool_id = escape(pool_id)
             return Markup("<a href='{url}'>{queued_slots}</a>".format(**locals()))
         else:
             return Markup('<span class="label label-danger">Invalid</span>')

--- a/tests/www_rbac/test_views.py
+++ b/tests/www_rbac/test_views.py
@@ -257,6 +257,7 @@ class TestPoolModelView(TestBase):
         self.session.commit()
         resp = self.client.get('/pool/list/')
         self.check_content_in_response('test-pool&lt;script&gt;', resp)
+        self.check_content_not_in_response('test-pool<script>', resp)
 
 
 class TestMountPoint(unittest.TestCase):


### PR DESCRIPTION
The previous PR for this (#4463) got half-way ther but missed a view
cases. This now uses `url_for()` which handles ell the edge cases a lot
better and doesn't need us to generate urls by string-concatenation so
should be less error prone in the future

Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-3655


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
