### PR TITLE
AIRFLOW-3590: Change log message of executor exit status

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1451,7 +1451,8 @@ class SchedulerJob(BaseJob):
                                    .items()):
             dag_id, task_id, execution_date, try_number = key
             self.log.info(
-                "Executor reports %s.%s execution_date=%s as %s for try_number %s",
+                "Executor reports execution of %s.%s execution_date=%s "
+                "exited with status %s for try_number %s",
                 dag_id, task_id, execution_date, state, try_number
             )
             if state == State.FAILED or state == State.SUCCESS:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3590

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
  - Change the log message when the executor finishes to clarify that "success" or "failed" refers to the exit value of the executed script, not the status of the task instance (which may be skipped or up_for_reschedule or up_for_retry).

### Tests

- [X] My PR does not need testing for this extremely good reason:
  - Only the log message was changed

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X] Passes `flake8`
