### PR TITLE
[AIRFLOW-3895] GoogleCloudStorageHook create_bucket with optional request body

### DIFF
--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -28,6 +28,7 @@ import gzip as gz
 import shutil
 import re
 import os
+import copy
 
 
 class GoogleCloudStorageHook(GoogleCloudBaseHook):
@@ -478,6 +479,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
 
     def create_bucket(self,
                       bucket_name,
+                      resource=None,
                       storage_class='MULTI_REGIONAL',
                       location='US',
                       project_id=None,
@@ -493,6 +495,10 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
 
         :param bucket_name: The name of the bucket.
         :type bucket_name: str
+        :param resource: An optional dict with parameters for creating the bucket.
+            For information on available parameters, see Cloud Storage API doc:
+            https://cloud.google.com/storage/docs/json_api/v1/buckets/insert
+        :type resource: dict
         :param storage_class: This defines how objects in the bucket are stored
             and determines the SLA and the cost of storage. Values include
 
@@ -543,11 +549,12 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
             raise ValueError('Bucket names must end with a number or letter.')
 
         service = self.get_conn()
-        bucket_resource = {
+        bucket_resource = copy.copy(resource)
+        bucket_resource.update({
             'name': bucket_name,
             'location': location,
             'storageClass': storage_class
-        }
+        })
 
         self.log.info('The Default Project ID is %s', self.project_id)
 

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
 from googleapiclient.errors import HttpError
@@ -28,7 +29,6 @@ import gzip as gz
 import shutil
 import re
 import os
-import copy
 
 
 class GoogleCloudStorageHook(GoogleCloudBaseHook):
@@ -549,7 +549,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
             raise ValueError('Bucket names must end with a number or letter.')
 
         service = self.get_conn()
-        bucket_resource = copy.copy(resource)
+        bucket_resource = resource or {}
         bucket_resource.update({
             'name': bucket_name,
             'location': location,

--- a/airflow/contrib/operators/gcs_operator.py
+++ b/airflow/contrib/operators/gcs_operator.py
@@ -34,6 +34,10 @@ class GoogleCloudStorageCreateBucketOperator(BaseOperator):
 
     :param bucket_name: The name of the bucket. (templated)
     :type bucket_name: str
+    :param resource: An optional dict with parameters for creating the bucket.
+            For information on available parameters, see Cloud Storage API doc:
+            https://cloud.google.com/storage/docs/json_api/v1/buckets/insert
+    :type resource: dict
     :param storage_class: This defines how objects in the bucket are stored
             and determines the SLA and the cost of storage (templated). Values include
 
@@ -86,6 +90,7 @@ class GoogleCloudStorageCreateBucketOperator(BaseOperator):
     @apply_defaults
     def __init__(self,
                  bucket_name,
+                 resource=None,
                  storage_class='MULTI_REGIONAL',
                  location='US',
                  project_id=None,
@@ -96,6 +101,7 @@ class GoogleCloudStorageCreateBucketOperator(BaseOperator):
                  **kwargs):
         super(GoogleCloudStorageCreateBucketOperator, self).__init__(*args, **kwargs)
         self.bucket_name = bucket_name
+        self.resource = resource
         self.storage_class = storage_class
         self.location = location
         self.project_id = project_id
@@ -116,6 +122,7 @@ class GoogleCloudStorageCreateBucketOperator(BaseOperator):
         )
 
         hook.create_bucket(bucket_name=self.bucket_name,
+                           resource=self.resource,
                            storage_class=self.storage_class,
                            location=self.location,
                            project_id=self.project_id,

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -408,6 +408,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
             }
         )
 
+    @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
     def test_compose(self, mock_service):
         test_bucket = 'test_bucket'
         test_source_objects = ['test_object_1', 'test_object_2', 'test_object_3']

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -389,7 +389,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         # Assert for resource other than None.
         response = self.gcs_hook.create_bucket(
             bucket_name=test_bucket,
-            resource={"lifecycle":{"rule": [{"action": {"type": "Delete"}, "condition": {"age": 7}}]}},
+            resource={"lifecycle": {"rule": [{"action": {"type": "Delete"}, "condition": {"age": 7}}]}},
             storage_class=test_storage_class,
             location=test_location,
             labels=test_labels,
@@ -405,8 +405,9 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
                 'location': test_location,
                 'storageClass': test_storage_class,
                 'labels': test_labels
-            }        
-          
+            }
+        )
+
     def test_compose(self, mock_service):
         test_bucket = 'test_bucket'
         test_source_objects = ['test_object_1', 'test_object_2', 'test_object_3']

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -342,6 +342,73 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
 
         self.assertFalse(response)
 
