### PR TITLE
[AIRFLOW-3730] Standarization use of logs mechanisms

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -44,7 +44,7 @@ from pandas_gbq.gbq import \
 from pandas_gbq.gbq import GbqConnector
 
 
-class BigQueryHook(GoogleCloudBaseHook, DbApiHook, LoggingMixin):
+class BigQueryHook(GoogleCloudBaseHook, DbApiHook):
     """
     Interact with BigQuery. This hook uses the Google Cloud Platform
     connection.

--- a/airflow/contrib/hooks/databricks_hook.py
+++ b/airflow/contrib/hooks/databricks_hook.py
@@ -26,8 +26,6 @@ from requests import exceptions as requests_exceptions
 from requests.auth import AuthBase
 from time import sleep
 
-from airflow.utils.log.logging_mixin import LoggingMixin
-
 try:
     from urllib import parse as urlparse
 except ImportError:
@@ -44,7 +42,7 @@ CANCEL_RUN_ENDPOINT = ('POST', 'api/2.0/jobs/runs/cancel')
 USER_AGENT_HEADER = {'user-agent': 'airflow-{v}'.format(v=__version__)}
 
 
-class DatabricksHook(BaseHook, LoggingMixin):
+class DatabricksHook(BaseHook):
     """
     Interact with Databricks.
     """

--- a/airflow/contrib/hooks/ftp_hook.py
+++ b/airflow/contrib/hooks/ftp_hook.py
@@ -24,8 +24,6 @@ import os.path
 from airflow.hooks.base_hook import BaseHook
 from past.builtins import basestring
 
-from airflow.utils.log.logging_mixin import LoggingMixin
-
 
 def mlsd(conn, path="", facts=None):
     """
@@ -60,7 +58,7 @@ def mlsd(conn, path="", facts=None):
         yield (name, entry)
 
 
-class FTPHook(BaseHook, LoggingMixin):
+class FTPHook(BaseHook):
     """
     Interact with FTP.
 

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -27,13 +27,12 @@ import google.oauth2.service_account
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
-from airflow.utils.log.logging_mixin import LoggingMixin
 
 
 _DEFAULT_SCOPES = ('https://www.googleapis.com/auth/cloud-platform',)
 
 
-class GoogleCloudBaseHook(BaseHook, LoggingMixin):
+class GoogleCloudBaseHook(BaseHook):
     """
     A base hook for Google cloud-related hooks. Google cloud has a shared REST
     API client that is built in the same way no matter which service you use.

--- a/airflow/contrib/hooks/jira_hook.py
+++ b/airflow/contrib/hooks/jira_hook.py
@@ -21,10 +21,9 @@ from jira.exceptions import JIRAError
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
-from airflow.utils.log.logging_mixin import LoggingMixin
 
 
-class JiraHook(BaseHook, LoggingMixin):
+class JiraHook(BaseHook):
     """
     Jira interaction hook, a Wrapper around JIRA Python SDK.
 

--- a/airflow/contrib/hooks/redis_hook.py
+++ b/airflow/contrib/hooks/redis_hook.py
@@ -22,10 +22,9 @@ RedisHook module
 """
 from redis import StrictRedis
 from airflow.hooks.base_hook import BaseHook
-from airflow.utils.log.logging_mixin import LoggingMixin
 
 
-class RedisHook(BaseHook, LoggingMixin):
+class RedisHook(BaseHook):
     """
     Wrapper for connection to interact with Redis in-memory data structure store
     """

