### PR TITLE
[AIRFLOW-XXX] Mock optional modules when building docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,28 +33,60 @@
 # serve to show the default.
 import os
 import sys
-import mock
 
 import airflow
 
-MOCK_MODULES = [
-    'google.auth.default',
-    'google.oauth2.service_account',
+autodoc_mock_imports = [
+    'MySQLdb',
+    'adal',
+    'analytics',
+    'azure',
+    'azure.cosmos',
+    'azure.datalake',
+    'azure.mgmt',
+    'boto3',
+    'botocore',
+    'bson',
+    'cassandra',
+    'celery',
+    'cloudant',
+    'cx_Oracle',
+    'datadog',
+    'docker',
+    'google',
     'google_auth_httplib2',
     'googleapiclient',
-    'googleapiclient.discovery',
-    'googleapiclient.errors',
-    'googleapiclient.http',
+    'hdfs',
+    'httplib2',
+    'jaydebeapi',
+    'jenkins',
+    'jira',
+    'kubernetes',
     'mesos',
-    'mesos.interface',
-    'mesos.native',
-    'pandas.io.gbq',
+    'msrestazure',
+    'pandas',
+    'pandas_gbq',
+    'paramiko',
+    'pinotdb',
+    'psycopg2',
+    'pydruid',
+    'pyhive',
+    'pyhive',
+    'pymongo',
     'pymssql',
+    'pysftp',
+    'qds_sdk',
+    'redis',
     'simple_salesforce',
+    'slackclient',
+    'smbclient',
+    'snowflake',
+    'sshtunnel',
+    'tenacity',
     'vertica_python',
+    'winrm',
+    'zdesk',
 ]
-for mod_name in MOCK_MODULES:
-    sys.modules[mod_name] = mock.Mock()
 
 # Hack to allow changing for piece of the code to behave differently while
 # the docs are being built. The main objective was to alter the

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,6 @@ dask = [
 databricks = ['requests>=2.20.0, <3']
 datadog = ['datadog>=0.14.0']
 doc = [
-    'mock',
     'sphinx>=1.2.3',
     'sphinx-argparse>=0.1.13',
     'sphinx-rtd-theme>=0.1.6',


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [x] No Jira.

### Description

We attempted to mock the modules before, but many were missing or
incompletely mocked.

This switches it to use sphinx.autodoc's built in mocking, and adds
all the modules not installed via `apache-airflow[doc]` that sphinx
complained about.

With this change on a fresh/empty virtualenv we get docs for all the operators included.

/cc @mik-laj 

### Tests

- Doc only

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x Passes `flake8`
