### PR TITLE
[AIRFLOW-3744] Abandon the use of obsolete aliases of methods

### DIFF
--- a/tests/api/common/experimental/test_trigger_dag.py
+++ b/tests/api/common/experimental/test_trigger_dag.py
@@ -106,7 +106,7 @@ class TriggerDagTests(unittest.TestCase):
             execution_date=None,
             replace_microseconds=True)
 
-        self.assertEquals(triggers[0].conf, json.loads(conf))
+        self.assertEqual(triggers[0].conf, json.loads(conf))
 
     @mock.patch('airflow.models.DagBag')
     def test_trigger_dag_with_dict_conf(self, dag_bag_mock):
@@ -125,7 +125,7 @@ class TriggerDagTests(unittest.TestCase):
             execution_date=None,
             replace_microseconds=True)
 
-        self.assertEquals(triggers[0].conf, conf)
+        self.assertEqual(triggers[0].conf, conf)
 
 
 if __name__ == '__main__':

--- a/tests/cli/test_worker_initialisation.py
+++ b/tests/cli/test_worker_initialisation.py
@@ -70,4 +70,4 @@ class TestWorkerPrecheck(unittest.TestCase):
         """
         mock_getboolean.return_value = True
         mock_session.side_effect = sqlalchemy.exc.OperationalError("m1", "m2", "m3", "m4")
-        self.assertEquals(airflow.settings.validate_session(), False)
+        self.assertEqual(airflow.settings.validate_session(), False)

--- a/tests/contrib/executors/test_kubernetes_executor.py
+++ b/tests/contrib/executors/test_kubernetes_executor.py
@@ -84,7 +84,7 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
         new_datetime_obj = AirflowKubernetesScheduler._label_safe_datestring_to_datetime(
             serialized_datetime)
 
-        self.assertEquals(datetime_obj, new_datetime_obj)
+        self.assertEqual(datetime_obj, new_datetime_obj)
 
 
 class TestKubernetesWorkerConfiguration(unittest.TestCase):

--- a/tests/contrib/hooks/test_aws_firehose_hook.py
+++ b/tests/contrib/hooks/test_aws_firehose_hook.py
@@ -57,7 +57,7 @@ class TestAwsFirehoseHook(unittest.TestCase):
         )
 
         stream_arn = response['DeliveryStreamARN']
-        self.assertEquals(
+        self.assertEqual(
             stream_arn, "arn:aws:firehose:us-east-1:123456789012:deliverystream/test_airflow")
 
         records = [{"Data": str(uuid.uuid4())}
@@ -65,8 +65,8 @@ class TestAwsFirehoseHook(unittest.TestCase):
 
         response = hook.put_records(records)
 
-        self.assertEquals(response['FailedPutCount'], 0)
-        self.assertEquals(response['ResponseMetadata']['HTTPStatusCode'], 200)
+        self.assertEqual(response['FailedPutCount'], 0)
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
 
 
 if __name__ == '__main__':

--- a/tests/contrib/hooks/test_aws_glue_catalog_hook.py
+++ b/tests/contrib/hooks/test_aws_glue_catalog_hook.py
@@ -43,12 +43,12 @@ class TestAwsGlueCatalogHook(unittest.TestCase):
     @mock_glue
     def test_conn_id(self):
         hook = AwsGlueCatalogHook(aws_conn_id='my_aws_conn_id', region_name="us-east-1")
-        self.assertEquals(hook.aws_conn_id, 'my_aws_conn_id')
+        self.assertEqual(hook.aws_conn_id, 'my_aws_conn_id')
 
     @mock_glue
     def test_region(self):
         hook = AwsGlueCatalogHook(region_name="us-west-2")
-        self.assertEquals(hook.region_name, 'us-west-2')
+        self.assertEqual(hook.region_name, 'us-west-2')
 
     @mock_glue
     @mock.patch.object(AwsGlueCatalogHook, 'get_conn')
@@ -57,7 +57,7 @@ class TestAwsGlueCatalogHook(unittest.TestCase):
         mock_get_conn.get_paginator.paginate.return_value = response
         hook = AwsGlueCatalogHook(region_name="us-east-1")
 
-        self.assertEquals(hook.get_partitions('db', 'tbl'), set())
+        self.assertEqual(hook.get_partitions('db', 'tbl'), set())
 
     @mock_glue
     @mock.patch.object(AwsGlueCatalogHook, 'get_conn')
@@ -79,7 +79,7 @@ class TestAwsGlueCatalogHook(unittest.TestCase):
                                      page_size=2,
                                      max_items=3)
 
-        self.assertEquals(result, set([('2015-01-01',)]))
+        self.assertEqual(result, set([('2015-01-01',)]))
         mock_conn.get_paginator.assert_called_once_with('get_partitions')
         mock_paginator.paginate.assert_called_once_with(DatabaseName='db',
                                                         TableName='tbl',

--- a/tests/contrib/hooks/test_aws_lambda_hook.py
+++ b/tests/contrib/hooks/test_aws_lambda_hook.py
@@ -78,7 +78,7 @@ def lambda_handler(event, context):
         input = {'hello': 'airflow'}
         response = hook.invoke_lambda(payload=json.dumps(input))
 
-        self.assertEquals(response["StatusCode"], 202)
+        self.assertEqual(response["StatusCode"], 202)
 
 
 if __name__ == '__main__':

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -715,7 +715,7 @@ class TestBigQueryHookLocation(unittest.TestCase):
             self.assertIsNone(bq_cursor.location)
             bq_cursor.run_query(sql='select 1', location='US')
             run_with_config.assert_called_once()
-            self.assertEquals(bq_cursor.location, 'US')
+            self.assertEqual(bq_cursor.location, 'US')
 
 
 if __name__ == '__main__':

--- a/tests/contrib/hooks/test_databricks_hook.py
+++ b/tests/contrib/hooks/test_databricks_hook.py
@@ -180,11 +180,11 @@ class DatabricksHookTest(unittest.TestCase):
 
     def test_parse_host_with_proper_host(self):
         host = self.hook._parse_host(HOST)
-        self.assertEquals(host, HOST)
+        self.assertEqual(host, HOST)
 
     def test_parse_host_with_scheme(self):
         host = self.hook._parse_host(HOST_WITH_SCHEME)
-        self.assertEquals(host, HOST)
+        self.assertEqual(host, HOST)
 
     def test_init_bad_retry_limit(self):
         with self.assertRaises(ValueError):
@@ -203,7 +203,7 @@ class DatabricksHookTest(unittest.TestCase):
                     with self.assertRaises(AirflowException):
                         self.hook._do_api_call(SUBMIT_RUN_ENDPOINT, {})
 
-                    self.assertEquals(mock_errors.call_count, self.hook.retry_limit)
+                    self.assertEqual(mock_errors.call_count, self.hook.retry_limit)
 
     @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
     def test_do_api_call_does_not_retry_with_non_retryable_error(self, mock_requests):
@@ -234,8 +234,8 @@ class DatabricksHookTest(unittest.TestCase):
 
                     response = self.hook._do_api_call(SUBMIT_RUN_ENDPOINT, {})
 
-                    self.assertEquals(mock_errors.call_count, 2)
-                    self.assertEquals(response, {'run_id': '1'})
+                    self.assertEqual(mock_errors.call_count, 2)
+                    self.assertEqual(response, {'run_id': '1'})
 
     @mock.patch('airflow.contrib.hooks.databricks_hook.sleep')
     def test_do_api_call_waits_between_retries(self, mock_sleep):
@@ -255,7 +255,7 @@ class DatabricksHookTest(unittest.TestCase):
                     with self.assertRaises(AirflowException):
                         self.hook._do_api_call(SUBMIT_RUN_ENDPOINT, {})
 
-                    self.assertEquals(len(mock_sleep.mock_calls), self.hook.retry_limit - 1)
+                    self.assertEqual(len(mock_sleep.mock_calls), self.hook.retry_limit - 1)
                     mock_sleep.assert_called_with(retry_delay)
 
     @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
@@ -267,7 +267,7 @@ class DatabricksHookTest(unittest.TestCase):
         }
         run_id = self.hook.submit_run(json)
 
-        self.assertEquals(run_id, '1')
+        self.assertEqual(run_id, '1')
         mock_requests.post.assert_called_once_with(
             submit_run_endpoint(HOST),
             json={
@@ -291,7 +291,7 @@ class DatabricksHookTest(unittest.TestCase):
         }
         run_id = self.hook.run_now(json)
 
-        self.assertEquals(run_id, '1')
+        self.assertEqual(run_id, '1')
 
         mock_requests.post.assert_called_once_with(
             run_now_endpoint(HOST),
@@ -310,7 +310,7 @@ class DatabricksHookTest(unittest.TestCase):
 
         run_page_url = self.hook.get_run_page_url(RUN_ID)
 
-        self.assertEquals(run_page_url, RUN_PAGE_URL)
+        self.assertEqual(run_page_url, RUN_PAGE_URL)
         mock_requests.get.assert_called_once_with(
             get_run_endpoint(HOST),
             json={'run_id': RUN_ID},
@@ -324,7 +324,7 @@ class DatabricksHookTest(unittest.TestCase):
 
         run_state = self.hook.get_run_state(RUN_ID)
 
-        self.assertEquals(run_state, RunState(
+        self.assertEqual(run_state, RunState(
             LIFE_CYCLE_STATE,
             RESULT_STATE,
             STATE_MESSAGE))
@@ -424,10 +424,10 @@ class DatabricksHookTokenTest(unittest.TestCase):
         }
         run_id = self.hook.submit_run(json)
 
-        self.assertEquals(run_id, '1')
+        self.assertEqual(run_id, '1')
         args = mock_requests.post.call_args
         kwargs = args[1]
-        self.assertEquals(kwargs['auth'].token, TOKEN)
+        self.assertEqual(kwargs['auth'].token, TOKEN)
 
 
 class RunStateTest(unittest.TestCase):

--- a/tests/contrib/hooks/test_gcp_bigtable_hook.py
+++ b/tests/contrib/hooks/test_gcp_bigtable_hook.py
@@ -133,7 +133,7 @@ class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
             main_cluster_zone=CBT_ZONE)
         get_client.assert_called_once_with(project_id='example-project')
         instance_create.assert_called_once_with(clusters=mock.ANY)
-        self.assertEquals(res.instance_id, 'instance')
+        self.assertEqual(res.instance_id, 'instance')
 
     @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
     def test_delete_table_missing_project_id(self, get_client):
@@ -263,7 +263,7 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
             main_cluster_zone=CBT_ZONE)
         get_client.assert_called_once_with(project_id='example-project')
         instance_create.assert_called_once_with(clusters=mock.ANY)
-        self.assertEquals(res.instance_id, 'instance')
+        self.assertEqual(res.instance_id, 'instance')
 
     @mock.patch('google.cloud.bigtable.instance.Instance.create')
     @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
@@ -278,7 +278,7 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
             main_cluster_zone=CBT_ZONE)
         get_client.assert_called_once_with(project_id='new-project')
         instance_create.assert_called_once_with(clusters=mock.ANY)
-        self.assertEquals(res.instance_id, 'instance')
+        self.assertEqual(res.instance_id, 'instance')
 
     @mock.patch('airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook._get_client')
     def test_delete_table(self, get_client):

--- a/tests/contrib/hooks/test_gcp_container_hook.py
+++ b/tests/contrib/hooks/test_gcp_container_hook.py
@@ -161,7 +161,7 @@ class GKEClusterHookCreateTest(unittest.TestCase):
 
         self.gke_hook.create_cluster({})
         wait_mock.assert_not_called()
-        self.assertEquals(convert_mock.call_count, 1)
+        self.assertEqual(convert_mock.call_count, 1)
         log_mock.info.assert_any_call("Assuming Success: " + message)
 
 

--- a/tests/contrib/hooks/test_gcp_dataflow_hook.py
+++ b/tests/contrib/hooks/test_gcp_dataflow_hook.py
@@ -180,7 +180,7 @@ class DataFlowHookTest(unittest.TestCase):
             job_name=JOB_NAME, append_job_name=False
         )
 
-        self.assertEquals(job_name, JOB_NAME)
+        self.assertEqual(job_name, JOB_NAME)
 
     def test_fix_underscore_in_job_name(self):
         job_name_with_underscore = 'test_example'
@@ -191,7 +191,7 @@ class DataFlowHookTest(unittest.TestCase):
             job_name=job_name_with_underscore, append_job_name=False
         )
 
-        self.assertEquals(job_name, fixed_job_name)
+        self.assertEqual(job_name, fixed_job_name)
 
     def test_invalid_dataflow_job_name(self):
         invalid_job_name = '9test_invalid_name'
@@ -208,19 +208,19 @@ class DataFlowHookTest(unittest.TestCase):
 
     def test_dataflow_job_regex_check(self):
 
-        self.assertEquals(self.dataflow_hook._build_dataflow_job_name(
+        self.assertEqual(self.dataflow_hook._build_dataflow_job_name(
             job_name='df-job-1', append_job_name=False
         ), 'df-job-1')
 
-        self.assertEquals(self.dataflow_hook._build_dataflow_job_name(
+        self.assertEqual(self.dataflow_hook._build_dataflow_job_name(
             job_name='df-job', append_job_name=False
         ), 'df-job')
 
-        self.assertEquals(self.dataflow_hook._build_dataflow_job_name(
+        self.assertEqual(self.dataflow_hook._build_dataflow_job_name(
             job_name='dfjob', append_job_name=False
         ), 'dfjob')
 
-        self.assertEquals(self.dataflow_hook._build_dataflow_job_name(
+        self.assertEqual(self.dataflow_hook._build_dataflow_job_name(
             job_name='dfjob1', append_job_name=False
         ), 'dfjob1')
 

--- a/tests/contrib/hooks/test_gcp_function_hook.py
+++ b/tests/contrib/hooks/test_gcp_function_hook.py
@@ -118,7 +118,7 @@ class TestFunctionHookNoDefaultProjectId(unittest.TestCase):
                 location=GCF_LOCATION,
                 zip_path="/tmp/path.zip"
             )
-            self.assertEquals("http://uploadHere", res)
+            self.assertEqual("http://uploadHere", res)
             generate_upload_url_method.assert_called_with(
                 parent='projects/example-project/locations/location')
             execute_method.assert_called_once_with(num_retries=5)
@@ -183,7 +183,7 @@ class TestFunctionHookDefaultProjectId(unittest.TestCase):
             name=GCF_FUNCTION
         )
         self.assertIsNotNone(res)
-        self.assertEquals('function', res['name'])
+        self.assertEqual('function', res['name'])
         get_method.assert_called_once_with(name='function')
         execute_method.assert_called_once_with(num_retries=5)
 
@@ -238,7 +238,7 @@ class TestFunctionHookDefaultProjectId(unittest.TestCase):
                 location=GCF_LOCATION,
                 zip_path="/tmp/path.zip"
             )
-            self.assertEquals("http://uploadHere", res)
+            self.assertEqual("http://uploadHere", res)
             generate_upload_url_method.assert_called_with(
                 parent='projects/example-project/locations/location')
             execute_method.assert_called_once_with(num_retries=5)
@@ -264,7 +264,7 @@ class TestFunctionHookDefaultProjectId(unittest.TestCase):
                 location=GCF_LOCATION,
                 zip_path="/tmp/path.zip"
             )
-            self.assertEquals("http://uploadHere", res)
+            self.assertEqual("http://uploadHere", res)
             generate_upload_url_method.assert_called_with(
                 parent='projects/new-project/locations/location')
             execute_method.assert_called_once_with(num_retries=5)

--- a/tests/contrib/hooks/test_gcp_mlengine_hook.py
+++ b/tests/contrib/hooks/test_gcp_mlengine_hook.py
@@ -90,7 +90,7 @@ class _TestMLEngineHook(object):
         # Propogating exceptions here since assert will silence them.
         if any(args):
             return None
-        self._test_cls.assertEquals(
+        self._test_cls.assertEqual(
             [self._normalize_requests_for_comparison(x[0], x[1], x[2])
                 for x in self._actual_requests],
             self._expected_requests)
@@ -132,7 +132,7 @@ class TestMLEngineHook(unittest.TestCase):
             create_version_response = cml_hook.create_version(
                 project_id=project, model_name=model_name,
                 version_spec=version)
-            self.assertEquals(create_version_response, response_body)
+            self.assertEqual(create_version_response, response_body)
 
     @_SKIP_IF
     def test_set_default_version(self):
@@ -158,7 +158,7 @@ class TestMLEngineHook(unittest.TestCase):
             set_default_version_response = cml_hook.set_default_version(
                 project_id=project, model_name=model_name,
                 version_name=version)
-            self.assertEquals(set_default_version_response, response_body)
+            self.assertEqual(set_default_version_response, response_body)
 
     @_SKIP_IF
     def test_list_versions(self):
@@ -196,7 +196,7 @@ class TestMLEngineHook(unittest.TestCase):
                 expected_requests=expected_requests) as cml_hook:
             list_versions_response = cml_hook.list_versions(
                 project_id=project, model_name=model_name)
-            self.assertEquals(list_versions_response, versions)
+            self.assertEqual(list_versions_response, versions)
 
     @_SKIP_IF
     def test_delete_version(self):
@@ -230,7 +230,7 @@ class TestMLEngineHook(unittest.TestCase):
             delete_version_response = cml_hook.delete_version(
                 project_id=project, model_name=model_name,
                 version_name=version)
-            self.assertEquals(delete_version_response, done_response_body)
+            self.assertEqual(delete_version_response, done_response_body)
 
     @_SKIP_IF
     def test_create_model(self):
@@ -254,7 +254,7 @@ class TestMLEngineHook(unittest.TestCase):
                 expected_requests=expected_requests) as cml_hook:
             create_model_response = cml_hook.create_model(
                 project_id=project, model=model)
-            self.assertEquals(create_model_response, response_body)
+            self.assertEqual(create_model_response, response_body)
 
     @_SKIP_IF
     def test_get_model(self):
@@ -275,7 +275,7 @@ class TestMLEngineHook(unittest.TestCase):
                 expected_requests=expected_requests) as cml_hook:
             get_model_response = cml_hook.get_model(
                 project_id=project, model_name=model_name)
-            self.assertEquals(get_model_response, response_body)
+            self.assertEqual(get_model_response, response_body)
 
     @_SKIP_IF
     def test_create_mlengine_job(self):
@@ -311,7 +311,7 @@ class TestMLEngineHook(unittest.TestCase):
                 expected_requests=expected_requests) as cml_hook:
             create_job_response = cml_hook.create_job(
                 project_id=project, job=my_job)
-            self.assertEquals(create_job_response, my_job)
+            self.assertEqual(create_job_response, my_job)
 
     @_SKIP_IF
     def test_create_mlengine_job_reuse_existing_job_by_default(self):
@@ -343,7 +343,7 @@ class TestMLEngineHook(unittest.TestCase):
                 expected_requests=expected_requests) as cml_hook:
             create_job_response = cml_hook.create_job(
                 project_id=project, job=my_job)
-            self.assertEquals(create_job_response, my_job)
+            self.assertEqual(create_job_response, my_job)
 
     @_SKIP_IF
     def test_create_mlengine_job_check_existing_job(self):
@@ -414,7 +414,7 @@ class TestMLEngineHook(unittest.TestCase):
             create_job_response = cml_hook.create_job(
                 project_id=project, job=my_job,
                 use_existing_job_fn=check_input)
-            self.assertEquals(create_job_response, my_job)
+            self.assertEqual(create_job_response, my_job)
 
 
 if __name__ == '__main__':

--- a/tests/contrib/hooks/test_gcp_pubsub_hook.py
+++ b/tests/contrib/hooks/test_gcp_pubsub_hook.py
@@ -93,8 +93,8 @@ class PubSubHookTest(unittest.TestCase):
         with self.assertRaises(PubSubException) as e:
             self.pubsub_hook.delete_topic(TEST_PROJECT, TEST_TOPIC, True)
 
-        self.assertEquals(str(e.exception),
-                          'Topic does not exist: %s' % EXPANDED_TOPIC)
+        self.assertEqual(str(e.exception),
+                         'Topic does not exist: %s' % EXPANDED_TOPIC)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
     def test_create_preexisting_topic_failifexists(self, mock_service):
@@ -104,8 +104,8 @@ class PubSubHookTest(unittest.TestCase):
 
         with self.assertRaises(PubSubException) as e:
             self.pubsub_hook.create_topic(TEST_PROJECT, TEST_TOPIC, True)
-        self.assertEquals(str(e.exception),
-                          'Topic already exists: %s' % EXPANDED_TOPIC)
+        self.assertEqual(str(e.exception),
+                         'Topic already exists: %s' % EXPANDED_TOPIC)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
     def test_create_preexisting_topic_nofailifexists(self, mock_service):
@@ -130,7 +130,7 @@ class PubSubHookTest(unittest.TestCase):
         create_method.assert_called_with(name=EXPANDED_SUBSCRIPTION,
                                          body=expected_body)
         create_method.return_value.execute.assert_called_with()
-        self.assertEquals(TEST_SUBSCRIPTION, response)
+        self.assertEqual(TEST_SUBSCRIPTION, response)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
     def test_create_subscription_different_project_topic(self, mock_service):
@@ -150,7 +150,7 @@ class PubSubHookTest(unittest.TestCase):
         create_method.assert_called_with(name=expected_subscription,
                                          body=expected_body)
         create_method.return_value.execute.assert_called_with()
-        self.assertEquals(TEST_SUBSCRIPTION, response)
+        self.assertEqual(TEST_SUBSCRIPTION, response)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
     def test_delete_subscription(self, mock_service):
@@ -172,9 +172,9 @@ class PubSubHookTest(unittest.TestCase):
             self.pubsub_hook.delete_subscription(
                 TEST_PROJECT, TEST_SUBSCRIPTION, fail_if_not_exists=True)
 
-        self.assertEquals(str(e.exception),
-                          'Subscription does not exist: %s' %
-                          EXPANDED_SUBSCRIPTION)
+        self.assertEqual(str(e.exception),
+                         'Subscription does not exist: %s' %
+                         EXPANDED_SUBSCRIPTION)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
     @mock.patch(PUBSUB_STRING.format('uuid4'),
@@ -194,7 +194,7 @@ class PubSubHookTest(unittest.TestCase):
         create_method.assert_called_with(name=expected_name,
                                          body=expected_body)
         create_method.return_value.execute.assert_called_with()
-        self.assertEquals('sub-%s' % TEST_UUID, response)
+        self.assertEqual('sub-%s' % TEST_UUID, response)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
     def test_create_subscription_with_ack_deadline(self, mock_service):
@@ -211,7 +211,7 @@ class PubSubHookTest(unittest.TestCase):
         create_method.assert_called_with(name=EXPANDED_SUBSCRIPTION,
                                          body=expected_body)
         create_method.return_value.execute.assert_called_with()
-        self.assertEquals(TEST_SUBSCRIPTION, response)
+        self.assertEqual(TEST_SUBSCRIPTION, response)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
     def test_create_subscription_failifexists(self, mock_service):
@@ -225,9 +225,9 @@ class PubSubHookTest(unittest.TestCase):
                 TEST_PROJECT, TEST_TOPIC, TEST_SUBSCRIPTION,
                 fail_if_exists=True)
 
-        self.assertEquals(str(e.exception),
-                          'Subscription already exists: %s' %
-                          EXPANDED_SUBSCRIPTION)
+        self.assertEqual(str(e.exception),
+                         'Subscription already exists: %s' %
+                         EXPANDED_SUBSCRIPTION)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
     def test_create_subscription_nofailifexists(self, mock_service):
@@ -238,7 +238,7 @@ class PubSubHookTest(unittest.TestCase):
         response = self.pubsub_hook.create_subscription(
             TEST_PROJECT, TEST_TOPIC, TEST_SUBSCRIPTION
         )
-        self.assertEquals(TEST_SUBSCRIPTION, response)
+        self.assertEqual(TEST_SUBSCRIPTION, response)
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))
     def test_publish(self, mock_service):

--- a/tests/contrib/hooks/test_gcp_sql_hook.py
+++ b/tests/contrib/hooks/test_gcp_sql_hook.py
@@ -145,7 +145,7 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
         res = self.cloudsql_hook.get_instance(
             instance='instance')
         self.assertIsNotNone(res)
-        self.assertEquals('instance', res['name'])
+        self.assertEqual('instance', res['name'])
         get_method.assert_called_once_with(instance='instance', project='example-project')
         execute_method.assert_called_once_with(num_retries=5)
         wait_for_operation_to_complete.assert_not_called()
@@ -161,7 +161,7 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
             project_id='new-project',
             instance='instance')
         self.assertIsNotNone(res)
-        self.assertEquals('instance', res['name'])
+        self.assertEqual('instance', res['name'])
         get_method.assert_called_once_with(instance='instance', project='new-project')
         execute_method.assert_called_once_with(num_retries=5)
         wait_for_operation_to_complete.assert_not_called()
@@ -278,7 +278,7 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
             database='database',
             instance='instance')
         self.assertIsNotNone(res)
-        self.assertEquals('database', res['name'])
+        self.assertEqual('database', res['name'])
         get_method.assert_called_once_with(instance='instance',
                                            database='database',
                                            project='example-project')
@@ -297,7 +297,7 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
             database='database',
             instance='instance')
         self.assertIsNotNone(res)
-        self.assertEquals('database', res['name'])
+        self.assertEqual('database', res['name'])
         get_method.assert_called_once_with(instance='instance',
                                            database='database',
                                            project='new-project')
@@ -507,7 +507,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
             project_id='example-project',
             instance='instance')
         self.assertIsNotNone(res)
-        self.assertEquals('instance', res['name'])
+        self.assertEqual('instance', res['name'])
         get_method.assert_called_once_with(instance='instance', project='example-project')
         execute_method.assert_called_once_with(num_retries=5)
         wait_for_operation_to_complete.assert_not_called()
@@ -641,7 +641,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
             database='database',
             instance='instance')
         self.assertIsNotNone(res)
-        self.assertEquals('database', res['name'])
+        self.assertEqual('database', res['name'])
         get_method.assert_called_once_with(instance='instance',
                                            database='database',
                                            project='example-project')

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -207,7 +207,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
                                destination_bucket=destination_bucket,
                                destination_object=destination_object)
 
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             'Either source/destination bucket or source/destination object '
             'must be different, not both the same: bucket=%s, object=%s' %
@@ -227,7 +227,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
                                destination_bucket=destination_bucket,
                                destination_object=destination_object)
 
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             'source_bucket and source_object cannot be empty.'
         )
@@ -245,7 +245,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
                                destination_bucket=destination_bucket,
                                destination_object=destination_object)
 
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             'source_bucket and source_object cannot be empty.'
         )

--- a/tests/contrib/hooks/test_imap_hook.py
+++ b/tests/contrib/hooks/test_imap_hook.py
@@ -125,7 +125,7 @@ class TestImapHook(unittest.TestCase):
         with ImapHook() as imap_hook:
             attachments_in_inbox = imap_hook.retrieve_mail_attachments('test1.csv')
 
-        self.assertEquals(attachments_in_inbox, [('test1.csv', b'SWQsTmFtZQoxLEZlbGl4')])
+        self.assertEqual(attachments_in_inbox, [('test1.csv', b'SWQsTmFtZQoxLEZlbGl4')])
 
     @patch(imaplib_string)
     def test_retrieve_mail_attachments_not_found(self, mock_imaplib):
@@ -134,7 +134,7 @@ class TestImapHook(unittest.TestCase):
         with ImapHook() as imap_hook:
             attachments_in_inbox = imap_hook.retrieve_mail_attachments('test1.txt')
 
-        self.assertEquals(attachments_in_inbox, [])
+        self.assertEqual(attachments_in_inbox, [])
 
     @patch(imaplib_string)
     def test_retrieve_mail_attachments_with_regex_found(self, mock_imaplib):
@@ -146,7 +146,7 @@ class TestImapHook(unittest.TestCase):
                 check_regex=True
             )
 
-        self.assertEquals(attachments_in_inbox, [('test1.csv', b'SWQsTmFtZQoxLEZlbGl4')])
+        self.assertEqual(attachments_in_inbox, [('test1.csv', b'SWQsTmFtZQoxLEZlbGl4')])
 
     @patch(imaplib_string)
     def test_retrieve_mail_attachments_with_regex_not_found(self, mock_imaplib):
@@ -158,7 +158,7 @@ class TestImapHook(unittest.TestCase):
                 check_regex=True
             )
 
-        self.assertEquals(attachments_in_inbox, [])
+        self.assertEqual(attachments_in_inbox, [])
 
     @patch(imaplib_string)
     def test_retrieve_mail_attachments_latest_only(self, mock_imaplib):
@@ -170,7 +170,7 @@ class TestImapHook(unittest.TestCase):
                 latest_only=True
             )
 
-        self.assertEquals(attachments_in_inbox, [('test1.csv', b'SWQsTmFtZQoxLEZlbGl4')])
+        self.assertEqual(attachments_in_inbox, [('test1.csv', b'SWQsTmFtZQoxLEZlbGl4')])
 
     @patch(open_string, new_callable=mock_open)
     @patch(imaplib_string)

--- a/tests/contrib/hooks/test_pinot_hook.py
+++ b/tests/contrib/hooks/test_pinot_hook.py
@@ -51,7 +51,7 @@ class TestPinotDbApiHook(unittest.TestCase):
         Test on getting a pinot connection uri
         """
         db_hook = self.db_hook()
