### PR TITLE
[AIRFLOW-3770] Validation of documentation on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,9 @@ jobs:
     - name: Check license header
       stage: pre-test
       script: scripts/ci/6-check-license.sh
+    - name: Check docs
+      stage: pre-test
+      script: pip install -e .[doc] && docs/build.sh
 
 cache:
   directories:

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -18,5 +18,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-rm -r _build
-make html
+set -e
+
+FWDIR="$(cd "`dirname "$0"`"; pwd)"
+cd "$FWDIR"
+
+[ -d _build ] && rm -r _build
+
+NUM_IGNORED_WARNINGS=4
+NUM_CURRENT_WARNINGS=$(make html |\
+    tee /dev/tty |\
+    grep 'build succeeded' |\
+    head -1 |\
+    sed -E 's/build succeeded, ([0-9]+) warnings\./\1/g')
+
+if [ "${NUM_CURRENT_WARNINGS}" != "${NUM_IGNORED_WARNINGS}" ]; then
+    echo
+    echo "Unexpected problems found in the documentation. "
+    echo "Currently, ${NUM_IGNORED_WARNINGS} warnings are ignored."
+    echo
+    exit 1
+fi


### PR DESCRIPTION
Cześć,

### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3770

### Description

Some errors can not be fixed quickly, so I added a threshold for warnings that may occur.
More info: https://github.com/apache/airflow/pull/4588

### Tests

Not applicable

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

Not applicable

### Code Quality

Not applicable
