### PR TITLE
[AIRFLOW-3616][AIRFLOW-1215] Add aliases for schema with underscore

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -110,22 +110,24 @@ class Connection(Base, LoggingMixin):
             self.extra = extra
 
     def parse_from_uri(self, uri):
-        temp_uri = urlparse(uri)
-        hostname = temp_uri.hostname or ''
-        conn_type = temp_uri.scheme
+        uri_parts = urlparse(uri)
+        hostname = uri_parts.hostname or ''
+        conn_type = uri_parts.scheme
         if conn_type == 'postgresql':
             conn_type = 'postgres'
+        elif '-' in conn_type:
+            conn_type = conn_type.replace('-', '_')
         self.conn_type = conn_type
         self.host = unquote(hostname) if hostname else hostname
-        quoted_schema = temp_uri.path[1:]
+        quoted_schema = uri_parts.path[1:]
         self.schema = unquote(quoted_schema) if quoted_schema else quoted_schema
-        self.login = unquote(temp_uri.username) \
-            if temp_uri.username else temp_uri.username
-        self.password = unquote(temp_uri.password) \
-            if temp_uri.password else temp_uri.password
-        self.port = temp_uri.port
-        if temp_uri.query:
-            self.extra = json.dumps(dict(parse_qsl(temp_uri.query)))
+        self.login = unquote(uri_parts.username) \
+            if uri_parts.username else uri_parts.username
+        self.password = unquote(uri_parts.password) \
+            if uri_parts.password else uri_parts.password
+        self.port = uri_parts.port
+        if uri_parts.query:
+            self.extra = json.dumps(dict(parse_qsl(uri_parts.query)))
 
     def get_password(self):
         if self._password and self.is_encrypted:

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -400,13 +400,13 @@ for some basic load balancing and fault tolerance when used in conjunction
 with retries.
 
 Airflow also has the ability to reference connections via environment
-variables from the operating system. But it only supports URI format. If you
-need to specify ``extra`` for your connection, please use web UI.
+variables from the operating system. Then connection parameters must
+be saved in URI format.
 
 If connections with the same ``conn_id`` are defined in both Airflow metadata
 database and environment variables, only the one in environment variables
-will be referenced by Airflow (for example, given ``conn_id`` ``postgres_master``,
-Airflow will search for ``AIRFLOW_CONN_POSTGRES_MASTER``
+will be referenced by Airflow (for example, given ``conn_id``
+``postgres_master``, Airflow will search for ``AIRFLOW_CONN_POSTGRES_MASTER``
 in environment variables first and directly reference it if found,
 before it starts to search in metadata database).
 

--- a/docs/howto/manage-connections.rst
+++ b/docs/howto/manage-connections.rst
@@ -70,10 +70,15 @@ When referencing the connection in the Airflow pipeline, the ``conn_id``
 should be the name of the variable without the prefix. For example, if the
 ``conn_id`` is named ``postgres_master`` the environment variable should be
 named ``AIRFLOW_CONN_POSTGRES_MASTER`` (note that the environment variable
-must be all uppercase). Airflow assumes the value returned from the
-environment variable to be in a URI format (e.g.
-``postgres://user:password@localhost:5432/master`` or
-``s3://accesskey:secretkey@S3``).
+must be all uppercase).
+
+Airflow assumes the value returned from the environment variable to be in a URI
+format (e.g.``postgres://user:password@localhost:5432/master`` or
+``s3://accesskey:secretkey@S3``). The underscore character is not allowed
+in the scheme part of URI, so it must be changed to a hyphen character
+(e.g. `google-compute-platform` if `conn_type` is `google_compute_platform`).
+Query parameters are parsed to one-dimensional dict and then used to fill extra.
+
 
 .. _manage-connections-connection-types:
 
@@ -158,6 +163,28 @@ Scopes (comma separated)
         Scopes are ignored when using application default credentials. See
         issue `AIRFLOW-2522
         <https://issues.apache.org/jira/browse/AIRFLOW-2522>`_.
+
+    When specifying the connection in environment variable you should specify
+    it using URI syntax, with the following requirements:
+
+      * scheme part should be equals ``google-cloud-platform`` (Note: look for a
+        hyphen character)
+      * authority (username, password, host, port), path is ignored
+      * query parameters contains information specific to this type of
+        connection. The following keys are accepted:
+
+        * ``extra__google_cloud_platform__project`` - Project Id
+        * ``extra__google_cloud_platform__key_path`` - Keyfile Path
+        * ``extra__google_cloud_platform__key_dict`` - Keyfile JSON
+        * ``extra__google_cloud_platform__scope`` - Scopes
+
+    Note that all components of the URI should be URL-encoded.
+
+    For example:
+
+    .. code-block:: bash
+
+       google-cloud-platform://?extra__google_cloud_platform__key_path=%2Fkeys%2Fkey.json&extra__google_cloud_platform__scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform&extra__google_cloud_platform__project=airflow
 
 Amazon Web Services
 ~~~~~~~~~~~~~~~~~~~

--- a/tests/models.py
+++ b/tests/models.py
@@ -3398,3 +3398,20 @@ class ConnectionTest(unittest.TestCase):
         self.assertEqual(connection.login, 'user')
         self.assertEqual(connection.password, 'password with space')
         self.assertEqual(connection.port, 1234)
+
+    def test_connection_from_uri_with_underscore(self):
+        uri = 'google-cloud-platform://?extra__google_cloud_platform__key_' \
+              'path=%2Fkeys%2Fkey.json&extra__google_cloud_platform__scope=' \
+              'https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform&extra' \
+              '__google_cloud_platform__project=airflow'
+        connection = Connection(uri=uri)
+        self.assertEqual(connection.conn_type, 'google_cloud_platform')
+        self.assertEqual(connection.host, '')
+        self.assertEqual(connection.schema, '')
+        self.assertEqual(connection.login, None)
+        self.assertEqual(connection.password, None)
+        self.assertEqual(connection.extra_dejson, dict(
+            extra__google_cloud_platform__key_path='/keys/key.json',
+            extra__google_cloud_platform__project='airflow',
+            extra__google_cloud_platform__scope='https://www.googleapis.com/'
+                                                'auth/cloud-platform'))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-3616\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3616
  - https://issues.apache.org/jira/browse/AIRFLOW-1215

### Description

- [ ] A comprehensive description is included in JIRA Ticket, include analysis of other possible solutions.

### Tests

- [x] Add test_connection_from_uri_with_underscore in tests.models:ConnectionTest

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
