### PR TITLE
[AIRFLOW-3774] Register blueprints with app

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -194,7 +194,10 @@ for p in plugins:
     macros_modules.append(make_module('airflow.macros.' + p.name, p.macros))
 
     admin_views.extend(p.admin_views)
-    flask_blueprints.extend(p.flask_blueprints)
     menu_links.extend(p.menu_links)
     flask_appbuilder_views.extend(p.appbuilder_views)
     flask_appbuilder_menu_links.extend(p.appbuilder_menu_items)
+    flask_blueprints.extend([{
+        'name': p.name,
+        'blueprint': bp
+    } for bp in p.flask_blueprints])

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -141,7 +141,8 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
             def integrate_plugins():
                 """Integrate plugins to the context"""
                 from airflow.plugins_manager import (
-                    flask_appbuilder_views, flask_appbuilder_menu_links)
+                    flask_appbuilder_views, flask_appbuilder_menu_links
+                )
 
                 for v in flask_appbuilder_views:
                     log.debug("Adding view %s", v["name"])
@@ -161,7 +162,15 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
             # will add the new Views and Menus names to the backend, but will not
             # delete the old ones.
 
+        def init_plugin_blueprints(app):
+            from airflow.plugins_manager import flask_blueprints
+
+            for bp in flask_blueprints:
+                log.debug("Adding blueprint %s:%s", bp["name"], bp["blueprint"].import_name)
+                app.register_blueprint(bp["blueprint"])
+
         init_views(appbuilder)
+        init_plugin_blueprints(app)
 
         security_manager = appbuilder.sm
         security_manager.sync_roles()

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -66,3 +66,10 @@ class PluginsTestRBAC(unittest.TestCase):
         link = links[0]
         self.assertEqual(link.name, appbuilder_mitem['category'])
         self.assertEqual(link.childs[0].name, appbuilder_mitem['name'])
+
+    def test_app_blueprints(self):
+        from tests.plugins.test_plugin import bp
+
+        # Blueprint should be present in the app
+        self.assertTrue('test_plugin' in self.app.blueprints)
+        self.assertEqual(self.app.blueprints['test_plugin'].name, bp.name)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3774

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
It would appear that flask blueprints are not being loaded from plugins. A grep of the entire repo shows flask_blueprints is never read from, and only written into in airflow.plugins_manager.

I am new to flask, but I am under the assumption, that the blue prints must be passed to a app.register_blueprint(my_blueprint) function to be loaded.

This PR registers blueprints with the app at the same point the views from plugins are registered.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
