### PR TITLE
[AIRFLOW-3780] Fix some pages are incorrectly directly after set base_url

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -40,7 +40,7 @@
       {% endif %}
     </h3>
     <h4 class="pull-right">
-      <a class="label label-default" href="/admin/dagrun/?flt2_dag_id_equals={{ dag.dag_id }}">
+      <a class="label label-default" href="{{ url_for('dagrun.index_view') }}?_flt_2_dag_id={{ dag.dag_id }}">
         schedule: {{ dag.schedule_interval }}
       </a>
     </h4>
@@ -369,7 +369,7 @@ function updateQueryStringParameter(uri, key, value) {
     });
 
     $("#btn_ti").click(function(){
-      url = "/admin/taskinstance/" +
+      url = "{{ url_for('taskinstance.index_view') }}" +
         "?flt1_dag_id_equals=" + encodeURIComponent(dag_id) +
         "&flt2_task_id_equals=" + encodeURIComponent(task_id) +
         "&sort=3&desc=1";
@@ -481,7 +481,7 @@ function updateQueryStringParameter(uri, key, value) {
     });
 
     $('#btn_edit_dagrun').click(function(){
-      window.location = '/admin/dagrun/edit/?id=' + id;
+      window.location = "{{ url_for('dagrun.edit_view') }}?id=" + id;
     });
 
   </script>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -139,7 +139,7 @@
                 {% if dag %}
 
                 <!-- Trigger Dag -->
-                <a href="{{ url_for('airflow.trigger', dag_id=dag.dag_id) }}"
+                <a href="{{ url_for('airflow.trigger', dag_id=dag.dag_id) }}&origin={{ request.base_url }}"
                    onclick="return confirmTriggerDag('{{ dag.safe_dag_id }}')">
                     <span class="glyphicon glyphicon-play-circle" aria-hidden="true" data-original-title="Trigger Dag"></span>
                 </a>

--- a/airflow/www_rbac/templates/airflow/dags.html
+++ b/airflow/www_rbac/templates/airflow/dags.html
@@ -140,7 +140,7 @@
                 {% if dag %}
 
                 <!-- Trigger Dag -->
-                <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id) }}"
+                <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id) }}&origin={{ request.base_url }}"
                    onclick="return confirmTriggerDag('{{ dag.safe_dag_id }}')">
                     <span class="glyphicon glyphicon-play-circle" aria-hidden="true" data-original-title="Trigger Dag"></span>
                 </a>


### PR DESCRIPTION
Make sure you have checked all steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3780
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We found that after set the base_url, some of the aiflow pages cannot be redirected  to correct path. The pages include:
* Task instances in the dag detail page
* The schedule interval tag in the dag detail page
* Trigger button in the dag list page

In the first two pages, the root cause is the path is hard coded. In the PR, I change them to {{ url_for( ... ) }} to use the path generated by backend.

In the third one, the root cause is that the 'origin' param is not passed to the backend correctly. I added a javascript function to add the origin param to the url.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I don't know how to do test on UI link change

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
wait for travis
