### PR TITLE
[AIRFLOW-3707] Group subpackages by cloud providers

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,22 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Renamed "extra" requirments for cloud providers
+
+Subpackages for specific services have been combined into one variant for
+each cloud provider.
+
+If you want to install integration for Microsoft Azure, then instead of
+```
+pip install apache-airflow[azure_blob_storage,azure_data_lake,azure_cosmos,azure_container_instances]
+```
+you should execute `pip install apache-airflow[azure]`
+
+If you want to install integration for Amazon Web Services, then instead of
+`pip install apache-airflow[s3,emr]`, you should execute `pip install apache-airflow[aws]`
+
+The integration with GCP is unchanged.
+
 ## Changes in Google Cloud Platform related operators
 
 Most GCP-related operators have now optional `PROJECT_ID` parameter. In case you do not specify it,

--- a/airflow/utils/log/s3_task_handler.py
+++ b/airflow/utils/log/s3_task_handler.py
@@ -45,7 +45,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         except Exception:
             self.log.error(
                 'Could not create an S3Hook with connection id "%s". '
-                'Please make sure that airflow[s3] is installed and '
+                'Please make sure that airflow[aws] is installed and '
                 'the S3 connection exists.', remote_conn_id
             )
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,11 +27,11 @@ The easiest way to install the latest stable version of Airflow is with ``pip``:
 
     pip install apache-airflow
 
-You can also install Airflow with support for extra features like ``s3`` or ``postgres``:
+You can also install Airflow with support for extra features like ``gcp_api`` or ``postgres``:
 
 .. code-block:: bash
 
-    pip install apache-airflow[postgres,s3]
+    pip install apache-airflow[postgres,gcp_api]
 
 Extra Packages
 ''''''''''''''
@@ -55,6 +55,10 @@ Here's the list of the subpackages and what they enable:
 | all_dbs             | ``pip install apache-airflow[all_dbs]``           | All databases integrations                                           |
 +---------------------+---------------------------------------------------+----------------------------------------------------------------------+
 | async               | ``pip install apache-airflow[async]``             | Async worker classes for Gunicorn                                    |
++---------------------+---------------------------------------------------+----------------------------------------------------------------------+
+| azure               | ``pip install apache-airflow[azure]``             | Microsoft Azure                                                      |
++---------------------+---------------------------------------------------+----------------------------------------------------------------------+
+| aws                 | ``pip install apache-airflow[aws]``               | Amazon Web Services                                                  |
 +---------------------+---------------------------------------------------+----------------------------------------------------------------------+
 | celery              | ``pip install apache-airflow[celery]``            | CeleryExecutor                                                       |
 +---------------------+---------------------------------------------------+----------------------------------------------------------------------+
@@ -107,8 +111,6 @@ Here's the list of the subpackages and what they enable:
 | rabbitmq            | ``pip install apache-airflow[rabbitmq]``          | RabbitMQ support as a Celery backend                                 |
 +---------------------+---------------------------------------------------+----------------------------------------------------------------------+
 | redis               | ``pip install apache-airflow[redis]``             | Redis hooks and sensors                                              |
-+---------------------+---------------------------------------------------+----------------------------------------------------------------------+
-| s3                  | ``pip install apache-airflow[s3]``                | ``S3KeySensor``, ``S3PrefixSensor``                                  |
 +---------------------+---------------------------------------------------+----------------------------------------------------------------------+
 | samba               | ``pip install apache-airflow[samba]``             | :class:`airflow.operators.hive_to_samba_operator.Hive2SambaOperator` |
 +---------------------+---------------------------------------------------+----------------------------------------------------------------------+

--- a/setup.py
+++ b/setup.py
@@ -131,14 +131,17 @@ async_packages = [
     'gevent>=0.13'
 ]
 atlas = ['atlasclient>=0.1.2']