-        self.assertEquals(db_hook.get_uri(), 'http://host:1000/pql')
+        self.assertEqual(db_hook.get_uri(), 'http://host:1000/pql')
 
     def test_get_conn(self):
         """

--- a/tests/contrib/hooks/test_spark_jdbc_hook.py
+++ b/tests/contrib/hooks/test_spark_jdbc_hook.py
@@ -126,7 +126,7 @@ class TestSparkJDBCHook(unittest.TestCase):
             '-createTableColumnTypes', 'columnMcColumnFace INTEGER(100), name CHAR(64),'
                                        'comments VARCHAR(1024)'
         ]
-        self.assertEquals(expected_jdbc_arguments, cmd)
+        self.assertEqual(expected_jdbc_arguments, cmd)
 
     def test_build_jdbc_arguments_invalid(self):
         # Given

--- a/tests/contrib/hooks/test_spark_submit_hook.py
+++ b/tests/contrib/hooks/test_spark_submit_hook.py
@@ -163,7 +163,7 @@ class TestSparkSubmitHook(unittest.TestCase):
             '--with-spaces', 'args should keep embdedded spaces',
             'baz'
         ]
-        self.assertEquals(expected_build_cmd, cmd)
+        self.assertEqual(expected_build_cmd, cmd)
 
     @patch('airflow.contrib.hooks.spark_submit_hook.subprocess.Popen')
     def test_spark_process_runcmd(self, mock_popen):

--- a/tests/contrib/operators/test_awsbatch_operator.py
+++ b/tests/contrib/operators/test_awsbatch_operator.py
@@ -119,7 +119,7 @@ class TestAWSBatchOperator(unittest.TestCase):
         client_mock.get_waiter.return_value.wait.assert_called_once_with(
             jobs=['8ba9d676-4108-4474-9dca-8bbac1da9b19']
         )
-        self.assertEquals(sys.maxsize, client_mock.get_waiter.return_value.config.max_attempts)
+        self.assertEqual(sys.maxsize, client_mock.get_waiter.return_value.config.max_attempts)
 
     def test_check_success_tasks_raises(self):
         client_mock = mock.Mock()

--- a/tests/contrib/operators/test_cassandra_to_gcs_operator.py
+++ b/tests/contrib/operators/test_cassandra_to_gcs_operator.py
@@ -44,49 +44,49 @@ class CassandraToGCSTest(unittest.TestCase):
 
     def test_convert_value(self):
         op = CassandraToGoogleCloudStorageOperator
-        self.assertEquals(op.convert_value('None', None), None)
-        self.assertEquals(op.convert_value('int', 1), 1)
-        self.assertEquals(op.convert_value('float', 1.0), 1.0)
-        self.assertEquals(op.convert_value('str', "text"), "text")
-        self.assertEquals(op.convert_value('bool', True), True)
-        self.assertEquals(op.convert_value('dict', {"a": "b"}), {"a": "b"})
+        self.assertEqual(op.convert_value('None', None), None)
+        self.assertEqual(op.convert_value('int', 1), 1)
+        self.assertEqual(op.convert_value('float', 1.0), 1.0)
+        self.assertEqual(op.convert_value('str', "text"), "text")
+        self.assertEqual(op.convert_value('bool', True), True)
+        self.assertEqual(op.convert_value('dict', {"a": "b"}), {"a": "b"})
 
         from datetime import datetime
         now = datetime.now()
-        self.assertEquals(op.convert_value('datetime', now), str(now))
+        self.assertEqual(op.convert_value('datetime', now), str(now))
 
         from cassandra.util import Date
         date_str = '2018-01-01'
         date = Date(date_str)
-        self.assertEquals(op.convert_value('date', date), str(date_str))
+        self.assertEqual(op.convert_value('date', date), str(date_str))
 
         import uuid
         from base64 import b64encode
         test_uuid = uuid.uuid4()
         encoded_uuid = b64encode(test_uuid.bytes).decode('ascii')
-        self.assertEquals(op.convert_value('uuid', test_uuid), encoded_uuid)
+        self.assertEqual(op.convert_value('uuid', test_uuid), encoded_uuid)
 
         b = b'abc'
         encoded_b = b64encode(b).decode('ascii')
-        self.assertEquals(op.convert_value('binary', b), encoded_b)
+        self.assertEqual(op.convert_value('binary', b), encoded_b)
 
         from decimal import Decimal
         d = Decimal(1.0)
-        self.assertEquals(op.convert_value('decimal', d), float(d))
+        self.assertEqual(op.convert_value('decimal', d), float(d))
 
         from cassandra.util import Time
         time = Time(0)
-        self.assertEquals(op.convert_value('time', time), '00:00:00')
+        self.assertEqual(op.convert_value('time', time), '00:00:00')
 
         date_str_lst = ['2018-01-01', '2018-01-02', '2018-01-03']
         date_lst = [Date(d) for d in date_str_lst]
-        self.assertEquals(op.convert_value('list', date_lst), date_str_lst)
+        self.assertEqual(op.convert_value('list', date_lst), date_str_lst)
 
         date_tpl = tuple(date_lst)
-        self.assertEquals(op.convert_value('tuple', date_tpl),
-                          {'field_0': '2018-01-01',
-                           'field_1': '2018-01-02',
-                           'field_2': '2018-01-03', })
+        self.assertEqual(op.convert_value('tuple', date_tpl),
+                         {'field_0': '2018-01-01',
+                          'field_1': '2018-01-02',
+                          'field_2': '2018-01-03', })
 
 
 if __name__ == '__main__':

--- a/tests/contrib/operators/test_databricks_operator.py
+++ b/tests/contrib/operators/test_databricks_operator.py
@@ -219,7 +219,7 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
         db_mock.submit_run.assert_called_once_with(expected)
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
         db_mock.get_run_state.assert_called_once_with(RUN_ID)
-        self.assertEquals(RUN_ID, op.run_id)
+        self.assertEqual(RUN_ID, op.run_id)
 
     @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
     def test_exec_failure(self, db_mock_class):
@@ -250,7 +250,7 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
         db_mock.submit_run.assert_called_once_with(expected)
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
         db_mock.get_run_state.assert_called_once_with(RUN_ID)
-        self.assertEquals(RUN_ID, op.run_id)
+        self.assertEqual(RUN_ID, op.run_id)
 
     @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
     def test_on_kill(self, db_mock_class):
@@ -388,7 +388,7 @@ class DatabricksRunNowOperatorTest(unittest.TestCase):
         db_mock.run_now.assert_called_once_with(expected)
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
         db_mock.get_run_state.assert_called_once_with(RUN_ID)
-        self.assertEquals(RUN_ID, op.run_id)
+        self.assertEqual(RUN_ID, op.run_id)
 
     @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
     def test_exec_failure(self, db_mock_class):
@@ -421,7 +421,7 @@ class DatabricksRunNowOperatorTest(unittest.TestCase):
         db_mock.run_now.assert_called_once_with(expected)
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
         db_mock.get_run_state.assert_called_once_with(RUN_ID)
-        self.assertEquals(RUN_ID, op.run_id)
+        self.assertEqual(RUN_ID, op.run_id)
 
     @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
     def test_on_kill(self, db_mock_class):

--- a/tests/contrib/operators/test_dataflow_operator.py
+++ b/tests/contrib/operators/test_dataflow_operator.py
@@ -213,7 +213,7 @@ class GoogleCloudBucketHelperTest(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             gcs_bucket_helper.google_cloud_to_local(file_name)
 
-        self.assertEquals(
+        self.assertEqual(
             'Invalid Google Cloud Storage (GCS) object path: {}'.format(file_name),
             str(context.exception))
 
@@ -261,6 +261,6 @@ class GoogleCloudBucketHelperTest(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             gcs_bucket_helper.google_cloud_to_local(file_name)
 
-        self.assertEquals(
+        self.assertEqual(
             'Failed to download Google Cloud Storage (GCS) object: {}'.format(file_name),
             str(context.exception))

--- a/tests/contrib/operators/test_ecs_operator.py
+++ b/tests/contrib/operators/test_ecs_operator.py
@@ -174,7 +174,7 @@ class TestECSOperator(unittest.TestCase):
         client_mock.get_waiter.assert_called_once_with('tasks_stopped')
         client_mock.get_waiter.return_value.wait.assert_called_once_with(
             cluster='c', tasks=['arn'])
-        self.assertEquals(
+        self.assertEqual(
             sys.maxsize, client_mock.get_waiter.return_value.config.max_attempts)
 
     def test_check_success_tasks_raises(self):

--- a/tests/contrib/operators/test_gcp_container_operator.py
+++ b/tests/contrib/operators/test_gcp_container_operator.py
@@ -254,7 +254,7 @@ class GKEPodOperatorTest(unittest.TestCase):
         }
 
         self.gke_op._set_env_from_extras(extras)
-        self.assertEquals(os.environ[GAC_ENV_VAR], FILE_NAME)
+        self.assertEqual(os.environ[GAC_ENV_VAR], FILE_NAME)
 
         file_mock.return_value.write.assert_called_once_with(KEYFILE_DICT_STR)
 
@@ -267,7 +267,7 @@ class GKEPodOperatorTest(unittest.TestCase):
         }
 
         self.gke_op._set_env_from_extras(extras)
-        self.assertEquals(os.environ[GAC_ENV_VAR], TEST_PATH)
+        self.assertEqual(os.environ[GAC_ENV_VAR], TEST_PATH)
 
     def test_get_field(self):
         FIELD_NAME = 'test_field'

--- a/tests/contrib/operators/test_jenkins_operator.py
+++ b/tests/contrib/operators/test_jenkins_operator.py
@@ -70,7 +70,7 @@ class JenkinsOperatorTestCase(unittest.TestCase):
 
             operator.execute(None)
 
-            self.assertEquals(jenkins_mock.get_build_info.call_count, 1)
+            self.assertEqual(jenkins_mock.get_build_info.call_count, 1)
             jenkins_mock.get_build_info.assert_called_with(name='a_job_on_jenkins',
                                                            number='1')
 
@@ -107,7 +107,7 @@ class JenkinsOperatorTestCase(unittest.TestCase):
                 sleep_time=1)
 
             operator.execute(None)
-            self.assertEquals(jenkins_mock.get_build_info.call_count, 2)
+            self.assertEqual(jenkins_mock.get_build_info.call_count, 2)
 
     @unittest.skipIf(mock is None, 'mock package not present')
     def test_execute_job_failure(self):

--- a/tests/contrib/operators/test_mlengine_operator.py
+++ b/tests/contrib/operators/test_mlengine_operator.py
@@ -109,8 +109,8 @@ class MLEngineBatchPredictionOperatorTest(unittest.TestCase):
                     'jobId': 'test_prediction',
                     'predictionInput': input_with_model
                 }, ANY)
-            self.assertEquals(success_message['predictionOutput'],
-                              prediction_output)
+            self.assertEqual(success_message['predictionOutput'],
+                             prediction_output)
 
     def testSuccessWithVersion(self):
         with patch('airflow.contrib.operators.mlengine_operator.MLEngineHook') \
@@ -148,8 +148,8 @@ class MLEngineBatchPredictionOperatorTest(unittest.TestCase):
                     'jobId': 'test_prediction',
                     'predictionInput': input_with_version
                 }, ANY)
-            self.assertEquals(success_message['predictionOutput'],
-                              prediction_output)
+            self.assertEqual(success_message['predictionOutput'],
+                             prediction_output)
 
     def testSuccessWithURI(self):
         with patch('airflow.contrib.operators.mlengine_operator.MLEngineHook') \
@@ -185,8 +185,8 @@ class MLEngineBatchPredictionOperatorTest(unittest.TestCase):
                     'jobId': 'test_prediction',
                     'predictionInput': input_with_uri
                 }, ANY)
-            self.assertEquals(success_message['predictionOutput'],
-                              prediction_output)
+            self.assertEqual(success_message['predictionOutput'],
+                             prediction_output)
 
     def testInvalidModelOrigin(self):
         # Test that both uri and model is given
@@ -195,9 +195,9 @@ class MLEngineBatchPredictionOperatorTest(unittest.TestCase):
         task_args['model_name'] = 'fake_model'
         with self.assertRaises(AirflowException) as context:
             MLEngineBatchPredictionOperator(**task_args).execute(None)
-        self.assertEquals('Ambiguous model origin: Both uri and '
-                          'model/version name are provided.',
-                          str(context.exception))
+        self.assertEqual('Ambiguous model origin: Both uri and '
+                         'model/version name are provided.',
+                         str(context.exception))
 
         # Test that both uri and model/version is given
         task_args = self.BATCH_PREDICTION_DEFAULT_ARGS.copy()
@@ -206,24 +206,24 @@ class MLEngineBatchPredictionOperatorTest(unittest.TestCase):
         task_args['version_name'] = 'fake_version'
         with self.assertRaises(AirflowException) as context:
             MLEngineBatchPredictionOperator(**task_args).execute(None)
-        self.assertEquals('Ambiguous model origin: Both uri and '
-                          'model/version name are provided.',
-                          str(context.exception))
+        self.assertEqual('Ambiguous model origin: Both uri and '
+                         'model/version name are provided.',
+                         str(context.exception))
 
         # Test that a version is given without a model
         task_args = self.BATCH_PREDICTION_DEFAULT_ARGS.copy()
         task_args['version_name'] = 'bare_version'
         with self.assertRaises(AirflowException) as context:
             MLEngineBatchPredictionOperator(**task_args).execute(None)
-        self.assertEquals('Missing model: Batch prediction expects a model '
-                          'name when a version name is provided.',
-                          str(context.exception))
+        self.assertEqual('Missing model: Batch prediction expects a model '
+                         'name when a version name is provided.',
+                         str(context.exception))
 
         # Test that none of uri, model, model/version is given
         task_args = self.BATCH_PREDICTION_DEFAULT_ARGS.copy()
         with self.assertRaises(AirflowException) as context:
             MLEngineBatchPredictionOperator(**task_args).execute(None)
-        self.assertEquals(
+        self.assertEqual(
             'Missing model origin: Batch prediction expects a '
             'model, a model & version combination, or a URI to a savedModel.',
             str(context.exception))
@@ -264,7 +264,7 @@ class MLEngineBatchPredictionOperatorTest(unittest.TestCase):
                         'predictionInput': input_with_model
                     }, ANY)
 
-            self.assertEquals(http_error_code, context.exception.resp.status)
+            self.assertEqual(http_error_code, context.exception.resp.status)
 
     def testFailedJobError(self):
         with patch('airflow.contrib.operators.mlengine_operator.MLEngineHook') \
@@ -280,7 +280,7 @@ class MLEngineBatchPredictionOperatorTest(unittest.TestCase):
             with self.assertRaises(RuntimeError) as context:
                 MLEngineBatchPredictionOperator(**task_args).execute(None)
 
-            self.assertEquals('A failure message', str(context.exception))
+            self.assertEqual('A failure message', str(context.exception))
 
 
 class MLEngineTrainingOperatorTest(unittest.TestCase):
@@ -320,7 +320,7 @@ class MLEngineTrainingOperatorTest(unittest.TestCase):
             mock_hook.assert_called_with(
                 gcp_conn_id='google_cloud_default', delegate_to=None)
             # Make sure only 'create_job' is invoked on hook instance
-            self.assertEquals(len(hook_instance.mock_calls), 1)
+            self.assertEqual(len(hook_instance.mock_calls), 1)
             hook_instance.create_job.assert_called_with(
                 'test-project', self.TRAINING_INPUT, ANY)
 
@@ -347,7 +347,7 @@ class MLEngineTrainingOperatorTest(unittest.TestCase):
             mock_hook.assert_called_with(gcp_conn_id='google_cloud_default',
                                          delegate_to=None)
             # Make sure only 'create_job' is invoked on hook instance
-            self.assertEquals(len(hook_instance.mock_calls), 1)
+            self.assertEqual(len(hook_instance.mock_calls), 1)
             hook_instance.create_job.assert_called_with(
                 'test-project', training_input, ANY)
 
@@ -370,10 +370,10 @@ class MLEngineTrainingOperatorTest(unittest.TestCase):
             mock_hook.assert_called_with(
                 gcp_conn_id='google_cloud_default', delegate_to=None)
             # Make sure only 'create_job' is invoked on hook instance
-            self.assertEquals(len(hook_instance.mock_calls), 1)
+            self.assertEqual(len(hook_instance.mock_calls), 1)
             hook_instance.create_job.assert_called_with(
                 'test-project', self.TRAINING_INPUT, ANY)
-            self.assertEquals(http_error_code, context.exception.resp.status)
+            self.assertEqual(http_error_code, context.exception.resp.status)
 
     def testFailedJobError(self):
         with patch('airflow.contrib.operators.mlengine_operator.MLEngineHook') \
@@ -392,10 +392,10 @@ class MLEngineTrainingOperatorTest(unittest.TestCase):
             mock_hook.assert_called_with(
                 gcp_conn_id='google_cloud_default', delegate_to=None)
             # Make sure only 'create_job' is invoked on hook instance
-            self.assertEquals(len(hook_instance.mock_calls), 1)
+            self.assertEqual(len(hook_instance.mock_calls), 1)
             hook_instance.create_job.assert_called_with(
                 'test-project', self.TRAINING_INPUT, ANY)
-            self.assertEquals('A failure message', str(context.exception))
+            self.assertEqual('A failure message', str(context.exception))
 
 
 class MLEngineVersionOperatorTest(unittest.TestCase):
@@ -425,7 +425,7 @@ class MLEngineVersionOperatorTest(unittest.TestCase):
             mock_hook.assert_called_with(gcp_conn_id='google_cloud_default',
                                          delegate_to=None)
             # Make sure only 'create_version' is invoked on hook instance
-            self.assertEquals(len(hook_instance.mock_calls), 1)
+            self.assertEqual(len(hook_instance.mock_calls), 1)
             hook_instance.create_version.assert_called_with(
                 'test-project', 'test-model', self.VERSION_INPUT)
 

--- a/tests/contrib/operators/test_pubsub_operator.py
+++ b/tests/contrib/operators/test_pubsub_operator.py
@@ -101,7 +101,7 @@ class PubSubSubscriptionCreateOperatorTest(unittest.TestCase):
         mock_hook.return_value.create_subscription.assert_called_once_with(
             TEST_PROJECT, TEST_TOPIC, TEST_SUBSCRIPTION, None,
             10, False)
-        self.assertEquals(response, TEST_SUBSCRIPTION)
+        self.assertEqual(response, TEST_SUBSCRIPTION)
 
     @mock.patch('airflow.contrib.operators.pubsub_operator.PubSubHook')
     def test_execute_different_project_ids(self, mock_hook):
@@ -116,7 +116,7 @@ class PubSubSubscriptionCreateOperatorTest(unittest.TestCase):
         mock_hook.return_value.create_subscription.assert_called_once_with(
             TEST_PROJECT, TEST_TOPIC, TEST_SUBSCRIPTION, another_project,
             10, False)
-        self.assertEquals(response, TEST_SUBSCRIPTION)
+        self.assertEqual(response, TEST_SUBSCRIPTION)
 
     @mock.patch('airflow.contrib.operators.pubsub_operator.PubSubHook')
     def test_execute_no_subscription(self, mock_hook):
@@ -127,7 +127,7 @@ class PubSubSubscriptionCreateOperatorTest(unittest.TestCase):
         response = operator.execute(None)
         mock_hook.return_value.create_subscription.assert_called_once_with(
             TEST_PROJECT, TEST_TOPIC, None, None, 10, False)
-        self.assertEquals(response, TEST_SUBSCRIPTION)
+        self.assertEqual(response, TEST_SUBSCRIPTION)
 
 
 class PubSubSubscriptionDeleteOperatorTest(unittest.TestCase):

--- a/tests/contrib/operators/test_ssh_operator.py
+++ b/tests/contrib/operators/test_ssh_operator.py
@@ -74,8 +74,8 @@ class SSHOperatorTest(unittest.TestCase):
 
         task.execute(None)
 
-        self.assertEquals(TIMEOUT, task.ssh_hook.timeout)
-        self.assertEquals(SSH_ID, task.ssh_hook.ssh_conn_id)
+        self.assertEqual(TIMEOUT, task.ssh_hook.timeout)
+        self.assertEqual(SSH_ID, task.ssh_hook.ssh_conn_id)
 
     def test_json_command_execution(self):
         configuration.conf.set("core", "enable_xcom_pickling", "False")

--- a/tests/contrib/sensors/test_pubsub_sensor.py
+++ b/tests/contrib/sensors/test_pubsub_sensor.py
@@ -66,7 +66,7 @@ class PubSubPullSensorTest(unittest.TestCase):
         operator = PubSubPullSensor(task_id=TASK_ID, project=TEST_PROJECT,
                                     subscription=TEST_SUBSCRIPTION)
         mock_hook.return_value.pull.return_value = []
-        self.assertEquals([], operator.poke(None))
+        self.assertEqual([], operator.poke(None))
 
     @mock.patch('airflow.contrib.sensors.pubsub_sensor.PubSubHook')
     def test_poke_with_ack_messages(self, mock_hook):
@@ -75,7 +75,7 @@ class PubSubPullSensorTest(unittest.TestCase):
                                     ack_messages=True)
         generated_messages = self._generate_messages(5)
         mock_hook.return_value.pull.return_value = generated_messages
-        self.assertEquals(generated_messages, operator.poke(None))
+        self.assertEqual(generated_messages, operator.poke(None))
         mock_hook.return_value.acknowledge.assert_called_with(
             TEST_PROJECT, TEST_SUBSCRIPTION, ['1', '2', '3', '4', '5']
         )
@@ -90,7 +90,7 @@ class PubSubPullSensorTest(unittest.TestCase):
         response = operator.execute(None)
         mock_hook.return_value.pull.assert_called_with(
             TEST_PROJECT, TEST_SUBSCRIPTION, 5, False)
-        self.assertEquals(response, generated_messages)
+        self.assertEqual(response, generated_messages)
 
     @mock.patch('airflow.contrib.sensors.pubsub_sensor.PubSubHook')
     def test_execute_timeout(self, mock_hook):

--- a/tests/core.py
+++ b/tests/core.py
@@ -656,26 +656,26 @@ class CoreTest(unittest.TestCase):
         context = ti.get_template_context()
 
         # DEFAULT DATE is 2015-01-01
-        self.assertEquals(context['ds'], '2015-01-01')
-        self.assertEquals(context['ds_nodash'], '20150101')
+        self.assertEqual(context['ds'], '2015-01-01')
+        self.assertEqual(context['ds_nodash'], '20150101')
 
         # next_ds is 2015-01-02 as the dag interval is daily
-        self.assertEquals(context['next_ds'], '2015-01-02')
-        self.assertEquals(context['next_ds_nodash'], '20150102')
+        self.assertEqual(context['next_ds'], '2015-01-02')
+        self.assertEqual(context['next_ds_nodash'], '20150102')
 
         # prev_ds is 2014-12-31 as the dag interval is daily
-        self.assertEquals(context['prev_ds'], '2014-12-31')
-        self.assertEquals(context['prev_ds_nodash'], '20141231')
+        self.assertEqual(context['prev_ds'], '2014-12-31')
+        self.assertEqual(context['prev_ds_nodash'], '20141231')
 
-        self.assertEquals(context['ts'], '2015-01-01T00:00:00+00:00')
-        self.assertEquals(context['ts_nodash'], '20150101T000000')
-        self.assertEquals(context['ts_nodash_with_tz'], '20150101T000000+0000')
+        self.assertEqual(context['ts'], '2015-01-01T00:00:00+00:00')
+        self.assertEqual(context['ts_nodash'], '20150101T000000')
+        self.assertEqual(context['ts_nodash_with_tz'], '20150101T000000+0000')
 
-        self.assertEquals(context['yesterday_ds'], '2014-12-31')
-        self.assertEquals(context['yesterday_ds_nodash'], '20141231')
+        self.assertEqual(context['yesterday_ds'], '2014-12-31')
+        self.assertEqual(context['yesterday_ds_nodash'], '20141231')
 
-        self.assertEquals(context['tomorrow_ds'], '2015-01-02')
-        self.assertEquals(context['tomorrow_ds_nodash'], '20150102')
+        self.assertEqual(context['tomorrow_ds'], '2015-01-02')
+        self.assertEqual(context['tomorrow_ds_nodash'], '20150102')
 
     def test_import_examples(self):
         self.assertEqual(len(self.dagbag.dags), NUM_EXAMPLE_DAGS)
@@ -986,9 +986,9 @@ class CoreTest(unittest.TestCase):
         task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
         dag_runs = models.DagRun.find(dag_id='example_bash_operator',
                                       run_id=run_id)
-        self.assertEquals(len(dag_runs), 1)
+        self.assertEqual(len(dag_runs), 1)
         dag_run = dag_runs[0]
-        self.assertEquals(dag_run.execution_date, utc_now)
+        self.assertEqual(dag_run.execution_date, utc_now)
 
     def test_trigger_dagrun_with_str_execution_date(self):
         utc_now_str = timezone.utcnow().isoformat()
@@ -1008,9 +1008,9 @@ class CoreTest(unittest.TestCase):
         task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
         dag_runs = models.DagRun.find(dag_id='example_bash_operator',
                                       run_id=run_id)
-        self.assertEquals(len(dag_runs), 1)
+        self.assertEqual(len(dag_runs), 1)
         dag_run = dag_runs[0]
-        self.assertEquals(dag_run.execution_date.isoformat(), utc_now_str)
+        self.assertEqual(dag_run.execution_date.isoformat(), utc_now_str)
 
     def test_trigger_dagrun_with_templated_execution_date(self):
         task = TriggerDagRunOperator(
@@ -1052,11 +1052,11 @@ class CoreTest(unittest.TestCase):
         context = ti.get_template_context()
 
         # next_ds/prev_ds should be the execution date for manually triggered runs
-        self.assertEquals(context['next_ds'], EXECUTION_DS)
-        self.assertEquals(context['next_ds_nodash'], EXECUTION_DS_NODASH)
+        self.assertEqual(context['next_ds'], EXECUTION_DS)
+        self.assertEqual(context['next_ds_nodash'], EXECUTION_DS_NODASH)
 
-        self.assertEquals(context['prev_ds'], EXECUTION_DS)
-        self.assertEquals(context['prev_ds_nodash'], EXECUTION_DS_NODASH)
+        self.assertEqual(context['prev_ds'], EXECUTION_DS)
+        self.assertEqual(context['prev_ds_nodash'], EXECUTION_DS_NODASH)
 
 
 class CliTests(unittest.TestCase):

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -137,8 +137,8 @@ class CeleryExecutorTest(unittest.TestCase):
             value_tuple = 'command', '_', 'queue', 'should_be_a_simple_ti'
             executor.queued_tasks['key'] = value_tuple
             executor.heartbeat()
-        self.assertEquals(1, len(executor.queued_tasks))
-        self.assertEquals(executor.queued_tasks['key'], value_tuple)
+        self.assertEqual(1, len(executor.queued_tasks))
+        self.assertEqual(executor.queued_tasks['key'], value_tuple)
 
     def test_exception_propagation(self):
         with self._prepare_app() as app:

--- a/tests/hooks/test_druid_hook.py
+++ b/tests/hooks/test_druid_hook.py
@@ -132,7 +132,7 @@ class TestDruidHook(unittest.TestCase):
         get_conn_value.extra_dejson = {'endpoint': 'ingest'}
         mock_get_connection.return_value = get_conn_value
         hook = DruidHook(timeout=1, max_ingestion_time=5)
-        self.assertEquals(hook.get_conn_url(), 'https://test_host:1/ingest')
+        self.assertEqual(hook.get_conn_url(), 'https://test_host:1/ingest')
 
 
 class TestDruidDbApiHook(unittest.TestCase):
@@ -158,7 +158,7 @@ class TestDruidDbApiHook(unittest.TestCase):
 
     def test_get_uri(self):
         db_hook = self.db_hook()
-        self.assertEquals('druid://host:1000/druid/v2/sql', db_hook.get_uri())
+        self.assertEqual('druid://host:1000/druid/v2/sql', db_hook.get_uri())
 
     def test_get_first_record(self):
         statement = 'SQL'

--- a/tests/hooks/test_http_hook.py
+++ b/tests/hooks/test_http_hook.py
@@ -82,7 +82,7 @@ class TestHttpHook(unittest.TestCase):
         ):
 
             resp = self.get_hook.run('v1/test')
-            self.assertEquals(resp.text, '{"status":{"status": 200}}')
+            self.assertEqual(resp.text, '{"status":{"status": 200}}')
 
     @requests_mock.mock()
     @mock.patch('requests.Request')
@@ -125,7 +125,7 @@ class TestHttpHook(unittest.TestCase):
             side_effect=get_airflow_connection
         ):
             resp = self.get_hook.run('v1/test', extra_options={'check_response': False})
-            self.assertEquals(resp.text, '{"status":{"status": 404}}')
+            self.assertEqual(resp.text, '{"status":{"status": 404}}')
 
     @requests_mock.mock()
     def test_hook_contains_header_from_extra_field(self, m):
@@ -136,12 +136,12 @@ class TestHttpHook(unittest.TestCase):
             expected_conn = get_airflow_connection()
             conn = self.get_hook.get_conn()
             self.assertDictContainsSubset(json.loads(expected_conn.extra), conn.headers)
-            self.assertEquals(conn.headers.get('bareer'), 'test')
+            self.assertEqual(conn.headers.get('bareer'), 'test')
 
     @requests_mock.mock()
     def test_hook_uses_provided_header(self, m):
             conn = self.get_hook.get_conn(headers={"bareer": "newT0k3n"})
-            self.assertEquals(conn.headers.get('bareer'), "newT0k3n")
+            self.assertEqual(conn.headers.get('bareer'), "newT0k3n")
 
     @requests_mock.mock()
     def test_hook_has_no_header_from_extra(self, m):
@@ -155,7 +155,7 @@ class TestHttpHook(unittest.TestCase):
             side_effect=get_airflow_connection
         ):
             conn = self.get_hook.get_conn(headers={"bareer": "newT0k3n"})
-            self.assertEquals(conn.headers.get('bareer'), 'newT0k3n')
+            self.assertEqual(conn.headers.get('bareer'), 'newT0k3n')
 
     @requests_mock.mock()
     def test_post_request(self, m):
@@ -172,7 +172,7 @@ class TestHttpHook(unittest.TestCase):
             side_effect=get_airflow_connection
         ):
             resp = self.post_hook.run('v1/test')
-            self.assertEquals(resp.status_code, 200)
+            self.assertEqual(resp.status_code, 200)
 
     @requests_mock.mock()
     def test_post_request_with_error_code(self, m):
@@ -206,7 +206,7 @@ class TestHttpHook(unittest.TestCase):
             side_effect=get_airflow_connection
         ):
             resp = self.post_hook.run('v1/test', extra_options={'check_response': False})
-            self.assertEquals(resp.status_code, 418)
+            self.assertEqual(resp.status_code, 418)
 
     @mock.patch('airflow.hooks.http_hook.requests.Session')
     def test_retry_on_conn_error(self, mocked_session):
@@ -227,7 +227,7 @@ class TestHttpHook(unittest.TestCase):
                 endpoint='v1/test',
                 _retry_args=retry_args
             )
-        self.assertEquals(
+        self.assertEqual(
             self.get_hook._retry_obj.stop.max_attempt_number + 1,
             mocked_session.call_count
         )
@@ -248,8 +248,8 @@ class TestHttpHook(unittest.TestCase):
             ):
                 pr = self.get_hook.run('v1/test', headers={'some_other_header': 'test'})
                 actual = dict(pr.headers)
-                self.assertEquals(actual.get('bareer'), 'test')
-                self.assertEquals(actual.get('some_other_header'), 'test')
+                self.assertEqual(actual.get('bareer'), 'test')
+                self.assertEqual(actual.get('some_other_header'), 'test')
 
     @mock.patch('airflow.hooks.http_hook.HttpHook.get_connection')
     def test_http_connection(self, mock_get_connection):

--- a/tests/macros/test_hive.py
+++ b/tests/macros/test_hive.py
@@ -33,13 +33,13 @@ class Hive(unittest.TestCase):
         target_dt = datetime.strptime('2017-04-27', '%Y-%m-%d')
         date_list = [d1, d2, d3, d4, d5]
 
-        self.assertEquals("2017-04-26", str(hive._closest_date(target_dt, date_list, True)))
-        self.assertEquals("2017-04-28", str(hive._closest_date(target_dt, date_list, False)))
+        self.assertEqual("2017-04-26", str(hive._closest_date(target_dt, date_list, True)))
+        self.assertEqual("2017-04-28", str(hive._closest_date(target_dt, date_list, False)))
 
         # when before is not set, the closest date should be returned
-        self.assertEquals("2017-04-26", str(hive._closest_date(target_dt, [d1, d2, d3, d5], None)))
-        self.assertEquals("2017-04-28", str(hive._closest_date(target_dt, [d1, d2, d4, d5])))
-        self.assertEquals("2017-04-26", str(hive._closest_date(target_dt, date_list)))
+        self.assertEqual("2017-04-26", str(hive._closest_date(target_dt, [d1, d2, d3, d5], None)))
+        self.assertEqual("2017-04-28", str(hive._closest_date(target_dt, [d1, d2, d4, d5])))
+        self.assertEqual("2017-04-26", str(hive._closest_date(target_dt, date_list)))
 
 
 if __name__ == '__main__':

--- a/tests/models.py
+++ b/tests/models.py
@@ -232,7 +232,7 @@ class DagTest(unittest.TestCase):
             start_date=DEFAULT_DATE,
             default_args={'owner': 'owner1'})
 
-        self.assertEquals(tuple(), dag.topological_sort())
+        self.assertEqual(tuple(), dag.topological_sort())
 
     def test_dag_naive_default_args_start_date(self):
         dag = DAG('DAG', default_args={'start_date': datetime.datetime(2018, 1, 1)})
@@ -277,7 +277,7 @@ class DagTest(unittest.TestCase):
                 correct_weight = ((depth - (task_depth + 1)) * width + 1) * weight
 
                 calculated_weight = task.priority_weight_total
-                self.assertEquals(calculated_weight, correct_weight)
+                self.assertEqual(calculated_weight, correct_weight)
 
         # Same test as above except use 'upstream' for weight calculation
         weight = 3
@@ -303,7 +303,7 @@ class DagTest(unittest.TestCase):
                 correct_weight = (task_depth * width + 1) * weight
 
                 calculated_weight = task.priority_weight_total
-                self.assertEquals(calculated_weight, correct_weight)
+                self.assertEqual(calculated_weight, correct_weight)
 
         # Same test as above except use 'absolute' for weight calculation
         weight = 10
@@ -329,7 +329,7 @@ class DagTest(unittest.TestCase):
                 correct_weight = weight
 
                 calculated_weight = task.priority_weight_total
-                self.assertEquals(calculated_weight, correct_weight)
+                self.assertEqual(calculated_weight, correct_weight)
 
         # Test if we enter an invalid weight rule
         with DAG('dag', start_date=DEFAULT_DATE,
@@ -842,7 +842,7 @@ class DagRunTest(unittest.TestCase):
             DagRun.dag_id == dag_id,
             DagRun.execution_date == now
         ).first()
-        self.assertEquals(dr0.state, State.RUNNING)
+        self.assertEqual(dr0.state, State.RUNNING)
 
     def test_id_for_date(self):
         run_id = models.DagRun.id_for_date(
@@ -1304,20 +1304,20 @@ class DagRunTest(unittest.TestCase):
 
         dagrun = self.create_dag_run(dag)
         flaky_ti = dagrun.get_task_instances()[0]
-        self.assertEquals('flaky_task', flaky_ti.task_id)
-        self.assertEquals(State.NONE, flaky_ti.state)
+        self.assertEqual('flaky_task', flaky_ti.task_id)
+        self.assertEqual(State.NONE, flaky_ti.state)
 
         dagrun.dag = with_all_tasks_removed(dag)
 
         dagrun.verify_integrity()
         flaky_ti.refresh_from_db()
-        self.assertEquals(State.NONE, flaky_ti.state)
+        self.assertEqual(State.NONE, flaky_ti.state)
 
         dagrun.dag.add_task(DummyOperator(task_id='flaky_task', owner='test'))
 
         dagrun.verify_integrity()
         flaky_ti.refresh_from_db()
-        self.assertEquals(State.NONE, flaky_ti.state)
+        self.assertEqual(State.NONE, flaky_ti.state)
 
 
 class DagBagTest(unittest.TestCase):
@@ -1472,12 +1472,12 @@ class DagBagTest(unittest.TestCase):
 
         for dag_id in expected_dag_ids:
             actual_dagbag.log.info('validating %s' % dag_id)
-            self.assertEquals(
+            self.assertEqual(
                 dag_id in actual_found_dag_ids, should_be_found,
                 'dag "%s" should %shave been found after processing dag "%s"' %
                 (dag_id, '' if should_be_found else 'not ', expected_parent_dag.dag_id)
             )
-            self.assertEquals(
+            self.assertEqual(
                 dag_id in actual_dagbag.dags, should_be_found,
                 'dag "%s" should %sbe in dagbag.dags after processing dag "%s"' %
                 (dag_id, '' if should_be_found else 'not ', expected_parent_dag.dag_id)
@@ -1816,7 +1816,7 @@ class DagBagTest(unittest.TestCase):
             if dag.dag_id in expected_active_dags:
                 self.assertTrue(dag.is_active)
             else:
-                self.assertEquals(dag.dag_id, 'test_deactivate_unknown_dags')
+                self.assertEqual(dag.dag_id, 'test_deactivate_unknown_dags')
                 self.assertFalse(dag.is_active)
 
         # clean up
@@ -1878,7 +1878,7 @@ class TaskInstanceTest(unittest.TestCase):
         op_no_dag = DummyOperator(task_id='op_no_dag')
         ti = TI(task=op_no_dag, execution_date=NAIVE_DATETIME)
 
-        self.assertEquals(ti.execution_date, DEFAULT_DATE)
+        self.assertEqual(ti.execution_date, DEFAULT_DATE)
 
         # check with dag without localized execution_date
         dag = DAG('dag', start_date=DEFAULT_DATE)
@@ -1886,14 +1886,14 @@ class TaskInstanceTest(unittest.TestCase):
         dag.add_task(op1)
         ti = TI(task=op1, execution_date=NAIVE_DATETIME)
 
-        self.assertEquals(ti.execution_date, DEFAULT_DATE)
+        self.assertEqual(ti.execution_date, DEFAULT_DATE)
 
         # with dag and localized execution_date
         tz = pendulum.timezone("Europe/Amsterdam")
         execution_date = timezone.datetime(2016, 1, 1, 1, 0, 0, tzinfo=tz)
         utc_date = timezone.convert_to_utc(execution_date)
         ti = TI(task=op1, execution_date=execution_date)
-        self.assertEquals(ti.execution_date, utc_date)
+        self.assertEqual(ti.execution_date, utc_date)
 
     def test_task_naive_datetime(self):
         NAIVE_DATETIME = DEFAULT_DATE.replace(tzinfo=None)
@@ -2603,9 +2603,9 @@ class TaskInstanceTest(unittest.TestCase):
         session.add(ti3)
         session.commit()
 
-        self.assertEquals(1, ti1.get_num_running_task_instances(session=session))
-        self.assertEquals(1, ti2.get_num_running_task_instances(session=session))
-        self.assertEquals(1, ti3.get_num_running_task_instances(session=session))
+        self.assertEqual(1, ti1.get_num_running_task_instances(session=session))
+        self.assertEqual(1, ti2.get_num_running_task_instances(session=session))
+        self.assertEqual(1, ti3.get_num_running_task_instances(session=session))
 
     # def test_log_url(self):
     #     now = pendulum.now('Europe/Brussels')

--- a/tests/operators/test_python_operator.py
+++ b/tests/operators/test_python_operator.py
@@ -131,11 +131,11 @@ class PythonOperatorTest(unittest.TestCase):
         )
         new_task = copy.deepcopy(original_task)
         # shallow copy op_kwargs
-        self.assertEquals(id(original_task.op_kwargs['certain_attrs']),
-                          id(new_task.op_kwargs['certain_attrs']))
+        self.assertEqual(id(original_task.op_kwargs['certain_attrs']),
+                         id(new_task.op_kwargs['certain_attrs']))
         # shallow copy python_callable
-        self.assertEquals(id(original_task.python_callable),
-                          id(new_task.python_callable))
+        self.assertEqual(id(original_task.python_callable),
+                         id(new_task.python_callable))
 
     def _env_var_check_callback(self):
         self.assertEqual('test_dag', os.environ['AIRFLOW_CTX_DAG_ID'])
@@ -218,12 +218,12 @@ class BranchOperatorTest(unittest.TestCase):
 
         for ti in tis:
             if ti.task_id == 'make_choice':
-                self.assertEquals(ti.state, State.SUCCESS)
+                self.assertEqual(ti.state, State.SUCCESS)
             elif ti.task_id == 'branch_1':
                 # should exist with state None
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
             elif ti.task_id == 'branch_2':
-                self.assertEquals(ti.state, State.SKIPPED)
+                self.assertEqual(ti.state, State.SKIPPED)
             else:
                 raise Exception
 
@@ -256,7 +256,7 @@ class BranchOperatorTest(unittest.TestCase):
 
         for ti in tis:
             if ti.task_id in expected:
-                self.assertEquals(ti.state, expected[ti.task_id])
+                self.assertEqual(ti.state, expected[ti.task_id])
             else:
                 raise Exception
 
@@ -281,11 +281,11 @@ class BranchOperatorTest(unittest.TestCase):
         tis = dr.get_task_instances()
         for ti in tis:
             if ti.task_id == 'make_choice':
-                self.assertEquals(ti.state, State.SUCCESS)
+                self.assertEqual(ti.state, State.SUCCESS)
             elif ti.task_id == 'branch_1':
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
             elif ti.task_id == 'branch_2':
-                self.assertEquals(ti.state, State.SKIPPED)
+                self.assertEqual(ti.state, State.SKIPPED)
             else:
                 raise Exception
 
@@ -342,12 +342,12 @@ class ShortCircuitOperatorTest(unittest.TestCase):
 
         for ti in tis:
             if ti.task_id == 'make_choice':
-                self.assertEquals(ti.state, State.SUCCESS)
+                self.assertEqual(ti.state, State.SUCCESS)
             elif ti.task_id == 'upstream':
                 # should not exist
                 raise Exception
             elif ti.task_id == 'branch_1' or ti.task_id == 'branch_2':
-                self.assertEquals(ti.state, State.SKIPPED)
+                self.assertEqual(ti.state, State.SKIPPED)
             else:
                 raise Exception
 
@@ -357,12 +357,12 @@ class ShortCircuitOperatorTest(unittest.TestCase):
         short_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
         for ti in tis:
             if ti.task_id == 'make_choice':
-                self.assertEquals(ti.state, State.SUCCESS)
+                self.assertEqual(ti.state, State.SUCCESS)
             elif ti.task_id == 'upstream':
                 # should not exist
                 raise Exception
             elif ti.task_id == 'branch_1' or ti.task_id == 'branch_2':
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
             else:
                 raise Exception
 
@@ -402,11 +402,11 @@ class ShortCircuitOperatorTest(unittest.TestCase):
         self.assertEqual(len(tis), 4)
         for ti in tis:
             if ti.task_id == 'make_choice':
-                self.assertEquals(ti.state, State.SUCCESS)
+                self.assertEqual(ti.state, State.SUCCESS)
             elif ti.task_id == 'upstream':
-                self.assertEquals(ti.state, State.SUCCESS)
+                self.assertEqual(ti.state, State.SUCCESS)
             elif ti.task_id == 'branch_1' or ti.task_id == 'branch_2':
-                self.assertEquals(ti.state, State.SKIPPED)
+                self.assertEqual(ti.state, State.SKIPPED)
             else:
                 raise Exception
 
@@ -420,10 +420,10 @@ class ShortCircuitOperatorTest(unittest.TestCase):
         self.assertEqual(len(tis), 4)
         for ti in tis:
             if ti.task_id == 'make_choice':
-                self.assertEquals(ti.state, State.SUCCESS)
+                self.assertEqual(ti.state, State.SUCCESS)
             elif ti.task_id == 'upstream':
-                self.assertEquals(ti.state, State.SUCCESS)
+                self.assertEqual(ti.state, State.SUCCESS)
             elif ti.task_id == 'branch_1' or ti.task_id == 'branch_2':
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
             else:
                 raise Exception

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -106,12 +106,12 @@ class BaseSensorTest(unittest.TestCase):
 
         self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
-                self.assertEquals(ti.state, State.SUCCESS)
+                self.assertEqual(ti.state, State.SUCCESS)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
     def test_fail(self):
         sensor = self._make_sensor(False)
@@ -120,12 +120,12 @@ class BaseSensorTest(unittest.TestCase):
         with self.assertRaises(AirflowSensorTimeout):
             self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
-                self.assertEquals(ti.state, State.FAILED)
+                self.assertEqual(ti.state, State.FAILED)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
     def test_soft_fail(self):
         sensor = self._make_sensor(False, soft_fail=True)
@@ -133,9 +133,9 @@ class BaseSensorTest(unittest.TestCase):
 
         self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
-            self.assertEquals(ti.state, State.SKIPPED)
+            self.assertEqual(ti.state, State.SKIPPED)
 
     def test_soft_fail_with_retries(self):
         sensor = self._make_sensor(
@@ -149,20 +149,20 @@ class BaseSensorTest(unittest.TestCase):
         with self.assertRaises(AirflowSensorTimeout):
             self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
-                self.assertEquals(ti.state, State.UP_FOR_RETRY)
+                self.assertEqual(ti.state, State.UP_FOR_RETRY)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
         sleep(0.001)
         # after retry DAG run is skipped
         self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
-            self.assertEquals(ti.state, State.SKIPPED)
+            self.assertEqual(ti.state, State.SKIPPED)
 
     def test_ok_with_reschedule(self):
         sensor = self._make_sensor(
@@ -178,56 +178,56 @@ class BaseSensorTest(unittest.TestCase):
         with freeze_time(date1):
             self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
                 # verify task is re-scheduled, i.e. state set to NONE
-                self.assertEquals(ti.state, State.UP_FOR_RESCHEDULE)
+                self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
                 # verify task start date is the initial one
-                self.assertEquals(ti.start_date, date1)
+                self.assertEqual(ti.start_date, date1)
                 # verify one row in task_reschedule table
                 task_reschedules = TaskReschedule.find_for_task_instance(ti)
-                self.assertEquals(len(task_reschedules), 1)
-                self.assertEquals(task_reschedules[0].start_date, date1)
-                self.assertEquals(task_reschedules[0].reschedule_date,
-                                  date1 + timedelta(seconds=sensor.poke_interval))
+                self.assertEqual(len(task_reschedules), 1)
+                self.assertEqual(task_reschedules[0].start_date, date1)
+                self.assertEqual(task_reschedules[0].reschedule_date,
+                                 date1 + timedelta(seconds=sensor.poke_interval))
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
         # second poke returns False and task is re-scheduled
         date2 = date1 + timedelta(seconds=sensor.poke_interval)
         with freeze_time(date2):
             self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
                 # verify task is re-scheduled, i.e. state set to NONE
-                self.assertEquals(ti.state, State.UP_FOR_RESCHEDULE)
+                self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
                 # verify task start date is the initial one
-                self.assertEquals(ti.start_date, date1)
+                self.assertEqual(ti.start_date, date1)
                 # verify two rows in task_reschedule table
                 task_reschedules = TaskReschedule.find_for_task_instance(ti)
-                self.assertEquals(len(task_reschedules), 2)
-                self.assertEquals(task_reschedules[1].start_date, date2)
-                self.assertEquals(task_reschedules[1].reschedule_date,
-                                  date2 + timedelta(seconds=sensor.poke_interval))
+                self.assertEqual(len(task_reschedules), 2)
+                self.assertEqual(task_reschedules[1].start_date, date2)
+                self.assertEqual(task_reschedules[1].reschedule_date,
+                                 date2 + timedelta(seconds=sensor.poke_interval))
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
         # third poke returns True and task succeeds
         date3 = date2 + timedelta(seconds=sensor.poke_interval)
         with freeze_time(date3):
             self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
-                self.assertEquals(ti.state, State.SUCCESS)
+                self.assertEqual(ti.state, State.SUCCESS)
                 # verify task start date is the initial one
-                self.assertEquals(ti.start_date, date1)
+                self.assertEqual(ti.start_date, date1)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
     def test_fail_with_reschedule(self):
         sensor = self._make_sensor(
@@ -242,12 +242,12 @@ class BaseSensorTest(unittest.TestCase):
         with freeze_time(date1):
             self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
-                self.assertEquals(ti.state, State.UP_FOR_RESCHEDULE)
+                self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
         # second poke returns False, timeout occurs
         date2 = date1 + timedelta(seconds=sensor.poke_interval)
@@ -255,12 +255,12 @@ class BaseSensorTest(unittest.TestCase):
             with self.assertRaises(AirflowSensorTimeout):
                 self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
-                self.assertEquals(ti.state, State.FAILED)
+                self.assertEqual(ti.state, State.FAILED)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
     def test_soft_fail_with_reschedule(self):
         sensor = self._make_sensor(
@@ -276,21 +276,21 @@ class BaseSensorTest(unittest.TestCase):
         with freeze_time(date1):
             self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
-                self.assertEquals(ti.state, State.UP_FOR_RESCHEDULE)
+                self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
         # second poke returns False, timeout occurs
         date2 = date1 + timedelta(seconds=sensor.poke_interval)
         with freeze_time(date2):
             self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
-            self.assertEquals(ti.state, State.SKIPPED)
+            self.assertEqual(ti.state, State.SKIPPED)
 
     def test_ok_with_reschedule_and_retry(self):
         sensor = self._make_sensor(
@@ -308,19 +308,19 @@ class BaseSensorTest(unittest.TestCase):
         with freeze_time(date1):
             self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
-                self.assertEquals(ti.state, State.UP_FOR_RESCHEDULE)
+                self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
                 # verify one row in task_reschedule table
                 task_reschedules = TaskReschedule.find_for_task_instance(ti)
-                self.assertEquals(len(task_reschedules), 1)
-                self.assertEquals(task_reschedules[0].start_date, date1)
-                self.assertEquals(task_reschedules[0].reschedule_date,
-                                  date1 + timedelta(seconds=sensor.poke_interval))
+                self.assertEqual(len(task_reschedules), 1)
+                self.assertEqual(task_reschedules[0].start_date, date1)
+                self.assertEqual(task_reschedules[0].reschedule_date,
+                                 date1 + timedelta(seconds=sensor.poke_interval))
                 self.assertEqual(task_reschedules[0].try_number, 1)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
         # second poke fails and task instance is marked up to retry
         date2 = date1 + timedelta(seconds=sensor.poke_interval)
@@ -328,43 +328,43 @@ class BaseSensorTest(unittest.TestCase):
             with self.assertRaises(AirflowSensorTimeout):
                 self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
-                self.assertEquals(ti.state, State.UP_FOR_RETRY)
+                self.assertEqual(ti.state, State.UP_FOR_RETRY)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
         # third poke returns False and task is rescheduled again
         date3 = date2 + timedelta(seconds=sensor.poke_interval) + sensor.retry_delay
         with freeze_time(date3):
             self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
-                self.assertEquals(ti.state, State.UP_FOR_RESCHEDULE)
+                self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
                 # verify one row in task_reschedule table
                 task_reschedules = TaskReschedule.find_for_task_instance(ti)
-                self.assertEquals(len(task_reschedules), 1)
-                self.assertEquals(task_reschedules[0].start_date, date3)
-                self.assertEquals(task_reschedules[0].reschedule_date,
-                                  date3 + timedelta(seconds=sensor.poke_interval))
+                self.assertEqual(len(task_reschedules), 1)
+                self.assertEqual(task_reschedules[0].start_date, date3)
+                self.assertEqual(task_reschedules[0].reschedule_date,
+                                 date3 + timedelta(seconds=sensor.poke_interval))
                 self.assertEqual(task_reschedules[0].try_number, 2)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
         # fourth poke return True and task succeeds
         date4 = date3 + timedelta(seconds=sensor.poke_interval)
         with freeze_time(date4):
             self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
-                self.assertEquals(ti.state, State.SUCCESS)
+                self.assertEqual(ti.state, State.SUCCESS)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
     def test_should_include_ready_to_reschedule_dep(self):
         sensor = self._make_sensor(True)
@@ -395,46 +395,46 @@ class BaseSensorTest(unittest.TestCase):
         with freeze_time(date1):
             self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
                 # verify task is re-scheduled, i.e. state set to NONE
-                self.assertEquals(ti.state, State.UP_FOR_RESCHEDULE)
+                self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
                 # verify one row in task_reschedule table
                 task_reschedules = TaskReschedule.find_for_task_instance(ti)
-                self.assertEquals(len(task_reschedules), 1)
-                self.assertEquals(task_reschedules[0].start_date, date1)
-                self.assertEquals(task_reschedules[0].reschedule_date, date2)
+                self.assertEqual(len(task_reschedules), 1)
+                self.assertEqual(task_reschedules[0].start_date, date1)
+                self.assertEqual(task_reschedules[0].reschedule_date, date2)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
         # second poke returns False and task is re-scheduled
         with freeze_time(date2):
             self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
                 # verify task is re-scheduled, i.e. state set to NONE
-                self.assertEquals(ti.state, State.UP_FOR_RESCHEDULE)
+                self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
                 # verify two rows in task_reschedule table
                 task_reschedules = TaskReschedule.find_for_task_instance(ti)
-                self.assertEquals(len(task_reschedules), 2)
-                self.assertEquals(task_reschedules[1].start_date, date2)
-                self.assertEquals(task_reschedules[1].reschedule_date, date3)
+                self.assertEqual(len(task_reschedules), 2)
+                self.assertEqual(task_reschedules[1].start_date, date2)
+                self.assertEqual(task_reschedules[1].reschedule_date, date3)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
         # third poke returns True and task succeeds
         with freeze_time(date3):
             self._run(sensor)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
-                self.assertEquals(ti.state, State.SUCCESS)
+                self.assertEqual(ti.state, State.SUCCESS)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
 
     def test_reschedule_with_test_mode(self):
         sensor = self._make_sensor(
@@ -453,13 +453,13 @@ class BaseSensorTest(unittest.TestCase):
                     ignore_ti_state=True,
                     test_mode=True)
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
         for ti in tis:
             if ti.task_id == SENSOR_OP:
                 # in test mode state is not modified
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)
                 # in test mode no reschedule request is recorded
                 task_reschedules = TaskReschedule.find_for_task_instance(ti)
-                self.assertEquals(len(task_reschedules), 0)
+                self.assertEqual(len(task_reschedules), 0)
             if ti.task_id == DUMMY_OP:
-                self.assertEquals(ti.state, State.NONE)
+                self.assertEqual(ti.state, State.NONE)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -245,12 +245,12 @@ key3 = value3
 
         with self.assertWarns(DeprecationWarning):
             os.environ['AIRFLOW__CELERY__CELERYD_CONCURRENCY'] = '99'
-            self.assertEquals(conf.getint('celery', 'worker_concurrency'), 99)
+            self.assertEqual(conf.getint('celery', 'worker_concurrency'), 99)
             os.environ.pop('AIRFLOW__CELERY__CELERYD_CONCURRENCY')
 
         with self.assertWarns(DeprecationWarning):
             conf.set('celery', 'celeryd_concurrency', '99')
-            self.assertEquals(conf.getint('celery', 'worker_concurrency'), 99)
+            self.assertEqual(conf.getint('celery', 'worker_concurrency'), 99)
             conf.remove_option('celery', 'celeryd_concurrency')
 
     def test_deprecated_options_cmd(self):
@@ -266,6 +266,6 @@ key3 = value3
             tmp = None
             if 'AIRFLOW__CELERY__RESULT_BACKEND' in os.environ:
                 tmp = os.environ.pop('AIRFLOW__CELERY__RESULT_BACKEND')
-            self.assertEquals(conf.getint('celery', 'result_backend'), 99)
+            self.assertEqual(conf.getint('celery', 'result_backend'), 99)
             if tmp:
                 os.environ['AIRFLOW__CELERY__RESULT_BACKEND'] = tmp

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -106,7 +106,7 @@ class BaseJobTest(unittest.TestCase):
         job = self.TestJob(lambda: True)
         job.run()
 
-        self.assertEquals(job.state, State.SUCCESS)
+        self.assertEqual(job.state, State.SUCCESS)
         self.assertIsNotNone(job.end_date)
 
     def test_state_sysexit(self):
@@ -114,7 +114,7 @@ class BaseJobTest(unittest.TestCase):
         job = self.TestJob(lambda: sys.exit(0))
         job.run()
 
-        self.assertEquals(job.state, State.SUCCESS)
+        self.assertEqual(job.state, State.SUCCESS)
         self.assertIsNotNone(job.end_date)
 
     def test_state_failed(self):
@@ -125,7 +125,7 @@ class BaseJobTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             job.run()
 
-        self.assertEquals(job.state, State.FAILED)
+        self.assertEqual(job.state, State.FAILED)
         self.assertIsNotNone(job.end_date)
 
 
@@ -298,7 +298,7 @@ class BackfillJobTest(unittest.TestCase):
         ti = TI(task=dag.get_task('test_backfill_run_rescheduled_task-1'),
                 execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
-        self.assertEquals(ti.state, State.SUCCESS)
+        self.assertEqual(ti.state, State.SUCCESS)
 
     def test_backfill_rerun_failed_tasks(self):
         dag = DAG(
@@ -337,7 +337,7 @@ class BackfillJobTest(unittest.TestCase):
         ti = TI(task=dag.get_task('test_backfill_rerun_failed_task-1'),
                 execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
-        self.assertEquals(ti.state, State.SUCCESS)
+        self.assertEqual(ti.state, State.SUCCESS)
 
     def test_backfill_rerun_upstream_failed_tasks(self):
             dag = DAG(
@@ -377,7 +377,7 @@ class BackfillJobTest(unittest.TestCase):
             ti = TI(task=dag.get_task('test_backfill_rerun_upstream_failed_task-1'),
                     execution_date=DEFAULT_DATE)
             ti.refresh_from_db()
-            self.assertEquals(ti.state, State.SUCCESS)
+            self.assertEqual(ti.state, State.SUCCESS)
 
     def test_backfill_rerun_failed_tasks_without_flag(self):
         dag = DAG(
@@ -515,7 +515,7 @@ class BackfillJobTest(unittest.TestCase):
         # ti should have succeeded
         ti = TI(dag.tasks[0], run_date)
         ti.refresh_from_db()
-        self.assertEquals(ti.state, State.SUCCESS)
+        self.assertEqual(ti.state, State.SUCCESS)
 
     def test_run_ignores_all_dependencies(self):
         """