--- a/airflow/contrib/hooks/salesforce_hook.py
+++ b/airflow/contrib/hooks/salesforce_hook.py
@@ -37,7 +37,7 @@ import time
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 
-class SalesforceHook(BaseHook, LoggingMixin):
+class SalesforceHook(BaseHook):
     def __init__(
             self,
             conn_id,

--- a/airflow/contrib/hooks/segment_hook.py
+++ b/airflow/contrib/hooks/segment_hook.py
@@ -29,10 +29,8 @@ import analytics
 from airflow.hooks.base_hook import BaseHook
 from airflow.exceptions import AirflowException
 
-from airflow.utils.log.logging_mixin import LoggingMixin
 
-
-class SegmentHook(BaseHook, LoggingMixin):
+class SegmentHook(BaseHook):
     def __init__(
             self,
             segment_conn_id='segment_default',

--- a/airflow/contrib/hooks/sftp_hook.py
+++ b/airflow/contrib/hooks/sftp_hook.py
@@ -19,7 +19,6 @@
 
 import stat
 import pysftp
-import logging
 import datetime
 from airflow.contrib.hooks.ssh_hook import SSHHook
 
@@ -181,10 +180,9 @@ class SFTPHook(SSHHook):
         :type local_full_path: str
         """
         conn = self.get_conn()
-        logging.info('Retrieving file from FTP: {}'.format(remote_full_path))
+        self.log.info('Retrieving file from FTP: %s', remote_full_path)
         conn.get(remote_full_path, local_full_path)
-        logging.info('Finished retrieving file from FTP: {}'.format(
-            remote_full_path))
+        self.log.info('Finished retrieving file from FTP: %s', remote_full_path)
 
     def store_file(self, remote_full_path, local_full_path):
         """

--- a/airflow/contrib/hooks/sqoop_hook.py
+++ b/airflow/contrib/hooks/sqoop_hook.py
@@ -25,11 +25,10 @@ import subprocess
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
-from airflow.utils.log.logging_mixin import LoggingMixin
 from copy import deepcopy
 
 
-class SqoopHook(BaseHook, LoggingMixin):
+class SqoopHook(BaseHook):
     """
     This hook is a wrapper around the sqoop 1 binary. To be able to use the hook
     it is required that "sqoop" is in the PATH.

--- a/airflow/contrib/hooks/ssh_hook.py
+++ b/airflow/contrib/hooks/ssh_hook.py
@@ -27,10 +27,9 @@ from sshtunnel import SSHTunnelForwarder
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
-from airflow.utils.log.logging_mixin import LoggingMixin
 
 
-class SSHHook(BaseHook, LoggingMixin):
+class SSHHook(BaseHook):
     """
     Hook for ssh remote execution using Paramiko.
     ref: https://github.com/paramiko/paramiko

--- a/airflow/contrib/hooks/winrm_hook.py
+++ b/airflow/contrib/hooks/winrm_hook.py
@@ -24,10 +24,9 @@ from winrm.protocol import Protocol
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
-from airflow.utils.log.logging_mixin import LoggingMixin
 
 
-class WinRMHook(BaseHook, LoggingMixin):
+class WinRMHook(BaseHook):
     """
     Hook for winrm remote execution using pywinrm.
 

--- a/airflow/contrib/operators/vertica_to_mysql.py
+++ b/airflow/contrib/operators/vertica_to_mysql.py
@@ -17,7 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import logging
 import MySQLdb
 
 from airflow.contrib.hooks.vertica_hook import VerticaHook
@@ -103,10 +102,10 @@ class VerticaToMySqlTransfer(BaseOperator):
                 if self.bulk_load:
                     tmpfile = NamedTemporaryFile("w")
 
-                    logging.info(
-                        "Selecting rows from Vertica to local file " + str(
-                            tmpfile.name) + "...")
-                    logging.info(self.sql)
+                    self.log.info(
+                        "Selecting rows from Vertica to local file %s...",
+                        tmpfile.name)
+                    self.log.info(self.sql)
 
                     csv_writer = csv.writer(tmpfile, delimiter='\t', encoding='utf-8')
                     for row in cursor.iterate():
@@ -115,21 +114,21 @@ class VerticaToMySqlTransfer(BaseOperator):
 
                     tmpfile.flush()
                 else:
-                    logging.info("Selecting rows from Vertica...")
-                    logging.info(self.sql)
+                    self.log.info("Selecting rows from Vertica...")
+                    self.log.info(self.sql)
 
                     result = cursor.fetchall()
                     count = len(result)
 
-                logging.info("Selected rows from Vertica " + str(count))
+                self.log.info("Selected rows from Vertica %s", count)
 
         if self.mysql_preoperator:
-            logging.info("Running MySQL preoperator...")
+            self.log.info("Running MySQL preoperator...")
             mysql.run(self.mysql_preoperator)
 
         try:
             if self.bulk_load:
-                logging.info("Bulk inserting rows into MySQL...")
+                self.log.info("Bulk inserting rows into MySQL...")
                 with closing(mysql.get_conn()) as conn:
                     with closing(conn.cursor()) as cursor:
                         cursor.execute("LOAD DATA LOCAL INFILE '%s' INTO "
@@ -140,17 +139,17 @@ class VerticaToMySqlTransfer(BaseOperator):
                         conn.commit()
                 tmpfile.close()
             else:
-                logging.info("Inserting rows into MySQL...")
+                self.log.info("Inserting rows into MySQL...")
                 mysql.insert_rows(table=self.mysql_table,
                                   rows=result,
                                   target_fields=selected_columns)
-            logging.info("Inserted rows into MySQL " + str(count))
+            self.log.info("Inserted rows into MySQL %s", count)
         except (MySQLdb.Error, MySQLdb.Warning):
-            logging.error("Inserted rows into MySQL 0")
+            self.log.info("Inserted rows into MySQL 0")
             raise
 
         if self.mysql_postoperator:
-            logging.info("Running MySQL postoperator...")
+            self.log.info("Running MySQL postoperator...")
             mysql.run(self.mysql_postoperator)
 
-        logging.info("Done")
+        self.log.info("Done")

--- a/airflow/contrib/sensors/sftp_sensor.py
+++ b/airflow/contrib/sensors/sftp_sensor.py
@@ -17,7 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import logging
 from paramiko import SFTP_NO_SUCH_FILE
 from airflow.contrib.hooks.sftp_hook import SFTPHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
@@ -42,7 +41,7 @@ class SFTPSensor(BaseSensorOperator):
         self.hook = SFTPHook(sftp_conn_id)
 
     def poke(self, context):
-        logging.info('Poking for %s', self.path)
+        self.log.info('Poking for %s', self.path)
         try:
             self.hook.get_mod_time(self.path)
         except IOError as e:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3730
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

Some operators did not use the logging mechanism from Airflow, but used the Python mechanism.
Some operators extend the 'LoggingMixin' class when it is not needed.
This change standardizes these changes.

### Tests

I'm not introducing new changes. Only rewrites the code.

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
