### PR TITLE
[AIRFLOW-3282] Implement Azure Kubernetes Service Operator

### DIFF
--- a/airflow/contrib/example_dags/example_azure_kubernetes_operator.py
+++ b/airflow/contrib/example_dags/example_azure_kubernetes_operator.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Example DAG for usage of the AKS Operator
+"""
+
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.contrib.operators.azure_kubernetes_operator import AzureKubernetesOperator
+
+seven_days_ago = datetime.combine(datetime.today() - timedelta(7),
+                                  datetime.min.time())
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': seven_days_ago,
+    'email': ['email@microsoft.com'],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5),
+}
+
+dag = DAG(
+    dag_id='aks_container',
+    default_args=default_args,
+    schedule_interval=None,
+)
+
+start_aks_container = AzureKubernetesOperator(
+    task_id="start_aks_container",
+    ci_conn_id='azure',
+    resource_group="apraotest1",
+    name="akres1",
+    ssh_key_value=None,
+    dns_name_prefix=None,
+    location="eastus",
+    tags=None,
+    dag=dag)

--- a/airflow/contrib/hooks/azure_kubernetes_hook.py
+++ b/airflow/contrib/hooks/azure_kubernetes_hook.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+AKS Hook that can create a cluster for Kubernetes hosted in Azure
+"""
+
+import os
+
+from azure.common.credentials import ServicePrincipalCredentials
+from azure.mgmt.containerservice import ContainerServiceClient
+from azure.mgmt.resource import ResourceManagementClient
+from airflow.hooks.base_hook import BaseHook
+from airflow.exceptions import AirflowException
+from airflow.contrib.utils.aks_utils import load_json
+
+
+class AzureKubernetesServiceHook(BaseHook):
+    """
+    Azure Kubernetes Service (AKS) hook simplifies the deployment and operations of Kubernetes
+    and enables you to dynamically scale your application infrastructure.
+    """
+
+    def __init__(self, conn_id='azure_default'):
+        self.conn_id = conn_id
+        self.connection = self.get_conn()
+        self.config_data = None
+        self.credentials = None
+        self.subscription_id = None
+        self.client_id = None
+        self.client_secret = None
+
+    def get_conn(self):
+        if self.conn_id:
+            conn = self.get_connection(self.conn_id)
+            key_path = conn.extra_dejson.get('key_path', False)
+            if key_path:
+                if key_path.endswith('.json'):
+                    self.log.info('Getting connection using a JSON key file.')
+
+                    self.config_data = load_json(key_path)
+                else:
+                    raise AirflowException('Unrecognised extension for key file.')
+
+        if os.environ.get('AIRFLOW_CONN_AZURE_DEFAULT'):
+            key_path = os.environ.get('AIRFLOW_CONN_AZURE_DEFAULT')
+            if key_path.endswith('.json'):
+                self.log.info('Getting connection using a JSON key file.')
+                self.config_data = load_json(key_path)
+            else:
+                raise AirflowException('Unrecognised extension for key file.')
+
+        self.credentials = ServicePrincipalCredentials(
+            client_id=self.config_data['clientId'],
+            secret=self.config_data['clientSecret'],
+            tenant=self.config_data['tenantId']
+        )
+
+        self.subscription_id = self.config_data['subscriptionId']
+        self.client_id = self.config_data["clientId"]
+        self.client_secret = self.config_data["clientSecret"]
+        return ContainerServiceClient(self.credentials, str(self.subscription_id))
+
+    def check_resource(self, credentials, subscription_id, resource_group):
+        """
+        Check that the Azure Resource exists in the given subscription and resource group
+        """
+        resource_grp = ResourceManagementClient(credentials, subscription_id)
+        return resource_grp.resource_groups.check_existence(resource_group)
+
+    def create_resource(self, credentials, subscription_id, resource_group, location):
+        """
+        Create the AKS cluster
+        """
+        resource_grp = ResourceManagementClient(credentials, subscription_id)
+        return resource_grp.resource_groups.create_or_update(resource_group, location)

