### PR TITLE
[AIRFLOW-3881] Correct to_csv row number

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -908,7 +908,7 @@ class HiveServer2Hook(BaseHook):
                     self.log.debug('Cursor description is %s', header)
                     writer.writerow([c[0] for c in header])
 
-                for i, row in enumerate(results_iter):
+                for i, row in enumerate(results_iter, 1):
                     writer.writerow(row)
                     if i % fetch_size == 0:
                         self.log.info("Written %s rows so far.", i)

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -21,6 +21,7 @@
 import datetime
 import itertools
 import os
+import sys
 import random
 import unittest
 from collections import OrderedDict
@@ -43,6 +44,7 @@ configuration.load_test_config()
 DEFAULT_DATE = timezone.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
 DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
+NOT_ASSERTLOGS_VERSION = sys.version_info.major + sys.version_info.minor / 10
 
 
 class HiveEnvironmentTest(unittest.TestCase):
@@ -451,7 +453,8 @@ class TestHiveServer2Hook(unittest.TestCase):
         results = hook.get_results(query, schema=self.database)
         self.assertListEqual(results['data'], [(1, 1), (2, 2)])
 
-    def test_to_csv(self):
+    @unittest.skipIf(NOT_ASSERTLOGS_VERSION < 3.4, 'assertLogs not support before python 3.4')
+    def test_to_csv_assertLogs(self):
         hook = HiveServer2Hook()
         query = "SELECT * FROM {}".format(self.table)
         csv_filepath = 'query_results.csv'
@@ -464,6 +467,18 @@ class TestHiveServer2Hook(unittest.TestCase):
             self.assertEqual(len(df), 2)
             self.assertIn('INFO:airflow.hooks.hive_hooks.HiveServer2Hook:'
                           'Written 2 rows so far.', cm.output)
+
+    @unittest.skipIf(NOT_ASSERTLOGS_VERSION >= 3.4, 'test could cover by test_to_csv_assertLogs')
+    def test_to_csv(self):
+        hook = HiveServer2Hook()
+        query = "SELECT * FROM {}".format(self.table)
+        csv_filepath = 'query_results.csv'
+        hook.to_csv(query, csv_filepath, schema=self.database,
+                    delimiter=',', lineterminator='\n', output_header=True, fetch_size=2)
+        df = pd.read_csv(csv_filepath, sep=',')
+        self.assertListEqual(df.columns.tolist(), self.columns)
+        self.assertListEqual(df[self.columns[0]].values.tolist(), [1, 2])
+        self.assertEqual(len(df), 2)
 
     def test_multi_statements(self):
         sqls = [

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -21,8 +21,8 @@
 import datetime
 import itertools
 import os
-import sys
 import random
+import sys
 import unittest
 from collections import OrderedDict
 
@@ -39,7 +39,6 @@ from airflow.utils.operator_helpers import AIRFLOW_VAR_NAME_FORMAT_MAPPING
 from airflow.utils.tests import assertEqualIgnoreMultipleSpaces
 
 configuration.load_test_config()
-
 
 DEFAULT_DATE = timezone.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
@@ -454,7 +453,7 @@ class TestHiveServer2Hook(unittest.TestCase):
         self.assertListEqual(results['data'], [(1, 1), (2, 2)])
 
     @unittest.skipIf(NOT_ASSERTLOGS_VERSION < 3.4, 'assertLogs not support before python 3.4')
-    def test_to_csv_assertLogs(self):
+    def test_to_csv_assertlogs(self):
         hook = HiveServer2Hook()
         query = "SELECT * FROM {}".format(self.table)
         csv_filepath = 'query_results.csv'
@@ -469,12 +468,12 @@ class TestHiveServer2Hook(unittest.TestCase):
                           'Written 2 rows so far.', cm.output)
 
     @unittest.skipIf(NOT_ASSERTLOGS_VERSION >= 3.4, 'test could cover by test_to_csv_assertLogs')
