### PR TITLE
[AIRFLOW-3615] Parse hostname using netloc

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -30,6 +30,20 @@ from airflow.models import get_fernet
 from airflow.models.base import Base, ID_LEN
 
 
+# Python automatically converts all letters to lowercase in hostname
+# See: https://issues.apache.org/jira/browse/AIRFLOW-3615
+def parse_netloc_to_hostname(uri_parts):
+    hostname = unquote(uri_parts.hostname or '')
+    if '/' in hostname:
+        hostname = uri_parts.netloc
+        if "@" in hostname:
+            hostname = hostname.rsplit("@", 1)[1]
+        if ":" in hostname:
+            hostname = hostname.split(":", 1)[0]
+        hostname = unquote(hostname)
+    return hostname
+
+
 class Connection(Base, LoggingMixin):
     """
     Placeholder to store information about different database instances
@@ -112,14 +126,13 @@ class Connection(Base, LoggingMixin):
 
     def parse_from_uri(self, uri):
         uri_parts = urlparse(uri)
-        hostname = uri_parts.hostname or ''
         conn_type = uri_parts.scheme
         if conn_type == 'postgresql':
             conn_type = 'postgres'
         elif '-' in conn_type:
             conn_type = conn_type.replace('-', '_')
         self.conn_type = conn_type
-        self.host = unquote(hostname) if hostname else hostname
+        self.host = parse_netloc_to_hostname(uri_parts)
         quoted_schema = uri_parts.path[1:]
         self.schema = unquote(quoted_schema) if quoted_schema else quoted_schema
         self.login = unquote(uri_parts.username) \


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3615
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

Python 3.5 and 2.7 replace the hostname always with small characters. In the case of a path this is unexpected.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
