### PR TITLE
[AIRFLOW-3773] Fix /refresh_all endpoint

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1687,8 +1687,9 @@ class Airflow(AirflowBaseView):
     @action_logging
     def refresh_all(self):
         dagbag.collect_dags(only_if_updated=False)
-        # sync permissions for all dags
-        appbuilder.sm.sync_perm_for_dag()
+        for dag_id in dagbag.dags:
+            # sync permissions for all dags
+            appbuilder.sm.sync_perm_for_dag(dag_id)
         flash("All DAGs are now up to date")
         return redirect('/')
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -1867,41 +1867,6 @@ class SecurityTests(unittest.TestCase):
         self.dag_bash.clear(start_date=DEFAULT_DATE, end_date=timezone.utcnow())
 
 
-class FabTests(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-        from airflow.www import app as application
-        self.app, self.appbuilder = application.create_app(session=Session, testing=True)
-        self.app.config['TESTING'] = True
-        self.app.config['WTF_CSRF_ENABLED'] = False
-        self.client = self.app.test_client()
-        role_admin = self.appbuilder.sm.find_role('Admin')
-        self.admin_user = self.appbuilder.sm.add_user(username='test_admin',
-                                                      first_name='admin',
-                                                      last_name='user',
-                                                      email='admin@airflow.org',
-                                                      password='password',
-                                                      role=role_admin)
-
-    def tearDown(self):
-        admin_user = self.appbuilder.sm.find_user(username='test_admin')
-        self.appbuilder.sm.del_register_user(admin_user)
-        super(FabTests, self).tearDown()
-
-    def _login(self):
-        response = self.client.post('/login/',
-                                    data={'username': 'test_admin',
-                                          'password': 'password'},
-                                    follow_redirects=True)
-        self.assertEqual(response.status_code, 200)
-
-    def test_refresh_all(self):
-        self._login()
-        response = self.client.get("/refresh_all",
-                                   follow_redirects=True)
-        self.assertEqual(response.status_code, 200)
-
-
 @unittest.skip(reason="Skipping because now we are using FAB")
 class WebUiTests(unittest.TestCase):
     def setUp(self):

--- a/tests/core.py
+++ b/tests/core.py
@@ -1867,6 +1867,41 @@ class SecurityTests(unittest.TestCase):
         self.dag_bash.clear(start_date=DEFAULT_DATE, end_date=timezone.utcnow())
 
 
+class FabTests(unittest.TestCase):
+    def setUp(self):
+        configuration.load_test_config()
+        from airflow.www import app as application
+        self.app, self.appbuilder = application.create_app(session=Session, testing=True)
+        self.app.config['TESTING'] = True
+        self.app.config['WTF_CSRF_ENABLED'] = False
+        self.client = self.app.test_client()
+        role_admin = self.appbuilder.sm.find_role('Admin')
+        self.admin_user = self.appbuilder.sm.add_user(username='test_admin',
+                                                      first_name='admin',
+                                                      last_name='user',
+                                                      email='admin@airflow.org',
+                                                      password='password',
+                                                      role=role_admin)
+
+    def tearDown(self):
+        admin_user = self.appbuilder.sm.find_user(username='test_admin')
+        self.appbuilder.sm.del_register_user(admin_user)
+        super(FabTests, self).tearDown()
+
+    def _login(self):
+        response = self.client.post('/login/',
+                                    data={'username': 'test_admin',
+                                          'password': 'password'},
+                                    follow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+
+    def test_refresh_all(self):
+        self._login()
+        response = self.client.get("/refresh_all",
+                                   follow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+
+
 @unittest.skip(reason="Skipping because now we are using FAB")
 class WebUiTests(unittest.TestCase):
     def setUp(self):

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -518,6 +518,11 @@ class TestAirflowBaseViews(TestBase):
         resp = self.client.get('refresh?dag_id=example_bash_operator')
         self.check_content_in_response('', resp, resp_code=302)
 
+    def test_refresh_all(self):
+        resp = self.client.get("/refresh_all",
+                               follow_redirects=True)
+        self.check_content_in_response('', resp, resp_code=200)
+
     def test_delete_dag_button_normal(self):
         resp = self.client.get('/', follow_redirects=True)
         self.check_content_in_response('/delete?dag_id=example_bash_operator', resp)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3773

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:

Call `sync_perm_for_dag` for each DAG in the DagBag (`dag_id` is a
required argument).

### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I looked for a test suite for the web UI, but it seems the existing
tests have all been disabled since the switch to FAB. I've created a new
class for FAB tests and added a test to exercise the `/refresh_all`
endpoint.

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ X ] Passes `flake8`
