### PR TITLE
[AIRFLOW-3229] Loosen upper-bound on tenacity version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -318,7 +318,7 @@ def do_setup():
             'setproctitle>=1.1.8, <2',
             'sqlalchemy>=1.1.15, <1.3.0',
             'tabulate>=0.7.5, <=0.8.2',
-            'tenacity==4.8.0',
+            'tenacity>=4.8, <5.0',
             'text-unidecode==1.2',  # Avoid GPL dependency, pip uses reverse order(!)
             'thrift>=0.9.2',
             'tzlocal>=1.4',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3229
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:

I don't know much about this dependency - just trying to get rid of these
backtraces in the output of all `airflow` commands:

    [2019-01-30 13:47:01,090] {__init__.py:51} INFO - Using executor SequentialExecutor
    [2019-01-30 13:47:01,260] {__init__.py:295} INFO - Filling up the DagBag from ~/airflow/dags
    [2019-01-30 13:47:01,284] {__init__.py:399} ERROR - Failed to import: ~/.virtualenvs/airflow3/lib/python3.7/site-packages/apache_airflow-2.0.0.dev0_-py3.7.egg/airflow/example_dags/example_http_operator.py
    Traceback (most recent call last):
      File "~/.virtualenvs/airflow3/lib/python3.7/site-packages/apache_airflow-2.0.0.dev0_-py3.7.egg/airflow/models/__init__.py", line 396, in process_file
	m = imp.load_source(mod_name, filepath)
      File "~/.virtualenvs/airflow3/lib/python3.7/imp.py", line 171, in load_source
	module = _load(spec)
      File "<frozen importlib._bootstrap>", line 696, in _load
      File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 728, in exec_module
      File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
      File "~/.virtualenvs/airflow3/lib/python3.7/site-packages/apache_airflow-2.0.0.dev0_-py3.7.egg/airflow/example_dags/example_http_operator.py", line 27, in <module>
	from airflow.operators.http_operator import SimpleHttpOperator
      File "~/.virtualenvs/airflow3/lib/python3.7/site-packages/apache_airflow-2.0.0.dev0_-py3.7.egg/airflow/operators/http_operator.py", line 21, in <module>
	from airflow.hooks.http_hook import HttpHook
      File "~/.virtualenvs/airflow3/lib/python3.7/site-packages/apache_airflow-2.0.0.dev0_-py3.7.egg/airflow/hooks/http_hook.py", line 23, in <module>
	import tenacity
    ModuleNotFoundError: No module named 'tenacity'

I confirmed that this error goes away with tenacity==4.12 on Python3.

If anyone has concerns about upgrading tenacity, we could loosen the
upper-bound only for Python3 (for which this is currently broken, anyway).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ X ] Passes `flake8`
