### PR TITLE
[AIRFLOW-3901] add role as optional config parameter for SnowflakeHook

### DIFF
--- a/airflow/contrib/hooks/snowflake_hook.py
+++ b/airflow/contrib/hooks/snowflake_hook.py
@@ -40,6 +40,7 @@ class SnowflakeHook(DbApiHook):
         self.warehouse = kwargs.pop("warehouse", None)
         self.database = kwargs.pop("database", None)
         self.region = kwargs.pop("region", None)
+        self.role = kwargs.pop("role", None)
 
     def _get_conn_params(self):
         """
@@ -51,6 +52,7 @@ class SnowflakeHook(DbApiHook):
         warehouse = conn.extra_dejson.get('warehouse', None)
         database = conn.extra_dejson.get('database', None)
         region = conn.extra_dejson.get("region", None)
+        role = conn.extra_dejson.get('role', None)
 
         conn_config = {
             "user": conn.login,
@@ -59,7 +61,8 @@ class SnowflakeHook(DbApiHook):
             "database": self.database or database or '',
             "account": self.account or account or '',
             "warehouse": self.warehouse or warehouse or '',
-            "region": self.region or region or ''
+            "region": self.region or region or '',
+            "role": self.role or role or '',
         }
         return conn_config
 
@@ -69,9 +72,8 @@ class SnowflakeHook(DbApiHook):
         """
         conn_config = self._get_conn_params()
         uri = 'snowflake://{user}:{password}@{account}/{database}/'
-        uri += '{schema}?warehouse={warehouse}'
-        return uri.format(
-            **conn_config)
+        uri += '{schema}?warehouse={warehouse}&role={role}'
+        return uri.format(**conn_config)
 
     def get_conn(self):
         """

--- a/tests/contrib/hooks/test_snowflake_hook.py
+++ b/tests/contrib/hooks/test_snowflake_hook.py
@@ -40,7 +40,8 @@ class TestSnowflakeHook(unittest.TestCase):
         self.conn.extra_dejson = {'database': 'db',
                                   'account': 'airflow',
                                   'warehouse': 'af_wh',
-                                  'region': 'af_region'}
+                                  'region': 'af_region',
+                                  'role': 'af_role'}
 
         class UnitTestSnowflakeHook(SnowflakeHook):
             conn_name_attr = 'snowflake_conn_id'
@@ -54,7 +55,7 @@ class TestSnowflakeHook(unittest.TestCase):
         self.db_hook = UnitTestSnowflakeHook()
 
     def test_get_uri(self):
-        uri_shouldbe = 'snowflake://user:pw@airflow/db/public?warehouse=af_wh'
+        uri_shouldbe = 'snowflake://user:pw@airflow/db/public?warehouse=af_wh&role=af_role'
         self.assertEqual(uri_shouldbe, self.db_hook.get_uri())
 
     def test_get_conn_params(self):
@@ -64,7 +65,8 @@ class TestSnowflakeHook(unittest.TestCase):
                                 'database': 'db',
                                 'account': 'airflow',
                                 'warehouse': 'af_wh',
-                                'region': 'af_region'}
+                                'region': 'af_region',
+                                'role': 'af_role'}
         self.assertEqual(conn_params_shouldbe, self.db_hook._get_conn_params())
 
     def test_get_conn(self):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3901
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-3901\], code changes always need a Jira issue.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
I just added role as an optional param for snowflake hook.  Can be passed in extras.

#### Note on role's optional-ness
If role is neither supplied in instantiation nor connection extras, then instance attribute `role` will get  value of `''`.  It is reasonable to ask whether this will overwrite a default role if one is set in the server.  It does not. 
So if you already have a default role set up for your user in snowflake, after this change, if you still don't supply role, then you will still connect with the default role defined in the server.  The same was already true of `warehouse`.
So e.g. if you try to connect with a uri of `SOME_SCHEMA?warehouse=&role=`, then any defaults set in server will still work.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:



### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does


### Code Quality

- [X] Passes `flake8`
