### PR TITLE
[AIRFLOW-XXX] Move out the examples from integration.rst

### DIFF
--- a/airflow/contrib/operators/dataflow_operator.py
+++ b/airflow/contrib/operators/dataflow_operator.py
@@ -33,6 +33,40 @@ class DataFlowJavaOperator(BaseOperator):
     Start a Java Cloud DataFlow batch job. The parameters of the operation
     will be passed to the job.
 
+    **Example**: ::
+
+        default_args = {
+            'owner': 'airflow',
+            'depends_on_past': False,
+            'start_date':
+                (2016, 8, 1),
+            'email': ['alex@vanboxel.be'],
+            'email_on_failure': False,
+            'email_on_retry': False,
+            'retries': 1,
+            'retry_delay': timedelta(minutes=30),
+            'dataflow_default_options': {
+                'project': 'my-gcp-project',
+                'zone': 'us-central1-f',
+                'stagingLocation': 'gs://bucket/tmp/dataflow/staging/',
+            }
+        }
+
+        dag = DAG('test-dag', default_args=default_args)
+
+        task = DataFlowJavaOperator(
+            gcp_conn_id='gcp_default',
+            task_id='normalize-cal',
+            jar='{{var.value.gcp_dataflow_base}}pipeline-ingress-cal-normalize-1.0.jar',
+            options={
+                'autoscalingAlgorithm': 'BASIC',
+                'maxNumWorkers': '50',
+                'start': '{{ds}}',
+                'partitionType': 'DAY'
+
+            },
+            dag=dag)
+
     .. seealso::
         For more detail on job submission have a look at the reference:
         https://cloud.google.com/dataflow/pipelines/specifying-exec-params

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -479,45 +479,6 @@ Cloud DataFlow
 
 They also use :class:`airflow.contrib.hooks.gcp_dataflow_hook.DataFlowHook` to communicate with Google Cloud Platform.
 
-.. _DataFlowJavaOperator:
-
-DataFlowJavaOperator
-^^^^^^^^^^^^^^^^^^^^
-
-.. code:: python
-
-    default_args = {
-        'owner': 'airflow',
-        'depends_on_past': False,
-        'start_date':
-            (2016, 8, 1),
-        'email': ['alex@vanboxel.be'],
-        'email_on_failure': False,
-        'email_on_retry': False,
-        'retries': 1,
-        'retry_delay': timedelta(minutes=30),
-        'dataflow_default_options': {
-            'project': 'my-gcp-project',
-            'zone': 'us-central1-f',
-            'stagingLocation': 'gs://bucket/tmp/dataflow/staging/',
-        }
-    }
-
-    dag = DAG('test-dag', default_args=default_args)
-
-    task = DataFlowJavaOperator(
-        gcp_conn_id='gcp_default',
-        task_id='normalize-cal',
-        jar='{{var.value.gcp_dataflow_base}}pipeline-ingress-cal-normalize-1.0.jar',
-        options={
-            'autoscalingAlgorithm': 'BASIC',
-            'maxNumWorkers': '50',
-            'start': '{{ds}}',
-            'partitionType': 'DAY'
-
-        },
-        dag=dag)
-
 
 Cloud DataProc
 ''''''''''''''


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

No applicable

### Description

Currently, `integration.rst` file is a list of operators grouped by services and cloud provider. Examples should not be included there. I'm moving example to another place. This is not the best place. Such things should be in the `howto/operator.rst` file, but this would require writing a lot more documentation.  Other operators have examples in the class description, so this is not an invalid change. Step by step.  Cleaning `integration.rst` file is the first goal. In the future, I hope that we will be able to improve class descriptions.

### Tests

No applicable

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

No applicable

### Code Quality

No applicable