--- a/airflow/contrib/operators/azure_kubernetes_operator.py
+++ b/airflow/contrib/operators/azure_kubernetes_operator.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Operator for Azure Kubernetes Service cluster operations
+"""
+
+from azure.mgmt.containerservice.models import ContainerServiceLinuxProfile
+from azure.mgmt.containerservice.models import ContainerServiceServicePrincipalProfile
+from azure.mgmt.containerservice.models import ContainerServiceSshConfiguration
+from azure.mgmt.containerservice.models import ContainerServiceSshPublicKey
+from azure.mgmt.containerservice.models import ContainerServiceStorageProfileTypes
+from azure.mgmt.containerservice.models import ManagedCluster
+from azure.mgmt.containerservice.models import ManagedClusterAgentPoolProfile
+
+from msrestazure.azure_exceptions import CloudError
+
+from airflow.contrib.hooks.azure_kubernetes_hook import AzureKubernetesServiceHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+from airflow.contrib.utils.aks_utils import \
+    is_valid_ssh_rsa_public_key, get_poller_result, get_public_key, get_default_dns_prefix
+
+
+class AzureKubernetesOperator(BaseOperator):
+    """
+    Start a Azure Kubernetes Service
+
+    :param ci_conn_id: connection id of a
+        service principal which will be used to start the azure kubernetes service
+    :type ci_conn_id: str
+    :param resource_group: Required name of the resource group
+        wherein this container instance should be started
+    :type resource_group: str
+    :param name: Required name of this container. Please note this name
+        has to be unique in order to run containers in parallel.
+    :type name: str
+    :param ssh_key_value: the ssh value used to connect to machine to be used
+    :type ssh_key_value: str
+    :param dns_name_prefix: DNS prefix specified when creating the managed cluster.
+    :type region: dns_name_prefix
+    :param admin_username: The administrator username to use for Linux VMs.
+    :type admin_username: str
+    :param kubernetes_version: Version of Kubernetes specified when creating the managed cluster.
+    :type kubernetes_version: str
+    :param node_vm_size: Vm to be spin up.
+    :type node_vm_size: str or ContainerServiceVMSizeTypes Enum
+    :param node_osdisk_size: Size in GB to be used to specify the disk size for
+        every machine in this master/agent pool. If you specify 0, it will apply the default
+        osDisk size according to the vmSize specified.
+    :type node_osdisk_size: int
+    :param node_count: Number of agents (VMs) to host docker containers.
+        Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1.
+    :type node_count: int
+    :param no_ssh_key: Specified if it is linuxprofile.
+    :type no_ssh_key: boolean
+    :param vnet_subnet_id: VNet SubnetID specifies the vnet's subnet identifier.
+    :type vnet_subnet_id: str
+    :param max_pods: Maximum number of pods that can run on a node.
+    :type max_pods: int
+    :param os_type: OsType to be used to specify os type. Choose from Linux and Windows.
+        Default to Linux.
+    :type os_type: str or OSType Enum
+    :param tags: Resource tags.
+    :type tags: dict[str, str]
+    :param location: Required resource location
+    :type location: str
+
+    :Example:
+
+    >>> a = AzureKubernetesOperator(task_id="task",ci_conn_id='azure_kubernetes_default',
+            resource_group="my_resource_group",
+            name="my_aks_container",
+            ssh_key_value=None,
+            dns_name_prefix=None,
+            location="my_region",
+            tags=None
+        )
+    """
+
+    # Disabling pylint warnings - all of these arguments are required for cluster creation
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-arguments
+    @apply_defaults
+    def __init__(self, ci_conn_id, resource_group, name, ssh_key_value,
+                 dns_name_prefix=None,
+                 location=None,
+                 admin_username="azureuser",
+                 kubernetes_version='',
+                 node_vm_size="Standard_DS2_v2",
+                 node_osdisk_size=0,
+                 node_count=3,
+                 no_ssh_key=False,
+                 vnet_subnet_id=None,
+                 max_pods=None,
+                 os_type="Linux",
+                 tags=None,
+                 *args, **kwargs):
+
+        self.ci_conn_id = ci_conn_id
+        self.resource_group = resource_group
+        self.name = name
+        self.no_ssh_key = no_ssh_key
+        self.dns_name_prefix = dns_name_prefix
+        self.location = location
+        self.admin_username = admin_username
+        self.node_vm_size = node_vm_size
+        self.node_count = node_count
+        self.ssh_key_value = ssh_key_value
+        self.vnet_subnet_id = vnet_subnet_id
+        self.max_pods = max_pods
+        self.os_type = os_type
+        self.tags = tags
+        self.node_osdisk_size = node_osdisk_size
+        self.kubernetes_version = kubernetes_version
+
+        super(AzureKubernetesOperator, self).__init__(*args, **kwargs)
+
+    def execute(self, context):
+        ci_hook = AzureKubernetesServiceHook(self.ci_conn_id)
+
+        containerservice = ci_hook.get_conn()
+
+        if not self.no_ssh_key:
+            try:
+                if not self.ssh_key_value or not is_valid_ssh_rsa_public_key(self.ssh_key_value):
+                    raise ValueError()
+            except (TypeError, ValueError):
+                self.ssh_key_value = get_public_key()
+
+        # dns_prefix
+        if not self.dns_name_prefix:
+            self.dns_name_prefix = get_default_dns_prefix(
+                self.name, self.resource_group, ci_hook.subscription_id)
+
+        # Check if the resource group exists
+        if ci_hook.check_resource(ci_hook.credentials, ci_hook.subscription_id, self.resource_group):
+            self.log.info("Resource group already existing: %s", self.resource_group)
+        else:
+            self.log.info("Creating resource %s", self.resource_group)
+            created_resource_group = ci_hook.create_resource(
+                ci_hook.credentials, ci_hook.subscription_id, self.resource_group, {
+                    'location': self.location})
+            print("Got resource group %s", created_resource_group.name)
+
+        # Add agent_pool_profile
+        agent_pool_profile = ManagedClusterAgentPoolProfile(
+            name='nodepool1',  # Must be 12 chars or less before ACS RP adds to it
+            count=int(self.node_count),
+            vm_size=self.node_vm_size,
+            os_type=self.os_type,
+            storage_profile=ContainerServiceStorageProfileTypes.managed_disks,
+            vnet_subnet_id=self.vnet_subnet_id,
+            max_pods=int(self.max_pods) if self.max_pods else None
+        )
+
+        if self.node_osdisk_size:
+            agent_pool_profile.os_disk_size_gb = int(self.node_osdisk_size)
+
+        linux_profile = None
+
+        # LinuxProfile is just used for SSH access to VMs, so omit it if --no-ssh-key was specified.
+        if not self.no_ssh_key:
+            ssh_config = ContainerServiceSshConfiguration(
+                public_keys=[ContainerServiceSshPublicKey(key_data=self.ssh_key_value)])
+            linux_profile = ContainerServiceLinuxProfile(admin_username=self.admin_username, ssh=ssh_config)
+
+        service_profile = ContainerServiceServicePrincipalProfile(
+            client_id=ci_hook.client_id, secret=ci_hook.client_secret, key_vault_secret_ref=None)
+
+        managed_cluster = ManagedCluster(
+            location=self.location, tags=self.tags,
+            dns_prefix=self.dns_name_prefix,
+            kubernetes_version=self.kubernetes_version,
+            agent_pool_profiles=[agent_pool_profile],
+            linux_profile=linux_profile,
+            service_principal_profile=service_profile)
+
+        try:
+            self.log.info("Checking if the AKS instance %s is present", self.name)
+            response = containerservice.managed_clusters.get(self.resource_group, self.name)
+            self.log.info("AKS instance : %s found", response.name)
+            return response
+        except CloudError:
+            poller = containerservice.managed_clusters.create_or_update(
+                resource_group_name=self.resource_group, resource_name=self.name, parameters=managed_cluster)
+            response = get_poller_result(self, poller)
+            self.log.info("AKS instance created %s", self.name)
+            return response

--- a/airflow/contrib/utils/aks_utils.py
+++ b/airflow/contrib/utils/aks_utils.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Utility methods for AKS operator/hook
+"""
+
+import json
+import re
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+
+
+def is_valid_ssh_rsa_public_key(openssh_pubkey):
+    """
+    A "good enough" check is to see if the key starts with the correct header.
+    http://stackoverflow.com/questions/2494450/ssh-rsa-public-key-validation-using-a-regular-expression
+    """
+    import struct
+    try:
+        from base64 import decodebytes as base64_decode
+    except ImportError:
+        # deprecated and redirected to decodebytes in Python 3
+        from base64 import decodestring as base64_decode
+
+    parts = openssh_pubkey.split()
+    if len(parts) < 2:
+        return False
+    key_type = parts[0]
+    key_string = parts[1]
+
+    data = base64_decode(key_string.encode())  # pylint:disable=deprecated-method
+    int_len = 4
+    str_len = struct.unpack('>I', data[:int_len])[0]  # this should return 7
+    return data[int_len:int_len + str_len] == key_type.encode()
+
+
+def get_public_key():
+    """
+    Generates a public key
+    """
+    key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=2048)
+    return key.public_key().public_bytes(serialization.Encoding.OpenSSH,
+                                         serialization.PublicFormat.OpenSSH).decode('utf-8')
+
+
+def load_json(file_path):
+    """
+    Loads JSON from file_path
+    """
+    try:
+        with open(file_path) as config_file:
+            config_data = json.load(config_file)
+    except FileNotFoundError:
+        print("Error: Expecting azurermconfig.json in current folder")
+        raise
+    return config_data
+
+
+def get_poller_result(self, poller, wait=5):
+    '''
+    Consistent method of waiting on and retrieving results from Azure's long poller
+    :param poller Azure poller object
+    :return object resulting from the original request
+    '''
+    try:
+        delay = wait
+        while not poller.done():
+            self.log.info("Waiting for {0} sec".format(delay))
+            poller.wait(timeout=delay)
+        return poller.result()
+    except Exception as exc:
+        self.log.info("exception here %s", exc)
+        raise
+
+
+def get_default_dns_prefix(name, resource_group, subscription_id):
+    """
+    Use subscription id to provide uniqueness and prevent DNS name clashes
+    """
+    name_part = re.sub('[^A-Za-z0-9-]', '', name)[0:10]
+    if not name_part[0].isalpha():
+        name_part = (str('a') + name_part)[0:10]
+    resource_group_part = re.sub('[^A-Za-z0-9-]', '', resource_group)[0:16]
+    return '{}-{}-{}'.format(name_part, resource_group_part, subscription_id[0:6])

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -102,6 +102,7 @@ class Connection(Base, LoggingMixin):
         ('azure_data_lake', 'Azure Data Lake'),
         ('azure_container_instances', 'Azure Container Instances'),
         ('azure_cosmos', 'Azure CosmosDB'),