@@ -538,7 +538,7 @@ class BackfillJobTest(unittest.TestCase):
             execution_date=DEFAULT_DATE)
 
         ti_dependent0.refresh_from_db()
-        self.assertEquals(ti_dependent0.state, State.FAILED)
+        self.assertEqual(ti_dependent0.state, State.FAILED)
 
         task1_id = 'test_run_dependency_task'
         args1 = ['run',
@@ -552,7 +552,7 @@ class BackfillJobTest(unittest.TestCase):
             task=dag.get_task(task1_id),
             execution_date=DEFAULT_DATE + datetime.timedelta(days=1))
         ti_dependency.refresh_from_db()
-        self.assertEquals(ti_dependency.state, State.FAILED)
+        self.assertEqual(ti_dependency.state, State.FAILED)
 
         task2_id = 'test_run_dependent_task'
         args2 = ['run',
@@ -566,7 +566,7 @@ class BackfillJobTest(unittest.TestCase):
             task=dag.get_task(task2_id),
             execution_date=DEFAULT_DATE + datetime.timedelta(days=1))
         ti_dependent.refresh_from_db()
-        self.assertEquals(ti_dependent.state, State.SUCCESS)
+        self.assertEqual(ti_dependent.state, State.SUCCESS)
 
     def test_run_naive_taskinstance(self):
         """
@@ -591,7 +591,7 @@ class BackfillJobTest(unittest.TestCase):
             execution_date=NAIVE_DATE)
 
         ti_dependent0.refresh_from_db()
-        self.assertEquals(ti_dependent0.state, State.FAILED)
+        self.assertEqual(ti_dependent0.state, State.FAILED)
 
     def test_cli_backfill_depends_on_past(self):
         """
