### PR TITLE
AIRFLOW-3543: Fix deletion of DAG with rescheduled tasks

### DIFF
--- a/airflow/migrations/versions/4ebbffe0a39a_merge_heads.py
+++ b/airflow/migrations/versions/4ebbffe0a39a_merge_heads.py
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Merge heads
+
+Revision ID: 4ebbffe0a39a
+Revises: dd4ecb8fbee3, cf5dc11e79ad, a56c9515abdc
+Create Date: 2019-02-04 20:19:50.628137
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4ebbffe0a39a'
+down_revision = ('dd4ecb8fbee3', 'cf5dc11e79ad', 'a56c9515abdc')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/airflow/migrations/versions/939bb1e647c8_task_reschedule_fk_on_cascade_delete.py
+++ b/airflow/migrations/versions/939bb1e647c8_task_reschedule_fk_on_cascade_delete.py
@@ -1,0 +1,62 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""task reschedule fk on cascade delete
+
+Revision ID: 939bb1e647c8
+Revises: 4ebbffe0a39a
+Create Date: 2019-02-04 20:21:50.669751
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '939bb1e647c8'
+down_revision = '4ebbffe0a39a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('task_reschedule') as batch_op:
+        batch_op.drop_constraint(
+            'task_reschedule_dag_task_date_fkey',
+            type_='foreignkey'
+        )
+        batch_op.create_foreign_key(
+            'task_reschedule_dag_task_date_fkey',
+            'task_instance',
+            ['task_id', 'dag_id', 'execution_date'],
+            ['task_id', 'dag_id', 'execution_date'],
+            ondelete='CASCADE'
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('task_reschedule') as batch_op:
+        batch_op.drop_constraint(
+            'task_reschedule_dag_task_date_fkey',
+            type_='foreignkey'
+        )
+        batch_op.create_foreign_key(
+            'task_reschedule_dag_task_date_fkey',
+            'task_instance',
+            ['task_id', 'dag_id', 'execution_date'],
+            ['task_id', 'dag_id', 'execution_date']
+        )

--- a/airflow/models/taskreschedule.py
+++ b/airflow/models/taskreschedule.py
@@ -47,7 +47,8 @@ class TaskReschedule(Base):
         ForeignKeyConstraint([task_id, dag_id, execution_date],
                              ['task_instance.task_id', 'task_instance.dag_id',
                               'task_instance.execution_date'],
-                             name='task_reschedule_dag_task_date_fkey')
+                             name='task_reschedule_dag_task_date_fkey',
+                             ondelete='CASCADE')
     )
 
     def __init__(self, task, execution_date, try_number, start_date, end_date,

--- a/tests/api/common/experimental/test_delete_dag.py
+++ b/tests/api/common/experimental/test_delete_dag.py
@@ -20,61 +20,61 @@
 import unittest
 
 from airflow import models
-from airflow import settings
 from airflow.api.common.experimental.delete_dag import delete_dag
 from airflow.exceptions import DagNotFound, DagFileExists
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils.dates import days_ago
+from airflow.utils.db import create_session
 from airflow.utils.state import State
 
 DM = models.DagModel
 DR = models.DagRun
 TI = models.TaskInstance
 LOG = models.log.Log
+TF = models.taskfail.TaskFail
+TR = models.taskreschedule.TaskReschedule
 
 
 class TestDeleteDAGCatchError(unittest.TestCase):
 
     def setUp(self):
-        self.session = settings.Session()
         self.dagbag = models.DagBag(include_examples=True)
         self.dag_id = 'example_bash_operator'
         self.dag = self.dagbag.dags[self.dag_id]
 
     def tearDown(self):
         self.dag.clear()
-        self.session.close()
 
     def test_delete_dag_non_existent_dag(self):
         with self.assertRaises(DagNotFound):
             delete_dag("non-existent DAG")
 
     def test_delete_dag_dag_still_in_dagbag(self):
-        models_to_check = ['DagModel', 'DagRun', 'TaskInstance']
-        record_counts = {}
+        with create_session() as session:
+            models_to_check = ['DagModel', 'DagRun', 'TaskInstance']
+            record_counts = {}
 
-        for model_name in models_to_check:
-            m = getattr(models, model_name)
-            record_counts[model_name] = self.session.query(m).filter(m.dag_id == self.dag_id).count()
+            for model_name in models_to_check:
+                m = getattr(models, model_name)
+                record_counts[model_name] = session.query(m).filter(m.dag_id == self.dag_id).count()
 
-        with self.assertRaises(DagFileExists):
-            delete_dag(self.dag_id)
+            with self.assertRaises(DagFileExists):
+                delete_dag(self.dag_id)
 
-        # No change should happen in DB
-        for model_name in models_to_check:
-            m = getattr(models, model_name)
-            self.assertEqual(
-                self.session.query(m).filter(
-                    m.dag_id == self.dag_id
-                ).count(),
-                record_counts[model_name]
-            )
+            # No change should happen in DB
+            for model_name in models_to_check:
+                m = getattr(models, model_name)
+                self.assertEqual(
+                    session.query(m).filter(
+                        m.dag_id == self.dag_id
+                    ).count(),
+                    record_counts[model_name]
+                )
 
 
 class TestDeleteDAGSuccessfulDelete(unittest.TestCase):
 
     def setUp(self):
-        self.session = settings.Session()
         self.key = "test_dag_id"
 
         task = DummyOperator(task_id='dummy',
@@ -82,52 +82,71 @@ class TestDeleteDAGSuccessfulDelete(unittest.TestCase):
                                             default_args={'start_date': days_ago(2)}),
                              owner='airflow')
 
