### PR TITLE
[AIRFLOW-2843] Add flag in ExternalTaskSensor to check if external DAG/task exists

### DIFF
--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -21,7 +21,7 @@ from datetime import timedelta, time
 
 from airflow import DAG, configuration, settings
 from airflow import exceptions
-from airflow.exceptions import AirflowSensorTimeout
+from airflow.exceptions import AirflowException, AirflowSensorTimeout
 from airflow.models import TaskInstance, DagBag
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
@@ -288,4 +288,36 @@ exit 0
                 external_task_id=None,
                 allowed_states=['invalid_state'],
                 dag=self.dag
+            )
+
+    def test_external_task_sensor_waits_for_task_check_existence(self):
+        t = ExternalTaskSensor(
+            task_id='test_external_task_sensor_check',
+            external_dag_id="example_bash_operator",
+            external_task_id="non-existing-task",
+            check_existence=True,
+            dag=self.dag
+        )
+
+        with self.assertRaises(AirflowException):
+            t.run(
+                start_date=DEFAULT_DATE,
+                end_date=DEFAULT_DATE,
+                ignore_ti_state=True
+            )
+
+    def test_external_task_sensor_waits_for_dag_check_existence(self):
+        t = ExternalTaskSensor(
+            task_id='test_external_task_sensor_check',
+            external_dag_id="non-existing-dag",
+            external_task_id=None,
+            check_existence=True,
+            dag=self.dag
+        )
+
+        with self.assertRaises(AirflowException):
+            t.run(
+                start_date=DEFAULT_DATE,
+                end_date=DEFAULT_DATE,
+                ignore_ti_state=True
             )


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-2843

### Description

#### Background
`ExternalTaskSensor` will keep waiting even if the external DAG/task specified doesn't exist at all (this is making sense in some scenarios).

But it may be good to provide an option to cease waiting immediately if the external task specified doesn't exist.

#### Proposal
Provide a flag `check_existence`. Set to `True` to check if the external DAG/task exists, and immediately cease waiting if the external DAG/task does not exist.

- **Case - 1 Waiting for External DAG**: will check if the DAG exists in DB, AND whether the DAG file exists in file system
- **Case - 2 Waiting for External Task**: the check to do for DAG will happen as well. In addition, re-scan the DAG and check if this task is in the DAG.

**The default value is set to `False` (no check or ceasing will happen), so it will not affect any existing DAGs or user expectation.**


This is a follow-up on https://github.com/apache/airflow/pull/3688