### PR TITLE
[AIRFLOW- boyscout] Enforce delimiter for gcs_to_gcs operator using a flag, enforce_delimiter

### DIFF
--- a/tests/contrib/operators/test_gcs_to_gcs_operator.py
+++ b/tests/contrib/operators/test_gcs_to_gcs_operator.py
@@ -69,7 +69,7 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
 
         operator.execute(None)
         mock_hook.return_value.list.assert_called_once_with(
-            TEST_BUCKET, prefix="", delimiter="test_object"
+            TEST_BUCKET, prefix="", delimiter="test_object", enforce_delimiter=False
         )
 
     @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
@@ -81,7 +81,7 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
 
         operator.execute(None)
         mock_hook.return_value.list.assert_called_once_with(
-            TEST_BUCKET, prefix="test_object", delimiter=""
+            TEST_BUCKET, prefix="test_object", delimiter="", enforce_delimiter=False
         )
 
     @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
@@ -93,7 +93,7 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
 
         operator.execute(None)
         mock_hook.return_value.list.assert_called_once_with(
-            TEST_BUCKET, prefix="test", delimiter="object"
+            TEST_BUCKET, prefix="test", delimiter="object", enforce_delimiter=False
         )
 
     # copy with wildcard


### PR DESCRIPTION
Problem now:
Given the files: test1.csv, test2.csv, test10.csv, test100.csv, test1.gz, test2.gz, test10.gz, test100.gz
When trying to match test*.csv
Result all files above is match
Fix:
Given the files: test1.csv, test2.csv, test10.csv, test100.csv, test1.gz, test2.gz, test10.gz, test100.gz
When trying to match test*.csv
Result only the files test1.csv, test2.csv, test10.csv, test100.csv is a match

Problem that still in the code: when using multiple wildcards it does not enforces the 'middle part' of it:
Given the files: testProd1.csv, test2Prod.csv, testProd10.csv, testProd100.csv, testProd1.gz, test2Prod.gz, test10Prod.gz, test100Prod.gz, in directory dir1 and dir2
When trying to match /testAcceptance.csv
Result all files above is match
Expect: No files should be returned

The enforce_delimiter flag has a default value of False and do not change the current operator if the flag value is set to False or left unset.
When set to True it uses a new hook, list_with_delimiter, in this hook the value after the last wildcard '*' is enforced.
Notice that this PR fix only the problem of enforcing the last part of the path, the middle part stays as it is, as per above