### PR TITLE
[AIRFLOW-3732] Fix issue when editing connection in RBAC UI

### DIFF
--- a/airflow/www/templates/airflow/conn_edit.html
+++ b/airflow/www/templates/airflow/conn_edit.html
@@ -19,5 +19,5 @@
 
 {% block tail %}
   {{ super() }}
-    <script src="{{ url_for_asset('static', filename='connectionForm.js') }}"></script>
+    <script src="{{ url_for_asset(filename='connectionForm.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3732


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Error:
```

                          ____/ (  (    )   )  \___
                         /( (  (  )   _    ))  )   )\
                       ((     (   )(    )  )   (   )  )
                     ((/  ( _(   )   (   _) ) (  () )  )
                    ( (  ( (_)   ((    (   )  .((_ ) .  )_
                   ( (  )    (      (  )    )   ) . ) (   )
                  (  (   (  (   ) (  _  ( _) ).  ) . ) ) ( )
                  ( (  (   ) (  )   (  ))     ) _)(   )  )  )
                 ( (  ( \ ) (    (_  ( ) ( )  )   ) )  )) ( )
                  (  (   (  (   (_ ( ) ( _    )  ) (  )  )   )
                 ( (  ( (  (  )     (_  )  ) )  _)   ) _( ( )
                  ((  (   )(    (     _    )   _) _(_ (  (_ )
                   (_((__(_(__(( ( ( |  ) ) ) )_))__))_)___)
                   ((__)        \\||lll|l||///          \_))
                            (   /(/ (  )  ) )\   )
                          (    ( ( ( | | ) ) )\   )
                           (   /(| / ( )) ) ) )) )
                         (     ( ((((_(|)_)))))     )
                          (      ||\(|(|)|/||     )
                        (        |(||(||)||||        )
                          (     //|/l|||)|\\ \     )
                        (/ / //  /|//||||\\  \ \  \ _)
-------------------------------------------------------------------------------
Node: Kaxils-MacBook-Pro.local
-------------------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/flask_appbuilder/security/decorators.py", line 26, in wraps
    return f(self, *args, **kwargs)
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/flask_appbuilder/views.py", line 531, in edit
    related_views=self._related_views)
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/flask_appbuilder/baseviews.py", line 160, in render_template
    return render_template(template, **dict(list(kwargs.items()) + list(self.extra_args.items())))
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/flask/templating.py", line 134, in render_template
    context, ctx.app)
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/flask/templating.py", line 116, in _render
    rv = template.render(context)
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/airflow/www_rbac/templates/airflow/conn_edit.html", line 18, in top-level template code
    {% extends 'appbuilder/general/model/edit.html' %}
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/flask_appbuilder/templates/appbuilder/general/model/edit.html", line 2, in top-level template code
    {% import 'appbuilder/general/lib.html' as lib %}
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/flask_appbuilder/templates/appbuilder/base.html", line 1, in top-level template code
    {% extends base_template %}
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/airflow/www_rbac/templates/appbuilder/baselayout.html", line 19, in top-level template code
    {% import 'appbuilder/baselib.html' as baselib %}
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/flask_appbuilder/templates/appbuilder/init.html", line 60, in top-level template code
    {% block tail %}
  File "/Users/kaxil/.virtualenvs/airflow_1.10.2rc2/lib/python2.7/site-packages/airflow/www_rbac/templates/airflow/conn_edit.html", line 22, in block "tail"
    <script src="{{ url_for_asset('static', filename='connectionForm.js') }}"></script>
TypeError: get_asset_url() got multiple values for keyword argument 'filename'
```
![image](https://user-images.githubusercontent.com/8811558/51428899-47672d80-1c01-11e9-9fda-8ee428e1c20e.png)
![image](https://user-images.githubusercontent.com/8811558/51428903-4cc47800-1c01-11e9-8b66-2f9bb9142331.png)


### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
