### PR TITLE
[AIRFLOW-3894] unstructured connection to webhdfs

### DIFF
--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -98,7 +98,7 @@ class BaseHook(LoggingMixin):
             for i in range(len(conn_tmp) - 1):
                 conn = conn + conn_id + conn_tmp[i] + ':' + conn_port + ';'
                 if i == len(conn_tmp) - 2:
-                   conn = conn + conn_id + conn_tmp[i + 1] + ':' + conn_port
+                    conn = conn + conn_id + conn_tmp[i + 1] + ':' + conn_port
         return conn
 
     def get_conn(self):

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -88,6 +88,19 @@ class BaseHook(LoggingMixin):
         connection = cls.get_connection(conn_id)
         return connection.get_hook()
 
+    @classmethod
+    def connection_url(cls, conn_id, conn_url, conn_port):
+        conn = 
+        conn_tmp = conn_url.split(';')
+        if len(conn_tmp) == 1:
+            conn = conn_id + conn_tmp[0] + ':' + conn_port
+        else:
+            for i in range(len(conn_tmp)-1):
+                conn = conn + conn_id + conn_tmp[i] + ':' +  conn_port + ';'
+                if i == len(conn_tmp)-2:
+                   conn = conn + conn_id + conn_tmp[i+1] + ':' + conn_port
+        return conn
+    
     def get_conn(self):
         raise NotImplementedError()
 

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -87,19 +87,6 @@ class BaseHook(LoggingMixin):
     def get_hook(cls, conn_id):
         connection = cls.get_connection(conn_id)
         return connection.get_hook()
-
-    @classmethod
-    def connection_url(cls, conn_id, conn_url, conn_port):
-        conn = 
-        conn_tmp = conn_url.split(';')
-        if len(conn_tmp) == 1:
-            conn = conn_id + conn_tmp[0] + ':' + conn_port
-        else:
-            for i in range(len(conn_tmp)-1):
-                conn = conn + conn_id + conn_tmp[i] + ':' +  conn_port + ';'
-                if i == len(conn_tmp)-2:
-                   conn = conn + conn_id + conn_tmp[i+1] + ':' + conn_port
-        return conn
     
     def get_conn(self):
         raise NotImplementedError()

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -95,13 +95,12 @@ class BaseHook(LoggingMixin):
         if len(conn_tmp) == 1:
             conn = conn_id + conn_tmp[0] + ':' + conn_port
         else:
-            for i in range(len(conn_tmp)-1):
-                conn = conn + conn_id + conn_tmp[i] + ':' +  conn_port + ';'
-                if i == len(conn_tmp)-2:
-                   conn = conn + conn_id + conn_tmp[i+1] + ':' + conn_port
+            for i in range(len(conn_tmp) - 1):
+                conn = conn + conn_id + conn_tmp[i] + ':' + conn_port + ';'
+                if i == len(conn_tmp) - 2:
+                   conn = conn + conn_id + conn_tmp[i + 1] + ':' + conn_port
         return conn
 
-    
     def get_conn(self):
         raise NotImplementedError()
 

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -90,7 +90,7 @@ class BaseHook(LoggingMixin):
 
     @classmethod
     def connection_url(cls, conn_id, conn_url, conn_port):
-        conn = 
+        conn = ''
         conn_tmp = conn_url.split(';')
         if len(conn_tmp) == 1:
             conn = conn_id + conn_tmp[0] + ':' + conn_port

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -87,6 +87,20 @@ class BaseHook(LoggingMixin):
     def get_hook(cls, conn_id):
         connection = cls.get_connection(conn_id)
         return connection.get_hook()
+
+    @classmethod
+    def connection_url(cls, conn_id, conn_url, conn_port):
+        conn = 
+        conn_tmp = conn_url.split(';')
+        if len(conn_tmp) == 1:
+            conn = conn_id + conn_tmp[0] + ':' + conn_port
+        else:
+            for i in range(len(conn_tmp)-1):
+                conn = conn + conn_id + conn_tmp[i] + ':' +  conn_port + ';'
+                if i == len(conn_tmp)-2:
+                   conn = conn + conn_id + conn_tmp[i+1] + ':' + conn_port
+        return conn
+
     
     def get_conn(self):
         raise NotImplementedError()

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -24,8 +24,6 @@ import os
 import re
 import subprocess
 import time
-import socket
-import logging
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile
 

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -24,6 +24,8 @@ import os
 import re
 import subprocess
 import time
+import socket
+import logging
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile
 