+    @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
+    def test_create_bucket(self, mock_service):
+        test_bucket = 'test_bucket'
+        test_project = 'test-project'
+        test_location = 'EU',
+        test_labels = {'env': 'prod'}
+        test_storage_class = 'MULTI_REGIONAL'
+        test_response_id = "{}/0123456789012345".format(test_bucket)
+
+        (mock_service.return_value.buckets.return_value
+         .insert.return_value.execute.return_value) = {"id": test_response_id}
+
+        response = self.gcs_hook.create_bucket(
+            bucket_name=test_bucket,
+            storage_class=test_storage_class,
+            location=test_location,
+            labels=test_labels,
+            project_id=test_project
+        )
+
+        self.assertEqual(response, test_response_id)
+        mock_service.return_value.buckets.return_value.insert.assert_called_with(
+            project=test_project,
+            body={
+                'name': test_bucket,
+                'location': test_location,
+                'storageClass': test_storage_class,
+                'labels': test_labels
+            }
+        )
+
+
+    @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
+    def test_create_bucket_with_resource(self, mock_service):
+        test_bucket = 'test_bucket'
+        test_project = 'test-project'
+        test_location = 'EU',
+        test_labels = {'env': 'prod'}
+        test_storage_class = 'MULTI_REGIONAL'
+        test_response_id = "{}/0123456789012345".format(test_bucket)
+        test_lifecycle = {"rule": [{"action": {"type": "Delete"}, "condition": {"age": 7}}]}
+
+        (mock_service.return_value.buckets.return_value
+         .insert.return_value.execute.return_value) = {"id": test_response_id}
+
+        # Assert for resource other than None.
+        response = self.gcs_hook.create_bucket(
+            bucket_name=test_bucket,
+            resource={"lifecycle":{"rule": [{"action": {"type": "Delete"}, "condition": {"age": 7}}]}},
+            storage_class=test_storage_class,
+            location=test_location,
+            labels=test_labels,
+            project_id=test_project
+        )
+
+        self.assertEqual(response, test_response_id)
+        mock_service.return_value.buckets.return_value.insert.assert_called_with(
+            project=test_project,
+            body={
+                "lifecycle": test_lifecycle,
+                'name': test_bucket,
+                'location': test_location,
+                'storageClass': test_storage_class,
+                'labels': test_labels
+            }
+        )
+
 
 class TestGoogleCloudStorageHookUpload(unittest.TestCase):
     def setUp(self):

--- a/tests/contrib/operators/test_gcs_operator.py
+++ b/tests/contrib/operators/test_gcs_operator.py
@@ -42,6 +42,12 @@ class GoogleCloudStorageCreateBucketTest(unittest.TestCase):
         operator = GoogleCloudStorageCreateBucketOperator(
             task_id=TASK_ID,
             bucket_name=TEST_BUCKET,
+            resource={"lifecycle": {
+                "rule": [{"action": {"type": "Delete"},
+                          "condition": {"age": 7}
+                          }
+                         ]}
+            },
             storage_class='MULTI_REGIONAL',
             location='EU',
             labels={'env': 'prod'},

--- a/tests/contrib/operators/test_gcs_operator.py
+++ b/tests/contrib/operators/test_gcs_operator.py
@@ -42,12 +42,7 @@ class GoogleCloudStorageCreateBucketTest(unittest.TestCase):
         operator = GoogleCloudStorageCreateBucketOperator(
             task_id=TASK_ID,
             bucket_name=TEST_BUCKET,
-            resource={"lifecycle": {
-                "rule": [{"action": {"type": "Delete"},
-                          "condition": {"age": 7}
-                          }
-                         ]}
-            },
+            resource={"lifecycle": {"rule": [{"action": {"type": "Delete"}, "condition": {"age": 7}}]}},
             storage_class='MULTI_REGIONAL',
             location='EU',
             labels={'env': 'prod'},
@@ -60,5 +55,6 @@ class GoogleCloudStorageCreateBucketTest(unittest.TestCase):
             location='EU', labels={
                 'airflow-version': 'v' + version.replace('.', '-').replace('+', '-'),
                 'env': 'prod'
-            }, project_id=TEST_PROJECT
+            }, project_id=TEST_PROJECT,
+            resource={'lifecycle': {'rule': [{'action': {'type': 'Delete'}, 'condition': {'age': 7}}]}}
         )


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

When creating a new bucket in Google Cloud Storage, GoogleCloudStorageHook.create_bucket, I would like to have the option of supplying missing parameters.

For instance, the field [lifecycle](https://cloud.google.com/storage/docs/json_api/v1/buckets#lifecycle) is not available. 

My suggestion to supply this is to add an optional dict to the parameters that gets overwritten with bucket_name, storage_class and collection.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- Updates `GoogleCloudStorageCreateBucketTest` with `resource` param
- Added two tests for `GoogleCloudStorageHook.create_bucket`

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
