### PR TITLE
[AIRFLOW-3712] Remove settings.RBAC from GCP System Tests

### DIFF
--- a/tests/contrib/utils/base_gcp_system_test_case.py
+++ b/tests/contrib/utils/base_gcp_system_test_case.py
@@ -24,7 +24,7 @@ from shutil import move
 from tempfile import mkdtemp
 
 from airflow.utils import db as db_utils
-from airflow import models, settings, AirflowException, LoggingMixin
+from airflow import models, AirflowException, LoggingMixin
 from airflow.utils.timezone import datetime
 from tests.contrib.utils.gcp_authenticator import GcpAuthenticator
 from tests.contrib.utils.run_once_decorator import run_once
@@ -244,7 +244,7 @@ You can create the database via these commands:
             self._store_dags_to_temporary_directory()
             try:
                 db_utils.upgradedb()
-                db_utils.resetdb(settings.RBAC)
+                db_utils.resetdb()
             finally:
                 self._restore_dags_from_temporary_directory()
             self._symlink_dag_and_associated_files()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3712

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Remove settings.RBAC from GCP System Tests

### Tests

- [x] My PR does not need testing for this extremely good reason. It's a test code itself :)

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
