### PR TITLE
[AIRFLOW-3792] Fix in BigQuery hook queryParameters and useLegacySQL flags

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -681,9 +681,9 @@ class BigQueryBaseCursor(LoggingMixin):
         :param create_disposition: Specifies whether the job is allowed to
             create new tables.
         :type create_disposition: str
-        :param query_params: a dictionary containing query parameter types and
+        :param query_params: a list of dictionary containing query parameter types and
             values, passed to BigQuery
-        :type query_params: dict
+        :type query_params: list
         :param labels: a dictionary containing labels for the job/query,
             passed to BigQuery
         :type labels: dict
@@ -771,7 +771,7 @@ class BigQueryBaseCursor(LoggingMixin):
             (sql, 'query', None, six.string_types),
             (priority, 'priority', 'INTERACTIVE', six.string_types),
             (use_legacy_sql, 'useLegacySql', self.use_legacy_sql, bool),
-            (query_params, 'queryParameters', None, dict),
+            (query_params, 'queryParameters', None, list),
             (udf_config, 'userDefinedFunctionResources', None, list),
             (maximum_billing_tier, 'maximumBillingTier', None, int),
             (maximum_bytes_billed, 'maximumBytesBilled', None, float),
@@ -824,7 +824,7 @@ class BigQueryBaseCursor(LoggingMixin):
                         'createDisposition': create_disposition,
                     })
 
-        if 'useLegacySql' in configuration['query'] and \
+        if 'useLegacySql' in configuration['query'] and configuration['query']['useLegacySql'] and\
                 'queryParameters' in configuration['query']:
             raise ValueError("Query parameters are not allowed "
                              "when using legacy SQL")

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -290,6 +290,29 @@ class TestBigQueryBaseCursor(unittest.TestCase):
             self.assertIs(args[0]['query']['useLegacySql'], bool_val)
 
     @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')
+    def test_run_query_sql_dialect_legacy_with_query_params(self, run_with_config):
+        cursor = hook.BigQueryBaseCursor(mock.Mock(), "project_id")
+        params = [{
+            'name': "param_name",
+            'parameterType': {'type': "STRING"},
+            'parameterValue': {'value': "param_value"}
+        }]
+        cursor.run_query('query', use_legacy_sql=False, query_params=params)
+        args, kwargs = run_with_config.call_args
+        self.assertIs(args[0]['query']['useLegacySql'], False)
+
+    @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')
+    def test_run_query_sql_dialect_legacy_with_query_params_fails(self, run_with_config):
+        cursor = hook.BigQueryBaseCursor(mock.Mock(), "project_id")
+        params = [{
+            'name': "param_name",
+            'parameterType': {'type': "STRING"},
+            'parameterValue': {'value': "param_value"}
+        }]
+        with self.assertRaises(ValueError):
+            cursor.run_query('query', use_legacy_sql=True, query_params=params)
+
+    @mock.patch.object(hook.BigQueryBaseCursor, 'run_with_configuration')
     def test_api_resource_configs(self, run_with_config):
         for bool_val in [True, False]:
             cursor = hook.BigQueryBaseCursor(mock.Mock(), "project_id")


### PR DESCRIPTION
### Description

This PR fixes a bug [AIRFLOW-3792](https://issues.apache.org/jira/browse/AIRFLOW-3792) in BigQuery Hook when using : 
- useLegacySQL to False
- or queryParameters, because since 1.10 the queryParameters were validated as dict instead of what google's API expects (a list of dict)

### Tests

- [x] My PR adds the following unit tests : in `contrib/test_bigquery_hook.py` a test called `test_run_query_sql_dialect_legacy_with_query_params` which tests both the proper form of query params and the legacy sql flag set to False in conjonction.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"

### Documentation
- [x] No new thing, just a bug fix.

### Code Quality

- [x] Passes `flake8`
