### PR TITLE
[AIRFLOW-3814] Add exception details to warning log

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -81,7 +81,7 @@ try:
             prefix=conf.get('scheduler', 'statsd_prefix'))
         Stats = statsd
 except (socket.gaierror, ImportError) as e:
-    log.warning("Could not configure StatsClient: ", e, ", using DummyStatsLogger instead.")
+    log.warning("Could not configure StatsClient: %s, using DummyStatsLogger instead.", e)
 
 HEADER = '\n'.join([
     r'  ____________       _____________',

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -80,8 +80,8 @@ try:
             port=conf.getint('scheduler', 'statsd_port'),
             prefix=conf.get('scheduler', 'statsd_prefix'))
         Stats = statsd
-except (socket.gaierror, ImportError):
-    log.warning("Could not configure StatsClient, using DummyStatsLogger instead.")
+except (socket.gaierror, ImportError) as e:
+    log.warning("Could not configure StatsClient: ", e, ", using DummyStatsLogger instead.")
 
 HEADER = '\n'.join([
     r'  ____________       _____________',


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3814

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
  - Add exception details when `StatsClient` initialization fails.
  - Currently it outputs only `Could not configure StatsClient, using DummyStatsLogger instead.` so 
it's hard to do troubleshoot.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x/] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
