### PR TITLE
[AIRFLOW-3813] Add CLI commands to manage roles

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -195,6 +195,23 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         else:
             self.log.info('Existing permissions for the role:%s within the database will persist.', role_name)
 
+    def delete_role(self, role_name):
+        """Delete the given Role
+
+        :param role_name: the name of a role in the ab_role table
+        """
+        session = self.get_session
+        role = session.query(sqla_models.Role)\
+                      .filter(sqla_models.Role.name == role_name)\
+                      .first()
+        if role:
+            self.log.info("Deleting role '{}'".format(role_name))
+            session.delete(role)
+            session.commit()
+        else:
+            raise AirflowException("Role named '{}' does not exist".format(
+                role_name))
+
     def get_user_roles(self, user=None):
         """
         Get all the roles associated with the user.

--- a/docs/howto/add-new-role.rst
+++ b/docs/howto/add-new-role.rst
@@ -28,7 +28,12 @@ and click ``List Roles`` in the new UI.
 .. image:: ../img/add-role.png
 .. image:: ../img/new-role.png
 
+The image shows the creation of a role which can only write to
+``example_python_operator``. You can also create roles via the CLI
+using the ``airflow roles`` command, e.g.:
 
-The image shows a role which could only write to example_python_operator is created.
-And we could assign the given role to a new user using ``airflow users --add-role`` cli command.
-Default roles(Admin, User, Viewer, Op) shiped with RBAC could view the details for every dag.
+    airflow roles --create Role1 Role2
+
+And we could assign the given role to a new user using the ``airflow
+users --add-role`` CLI command.  Default roles(Admin, User, Viewer,
+Op) shipped with RBAC could view the details for every dag.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3813
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:

Here is the help text of the new command `airflow roles`:

    usage: airflow roles [-h] [-c] [-d] [-l] [role [role ...]]

    positional arguments:
      role          The name of a role

    optional arguments:
      -h, --help    show this help message and exit
      -c, --create  Create a new role
      -d, --delete  Delete an existing role
      -l, --list    List roles

Create and delete are both reentrant, i.e., `create` only adds a new
role if it does not exist, and `delete` only removes roles that do
exist.

### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added unit tests for creating, deleting, and listing roles in tests/core.py

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ X ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ X ] Passes `flake8`