-        self.session.add(DM(dag_id=self.key))
-        self.session.add(DR(dag_id=self.key))
-        self.session.add(TI(task=task,
-                            execution_date=days_ago(1),
-                            state=State.SUCCESS))
-        self.session.add(LOG(dag_id=self.key, task_id=None, task_instance=None,
-                             execution_date=days_ago(1), event="varimport"))
-
-        self.session.commit()
+        d = days_ago(1)
+        with create_session() as session:
+            session.add(DM(dag_id=self.key))
+            session.add(DR(dag_id=self.key))
+            session.add(TI(task=task,
+                           execution_date=d,
+                           state=State.SUCCESS))
+            # flush to ensure task instance if written before
+            # task reschedule because of FK constraint
+            session.flush()
+            session.add(LOG(dag_id=self.key, task_id=None, task_instance=None,
+                            execution_date=d, event="varimport"))
+            session.add(TF(task=task, execution_date=d,
+                           start_date=d, end_date=d))
+            session.add(TR(task=task, execution_date=d,
+                           start_date=d, end_date=d,
+                           try_number=1, reschedule_date=d))
 
     def tearDown(self):
-        self.session.query(DM).filter(DM.dag_id == self.key).delete()
-        self.session.query(DR).filter(DR.dag_id == self.key).delete()
-        self.session.query(TI).filter(TI.dag_id == self.key).delete()
-        self.session.query(LOG).filter(LOG.dag_id == self.key).delete()
-        self.session.commit()
-
-        self.session.close()
+        with create_session() as session:
+            session.query(TR).filter(TR.dag_id == self.key).delete()
+            session.query(TF).filter(TF.dag_id == self.key).delete()
+            session.query(TI).filter(TI.dag_id == self.key).delete()
+            session.query(DR).filter(DR.dag_id == self.key).delete()
+            session.query(DM).filter(DM.dag_id == self.key).delete()
+            session.query(LOG).filter(LOG.dag_id == self.key).delete()
 
     def test_delete_dag_successful_delete(self):
