### PR TITLE
 Decreasing scheduler delay between tasks

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -4477,11 +4477,12 @@ class DagRun(Base, LoggingMixin):
         ).first()
 
     @provide_session
-    def update_state(self, session=None):
+    def update_state(self, session=None, finished_tasks=None):
         """
         Determines the overall state of the DagRun based on the state
         of its TaskInstances.
 
+        :param finished_tasks: The finished tasks collected ordered by dagrun as a column (task_name, state)
         :return: State
         """
 
@@ -4520,7 +4521,8 @@ class DagRun(Base, LoggingMixin):
                     dep_context=DepContext(
                         flag_upstream_failed=True,
                         ignore_in_retry_period=True,
-                        ignore_in_reschedule_period=True),
+                        ignore_in_reschedule_period=True,
+                        finished_tasks=finished_tasks),
                     session=session)
                 if deps_met or old_state != ut.current_state(session=session):
                     no_dependencies_met = False

--- a/airflow/ti_deps/dep_context.py
+++ b/airflow/ti_deps/dep_context.py
@@ -65,6 +65,8 @@ class DepContext(object):
     :type ignore_task_deps: bool
     :param ignore_ti_state: Ignore the task instance's previous failure/success
     :type ignore_ti_state: bool
+    :param finished_tasks: The finished tasks collected ordered by dagrun as a column (task_name, state)
+    :type finished_tasks: Dict
     """
     def __init__(
             self,
@@ -75,7 +77,8 @@ class DepContext(object):
             ignore_in_retry_period=False,
             ignore_in_reschedule_period=False,
             ignore_task_deps=False,
-            ignore_ti_state=False):
+            ignore_ti_state=False,
+            finished_tasks=None):
         self.deps = deps or set()
         self.flag_upstream_failed = flag_upstream_failed
         self.ignore_all_deps = ignore_all_deps
@@ -84,6 +87,7 @@ class DepContext(object):
         self.ignore_in_reschedule_period = ignore_in_reschedule_period
         self.ignore_task_deps = ignore_task_deps
         self.ignore_ti_state = ignore_ti_state
+        self.finished_tasks = finished_tasks
 
 
 # In order to be able to get queued a task must have one of these states


### PR DESCRIPTION
### Jira
-  My PR addresses the following https://issues.apache.org/jira/browse/AIRFLOW-3607 and references them in the PR title
  - Decreasing scheduler delay between tasks


### Description
-  The delay between tasks can be a major issue, especially when we have dags with many subdags, 
   figures out that the scheduling process spends plenty of time in dependency checking,  we took the 
   trigger rule dependency which calls the db for each task instance,  we made it call the db just once for 
   each dag_run. 
 

### Tests
-  My PR does not need extra testing for this extremely good reason:
My pr uses the code from the  and also has a fall back to the original behaviour, the ci covers all of the logic and cases that might happen already


### Commits
- removed unnecessary queries  - run on each dag run instead of each ti 


### Documentation
no need for new docs


### Code Quality
- Passes `flake8`
