### PR TITLE
[AIRFLOW-XXX] Fixed note in plugins.rst

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -232,11 +232,12 @@ It is possible to load plugins via `setuptools entrypoint <https://packaging.pyt
 your plugin using an entrypoint in your package. If the package is installed, airflow
 will automatically load the registered plugins from the entrypoint list.
 
-_Note_: Neither the entrypoint name (eg, `my_plugin`) nor the name of the
-plugin class will contribute towards the module and class name of the plugin
-itself. The structure is determined by
-`airflow.plugins_manager.AirflowPlugin.name` and the class name of the plugin
-component with the pattern `airflow.{component}.{name}.{component_class_name}`.
+.. note:: 
+    Neither the entrypoint name (eg, `my_plugin`) nor the name of the
+    plugin class will contribute towards the module and class name of the plugin
+    itself. The structure is determined by
+    `airflow.plugins_manager.AirflowPlugin.name` and the class name of the plugin
+    component with the pattern `airflow.{component}.{name}.{component_class_name}`.
 
 .. code-block:: python
 


### PR DESCRIPTION
Changing it to rst notation, so it stands out in read the docs.