+        ('azure', 'Azure'),
         ('cassandra', 'Cassandra',),
         ('qubole', 'Qubole'),
         ('mongo', 'MongoDB'),

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -275,6 +275,10 @@ def initdb():
             extra='{"tenantId": "<TENANT>", "subscriptionId": "<SUBSCRIPTION ID>" }'))
     merge_conn(
         Connection(
+            conn_id='azure_default', conn_type='azure',
+            extra='{"key_path": "<AZURE_AUTH_LOCATION>" }'))
+    merge_conn(
+        Connection(
             conn_id='cassandra_default', conn_type='cassandra',
             host='cassandra', port=9042))
     merge_conn(

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -133,7 +133,17 @@ The AzureContainerRegistryHook requires a host/login/password to be defined in t
 :class:`airflow.contrib.hooks.azure_container_registry_hook.AzureContainerRegistryHook`
     Interface with ACR
 
+Azure Kubernetes Service
+'''''''''''''''''''''''''
+Azure Kubernetes Service (AKS) simplifies the deployment and operations of Kubernetes and enables you to dynamically scale your application infrastructure.
+The AzureKubernetesServiceHook requires a service principal. The credentials for this principal can either be defined in the extra field `key_path`, as an
+environment variable named `AIRFLOW_CONN_AZURE_DEFAULT`.
 
+:class: `airflow.contrib.operators.aks_operator.AzureKubernetesOperator`
+   Start a new AKS
+
+:class: `airflow.contrib.hooks.azure_kubernetes_hook.AzureKubernetesServiceHook`
+   Interface with Azure Kubernetes
 
 .. _AWS:
 

--- a/setup.py
+++ b/setup.py
@@ -151,6 +151,7 @@ azure = [
     'azure-datalake-store==0.0.19',
     'azure-cosmos>=3.0.1',
     'azure-mgmt-containerinstance',
+    'azure-mgmt-containerservice'
 ]
 cassandra = ['cassandra-driver>=3.13.0']
 celery = [

--- a/tests/contrib/hooks/test_azure_kubernetes_hook.py
+++ b/tests/contrib/hooks/test_azure_kubernetes_hook.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+"""
+Tests for the Azure Kubernetes Hook
+"""
+
+import json
+import unittest
+
+from unittest import mock
+from airflow import configuration
+from airflow.exceptions import AirflowException
+from airflow.models.connection import Connection
+from airflow.contrib.hooks.azure_kubernetes_hook import AzureKubernetesServiceHook
+from airflow.utils import db
+
+CONFIG_DATA = {
+    "clientId": "Id",
+    "clientSecret": "secret",
+    "subscriptionId": "subscription",
+    "tenantId": "tenant"
+}
+
+
+class TestAzureKubernetesHook(unittest.TestCase):
+    """
+    Tests for AKS Hook
+    """
+
+    def setUp(self):
+        configuration.load_test_config()
+
+        self.conn = conn = mock.MagicMock()
+        self.conn.conn_id = 'azure_default'
+        self.conn.extra_dejson = {'key_path': 'test.json'}
+        db.merge_conn(
+            Connection(
+                conn_id='azure_default',
+                extra=json.dumps({"key_path": "azureauth.json"})
+            )
+        )
+
+        class AzureKubernetesUnitHook(AzureKubernetesServiceHook):
+            """
+            Mock AKS hook
+            """
+            def get_conn(self):
+                return conn
+
+            # pylint:disable=unused-argument
+            def get_connection(self, connection_id):
+                return conn
+
+        self.test_hook = AzureKubernetesUnitHook(conn_id='azure_default')
+
+    @mock.patch('airflow.contrib.hooks.azure_kubernetes_hook.load_json')
+    def test_conn(self, mock_json):
+        """ Test Connection ID """
+        expected_connection = self.test_hook.get_conn()
+        mock_json.return_value = CONFIG_DATA
+        self.assertEqual(expected_connection.conn_id, 'azure_default')
+
+    # pylint: disable=unused-argument
+    @mock.patch('airflow.contrib.hooks.azure_kubernetes_hook.load_json')
+    @mock.patch('airflow.contrib.hooks.azure_kubernetes_hook.ServicePrincipalCredentials')
+    @mock.patch('os.environ.get', new={'AIRFLOW_CONN_AZURE_DEFAULT': 'azureauth.json'}.get, spec_set=True)
+    def test_no_conn_id(self, mock_json, mock_service):
+        """ Test without a connection id set """
+        from azure.mgmt.containerservice import ContainerServiceClient
+        mock_json.return_value = CONFIG_DATA
+        hook = AzureKubernetesServiceHook(conn_id=None)
+        self.assertEqual(hook.conn_id, None)
+        self.assertIsInstance(hook.connection, ContainerServiceClient)
+
+    @mock.patch('os.environ.get', new={'AIRFLOW_CONN_AZURE_DEFAULT': 'azureauth.jpeg'}.get, spec_set=True)
+    def test_conn_with_failures(self):
+        """ Test a failed connection """
+        with self.assertRaises(AirflowException) as ex:
+            AzureKubernetesServiceHook(conn_id=None)
+
+        self.assertEqual(str(ex.exception), "Unrecognised extension for key file.")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/contrib/operators/test_aks_operator.py
+++ b/tests/contrib/operators/test_aks_operator.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Tests for the Azure Kubernetes Operator
+"""
+
+import unittest
+
+from unittest import mock
+from msrestazure.azure_exceptions import CloudError
+from airflow.contrib.operators.azure_kubernetes_operator import AzureKubernetesOperator
+
+
+class AzureKubernetesKubernetesOperatorTest(unittest.TestCase):
+    """
+    Tests for the AKS Operator
+    """
+
+    @mock.patch('airflow.contrib.operators.azure_kubernetes_operator.AzureKubernetesServiceHook')
+    def test_execute_existing_kubernetes(self, aks_hook_mock):
+        """ Test if the AKS cluster exists """
+        aks = AzureKubernetesOperator(ci_conn_id='azure_default',
+                                      resource_group="resource_group",
+                                      name="name",
+                                      ssh_key_value=None,
+                                      dns_name_prefix=None,
+                                      location="location",
+                                      tags=None,
+                                      task_id='task')
+
+        client_hook = aks_hook_mock.return_value.get_conn.return_value
+
+        aks.execute(None)
+
+        client_hook.managed_clusters.get.assert_called_once_with('resource_group', 'name')
+        self.assertEqual(client_hook.managed_clusters.create_or_update.call_count, 0)
+
+    @mock.patch('airflow.contrib.operators.azure_kubernetes_operator.AzureKubernetesServiceHook')
+    def test_execute_create_kubernetes(self, aks_hook_mock):
+        """ Test the AKS creation """
+        aks = AzureKubernetesOperator(ci_conn_id='azure_default',
+                                      resource_group="resource_group",
+                                      name="name",
+                                      ssh_key_value=None,
+                                      dns_name_prefix=None,
+                                      location="location",
+                                      tags=None,
+                                      task_id='task')
+
+        client_hook = aks_hook_mock.return_value.get_conn.return_value
+
+        resp = mock.MagicMock()
+        resp.status_code = 404
+        resp.text = '{"Message": "The Resource Microsoft.ContainerService/managedClusters/name \
+            under resource group resource_group was not found."}'
+
+        client_hook.managed_clusters.get.side_effect = CloudError(resp, error="Not found")
+
+        aks.execute(None)
+
+        self.assertEqual(client_hook.managed_clusters.get.call_count, 1)
+        self.assertEqual(client_hook.managed_clusters.create_or_update.call_count, 1)


### PR DESCRIPTION
Add an operator to spin up azure kubernetes service. Azure Kubernetes Service is use to deploy a managed kubernetes cluster in Azure.

Operator supports creating different AKS cluster.It checks whether there is already existing cluster if not creates one. 
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3282
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