@@ -977,12 +977,12 @@ class BackfillJobTest(unittest.TestCase):
             include_parentdag=True)
 
         ti0.refresh_from_db()
-        self.assertEquals(State.NONE, ti0.state)
+        self.assertEqual(State.NONE, ti0.state)
 
         ti1 = TI(
             task=dag.get_task('some-other-task'),
             execution_date=DEFAULT_DATE)
-        self.assertEquals(State.NONE, ti1.state)
+        self.assertEqual(State.NONE, ti1.state)
 
         # Checks that all the Downstream tasks for Parent DAG
         # have been cleared
@@ -991,7 +991,7 @@ class BackfillJobTest(unittest.TestCase):
                 task=dag.get_task(task.task_id),
                 execution_date=DEFAULT_DATE
             )
-            self.assertEquals(State.NONE, ti.state)
+            self.assertEqual(State.NONE, ti.state)
 
         subdag.clear()
         dag.clear()
@@ -1438,7 +1438,7 @@ class SchedulerJobTest(unittest.TestCase):
 
         scheduler._execute_task_instances(dagbag, [State.SCHEDULED])
         ti1.refresh_from_db()
-        self.assertEquals(State.SCHEDULED, ti1.state)
+        self.assertEqual(State.SCHEDULED, ti1.state)
 
     def test_execute_task_instances_no_dagrun_task_will_execute(self):
         """
@@ -1463,7 +1463,7 @@ class SchedulerJobTest(unittest.TestCase):
 
         scheduler._execute_task_instances(dagbag, [State.SCHEDULED])
         ti1.refresh_from_db()
-        self.assertEquals(State.QUEUED, ti1.state)
+        self.assertEqual(State.QUEUED, ti1.state)
 
     def test_execute_task_instances_backfill_tasks_wont_execute(self):
         """
