### PR TITLE
[AIRFLOW-XXX] Remove profiling link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,7 +80,6 @@ Content
     howto/index
     ui
     concepts
-    profiling
     cli
     scheduler
     plugins


### PR DESCRIPTION
Cześć,

### Jira

No applicable.

### Description

This page has been deleted in commit:
https://github.com/apache/airflow/commit/b6f207ff77ac706f08a65336cabb7140a9cd9816

The problem was discovered while I working on:
https://github.com/apache/airflow/pull/4593

CC: @feng-tao @kaxil @ashb 

### Tests

No applicable

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

No applicable.

### Code Quality

No applicable.
