### PR TITLE
[AIRFLOW-3808] Add cluster_fields to BigQueryHook's create_empty_table

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -230,7 +230,8 @@ class BigQueryBaseCursor(LoggingMixin):
                            time_partitioning=None,
                            cluster_fields=None,
                            labels=None,
-                           view=None):
+                           view=None,
+                           num_retries=5):
         """
         Creates a new, empty table in the dataset.
         To create a view, which is defined by a SQL query, parse a dictionary to 'view' kwarg
@@ -310,7 +311,7 @@ class BigQueryBaseCursor(LoggingMixin):
             self.service.tables().insert(
                 projectId=project_id,
                 datasetId=dataset_id,
-                body=table_resource).execute()
+                body=table_resource).execute(num_retries=num_retries)
 
             self.log.info('Table created successfully: %s:%s.%s',
                           project_id, dataset_id, table_id)

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -258,7 +258,7 @@ class BigQueryBaseCursor(LoggingMixin):
             .. seealso::
             https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#timePartitioning
         :type time_partitioning: dict
-        :param cluster_fields: The fields used for clustering.
+        :param cluster_fields: [Optional] The fields used for clustering.
             Must be specified with time_partitioning, data in the table will be first
             partitioned and subsequently clustered.
             https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#clustering.fields

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -228,6 +228,7 @@ class BigQueryBaseCursor(LoggingMixin):
                            table_id,
                            schema_fields=None,
                            time_partitioning=None,
+                           cluster_fields=None,
                            labels=None,
                            view=None):
         """
@@ -257,6 +258,11 @@ class BigQueryBaseCursor(LoggingMixin):
             .. seealso::
             https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#timePartitioning
         :type time_partitioning: dict
+        :param cluster_fields: The fields used for clustering.
+            Must be specified with time_partitioning, data in the table will be first
+            partitioned and subsequently clustered.
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#clustering.fields
+        :type cluster_fields: list
         :param view: [Optional] A dictionary containing definition for the view.
             If set, it will create a view instead of a table:
             https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#view
@@ -285,6 +291,11 @@ class BigQueryBaseCursor(LoggingMixin):
 
         if time_partitioning:
             table_resource['timePartitioning'] = time_partitioning
+
+        if cluster_fields:
+            table_resource['clustering'] = {
+                'fields': cluster_fields
+            }
 
         if labels:
             table_resource['labels'] = labels


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-3808](https://issues.apache.org/jira/browse/AIRFLOW-3808) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Enable BigQueryHook's create_empty_table to create table with clustering fields.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
tests.contrib.hooks.test_bigquery_hook:TestTableOperations.test_create_empty_table_succeed
tests.contrib.hooks.test_bigquery_hook:TestTableOperations.test_create_empty_table_with_extras_succeed
tests.contrib.hooks.test_bigquery_hook:TestTableOperations.test_create_empty_table_on_exception

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