@@ -1492,7 +1492,7 @@ class SchedulerJobTest(unittest.TestCase):
 
         scheduler._execute_task_instances(dagbag, [State.SCHEDULED])
         ti1.refresh_from_db()
-        self.assertEquals(State.SCHEDULED, ti1.state)
+        self.assertEqual(State.SCHEDULED, ti1.state)
 
     def test_find_executable_task_instances_backfill_nodagrun(self):
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_backfill_nodagrun'
@@ -2075,7 +2075,7 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertEqual(ti2.state, State.SCHEDULED)
 
         ti3.refresh_from_db(session=session)
-        self.assertEquals(ti3.state, State.NONE)
+        self.assertEqual(ti3.state, State.NONE)
 
         dr1.refresh_from_db(session=session)
         dr1.state = State.FAILED
@@ -2133,7 +2133,7 @@ class SchedulerJobTest(unittest.TestCase):
         scheduler_job._change_state_for_tasks_failed_to_execute()
 
         ti.refresh_from_db()
-        self.assertEquals(State.SCHEDULED, ti.state)
+        self.assertEqual(State.SCHEDULED, ti.state)
 
         # Tasks failed to execute with RUNNING state will not be set to SCHEDULED state.
         session.query(TI).delete()
@@ -2146,7 +2146,7 @@ class SchedulerJobTest(unittest.TestCase):
         scheduler_job._change_state_for_tasks_failed_to_execute()
 
         ti.refresh_from_db()
