### PR TITLE
[Airflow-XXX] - Docs: airflow pool is not honored by SubDAG

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -350,6 +350,8 @@ UI. As slots free up, queued tasks start running based on the
 Note that by default tasks aren't assigned to any pool and their
 execution parallelism is only limited to the executor's setting.
 
+To combine Pools with SubDAGs see the `SubDAGs`_ section.
+
 .. _concepts-connections:
 
 Connections
@@ -652,6 +654,9 @@ Some other tips when using SubDAGs:
    a single slot
 
 See ``airflow/example_dags`` for a demonstration.
+
+Note that airflow pool is not honored by SubDagOperator. Hence resources could be
+consumed by SubdagOperators.
 
 SLAs
 ====


### PR DESCRIPTION
Airflow pool is not honored by SubDagOperator.
This note is hidden in the source code - this is very important and needs to be reflected in the docs.
https://github.com/apache/airflow/blob/848e432865da82c86918bac8b466d17dc12cd84c/airflow/operators/subdag_operator.py#L94-L96
Adding note for it in both Pools and SubDAGs sections.