### PR TITLE
[AIRFLOW-3742] Fix handling of "fallback" for int/boolean config option

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -260,27 +260,27 @@ class AirflowConfigParser(ConfigParser):
                 "section/key [{section}/{key}] not found "
                 "in config".format(**locals()))
 
-    def getboolean(self, section, key):
-        val = str(self.get(section, key)).lower().strip()
+    def getboolean(self, section, key, **kwargs):
+        val = str(self.get(section, key, **kwargs)).lower().strip()
         if '#' in val:
             val = val.split('#')[0].strip()
-        if val.lower() in ('t', 'true', '1'):
+        if val in ('t', 'true', '1'):
             return True
-        elif val.lower() in ('f', 'false', '0'):
+        elif val in ('f', 'false', '0'):
             return False
         else:
             raise AirflowConfigException(
                 'The value for configuration option "{}:{}" is not a '
                 'boolean (received "{}").'.format(section, key, val))
 
-    def getint(self, section, key):
-        return int(self.get(section, key))
+    def getint(self, section, key, **kwargs):
+        return int(self.get(section, key, **kwargs))
 
-    def getfloat(self, section, key):
-        return float(self.get(section, key))
+    def getfloat(self, section, key, **kwargs):
+        return float(self.get(section, key, **kwargs))
 
-    def read(self, filenames):
-        super(AirflowConfigParser, self).read(filenames)
+    def read(self, filenames, **kwargs):
+        super(AirflowConfigParser, self).read(filenames, **kwargs)
         self._validate()
 
     def read_dict(self, *args, **kwargs):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -139,7 +139,7 @@ class ConfTest(unittest.TestCase):
         self.assertEqual(cfg_dict['testsection']['testpercent'], 'with%%percent')
         self.assertEqual(cfg_dict['core']['percent'], 'with%%inside')
 
-    def test_command_config(self):
+    def test_command_precedence(self):
         TEST_CONFIG = '''[test]
 key1 = hello
 key2_cmd = printf cmd_result
@@ -170,6 +170,9 @@ key6 = value6
         self.assertEqual('hello', test_conf.get('test', 'key1', fallback='fb'))
         self.assertEqual('value6', test_conf.get('another', 'key6', fallback='fb'))
         self.assertEqual('fb', test_conf.get('another', 'key7', fallback='fb'))
+        self.assertEqual(True, test_conf.getboolean('another', 'key8_boolean', fallback='True'))
+        self.assertEqual(10, test_conf.getint('another', 'key8_int', fallback='10'))
+        self.assertEqual(1.0, test_conf.getfloat('another', 'key8_float', fallback='1'))
 
         self.assertTrue(test_conf.has_option('test', 'key1'))
         self.assertTrue(test_conf.has_option('test', 'key2'))


### PR DESCRIPTION
Support for a fallback kwarg was added in `AirflowConfigParser.get`
in [AIRFLOW-3742], but, `AirflowConfigParser.getboolean` also needs
to support it.

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3852
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

On the latest master, when I ran `airflow worker`, I got the following error:
```
[2019-02-09 00:12:25,983] {__init__.py:51} INFO - Using executor SequentialExecutor
Traceback (most recent call last):
File "/home/tanay/Coding/airflow/.env/bin/airflow", line 6, in <module>
exec(compile(open(__file__).read(), __file__, 'exec'))
File "/home/tanay/Coding/airflow/airflow/bin/airflow", line 32, in <module>
args.func(args)
File "/home/tanay/Coding/airflow/airflow/utils/cli.py", line 74, in wrapper
return f(*args, **kwargs)
File "/home/tanay/Coding/airflow/airflow/bin/cli.py", line 1058, in worker
if not settings.validate_session():
File "/home/tanay/Coding/airflow/airflow/settings.py", line 226, in validate_session
worker_precheck = conf.getboolean('core', 'worker_precheck', fallback=False)
TypeError: getboolean() got an unexpected keyword argument 'fallback'
```
Support for a `fallback` kwarg in `AirflowConfigParser.get` was added by @ashb in https://github.com/apache/airflow/pull/4567.
Support for it also needs to be in `AirflowConfigParser.getboolean`.


### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Not Needed.
### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X] Passes `flake8`
