### PR TITLE
AIRFLOW-3791:

### DIFF
--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -118,6 +118,8 @@ class DataFlowJavaOperator(BaseOperator):
             delegate_to=None,
             poll_sleep=10,
             job_class=None,
+            check_if_running=None,
+            multiple_jobs=None,
             *args,
             **kwargs):
         super(DataFlowJavaOperator, self).__init__(*args, **kwargs)
@@ -129,25 +131,30 @@ class DataFlowJavaOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.jar = jar
+        self.multiple_jobs = multiple_jobs
         self.job_name = job_name
         self.dataflow_default_options = dataflow_default_options
         self.options = options
         self.poll_sleep = poll_sleep
         self.job_class = job_class
+        self.check_if_running = check_if_running
 
     def execute(self, context):
         bucket_helper = GoogleCloudBucketHelper(
             self.gcp_conn_id, self.delegate_to)
-        self.jar = bucket_helper.google_cloud_to_local(self.jar)
         hook = DataFlowHook(gcp_conn_id=self.gcp_conn_id,
                             delegate_to=self.delegate_to,
                             poll_sleep=self.poll_sleep)
-
         dataflow_options = copy.copy(self.dataflow_default_options)
         dataflow_options.update(self.options)
+        is_running = False
+        if self.check_if_running:
+            is_running = hook.is_job_dataflow_running(self.job_name, dataflow_options)
 
-        hook.start_java_dataflow(self.job_name, dataflow_options,
-                                 self.jar, self.job_class)
+        if not is_running:
+            self.jar = bucket_helper.google_cloud_to_local(self.jar)
+            hook.start_java_dataflow(self.job_name, dataflow_options,
+                                     self.jar, self.job_class, self.multiple_jobs)
 
 
 class DataflowTemplateOperator(BaseOperator):
@@ -312,7 +319,6 @@ class DataFlowPythonOperator(BaseOperator):
             poll_sleep=10,
             *args,
             **kwargs):
-
         super(DataFlowPythonOperator, self).__init__(*args, **kwargs)
 
         self.py_file = py_file
@@ -376,7 +382,7 @@ class GoogleCloudBucketHelper(object):
         if len(path_components) < 2:
             raise Exception(
                 'Invalid Google Cloud Storage (GCS) object path: {}'
-                .format(file_name))
+                    .format(file_name))
 
         bucket_id = path_components[0]
         object_id = '/'.join(path_components[1:])
@@ -388,4 +394,4 @@ class GoogleCloudBucketHelper(object):
             return local_file
         raise Exception(
             'Failed to download Google Cloud Storage (GCS) object: {}'
-            .format(file_name))
+                .format(file_name))

--- a/tests/contrib/operators/test_dataflow_operator.py
+++ b/tests/contrib/operators/test_dataflow_operator.py
@@ -139,6 +139,7 @@ class DataFlowJavaOperatorTest(unittest.TestCase):
         self.assertEqual(self.dataflow.jar, JAR_FILE)
         self.assertEqual(self.dataflow.options,
                          EXPECTED_ADDITIONAL_OPTIONS)
+        self.assertEqual(self.dataflow.check_if_running, None)
 
     @mock.patch('airflow.contrib.operators.dataflow_operator.DataFlowHook')
     @mock.patch(GCS_HOOK_STRING.format('GoogleCloudBucketHelper'))
