### PR TITLE
[AIRFLOW-XXX] Fixing a typo of config

### DIFF
--- a/docs/howto/set-config.rst
+++ b/docs/howto/set-config.rst
@@ -58,7 +58,7 @@ The following config options support this ``_cmd`` version:
 
 The idea behind this is to not store passwords on boxes in plain text files.
 
-The order of precedence for all connfig options is as follows -
+The order of precedence for all config options is as follows -
 
 1. environment variable
 2. configuration in airflow.cfg


### PR DESCRIPTION
Fixing a tiny documentation typo.

connfig -> config

