### PR TITLE
[AIRFLOW-3853] Default to delete local logs after remote upload

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,12 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Default to deleting local logs after remote upload
+
+Following a successful upload of local TaskInstance log files to S3, GCS, or WASB, the default behavior has been changed to delete the log file.
+
+To disable this behavior, modify `DEFAULT_LOGGING_CONFIG` to have `'delete_local_copy': False` for any `'task'`
+
 ### Changes to CloudantHook
 
 * upgraded cloudant version from `>=0.5.9,<2.0` to `>=2.0`

--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -138,6 +138,7 @@ REMOTE_HANDLERS = {
             'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
             's3_log_folder': REMOTE_BASE_LOG_FOLDER,
             'filename_template': FILENAME_TEMPLATE,
+            'delete_local_copy': True,
         },
         'processor': {
             'class': 'airflow.utils.log.s3_task_handler.S3TaskHandler',
@@ -145,6 +146,7 @@ REMOTE_HANDLERS = {
             'base_log_folder': os.path.expanduser(PROCESSOR_LOG_FOLDER),
             's3_log_folder': REMOTE_BASE_LOG_FOLDER,
             'filename_template': PROCESSOR_FILENAME_TEMPLATE,
+            'delete_local_copy': False,
         },
     },
     'gcs': {
@@ -154,6 +156,7 @@ REMOTE_HANDLERS = {
             'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
             'gcs_log_folder': REMOTE_BASE_LOG_FOLDER,
             'filename_template': FILENAME_TEMPLATE,
+            'delete_local_copy': True,
         },
         'processor': {
             'class': 'airflow.utils.log.gcs_task_handler.GCSTaskHandler',
@@ -161,6 +164,7 @@ REMOTE_HANDLERS = {
             'base_log_folder': os.path.expanduser(PROCESSOR_LOG_FOLDER),
             'gcs_log_folder': REMOTE_BASE_LOG_FOLDER,
             'filename_template': PROCESSOR_FILENAME_TEMPLATE,
+            'delete_local_copy': False,
         },
     },
     'wasb': {
@@ -171,7 +175,7 @@ REMOTE_HANDLERS = {
             'wasb_log_folder': REMOTE_BASE_LOG_FOLDER,
             'wasb_container': 'airflow-logs',
             'filename_template': FILENAME_TEMPLATE,
-            'delete_local_copy': False,
+            'delete_local_copy': True,
         },
         'processor': {
             'class': 'airflow.utils.log.wasb_task_handler.WasbTaskHandler',

--- a/airflow/utils/log/wasb_task_handler.py
+++ b/airflow/utils/log/wasb_task_handler.py
@@ -90,9 +90,8 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
             # read log and remove old logs to get just the latest additions
             with open(local_loc, 'r') as logfile:
                 log = logfile.read()
-            self.wasb_write(log, remote_loc, append=True)
-
-            if self.delete_local_copy:
+            successfully_written = self.wasb_write(log, remote_loc)
+            if successfully_written and self.delete_local_copy:
                 shutil.rmtree(os.path.dirname(local_loc))
         # Mark closed so we don't double write if close is called twice
         self.closed = True
@@ -176,6 +175,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
                 self.wasb_container,
                 remote_log_location,
             )
+            return True
         except AzureHttpError:
-            self.log.exception('Could not write logs to %s',
-                               remote_log_location)
+            self.log.exception('Could not write logs to %s', remote_log_location)
+        return False


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3853) issues and references them in the PR title. For example, "\[AIRFLOW-3853\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3853

### Description

- [X] We've recently started to see duplicate logs in S3. After digging into it, we discovered that this was due to our use of the new `reschedule` mode on our sensors. Because the same `try_number` is used when a task reschedules, the local log file frequently contains results from previous attempts. Additionally, because the `s3_task_helper.py` always tries to `append` the local log file to the remove log file, this can result in massive logs (we found one that 400 mb).

To fix this, we'd like to remove the local log after a successful upload. Because the file is uploaded to S3, no data will be lost.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: I've modified the following unit tests to cover the change to `s3_write`: `test_write`, `test_write_existing`, `test_write_raises`.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X] Passes `flake8`
