### PR TITLE
[AIRFLOW-3801] Fix DagBag collect dags invocation to prevent examples…

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -304,7 +304,7 @@ class DagBag(BaseDagBag, LoggingMixin):
         self.import_errors = {}
         self.has_logged = False
 
-        self.collect_dags(dag_folder, include_examples)
+        self.collect_dags(dag_folder=dag_folder, include_examples=include_examples)
 
     def size(self):
         """
@@ -559,7 +559,7 @@ class DagBag(BaseDagBag, LoggingMixin):
         stats = []
         FileLoadStat = namedtuple(
             'FileLoadStat', "file duration dag_num task_num dags")
-        for filepath in list_py_file_paths(dag_folder, include_examples):
+        for filepath in list_py_file_paths(dag_folder, include_examples=include_examples):
             try:
                 ts = timezone.utcnow()
                 found_dags = self.process_file(

--- a/tests/models.py
+++ b/tests/models.py
@@ -1475,7 +1475,7 @@ class DagBagTest(unittest.TestCase):
 
     def test_dont_load_example(self):
         """
-        test that check that the example are not loaded
+        test that the example are not loaded
         """
         dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1473,6 +1473,14 @@ class DagBagTest(unittest.TestCase):
         non_existing_dag_id = "non_existing_dag_id"
         self.assertIsNone(dagbag.get_dag(non_existing_dag_id))
 
+    def test_dont_load_example(self):
+        """
+        test that check that the example are not loaded
+        """
+        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)
+
+        self.assertEqual(dagbag.size(), 0)
+
     def test_process_file_that_contains_multi_bytes_char(self):
         """
         test that we're able to parse file that contains multi-byte char


### PR DESCRIPTION
I closed the PR #4645 in favor of this one to set the correct base branch.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3801) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3801

### Description

- Fix in DagBag init method the`include_examples` parameters which was not use properly.

### Tests

- [X] tests.models.DagBagTest#test_dont_load_example : When the parameter `include_examples` is set to false on a empty dags folder, this validate that the dagbag is empty.

### Documentation

- N/A

### Code Quality

- [X] Passes `flake8`
