### PR TITLE
[AIRFLOW-3749] Fix Edit Dag Run page when using RBAC

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -521,7 +521,7 @@ function updateQueryStringParameter(uri, key, value) {
     });
 
     $('#btn_edit_dagrun').click(function() {
-      window.location = "{{ url_for('DagModelView.show', pk=dag.dag_id) }}";
+      window.location = "{{ url_for('DagModelView.edit', pk=dag.dag_id) }}";
     });
 
   </script>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2429,7 +2429,7 @@ class DagModelView(AirflowModelView):
 
     datamodel = AirflowModelView.CustomSQLAInterface(models.DagModel)
 
-    base_permissions = ['can_list', 'can_show']
+    base_permissions = ['can_list', 'can_show', 'can_edit']
 
     list_columns = ['dag_id', 'is_paused', 'last_scheduler_run',
                     'last_expired', 'scheduler_lock', 'fileloc', 'owners']

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -21,19 +21,19 @@ import copy
 import io
 import json
 import logging.config
-import mock
 import os
 import shutil
 import sys
 import tempfile
 import unittest
 import urllib
-
 from datetime import timedelta
-from flask._compat import PY2
-from parameterized import parameterized
 from urllib.parse import quote_plus
 
+import mock
+from flask import url_for
+from flask._compat import PY2
+from parameterized import parameterized
 from werkzeug.test import Client
 
 from airflow import configuration as conf
@@ -411,6 +411,15 @@ class TestAirflowBaseViews(TestBase):
                .format(self.percent_encode(self.EXAMPLE_DAG_DEFAULT_DATE)))
         resp = self.client.get(url, follow_redirects=True)
         self.check_content_in_response('XCom', resp)
+
+    def test_edit_dagrun_page(self):
+        resp = self.client.get('dagmodel/edit/example_bash_operator', follow_redirects=False)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_edit_dagrun_url(self):
+        with self.app.test_request_context():
+            url = url_for('DagModelView.edit', pk='example_bash_operator')
+            self.assertEqual(url, '/dagmodel/edit/example_bash_operator')
 
     def test_rendered(self):
         url = ('rendered?task_id=runme_0&dag_id=example_bash_operator&execution_date={}'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3749
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When accessing the "Edit Dag Run" Page with RBAC enabled you previously got redirected to a 404 Page (/dagmodel/show).

1.) Now this has been fixed and the url has been changed to point to /dagmodel/edit instead of /dagmodel/show.
2.) It also adds `can_edit` base permission to the `DagModelView` to be able to edit the Dag Run.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR adds tests for both changes:
* the correct url has been generated
* permissions has been granted to edit the Dag Model 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