-    def test_to_csv(self):
+    def test_to_csv_without_assertlogs(self):
         hook = HiveServer2Hook()
         query = "SELECT * FROM {}".format(self.table)
         csv_filepath = 'query_results.csv'
         hook.to_csv(query, csv_filepath, schema=self.database,
-                    delimiter=',', lineterminator='\n', output_header=True, fetch_size=2)
+                    delimiter=',', lineterminator='\n', output_header=True)
         df = pd.read_csv(csv_filepath, sep=',')
         self.assertListEqual(df.columns.tolist(), self.columns)
         self.assertListEqual(df[self.columns[0]].values.tolist(), [1, 2])

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -455,15 +455,15 @@ class TestHiveServer2Hook(unittest.TestCase):
         hook = HiveServer2Hook()
         query = "SELECT * FROM {}".format(self.table)
         csv_filepath = 'query_results.csv'
-        with self.assertLogs(LoggingMixin().log, level='INFO') as cm:
+        with self.assertLogs() as cm:
             hook.to_csv(query, csv_filepath, schema=self.database,
                         delimiter=',', lineterminator='\n', output_header=True, fetch_size=2)
             df = pd.read_csv(csv_filepath, sep=',')
             self.assertListEqual(df.columns.tolist(), self.columns)
             self.assertListEqual(df[self.columns[0]].values.tolist(), [1, 2])
             self.assertEqual(len(df), 2)
-            self.assertIn('INFO:airflow.hooks.hive_hooks.HiveServer2Hook:'
-                          'Written 2 rows so far.', cm.output)
+            self.assertIn('airflow.hooks.hive_hooks.HiveServer2Hook: '
+                          'INFO: Written 2 rows so far.', cm.output)
 
     def test_multi_statements(self):
         sqls = [

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -29,7 +29,7 @@ import mock
 import pandas as pd
 from hmsclient import HMSClient
 
-from airflow import DAG, configuration, LoggingMixin
+from airflow import DAG, configuration
 from airflow.exceptions import AirflowException
 from airflow.hooks.hive_hooks import HiveCliHook, HiveMetastoreHook, HiveServer2Hook
 from airflow.operators.hive_operator import HiveOperator

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -462,8 +462,8 @@ class TestHiveServer2Hook(unittest.TestCase):
             self.assertListEqual(df.columns.tolist(), self.columns)
             self.assertListEqual(df[self.columns[0]].values.tolist(), [1, 2])
             self.assertEqual(len(df), 2)
-            self.assertIn('airflow.hooks.hive_hooks.HiveServer2Hook: '
-                          'INFO: Written 2 rows so far.', cm.output)
+            self.assertIn('INFO:airflow.hooks.hive_hooks.HiveServer2Hook:'
+                          'Written 2 rows so far.', cm.output)
 
     def test_multi_statements(self):
         sqls = [

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -455,12 +455,14 @@ class TestHiveServer2Hook(unittest.TestCase):
         hook = HiveServer2Hook()
         query = "SELECT * FROM {}".format(self.table)
         csv_filepath = 'query_results.csv'
-        hook.to_csv(query, csv_filepath, schema=self.database,
-                    delimiter=',', lineterminator='\n', output_header=True)
-        df = pd.read_csv(csv_filepath, sep=',')
-        self.assertListEqual(df.columns.tolist(), self.columns)
-        self.assertListEqual(df[self.columns[0]].values.tolist(), [1, 2])
-        self.assertEqual(len(df), 2)
+        with self.assertLogs() as cm:
+            hook.to_csv(query, csv_filepath, schema=self.database,
+                        delimiter=',', lineterminator='\n', output_header=True)
+            df = pd.read_csv(csv_filepath, sep=',')
+            self.assertListEqual(df.columns.tolist(), self.columns)
+            self.assertListEqual(df[self.columns[0]].values.tolist(), [1, 2])
+            self.assertEqual(len(df), 2)
+            self.assertIn('Written %s rows so far.', cm.output)
 
     def test_multi_statements(self):
         sqls = [


### PR DESCRIPTION
Correct row number each patch write log

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3881

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Correct hive_hooks to_csv function row number while logging.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

minor change, existing test could test it.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
