### PR TITLE
[AIRFLOW-3874] Improve BigQueryHook.run_with_configuration's location support

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1204,7 +1204,7 @@ class BigQueryBaseCursor(LoggingMixin):
         """
         jobs = self.service.jobs()
         job_data = {'configuration': configuration}
-        print(1)
+
         # Send query and wait for reply.
         query_reply = jobs \
             .insert(projectId=self.project_id, body=job_data) \
@@ -1214,7 +1214,6 @@ class BigQueryBaseCursor(LoggingMixin):
             location = query_reply['jobReference']['location']
         else:
             location = self.location
-        print(location)
 
         # Wait for query to finish.
         keep_polling_job = True

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1204,22 +1204,27 @@ class BigQueryBaseCursor(LoggingMixin):
         """
         jobs = self.service.jobs()
         job_data = {'configuration': configuration}
-
+        print(1)
         # Send query and wait for reply.
         query_reply = jobs \
             .insert(projectId=self.project_id, body=job_data) \
             .execute()
         self.running_job_id = query_reply['jobReference']['jobId']
+        if 'location' in query_reply['jobReference']:
+            location = query_reply['jobReference']['location']
+        else:
+            location = self.location
+        print(location)
 
         # Wait for query to finish.
         keep_polling_job = True
         while keep_polling_job:
             try:
-                if self.location:
+                if location:
                     job = jobs.get(
                         projectId=self.project_id,
                         jobId=self.running_job_id,
-                        location=self.location).execute()
+                        location=location).execute()
                 else:
                     job = jobs.get(
                         projectId=self.project_id,

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -823,5 +823,38 @@ class TestBigQueryHookLocation(unittest.TestCase):
             self.assertEqual(bq_cursor.location, 'US')
 
 
+class TestBigQueryHookRunWithConfiguration(unittest.TestCase):
+    def test_run_with_configuration_location(self):
+        project_id = 'bq-project'
+        running_job_id = 'job_vjdi28vskdui2onru23'
+        location = 'asia-east1'
+
+        mock_service = mock.Mock()
+        method = (mock_service.jobs.return_value.get)
+
+        mock_service.jobs.return_value.insert.return_value.execute.return_value = {
+            'jobReference': {
+                'jobId': running_job_id,
+                'location': location
+            }
+        }
+
+        mock_service.jobs.return_value.get.return_value.execute.return_value = {
+            'status': {
+                'state': 'DONE'
+            }
+        }
+
+        cursor = hook.BigQueryBaseCursor(mock_service, project_id)
+        cursor.running_job_id = running_job_id
+        cursor.run_with_configuration({})
+
+        method.assert_called_once_with(
+            projectId=project_id,
+            jobId=running_job_id,
+            location=location
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
BigQueryHook.run_with_configuration creates a new job and receives a response with location field. It should use that field for the keep_polling_job loop. Otherwise, it returns 404 job not found if the location is not US or EU.

After inserting new job and get the resp of the job details, it should retrieve the location and use it for the jobs.get request.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-3874](https://issues.apache.org/jira/browse/AIRFLOW-3874) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
test_bigquery_hook.py::TestBigQueryHookRunWithConfiguration

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
