### PR TITLE
[AIRFLOW-3905] Allow using "parameters" in SqlSensor

### DIFF
--- a/airflow/sensors/sql_sensor.py
+++ b/airflow/sensors/sql_sensor.py
@@ -34,22 +34,25 @@ class SqlSensor(BaseSensorOperator):
     :param sql: The sql to run. To pass, it needs to return at least one cell
         that contains a non-zero / empty string value.
     :type sql: str
+    :param parameters: The parameters to render the SQL query with (optional).
+    :type parameters: mapping or iterable
     """
     template_fields = ('sql',)
     template_ext = ('.hql', '.sql',)
     ui_color = '#7c7287'
 
     @apply_defaults
-    def __init__(self, conn_id, sql, *args, **kwargs):
-        self.sql = sql
+    def __init__(self, conn_id, sql, parameters=None, *args, **kwargs):
         self.conn_id = conn_id
+        self.sql = sql
+        self.parameters = parameters
         super(SqlSensor, self).__init__(*args, **kwargs)
 
     def poke(self, context):
         hook = BaseHook.get_connection(self.conn_id).get_hook()
 
-        self.log.info('Poking: %s', self.sql)
-        records = hook.get_records(self.sql)
+        self.log.info('Poking: %s (with parameters %s)', self.sql, self.parameters)
+        records = hook.get_records(self.sql, self.parameters)
         if not records:
             return False
         return str(records[0][0]) not in ('0', '')

--- a/tests/sensors/test_sql_sensor.py
+++ b/tests/sensors/test_sql_sensor.py
@@ -43,24 +43,42 @@ class SqlSensorTests(unittest.TestCase):
     @unittest.skipUnless(
         'mysql' in configuration.conf.get('core', 'sql_alchemy_conn'), "this is a mysql test")
     def test_sql_sensor_mysql(self):
-        t = SqlSensor(
+        t1 = SqlSensor(
             task_id='sql_sensor_check',
             conn_id='mysql_default',
             sql="SELECT count(1) FROM INFORMATION_SCHEMA.TABLES",
             dag=self.dag
         )
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        t1.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+        t2 = SqlSensor(
+            task_id='sql_sensor_check',
+            conn_id='mysql_default',
+            sql="SELECT count(%s) FROM INFORMATION_SCHEMA.TABLES",
+            parameters=["table_name"],
+            dag=self.dag
+        )
+        t2.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     @unittest.skipUnless(
         'postgresql' in configuration.conf.get('core', 'sql_alchemy_conn'), "this is a postgres test")
     def test_sql_sensor_postgres(self):
-        t = SqlSensor(
+        t1 = SqlSensor(
             task_id='sql_sensor_check',
             conn_id='postgres_default',
             sql="SELECT count(1) FROM INFORMATION_SCHEMA.TABLES",
             dag=self.dag
         )
-        t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        t1.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+        t2 = SqlSensor(
+            task_id='sql_sensor_check',
+            conn_id='postgres_default',
+            sql="SELECT count(%s) FROM INFORMATION_SCHEMA.TABLES",
+            parameters=["table_name"],
+            dag=self.dag
+        )
+        t2.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     @mock.patch('airflow.sensors.sql_sensor.BaseHook')
     def test_sql_sensor_postgres_poke(self, mock_hook):


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3905

### Description

In most SQL-related operators/sensors, argument `parameters` is available to help render SQL command conveniently, like `MySqlOperator` (https://github.com/apache/airflow/blob/master/airflow/operators/mysql_operator.py#L25) and `PostgresOperator` (https://github.com/apache/airflow/blob/master/airflow/operators/postgres_operator.py#L24).

But this is not available in `SqlSensor` yet.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Tests passed.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
