### PR TITLE
[AIRFLOW-3727] Change references of is_localized to is_aware

### DIFF
--- a/airflow/api/common/experimental/mark_tasks.py
+++ b/airflow/api/common/experimental/mark_tasks.py
@@ -74,7 +74,7 @@ def set_state(task, execution_date, upstream=False, downstream=False,
     :param session: database session
     :return: list of tasks that have been created and updated
     """
-    assert timezone.is_localized(execution_date)
+    assert timezone.is_aware(execution_date)
 
     assert task.dag is not None
     dag = task.dag

--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -42,7 +42,7 @@ def _trigger_dag(
     if not execution_date:
         execution_date = timezone.utcnow()
 
-    assert timezone.is_localized(execution_date)
+    assert timezone.is_aware(execution_date)
 
     if replace_microseconds:
         execution_date = execution_date.replace(microsecond=0)

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -676,7 +676,7 @@ class TaskInstance(Base, LoggingMixin):
         self._log = logging.getLogger("airflow.task")
 
         # make sure we have a localized execution_date stored in UTC
-        if execution_date and not timezone.is_localized(execution_date):
+        if execution_date and not timezone.is_aware(execution_date):
             self.log.warning("execution date %s has no timezone information. Using "
                              "default from dag or system", execution_date)
             if self.task.has_dag():

--- a/airflow/utils/timezone.py
+++ b/airflow/utils/timezone.py
@@ -27,7 +27,7 @@ from airflow.settings import TIMEZONE
 utc = pendulum.timezone('UTC')
 
 
-def is_localized(value):
+def is_aware(value):
     """
     Determine if a given datetime.datetime is aware.
     The concept is defined in Python's docs:
@@ -89,7 +89,7 @@ def convert_to_utc(value):
     if not value:
         return value
 
-    if not is_localized(value):
+    if not is_aware(value):
         value = pendulum.instance(value, TIMEZONE)
 
     return value.astimezone(utc)
@@ -108,7 +108,7 @@ def make_aware(value, timezone=None):
         timezone = TIMEZONE
 
     # Check that we won't overwrite the timezone of an aware datetime.
-    if is_localized(value):
+    if is_aware(value):
         raise ValueError(
             "make_aware expects a naive datetime, got %s" % value)
 

--- a/tests/utils/test_timezone.py
+++ b/tests/utils/test_timezone.py
@@ -31,8 +31,8 @@ UTC = timezone.utc
 
 class TimezoneTest(unittest.TestCase):
     def test_is_aware(self):
-        self.assertTrue(timezone.is_localized(datetime.datetime(2011, 9, 1, 13, 20, 30, tzinfo=EAT)))
-        self.assertFalse(timezone.is_localized(datetime.datetime(2011, 9, 1, 13, 20, 30)))
+        self.assertTrue(timezone.is_aware(datetime.datetime(2011, 9, 1, 13, 20, 30, tzinfo=EAT)))
+        self.assertFalse(timezone.is_aware(datetime.datetime(2011, 9, 1, 13, 20, 30)))
 
     def test_is_naive(self):
         self.assertFalse(timezone.is_naive(datetime.datetime(2011, 9, 1, 13, 20, 30, tzinfo=EAT)))
@@ -40,7 +40,7 @@ class TimezoneTest(unittest.TestCase):
 
     def test_utcnow(self):
         now = timezone.utcnow()
-        self.assertTrue(timezone.is_localized(now))
+        self.assertTrue(timezone.is_aware(now))
         self.assertEqual(now.replace(tzinfo=None), now.astimezone(UTC).replace(tzinfo=None))
 
     def test_convert_to_utc(self):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3727
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] The timezone section of the documentation (https://airflow.apache.org/timezone.html says) says you can use `timezone.is_aware()` and `timezone.is_naive()` to determine whether date times are aware or naive. However, in the source code, the current method is called `timezone.is_localized().` My changes are to rename all `is_localized` references to `is_aware`.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: There are existing unit tests that already test the `timezone.is_localized()` method. After the update, the same unit tests should test against the new `timezone.is_aware()` method name.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