-azure_blob_storage = ['azure-storage>=0.34.0']
-azure_data_lake = [
+aws = [
+    'boto3>=1.7.0, <1.8.0',
+]
+azure = [
+    'azure-storage>=0.34.0',
     'azure-mgmt-resource==1.2.2',
     'azure-mgmt-datalake-store==0.4.0',
-    'azure-datalake-store==0.0.19'
+    'azure-datalake-store==0.0.19',
+    'azure-cosmos>=3.0.1',
+    'azure-mgmt-containerinstance',
 ]
-azure_cosmos = ['azure-cosmos>=3.0.1']
-azure_container_instances = ['azure-mgmt-containerinstance']
 cassandra = ['cassandra-driver>=3.13.0']
 celery = [
     'celery>=4.1.1, <4.2.0',
@@ -168,7 +171,6 @@ elasticsearch = [
     'elasticsearch>=5.0.0,<6.0.0',
     'elasticsearch-dsl>=5.0.0,<6.0.0'
 ]
-emr = ['boto3>=1.0.0, <1.8.0']
 gcp_api = [
     'httplib2>=0.9.2',
     'google-api-python-client>=1.6.0, <2.0.0dev',
@@ -210,7 +212,6 @@ postgres = ['psycopg2>=2.7.4']
 qds = ['qds-sdk>=1.10.4']
 rabbitmq = ['librabbitmq>=1.6.1']
 redis = ['redis>=2.10.5,<3.0.0']
-s3 = ['boto3>=1.7.0, <1.8.0']
 salesforce = ['simple-salesforce>=0.72']
 samba = ['pysmbclient>=0.1.3']
 segment = ['analytics-python>=1.2.9']
@@ -254,14 +255,13 @@ devel = [
 if not PY3:
     devel += ['unittest2']
 
-devel_minreq = devel + kubernetes + mysql + doc + password + s3 + cgroups
+devel_minreq = devel + kubernetes + mysql + doc + password + cgroups
 devel_hadoop = devel_minreq + hive + hdfs + webhdfs + kerberos
-devel_azure = devel_minreq + azure_data_lake + azure_cosmos
-devel_all = (sendgrid + devel + all_dbs + doc + samba + s3 + slack + crypto + oracle +
-             docker + ssh + kubernetes + celery + azure_blob_storage + redis + gcp_api +
+devel_all = (sendgrid + devel + all_dbs + doc + samba + slack + crypto + oracle +
+             docker + ssh + kubernetes + celery + redis + gcp_api +
              datadog + zendesk + jdbc + ldap + kerberos + password + webhdfs + jenkins +
-             druid + pinot + segment + snowflake + elasticsearch + azure_data_lake + azure_cosmos +
-             atlas + azure_container_instances)
+             druid + pinot + segment + snowflake + elasticsearch +
+             atlas + azure + aws)
 
 # Snakebite & Google Cloud Dataflow are not Python 3 compatible :'(
 if PY3:
@@ -335,10 +335,8 @@ def do_setup():
             'all_dbs': all_dbs,
             'atlas': atlas,
             'async': async_packages,
-            'azure_blob_storage': azure_blob_storage,
-            'azure_data_lake': azure_data_lake,
-            'azure_cosmos': azure_cosmos,
-            'azure_container_instances': azure_container_instances,
+            'aws': aws,
+            'azure': azure,
             'cassandra': cassandra,
             'celery': celery,
             'cgroups': cgroups,
@@ -349,12 +347,10 @@ def do_setup():
             'datadog': datadog,
             'devel': devel_minreq,
             'devel_hadoop': devel_hadoop,
-            'devel_azure': devel_azure,
             'doc': doc,
             'docker': docker,
             'druid': druid,
             'elasticsearch': elasticsearch,
-            'emr': emr,
             'gcp_api': gcp_api,
             'github_enterprise': github_enterprise,
             'google_auth': google_auth,
@@ -375,7 +371,6 @@ def do_setup():
             'qds': qds,
             'rabbitmq': rabbitmq,
             'redis': redis,
-            's3': s3,
             'salesforce': salesforce,
             'samba': samba,
             'sendgrid': sendgrid,

--- a/tests/utils/log/test_s3_task_handler.py
+++ b/tests/utils/log/test_s3_task_handler.py
@@ -90,7 +90,7 @@ class TestS3TaskHandler(unittest.TestCase):
 
             mock_error.assert_called_once_with(
                 'Could not create an S3Hook with connection id "%s". Please make '
-                'sure that airflow[s3] is installed and the S3 connection exists.',
+                'sure that airflow[aws] is installed and the S3 connection exists.',
                 ''
             )
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3707

### Description

I propose to group sub packages by. cloud providers. There is a good chance that if the user needs one package of the given clouds, he will need more in a moment. This will be more than consistent with the way the `gcp_api` package works.

### Tests

- No tests

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- Updated docs

### Code Quality

- [ ] Passes `flake8`
