### PR TITLE
[AIRFLOW-3821] Add replicas logic to GCP SQL example DAG

### DIFF
--- a/airflow/contrib/example_dags/example_gcp_sql.py
+++ b/airflow/contrib/example_dags/example_gcp_sql.py
@@ -58,6 +58,11 @@ IMPORT_URI = os.environ.get('GCSQL_MYSQL_IMPORT_URI', 'gs://bucketName/fileName'
 # Bodies below represent Cloud SQL instance resources:
 # https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances
 
+# [START howto_operator_cloudsql_create_arguments]
+FAILOVER_REPLICA_NAME = INSTANCE_NAME + "-failover-replica"
+READ_REPLICA_NAME = INSTANCE_NAME + "-read-replica"
+# [END howto_operator_cloudsql_create_arguments]
+
 # [START howto_operator_cloudsql_create_body]
 body = {
     "name": INSTANCE_NAME,
@@ -86,11 +91,14 @@ body = {
         },
         "pricingPlan": "PER_USE",
         "replicationType": "ASYNCHRONOUS",
-        "storageAutoResize": False,
+        "storageAutoResize": True,
         "storageAutoResizeLimit": 0,
         "userLabels": {
             "my-key": "my-value"
         }
+    },
+    "failoverReplica": {
+        "name": FAILOVER_REPLICA_NAME
     },
     "databaseVersion": "MYSQL_5_7",
     "region": "europe-west4",
@@ -105,6 +113,19 @@ body2 = {
     "databaseVersion": "MYSQL_5_7",
     "region": "europe-west4",
 }
+
+# [START howto_operator_cloudsql_create_replica]
+read_replica_body = {
+    "name": READ_REPLICA_NAME,
+    "settings": {
+        "tier": "db-n1-standard-1",
+    },
+    "databaseVersion": "MYSQL_5_7",
+    "region": "europe-west4",
+    "masterInstanceName": INSTANCE_NAME,
+}
+# [END howto_operator_cloudsql_create_replica]
+
 
 # [START howto_operator_cloudsql_patch_body]
 patch_body = {
@@ -193,6 +214,14 @@ with models.DAG(
 
     prev_task = sql_instance_create_task
     prev_task = next_dep(sql_instance_create_2_task, prev_task)
+
+    sql_instance_read_replica_create = CloudSqlInstanceCreateOperator(
+        project_id=GCP_PROJECT_ID,
+        body=read_replica_body,
+        instance=INSTANCE_NAME2,
+        task_id='sql_instance_read_replica_create'
+    )
+    prev_task = next_dep(sql_instance_read_replica_create, prev_task)
 
     # ############################################## #
     # ### MODIFYING INSTANCE AND ITS DATABASE ###### #
@@ -355,6 +384,23 @@ with models.DAG(
     # ############################################## #
     # ### INSTANCES TEAR DOWN ###################### #
     # ############################################## #
+
+    # [START howto_operator_cloudsql_replicas_delete]
+    sql_instance_failover_replica_delete_task = CloudSqlInstanceDeleteOperator(
+        project_id=GCP_PROJECT_ID,
+        instance=FAILOVER_REPLICA_NAME,
+        task_id='sql_instance_failover_replica_delete_task'
+    )
+
+    sql_instance_read_replica_delete_task = CloudSqlInstanceDeleteOperator(
+        project_id=GCP_PROJECT_ID,
+        instance=READ_REPLICA_NAME,
+        task_id='sql_instance_read_replica_delete_task'
+    )
+    # [END howto_operator_cloudsql_replicas_delete]
+
+    prev_task = next_dep(sql_instance_failover_replica_delete_task, prev_task)
+    prev_task = next_dep(sql_instance_read_replica_delete_task, prev_task)
 
     # [START howto_operator_cloudsql_delete]
     sql_instance_delete_task = CloudSqlInstanceDeleteOperator(

--- a/docs/howto/operator.rst
+++ b/docs/howto/operator.rst
@@ -1145,6 +1145,8 @@ CloudSqlInstanceDeleteOperator
 
 Deletes a Cloud SQL instance in Google Cloud Platform.
 
+It is also used for deleting read and failover replicas.
+
 For parameter definition, take a look at
 :class:`~airflow.contrib.operators.gcp_sql_operator.CloudSqlInstanceDeleteOperator`.
 
@@ -1169,6 +1171,15 @@ it will be retrieved from the GCP connection used. Both variants are shown:
     :dedent: 4
     :start-after: [START howto_operator_cloudsql_delete]
     :end-before: [END howto_operator_cloudsql_delete]
+
+Note: If the instance has read or failover replicas you need to delete them before you delete the primary instance.
+Replicas are deleted the same way as primary instances:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_cloudsql_replicas_delete]
+    :end-before: [END howto_operator_cloudsql_replicas_delete]
 
 Templating
 """"""""""
@@ -1369,6 +1380,8 @@ CloudSqlInstanceCreateOperator
 
 Creates a new Cloud SQL instance in Google Cloud Platform.
 
+It is also used for creating read replicas.
+
 For parameter definition, take a look at
 :class:`~airflow.contrib.operators.gcp_sql_operator.CloudSqlInstanceCreateOperator`.
 
@@ -1385,12 +1398,29 @@ Some arguments in the example DAG are taken from OS environment variables:
     :start-after: [START howto_operator_cloudsql_arguments]
     :end-before: [END howto_operator_cloudsql_arguments]
 
-Example body defining the instance:
+Some other arguments are created based on the arguments above:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
+    :language: python
+    :start-after: [START howto_operator_cloudsql_create_arguments]
+    :end-before: [END howto_operator_cloudsql_create_arguments]
+
+Example body defining the instance with failover replica:
 
 .. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
     :language: python
     :start-after: [START howto_operator_cloudsql_create_body]
     :end-before: [END howto_operator_cloudsql_create_body]
+
+Example body defining read replica for the instance above:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
+    :language: python
+    :start-after: [START howto_operator_cloudsql_create_replica]
+    :end-before: [END howto_operator_cloudsql_create_replica]
+
+Note: Failover replicas are created together with the instance in a single task.
+Read replicas need to be created in separate tasks.
 
 Using the operator
 """"""""""""""""""

--- a/tests/contrib/operators/test_gcp_sql_operator_system.py
+++ b/tests/contrib/operators/test_gcp_sql_operator_system.py
@@ -43,6 +43,8 @@ class CloudSqlExampleDagsIntegrationTest(DagGcpSystemTestCase):
         # Delete instances just in case the test failed and did not cleanup after itself
         self.gcp_authenticator.gcp_authenticate()
         try:
+            SQL_QUERY_TEST_HELPER.delete_instances(instance_suffix="-failover-replica")
+            SQL_QUERY_TEST_HELPER.delete_instances(instance_suffix="-read-replica")
             SQL_QUERY_TEST_HELPER.delete_instances()
             SQL_QUERY_TEST_HELPER.delete_instances(instance_suffix="2")
             SQL_QUERY_TEST_HELPER.delete_service_account_acls()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

https://issues.apache.org/jira/browse/AIRFLOW-3821

### Description

Edited GCP SQL example dag to show how to create and delete read and failover replicas.

CC @kaxil @potiuk 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
