### PR TITLE
[AIRFLOW-3762] Add list_jobs to CLI

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -659,14 +659,14 @@ def list_jobs(args, dag=None):
                     .order_by(jobs.BaseJob.start_date.desc())
                     .limit(args.limit)
                     .all())
-    fields = ['dag_id', 'state', 'job_type', 'start_date', 'end_date']
-    all_jobs = [[j.__getattribute__(field) for field in fields] for j in all_jobs]
-    msg = tabulate(all_jobs,
-                   [field.capitalize().replace('_', ' ') for field in fields],
-                   tablefmt="fancy_grid")
-    if sys.version_info[0] < 3:
-        msg = msg.encode('utf-8')
-    print(msg)
+        fields = ['dag_id', 'state', 'job_type', 'start_date', 'end_date']
+        all_jobs = [[job.__getattribute__(field) for field in fields] for job in all_jobs]
+        msg = tabulate(all_jobs,
+                       [field.capitalize().replace('_', ' ') for field in fields],
+                       tablefmt="fancy_grid")
+        if sys.version_info[0] < 3:
+            msg = msg.encode('utf-8')
+        print(msg)
 
 
 @cli_utils.action_logging

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -637,6 +637,41 @@ def list_tasks(args, dag=None):
 
 
 @cli_utils.action_logging
+def list_jobs(args, dag=None):
+    queries = []
+    if dag:
+        args.dag_id = dag.dag_id
+    if args.dag_id:
+        dagbag = DagBag()
+
+        if args.dag_id not in dagbag.dags:
+            error_message = "Dag id {} not found".format(args.dag_id)
+            raise AirflowException(error_message)
+        queries.append(jobs.BaseJob.dag_id == args.dag_id)
+
+    if args.state:
+        queries.append(jobs.BaseJob.state == args.state)
+
+    limit = args.limit if args.limit else -1
+
+    with db.create_session() as session:
+        all_jobs = (session
+                    .query(jobs.BaseJob)
+                    .filter(*queries)
+                    .order_by(jobs.BaseJob.start_date.desc())
+                    .limit(limit)
+                    .all())
+    fields = ['dag_id', 'state', 'job_type', 'start_date', 'end_date']
+    all_jobs = [[j.__getattribute__(field) for field in fields] for j in all_jobs]
+    msg = tabulate(all_jobs,
+                   [field.capitalize().replace('_', ' ') for field in fields],
+                   tablefmt="fancy_grid")
+    if sys.version_info[0] < 3:
+        msg = msg.encode('utf-8')
+    print(msg)
+
+
+@cli_utils.action_logging
 def test(args, dag=None):
     # We want log outout from operators etc to show up here. Normally
     # airflow.task would redirect to a file, but here we want it to propagate
@@ -1560,6 +1595,12 @@ class CLIFactory(object):
             "Only list the dag runs corresponding to the state"
         ),
 
+        # list_jobs
+        'limit': Arg(
+            ("--limit",),
+            "Return a limited number of records"
+        ),
+
         # backfill
         'mark_success': Arg(
             ("-m", "--mark_success"),
@@ -1995,6 +2036,10 @@ class CLIFactory(object):
             'func': list_tasks,
             'help': "List the tasks within a DAG",
             'args': ('dag_id', 'tree', 'subdir'),
+        }, {
+            'func': list_jobs,
+            'help': "List the jobs",
+            'args': ('dag_id_opt', 'state', 'limit'),
         }, {
             'func': clear,
             'help': "Clear a set of task instance, as if they never ran",

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -652,14 +652,12 @@ def list_jobs(args, dag=None):
     if args.state:
         queries.append(jobs.BaseJob.state == args.state)
 
-    limit = args.limit if args.limit else -1
-
     with db.create_session() as session:
         all_jobs = (session
                     .query(jobs.BaseJob)
                     .filter(*queries)
                     .order_by(jobs.BaseJob.start_date.desc())
-                    .limit(limit)
+                    .limit(args.limit)
                     .all())
     fields = ['dag_id', 'state', 'job_type', 'start_date', 'end_date']
     all_jobs = [[j.__getattribute__(field) for field in fields] for j in all_jobs]

--- a/tests/core.py
+++ b/tests/core.py
@@ -1234,6 +1234,7 @@ class CliTests(unittest.TestCase):
     def test_cli_list_jobs_with_args(self):
         args = self.parser.parse_args(['list_jobs', '--dag_id',
                                        'example_bash_operator',
+                                       '--state', 'success',
                                        '--limit', '100'])
         cli.list_jobs(args)
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -1227,6 +1227,16 @@ class CliTests(unittest.TestCase):
             'list_tasks', 'example_bash_operator', '--tree'])
         cli.list_tasks(args)
 
+    def test_cli_list_jobs(self):
+        args = self.parser.parse_args(['list_jobs'])
+        cli.list_jobs(args)
+
+    def test_cli_list_jobs_with_args(self):
+        args = self.parser.parse_args(['list_jobs', '--dag_id',
+                                       'example_bash_operator',
+                                       '--limit', '100'])
+        cli.list_jobs(args)
+
     @mock.patch("airflow.bin.cli.db.initdb")
     def test_cli_initdb(self, initdb_mock):
         cli.initdb(self.parser.parse_args(['initdb']))


### PR DESCRIPTION
Add list_jobs to CLI

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-3762](https://issues.apache.org/jira/browse/AIRFLOW-3762) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
$ airflow list_jobs
$ airflow list_jobs --dag_id example_bash_operator --state success --limit 10

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests.core:CliTests.test_cli_list_jobs
tests.core:CliTests.test_cli_list_jobs_with_args

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
