### PR TITLE
[AIRFLOW-3619] Improve flake8 excludes without excluding requirements.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length = 110
 ignore = E731,W504
+exclude = .git, env, venv, .venv, VENV, ENV, .tox, .eggs, build, sdist, wheels, develop-eggs

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -55,8 +55,6 @@ class AirflowRescheduleException(AirflowException):
     :type reschedule: datetime.datetime
     """
     def __init__(self, reschedule_date):
-
-        
         self.reschedule_date = reschedule_date
 
 

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -55,6 +55,8 @@ class AirflowRescheduleException(AirflowException):
     :type reschedule: datetime.datetime
     """
     def __init__(self, reschedule_date):
+
+        
         self.reschedule_date = reschedule_date
 
 


### PR DESCRIPTION
## Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:

Update the flake8 excludes

### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

We can verify the flake8 excludes with these three CI results:
1) Create new flake8 excludes (pass CI) - https://travis-ci.org/holdenk/incubator-airflow/builds/493380756 
2) Create a style violation (fail CI in branch) - https://travis-ci.org/holdenk/incubator-airflow/builds/493385836
3) Fix style violation (pass CI in branch) - https://travis-ci.org/holdenk/incubator-airflow/builds/493386468 

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

There's 3 commits so it's clear the passing/failing of CI status

### Documentation

- [ X ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

No change in usage required

### Code Quality

- [ ] Passes `flake8`
