### PR TITLE
[AIRFLOW-3869] Raise consistent exception in AirflowConfigParser.getboolean

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -269,7 +269,7 @@ class AirflowConfigParser(ConfigParser):
         elif val in ('f', 'false', '0'):
             return False
         else:
-            raise AirflowConfigException(
+            raise ValueError(
                 'The value for configuration option "{}:{}" is not a '
                 'boolean (received "{}").'.format(section, key, val))
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -185,6 +185,67 @@ key6 = value6
         self.assertEqual('cmd_result', cfg_dict['test']['key2'])
         self.assertNotIn('key2_cmd', cfg_dict['test'])
 
+    def test_getboolean(self):
+        """Test AirflowConfigParser.getboolean"""
+        TEST_CONFIG = """
+[type_validation]
+key1 = non_bool_value
+
+[true]
+key2 = t
+key3 = true
+key4 = 1
+
+[false]
+key5 = f
+key6 = false
+key7 = 0
+
+[inline-comment]
+key8 = true #123
+"""
+        test_conf = AirflowConfigParser(default_config=TEST_CONFIG)
+        with self.assertRaises(ValueError):
+            test_conf.getboolean('type_validation', 'key1')
+        self.assertTrue(isinstance(test_conf.getboolean('true', 'key3'), bool))
+        self.assertEqual(True, test_conf.getboolean('true', 'key2'))
+        self.assertEqual(True, test_conf.getboolean('true', 'key3'))
+        self.assertEqual(True, test_conf.getboolean('true', 'key4'))
+        self.assertEqual(False, test_conf.getboolean('false', 'key5'))
+        self.assertEqual(False, test_conf.getboolean('false', 'key6'))
+        self.assertEqual(False, test_conf.getboolean('false', 'key7'))
+        self.assertEqual(True, test_conf.getboolean('inline-comment', 'key8'))
+
+    def test_getint(self):
+        """Test AirflowConfigParser.getint"""
+        TEST_CONFIG = """
+[invalid]
+key1 = str
+
+[valid]
+key2 = 1
+"""
+        test_conf = AirflowConfigParser(default_config=TEST_CONFIG)
+        with self.assertRaises(ValueError):
+            test_conf.getint('invalid', 'key1')
+        self.assertTrue(isinstance(test_conf.getint('valid', 'key2'), int))
+        self.assertEqual(1, test_conf.getint('valid', 'key2'))
+
+    def test_getfloat(self):
+        """Test AirflowConfigParser.getfloat"""
+        TEST_CONFIG = """
+[invalid]
+key1 = str
+
+[valid]
+key2 = 1.23
+"""
+        test_conf = AirflowConfigParser(default_config=TEST_CONFIG)
+        with self.assertRaises(ValueError):
+            test_conf.getfloat('invalid', 'key1')
+        self.assertTrue(isinstance(test_conf.getfloat('valid', 'key2'), float))
+        self.assertEqual(1.23, test_conf.getfloat('valid', 'key2'))
+
     def test_remove_option(self):
         TEST_CONFIG = '''[test]
 key1 = hello


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3869
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

AirflowConfigParser.getboolean raises an AirflowConfigException when the value of a configuration cannot be converted to boolean. But, getint and getfloat raise a ValueError in the same case when the value cannot be casted to the desired type.
They should raise the same exception - ValueError.

Also, added tests for getboolean, getint and getfloat.


### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
1. test_getboolean
2. test_getint
3. test_getfloat
### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
