### PR TITLE
[AIRFLOW-3864] Recognize lists as JSON in variables --import

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -372,7 +372,7 @@ def import_helper(filepath):
         try:
             n = 0
             for k, v in d.items():
-                if isinstance(v, dict):
+                if isinstance(v, dict) or isinstance(v, list):
                     Variable.set(k, v, serialize_json=True)
                 else:
                     Variable.set(k, v)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3864
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
  - When settings a variable via import, sets `serialize_json=True` if its value is a list

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - There doesn't seem to be support currently for cli tests

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