@@ -153,7 +154,64 @@ class DataFlowJavaOperatorTest(unittest.TestCase):
         self.assertTrue(dataflow_mock.called)
         gcs_download_hook.assert_called_once_with(JAR_FILE)
         start_java_hook.assert_called_once_with(JOB_NAME, mock.ANY,
-                                                mock.ANY, JOB_CLASS)
+                                                mock.ANY, JOB_CLASS, None)
+
+    @mock.patch('airflow.contrib.operators.dataflow_operator.DataFlowHook')
+    @mock.patch(GCS_HOOK_STRING.format('GoogleCloudBucketHelper'))
+    def test_check_job_running_exec(self, gcs_hook, dataflow_mock):
+        """Test DataFlowHook is created and the right args are passed to
+        start_java_workflow.
+
+        """
+        dataflow_running = dataflow_mock.return_value.is_job_dataflow_running
+        dataflow_running.return_value = True
+        start_java_hook = dataflow_mock.return_value.start_java_dataflow
+        gcs_download_hook = gcs_hook.return_value.google_cloud_to_local
+        self.dataflow.check_if_running = True
+        self.dataflow.execute(None)
+        self.assertTrue(dataflow_mock.called)
+        gcs_download_hook.assert_not_called()
+        start_java_hook.assert_not_called()
+        dataflow_running.assert_called_once_with(JOB_NAME, mock.ANY)
+
+    @mock.patch('airflow.contrib.operators.dataflow_operator.DataFlowHook')
+    @mock.patch(GCS_HOOK_STRING.format('GoogleCloudBucketHelper'))
+    def test_check_job_not_running_exec(self, gcs_hook, dataflow_mock):
+        """Test DataFlowHook is created and the right args are passed to
+        start_java_workflow with option to check if job is running
+
+        """
+        dataflow_running = dataflow_mock.return_value.is_job_dataflow_running
+        dataflow_running.return_value = False
+        start_java_hook = dataflow_mock.return_value.start_java_dataflow
+        gcs_download_hook = gcs_hook.return_value.google_cloud_to_local
+        self.dataflow.check_if_running = True
+        self.dataflow.execute(None)
+        self.assertTrue(dataflow_mock.called)
+        gcs_download_hook.assert_called_once_with(JAR_FILE)
+        start_java_hook.assert_called_once_with(JOB_NAME, mock.ANY,
+                                                mock.ANY, JOB_CLASS, None)
+        dataflow_running.assert_called_once_with(JOB_NAME, mock.ANY)
+
+    @mock.patch('airflow.contrib.operators.dataflow_operator.DataFlowHook')
+    @mock.patch(GCS_HOOK_STRING.format('GoogleCloudBucketHelper'))
+    def test_check_multiple_job_exec(self, gcs_hook, dataflow_mock):
+        """Test DataFlowHook is created and the right args are passed to
+        start_java_workflow with option to check multiple jobs
+
+        """
+        dataflow_running = dataflow_mock.return_value.is_job_dataflow_running
+        dataflow_running.return_value = False
+        start_java_hook = dataflow_mock.return_value.start_java_dataflow
+        gcs_download_hook = gcs_hook.return_value.google_cloud_to_local
+        self.dataflow.multiple_jobs = True
+        self.dataflow.check_if_running = True
+        self.dataflow.execute(None)
+        self.assertTrue(dataflow_mock.called)
+        gcs_download_hook.assert_called_once_with(JAR_FILE)
+        start_java_hook.assert_called_once_with(JOB_NAME, mock.ANY,
+                                                mock.ANY, JOB_CLASS, True)
+        dataflow_running.assert_called_once_with(JOB_NAME, mock.ANY)
 
 
 class DataFlowTemplateOperatorTest(unittest.TestCase):
@@ -202,7 +260,6 @@ class GoogleCloudBucketHelperTest(unittest.TestCase):
         'airflow.contrib.operators.dataflow_operator.GoogleCloudBucketHelper.__init__'
     )
     def test_invalid_object_path(self, mock_parent_init):
-
         # This is just the path of a bucket hence invalid filename
         file_name = 'gs://test-bucket'
         mock_parent_init.return_value = None
@@ -221,7 +278,6 @@ class GoogleCloudBucketHelperTest(unittest.TestCase):
         'airflow.contrib.operators.dataflow_operator.GoogleCloudBucketHelper.__init__'
     )
     def test_valid_object(self, mock_parent_init):
-
         file_name = 'gs://test-bucket/path/to/obj.jar'
         mock_parent_init.return_value = None
 
@@ -243,7 +299,6 @@ class GoogleCloudBucketHelperTest(unittest.TestCase):
         'airflow.contrib.operators.dataflow_operator.GoogleCloudBucketHelper.__init__'
     )
     def test_empty_object(self, mock_parent_init):
-
         file_name = 'gs://test-bucket/path/to/obj.jar'
         mock_parent_init.return_value = None
 


### PR DESCRIPTION
Support to check if job is already running before starting java job
In case dataflow creates more than one job, we need to track all jobs for status

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
