### PR TITLE
[AIRFLOW-1814] : templatize PythonOperator op_args and op_kwargs fields

### DIFF
--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -49,10 +49,10 @@ class PythonOperator(BaseOperator):
     :type python_callable: python callable
     :param op_kwargs: a dictionary of keyword arguments that will get unpacked
         in your function
-    :type op_kwargs: dict
+    :type op_kwargs: dict (templated)
     :param op_args: a list of positional arguments that will get unpacked when
         calling your callable
-    :type op_args: list
+    :type op_args: list (templated)
     :param provide_context: if set to true, Airflow will pass a set of
         keyword arguments that can be used in your function. This set of
         kwargs correspond exactly to what you can use in your jinja
@@ -68,7 +68,7 @@ class PythonOperator(BaseOperator):
         processing templated fields, for examples ``['.sql', '.hql']``
     :type templates_exts: list[str]
     """
-    template_fields = ('templates_dict',)
+    template_fields = ('templates_dict', 'op_args', 'op_kwargs')
     template_ext = tuple()
     ui_color = '#ffefeb'
 

--- a/tests/operators/test_python_operator.py
+++ b/tests/operators/test_python_operator.py
@@ -53,6 +53,12 @@ class Call:
 
 
 def build_recording_function(calls_collection):
+    """
+    We can not use a Mock instance as a PythonOperator callable function or some tests fail with a
+    TypeError: Object of type Mock is not JSON serializable
+    Then using this custom function recording custom Call objects for further testing
+    (replacing Mock.assert_called_with assertion method)
+    """
     def recording_function(*args, **kwargs):
         calls_collection.append(Call(*args, **kwargs))
     return recording_function
@@ -138,6 +144,8 @@ class PythonOperatorTest(unittest.TestCase):
 
         task = PythonOperator(
             task_id='python_operator',
+            # a Mock instance cannot be used as a callable function or test fails with a
+            # TypeError: Object of type Mock is not JSON serializable
             python_callable=(build_recording_function(recorded_calls)),
             op_args=[
                 4,
@@ -168,6 +176,8 @@ class PythonOperatorTest(unittest.TestCase):
 
         task = PythonOperator(
             task_id='python_operator',
+            # a Mock instance cannot be used as a callable function or test fails with a
+            # TypeError: Object of type Mock is not JSON serializable
             python_callable=(build_recording_function(recorded_calls)),
             op_kwargs={
                 'an_int': 4,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira 1814](https://issues.apache.org/jira/browse/AIRFLOW-1814) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-1814
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes: 
   **See JIRA [AIRFLOW-1814](https://issues.apache.org/jira/browse/AIRFLOW-1814) description**

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   - `test_python_operator.test_python_callable_arguments_are_templatized`
   - `test_python_operator.test_python_callable_keyword_arguments_are_templatized`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
      **Docstring updated**

### Code Quality

- [x] Passes `flake8`
