### PR TITLE
[Airflow-2840] - add update connection cli option

### DIFF
--- a/airflow/api/client/api_client.py
+++ b/airflow/api/client/api_client.py
@@ -69,3 +69,67 @@ class Client(object):
         :param name: pool name
         """
         raise NotImplementedError()
+
+    def add_connection(self, conn_id,
+                       conn_uri=None,
+                       conn_type=None,
+                       conn_host=None,
+                       conn_login=None,
+                       conn_password=None,
+                       conn_schema=None,
+                       conn_port=None,
+                       conn_extra=None):
+        """
+
+        :param conn_id:
+        :param conn_uri:
+        :param conn_type:
+        :param conn_host:
+        :param conn_login:
+        :param conn_password:
+        :param conn_schema:
+        :param conn_port:
+        :param conn_extra:
+        :return: The new Connection
+        """
+        raise NotImplementedError()
+
+    def delete_connection(self, conn_id, delete_all=False):
+        """
+
+        :param conn_id:
+        :param delete_all:
+        :return: the conn_id(s) of the Connection(s) that were removed
+        """
+        raise NotImplementedError()
+
+    def list_connections(self):
+        """
+
+        :return: All Connections
+        """
+        raise NotImplementedError()
+
+    def update_connection(self, conn_id,
+                          conn_uri=None,
+                          conn_type=None,
+                          conn_host=None,
+                          conn_login=None,
+                          conn_password=None,
+                          conn_schema=None,
+                          conn_port=None,
+                          conn_extra=None):
+        """
+
+        :param conn_id:
+        :param conn_uri:
+        :param conn_type:
+        :param conn_host:
+        :param conn_login:
+        :param conn_password:
+        :param conn_schema:
+        :param conn_port:
+        :param conn_extra:
+        :return: The updated Connection
+        """
+        raise NotImplementedError()

--- a/airflow/api/client/json_client.py
+++ b/airflow/api/client/json_client.py
@@ -26,7 +26,8 @@ from airflow.api.client import api_client
 class Client(api_client.Client):
     """Json API client implementation."""
 
-    def _request(self, url, method='GET', json=None):
+    def _request(self, endpoint, method='GET', json=None):
+        url = urljoin(self._api_base_url, endpoint)
         params = {
             'url': url,
             'auth': self._auth,
@@ -46,8 +47,7 @@ class Client(api_client.Client):
 
     def trigger_dag(self, dag_id, run_id=None, conf=None, execution_date=None):
         endpoint = '/api/experimental/dags/{}/dag_runs'.format(dag_id)
-        url = urljoin(self._api_base_url, endpoint)
-        data = self._request(url, method='POST',
+        data = self._request(endpoint, method='POST',
                              json={
                                  "run_id": run_id,
                                  "conf": conf,
@@ -57,26 +57,22 @@ class Client(api_client.Client):
 
     def delete_dag(self, dag_id):
         endpoint = '/api/experimental/dags/{}/delete_dag'.format(dag_id)
-        url = urljoin(self._api_base_url, endpoint)
-        data = self._request(url, method='DELETE')
+        data = self._request(endpoint, method='DELETE')
         return data['message']
 
     def get_pool(self, name):
         endpoint = '/api/experimental/pools/{}'.format(name)
-        url = urljoin(self._api_base_url, endpoint)
-        pool = self._request(url)
+        pool = self._request(endpoint)
         return pool['pool'], pool['slots'], pool['description']
 
     def get_pools(self):
         endpoint = '/api/experimental/pools'
-        url = urljoin(self._api_base_url, endpoint)
-        pools = self._request(url)
+        pools = self._request(endpoint)
         return [(p['pool'], p['slots'], p['description']) for p in pools]
 
     def create_pool(self, name, slots, description):
         endpoint = '/api/experimental/pools'
-        url = urljoin(self._api_base_url, endpoint)
-        pool = self._request(url, method='POST',
+        pool = self._request(endpoint, method='POST',
                              json={
                                  'name': name,
                                  'slots': slots,
@@ -86,6 +82,82 @@ class Client(api_client.Client):
 
     def delete_pool(self, name):
         endpoint = '/api/experimental/pools/{}'.format(name)
-        url = urljoin(self._api_base_url, endpoint)
-        pool = self._request(url, method='DELETE')
+        pool = self._request(endpoint, method='DELETE')
         return pool['pool'], pool['slots'], pool['description']
+
+    def add_connection(self, conn_id,
+                       conn_uri=None,
+                       conn_type=None,
+                       conn_host=None,
+                       conn_login=None,
+                       conn_password=None,
+                       conn_schema=None,
+                       conn_port=None,
+                       conn_extra=None):
+        endpoint = '/api/experimental/connections'
+        conn = self._request(endpoint, method='POST', json={
+            'conn_id': conn_id,
+            'conn_uri': conn_uri,
+            'conn_type': conn_type,
+            'conn_host': conn_host,
+            'conn_login': conn_login,
+            'conn_password': conn_password,
+            'conn_schema': conn_schema,
+            'conn_port': conn_port,
+            'conn_extra': conn_extra})
+        return conn.to_json()
+
+    def delete_connection(self, conn_id, delete_all=False):
+        """
+
+        :param conn_id:
+        :param delete_all:
+        :return: the conn_id(s) of the Connection(s) that were removed
+        """
+        endpoint = '/api/experimental/connections/{}'.format(conn_id)
+        conn_id = self._request(endpoint, method='DELETE', json={'delete_all': delete_all})
+        return conn_id
+
+    def list_connections(self):
+        """
+
+        :return: All Connections
+        """
+        endpoint = '/api/experimental/connections'
+        conns = self._request(endpoint)
+        return conns
+
+    def update_connection(self, conn_id,
+                          conn_uri=None,
+                          conn_type=None,
+                          conn_host=None,
+                          conn_login=None,
+                          conn_password=None,
+                          conn_schema=None,
+                          conn_port=None,
+                          conn_extra=None):
+        """
+
+        :param conn_id:
+        :param conn_uri:
+        :param conn_type:
+        :param conn_host:
+        :param conn_login:
+        :param conn_password:
+        :param conn_schema:
+        :param conn_port:
+        :param conn_extra:
+        :return: The updated Connection
+        """
+        endpoint = '/api/experimental/connections/'
+        conn = self._request(endpoint, method='PATCH', json={
+            'conn_id': conn_id,
+            'conn_uri': conn_uri,
+            'conn_type': conn_type,
+            'conn_host': conn_host,
+            'conn_login': conn_login,
+            'conn_password': conn_password,
+            'conn_schema': conn_schema,
+            'conn_port': conn_port,
+            'conn_extra': conn_extra})
+        return conn.to_json()

--- a/airflow/api/client/local_client.py
+++ b/airflow/api/client/local_client.py
@@ -18,7 +18,7 @@
 # under the License.
 
 from airflow.api.client import api_client
-from airflow.api.common.experimental import pool
+from airflow.api.common.experimental import pool, connections
 from airflow.api.common.experimental import trigger_dag
 from airflow.api.common.experimental import delete_dag
 
@@ -51,3 +51,83 @@ class Client(api_client.Client):
     def delete_pool(self, name):
         p = pool.delete_pool(name=name)
         return p.pool, p.slots, p.description
+
+    def add_connection(self, conn_id,
+                       conn_uri=None,
+                       conn_type=None,
+                       conn_host=None,
+                       conn_login=None,
+                       conn_password=None,
+                       conn_schema=None,
+                       conn_port=None,
+                       conn_extra=None):
+        """
+
+        :param conn_id:
+        :param conn_uri:
+        :param conn_type:
+        :param conn_host:
+        :param conn_login:
+        :param conn_password:
+        :param conn_schema:
+        :param conn_port:
+        :param conn_extra:
+        :return: The new Connection
+        """
+        return connections.add_connection(conn_id,
+                                          conn_uri,
+                                          conn_type,
+                                          conn_host,
+                                          conn_login,
+                                          conn_password,
+                                          conn_schema,
+                                          conn_port,
+                                          conn_extra).to_json()
+
+    def delete_connection(self, conn_id, delete_all=False):
+        """
+
+        :param conn_id:
+        :param delete_all:
+        :return: the conn_id(s) of the Connection(s) that were removed
+        """
+        return connections.delete_connection(conn_id, delete_all)
+
+    def list_connections(self):
+        """
+
+        :return: All Connections
+        """
+        return [conn.to_json() for conn in connections.list_connections()]
+
+    def update_connection(self, conn_id,
+                          conn_uri=None,
+                          conn_type=None,
+                          conn_host=None,
+                          conn_login=None,
+                          conn_password=None,
+                          conn_schema=None,
+                          conn_port=None,
+                          conn_extra=None):
+        """
+
+        :param conn_id:
+        :param conn_uri:
+        :param conn_type:
+        :param conn_host:
+        :param conn_login:
+        :param conn_password:
+        :param conn_schema:
+        :param conn_port:
+        :param conn_extra:
+        :return: The updated Connection
+        """
+        return connections.update_connection(conn_id,
+                                             conn_uri,
+                                             conn_type,
+                                             conn_host,
+                                             conn_login,
+                                             conn_password,
+                                             conn_schema,
+                                             conn_port,
+                                             conn_extra).to_json()

--- a/airflow/api/common/experimental/connections.py
+++ b/airflow/api/common/experimental/connections.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from sqlalchemy.orm import exc
+from airflow import settings
+from airflow.exceptions import MissingArgument, ConnectionNotFound, MultipleConnectionsFound, \
+    IncompatibleArgument
+from airflow.models.connection import Connection
+
+
+def add_connection(
+    conn_id,
+    conn_uri=None,
+    conn_type=None,
+    conn_host=None,
+    conn_login=None,
+    conn_password=None,
+    conn_schema=None,
+    conn_port=None,
+    conn_extra=None,
+):
+    # Check that the conn_id and conn_uri args were passed to the command:
+    missing_args = list()
+    invalid_args = list()
+    if not conn_id:
+        missing_args.append('conn_id')
+
+    if conn_uri:
+        if conn_type:
+            invalid_args.append(conn_type)
+        if conn_host:
+            invalid_args.append(conn_host)
+        if conn_login:
+            invalid_args.append(conn_login)
+        if conn_password:
+            invalid_args.append(conn_password)
+        if conn_schema:
+            invalid_args.append(conn_schema)
+        if conn_port:
+            invalid_args.append(conn_port)
+    elif not conn_type:
+        missing_args.append('conn_uri or conn_type')
+
+    if missing_args:
+        msg = ('The following args are required to add a connection:' +
+               ' {missing!r}'.format(missing=missing_args))
+        raise MissingArgument(msg)
+    if invalid_args:
+        msg = ('The following args are not compatible with the ' +
+               '--add flag and --conn_uri flag: {invalid!r}')
+        msg = msg.format(invalid=invalid_args)
+        raise MissingArgument(msg)
+
+    if conn_uri:
+        new_conn = Connection(conn_id=conn_id, uri=conn_uri)
+    else:
+        new_conn = Connection(conn_id=conn_id,
+                              conn_type=conn_type,
+                              host=conn_host,
+                              login=conn_login,
+                              password=conn_password,
+                              schema=conn_schema,
+                              port=conn_port)
+    if conn_extra is not None:
+        new_conn.set_extra(conn_extra)
+
+    session = settings.Session()
+    existing_connections = (session
+                            .query(Connection)
+                            .filter(Connection.conn_id == conn_id)).all()
+
+    if not all(c.conn_type == new_conn.conn_type for c in existing_connections):
+        raise IncompatibleArgument('Connections with the same id must all be of the same type')
+
+    session.add(new_conn)
+    session.commit()
+    return new_conn
+
+
+def delete_connection(conn_id, delete_all=False):
+    if conn_id is None:
+        raise MissingArgument('To delete a connection, you must provide a value for ' +
+                              'the --conn_id flag.')
+
+    session = settings.Session()
+    to_delete = (session
+                 .query(Connection)
+                 .filter(Connection.conn_id == conn_id)).all()
+
+    if len(to_delete) == 1:
+        deleted_conn_id = to_delete[0].conn_id
+        for conn in to_delete:
+            session.delete(conn)
+        session.commit()
+        msg = 'Successfully deleted `conn_id`={conn_id}'
+        msg = msg.format(conn_id=deleted_conn_id)
+        return msg
+    elif len(to_delete) > 1:
+        if delete_all:
+            deleted_conn_id = to_delete[0].conn_id
+            num_conns = len(to_delete)
+            for conn in to_delete:
+                session.delete(conn)
+            session.commit()
+
+            msg = 'Successfully deleted {num_conns} connections with `conn_id`={conn_id}'
+            msg = msg.format(conn_id=deleted_conn_id, num_conns=num_conns)
+            return msg
+        else:
+            msg = ('Found {num_conns} connection with ' +
+                   '`conn_id`={conn_id}. Specify `delete_all=True` to remove all')
+            msg = msg.format(conn_id=conn_id, num_conns=len(to_delete))
+            return msg
+    elif len(to_delete) == 0:
+        raise ConnectionNotFound('Did not find a connection with `conn_id`={conn_id}'.format(conn_id=conn_id))
+
+
+def list_connections():
+    session = settings.Session()
+    return session.query(Connection).all()
+
+
+def update_connection(conn_id,
+                      conn_uri=None,
+                      conn_type=None,
+                      conn_host=None,
+                      conn_login=None,
+                      conn_password=None,
+                      conn_schema=None,
+                      conn_port=None,
+                      conn_extra=None):
+    # Check that the conn_id and conn_uri args were passed to the command:
+    missing_args = list()
+    invalid_args = list()
+    if not conn_id:
+        missing_args.append('conn_id')
+    if conn_uri:
+        if conn_type:
+            invalid_args.append(conn_type)
+        if conn_host:
+            invalid_args.append(conn_host)
+        if conn_login:
+            invalid_args.append(conn_login)
+        if conn_password:
+            invalid_args.append(conn_password)
+        if conn_schema:
+            invalid_args.append(conn_schema)
+        if conn_port:
+            invalid_args.append(conn_port)
+    elif not conn_type:
+        missing_args.append('conn_uri or conn_type')
+
+    if missing_args:
+        msg = ('The following args are required to update a connection:' +
+               ' {missing!r}'.format(missing=missing_args))
+        raise MissingArgument(msg)
+    if invalid_args:
+        msg = ('The following args are not compatible with the ' +
+               '--update flag and --conn_uri flag: {invalid!r}')
+        msg = msg.format(invalid=invalid_args)
+        raise MissingArgument(msg)
+
+    # Update....
+    session = settings.Session()
+    try:
+        to_update = (session
+                     .query(Connection)
+                     .filter(Connection.conn_id == conn_id)
+                     .one())
+    except exc.NoResultFound:
+        msg = 'Did not find a connection with `conn_id`={conn_id}'
+        msg = msg.format(conn_id=conn_id)
+        raise ConnectionNotFound(msg)
+    except exc.MultipleResultsFound:
+        msg = ('Updating multiple connections is not supported, Found multiple connections with ' +
+               '`conn_id`={conn_id}')
+        msg = msg.format(conn_id=conn_id)
+        raise MultipleConnectionsFound(msg)
+    else:
+
+        # build a new connection to update from
+        if conn_uri:
+            temp_conn = Connection(conn_id='new_conn', uri=conn_uri)
+        else:
+            temp_conn = Connection(conn_id='new_conn',
+                                   conn_type=conn_type,
+                                   host=conn_host,
+                                   login=conn_login,
+                                   password=conn_password,
+                                   schema=conn_schema,
+                                   port=conn_port)
+        if conn_extra is not None:
+            temp_conn.set_extra(conn_extra)
+
+        to_update.conn_type = temp_conn.conn_type or to_update.conn_type
+        to_update.host = temp_conn.host or to_update.host
+        to_update.login = temp_conn.login or to_update.login
+        to_update.password = temp_conn.password or to_update.password
+        to_update.schema = temp_conn.schema or to_update.schema
+        to_update.port = temp_conn.port or to_update.port
+
+        if temp_conn.extra is not None:
+            to_update.set_extra(temp_conn.extra)
+        session.commit()
+
+        return to_update

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -107,3 +107,23 @@ class TaskInstanceNotFound(AirflowNotFoundException):
 class PoolNotFound(AirflowNotFoundException):
     """Raise when a Pool is not available in the system"""
     pass
+
+
+class MissingArgument(AirflowBadRequest):
+    """Raise when a required argument is missing"""
+    pass
+
+
+class IncompatibleArgument(AirflowBadRequest):
+    """Raise when one or more argument(s) are incompatible"""
+    pass
+
+
+class ConnectionNotFound(AirflowNotFoundException):
+    """Raise when a connection is not found"""
+    pass
+
+
+class MultipleConnectionsFound(AirflowBadRequest):
+    """Raise when multiple connections are found"""
+    pass

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -19,7 +19,7 @@
 
 import json
 from builtins import bytes
-from urllib.parse import urlparse, unquote, parse_qsl
+from urllib.parse import urlparse, unquote, parse_qsl, urlunparse
 
 from sqlalchemy import Column, Integer, String, Boolean
 from sqlalchemy.ext.declarative import declared_attr
@@ -246,8 +246,34 @@ class Connection(Base, LoggingMixin):
             elif self.conn_type == 'gcpcloudsql':
                 from airflow.contrib.hooks.gcp_sql_hook import CloudSqlDatabaseHook
                 return CloudSqlDatabaseHook(gcp_cloudsql_conn_id=self.conn_id)
-        except Exception:
+        except Exception as ex:
+            self.log.exception(ex)
+            self.log.error('Exception getting hook: {ex}'.format(ex=ex))
             pass
+
+    def get_uri(self, show_password=True):
+        return urlunparse((self.conn_type,
+                           '{login}:{password}@{host}:{port}'
+                           .format(login=self.login or '',
+                                   password=(self.password or '') if show_password else '******',
+                                   host=self.host or '',
+                                   port=self.port or ''),
+                           self.schema or '', '', '', ''))
+
+    def to_json(self, show_password=True):
+        return {
+            'conn_id': self.conn_id,
+            'conn_type': self.conn_type,
+            'host': self.host,
+            'login': self.login,
+            # 'password': self.password ,
+            'schema': self.schema,
+            'port': self.port,
+            'is_encrypted': self.is_encrypted,
+            'is_extra_encrypted': self.is_extra_encrypted,
+            'extra': self.get_extra(),
+            'uri': self.get_uri(show_password=show_password)
+        }
 
     def __repr__(self):
         return self.conn_id
@@ -275,3 +301,16 @@ class Connection(Base, LoggingMixin):
                 self.log.error("Failed parsing the json for conn_id %s", self.conn_id)
 
         return obj
+
+    def __eq__(self, other):
+        self_dict = self.__dict__
+        other_dict = other.__dict__
+
+        return \
+            self_dict['conn_type'] == other_dict['conn_type'] and \
+            self_dict['host'] == other_dict['host'] and \
+            self_dict['login'] == other_dict['login'] and \
+            self.get_password() == other.get_password() and \
+            self_dict['schema'] == other_dict['schema'] and \
+            self_dict['port'] == other_dict['port'] and \
+            self.get_extra() == other.get_extra()

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -92,6 +92,22 @@ Endpoints
 
   Delete pool.
 
+.. http:get:: /api/experimental/connections
+
+  Get all connections.
+
+.. http:post:: /api/experimental/connections
+
+  Create a connection.
+
+.. http:delete:: /api/experimental/connections/<string:conn_id>
+
+  Delete a connection.
+
+.. http:patch:: /api/experimental/connections/<string:conn_id>
+
+  Update a connection.
+
 
 CLI
 -----

--- a/tests/api/common/experimental/connection_tests.py
+++ b/tests/api/common/experimental/connection_tests.py
@@ -1,0 +1,421 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from airflow import settings, models
+from airflow.api.common.experimental import connections
+from airflow.exceptions import MissingArgument, MultipleConnectionsFound, IncompatibleArgument, \
+    ConnectionNotFound
+from airflow.models.connection import Connection
+from airflow.settings import Session
+
+
+class ConnectionTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(ConnectionTests, cls).setUpClass()
+        cls._cleanup()
+
+    def setUp(self):
+        super(ConnectionTests, self).setUp()
+        # from airflow.www_rbac import app as application
+        # configuration.load_test_config()
+        # self.app, self.appbuilder = application.create_app(session=Session, testing=True)
+        # self.app.config['TESTING'] = True
+
+        # self.dagbag = models.DagBag(dag_folder=DEV_NULL, include_examples=True)
+        settings.configure_orm()
+        self.session = Session
+
+    def tearDown(self):
+        self._cleanup(session=self.session)
+        super(ConnectionTests, self).tearDown()
+
+    @staticmethod
+    def _cleanup(session=None):
+        if session is None:
+            session = Session()
+
+        session.query(models.Pool).delete()
+        session.query(models.Variable).delete()
+        session.query(Connection).delete()
+        session.commit()
+        session.close()
+
+    def test_add_connection(self):
+        uri = 'postgres://airflow:airflow@host:5432/airflow'
+        # add a connection using conn_uri
+        self.assertEqual(connections.add_connection(
+            conn_id="new1",
+            conn_uri=uri
+        ), Connection(conn_id="new1", uri=uri))
+
+        # add a connection with all params defined
+        self.assertEqual(connections.add_connection(
+            conn_id="new2",
+            conn_type="postgres",
+            conn_host="host",
+            conn_login="airflow",
+            conn_password="airflow",
+            conn_schema="airflow",
+            conn_port="5432"
+        ), Connection(
+            conn_id="new2",
+            conn_type="postgres",
+            host="host",
+            login="airflow",
+            password="airflow",
+            schema="airflow",
+            port="5432"))
+
+        # add a connection with extra
+        con3_test = Connection(conn_id="new3", uri=uri)
+        con3_test.set_extra("{'foo':'bar'}")
+        self.assertEqual(connections.add_connection(
+            conn_id="new3",
+            conn_uri=uri,
+            conn_extra="{'foo':'bar'}"
+        ), con3_test)
+
+        # add a duplicate connection`
+        self.assertEqual(connections.add_connection(
+            conn_id="new3",
+            conn_uri=uri,
+            conn_extra="{'foo':'bar'}"
+        ), con3_test)
+
+        # add a connection with just type
+        self.assertEqual(connections.add_connection(
+            conn_id="new4",
+            conn_type="google_cloud_platform",
+            conn_uri="",
+            conn_extra="{'extra':'yes'}"
+        ), Connection(conn_id="new4",
+                      conn_type="google_cloud_platform",
+                      uri="",
+                      extra="{'extra':'yes'}"))
+
+        # Attempt to add without providing conn_id
+        with self.assertRaises(MissingArgument) as ma:
+            connections.add_connection(conn_id=None, conn_uri=uri)
+            self.assertEqual(ma.exception,
+                             "The following args are required to add a connection:" +
+                             " ['conn_id']")
+
+        # Attempt to add without providing conn_uri
+        with self.assertRaises(MissingArgument) as ma:
+            connections.add_connection(conn_id="new5")
+            self.assertEqual(ma.exception,
+                             "The following args are required to add a connection:" +
+                             " ['conn_id or conn_type']")
+
+        # Attempt to add duplicate connection with different type
+        with self.assertRaises(IncompatibleArgument) as ia:
+            connections.add_connection(conn_id="new2",
+                                       conn_type="not_postgres",
+                                       conn_host="host",
+                                       conn_login="airflow",
+                                       conn_password="airflow",
+                                       conn_schema="airflow",
+                                       conn_port="5432")
+            self.assertEqual(ia.exception, "Connections with the same id must all be of the same type")
+
+        # validate expected connections reached the DB
+        extra = {'new1': None,
+                 'new2': None,
+                 'new3': "{'foo':'bar'}", }
+
+        for index in range(1, 5):
+            conn_id = 'new%s' % index
+            result = (self.session
+                      .query(Connection)
+                      .filter(Connection.conn_id == conn_id)
+                      .first())
+            result = (result.conn_id, result.conn_type, result.host,
+                      result.port, result.get_extra())
+            if conn_id in ['new1', 'new2', 'new3']:
+                self.assertEqual(result, (conn_id, 'postgres', 'host', 5432,
+                                          extra[conn_id]))
+            elif conn_id == 'new4':
+                self.assertEqual(result, (conn_id, 'google_cloud_platform',
+                                          None, None, "{'extra':'yes'}"))
+
+        # validate duplicate connections made it to the db
+        dup_conns = (self.session
+                     .query(Connection)
+                     .filter(Connection.conn_id == 'new3')).all()
+        self.assertEqual(2, len(dup_conns))
+        for conn in dup_conns:
+            result = (conn.conn_id, conn.conn_type, conn.host,
+                      conn.port, conn.get_extra())
+            self.assertEqual(result, ('new3', 'postgres', 'host', 5432,
+                                      extra['new3']))
+
+    def test_delete_connection(self):
+        # add some conns to delete
+        uri = 'postgres://airflow:airflow@host:5432/airflow'
+
+        self.assertEqual(connections.add_connection(
+            conn_id="new1",
+            conn_uri=uri
+        ), Connection(conn_id="new1", uri=uri))
+
+        self.assertEqual(connections.add_connection(
+            conn_id="new2",
+            conn_uri=uri
+        ), Connection(conn_id="new2", uri=uri))
+
+        self.assertEqual(connections.add_connection(
+            conn_id="new2",
+            conn_uri=uri
+        ), Connection(conn_id="new2", uri=uri))
+
+        # delete one
+        self.assertEqual(connections.delete_connection(conn_id='new1'),
+                         "Successfully deleted `conn_id`=new1")
+
+        # try to delete multiple with delete_all=False
+        self.assertEqual(connections.delete_connection(conn_id='new2'),
+                         'Found 2 connection with ' +
+                         '`conn_id`=new2. Specify `delete_all=True` to remove all')
+
+        # make sure none were deleted
+        self.assertEqual(2, len((self.session.query(Connection)
+                                 .filter(Connection.conn_id == 'new2').all())))
+
+        self.assertEqual(connections.delete_connection(conn_id='new2', delete_all=True),
+                         "Successfully deleted 2 connections with `conn_id`=new2")
+
+        # make sure all were deleted
+        self.assertEqual(0, len((self.session.query(Connection).all())))
+
+        # Attempt to delete a non-existing connection
+        self.assertRaises(ConnectionNotFound, connections.delete_connection, 'non_existent')
+
+        # Attempt to delete a non-existing connection
+        self.assertRaises(MissingArgument, connections.delete_connection, None)
+
+        self.session.close()
+
+    def test_list_connections(self):
+
+        uri = 'postgres://airflow:airflow@host:5432/airflow'
+
+        # add a connection using conn_uri
+        self.assertEqual(connections.add_connection(
+            conn_id="new1",
+            conn_uri=uri
+        ), Connection(conn_id="new1", uri=uri))
+
+        # add a connection with all params defined
+        self.assertEqual(connections.add_connection(
+            conn_id="new2",
+            conn_type="postgres",
+            conn_host="host",
+            conn_login="airflow",
+            conn_password="airflow",
+            conn_schema="airflow",
+            conn_port="5432"
+        ), Connection(
+            conn_id="new2",
+            conn_type="postgres",
+            host="host",
+            login="airflow",
+            password="airflow",
+            schema="airflow",
+            port="5432"
+        ))
+
+        # add a connection with extra
+        con3 = Connection(conn_id="new3",
+                          uri=uri, )
+        con3.set_extra("{'bar':'foo'}")
+
+        self.assertEqual(connections.add_connection(
+            conn_id="new3",
+            conn_uri=uri,
+            conn_extra="{'bar':'foo'}"
+        ), con3)
+
+        # add a duplicate connection`
+        self.assertEqual(connections.add_connection(
+            conn_id="new3",
+            conn_uri=uri,
+            conn_extra="{'bar':'foo'}"
+        ), con3)
+
+        # add a connection with just type
+        con4 = Connection(conn_id="new4",
+                          conn_type="google_cloud_platform")
+        con4.set_extra("{'extra':'yes'}")
+
+        self.assertEqual(connections.add_connection(
+            conn_id="new4",
+            conn_type="google_cloud_platform",
+            conn_uri="",
+            conn_extra="{'extra':'yes'}"
+        ), con4)
+
+        conns = list(map(lambda conn: (conn.conn_id, conn.conn_type, conn.host,
+                                       conn.port, conn.is_extra_encrypted),
+                         connections.list_connections()))
+
+        self.assertEqual(conns,
+                         [('new1', 'postgres', 'host', 5432, False),
+                          ('new2', 'postgres', 'host', 5432, False),
+                          ('new3', 'postgres', 'host', 5432, True),
+                          ('new3', 'postgres', 'host', 5432, True),
+                          ('new4', 'google_cloud_platform', None, None, True)])
+
+    def test_update_connection(self):
+        uri = 'postgres://airflow:airflow@host:5432/airflow'
+
+        # add a connection using conn_uri
+        self.assertEqual(connections.add_connection(
+            conn_id="new1",
+            conn_uri=uri
+        ), Connection(conn_id="new1", uri=uri))
+
+        # add a connection with all params defined
+        self.assertEqual(connections.add_connection(
+            conn_id="new2",
+            conn_type="postgres",
+            conn_host="host",
+            conn_login="airflow",
+            conn_password="airflow",
+            conn_schema="airflow",
+            conn_port="5432"
+        ), Connection(
+            conn_id="new2",
+            conn_type="postgres",
+            host="host",
+            login="airflow",
+            password="airflow",
+            schema="airflow",
+            port="5432"
+        ))
+
+        # add a connection with extra
+        con3 = Connection(conn_id="new3",
+                          uri=uri, )
+        con3.set_extra("{'bar':'foo'}")
+
+        self.assertEqual(connections.add_connection(
+            conn_id="new3",
+            conn_uri=uri,
+            conn_extra="{'bar':'foo'}"
+        ), con3)
+
+        # add a duplicate connection`
+        self.assertEqual(connections.add_connection(
+            conn_id="new3",
+            conn_uri=uri,
+            conn_extra="{'bar':'foo'}"
+        ), con3)
+
+        # add a connection with just type
+        con4 = Connection(conn_id="new4",
+                          conn_type="google_cloud_platform")
+        con4.set_extra("{'extra':'yes'}")
+
+        self.assertEqual(connections.add_connection(
+            conn_id="new4",
+            conn_type="google_cloud_platform",
+            conn_uri="",
+            conn_extra="{'extra':'yes'}"
+        ), con4)
+
+        # Update Connections
+        new_uri = 'postgres://airflow:different_password@host:1234/airflow'
+        # update connection using conn_uri
+        self.assertEqual(connections.update_connection(
+            conn_id="new1",
+            conn_uri=new_uri
+        ), Connection(conn_id="new1",
+                      uri=new_uri))
+
+        # update connection with all params defined
+        self.assertEqual(connections.update_connection(
+            conn_id="new2",
+            conn_type="postgres",
+            conn_host="host",
+            conn_login="airflow",
+            conn_password="different_password",
+            conn_schema="airflow",
+            conn_port="1234"
+        ), Connection(conn_id="new2",
+                      conn_type="postgres",
+                      host="host",
+                      login="airflow",
+                      password="different_password",
+                      schema="airflow",
+                      port="1234"))
+
+        # update connection with just type
+        con4 = Connection(conn_id="new4",
+                          conn_type="random_type")
+        con4.set_extra("{'extra':'yes'}")
+
+        self.assertEqual(connections.update_connection(
+            conn_id="new4",
+            conn_type="random_type",
+            conn_uri="",
+            conn_extra="{'extra':'yes'}"
+        ), con4)
+
+        # validate updates reached the DB
+        extra = {'new1': None,
+                 'new2': None,
+                 'new3': "{'bar':'foo'}",
+                 'new4': "{'extra': 'yes'}", }
+
+        for index in range(1, 4):
+            conn_id = 'new%s' % index
+            result = (self.session
+                      .query(Connection)
+                      .filter(Connection.conn_id == conn_id)
+                      .first())
+            result = (result.conn_id, result.conn_type, result.host,
+                      result.port, result.get_extra())
+            if conn_id in ['new1', 'new2']:
+                self.assertEqual(result, (conn_id, 'postgres', 'host', 1234,
+                                          extra[conn_id]))
+            elif conn_id == 'new4':
+                self.assertEqual(result, (conn_id, 'random_type',
+                                          None, None, extra[conn_id]))
+
+        # try to update duplicate connection
+        self.assertRaises(MultipleConnectionsFound, connections.update_connection, conn_id="new3",
+                          conn_uri=new_uri,
+                          conn_extra="{'foo':'bar'}")
+
+        # validate duplicate connections did not update in db
+        dup_conns = (self.session
+                     .query(Connection)
+                     .filter(Connection.conn_id == 'new3')).all()
+        self.assertEqual(2, len(dup_conns))
+        for conn in dup_conns:
+            result = (conn.conn_id, conn.conn_type, conn.host,
+                      conn.port, conn.get_extra())
+            self.assertEqual(result, ('new3', 'postgres', 'host', 5432,
+                                      extra['new3']))
+
+        # Attempt to udpate without providing conn_uri
+        self.assertRaises(MissingArgument, connections.update_connection, conn_id="new1")

--- a/tests/core.py
+++ b/tests/core.py
@@ -149,7 +149,7 @@ class CoreTest(unittest.TestCase):
             datetime(2015, 1, 2, 0, 0),
             dag_run.execution_date,
             msg='dag_run.execution_date did not match expectation: {0}'
-            .format(dag_run.execution_date)
+                .format(dag_run.execution_date)
         )
         self.assertEqual(State.RUNNING, dag_run.state)
         self.assertFalse(dag_run.external_trigger)
@@ -1102,6 +1102,7 @@ class CliTests(unittest.TestCase):
 
         session.query(models.Pool).delete()
         session.query(models.Variable).delete()
+        session.query(Connection).delete()
         session.commit()
         session.close()
 
@@ -1421,7 +1422,36 @@ class CliTests(unittest.TestCase):
 
         resetdb_mock.assert_called_once_with()
 
-    def test_cli_connections_list(self):
+    def test_cli_list_connections(self):
+        uri = 'postgresql://airflow:airflow@host:5432/airflow'
+
+        cli.connections(self.parser.parse_args(
+            ['connections', '--add', '--conn_id=new1',
+             '--conn_uri=%s' % uri]))
+        cli.connections(self.parser.parse_args(
+            ['connections', '-a', '--conn_id=new2',
+             '--conn_uri=%s' % uri]))
+        cli.connections(self.parser.parse_args(
+            ['connections', '--add', '--conn_id=new3',
+             '--conn_uri=%s' % uri, '--conn_extra', "{'extra': 'yes'}"]))
+        cli.connections(self.parser.parse_args(
+            ['connections', '-a', '--conn_id=new4',
+             '--conn_uri=%s' % uri, '--conn_extra', "{'extra': 'yes'}"]))
+        cli.connections(self.parser.parse_args(
+            ['connections', '--add', '--conn_id=new5',
+             '--conn_type=hive_metastore', '--conn_login=airflow',
+             '--conn_password=airflow', '--conn_host=host',
+             '--conn_port=9083', '--conn_schema=airflow']))
+        cli.connections(self.parser.parse_args(
+            ['connections', '-a', '--conn_id=new6',
+             '--conn_uri', "", '--conn_type=google_cloud_platform', '--conn_extra', "{'extra': 'yes'}"]))
+        cli.connections(self.parser.parse_args(
+            ['connections', '--add', '--conn_id=duplicate1',
+             '--conn_uri=%s' % uri, '--conn_extra', "{'extra': 'yes'}"]))
+        cli.connections(self.parser.parse_args(
+            ['connections', '-a', '--conn_id=duplicate1',
+             '--conn_uri=%s' % uri, '--conn_extra', "{'extra': 'yes'}"]))
+
         with mock.patch('sys.stdout',
                         new_callable=six.StringIO) as mock_stdout:
             cli.connections(self.parser.parse_args(['connections', '--list']))
@@ -1433,33 +1463,13 @@ class CliTests(unittest.TestCase):
 
         # Assert that some of the connections are present in the output as
         # expected:
-        self.assertIn(['aws_default', 'aws'], conns)
-        self.assertIn(['beeline_default', 'beeline'], conns)
-        self.assertIn(['emr_default', 'emr'], conns)
-        self.assertIn(['mssql_default', 'mssql'], conns)
-        self.assertIn(['mysql_default', 'mysql'], conns)
-        self.assertIn(['postgres_default', 'postgres'], conns)
-        self.assertIn(['wasb_default', 'wasb'], conns)
-        self.assertIn(['segment_default', 'segment'], conns)
-
-        # Attempt to list connections with invalid cli args
-        with mock.patch('sys.stdout',
-                        new_callable=six.StringIO) as mock_stdout:
-            cli.connections(self.parser.parse_args(
-                ['connections', '--list', '--conn_id=fake', '--conn_uri=fake-uri',
-                 '--conn_type=fake-type', '--conn_host=fake_host',
-                 '--conn_login=fake_login', '--conn_password=fake_password',
-                 '--conn_schema=fake_schema', '--conn_port=fake_port', '--conn_extra=fake_extra']))
-            stdout = mock_stdout.getvalue()
-
-        # Check list attempt stdout
-        lines = [l for l in stdout.split('\n') if len(l) > 0]
-        self.assertListEqual(lines, [
-            ("\tThe following args are not compatible with the " +
-             "--list flag: ['conn_id', 'conn_uri', 'conn_extra', " +
-             "'conn_type', 'conn_host', 'conn_login', " +
-             "'conn_password', 'conn_schema', 'conn_port']"),
-        ])
+        self.assertIn(['new1', 'postgres'], conns)
+        self.assertIn(['new2', 'postgres'], conns)
+        self.assertIn(['new3', 'postgres'], conns)
+        self.assertIn(['new4', 'postgres'], conns)
+        self.assertIn(['new5', 'hive_metastore'], conns)
+        self.assertIn(['new6', 'google_cloud_platform'], conns)
+        self.assertIn(['duplicate1', 'postgres'], conns)
 
     def test_cli_connections_list_redirect(self):
         cmd = ['airflow', 'connections', '--list']
@@ -1468,7 +1478,7 @@ class CliTests(unittest.TestCase):
             p.wait()
             self.assertEqual(0, p.returncode)
 
-    def test_cli_connections_add_delete(self):
+    def test_cli_connections(self):
         # Add connections:
         uri = 'postgresql://airflow:airflow@host:5432/airflow'
         with mock.patch('sys.stdout',
@@ -1493,37 +1503,26 @@ class CliTests(unittest.TestCase):
             cli.connections(self.parser.parse_args(
                 ['connections', '-a', '--conn_id=new6',
                  '--conn_uri', "", '--conn_type=google_cloud_platform', '--conn_extra', "{'extra': 'yes'}"]))
+            cli.connections(self.parser.parse_args(
+                ['connections', '--add', '--conn_id=duplicate1',
+                 '--conn_uri=%s' % uri, '--conn_extra', "{'extra': 'yes'}"]))
+            cli.connections(self.parser.parse_args(
+                ['connections', '-a', '--conn_id=duplicate1',
+                 '--conn_uri=%s' % uri, '--conn_extra', "{'extra': 'yes'}"]))
             stdout = mock_stdout.getvalue()
 
         # Check addition stdout
         lines = [l for l in stdout.split('\n') if len(l) > 0]
-        self.assertListEqual(lines, [
-            ("\tSuccessfully added `conn_id`=new1 : " +
-             "postgresql://airflow:airflow@host:5432/airflow"),
-            ("\tSuccessfully added `conn_id`=new2 : " +
-             "postgresql://airflow:airflow@host:5432/airflow"),
-            ("\tSuccessfully added `conn_id`=new3 : " +
-             "postgresql://airflow:airflow@host:5432/airflow"),
-            ("\tSuccessfully added `conn_id`=new4 : " +
-             "postgresql://airflow:airflow@host:5432/airflow"),
-            ("\tSuccessfully added `conn_id`=new5 : " +
-             "hive_metastore://airflow:airflow@host:9083/airflow"),
-            ("\tSuccessfully added `conn_id`=new6 : " +
-             "google_cloud_platform://:@:")
-        ])
 
-        # Attempt to add duplicate
-        with mock.patch('sys.stdout',
-                        new_callable=six.StringIO) as mock_stdout:
-            cli.connections(self.parser.parse_args(
-                ['connections', '--add', '--conn_id=new1',
-                 '--conn_uri=%s' % uri]))
-            stdout = mock_stdout.getvalue()
-
-        # Check stdout for addition attempt
-        lines = [l for l in stdout.split('\n') if len(l) > 0]
         self.assertListEqual(lines, [
-            "\tA connection with `conn_id`=new1 already exists",
+            "Successfully added `conn_id`=new1 : postgres://airflow:airflow@host:5432/airflow",
+            "Successfully added `conn_id`=new2 : postgres://airflow:airflow@host:5432/airflow",
+            "Successfully added `conn_id`=new3 : postgres://airflow:airflow@host:5432/airflow",
+            "Successfully added `conn_id`=new4 : postgres://airflow:airflow@host:5432/airflow",
+            "Successfully added `conn_id`=new5 : hive_metastore://airflow:airflow@host:9083/airflow",
+            "Successfully added `conn_id`=new6 : google_cloud_platform://:@:",
+            "Successfully added `conn_id`=duplicate1 : postgres://airflow:airflow@host:5432/airflow",
+            "Successfully added `conn_id`=duplicate1 : postgres://airflow:airflow@host:5432/airflow",
         ])
 
         # Attempt to add without providing conn_id
@@ -1536,7 +1535,7 @@ class CliTests(unittest.TestCase):
         # Check stdout for addition attempt
         lines = [l for l in stdout.split('\n') if len(l) > 0]
         self.assertListEqual(lines, [
-            ("\tThe following args are required to add a connection:" +
+            ("The following args are required to add a connection:" +
              " ['conn_id']"),
         ])
 
@@ -1550,18 +1549,17 @@ class CliTests(unittest.TestCase):
         # Check stdout for addition attempt
         lines = [l for l in stdout.split('\n') if len(l) > 0]
         self.assertListEqual(lines, [
-            ("\tThe following args are required to add a connection:" +
+            ("The following args are required to add a connection:" +
              " ['conn_uri or conn_type']"),
         ])
 
-        # Prepare to add connections
+        # validate adding connections reached the DB
         session = settings.Session()
         extra = {'new1': None,
                  'new2': None,
                  'new3': "{'extra': 'yes'}",
-                 'new4': "{'extra': 'yes'}"}
+                 'new4': "{'extra': 'yes'}", }
 
-        # Add connections
         for index in range(1, 6):
             conn_id = 'new%s' % index
             result = (session
@@ -1576,6 +1574,109 @@ class CliTests(unittest.TestCase):
             elif conn_id == 'new5':
                 self.assertEqual(result, (conn_id, 'hive_metastore', 'host',
                                           9083, None))
+            elif conn_id == 'new6':
+                self.assertEqual(result, (conn_id, 'google_cloud_platform',
+                                          None, None, "{'extra': 'yes'}"))
+
+        # validate duplicate connections made it to the db
+        dup_conns = (session
+                     .query(Connection)
+                     .filter(Connection.conn_id == 'duplicate1')).all()
+        self.assertEqual(2, len(dup_conns))
+        for conn in dup_conns:
+            result = (conn.conn_id, conn.conn_type, conn.host,
+                      conn.port, conn.get_extra())
+            self.assertEqual(result, ('duplicate1', 'postgres', 'host', 5432,
+                                      "{'extra': 'yes'}"))
+
+        # Update Connections
+        new_uri = 'postgresql://airflow:different_password@host:1234/airflow'
+
+        with mock.patch('sys.stdout',
+                        new_callable=six.StringIO) as mock_stdout:
+            cli.connections(self.parser.parse_args(
+                ['connections', '--update', '--conn_id=new1',
+                 '--conn_uri=%s' % new_uri]))
+
+            cli.connections(self.parser.parse_args(
+                ['connections', '-u', '--conn_id=new2',
+                 '--conn_uri=%s' % new_uri]))
+
+            cli.connections(self.parser.parse_args(
+                ['connections', '--update', '--conn_id=new3',
+                 '--conn_uri=%s' % new_uri, '--conn_extra', "{'extra': 'yes'}"]))
+
+            cli.connections(self.parser.parse_args(
+                ['connections', '-u', '--conn_id=new4',
+                 '--conn_uri=%s' % new_uri, '--conn_extra', "{'extra': 'yes'}"]))
+
+            cli.connections(self.parser.parse_args(
+                ['connections', '--update', '--conn_id=new5',
+                 '--conn_type=hive_metastore', '--conn_login=airflow',
+                 '--conn_password=different_password', '--conn_host=host',
+                 '--conn_port=1234', '--conn_schema=airflow']))
+
+            cli.connections(self.parser.parse_args(
+                ['connections', '-u', '--conn_id=new6',
+                 '--conn_uri', "", '--conn_type=google_cloud_platform',
+                 '--conn_extra', "{'extra': 'yes'}"]))
+
+            # attempt to update a duplicate connection
+            cli.connections(self.parser.parse_args(
+                ['connections', '--update', '--conn_id=duplicate1',
+                 '--conn_uri=%s' % new_uri, '--conn_extra', "{'extra': 'yes'}"]))
+
+            stdout = mock_stdout.getvalue()
+
+        # Check update stdout
+        lines = [l for l in stdout.split('\n') if len(l) > 0]
+        self.assertListEqual(lines, [
+            "Successfully updated `conn_id`=new1 : postgres://airflow:different_password@host:1234/airflow",
+            "Successfully updated `conn_id`=new2 : postgres://airflow:different_password@host:1234/airflow",
+            "Successfully updated `conn_id`=new3 : postgres://airflow:different_password@host:1234/airflow",
+            "Successfully updated `conn_id`=new4 : postgres://airflow:different_password@host:1234/airflow",
+            "Successfully updated `conn_id`=new5 : "
+            "hive_metastore://airflow:different_password@host:1234/airflow",
+            "Successfully updated `conn_id`=new6 : google_cloud_platform://:@:",
+            "Updating multiple connections is not supported, "
+            "Found multiple connections with `conn_id`=duplicate1"
+        ])
+
+        # Attempt to udpate without providing conn_uri
+        with mock.patch('sys.stdout',
+                        new_callable=six.StringIO) as mock_stdout:
+            cli.connections(self.parser.parse_args(
+                ['connections', '--update', '--conn_id=new']))
+            stdout = mock_stdout.getvalue()
+
+        # Check stdout
+        lines = [l for l in stdout.split('\n') if len(l) > 0]
+        self.assertListEqual(lines, [
+            ("The following args are required to update a connection:" +
+             " ['conn_uri or conn_type']"),
+        ])
+
+        # validate updates reached the DB
+        session = settings.Session()
+        extra = {'new1': None,
+                 'new2': None,
+                 'new3': "{'extra': 'yes'}",
+                 'new4': "{'extra': 'yes'}", }
+
+        for index in range(1, 6):
+            conn_id = 'new%s' % index
+            result = (session
+                      .query(Connection)
+                      .filter(Connection.conn_id == conn_id)
+                      .first())
+            result = (result.conn_id, result.conn_type, result.host,
+                      result.port, result.get_extra())
+            if conn_id in ['new1', 'new2', 'new3', 'new4']:
+                self.assertEqual(result, (conn_id, 'postgres', 'host', 1234,
+                                          extra[conn_id]))
+            elif conn_id == 'new5':
+                self.assertEqual(result, (conn_id, 'hive_metastore', 'host',
+                                          1234, None))
             elif conn_id == 'new6':
                 self.assertEqual(result, (conn_id, 'google_cloud_platform',
                                           None, None, "{'extra': 'yes'}"))
@@ -1600,12 +1701,12 @@ class CliTests(unittest.TestCase):
         # Check deletion stdout
         lines = [l for l in stdout.split('\n') if len(l) > 0]
         self.assertListEqual(lines, [
-            "\tSuccessfully deleted `conn_id`=new1",
-            "\tSuccessfully deleted `conn_id`=new2",
-            "\tSuccessfully deleted `conn_id`=new3",
-            "\tSuccessfully deleted `conn_id`=new4",
-            "\tSuccessfully deleted `conn_id`=new5",
-            "\tSuccessfully deleted `conn_id`=new6"
+            "Successfully deleted `conn_id`=new1",
+            "Successfully deleted `conn_id`=new2",
+            "Successfully deleted `conn_id`=new3",
+            "Successfully deleted `conn_id`=new4",
+            "Successfully deleted `conn_id`=new5",
+            "Successfully deleted `conn_id`=new6"
         ])
 
         # Check deletions
@@ -1627,22 +1728,21 @@ class CliTests(unittest.TestCase):
         # Check deletion attempt stdout
         lines = [l for l in stdout.split('\n') if len(l) > 0]
         self.assertListEqual(lines, [
-            "\tDid not find a connection with `conn_id`=fake",
+            "Did not find a connection with `conn_id`=fake",
         ])
 
         # Attempt to delete with invalid cli args
         with mock.patch('sys.stdout',
                         new_callable=six.StringIO) as mock_stdout:
             cli.connections(self.parser.parse_args(
-                ['connections', '--delete', '--conn_id=fake',
+                ['connections', '--delete',
                  '--conn_uri=%s' % uri, '--conn_type=fake-type']))
             stdout = mock_stdout.getvalue()
 
         # Check deletion attempt stdout
         lines = [l for l in stdout.split('\n') if len(l) > 0]
         self.assertListEqual(lines, [
-            ("\tThe following args are not compatible with the " +
-             "--delete flag: ['conn_uri', 'conn_type']"),
+            'To delete a connection, you must provide a value for the --conn_id flag.',
         ])
 
         session.close()
@@ -2881,7 +2981,7 @@ class ConnectionTest(unittest.TestCase):
     def test_get_connections_db(self):
         conns = BaseHook.get_connections(conn_id='airflow_db')
         assert len(conns) == 1
-        assert conns[0].host == 'localhost'
+        assert conns[0].host == 'mysql'
         assert conns[0].schema == 'airflow'
         assert conns[0].login == 'root'
 


### PR DESCRIPTION
Adds an Update Connection CLI option.
This is useful for updating connections in a CI/CD environment where deleting and adding connection
could cause DAGS to fail.
Also exposes connection API via REST

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following JIRA: https://issues.apache.org/jira/browse/AIRFLOW-2840

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
See previously closed PR: https://github.com/apache/airflow/pull/3684
Adds cli update option, exposes connection api via REST, refactors entire API, Addresses https://issues.apache.org/jira/browse/AIRFLOW-2784 too
### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
* test/api/common/experimental/connection_tests.py
* modified tests in test/core.py

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
