### PR TITLE
[AIRFLOW-3706] Fix Tooltip Display Issue for Dag Run and Task

### DIFF
--- a/airflow/www_rbac/static/css/bootstrap-theme.css
+++ b/airflow/www_rbac/static/css/bootstrap-theme.css
@@ -5805,7 +5805,7 @@ button.close {
   padding: 0 5px;
 }
 .tooltip-inner {
-  max-width: 200px;
+  max-width: 500px;
   padding: 3px 8px;
   color: #ffffff;
   text-align: center;


### PR DESCRIPTION


### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3706

Tested and it does address the issue.

(I'm not really good at UI, so possibly there are better solution to this. But I believe the root-cause is this `.tooltip-inner max-width`)