### PR TITLE
[AIRFLOW-XXX] Correct typo for `prev_ds`

### DIFF
--- a/docs/code.rst
+++ b/docs/code.rst
@@ -334,7 +334,7 @@ Variable                            Description
 ``{{ ds_nodash }}``                 the execution date as ``YYYYMMDD``
 ``{{ prev_ds }}``                   the previous execution date as ``YYYY-MM-DD``
                                     if ``{{ ds }}`` is ``2018-01-08`` and ``schedule_interval`` is ``@weekly``,
-                                    ``{{ prev_ds }}`` will be ``2016-01-01``
+                                    ``{{ prev_ds }}`` will be ``2018-01-01``
 ``{{ prev_ds_nodash }}``            the previous execution date as ``YYYYMMDD`` if exists, else ``None``
 ``{{ next_ds }}``                   the next execution date as ``YYYY-MM-DD``
                                     if ``{{ ds }}`` is ``2018-01-01`` and ``schedule_interval`` is ``@weekly``,


### PR DESCRIPTION
`@weekly` probably shouldn't yield the date from 2 years + 1 week ago :)

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

Small documentation typo fixed

### Tests

No code altered