-        self.assertEquals(State.RUNNING, ti.state)
+        self.assertEqual(State.RUNNING, ti.state)
 
     def test_execute_helper_reset_orphaned_tasks(self):
         session = settings.Session()
@@ -2632,7 +2632,7 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertIsNotNone(dr)
 
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 1)
+        self.assertEqual(len(tis), 1)
 
         DummyOperator(
             task_id='dummy2',
@@ -2643,7 +2643,7 @@ class SchedulerJobTest(unittest.TestCase):
         scheduler._process_task_instances(dag, queue=queue)
 
         tis = dr.get_task_instances()
-        self.assertEquals(len(tis), 2)
+        self.assertEqual(len(tis), 2)
 
     def test_scheduler_verify_max_active_runs(self):
         """
@@ -2706,7 +2706,7 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertIsNotNone(dr2)
 
         dr.refresh_from_db(session=session)
-        self.assertEquals(dr.state, State.FAILED)
+        self.assertEqual(dr.state, State.FAILED)
 
     def test_scheduler_verify_max_active_runs_and_dagrun_timeout(self):
         """
@@ -2820,12 +2820,12 @@ class SchedulerJobTest(unittest.TestCase):
         # Create 2 dagruns, which will create 2 task instances.
         dr = scheduler.create_dag_run(dag)
         self.assertIsNotNone(dr)
-        self.assertEquals(dr.execution_date, DEFAULT_DATE)
+        self.assertEqual(dr.execution_date, DEFAULT_DATE)
         dr = scheduler.create_dag_run(dag)
         self.assertIsNotNone(dr)
         queue = []
         scheduler._process_task_instances(dag, queue=queue)
-        self.assertEquals(len(queue), 2)
+        self.assertEqual(len(queue), 2)
         dagbag = self._make_simple_dag_bag([dag])
 
         # Recreated part of the scheduler here, to kick off tasks -> executor
@@ -2844,7 +2844,7 @@ class SchedulerJobTest(unittest.TestCase):
                                           (State.SCHEDULED,
                                            State.UP_FOR_RETRY))
 
