### PR TITLE
[AIRFLOW-3274] Add run_as_user and fs_group options for Kubernetes

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -725,6 +725,18 @@ affinity =
 #   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#toleration-v1-core
 tolerations =
 
+# Worker pods security context options
+# See:
+#   https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+
+# Specifies the uid to run the first process of the worker pods containers as
+run_as_user =
+
+# Specifies a gid to associate with all containers in the worker pods
+# if using a git_ssh_key_secret_name use an fs_group
+# that allows for the key to be read, e.g. 65533
+fs_group =
+
 [kubernetes_node_selectors]
 # The Key-value pairs to be given to worker pods.
 # The worker pods will be scheduled to the nodes of the specified key-value pairs.

--- a/airflow/contrib/example_dags/example_kubernetes_executor_config.py
+++ b/airflow/contrib/example_dags/example_kubernetes_executor_config.py
@@ -73,4 +73,17 @@ second_task = PythonOperator(
     }
 )
 
+# Test that we can run tasks as a normal user
+third_task = PythonOperator(
+    task_id="non_root_task", python_callable=print_stuff, dag=dag,
+    executor_config={
+        "KubernetesExecutor": {
+            "securityContext": {
+                "runAsUser": 1000
+            }
+        }
+    }
+)
+
 start_task.set_downstream(second_task)
+second_task.set_downstream(third_task)

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -155,6 +155,10 @@ class KubeConfig:
         # this will set to True if so
         self.dags_in_image = conf.getboolean(self.kubernetes_section, 'dags_in_image')
 
+        # Run as user for pod security context
+        self.worker_run_as_user = conf.get(self.kubernetes_section, 'run_as_user')
+        self.worker_fs_group = conf.get(self.kubernetes_section, 'fs_group')
+
         # NOTE: `git_repo` and `git_branch` must be specified together as a pair
         # The http URL of the git repository to clone from
         self.git_repo = conf.get(self.kubernetes_section, 'git_repo')

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -18,6 +18,8 @@
 from abc import ABCMeta, abstractmethod
 import six
 
+from airflow.contrib.kubernetes.pod import Pod
+
 
 class KubernetesRequestFactory:
     """

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -18,8 +18,6 @@
 from abc import ABCMeta, abstractmethod
 import six
 
-from airflow.contrib.kubernetes.pod import Pod
-
 
 class KubernetesRequestFactory:
     """

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
@@ -130,4 +130,5 @@ spec:
         self.extract_affinity(pod, req)
         self.extract_hostnetwork(pod, req)
         self.extract_tolerations(pod, req)
+        self.extract_security_context(pod, req)
         return req

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -196,7 +196,7 @@ class WorkerConfiguration(LoggingMixin):
             security_context['fsGroup'] = self.kube_config.worker_fs_group
 
         # set fs_group to 65533 if not explicitly specified and using git ssh keypair auth
-        if self.kube_config.git_ssh_key_secret_name and security_context.get('fs_group') is None:
+        if self.kube_config.git_ssh_key_secret_name and security_context.get('fsGroup') is None:
             security_context['fsGroup'] = 65533
 
         return security_context

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -187,12 +187,19 @@ class WorkerConfiguration(LoggingMixin):
 
     def _get_security_context(self):
         """Defines the security context"""
-        if self.kube_config.git_ssh_key_secret_name:
-            return {
-                'fsGroup': 65533  # to make SSH key readable
-            }
-        else:
-            return None
+        security_context = {}
+
+        if self.kube_config.worker_run_as_user:
+            security_context['runAsUser'] = self.kube_config.worker_run_as_user
+
+        if self.kube_config.worker_fs_group:
+            security_context['fsGroup'] = self.kube_config.worker_fs_group
+
+        # set fs_group to 65533 if not explicitly specified and using git ssh keypair auth
+        if self.kube_config.git_ssh_key_secret_name and security_context.get('fs_group') is None:
+            security_context['fsGroup'] = 65533
+
+        return security_context
 
     def _get_volumes_and_mounts(self):
         def _construct_volume(name, claim, host):

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -124,6 +124,7 @@ class KubernetesPodOperator(BaseOperator):
             pod.hostnetwork = self.hostnetwork
             pod.tolerations = self.tolerations
             pod.configmaps = self.configmaps
+            pod.security_context = self.security_context
 
             launcher = pod_launcher.PodLauncher(kube_client=client,
                                                 extract_xcom=self.do_xcom_push)
@@ -174,6 +175,7 @@ class KubernetesPodOperator(BaseOperator):
                  hostnetwork=False,
                  tolerations=None,
                  configmaps=None,
+                 security_context=None,
                  *args,
                  **kwargs):
         super(KubernetesPodOperator, self).__init__(*args, **kwargs)
