### PR TITLE
[AIRFLOW-3782] Minor refinement of worker_autoscale in default_airflow.cfg

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -351,12 +351,13 @@ celery_app_name = airflow.executors.celery_executor
 # your worker box and the nature of your tasks
 worker_concurrency = 16
 
-# The minimum and maximum concurrency that will be used when starting workers with the
-# "airflow worker" command. Pick these numbers based on resources on
-# worker box and the nature of the task. If autoscale option is available worker_concurrency
-# will be ignored.
+# The maximum and minimum concurrency that will be used when starting workers with the
+# "airflow worker" command (always keep minimum processes, but grow to maximum if necessary).
+# Note the value should be "max_concurrency,min_concurrency"
+# Pick these numbers based on resources on worker box and the nature of the task.
+# If autoscale option is available, worker_concurrency will be ignored.
 # http://docs.celeryproject.org/en/latest/reference/celery.bin.worker.html#cmdoption-celery-worker-autoscale
-# worker_autoscale = 12,16
+# worker_autoscale = 16,12
 
 # When you start an airflow worker, airflow starts a tiny web server
 # subprocess to serve the workers local log files to the airflow main


### PR DESCRIPTION

### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3782

### Description

Celery supports `autoscale` by accepting values in format `max_concurrency,min_concurrency`.
But the default value in `default_airflow.cfg` is wrong, and the comment can be clearer.

Reference: http://docs.celeryproject.org/en/latest/reference/celery.bin.worker.html#cmdoption-celery-worker-autoscale