### PR TITLE
[AIRFLOW-3799] Add compose to GoogleCloudStorageHook

### DIFF
--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -655,7 +655,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                 'Object ACL entry creation failed. Error was: {}'.format(ex.content)
             )
 
-    def compose(self, bucket, source_objects, destination_object):
+    def compose(self, bucket, source_objects, destination_object, num_retries=5):
         """
         Composes a list of existing object into a new object in the same storage bucket
 
@@ -696,7 +696,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                 .compose(destinationBucket=bucket,
                          destinationObject=destination_object,
                          body=body) \
-                .execute()
+                .execute(num_retries=num_retries)
             return True
         except HttpError as ex:
             if ex.resp['status'] == '404':

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -655,6 +655,54 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                 'Object ACL entry creation failed. Error was: {}'.format(ex.content)
             )
 
+    def compose(self, bucket, source_objects, destination_object):
+        """
+        Composes a list of existing object into a new object in the same storage bucket
+
+        Currently it only supports up to 32 objects that can be concatenated
+        in a single operation
+
+        https://cloud.google.com/storage/docs/json_api/v1/objects/compose
+
+        :param bucket: The name of the bucket containing the source objects.
+            This is also the same bucket to store the composed destination object.
+        :type bucket: str
+        :param source_objects: The list of source objects that will be composed
+            into a single object.
+        :type source_objects: list
+        :param destination_object: The path of the object if given.
+        :type destination_object: str
+        """
+
+        if not source_objects or not len(source_objects):
+            raise ValueError('source_objects cannot be empty.')
+
+        if not bucket or not destination_object:
+            raise ValueError('bucket and destination_object cannot be empty.')
+
+        service = self.get_conn()
+
+        dict_source_objects = [{'name': source_object}
+                               for source_object in source_objects]
+        body = {
+            'sourceObjects': dict_source_objects
+        }
+
+        try:
+            self.log.info("Composing %s to %s in the bucket %s",
+                          source_objects, destination_object, bucket)
+            service \
+                .objects() \
+                .compose(destinationBucket=bucket,
+                         destinationObject=destination_object,
+                         body=body) \
+                .execute()
+            return True
+        except HttpError as ex:
+            if ex.resp['status'] == '404':
+                return False
+            raise
+
 
 def _parse_gcs_url(gsurl):
     """

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -342,6 +342,88 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
 
         self.assertFalse(response)
 
+    @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
+    def test_compose(self, mock_service):
+        test_bucket = 'test_bucket'
+        test_source_objects = ['test_object_1', 'test_object_2', 'test_object_3']
+        test_destination_object = 'test_object_composed'
+
+        method = (mock_service.return_value.objects.return_value.compose)
+
+        self.gcs_hook.compose(
+            bucket=test_bucket,
+            source_objects=test_source_objects,
+            destination_object=test_destination_object
+        )
+
+        body = {
+            'sourceObjects': [
+                {'name': 'test_object_1'},
+                {'name': 'test_object_2'},
+                {'name': 'test_object_3'}
+            ]
+        }
+
+        method.assert_called_once_with(
+            destinationBucket=test_bucket,
+            destinationObject=test_destination_object,
+            body=body
+        )
+
+    @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
+    def test_compose_with_empty_source_objects(self, mock_service):
+        test_bucket = 'test_bucket'
+        test_source_objects = []
+        test_destination_object = 'test_object_composed'
+
+        with self.assertRaises(ValueError) as e:
+            self.gcs_hook.compose(
+                bucket=test_bucket,
+                source_objects=test_source_objects,
+                destination_object=test_destination_object
+            )
+
+        self.assertEqual(
+            str(e.exception),
+            'source_objects cannot be empty.'
+        )
+
+    @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
+    def test_compose_without_bucket(self, mock_service):
+        test_bucket = None
+        test_source_objects = ['test_object_1', 'test_object_2', 'test_object_3']
+        test_destination_object = 'test_object_composed'
+
+        with self.assertRaises(ValueError) as e:
+            self.gcs_hook.compose(
+                bucket=test_bucket,
+                source_objects=test_source_objects,
+                destination_object=test_destination_object
+            )
+
+        self.assertEqual(
+            str(e.exception),
+            'bucket and destination_object cannot be empty.'
+        )
+
+    @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
+    def test_compose_without_destination_object(self, mock_service):
+        test_bucket = 'test_bucket'
+        test_source_objects = ['test_object_1', 'test_object_2', 'test_object_3']
+        test_destination_object = None
+
+        with self.assertRaises(ValueError) as e:
+            self.gcs_hook.compose(
+                bucket=test_bucket,
+                source_objects=test_source_objects,
+                destination_object=test_destination_object
+            )
+
+        self.assertEqual(
+            str(e.exception),
+            'bucket and destination_object cannot be empty.'
+        )
+
 
 class TestGoogleCloudStorageHookUpload(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Add compose to GoogleCloudStorageHook and unit tests

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-3799](https://issues.apache.org/jira/browse/AIRFLOW-3799) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
In GoogleCloudStorageHook, add compose function to concatenate a list of existing objects into a new object in the same bucket.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests.contrib.hooks.test_gcs_hook:TestGoogleCloudStorageHook.test_compose
tests.contrib.hooks.test_gcs_hook:TestGoogleCloudStorageHook.test_compose_with_empty_source_objects
tests.contrib.hooks.test_gcs_hook:TestGoogleCloudStorageHook.test_compose_without_bucket
tests.contrib.hooks.test_gcs_hook:TestGoogleCloudStorageHook.test_compose_without_destination_object

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