@@ -495,37 +497,49 @@ class HiveMetastoreHook(BaseHook):
         """
         Returns a Hive thrift client.
         """
-        import hmsclient
         from thrift.transport import TSocket, TTransport
         from thrift.protocol import TBinaryProtocol
+        result = 1
         ms = self.metastore_conn
         auth_mechanism = ms.extra_dejson.get('authMechanism', 'NOSASL')
         if configuration.conf.get('core', 'security') == 'kerberos':
             auth_mechanism = ms.extra_dejson.get('authMechanism', 'GSSAPI')
             kerberos_service_name = ms.extra_dejson.get('kerberos_service_name', 'hive')
-
-        socket = TSocket.TSocket(ms.host, ms.port)
+        hosts_list = ms.host.split(';') #split by semicolon
+        for host_name in range(len(hosts_list)):
+            host_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            logging.info("Trying to connect to " + hosts_list[host_name])
+            try:
+                result = host_socket.connect_ex((hosts_list[host_name], ms.port))
+                host_socket.close()
+            except Exception:
+                pass
+            if result == 0:
+                logging.info('Connected to ' + hosts_list[host_name] + ':' + str(ms.port))
+                conn_url = hosts_list[host_name]
+                break
+        conn_socket = TSocket.TSocket(conn_url, ms.port)
         if configuration.conf.get('core', 'security') == 'kerberos' \
                 and auth_mechanism == 'GSSAPI':
             try:
                 import saslwrapper as sasl
             except ImportError:
                 import sasl
-
+ 
             def sasl_factory():
                 sasl_client = sasl.Client()
-                sasl_client.setAttr("host", ms.host)
+                sasl_client.setAttr("host", conn_url)
                 sasl_client.setAttr("service", kerberos_service_name)
                 sasl_client.init()
                 return sasl_client
-
+ 
             from thrift_sasl import TSaslClientTransport
-            transport = TSaslClientTransport(sasl_factory, "GSSAPI", socket)
+            transport = TSaslClientTransport(sasl_factory, "GSSAPI", conn_socket)
         else:
-            transport = TTransport.TBufferedTransport(socket)
-
+            transport = TTransport.TBufferedTransport(conn_socket)
+ 
         protocol = TBinaryProtocol.TBinaryProtocol(transport)
-
+ 
         return hmsclient.HMSClient(iprot=protocol)
 
     def get_conn(self):

--- a/airflow/hooks/webhdfs_hook.py
+++ b/airflow/hooks/webhdfs_hook.py
@@ -56,8 +56,8 @@ class WebHDFSHook(BaseHook):
             try:
                 self.log.debug('Trying namenode %s', nn.host)
                 connection_str = self.connection_url('http://',
-                    '{nn.host}'.format(nn=nn),
-                    '{nn.port}'.format(nn=nn))
+                                '{nn.host}'.format(nn=nn),
+                                '{nn.port}'.format(nn=nn))
                 self.log.debug("Connection to WebHDFS: %s", connection_str)
                 if _kerberos_security_mode:
                     client = KerberosClient(connection_str)
@@ -65,8 +65,10 @@ class WebHDFSHook(BaseHook):
                     proxy_user = self.proxy_user or nn.login
                     client = InsecureClient(connection_str, user=proxy_user)
                 client.status('/')