-
-        self.assertEqual(self.session.query(DM).filter(DM.dag_id == self.key).count(), 1)
-        self.assertEqual(self.session.query(DR).filter(DR.dag_id == self.key).count(), 1)
-        self.assertEqual(self.session.query(TI).filter(TI.dag_id == self.key).count(), 1)
-        self.assertEqual(self.session.query(LOG).filter(LOG.dag_id == self.key).count(), 1)
+        with create_session() as session:
+            self.assertEqual(session.query(DM).filter(DM.dag_id == self.key).count(), 1)
+            self.assertEqual(session.query(DR).filter(DR.dag_id == self.key).count(), 1)
+            self.assertEqual(session.query(TI).filter(TI.dag_id == self.key).count(), 1)
+            self.assertEqual(session.query(TF).filter(TF.dag_id == self.key).count(), 1)
+            self.assertEqual(session.query(TR).filter(TR.dag_id == self.key).count(), 1)
+            self.assertEqual(session.query(LOG).filter(LOG.dag_id == self.key).count(), 1)
 
         delete_dag(dag_id=self.key)
 
-        self.assertEqual(self.session.query(DM).filter(DM.dag_id == self.key).count(), 0)
-        self.assertEqual(self.session.query(DR).filter(DR.dag_id == self.key).count(), 0)
-        self.assertEqual(self.session.query(TI).filter(TI.dag_id == self.key).count(), 0)
-        self.assertEqual(self.session.query(LOG).filter(LOG.dag_id == self.key).count(), 1)
+        with create_session() as session:
+            self.assertEqual(session.query(DM).filter(DM.dag_id == self.key).count(), 0)
+            self.assertEqual(session.query(DR).filter(DR.dag_id == self.key).count(), 0)
+            self.assertEqual(session.query(TI).filter(TI.dag_id == self.key).count(), 0)
+            self.assertEqual(session.query(TF).filter(TF.dag_id == self.key).count(), 0)
+            self.assertEqual(session.query(TR).filter(TR.dag_id == self.key).count(), 0)
+            self.assertEqual(session.query(LOG).filter(LOG.dag_id == self.key).count(), 1)
 
     def test_delete_dag_successful_delete_not_keeping_records_in_log(self):
 
-        self.assertEqual(self.session.query(DM).filter(DM.dag_id == self.key).count(), 1)
-        self.assertEqual(self.session.query(DR).filter(DR.dag_id == self.key).count(), 1)
-        self.assertEqual(self.session.query(TI).filter(TI.dag_id == self.key).count(), 1)
-        self.assertEqual(self.session.query(LOG).filter(LOG.dag_id == self.key).count(), 1)
+        with create_session() as session:
+            self.assertEqual(session.query(DM).filter(DM.dag_id == self.key).count(), 1)
+            self.assertEqual(session.query(DR).filter(DR.dag_id == self.key).count(), 1)
+            self.assertEqual(session.query(TI).filter(TI.dag_id == self.key).count(), 1)
+            self.assertEqual(session.query(TF).filter(TF.dag_id == self.key).count(), 1)
+            self.assertEqual(session.query(TR).filter(TR.dag_id == self.key).count(), 1)
+            self.assertEqual(session.query(LOG).filter(LOG.dag_id == self.key).count(), 1)
 
         delete_dag(dag_id=self.key, keep_records_in_log=False)
 
-        self.assertEqual(self.session.query(DM).filter(DM.dag_id == self.key).count(), 0)
-        self.assertEqual(self.session.query(DR).filter(DR.dag_id == self.key).count(), 0)
-        self.assertEqual(self.session.query(TI).filter(TI.dag_id == self.key).count(), 0)
-        self.assertEqual(self.session.query(LOG).filter(LOG.dag_id == self.key).count(), 0)
+        with create_session() as session:
+            self.assertEqual(session.query(DM).filter(DM.dag_id == self.key).count(), 0)
+            self.assertEqual(session.query(DR).filter(DR.dag_id == self.key).count(), 0)
+            self.assertEqual(session.query(TI).filter(TI.dag_id == self.key).count(), 0)
+            self.assertEqual(session.query(TF).filter(TF.dag_id == self.key).count(), 0)
+            self.assertEqual(session.query(TR).filter(TR.dag_id == self.key).count(), 0)
+            self.assertEqual(session.query(LOG).filter(LOG.dag_id == self.key).count(), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3543

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
  - `TaskReschedule` must be deleted before `TaskInstance` because of foreign key constraint

### Tests

- [X] My PR extends the following unit tests
  - `test_delete_dag.py`
  - Also changed tests to use `with create_session() as session`

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X] Passes `flake8`
