### PR TITLE
[AIRFLOW-3819] - Allow the configuration of a global default for work…

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -591,6 +591,15 @@ worker_container_repository =
 worker_container_tag =
 worker_container_image_pull_policy = IfNotPresent
 
+# The default resource values used for Kubernetes Worker Pods, can be overridden within a dag
+# If defined, both request and limit must be set for a property
+# See
+#   https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+worker_request_memory =
+worker_limit_memory =
+worker_request_cpu =
+worker_limit_cpu =
+
 # If True (default), worker pods will be deleted upon termination
 delete_worker_pods = True
 

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -143,6 +143,21 @@ class KubeConfig:
             self.kubernetes_section, 'worker_service_account_name')
         self.image_pull_secrets = conf.get(self.kubernetes_section, 'image_pull_secrets')
 
+        # NOTE: user may want to specify global defaults on kubernetes worker resource
+        # limits
+        # The requested memory for worker pods
+        self.kube_request_memory = conf.get(
+            self.kubernetes_section, 'worker_request_memory')
+        # The limit on memory for worker pods
+        self.kube_limit_memory = conf.get(
+            self.kubernetes_section, 'worker_limit_memory')
+        # The requested cpu resource for worker pods
+        self.kube_request_cpu = conf.get(
+            self.kubernetes_section, 'worker_request_cpu')
+        # The limit on cpu resource for worker pods
+        self.kube_limit_cpu = conf.get(
+            self.kubernetes_section, 'worker_limit_cpu')
+
         # NOTE: user can build the dags into the docker image directly,
         # this will set to True if so
         self.dags_in_image = conf.getboolean(self.kubernetes_section, 'dags_in_image')
@@ -244,13 +259,17 @@ class KubeConfig:
         if not self.dags_volume_claim \
            and not self.dags_volume_host \
            and not self.dags_in_image \
-           and (not self.git_repo or not self.git_branch or not self.git_dags_folder_mount_point):
+           and (not self.git_repo or not self.git_branch or not self.git_dags_folder_mount_point) \
+           and (not self.kube_request_memory or not self.kube_limit_memory) \
+           and (not self.kube_request_cpu or not self.kube_limit_cpu):
             raise AirflowConfigException(
                 'In kubernetes mode the following must be set in the `kubernetes` '
                 'config section: `dags_volume_claim` '
                 'or `dags_volume_host` '
                 'or `dags_in_image` '
-                'or `git_repo and git_branch and git_dags_folder_mount_point`')
+                'or `git_repo and git_branch and git_dags_folder_mount_point`'
+                'or `kube_request_memory` and `kube_limit_memory`'
+                'or `kube_request_cpu` and `kube_limit_cpu`')
 
 
 class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin, object):

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -216,10 +216,10 @@ class WorkerConfiguration(LoggingMixin):
         worker_init_container_spec = self._get_init_containers(
             copy.deepcopy(volume_mounts_dict))
         resources = Resources(
-            request_memory=kube_executor_config.request_memory,
-            request_cpu=kube_executor_config.request_cpu,
-            limit_memory=kube_executor_config.limit_memory,
-            limit_cpu=kube_executor_config.limit_cpu
+            request_memory=kube_executor_config.request_memory or self.kube_config.kube_request_memory,
+            request_cpu=kube_executor_config.request_cpu or self.kube_config.kube_request_cpu,
+            limit_memory=kube_executor_config.limit_memory or self.kube_config.kube_limit_memory,
+            limit_cpu=kube_executor_config.limit_cpu or self.kube_config.kube_limit_cpu
         )
         gcp_sa_key = kube_executor_config.gcp_service_account_key
         annotations = dict(kube_executor_config.annotations)

--- a/scripts/ci/kubernetes/kube/templates/configmaps.template.yaml
+++ b/scripts/ci/kubernetes/kube/templates/configmaps.template.yaml
@@ -172,6 +172,10 @@ data:
     worker_container_repository = airflow
     worker_container_tag = latest
     worker_container_image_pull_policy = IfNotPresent
+    worker_request_memory =
+    worker_limit_memory =
+    worker_request_cpu =
+    worker_limit_cpu =
     delete_worker_pods = True
     dags_in_image = False
     git_repo = https://github.com/{{CONFIGMAP_GIT_REPO}}.git


### PR DESCRIPTION
…imits and requests

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3819

### Description
Currently the kubernetes executor allows you to specify pod resources requests and limits (cpu and memory). For example:
```
# Limit resources on this operator/task with node affinity & tolerations
three_task = PythonOperator(
    task_id="three_task", python_callable=print_stuff, dag=dag,
    executor_config={
        "KubernetesExecutor": {"request_memory": "128Mi",
                               "limit_memory": "128Mi",
                               "tolerations": tolerations,
                               "affinity": affinity}}
)
```
These values are used by kubernetes when making scaling decisions. This PR allows you to specify a global default for these values, to ensure that each pod airflow creates has a value specified for these properties.
You are still able to modify these values on a dag by dag basis. 

### Tests

There are currently no tests around configuring resources limits/request values as used in the example above, and these would be non-trivial to add due to the integration with kube_client. 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.

`default_airflow.cfg` has been updated with the new settings with a descriptive comment and a link to the Kubernetes documentation. 

### Code Quality

- [x] Passes `flake8`
