### PR TITLE
AIRFLOW-3720

### DIFF
--- a/airflow/contrib/operators/gcs_to_s3.py
+++ b/airflow/contrib/operators/gcs_to_s3.py
@@ -93,6 +93,7 @@ class GoogleCloudStorageToS3Operator(GoogleCloudStorageListOperator):
     def execute(self, context):
         # use the super to list all files in an Google Cloud Storage bucket
         files = super(GoogleCloudStorageToS3Operator, self).execute(context)
+        files = filter(lambda k: not k.endswith("/"), files)
         s3_hook = S3Hook(aws_conn_id=self.dest_aws_conn_id, verify=self.dest_verify)
 
         if not self.replace:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira]
  - https://issues.apache.org/jira/browse/AIRFLOW-3720

### Description

- [ ] When comparing google storage to s3 buckets, folder names are not compared correctly