@@ -207,3 +209,4 @@ class KubernetesPodOperator(BaseOperator):
         self.hostnetwork = hostnetwork
         self.tolerations = tolerations or []
         self.configmaps = configmaps or []
+        self.security_context = security_context or {}

--- a/tests/contrib/executors/test_kubernetes_executor.py
+++ b/tests/contrib/executors/test_kubernetes_executor.py
@@ -399,6 +399,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         self.kube_config.dags_volume_claim = None
         self.kube_config.dags_volume_host = None
         self.kube_config.dags_in_image = None
+        self.kube_config.worker_fs_group = None
 
         worker_config = WorkerConfiguration(self.kube_config)
         kube_executor_config = KubernetesExecutorConfig(annotations=[],
@@ -417,7 +418,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
                                     None)
         self.assertTrue(git_ssh_key_file)
         self.assertTrue(volume_mount_ssh_key)
-        self.assertEqual({'fsGroup': 65533}, pod.security_context)
+        self.assertEqual(65533, pod.security_context['fs_group'])
         self.assertEqual(git_ssh_key_file,
                          volume_mount_ssh_key,
                          'The location where the git ssh secret is mounted'

--- a/tests/contrib/executors/test_kubernetes_executor.py
+++ b/tests/contrib/executors/test_kubernetes_executor.py
@@ -418,7 +418,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
                                     None)
         self.assertTrue(git_ssh_key_file)
         self.assertTrue(volume_mount_ssh_key)
-        self.assertEqual(65533, pod.security_context['fs_group'])
+        self.assertEqual(65533, pod.security_context['fsGroup'])
         self.assertEqual(git_ssh_key_file,
                          volume_mount_ssh_key,
                          'The location where the git ssh secret is mounted'

--- a/tests/contrib/kubernetes/kubernetes_request_factory/test_pod_request_factory.py
+++ b/tests/contrib/kubernetes/kubernetes_request_factory/test_pod_request_factory.py
@@ -55,7 +55,11 @@ class TestPodRequestFactory(unittest.TestCase):
                 Secret('volume', '/etc/foo', 'secret_b'),
                 # This should produce a single secret mounted in env
                 Secret('env', 'TARGET', 'secret_b', 'source_b'),
-            ]
+            ],
+            security_context={
+                'runAsUser': 1000,
+                'fsGroup': 2000,
+            }
         )
         self.maxDiff = None
         self.expected = {
@@ -120,7 +124,11 @@ class TestPodRequestFactory(unittest.TestCase):
                     {'name': 'pull_secret_a'},
                     {'name': 'pull_secret_b'}
                 ],
-                'affinity': {}
+                'affinity': {},
+                'securityContext': {
+                    'runAsUser': 1000,
+                    'fsGroup': 2000,
+                },
             }
         }
 

--- a/tests/contrib/minikube/test_kubernetes_pod_operator.py
+++ b/tests/contrib/minikube/test_kubernetes_pod_operator.py
@@ -265,6 +265,69 @@ class KubernetesPodOperatorTest(unittest.TestCase):
             k.execute(None)
             mock_logger.info.assert_any_call(b"retrieved from mount\n")
 
+    @staticmethod
+    def test_run_as_user_root():
+        security_context = {
+            'securityContext': {
+                'runAsUser': 0,
+            }
+        }
+
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo", "10"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            security_context=security_context,
+            executor_config={'KubernetesExecutor': {'securityContext': security_context}}
+        )
+        k.execute(None)
+
+    @staticmethod
+    def test_run_as_user_non_root():
+        security_context = {
+            'securityContext': {
+                'runAsUser': 1000,
+            }
+        }
+
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo", "10"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            security_context=security_context,
+            executor_config={'KubernetesExecutor': {'securityContext': security_context}}
+        )
+        k.execute(None)
+
+    @staticmethod
+    def test_fs_group():
+        security_context = {
+            'securityContext': {
+                'fsGroup': 1000,
+            }
+        }
+
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo", "10"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            security_context=security_context,
+            executor_config={'KubernetesExecutor': {'securityContext': security_context}}
+        )
+        k.execute(None)
+
     def test_faulty_image(self):
         bad_image_name = "foobar"
         k = KubernetesPodOperator(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3274
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

At this time it is not possible to add `run_as_user` or `fs_group` securityContext options to worker pods when using KubernetesExecutor. This makes it harder to use KubernetesExecutor on clusters with pod security policies which do not allow containers to run as root.

This PR adds `run_as_user` and `fs_group` options to Airflow in order to set these security context options on worker pods spawned by KubernetesExecutor.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- `test_security_context` in `tests/contrib/minikube/test_kubernetes_pod_operator.py`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

The PR adds configuration options documented with comments in the configuration template.

### Code Quality

- [x] Passes `flake8`