-                self.log.debug('Using namenode %s for hook',
-                                nn.host)
+                self.log.debug(
+                    'Using namenode %s for hook',
+                    nn.host
+                )
                 return client
             except HdfsError as e:
                 self.log.debug(

--- a/airflow/hooks/webhdfs_hook.py
+++ b/airflow/hooks/webhdfs_hook.py
@@ -57,8 +57,8 @@ class WebHDFSHook(BaseHook):
                 self.log.debug('Trying namenode %s', nn.host)
                 connection_str = self.connection_url(
                     'http://',
-                    '{nn.host}'.format(nn=nn),
-                    '{nn.port}'.format(nn=nn)
+                    nn.host,
+                    nn.port
                 )
                 self.log.debug("Connection to WebHDFS: %s", connection_str)
                 if _kerberos_security_mode:

--- a/airflow/hooks/webhdfs_hook.py
+++ b/airflow/hooks/webhdfs_hook.py
@@ -55,7 +55,8 @@ class WebHDFSHook(BaseHook):
         for nn in nn_connections:
             try:
                 self.log.debug('Trying namenode %s', nn.host)
-                connection_str = 'http://{nn.host}:{nn.port}'.format(nn=nn)
+                connection_str = self.connection_url('http://', '{nn.host}'.format(nn=nn), '{nn.port}'.format(nn=nn))
+                logging.info(connection_str)
                 if _kerberos_security_mode:
                     client = KerberosClient(connection_str)
                 else:
@@ -67,12 +68,14 @@ class WebHDFSHook(BaseHook):
             except HdfsError as e:
                 self.log.debug(
                     "Read operation on namenode {nn.host} "
-                    "failed with error: {e}".format(nn=nn, e=e)
+                    "failed with error: {e}".format(**locals())
                 )
         nn_hosts = [c.host for c in nn_connections]
+        logging.info(nn_host)
         no_nn_error = "Read operations failed " \
                       "on the namenodes below:\n{}".format("\n".join(nn_hosts))
         raise AirflowWebHDFSHookException(no_nn_error)
+
 
     def check_for_path(self, hdfs_path):
         """

--- a/airflow/hooks/webhdfs_hook.py
+++ b/airflow/hooks/webhdfs_hook.py
@@ -47,6 +47,14 @@ class WebHDFSHook(BaseHook):
         self.webhdfs_conn_id = webhdfs_conn_id
         self.proxy_user = proxy_user
 
+class WebHDFSHook(BaseHook):
+    """
+    Interact with HDFS. This class is a wrapper around the hdfscli library.
+    """
+    def __init__(self, webhdfs_conn_id='webhdfs_default', proxy_user=None):
+        self.webhdfs_conn_id = webhdfs_conn_id
+        self.proxy_user = proxy_user
+
     def get_conn(self):
         """
         Returns a hdfscli InsecureClient object.
@@ -55,7 +63,9 @@ class WebHDFSHook(BaseHook):
         for nn in nn_connections:
             try:
                 self.log.debug('Trying namenode %s', nn.host)
-                connection_str = 'http://{nn.host}:{nn.port}'.format(nn=nn)
+                #connection_str = 'httpl://{nn.host}:'.format(nn=nn):{nn.port}.format(nn=nn)'
+                connection_str = self.connection_url('http://', '{nn.host}'.format(nn=nn), '{nn.port}'.format(nn=nn))
+                logging.info(connection_str)
                 if _kerberos_security_mode:
                     client = KerberosClient(connection_str)
                 else:
@@ -67,9 +77,10 @@ class WebHDFSHook(BaseHook):
             except HdfsError as e:
                 self.log.debug(
                     "Read operation on namenode {nn.host} "
-                    "failed with error: {e}".format(nn=nn, e=e)
+                    "failed with error: {e}".format(**locals())
                 )
         nn_hosts = [c.host for c in nn_connections]
+        logging.info(nn_host)
         no_nn_error = "Read operations failed " \
                       "on the namenodes below:\n{}".format("\n".join(nn_hosts))
         raise AirflowWebHDFSHookException(no_nn_error)

--- a/airflow/hooks/webhdfs_hook.py
+++ b/airflow/hooks/webhdfs_hook.py
@@ -55,8 +55,7 @@ class WebHDFSHook(BaseHook):
         for nn in nn_connections:
             try:
                 self.log.debug('Trying namenode %s', nn.host)
-                connection_str = self.connection_url('http://', '{nn.host}'.format(nn=nn), '{nn.port}'.format(nn=nn))
-                logging.info(connection_str)
+                connection_str = 'http://{nn.host}:{nn.port}'.format(nn=nn)
                 if _kerberos_security_mode:
                     client = KerberosClient(connection_str)
                 else:
@@ -68,14 +67,12 @@ class WebHDFSHook(BaseHook):
             except HdfsError as e:
                 self.log.debug(
                     "Read operation on namenode {nn.host} "
-                    "failed with error: {e}".format(**locals())
+                    "failed with error: {e}".format(nn=nn, e=e)
                 )
         nn_hosts = [c.host for c in nn_connections]
-        logging.info(nn_host)
         no_nn_error = "Read operations failed " \
                       "on the namenodes below:\n{}".format("\n".join(nn_hosts))
         raise AirflowWebHDFSHookException(no_nn_error)
-
 
     def check_for_path(self, hdfs_path):
         """

--- a/airflow/hooks/webhdfs_hook.py
+++ b/airflow/hooks/webhdfs_hook.py
@@ -55,7 +55,9 @@ class WebHDFSHook(BaseHook):
         for nn in nn_connections:
             try:
                 self.log.debug('Trying namenode %s', nn.host)
-                connection_str = self.connection_url('http://', '{nn.host}'.format(nn=nn), '{nn.port}'.format(nn=nn))
+                connection_str = self.connection_url('http://',
+                    '{nn.host}'.format(nn=nn),
+                    '{nn.port}'.format(nn=nn))
                 self.log.debug("Connection to WebHDFS: %s", connection_str)
                 if _kerberos_security_mode:
                     client = KerberosClient(connection_str)

--- a/airflow/hooks/webhdfs_hook.py
+++ b/airflow/hooks/webhdfs_hook.py
@@ -49,7 +49,7 @@ class WebHDFSHook(BaseHook):
 
 class WebHDFSHook(BaseHook):
     """
-    Interact with HDFS. This class is a wrapper around the hdfscli library.
+    Interact with WebHDFS. This class is a wrapper around the hdfscli library.
     """
     def __init__(self, webhdfs_conn_id='webhdfs_default', proxy_user=None):
         self.webhdfs_conn_id = webhdfs_conn_id
@@ -63,9 +63,8 @@ class WebHDFSHook(BaseHook):
         for nn in nn_connections:
             try:
                 self.log.debug('Trying namenode %s', nn.host)
-                #connection_str = 'httpl://{nn.host}:'.format(nn=nn):{nn.port}.format(nn=nn)'
                 connection_str = self.connection_url('http://', '{nn.host}'.format(nn=nn), '{nn.port}'.format(nn=nn))
-                logging.info(connection_str)
+                self.log.debug("Connection to WebHDFS: %s", connection_str)
                 if _kerberos_security_mode:
                     client = KerberosClient(connection_str)
                 else:
@@ -77,10 +76,9 @@ class WebHDFSHook(BaseHook):
             except HdfsError as e:
                 self.log.debug(
                     "Read operation on namenode {nn.host} "
-                    "failed with error: {e}".format(**locals())
+                    "failed with error: {e}".format(nn=nn, e=e)
                 )
         nn_hosts = [c.host for c in nn_connections]
-        logging.info(nn_host)
         no_nn_error = "Read operations failed " \
                       "on the namenodes below:\n{}".format("\n".join(nn_hosts))
         raise AirflowWebHDFSHookException(no_nn_error)

--- a/airflow/hooks/webhdfs_hook.py
+++ b/airflow/hooks/webhdfs_hook.py
@@ -41,14 +41,6 @@ class AirflowWebHDFSHookException(AirflowException):
 
 class WebHDFSHook(BaseHook):
     """
-    Interact with HDFS. This class is a wrapper around the hdfscli library.
-    """
-    def __init__(self, webhdfs_conn_id='webhdfs_default', proxy_user=None):
-        self.webhdfs_conn_id = webhdfs_conn_id
-        self.proxy_user = proxy_user
-
-class WebHDFSHook(BaseHook):
-    """
     Interact with WebHDFS. This class is a wrapper around the hdfscli library.
     """
     def __init__(self, webhdfs_conn_id='webhdfs_default', proxy_user=None):
@@ -71,7 +63,8 @@ class WebHDFSHook(BaseHook):
                     proxy_user = self.proxy_user or nn.login
                     client = InsecureClient(connection_str, user=proxy_user)
                 client.status('/')
-                self.log.debug('Using namenode %s for hook', nn.host)
+                self.log.debug('Using namenode %s for hook',
+                                nn.host)
                 return client
             except HdfsError as e:
                 self.log.debug(

--- a/airflow/hooks/webhdfs_hook.py
+++ b/airflow/hooks/webhdfs_hook.py
@@ -55,9 +55,11 @@ class WebHDFSHook(BaseHook):
         for nn in nn_connections:
             try:
                 self.log.debug('Trying namenode %s', nn.host)
-                connection_str = self.connection_url('http://',
-                                '{nn.host}'.format(nn=nn),
-                                '{nn.port}'.format(nn=nn))
+                connection_str = self.connection_url(
+                    'http://',
+                    '{nn.host}'.format(nn=nn),
+                    '{nn.port}'.format(nn=nn)
+                )
                 self.log.debug("Connection to WebHDFS: %s", connection_str)
                 if _kerberos_security_mode:
                     client = KerberosClient(connection_str)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

https://issues.apache.org/jira/browse/AIRFLOW-3894

### Description

Therefore in the BaseHook class we introduced a new function that divides each of the namenodes after a semicolon, and then adds a prefix and port to each host.
This function is called from webhdfs_hook.py using the following parameters: prefix (https://), host and port.
It is also possible to expand this function, i.e. to receive a separator.