### PR TITLE
[AIRFLOW-XXX] Add note about plugin docs

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -97,6 +97,14 @@ looks like:
         appbuilder_views = []
         # A list of dictionaries containing FlaskAppBuilder BaseView object and some metadata. See example below
         appbuilder_menu_items = []
+        # A callback to perform actions when airflow starts and the plugin is loaded.
+        # NOTE: Ensure your plugin has *args, and **kwargs in the method definition
+        #   to protect against extra parameters injected into the on_load(...)
+        #   function in future changes
+        def on_load(*args, **kwargs):
+           # ... perform Plugin boot actions
+           pass
+
 
 
 
@@ -232,7 +240,7 @@ It is possible to load plugins via `setuptools entrypoint <https://packaging.pyt
 your plugin using an entrypoint in your package. If the package is installed, airflow
 will automatically load the registered plugins from the entrypoint list.
 
-.. note:: 
+.. note::
     Neither the entrypoint name (eg, `my_plugin`) nor the name of the
     plugin class will contribute towards the module and class name of the plugin
     itself. The structure is determined by


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Added a note about the plugin infrastructure which is already implemented.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Documentation update

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

Change is documentation

### Code Quality

- [x] Passes `flake8`
