### PR TITLE
[AIRFLOW-3857] spark_submit_hook cannot kill driver pod in kubernetes

### DIFF
--- a/airflow/contrib/hooks/spark_submit_hook.py
+++ b/airflow/contrib/hooks/spark_submit_hook.py
@@ -565,11 +565,12 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
                 # Currently only instantiate Kubernetes client for killing a spark pod.
                 try:
+                    import kubernetes
                     client = kube_client.get_kube_client()
                     api_response = client.delete_namespaced_pod(
                         self._kubernetes_driver_pod,
                         self._connection['namespace'],
-                        body=client.V1DeleteOptions(),
+                        body=kubernetes.client.V1DeleteOptions(),
                         pretty=True)
 
                     self.log.info("Spark on K8s killed with response: %s", api_response)

--- a/tests/contrib/hooks/test_spark_submit_hook.py
+++ b/tests/contrib/hooks/test_spark_submit_hook.py
@@ -614,6 +614,51 @@ class TestSparkSubmitHook(unittest.TestCase):
         self.assertEqual(kill_cmd[3], '--kill')
         self.assertEqual(kill_cmd[4], 'driver-20171128111415-0001')
 
+    @patch('airflow.contrib.kubernetes.kube_client.get_kube_client')
+    @patch('airflow.contrib.hooks.spark_submit_hook.subprocess.Popen')
+    def test_k8s_process_on_kill(self, mock_popen, mock_client_method):
+        # Given
+        mock_popen.return_value.stdout = six.StringIO('stdout')
+        mock_popen.return_value.stderr = six.StringIO('stderr')
+        mock_popen.return_value.poll.return_value = None
+        mock_popen.return_value.wait.return_value = 0
+        client = mock_client_method.return_value
+        hook = SparkSubmitHook(conn_id='spark_k8s_cluster')
+        log_lines = [
+            'INFO  LoggingPodStatusWatcherImpl:54 - State changed, new state:' +
+            'pod name: spark-pi-edf2ace37be7353a958b38733a12f8e6-driver' +
+            'namespace: default' +
+            'labels: spark-app-selector -> spark-465b868ada474bda82ccb84ab2747fcd,' +
+            'spark-role -> driver' +
+            'pod uid: ba9c61f6-205f-11e8-b65f-d48564c88e42' +
+            'creation time: 2018-03-05T10:26:55Z' +
+            'service account name: spark' +
+            'volumes: spark-init-properties, download-jars-volume,' +
+            'download-files-volume, spark-token-2vmlm' +
+            'node name: N/A' +
+            'start time: N/A' +
+            'container images: N/A' +
+            'phase: Pending' +
+            'status: []' +
+            '2018-03-05 11:26:56 INFO  LoggingPodStatusWatcherImpl:54 - State changed,' +
+            ' new state:' +
+            'pod name: spark-pi-edf2ace37be7353a958b38733a12f8e6-driver' +
+            'namespace: default' +
+            'Exit code: 0'
+        ]
+        hook._process_spark_submit_log(log_lines)
+        hook.submit()
+
+        # When
+        hook.on_kill()
+
+        # Then
+        import kubernetes
+        kwargs = {'pretty': True, 'body': kubernetes.client.V1DeleteOptions()}
+        client.delete_namespaced_pod.assert_called_once_with(
+            'spark-pi-edf2ace37be7353a958b38733a12f8e6-driver',
+            'mynamespace', **kwargs)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [AIRFLOW-3857](https://issues.apache.org/jira/browse/AIRFLOW-3857) issue.

### Description

- [x] The spark_submit_hook.on_kill method cannot kill a kubernetes driver pod because of an issue in the client used. The client used in 1.10.{0,1,2} is in fact the CoreV1Api instead of the kubernetes client which has the proper V1DeleteOptions value needed.

### Tests

- [x] No test was done on this part, I added a test, but it's not perfect it only mocks the kubernetes client and check the parameters which definitely fails with the last code so... in terms of TDD it works, but it's only a mock call parameter check.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] No new feature, just a bug fix

### Code Quality

- [x] Passes `flake8`
