### PR TITLE
[AIRFLOW-3629] remove abstract methods from base hook

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -141,6 +141,28 @@ class BigQueryHook(GoogleCloudBaseHook, DbApiHook, LoggingMixin):
                 return False
             raise
 
+    def bulk_dump(self, table, tmp_file):
+        """
+        Dumps a database table into a tab-delimited file
+
+        :param table: The name of the source table
+        :type table: str
+        :param tmp_file: The path of the target file
+        :type tmp_file: str
+        """
+        raise NotImplementedError()
+
+    def bulk_load(self, table, tmp_file):
+        """
+        Loads a tab-delimited file into a database table
+
+        :param table: The name of the target table
+        :type table: str
+        :param tmp_file: The path of the file to load into the table
+        :type tmp_file: str
+        """
+        raise NotImplementedError()
+
 
 class BigQueryPandasConnector(GbqConnector):
     """

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -57,7 +57,6 @@ class GoogleCloudBaseHook(BaseHook, LoggingMixin):
 
     JSON data provided in the UI: Specify 'Keyfile JSON'.
     """
-
     def __init__(self, gcp_conn_id='google_cloud_default', delegate_to=None):
         """
         :param gcp_conn_id: The connection ID to use when fetching connection info.

--- a/airflow/contrib/hooks/pinot_hook.py
+++ b/airflow/contrib/hooks/pinot_hook.py
@@ -103,3 +103,9 @@ class PinotDbApiHook(DbApiHook):
 
     def insert_rows(self, table, rows, target_fields=None, commit_every=1000):
         raise NotImplementedError()
+
+    def bulk_dump(self, table, tmp_file):
+        raise NotImplementedError()
+
+    def bulk_load(self, table, tmp_file):
+        raise NotImplementedError()

--- a/airflow/hooks/abstract_db_hook.py
+++ b/airflow/hooks/abstract_db_hook.py
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+class AbstractDbHook:
+    """
+    This class provides abstract interface for all DB-like hooks of Airflow.
+
+    Those are corresponding to the most basic API calls from python's DBAPI.
+    """
+    def get_records(self, sql, parameters=None):
+        """
+        Executes the sql and returns a set of records.
+
+        :param sql: the sql statement to be executed (str) or a list of
+            sql statements to execute
+        :type sql: str or list
+        :param parameters: The parameters to render the SQL query with.
+        :type parameters: mapping or iterable
+        """
+        raise NotImplementedError()
+
+    def get_pandas_df(self, sql, parameters=None):
+        """
+        Executes the sql and returns a pandas dataframe
+
+        :param sql: the sql statement to be executed (str) or a list of
+            sql statements to execute
+        :type sql: str or list
+        :param parameters: The parameters to render the SQL query with.
+        :type parameters: mapping or iterable
+        """
+        raise NotImplementedError()
+
+    def run(self, sql, autocommit=False, parameters=None):
+        """
+        Runs a command or a list of commands. Pass a list of sql
+        statements to the sql parameter to get them to execute
+        sequentially
+
+        :param sql: the sql statement to be executed (str) or a list of
+            sql statements to execute
+        :type sql: str or list
+        :param autocommit: What to set the connection's autocommit setting to
+            before executing the query.
+        :type autocommit: bool
+        :param parameters: The parameters to render the SQL query with.
+        :type parameters: mapping or iterable
+        """
+        raise NotImplementedError()

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -87,15 +87,3 @@ class BaseHook(LoggingMixin):
     def get_hook(cls, conn_id):
         connection = cls.get_connection(conn_id)
         return connection.get_hook()
-
-    def get_conn(self):
-        raise NotImplementedError()
-
-    def get_records(self, sql):
-        raise NotImplementedError()
-
-    def get_pandas_df(self, sql):
-        raise NotImplementedError()
-
-    def run(self, sql):
-        raise NotImplementedError()

--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -27,9 +27,10 @@ from sqlalchemy import create_engine
 
 from airflow.hooks.base_hook import BaseHook
 from airflow.exceptions import AirflowException
+from airflow.hooks.abstract_db_hook import AbstractDbHook
 
 
-class DbApiHook(BaseHook):
+class DbApiHook(BaseHook, AbstractDbHook):
     """
     Abstract base class for sql hooks.
     """

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -40,6 +40,7 @@ from airflow.security import utils
 from airflow.utils.file import TemporaryDirectory
 from airflow.utils.helpers import as_flattened_list
 from airflow.utils.operator_helpers import AIRFLOW_VAR_NAME_FORMAT_MAPPING
+from airflow.hooks.abstract_db_hook import AbstractDbHook
 
 HIVE_QUEUE_PRIORITIES = ['VERY_HIGH', 'HIGH', 'NORMAL', 'LOW', 'VERY_LOW']
 
@@ -750,13 +751,17 @@ class HiveMetastoreHook(BaseHook):
             return False
 
 
-class HiveServer2Hook(BaseHook):
+class HiveServer2Hook(BaseHook, AbstractDbHook):
     """
     Wrapper around the pyhive library
 
     Note that the default authMechanism is PLAIN, to override it you
     can specify it in the ``extra`` of your connection in the UI as in
     """
+
+    def run(self, sql):
+        raise NotImplementedError()
+
     def __init__(self, hiveserver2_conn_id='hiveserver2_default'):
         self.hiveserver2_conn_id = hiveserver2_conn_id
 

--- a/airflow/hooks/presto_hook.py
+++ b/airflow/hooks/presto_hook.py
@@ -39,7 +39,6 @@ class PrestoHook(DbApiHook):
     >>> ph.get_records(sql)
     [[340698]]
     """
-
     conn_name_attr = 'presto_conn_id'
     default_conn_name = 'presto_default'
 
@@ -138,3 +137,9 @@ class PrestoHook(DbApiHook):
         :type target_fields: iterable of strings
         """
         super(PrestoHook, self).insert_rows(table, rows, target_fields, 0)
+
+    def bulk_dump(self, table, tmp_file):
+        raise NotImplementedError()
+
+    def bulk_load(self, table, tmp_file):
+        raise NotImplementedError()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3629

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Those four abstract methods in Base Hook are removed:

get_conn()
get_records()
get_pandas_df()
run(sql)

Those methods being abstract (raising NotImplementedError) in
BaseHook are not needed.

They generate warnings in smart IDEs
(such as Pycharm/IntelliJ) but they bring no value. Not all hooks
are supposed to implement them. Seems that only hooks that have a
DB-hook-like behaviour implement most of the methods.

Having abstract DB class with those methods and having relevant
classes to inherit from them seems to make much more sense.

### Tests

- [x] My PR  does not need testing for this extremely good reason:

No new functionality. Existing tests should test it all :).

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
No new functionality

### Code Quality

- [x] Passes `flake8`
