### PR TITLE
[AIRFLOW-3751] Ignore malformed ldap schema option

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -524,6 +524,10 @@ basedn = dc=example,dc=com
 cacert = /etc/ca/ldap_ca.crt
 search_scope = LEVEL
 
+# This setting allows the use of LDAP servers that either return a 
+# broken schema, or do not return a schema. 
+ignore_malformed_schema = False
+
 [mesos]
 # Mesos master address which MesosExecutor will connect to.
 master = localhost:5050

--- a/airflow/contrib/auth/backends/ldap_auth.py
+++ b/airflow/contrib/auth/backends/ldap_auth.py
@@ -24,7 +24,7 @@ from flask import flash
 from wtforms import Form, PasswordField, StringField
 from wtforms.validators import InputRequired
 
-from ldap3 import Server, Connection, Tls, LEVEL, SUBTREE
+from ldap3 import Server, Connection, Tls, set_config_parameter, LEVEL, SUBTREE
 import ssl
 
 from flask import url_for, redirect
@@ -59,6 +59,14 @@ def get_ldap_connection(dn=None, password=None):
         cacert = configuration.conf.get("ldap", "cacert")
     except AirflowConfigException:
         pass
+
+    try:
+        ignore_malformed_schema = configuration.conf.get("ldap", "ignore_malformed_schema")
+    except AirflowConfigException:
+        pass
+
+    if ignore_malformed_schema:
+        set_config_parameter('IGNORE_MALFORMED_SCHEMA', ignore_malformed_schema)
 
     tls_configuration = Tls(validate=ssl.CERT_REQUIRED,
                             ca_certs_file=cacert)

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -138,6 +138,10 @@ Valid search_scope options can be found in the `ldap3 Documentation <http://ldap
     # Set search_scope to SUBTREE if using Active Directory, and not specifying an Organizational Unit
     search_scope = LEVEL
 
+    # This option tells ldap3 to ignore schemas that are considered malformed. This sometimes comes up
+    # when using hosted ldap services.
+    ignore_malformed_schema = False
+
 The superuser_filter and data_profiler_filter are optional. If defined, these configurations allow you to specify LDAP groups that users must belong to in order to have superuser (admin) and data-profiler permissions. If undefined, all users will be superusers and data profilers.
 
 Roll your own


### PR DESCRIPTION
### Jira

This PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3751/) issues and references them in the PR title.

### Description

This change includes a configuration option to allow ldap authentication to use ldap services that may not return schemas or return invalid ones. To allow malformed schemas, the configuration value of ignore_malformed_schema is added as a boolean. The default is the current behaviour.

### Tests

- The changes introduced by this PR are covered by existing unit tests.


### Code Quality

Passes `flake8`
