### PR TITLE
[AIRFLOW-3725] Add private_key to bigquery_hook get_pandas_df

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -108,13 +108,16 @@ class BigQueryHook(GoogleCloudBaseHook, DbApiHook, LoggingMixin):
             defaults to use `self.use_legacy_sql` if not specified
         :type dialect: str in {'legacy', 'standard'}
         """
+        private_key = self._get_field('key_path', None) or self._get_field('keyfile_dict', None)
+
         if dialect is None:
             dialect = 'legacy' if self.use_legacy_sql else 'standard'
 
         return read_gbq(sql,
                         project_id=self._get_field('project'),
                         dialect=dialect,
-                        verbose=False)
+                        verbose=False,
+                        private_key=private_key)
 
     def table_exists(self, project_id, dataset_id, table_id):
         """


### PR DESCRIPTION
[AIRFLOW-3725] Bigquery Hook authentication currently defaults to Google User-account
credentials, and the user is asked to authenticate with Pandas GBQ
manually. This diff allows users to specify a private_key in either
json or key_path form, in keeping with the Google Cloud Platform
connection type.

### Tests
The following unit tests have been added:
TestPandasGbqPrivateKey.test_key_path_provided
TestPandasGbqPrivateKey.test_key_json_provided
TestPandasGbqPrivateKey.test_no_key_provided

### Code Quality
- [✓] Passes `flake8`
