### PR TITLE
[AIRFLOW-3787] Import/export users from JSON file

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1474,6 +1474,107 @@ def users(args):
                 print('User "{}" added to role "{}".'.format(
                     user,
                     args.role))
+    elif args.export:
+        appbuilder = cached_appbuilder()
+        users = appbuilder.sm.get_all_users()
+        fields = ['id', 'username', 'email', 'first_name', 'last_name', 'roles']
+
+        # In the User model the first and last name fields have underscores,
+        # but the corresponding parameters in the CLI don't
+        def remove_underscores(s):
+            return re.sub("_", "", s)
+
+        users = [
+            {remove_underscores(field): user.__getattribute__(field)
+             if field != 'roles' else [r.name for r in user.roles]
+             for field in fields}
+            for user in users
+        ]
+
+        with open(args.export, 'w') as f:
+            f.write(json.dumps(users, sort_keys=True, indent=4))
+            print("{} users successfully exported to {}".format(len(users), f.name))
+
+    elif getattr(args, 'import'):  # "import" is a reserved word
+        json_file = getattr(args, 'import')
+        if not os.path.exists(json_file):
+            print("File '{}' does not exist")
+            exit(1)
+
+        users_list = None
+        try:
+            with open(json_file, 'r') as f:
+                users_list = json.loads(f.read())
+        except ValueError as e:
+            print("File '{}' is not valid JSON. Error: {}".format(json_file, e))
+            exit(1)
+
+        users_created, users_updated = _import_users(users_list)
+        if users_created:
+            print("Created the following users:\n\t{}".format(
+                "\n\t".join(users_created)))
+
+        if users_updated:
+            print("Updated the following users:\n\t{}".format(
+                "\n\t".join(users_updated)))
+
+
+def _import_users(users_list):
+    appbuilder = cached_appbuilder()
+    users_created = []
+    users_updated = []
+
+    for user in users_list:
+        roles = []
+        for rolename in user['roles']:
+            role = appbuilder.sm.find_role(rolename)
+            if not role:
+                print("Error: '{}' is not a valid role".format(rolename))
+                exit(1)
+            else:
+                roles.append(role)
+
+        required_fields = ['username', 'firstname', 'lastname',
+                           'email', 'roles']
+        for field in required_fields:
+            if not user.get(field):
+                print("Error: '{}' is a required field, but was not "
+                      "specified".format(field))
+                exit(1)
+
+        existing_user = appbuilder.sm.find_user(email=user['email'])
+        if existing_user:
+            print("Found existing user with email '{}'".format(user['email']))
+            existing_user.roles = roles
+            existing_user.first_name = user['firstname']
+            existing_user.last_name = user['lastname']
+
+            if existing_user.username != user['username']:
+                print("Error: Changing ther username is not allowed - "
+                      "please delete and recreate the user with "
+                      "email '{}'".format(user['email']))
+                exit(1)
+
+            appbuilder.sm.update_user(existing_user)
+            users_updated.append(user['email'])
+        else:
+            print("Creating new user with email '{}'".format(user['email']))
+            appbuilder.sm.add_user(
+                username=user['username'],
+                first_name=user['firstname'],
+                last_name=user['lastname'],
+                email=user['email'],
+                role=roles[0],  # add_user() requires exactly 1 role
+            )
+
+            if len(roles) > 1:
+                new_user = appbuilder.sm.find_user(email=user['email'])
+                new_user.roles = roles
+                appbuilder.sm.update_user(new_user)
+
+            users_created.append(user['email'])
+
+    return users_created, users_updated
 
 
 @cli_utils.action_logging
@@ -1998,6 +2099,14 @@ class CLIFactory(object):
             ('--remove-role',),
             help='Remove user from a role',
             action='store_true'),
+        'user_import': Arg(
+            ("-i", "--import"),
+            metavar="FILEPATH",
+            help="Import users from JSON file"),
+        'user_export': Arg(
+            ("-e", "--export"),
+            metavar="FILEPATH",
+            help="Export users to JSON file"),
         'autoscale': Arg(
             ('-a', '--autoscale'),
             help="Minimum and Maximum number of worker to autoscale"),
@@ -2166,7 +2275,7 @@ class CLIFactory(object):
             'func': users,
             'help': "List/Create/Delete/Update users",
             'args': ('list_users', 'create_user', 'delete_user',
-                     'add_role', 'remove_role',
+                     'add_role', 'remove_role', 'user_import', 'user_export',
                      'username', 'email', 'firstname', 'lastname', 'role',
                      'password', 'use_random_password'),
         },

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -31,6 +31,7 @@ from importlib import import_module
 import getpass
 import reprlib
 import argparse
+from argparse import RawTextHelpFormatter
 from builtins import input
 from collections import namedtuple
 
@@ -2102,7 +2103,18 @@ class CLIFactory(object):
         'user_import': Arg(
             ("-i", "--import"),
             metavar="FILEPATH",
-            help="Import users from JSON file"),
+            help="Import users from JSON file. Example format:" +
+                    textwrap.dedent('''
+                    [
+                        {
+                            "email": "foo@bar.org",
+                            "firstname": "Jon",
+                            "lastname": "Doe",
+                            "roles": ["Public"],
+                            "username": "jondoe"
+                        }
+                    ]'''),
+        ),
         'user_export': Arg(
             ("-e", "--export"),
             metavar="FILEPATH",
@@ -2312,6 +2324,7 @@ class CLIFactory(object):
         for sub in subparser_list:
             sub = cls.subparsers_dict[sub]
             sp = subparsers.add_parser(sub['func'].__name__, help=sub['help'])
+            sp.formatter_class = RawTextHelpFormatter
             for arg in sub['args']:
                 if 'dag_id' in arg and dag_parser:
                     continue


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3787
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:

Provide a CLI command to import or export users from a JSON file. The
CLI arguments are modeled after the import/export commands for Variables
and Pools.

Example Usage:

    airflow users -i users.json
    airflow users -e /tmp/exported-users.json

The import command will create any users that do not yet exist and
update any users that already exist. It never deletes users.

The format of the file produced by an export is compatible with the
import command, i.e., `import(export())` should succeed but have no
side-effects.

### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added unit tests for both import and export.

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ X ] Passes `flake8`
