### PR TITLE
[AIRFLOW-3758] Fix circular import in WasbTaskHandler

### DIFF
--- a/airflow/utils/log/wasb_task_handler.py
+++ b/airflow/utils/log/wasb_task_handler.py
@@ -20,7 +20,6 @@ import os
 import shutil
 
 from airflow import configuration
-from airflow.contrib.hooks.wasb_hook import WasbHook
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from azure.common import AzureHttpError
@@ -47,6 +46,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
     def _build_hook(self):
         remote_conn_id = configuration.get('core', 'REMOTE_LOG_CONN_ID')
         try:
+            from airflow.contrib.hooks.wasb_hook import WasbHook
             return WasbHook(remote_conn_id)
         except AzureHttpError:
             self.log.error(

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -253,14 +253,18 @@ class TestLoggingSettings(unittest.TestCase):
 
     def test_loading_remote_logging_with_wasb_handler(self):
         """Test if logging can be configured successfully for Azure Blob Storage"""
+        import logging
+        from airflow.config_templates import airflow_local_settings
         from airflow.logging_config import configure_logging
+        from airflow.utils.log.wasb_task_handler import WasbTaskHandler
+
         conf.set('core', 'remote_logging', 'True')
         conf.set('core', 'remote_log_conn_id', 'some_wasb')
         conf.set('core', 'remote_base_log_folder', 'wasb://some-folder')
+
+        six.moves.reload_module(airflow_local_settings)
         configure_logging()
 
-        import logging
-        from airflow.utils.log.wasb_task_handler import WasbTaskHandler
         logger = logging.getLogger('airflow.task')
         self.assertIsInstance(logger.handlers[0], WasbTaskHandler)
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -259,6 +259,11 @@ class TestLoggingSettings(unittest.TestCase):
         conf.set('core', 'remote_base_log_folder', 'wasb://some-folder')
         configure_logging()
 
+        import logging
+        from airflow.utils.log.wasb_task_handler import WasbTaskHandler
+        logger = logging.getLogger('airflow.task')
+        self.assertIsInstance(logger.handlers[0], WasbTaskHandler)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -95,6 +95,55 @@ LOGGING_CONFIG = {
 }
 """
 
+SETTINGS_FILE_WASB_HANDLER = """
+REMOTE_BASE_LOG_FOLDER = 'wasb'
+LOGGING_CONFIG = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'airflow': {
+            'format': '[%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s'
+        }
+    },
+    'handlers': {
+        'console': {
+            'class': 'airflow.utils.log.logging_mixin.RedirectStdHandler',
+            'formatter': 'airflow',
+            'stream': 'sys.stdout'
+        },
+        'processor': {
+            'base_log_folder': '$AIRFLOW_HOME/logs/scheduler',
+            'class': 'airflow.utils.log.file_processor_handler.FileProcessorHandler',
+            'filename_template': '{{ filename }}.log',
+            'formatter': 'airflow'
+        },
+        'task': {
+            'base_log_folder': '$AIRFLOW_HOME/logs',
+            'class': 'airflow.utils.log.file_task_handler.FileTaskHandler',
+            'filename_template': '{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log',
+            'formatter': 'airflow'
+        }
+    },
+    'loggers': {
+        'airflow.processor': {
+            'handlers': ['processor'],
+            'level': 'INFO',
+            'propagate': False
+        },
+        'airflow.task': {
+            'handlers': ['task'],
+            'level': 'INFO',
+            'propagate': False
+        },
+        'flask_appbuilder': {
+            'handler': ['console'],
+            'level': 'WARN',
+            'propagate': True
+        }
+    },
+}
+"""
+
 SETTINGS_FILE_EMPTY = """
 # Other settings here
 """
@@ -250,6 +299,19 @@ class TestLoggingSettings(unittest.TestCase):
                 self.assertEqual(conf.get('core', 'task_log_reader'), 'task')
         finally:
             conf.remove_option('core', 'task_log_reader', remove_default=False)
+
+    def test_loading_remote_logging_with_wasb_handler(self):
+        """Test if logging can be configured successfully for Azure Blob Storage"""
+        with settings_context(SETTINGS_FILE_WASB_HANDLER):
+            from airflow.logging_config import configure_logging, log
+            with patch.object(log, 'info') as mock_info:
+                configure_logging()
+                mock_info.assert_called_with(
+                    'Successfully imported user-defined logging config from %s',
+                    '{}.LOGGING_CONFIG'.format(
+                        SETTINGS_DEFAULT_NAME
+                    )
+                )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3758
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

Import for WasbHook in airflow.utils.log.WasbTaskHandler was causing a circular import when configure_logging() was called.
Closes [AIRFLOW-3758].

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   - Test configure_logging() with the settings for logging to Azure Blob Storage.
### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
