### PR TITLE
[AIRFLOW-3822] Delete KubernetesPodOperator pod on kill

### DIFF
--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -92,57 +92,60 @@ class KubernetesPodOperator(BaseOperator):
     template_fields = ('cmds', 'arguments', 'env_vars', 'config_file')
 
     def execute(self, context):
-        try:
-            client = kube_client.get_kube_client(in_cluster=self.in_cluster,
-                                                 cluster_context=self.cluster_context,
-                                                 config_file=self.config_file)
-            gen = pod_generator.PodGenerator()
+        client = kube_client.get_kube_client(in_cluster=self.in_cluster,
+                                             cluster_context=self.cluster_context,
+                                             config_file=self.config_file)
+        gen = pod_generator.PodGenerator()
 
-            for mount in self.volume_mounts:
-                gen.add_mount(mount)
-            for volume in self.volumes:
-                gen.add_volume(volume)
+        for mount in self.volume_mounts:
+            gen.add_mount(mount)
+        for volume in self.volumes:
+            gen.add_volume(volume)
 
-            pod = gen.make_pod(
-                namespace=self.namespace,
-                image=self.image,
-                pod_id=self.name,
-                cmds=self.cmds,
-                arguments=self.arguments,
-                labels=self.labels,
+        self.pod = gen.make_pod(
+            namespace=self.namespace,
+            image=self.image,
+            pod_id=self.name,
+            cmds=self.cmds,
+            arguments=self.arguments,
+            labels=self.labels,
+        )
+
+        self.pod.service_account_name = self.service_account_name
+        self.pod.secrets = self.secrets
+        self.pod.envs = self.env_vars
+        self.pod.image_pull_policy = self.image_pull_policy
+        self.pod.image_pull_secrets = self.image_pull_secrets
+        self.pod.annotations = self.annotations
+        self.pod.resources = self.resources
+        self.pod.affinity = self.affinity
+        self.pod.node_selectors = self.node_selectors
+        self.pod.hostnetwork = self.hostnetwork
+        self.pod.tolerations = self.tolerations
+        self.launcher = pod_launcher.PodLauncher(kube_client=client,
+                                                 extract_xcom=self.xcom_push)
+
+        (final_state, result) = self.launcher.run_pod(
+            self.pod,
+            startup_timeout=self.startup_timeout_seconds,
+            get_logs=self.get_logs)
+
+        if self.is_delete_operator_pod:
+            self.launcher.delete_pod(self.pod)
+
+        if final_state != State.SUCCESS:
+            raise AirflowException(
+                'Pod returned a failure: {state}'.format(state=final_state)
             )
+        if self.xcom_push:
+            return result
 
-            pod.service_account_name = self.service_account_name
-            pod.secrets = self.secrets
-            pod.envs = self.env_vars
-            pod.image_pull_policy = self.image_pull_policy
-            pod.image_pull_secrets = self.image_pull_secrets
-            pod.annotations = self.annotations
-            pod.resources = self.resources
-            pod.affinity = self.affinity
-            pod.node_selectors = self.node_selectors
-            pod.hostnetwork = self.hostnetwork
-            pod.tolerations = self.tolerations
-
-            launcher = pod_launcher.PodLauncher(kube_client=client,
-                                                extract_xcom=self.xcom_push)
-            try:
-                (final_state, result) = launcher.run_pod(
-                    pod,
-                    startup_timeout=self.startup_timeout_seconds,
-                    get_logs=self.get_logs)
-            finally:
-                if self.is_delete_operator_pod:
-                    launcher.delete_pod(pod)
-
-            if final_state != State.SUCCESS:
-                raise AirflowException(
-                    'Pod returned a failure: {state}'.format(state=final_state)
-                )
-            if self.xcom_push:
-                return result
-        except AirflowException as ex:
-            raise AirflowException('Pod Launching failed: {error}'.format(error=ex))
+    def on_kill(self):
+        if self.launcher is not None:
+            self.log.info('Deleting the pod')
+            self.launcher.delete_pod(self.pod)
+        else:
+            self.log.info('Pod was not launched, nothing to cleanup')
 
     @apply_defaults
     def __init__(self,
@@ -201,3 +204,5 @@ class KubernetesPodOperator(BaseOperator):
         self.is_delete_operator_pod = is_delete_operator_pod
         self.hostnetwork = hostnetwork
         self.tolerations = tolerations or []
+        self.launcher = None
+        self.pod = None

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -125,13 +125,14 @@ class KubernetesPodOperator(BaseOperator):
         self.launcher = pod_launcher.PodLauncher(kube_client=client,
                                                  extract_xcom=self.xcom_push)
 
-        (final_state, result) = self.launcher.run_pod(
-            self.pod,
-            startup_timeout=self.startup_timeout_seconds,
-            get_logs=self.get_logs)
-
-        if self.is_delete_operator_pod:
-            self.launcher.delete_pod(self.pod)
+        try:
+            (final_state, result) = self.launcher.run_pod(
+                self.pod,
+                startup_timeout=self.startup_timeout_seconds,
+                get_logs=self.get_logs)
+        finally:
+            if self.is_delete_operator_pod:
+                self.launcher.delete_pod(self.pod)
 
         if final_state != State.SUCCESS:
             raise AirflowException(


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

> - [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

https://issues.apache.org/jira/browse/AIRFLOW-3822

### Description

> - [X] Here are some details about my PR, including screenshots of any UI changes:

Correcting a behavior observed with the KubernetesExecutor + KubernetesPodOperator where a timeout kills the pod watcher but not the pod running the actual work.

* I added an on_kill hook which removes the pod when the watcher pod is terminated.
* I changed `pod` to `self.pod` in order to reference it in the `on_kill` function
* I removed the general catch AirflowException, because the logging message was not bringing debugging insight and it was upcasting a TimeoutException which was preventing the on_kill hook to be triggered

### Tests

> - [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

In order for a test to make sense it would need to run from within a Kubernetes cluster; I have tried building on top of the Docker image given in Contributing, adding postgres resources to be launched in a local kubernetes cluster, mounting the Airflow repo as a hostVolume, running `pip install -e` but the started KubernetesPods also needs a built image in order to run so I hit a wall there. (But even before hitting that wall I had created quite a big README at that point already)

Maybe we can have a chat on how to test this properly, I didn't see any test in the codebase using `in_cluster=True` so far.

Here's what I have attempted to do https://github.com/dmateusp/incubator-airflow/tree/AIRFLOW-3822_test

### Commits

> - [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

> - [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

Corrects a bug rather than creating a new feature

### Code Quality

> - [X] Passes `flake8`
