### PR TITLE
[AIRFLOW-3823] Exclude BranchPythonOperator choice's downstream tasks from the tasks to skip

### DIFF
--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -23,10 +23,11 @@ import pickle
 import subprocess
 import sys
 import types
+from builtins import str
 from textwrap import dedent
 
 import dill
-from builtins import str
+import six
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, SkipMixin
@@ -133,7 +134,7 @@ class BranchPythonOperator(PythonOperator, SkipMixin):
     """
     def execute(self, context):
         branch = super(BranchPythonOperator, self).execute(context)
-        if isinstance(branch, str):
+        if isinstance(branch, six.string_types):
             branch = [branch]
         self.log.info("Following branch %s", branch)
         self.log.info("Marking other directly downstream tasks as skipped")
@@ -141,8 +142,18 @@ class BranchPythonOperator(PythonOperator, SkipMixin):
         downstream_tasks = context['task'].downstream_list
         self.log.debug("Downstream task_ids %s", downstream_tasks)
 
-        skip_tasks = [t for t in downstream_tasks if t.task_id not in branch]
         if downstream_tasks:
+            # Also check downstream tasks of the branch task. In case the task to skip
+            # is a downstream task of the branch task, we exclude it from skipping.
+            branch_downstream_task_ids = set()
+            for b in branch:
+                branch_downstream_task_ids.update(context["dag"].
+                                                  get_task(b).
+                                                  get_flat_relative_ids(upstream=False))
+            skip_tasks = [t
+                          for t in downstream_tasks
+                          if t.task_id not in branch and
+                          t.task_id not in branch_downstream_task_ids]
             self.skip(context['dag_run'], context['ti'].execution_date, skip_tasks)
 
         self.log.info("Done.")


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3823
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

An extensive description of this PR is given in https://issues.apache.org/jira/browse/AIRFLOW-3823.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added 2 tests to test both BranchPythonOperator options in this edge case.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
