### PR TITLE
[AIRFLOW-3868] - Incorrect import of distutils in JenkinsHook

### DIFF
--- a/airflow/contrib/hooks/jenkins_hook.py
+++ b/airflow/contrib/hooks/jenkins_hook.py
@@ -21,7 +21,7 @@
 from airflow.hooks.base_hook import BaseHook
 
 import jenkins
-import distutils
+from distutils.util import strtobool
 
 
 class JenkinsHook(BaseHook):
@@ -38,7 +38,7 @@ class JenkinsHook(BaseHook):
             connection.extra = 'false'
             # set a default value to connection.extra
             # to avoid rising ValueError in strtobool
-        if distutils.util.strtobool(connection.extra):
+        if strtobool(connection.extra):
             connectionPrefix = 'https'
         url = '%s://%s:%d' % (connectionPrefix, connection.host, connection.port)
         self.log.info('Trying to connect to %s', url)


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### Jira

- [V] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3868) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3868

### Description
Fix error AttributeError: module 'distutils' has no attribute 'util'

**Before:**
```
Python 3.6.7
>>> import distutils
>>> print (distutils.util.strtobool('true'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'distutils' has no attribute 'util'
>>>
```

**After:**
```
Python 3.6.7
>>> from distutils.util import strtobool
>>> print (strtobool('true'))
1

```


### Code Quality

- [V] Passes `flake8`
