### PR TITLE
[AIRFLOW-3709] Validate `allowed_states` for ExternalTaskSensor

### DIFF
--- a/airflow/sensors/external_task_sensor.py
+++ b/airflow/sensors/external_task_sensor.py
@@ -61,6 +61,19 @@ class ExternalTaskSensor(BaseSensorOperator):
                  **kwargs):
         super(ExternalTaskSensor, self).__init__(*args, **kwargs)
         self.allowed_states = allowed_states or [State.SUCCESS]
+        if external_task_id:
+            if not set(self.allowed_states) <= set(State.task_states):
+                raise ValueError(
+                    'Valid values for `allowed_states` '
+                    'when `external_task_id` is not `None`: {}'.format(State.task_states)
+                )
+        else:
+            if not set(self.allowed_states) <= set(State.dag_states):
+                raise ValueError(
+                    'Valid values for `allowed_states` '
+                    'when `external_task_id` is `None`: {}'.format(State.dag_states)
+                )
+
         if execution_delta is not None and execution_date_fn is not None:
             raise ValueError(
                 'Only one of `execution_date` or `execution_date_fn` may'

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -270,3 +270,22 @@ exit 0
                 allowed_states=['success'],
                 dag=self.dag
             )
+
+    def test_catch_invalid_allowed_states(self):
+        with self.assertRaises(ValueError):
+            ExternalTaskSensor(
+                task_id='test_external_task_sensor_check',
+                external_dag_id=TEST_DAG_ID,
+                external_task_id=TEST_TASK_ID,
+                allowed_states=['invalid_state'],
+                dag=self.dag
+            )
+
+        with self.assertRaises(ValueError):
+            ExternalTaskSensor(
+                task_id='test_external_task_sensor_check',
+                external_dag_id=TEST_DAG_ID,
+                external_task_id=None,
+                allowed_states=['invalid_state'],
+                dag=self.dag
+            )


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3709


### Description

In `ExternalTaskSensor`, we can specify `allowed_states`. This commit adds validation for it, so that users will not specify any invalid state (by accident).

This change works no matter the sensor waits for a DAG (available since https://github.com/apache/airflow/commit/2a8c91b392fca53fdc6f7c5008577a7ed4007de7) or a specific task.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Tests are added.
