### PR TITLE
[AIRFLOW-XXX] Correct Typo in sensor's exception

### DIFF
--- a/airflow/sensors/external_task_sensor.py
+++ b/airflow/sensors/external_task_sensor.py
@@ -76,7 +76,7 @@ class ExternalTaskSensor(BaseSensorOperator):
 
         if execution_delta is not None and execution_date_fn is not None:
             raise ValueError(
-                'Only one of `execution_date` or `execution_date_fn` may'
+                'Only one of `execution_delta` or `execution_date_fn` may '
                 'be provided to ExternalTaskSensor; not both.')
 
         self.execution_delta = execution_delta


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - N/A
  - I am fixing a typo in the documentation and have prepended the commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] The exception is thrown based on setting both `execution_delta` and `execution_date_fn`. It would be confusing to see a thrown message claiming different conditions.

### Tests

- [x] My PR does not need testing for this extremely good reason: Grammatical changes only.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
