### PR TITLE
[AIRFLOW-XXX] Pin pinodb dependency to fix the existing issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -207,7 +207,7 @@ password = [
     'bcrypt>=2.0.0',
     'flask-bcrypt>=0.7.1',
 ]
-pinot = ['pinotdb>=0.1.1']
+pinot = ['pinotdb==0.1.1']
 postgres = ['psycopg2>=2.7.4']
 qds = ['qds-sdk>=1.10.4']
 rabbitmq = ['librabbitmq>=1.6.1']


### PR DESCRIPTION
pinodb 0.2.2 has a breaking change which breaks the unit test. Pin the dependency for now.

```======================================================================
47) ERROR: Failure: SyntaxError (invalid syntax (db.py, line 41))
----------------------------------------------------------------------
   Traceback (most recent call last):
    .tox/py27-backend_mysql-env_docker/lib/python2.7/site-packages/nose/loader.py line 418 in loadTestsFromName
      addr.filename, addr.module)
    .tox/py27-backend_mysql-env_docker/lib/python2.7/site-packages/nose/importer.py line 47 in importFromPath
      return self.importFromDir(dir_path, fqname)
    .tox/py27-backend_mysql-env_docker/lib/python2.7/site-packages/nose/importer.py line 94 in importFromDir
      mod = load_module(part_fqname, fh, filename, desc)
    tests/contrib/hooks/test_pinot_hook.py line 24 in <module>
      from airflow.contrib.hooks.pinot_hook import PinotDbApiHook
    airflow/contrib/hooks/pinot_hook.py line 22 in <module>
      from pinotdb import connect
    .tox/py27-backend_mysql-env_docker/lib/python2.7/site-packages/pinotdb/__init__.py line 1 in <module>
      from pinotdb.db import connect
   SyntaxError: invalid syntax (db.py, line 41)```