### PR TITLE
[AIRFLOW-3884] Fixing doc checker, no warnings allowed anymore and fixed the current…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -941,7 +941,7 @@ Airflow 1.10.0, 2018-08-03
 - [AIRFLOW-1688] Support load.time_partitioning in bigquery_hook
 - [AIRFLOW-1975] Make TriggerDagRunOperator callback optional
 - [AIRFLOW-1480] Render template attributes for ExternalTaskSensor fields
-- [AIRFLOW-1958] Add **kwargs to send_email
+- [AIRFLOW-1958] Add kwargs to send_email
 - [AIRFLOW-1976] Fix for missing log/logger attribute FileProcessHandler
 - [AIRFLOW-1982] Fix Executor event log formatting
 - [AIRFLOW-1971] Propagate hive config on impersonation
@@ -2167,7 +2167,7 @@ Airflow 1.7.1, 2016-05-19
 - Show only Airflow's deprecation warnings
 - Set DAG_FOLDER for unit tests
 - Missing comma in setup.py
-- Deprecate *args and **kwargs in BaseOperator
+- Deprecate args and kwargs in BaseOperator
 - Raise deep scheduler exceptions to force a process restart.
 - Change inconsistent example DAG owners
 - Fix module path of send_email_smtp in configuration

--- a/airflow/contrib/executors/mesos_executor.py
+++ b/airflow/contrib/executors/mesos_executor.py
@@ -19,9 +19,6 @@
 
 from future import standard_library
 
-from airflow.utils.log.logging_mixin import LoggingMixin
-
-
 from builtins import str
 from queue import Queue
 

--- a/airflow/contrib/executors/mesos_executor.py
+++ b/airflow/contrib/executors/mesos_executor.py
@@ -20,7 +20,6 @@
 from future import standard_library
 
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.www.utils import LoginMixin
 
 
 from builtins import str
@@ -49,7 +48,7 @@ def get_framework_name():
 
 # AirflowMesosScheduler, implements Mesos Scheduler interface
 # To schedule airflow jobs on mesos
-class AirflowMesosScheduler(mesos.interface.Scheduler, LoggingMixin):
+class AirflowMesosScheduler(mesos.interface.Scheduler):
     """
     Airflow Mesos scheduler implements mesos scheduler interface
     to schedule airflow tasks on mesos.
@@ -213,7 +212,7 @@ class AirflowMesosScheduler(mesos.interface.Scheduler, LoggingMixin):
             self.task_queue.task_done()
 
 
-class MesosExecutor(BaseExecutor, LoginMixin):
+class MesosExecutor(BaseExecutor):
     """
     MesosExecutor allows distributing the execution of task
     instances to multiple mesos workers.

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -2942,9 +2942,7 @@ class DAG(BaseDag, LoggingMixin):
     :param on_success_callback: Much like the ``on_failure_callback`` except
         that it is executed when the dag succeeds.
     :type on_success_callback: callable
-    :param access_control: Specify optional DAG-level permissions, e.g.,
-        {'role1': {'can_dag_read'},
-         'role2': {'can_dag_read', 'can_dag_edit'}}
+    :param access_control: Specify optional DAG-level permissions, e.g., {'role1': {'can_dag_read'}, 'role2': {'can_dag_read', 'can_dag_edit'}}
     :type access_control: dict
     """
 

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -2942,7 +2942,8 @@ class DAG(BaseDag, LoggingMixin):
     :param on_success_callback: Much like the ``on_failure_callback`` except
         that it is executed when the dag succeeds.
     :type on_success_callback: callable
-    :param access_control: Specify optional DAG-level permissions, e.g., {'role1': {'can_dag_read'}, 'role2': {'can_dag_read', 'can_dag_edit'}}
+    :param access_control: Specify optional DAG-level permissions, e.g.,
+        "{'role1': {'can_dag_read'}, 'role2': {'can_dag_read', 'can_dag_edit'}}"
     :type access_control: dict
     """
 

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -25,17 +25,18 @@ cd "$FWDIR"
 
 [ -d _build ] && rm -r _build
 
-NUM_IGNORED_WARNINGS=4
-NUM_CURRENT_WARNINGS=$(make html |\
+SUCCEED_LINE=$(make html |\
     tee /dev/tty |\
     grep 'build succeeded' |\
-    head -1 |\
-    sed -E 's/build succeeded, ([0-9]+) warnings\./\1/g')
+    head -1)
 
-if [ "${NUM_CURRENT_WARNINGS}" != "${NUM_IGNORED_WARNINGS}" ]; then
+NUM_CURRENT_WARNINGS=$(echo $SUCCEED_LINE |\
+    sed -E 's/build succeeded, ([0-9]+) warnings?\./\1/g')
+
+if echo $SUCCEED_LINE | grep -q "warning"; then
     echo
     echo "Unexpected problems found in the documentation. "
-    echo "Currently, ${NUM_IGNORED_WARNINGS} warnings are ignored."
+    echo "Currently, ${NUM_CURRENT_WARNINGS} warnings found"
     echo
     exit 1
 fi


### PR DESCRIPTION
… warnings

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3884

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`