### PR TITLE
[AIRFLOW-3108] Define get_autocommit method for MsSqlHook

### DIFF
--- a/airflow/hooks/mssql_hook.py
+++ b/airflow/hooks/mssql_hook.py
@@ -50,3 +50,6 @@ class MsSqlHook(DbApiHook):
 
     def set_autocommit(self, conn, autocommit):
         conn.autocommit(autocommit)
+
+    def get_autocommit(self, conn):
+        return conn.autocommit_state


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3108

### Description

The default implementation of DbApiHook merely checks for an attribute named `autocommit`.

Since `pymssql` Connection object actually has a method with that name, it returns a bound method when fetching an attribute with that name, evaluating to a "truthy" value. It resulted in SQL statements not actually being committed.

### Tests

No tests

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

No new functionality

### Code Quality

- [x] Passes `flake8`