-        self.assertEquals(len(scheduler.executor.queued_tasks), 1)
+        self.assertEqual(len(scheduler.executor.queued_tasks), 1)
 
     def test_scheduler_auto_align(self):
         """
@@ -2873,7 +2873,7 @@ class SchedulerJobTest(unittest.TestCase):
 
         dr = scheduler.create_dag_run(dag)
         self.assertIsNotNone(dr)
-        self.assertEquals(dr.execution_date, timezone.datetime(2016, 1, 2, 5, 4))
+        self.assertEqual(dr.execution_date, timezone.datetime(2016, 1, 2, 5, 4))
 
         dag = DAG(
             dag_id='test_scheduler_auto_align_2',
@@ -2895,7 +2895,7 @@ class SchedulerJobTest(unittest.TestCase):
 
         dr = scheduler.create_dag_run(dag)
         self.assertIsNotNone(dr)
-        self.assertEquals(dr.execution_date, timezone.datetime(2016, 1, 1, 10, 10))
+        self.assertEqual(dr.execution_date, timezone.datetime(2016, 1, 1, 10, 10))
 
     def test_scheduler_reschedule(self):
         """
@@ -2941,11 +2941,11 @@ class SchedulerJobTest(unittest.TestCase):
             scheduler.run()
 
         do_schedule()
