### PR TITLE
[AIRFLOW-3896] Add running command logging back to SSHOperator

### DIFF
--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -99,6 +99,8 @@ class SSHOperator(BaseOperator):
                 if self.command.startswith('sudo'):
                     get_pty = True
 
+                self.logger.info("Running command: {0}".format(self.command))
+
                 # set timeout taken as params
                 stdin, stdout, stderr = ssh_client.exec_command(command=self.command,
                                                                 get_pty=get_pty,

--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -99,7 +99,7 @@ class SSHOperator(BaseOperator):
                 if self.command.startswith('sudo'):
                     get_pty = True
 
-                self.logger.info("Running command: {0}".format(self.command))
+                self.log.info("Running command: %s", self.command)
 
                 # set timeout taken as params
                 stdin, stdout, stderr = ssh_client.exec_command(command=self.command,


### PR DESCRIPTION
Add the SSH command logging back to SSHOperator


Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-3896](https://issues.apache.org/jira/browse/AIRFLOW-3896) issues and references them in the PR title. 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Until v1.8.2, the [SSHExecuteOperator](https://github.com/apache/airflow/blob/1.8.2/airflow/contrib/operators/ssh_execute_operator.py#L131) was able to log the running bash command.

But since v1.9.0, that logging code has been removed from [SSHOperator](https://github.com/apache/airflow/blob/1.9.0/airflow/contrib/operators/ssh_operator.py).

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"


### Code Quality

- [x] Passes `flake8`
