### PR TITLE
[AIRFLOW-1262] Add missing doc for email configuration

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -660,9 +660,37 @@ Service Level Agreements, or time by which a task or DAG should have
 succeeded, can be set at a task level as a ``timedelta``. If
 one or many instances have not succeeded by that time, an alert email is sent
 detailing the list of tasks that missed their SLA. The event is also recorded
-in the database and made available in the web UI under ``Browse->Missed SLAs``
+in the database and made available in the web UI under ``Browse->SLA Misses``
 where events can be analyzed and documented.
 
+Email Configuration
+-------------------
+
+You can configure the email that is being sent in your ``airflow.cfg``
+by setting a ``subject_template`` and/or a ``html_content_template``
+in the ``email`` section.
+
+.. code::
+
+  [email]
+
+  email_backend = airflow.utils.email.send_email_smtp
+
+  subject_template = /path/to/my_subject_template_file
+  html_content_template = /path/to/my_html_content_template_file
+
+To access the task's information you use `Jinja Templating <http://jinja.pocoo.org/docs/dev/>`_  in your template files.
+
+For example a ``html_content_template`` file could look like this:
+
+.. code::
+
+  Try {{try_number}} out of {{max_tries + 1}}<br>
+  Exception:<br>{{exception_html}}<br>
+  Log: <a href="{{ti.log_url}}">Link</a><br>
+  Host: {{ti.hostname}}<br>
+  Log file: {{ti.log_filepath}}<br>
+  Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>
 
 Trigger Rules
 =============


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-1262
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds documentation for https://github.com/apache/airflow/pull/2338 about how to use email configuration for email alerts.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
