### PR TITLE
[AIRFLOW-XXX] Pin version of Pip in tests to work around pypa/pip#6163

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
-  - pip install --upgrade pip
+  - pip install --upgrade
 script:
   - if [ -z "$KUBERNETES_VERSION" ]; then docker-compose --log-level ERROR -f scripts/ci/docker-compose.yml run airflow-testing /app/scripts/ci/run-ci.sh; fi
   - if [ ! -z "$KUBERNETES_VERSION" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN set -x \
     && apt update \
     && if [ -n "${APT_DEPS}" ]; then apt install -y $APT_DEPS; fi \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install --no-cache-dir ${PYTHON_DEPS}; fi \
-    && pip install --no-cache-dir -e .[$AIRFLOW_DEPS] \
+    && pip install --no-cache-dir --no-use-pep517 -e .[$AIRFLOW_DEPS] \
     && apt purge --auto-remove -yqq $buildDeps \
     && apt autoremove -yqq --purge \
     && apt clean

--- a/scripts/ci/kubernetes/docker/Dockerfile
+++ b/scripts/ci/kubernetes/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN pip install -U setuptools && \
 
 # install airflow
 COPY airflow.tar.gz /tmp/airflow.tar.gz
-RUN pip install /tmp/airflow.tar.gz
+RUN pip install --no-use-pep517 /tmp/airflow.tar.gz
 
 COPY airflow-test-env-init.sh /tmp/airflow-test-env-init.sh
 

--- a/tox.ini
+++ b/tox.ini
@@ -54,8 +54,8 @@ setenv =
 passenv = *
 
 commands =
-  pip wheel --progress-bar off -w {homedir}/.wheelhouse -f {homedir}/.wheelhouse -e .[devel_ci]
-  pip install --progress-bar off --find-links={homedir}/.wheelhouse --no-index -e .[devel_ci]
+  pip wheel --no-use-pep517 --progress-bar off -w {homedir}/.wheelhouse -f {homedir}/.wheelhouse -e .[devel_ci]
+  pip install --no-use-pep517 --progress-bar off --find-links={homedir}/.wheelhouse --no-index -e .[devel_ci]
   env_docker: {toxinidir}/scripts/ci/1-setup-env.sh
   env_docker: {toxinidir}/scripts/ci/2-setup-kdc.sh
   backend_mysql: {toxinidir}/scripts/ci/3-setup-mysql.sh


### PR DESCRIPTION
There is a bug or a new feature that causes a number of our dependencies
to fail to install.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
