### PR TITLE
[AIRFLOW-3746] Fix DockerOperator missing container exit

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -231,6 +231,7 @@ class DockerOperator(BaseOperator):
             self.cli.start(self.container['Id'])
 
             line = ''
+            
             for line in self.cli.attach(container=self.container['Id'], stdout=True, stderr=True, stream=True):
                 line = line.strip()
                 if hasattr(line, 'decode'):

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -231,7 +231,6 @@ class DockerOperator(BaseOperator):
             self.cli.start(self.container['Id'])
 
             line = ''
-            
             for line in self.cli.attach(container=self.container['Id'], stdout=True, stderr=True, stream=True):
                 line = line.strip()
                 if hasattr(line, 'decode'):

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -231,7 +231,10 @@ class DockerOperator(BaseOperator):
             self.cli.start(self.container['Id'])
 
             line = ''
-            for line in self.cli.attach(container=self.container['Id'], stdout=True, stderr=True, stream=True):
+            for line in self.cli.attach(container=self.container['Id'],
+                                        stdout=True,
+                                        stderr=True,
+                                        stream=True):
                 line = line.strip()
                 if hasattr(line, 'decode'):
                     line = line.decode('utf-8')

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -231,7 +231,7 @@ class DockerOperator(BaseOperator):
             self.cli.start(self.container['Id'])
 
             line = ''
-            for line in self.cli.logs(container=self.container['Id'], stream=True):
+            for line in self.cli.attach(container=self.container['Id'], stdout=True, stderr=True, stream=True):
                 line = line.strip()
                 if hasattr(line, 'decode'):
                     line = line.decode('utf-8')

--- a/tests/operators/test_docker_operator.py
+++ b/tests/operators/test_docker_operator.py
@@ -82,7 +82,6 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock.images.assert_called_with(name='ubuntu:latest')
         client_mock.attach.assert_called_with(container='some_id', stdout=True,
                                               stderr=True, stream=True)
-        client_mock.logs.assert_called_with(container='some_id', stream=True)
         client_mock.pull.assert_called_with('ubuntu:latest', stream=True)
         client_mock.wait.assert_called_with('some_id')
 

--- a/tests/operators/test_docker_operator.py
+++ b/tests/operators/test_docker_operator.py
@@ -93,7 +93,6 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock.create_host_config.return_value = mock.Mock()
         client_mock.images.return_value = []
         client_mock.attach.return_value = []
-        client_mock.logs.return_value = []
         client_mock.pull.return_value = []
         client_mock.wait.return_value = {"StatusCode": 0}
 
@@ -120,7 +119,6 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock.create_host_config.return_value = mock.Mock()
         client_mock.images.return_value = []
         client_mock.attach.return_value = ['unicode container log 😁']
-        client_mock.logs.return_value = ['unicode container log 😁']
         client_mock.pull.return_value = []
         client_mock.wait.return_value = {"StatusCode": 0}
 
@@ -143,7 +141,6 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock.create_host_config.return_value = mock.Mock()
         client_mock.images.return_value = []
         client_mock.attach.return_value = []
-        client_mock.logs.return_value = []
         client_mock.pull.return_value = []
         client_mock.wait.return_value = {"StatusCode": 1}
 
@@ -173,7 +170,6 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock.images.return_value = []
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.attach.return_value = []
-        client_mock.logs.return_value = []
         client_mock.pull.return_value = []
         client_mock.wait.return_value = {"StatusCode": 0}
         operator_client_mock.return_value = client_mock
@@ -209,7 +205,6 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock.images.return_value = []
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.attach.return_value = []
-        client_mock.logs.return_value = []
         client_mock.pull.return_value = []
         client_mock.wait.return_value = {"StatusCode": 0}
         operator_client_mock.return_value = client_mock

--- a/tests/operators/test_docker_operator.py
+++ b/tests/operators/test_docker_operator.py
@@ -42,6 +42,7 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.create_host_config.return_value = host_config
         client_mock.images.return_value = []
+        client_mock.attach.return_value = ['container log']
         client_mock.logs.return_value = ['container log']
         client_mock.pull.return_value = [b'{"status":"pull log"}']
         client_mock.wait.return_value = {"StatusCode": 0}
@@ -79,6 +80,8 @@ class DockerOperatorTestCase(unittest.TestCase):
                                                           dns_search=None)
         mkdtemp_mock.assert_called_with(dir='/host/airflow', prefix='airflowtmp', suffix='')
         client_mock.images.assert_called_with(name='ubuntu:latest')
+        client_mock.attach.assert_called_with(container='some_id', stdout=True,
+                                              stderr=True, stream=True)
         client_mock.logs.assert_called_with(container='some_id', stream=True)
         client_mock.pull.assert_called_with('ubuntu:latest', stream=True)
         client_mock.wait.assert_called_with('some_id')
@@ -90,6 +93,7 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.create_host_config.return_value = mock.Mock()
         client_mock.images.return_value = []
+        client_mock.attach.return_value = []
         client_mock.logs.return_value = []
         client_mock.pull.return_value = []
         client_mock.wait.return_value = {"StatusCode": 0}
@@ -116,6 +120,7 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.create_host_config.return_value = mock.Mock()
         client_mock.images.return_value = []
+        client_mock.attach.return_value = ['unicode container log 😁']
         client_mock.logs.return_value = ['unicode container log 😁']
         client_mock.pull.return_value = []
         client_mock.wait.return_value = {"StatusCode": 0}
@@ -138,6 +143,7 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock.create_container.return_value = {'Id': 'some_id'}
         client_mock.create_host_config.return_value = mock.Mock()
         client_mock.images.return_value = []
+        client_mock.attach.return_value = []
         client_mock.logs.return_value = []
         client_mock.pull.return_value = []
         client_mock.wait.return_value = {"StatusCode": 1}
@@ -167,6 +173,7 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock = mock.Mock(name='DockerOperator.APIClient mock', spec=APIClient)
         client_mock.images.return_value = []
         client_mock.create_container.return_value = {'Id': 'some_id'}
+        client_mock.attach.return_value = []
         client_mock.logs.return_value = []
         client_mock.pull.return_value = []
         client_mock.wait.return_value = {"StatusCode": 0}
@@ -202,6 +209,7 @@ class DockerOperatorTestCase(unittest.TestCase):
         client_mock = mock.Mock(name='DockerOperator.APIClient mock', spec=APIClient)
         client_mock.images.return_value = []
         client_mock.create_container.return_value = {'Id': 'some_id'}
+        client_mock.attach.return_value = []
         client_mock.logs.return_value = []
         client_mock.pull.return_value = []
         client_mock.wait.return_value = {"StatusCode": 0}


### PR DESCRIPTION
My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3746)

switch from cli.logs to cli.attach to prevent missing container exit

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [(https://issues.apache.org/jira/browse/AIRFLOW-3746)] 
  - https://issues.apache.org/jira/browse/AIRFLOW-3746


### Description

- My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) 
switch from cli.logs to cli.attach to prevent missing container exit
With DockerOperator and using the celery executor, the task runs but never completes. It hungs as 
container.logs / certain container hangs.

since The contianer.logs() function is a wrapper around container .attach() method, which you can use instead if you want to fetch/stream container output without first retrieving the entire backlog.
So changing the container.logs() to container.attach() gives the same output and completes the task.
with the following log.
The docker_operator Task exited with return code 0

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:All the existing tests are fixed. No new tests are not required.

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
