### PR TITLE
[AIRFLOW-3737] Kubernetes executor cannot handle long dag/task names

### DIFF
--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -521,7 +521,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
 
         try:
             return (
-                annotations['dag_id'], annotations['task_id'],
+                annotations['org.apache.airflow/dag_id'], annotations['org.apache.airflow/task_id'],
                 self._label_safe_datestring_to_datetime(labels['execution_date']),
                 try_num,
             )

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -583,6 +583,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
         )
         return None
 
+
 class KubernetesExecutor(BaseExecutor, LoggingMixin):
     def __init__(self):
         self.kube_config = KubeConfig()

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -298,8 +298,8 @@ class WorkerConfiguration(LoggingMixin):
         if gcp_sa_key:
             annotations['iam.cloud.google.com/service-account'] = gcp_sa_key
 
-        annotations['dag_id'] = dag_id
-        annotations['task_id'] = task_id
+        annotations['org.apache.airflow/dag_id'] = dag_id
+        annotations['org.apache.airflow/task_id'] = task_id
 
         volumes = [value for value in volumes_dict.values()] + kube_executor_config.volumes
         volume_mounts = [value for value in volume_mounts_dict.values()] + kube_executor_config.volume_mounts

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -17,7 +17,6 @@
 
 import os
 import six
-import hashlib
 
 from airflow.configuration import conf
 from airflow.contrib.kubernetes.pod import Pod, Resources
@@ -298,9 +297,6 @@ class WorkerConfiguration(LoggingMixin):
         if gcp_sa_key:
             annotations['iam.cloud.google.com/service-account'] = gcp_sa_key
 
-        annotations['org.apache.airflow/dag_id'] = dag_id
-        annotations['org.apache.airflow/task_id'] = task_id
-
         volumes = [value for value in volumes_dict.values()] + kube_executor_config.volumes
         volume_mounts = [value for value in volume_mounts_dict.values()] + kube_executor_config.volume_mounts
 
@@ -316,8 +312,8 @@ class WorkerConfiguration(LoggingMixin):
             cmds=airflow_command,
             labels={
                 'airflow-worker': worker_uuid,
-                'dag_hash': hashlib.md5(dag_id.encode()).hexdigest(),
-                'task_hash': hashlib.md5(task_id.encode()).hexdigest(),
+                'dag_id': dag_id,
+                'task_id': task_id,
                 'execution_date': execution_date,
                 'try_number': str(try_number),
             },

--- a/tests/contrib/executors/test_kubernetes_executor.py
+++ b/tests/contrib/executors/test_kubernetes_executor.py
@@ -43,8 +43,12 @@ except ImportError:
 
 class TestAirflowKubernetesScheduler(unittest.TestCase):
     @staticmethod
-    def _gen_random_string(str_len):
-        return ''.join([random.choice(string.printable) for _ in range(str_len)])
+    def _gen_random_string(seed, str_len):
+        char_list = []
+        for char_seed in range(str_len):
+            random.seed(str(seed) * char_seed)
+            char_list.append(random.choice(string.printable))
+        return ''.join(char_list)
 
     def _cases(self):
         cases = [
@@ -56,26 +60,50 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
         ]
 
         cases.extend([
-            (self._gen_random_string(200), self._gen_random_string(200))
-            for _ in range(100)
+            (self._gen_random_string(seed, 200), self._gen_random_string(seed, 200))
+            for seed in range(100)
         ])
 
         return cases
 
     @staticmethod
-    def _is_valid_name(name):
+    def _is_valid_pod_id(name):
         regex = r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
         return (
             len(name) <= 253 and
             all(ch.lower() == ch for ch in name) and
             re.match(regex, name))
 
+    @staticmethod
+    def _is_safe_label_value(value):
+        regex = r'^[^a-z0-9A-Z]*|[^a-zA-Z0-9_\-\.]|[^a-z0-9A-Z]*$'
+        return (
+            len(value) <= 63 and
+            re.match(regex, value))
+
     @unittest.skipIf(AirflowKubernetesScheduler is None,
                      'kubernetes python package is not installed')
     def test_create_pod_id(self):
         for dag_id, task_id in self._cases():
             pod_name = AirflowKubernetesScheduler._create_pod_id(dag_id, task_id)
-            self.assertTrue(self._is_valid_name(pod_name))
+            self.assertTrue(self._is_valid_pod_id(pod_name))
+
+    def test_make_safe_label_value(self):
+        for dag_id, task_id in self._cases():
+            safe_dag_id = AirflowKubernetesScheduler._make_safe_label_value(dag_id)
+            self.assertTrue(self._is_safe_label_value(safe_dag_id))
+            safe_task_id = AirflowKubernetesScheduler._make_safe_label_value(task_id)
+            self.assertTrue(self._is_safe_label_value(safe_task_id))
+            id = "my_dag_id"
+            self.assertEqual(
+                id,
+                AirflowKubernetesScheduler._make_safe_label_value(id)
+            )
+            id = "my_dag_id_" + "a" * 64
+            self.assertEqual(
+                "my_dag_id_" + "a" * 43 + "-0ce114c45",
+                AirflowKubernetesScheduler._make_safe_label_value(id)
+            )
 
     @unittest.skipIf(AirflowKubernetesScheduler is None,
                      "kubernetes python package is not installed")


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira] https://issues.apache.org/jira/browse/AIRFLOW-3737

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Kubernetes has a 63char limit on label values, so when running either a
subdag or a dag with a name with a length longer than 63 chars, the pod
creation process will fail with the following error:

  [2019-01-21 08:07:05,337] {rest.py:219} DEBUG - response body:
  {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"unable
  to parse requirement: invalid label value:
  \"very_long_dag_name.very_long_task_name\": must be no more than 63
  characters","reason":"BadRequest","code":400}

Annotations however, allow for a relatively unrestricted length when
storing them against pods, and as such would be better suited in this
situation.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This pull request fixes a bug in `KubernetesJobWatcher`, which doesn't yet have any tests
(it is patched out in tests of the `KubernetesExecutor`).  It isn't straightforward to add meaningful
tests to the `KubernetesJobWatcher` due to its integration with `kube_client`. We could pass in
a mock, but we don't think this would actually achieve anything and could actually create difficulties
in the future as we would be making assumptions on how to code works, instead on what the code
does. This is really crying out for an integration test, but we believe that is outside the scope of this
pull request. We're happy to take advice from the community on this 

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X] Passes `flake8`