### PR TITLE
[AIRFLOW-3867] Rename GCP's subpackage

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,7 +24,7 @@ python:
         - doc
         - docker
         - emr
-        - gcp_api
+        - gcp
         - s3
         - salesforce
         - sendgrid

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -38,10 +38,11 @@ Sensors are now accessible via `airflow.sensors` and no longer via `airflow.oper
 For example: `from airflow.operators.sensors import BaseSensorOperator` 
 becomes `from airflow.sensors.base_sensor_operator import BaseSensorOperator`
 
-### Renamed "extra" requirments for cloud providers
+### Renamed "extra" requirements for cloud providers
 
 Subpackages for specific services have been combined into one variant for
-each cloud provider.
+each cloud provider. The name of the subpackage for the Google Cloud Platform
+has changed to follow style.
 
 If you want to install integration for Microsoft Azure, then instead of
 ```
@@ -52,7 +53,9 @@ you should execute `pip install apache-airflow[azure]`
 If you want to install integration for Amazon Web Services, then instead of
 `pip install apache-airflow[s3,emr]`, you should execute `pip install apache-airflow[aws]`
 
-The integration with GCP is unchanged.
+If you want to install integration for Google Cloud Platform, then instead of
+`pip install apache-airflow[gcp_api]`, you should execute `pip install apache-airflow[gcp]`.
+The old way will work until the release of Airflow 2.1.
 
 ### Changes in Google Cloud Platform related operators
 

--- a/airflow/utils/log/gcs_task_handler.py
+++ b/airflow/utils/log/gcs_task_handler.py
@@ -49,7 +49,7 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
         except Exception as e:
             self.log.error(
                 'Could not create a GoogleCloudStorageHook with connection id '
-                '"{}". {}\n\nPlease make sure that airflow[gcp_api] is installed '
+                '"{}". {}\n\nPlease make sure that airflow[gcp] is installed '
                 'and the GCS connection exists.'.format(remote_conn_id, str(e))
             )
 

--- a/docs/howto/write-logs.rst
+++ b/docs/howto/write-logs.rst
@@ -121,7 +121,7 @@ example:
     remote_base_log_folder = gs://my-bucket/path/to/logs
     remote_log_conn_id = MyGCSConn
 
-#. Install the ``gcp_api`` package first, like so: ``pip install apache-airflow[gcp_api]``.
+#. Install the ``gcp`` package first, like so: ``pip install apache-airflow[gcp]``.
 #. Make sure a Google Cloud Platform connection hook has been defined in Airflow. The hook should have read and write access to the Google Cloud Storage bucket defined above in ``remote_base_log_folder``.
 #. Restart the Airflow webserver and scheduler, and trigger (or wait for) a new task execution.
 #. Verify that logs are showing up for newly executed tasks in the bucket you've defined.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,11 +27,11 @@ The easiest way to install the latest stable version of Airflow is with ``pip``:
 
     pip install apache-airflow
 
-You can also install Airflow with support for extra features like ``gcp_api`` or ``postgres``:
+You can also install Airflow with support for extra features like ``gcp`` or ``postgres``:
 
 .. code-block:: bash
 
-    pip install apache-airflow[postgres,gcp_api]
+    pip install apache-airflow[postgres,gcp]
 
 Extra Packages
 ''''''''''''''
@@ -72,8 +72,7 @@ Here's the list of the subpackages and what they enable:
 +---------------------+---------------------------------------------------+----------------------------------------------------------------------+
 | druid               | ``pip install apache-airflow[druid]``             | Druid related operators & hooks                                      |
 +---------------------+---------------------------------------------------+----------------------------------------------------------------------+
-| gcp_api             | ``pip install apache-airflow[gcp_api]``           | Google Cloud Platform hooks and operators                            |
-|                     |                                                   | (using ``google-api-python-client``)                                 |
+| gcp                 | ``pip install apache-airflow[gcp]``               | Google Cloud Platform                                                |
 +---------------------+---------------------------------------------------+----------------------------------------------------------------------+
 | github_enterprise   | ``pip install apache-airflow[github_enterprise]`` | Github Enterprise auth backend                                       |
 +---------------------+---------------------------------------------------+----------------------------------------------------------------------+

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ elasticsearch = [
     'elasticsearch>=5.0.0,<6.0.0',
     'elasticsearch-dsl>=5.0.0,<6.0.0'
 ]
-gcp_api = [
+gcp = [
     'httplib2>=0.9.2',
     'google-api-python-client>=1.6.0, <2.0.0dev',
     'google-auth>=1.0.0, <2.0.0dev',
@@ -258,7 +258,7 @@ if not PY3:
 devel_minreq = devel + kubernetes + mysql + doc + password + cgroups
 devel_hadoop = devel_minreq + hive + hdfs + webhdfs + kerberos
 devel_all = (sendgrid + devel + all_dbs + doc + samba + slack + crypto + oracle +
-             docker + ssh + kubernetes + celery + redis + gcp_api +
+             docker + ssh + kubernetes + celery + redis + gcp +
              datadog + zendesk + jdbc + ldap + kerberos + password + webhdfs + jenkins +
              druid + pinot + segment + snowflake + elasticsearch +
              atlas + azure + aws)
@@ -351,7 +351,8 @@ def do_setup():
             'docker': docker,
             'druid': druid,
             'elasticsearch': elasticsearch,
-            'gcp_api': gcp_api,
+            'gcp': gcp,
+            'gcp_api': gcp,  # TODO: remove this in Airflow 2.1
             'github_enterprise': github_enterprise,
             'google_auth': google_auth,
             'hdfs': hdfs,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3867
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

The names for packages for Azure and AWS have been standarized. Google Cloud Platform should follow this trend.

Idea reported by @ashb during the discussion under PR: #4524 

This PR passed an internal review at [Polidea](https://www.polidea.com/): https://github.com/PolideaInternal/airflow/pull/59 

CC: @kaxil, @jmcarp @potiuk It is simple, but it affects all users of GCP operators, so I'm asking for feedback. I feel obliged to inform you about this change.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
