### PR TITLE
[AIRFLOW-3760] - Ensure that we pass the command to the Kubernetes Pod as a List

### DIFF
--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -238,7 +238,7 @@ class WorkerConfiguration(LoggingMixin):
             image=kube_executor_config.image or self.kube_config.kube_image,
             image_pull_policy=(kube_executor_config.image_pull_policy or
                                self.kube_config.kube_image_pull_policy),
-            cmds=airflow_command,
+            cmds=airflow_command.split(" "),
             labels={
                 'airflow-worker': worker_uuid,
                 'dag_id': dag_id,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] https://issues.apache.org/jira/browse/AIRFLOW-3760

### Description

- [X] AIRFLOW-2888 caused worker pod creation to fail, as we are not passing the command to kubernetes as a list item.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: This fixes an issue created with a previous pull request.
### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X] Passes `flake8`