-        self.assertEquals(1, len(executor.queued_tasks))
+        self.assertEqual(1, len(executor.queued_tasks))
         executor.queued_tasks.clear()
 
         do_schedule()
-        self.assertEquals(2, len(executor.queued_tasks))
+        self.assertEqual(2, len(executor.queued_tasks))
 
     def test_scheduler_sla_miss_callback(self):
         """
@@ -3113,7 +3113,7 @@ class SchedulerJobTest(unittest.TestCase):
             scheduler.run()
 
         do_schedule()
-        self.assertEquals(1, len(executor.queued_tasks))
+        self.assertEqual(1, len(executor.queued_tasks))
 
         def run_with_error(task):
             try:
@@ -3532,7 +3532,7 @@ class SchedulerJobTest(unittest.TestCase):
         session.commit()
 
         reset_tis = scheduler.reset_state_for_orphaned_tasks(session=session)
-        self.assertEquals(1, len(reset_tis))
+        self.assertEqual(1, len(reset_tis))
 
     def test_reset_orphaned_tasks_backfill_dag(self):
         dag_id = 'test_reset_orphaned_tasks_backfill_dag'
@@ -3553,7 +3553,7 @@ class SchedulerJobTest(unittest.TestCase):
         session.commit()
 
         self.assertTrue(dr1.is_backfill)
-        self.assertEquals(0, len(scheduler.reset_state_for_orphaned_tasks(session=session)))
+        self.assertEqual(0, len(scheduler.reset_state_for_orphaned_tasks(session=session)))
 
     def test_reset_orphaned_tasks_specified_dagrun(self):
         """Try to reset when we specify a dagrun and ensure nothing else is."""
@@ -3581,11 +3581,11 @@ class SchedulerJobTest(unittest.TestCase):
         session.commit()
 
         reset_tis = scheduler.reset_state_for_orphaned_tasks(filter_by_dag_run=dr2, session=session)
-        self.assertEquals(1, len(reset_tis))
+        self.assertEqual(1, len(reset_tis))
         ti1.refresh_from_db(session=session)
         ti2.refresh_from_db(session=session)
-        self.assertEquals(State.SCHEDULED, ti1.state)
-        self.assertEquals(State.NONE, ti2.state)
+        self.assertEqual(State.SCHEDULED, ti1.state)
+        self.assertEqual(State.NONE, ti2.state)
 
     def test_reset_orphaned_tasks_nonexistent_dagrun(self):
         """Make sure a task in an orphaned state is not reset if it has no dagrun. """
@@ -3606,7 +3606,7 @@ class SchedulerJobTest(unittest.TestCase):
         session.merge(ti)
         session.commit()
 
-        self.assertEquals(0, len(scheduler.reset_state_for_orphaned_tasks(session=session)))
+        self.assertEqual(0, len(scheduler.reset_state_for_orphaned_tasks(session=session)))
 
     def test_reset_orphaned_tasks_no_orphans(self):
         dag_id = 'test_reset_orphaned_tasks_no_orphans'
@@ -3625,9 +3625,9 @@ class SchedulerJobTest(unittest.TestCase):
         session.merge(tis[0])
         session.commit()
 
-        self.assertEquals(0, len(scheduler.reset_state_for_orphaned_tasks(session=session)))
+        self.assertEqual(0, len(scheduler.reset_state_for_orphaned_tasks(session=session)))
         tis[0].refresh_from_db()
-        self.assertEquals(State.RUNNING, tis[0].state)
+        self.assertEqual(State.RUNNING, tis[0].state)
 
     def test_reset_orphaned_tasks_non_running_dagruns(self):
         """Ensure orphaned tasks with non-running dagruns are not reset."""
@@ -3642,13 +3642,13 @@ class SchedulerJobTest(unittest.TestCase):
         dr1 = scheduler.create_dag_run(dag)
         dr1.state = State.SUCCESS
         tis = dr1.get_task_instances(session=session)
-        self.assertEquals(1, len(tis))
+        self.assertEqual(1, len(tis))
         tis[0].state = State.SCHEDULED
         session.merge(dr1)
         session.merge(tis[0])
         session.commit()
 
-        self.assertEquals(0, len(scheduler.reset_state_for_orphaned_tasks(session=session)))
+        self.assertEqual(0, len(scheduler.reset_state_for_orphaned_tasks(session=session)))
 
     def test_reset_orphaned_tasks_with_orphans(self):
         """Create dagruns and esnure only ones with correct states are reset."""

--- a/tests/utils/test_cli_util.py
+++ b/tests/utils/test_cli_util.py
@@ -42,17 +42,17 @@ class CliUtilTest(unittest.TestCase):
                     'task_id': 'bar',
                     'execution_date': exec_date}
         for k, v in expected.items():
-            self.assertEquals(v, metrics.get(k))
+            self.assertEqual(v, metrics.get(k))
 
         self.assertTrue(metrics.get('start_datetime') <= datetime.utcnow())
         self.assertTrue(metrics.get('full_command'))
 
         log_dao = metrics.get('log')
         self.assertTrue(log_dao)
-        self.assertEquals(log_dao.dag_id, metrics.get('dag_id'))
-        self.assertEquals(log_dao.task_id, metrics.get('task_id'))
-        self.assertEquals(log_dao.execution_date, metrics.get('execution_date'))
-        self.assertEquals(log_dao.owner, metrics.get('user'))
+        self.assertEqual(log_dao.dag_id, metrics.get('dag_id'))
+        self.assertEqual(log_dao.task_id, metrics.get('task_id'))
+        self.assertEqual(log_dao.execution_date, metrics.get('execution_date'))
+        self.assertEqual(log_dao.owner, metrics.get('user'))
 
     def test_fail_function(self):
         """

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -205,11 +205,11 @@ class TestDagFileProcessorManager(unittest.TestCase):
             manager._last_zombie_query_time = timezone.utcnow() - timedelta(
                 seconds=manager._zombie_threshold_secs + 1)
             zombies = manager._find_zombies()
-            self.assertEquals(1, len(zombies))
+            self.assertEqual(1, len(zombies))
             self.assertIsInstance(zombies[0], SimpleTaskInstance)
-            self.assertEquals(ti.dag_id, zombies[0].dag_id)
-            self.assertEquals(ti.task_id, zombies[0].task_id)
-            self.assertEquals(ti.execution_date, zombies[0].execution_date)
+            self.assertEqual(ti.dag_id, zombies[0].dag_id)
+            self.assertEqual(ti.task_id, zombies[0].task_id)
+            self.assertEqual(ti.execution_date, zombies[0].execution_date)
 
             session.query(TI).delete()
             session.query(LJ).delete()

--- a/tests/utils/test_email.py
+++ b/tests/utils/test_email.py
@@ -28,17 +28,17 @@ class EmailTest(unittest.TestCase):
     def test_get_email_address_comma_sep_string(self):
         emails_string = 'test1@example.com, test2@example.com'
 
-        self.assertEquals(
+        self.assertEqual(
             get_email_address_list(emails_string), EMAILS)
 
     def test_get_email_address_colon_sep_string(self):
         emails_string = 'test1@example.com; test2@example.com'
 
-        self.assertEquals(
+        self.assertEqual(
             get_email_address_list(emails_string), EMAILS)
 
     def test_get_email_address_list(self):
         emails_list = ['test1@example.com', 'test2@example.com']
 
-        self.assertEquals(
+        self.assertEqual(
             get_email_address_list(emails_list), EMAILS)

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -171,12 +171,12 @@ class TestHelpers(unittest.TestCase):
         self.assertTrue(helpers.is_container(["a", "list", "is", "a", "container"]))
 
     def test_as_tuple(self):
-        self.assertEquals(
+        self.assertEqual(
             helpers.as_tuple("a string is not a container"),
             ("a string is not a container",)
         )
 
-        self.assertEquals(
+        self.assertEqual(
             helpers.as_tuple(["a", "list", "is", "a", "container"]),
             ("a", "list", "is", "a", "container")
         )

--- a/tests/utils/test_timezone.py
+++ b/tests/utils/test_timezone.py
@@ -41,16 +41,16 @@ class TimezoneTest(unittest.TestCase):
     def test_utcnow(self):
         now = timezone.utcnow()
         self.assertTrue(timezone.is_localized(now))
-        self.assertEquals(now.replace(tzinfo=None), now.astimezone(UTC).replace(tzinfo=None))
+        self.assertEqual(now.replace(tzinfo=None), now.astimezone(UTC).replace(tzinfo=None))
 
     def test_convert_to_utc(self):
         naive = datetime.datetime(2011, 9, 1, 13, 20, 30)
         utc = datetime.datetime(2011, 9, 1, 13, 20, 30, tzinfo=UTC)
-        self.assertEquals(utc, timezone.convert_to_utc(naive))
+        self.assertEqual(utc, timezone.convert_to_utc(naive))
 
         eat = datetime.datetime(2011, 9, 1, 13, 20, 30, tzinfo=EAT)
         utc = datetime.datetime(2011, 9, 1, 10, 20, 30, tzinfo=UTC)
-        self.assertEquals(utc, timezone.convert_to_utc(eat))
+        self.assertEqual(utc, timezone.convert_to_utc(eat))
 
     def test_make_naive(self):
         self.assertEqual(

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -143,8 +143,8 @@ class TestSecurity(unittest.TestCase):
                          {('can_some_action', 'SomeBaseView')})
 
         mock_get_user_roles.return_value = []
-        self.assertEquals(len(self.security_manager
-                              .get_all_permissions_views()), 0)
+        self.assertEqual(len(self.security_manager
+                             .get_all_permissions_views()), 0)
 
     @mock.patch('airflow.www.security.AirflowSecurityManager'
                 '.get_all_permissions_views')
@@ -163,8 +163,8 @@ class TestSecurity(unittest.TestCase):
         mock_get_all_permissions_views.return_value = {('can_dag_read', 'dag_id')}
 
         mock_get_user_roles.return_value = [role]
-        self.assertEquals(self.security_manager
-                          .get_accessible_dag_ids(user), set(['dag_id']))
+        self.assertEqual(self.security_manager
+                         .get_accessible_dag_ids(user), set(['dag_id']))
 
     @mock.patch('airflow.www.security.AirflowSecurityManager._has_view_access')
     def test_has_access(self, mock_has_view_access):

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -94,7 +94,7 @@ class UtilsTest(unittest.TestCase):
 
     def test_params_no_values(self):
         """Should return an empty string if no params are passed"""
-        self.assertEquals('', utils.get_params())
+        self.assertEqual('', utils.get_params())
 
     def test_params_search(self):
         self.assertEqual('search=bash_',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3744

### Description

New versions of Python have marked some methods as obsolete. This change replaces valid calls.
https://docs.python.org/3/library/unittest.html#deprecated-aliases

### Tests

Not applicable.

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

Not applicable.

### Code Quality

- [X] Passes `flake8`
