### PR TITLE
[AIRFLOW-3851] ExternalTasksensor not check existence in later poke

### DIFF
--- a/airflow/sensors/external_task_sensor.py
+++ b/airflow/sensors/external_task_sensor.py
@@ -94,6 +94,8 @@ class ExternalTaskSensor(BaseSensorOperator):
         self.external_dag_id = external_dag_id
         self.external_task_id = external_task_id
         self.check_existence = check_existence
+        # we only check the existence for the first time.
+        self.has_checked_existence = False
 
     @provide_session
     def poke(self, context, session=None):
@@ -117,7 +119,9 @@ class ExternalTaskSensor(BaseSensorOperator):
         DM = DagModel
         TI = TaskInstance
         DR = DagRun
-        if self.check_existence:
+
+        # we only do the check for 1st time, no need for subsequent poke
+        if self.check_existence and not self.has_checked_existence:
             dag_to_wait = session.query(DM).filter(
                 DM.dag_id == self.external_dag_id
             ).first()
@@ -136,6 +140,7 @@ class ExternalTaskSensor(BaseSensorOperator):
                     raise AirflowException('The external task'
                                            '{} in DAG {} does not exist.'.format(self.external_task_id,
                                                                                  self.external_dag_id))
+            self.has_checked_existence = True
 
         if self.external_task_id:
             count = session.query(TI).filter(


### PR DESCRIPTION
…equent poke

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3851
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
No need to check the existence in subsequent poke for externalTasksensor as it conducts expensive operation to load dagBag.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
no test needed

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
