### PR TITLE
[AIRFLOW-3902] Add new singleton_operator and unittest

### DIFF
--- a/airflow/operators/singleton_operator.py
+++ b/airflow/operators/singleton_operator.py
@@ -1,0 +1,121 @@
+"""
+SingletonOperator class
+
+"""
+
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+#     specific language governing permissions and limitations
+# under the License.
+
+from airflow.models import BaseOperator, DagRun, TaskInstance
+from airflow.models.skipmixin import SkipMixin
+from airflow.utils.db import provide_session
+from airflow.utils.decorators import apply_defaults
+from airflow.utils.state import State
+
+
+class SingletonOperator(BaseOperator, SkipMixin):
+    """
+    Allows a workflow to ensure that only single `unfinished` task is being
+    executed at all times while allowing Airflow to schedule multiple DAGs to
+    execute other task instances that are not directly downstream of the task.
+    Unfinished task states: NONE, SCHEDULED, QUEUED, RUNNING, UP_FOR_RETRY
+    All directly downstream tasks will be skipped.
+
+    :param allow_external_trigger: If this is set, execution is allowed
+        regardless of dag_run states.
+    :type allow_external_trigger: Boolean
+    """
+
+    ui_color = '#e9ffdb'  # nyanza
+
+    @apply_defaults
+    def __init__(self, allow_external_trigger=False, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.task_instance = None
+        self.dag_run = None
+        self.allow_external_trigger = allow_external_trigger
+
+    def execute(self, context):
+        if self.allow_external_trigger and context['dag_run'].external_trigger:
+            self.log.info("Externally triggered dag_run: allowing execution.")
+            return
+
+        self.task_instance = context['ti']
+        self.dag_run = context['dag_run']
+        downstream_tasks = self.get_flat_relatives(upstream=False)
+        self.log.info("downstream_task_ids: %s", self.downstream_task_ids)
+        active_dag_runs = self.get_other_active_dag_runs()
+        self.log.info("Total active_dag_runs: %s", len(active_dag_runs))
+        result = self.skip_or_schedule(active_dag_runs, downstream_tasks)
+        self.log.info("%s execution: %s", result, self.downstream_task_ids)
+
+    def skip_or_schedule(self, active_dag_runs, downstream_tasks):
+        """
+        Returns if current dag should be scheduled or skipped.
+
+        :param active_dag_runs: list of all active dag_runs except oneself
+        :param downstream_tasks: list downstream tasks
+
+        :return: str - state - uppercase
+        """
+        for active_dag in active_dag_runs:
+            tasks, should_skip = self.unfinished_tasks(active_dag)
+            if should_skip:
+                self.log.info(
+                    "Found active_dag: %s with running tasks: %s, skipping...",
+                    active_dag, tasks)
+                self.skip(self.dag_run,
+                          self.task_instance.execution_date,
+                          downstream_tasks)
+                # Short circuit
+                return State.SKIPPED.upper()
+        return State.SCHEDULED.upper()
+
+    @provide_session
+    def unfinished_tasks(self, dag_run=DagRun, session=None):
+        """
+        Returns unfinished downstream tasks for a dag_run.
+
+        :param dag_run: current dag_run
+        :param session: database session
+
+        :return: list of tasks and size
+        """
+        tasks = session.query(TaskInstance).filter(
+            DagRun.dag_id == dag_run.dag_id,
+            DagRun.execution_date == dag_run.execution_date,
+            TaskInstance.task_id.in_(self.downstream_task_ids),
+            TaskInstance.state.in_([s for s in State.unfinished()])
+        ).all()
+        return tasks, len(tasks) > 0
+
+    @provide_session
+    def get_other_active_dag_runs(self, session=None):
+        """
+        Returns all other active dag_runs except oneself.
+
+        :param session: database session
+
+        :return: list of active dag_runs
+        """
+        return session.query(DagRun).filter(
+            DagRun.dag_id == self.task_instance.dag_id,
+            DagRun.state == State.RUNNING,
+            DagRun.execution_date != self.task_instance.execution_date
+        ).order_by(DagRun.execution_date.desc()).all()

--- a/tests/operators/test_singleton_operator.py
+++ b/tests/operators/test_singleton_operator.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+#     specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest import mock
+
+from datetime import datetime, timedelta
+
+from airflow.models import TaskInstance, DAG, DagRun
+from airflow.operators.singleton_operator import SingletonOperator
+from airflow.utils import timezone
+from airflow.utils.state import State
+
+DEFAULT_DATE = datetime(2019, 1, 1, tzinfo=timezone.utc)
+INTERVAL = timedelta(hours=12)
+
+
+class SingletonOperatorTest(unittest.TestCase):
+    """
+    Test cases for :py:class:SingletonOperator.
+    """
+
+    def setUp(self):
+        self.dag = DAG(
+            'test_dag',
+            default_args={
+                'owner': 'unittest',
+                'start_date': DEFAULT_DATE},
+            schedule_interval=INTERVAL)
+        self.singleton = SingletonOperator(task_id='singleton', dag=self.dag)
+        self.singleton_ext_trigger = SingletonOperator(task_id='singleton',
+                                                       allow_external_trigger=True,
+                                                       dag=self.dag)
+        self.ti = TaskInstance(task=self.singleton, execution_date=DEFAULT_DATE)
+        self.dag_run = DagRun()
+        self.dag_run.state = State.RUNNING
+        self.dag_run.run_id = "manual"
+        self.dag_run.dag_id = "test_dag"
+        self.dag_run.external_trigger = True
+        self.context = {"ti": self.ti, "dag_run": self.dag_run}
+
+    def tearDown(self):
+        self.dag_run = None
+        self.dag = None
+        self.context = None
+        self.singleton = None
+        self.singleton_ext_trigger = None
+        self.ti = None
+
+    def test_task_count(self):
+        self.assertEqual(len(self.dag.tasks), 1)
+
+    @mock.patch.object(SingletonOperator, 'get_other_active_dag_runs')
+    def test_get_other_active_dag_runs(self, get_other_active_dag_runs_mock):
+        get_other_active_dag_runs_mock.return_value = [self.dag_run]
+        active_dag_run = self.singleton.get_other_active_dag_runs()[0]
+        self.assertEqual(active_dag_run.dag_id, 'test_dag')
+        self.assertEqual(active_dag_run.external_trigger, True)
+        self.assertEqual(active_dag_run.run_id, "manual")
+
+    @mock.patch.object(SingletonOperator, 'unfinished_tasks')
+    def test_unfinished_tasks(self, unfinished_tasks_mock):
+        unfinished_tasks_mock.return_value = ['downstream', 1]
+        task, skip = self.singleton.unfinished_tasks(self.dag_run)
+        self.assertTrue(self.dag_run.state == State.RUNNING)
+        self.assertEqual(task, 'downstream')
+        self.assertTrue(skip)
+
+    @mock.patch.object(SingletonOperator, 'skip_or_schedule')
+    def test_skip_or_schedule(self, _skip_or_schedule_mock):
+        _skip_or_schedule_mock.return_value = 'SKIPPED'
+        result = self.singleton.skip_or_schedule(self.dag_run, [])
+        self.assertEqual(result, 'SKIPPED')
+        _skip_or_schedule_mock.return_value = 'SCHEDULED'
+        result = self.singleton.skip_or_schedule(self.dag_run, [])
+        self.assertEqual(result, 'SCHEDULED')
+
+    @mock.patch.object(SingletonOperator, 'get_other_active_dag_runs')
+    @mock.patch.object(SingletonOperator, 'skip_or_schedule')
+    def test_execute_skip(self,
+                          _skip_or_schedule_mock,
+                          get_other_active_dag_runs_mock):
+        get_other_active_dag_runs_mock.return_value = [self.dag_run]
+        _skip_or_schedule_mock.return_value = 'SKIPPED'
+        self.assertTrue(self.singleton.execute(self.context) is None)
+        self.singleton.skip_or_schedule(self.dag_run,
+                                        [])  # pylint: disable=W0212
+
+    @mock.patch.object(SingletonOperator, 'get_other_active_dag_runs')
+    @mock.patch.object(SingletonOperator, 'skip_or_schedule')
+    def test_execute_schedule(self, _skip_or_schedule_mock,
+                              get_other_active_dag_runs_mock):
+        self.assertTrue(self.singleton.execute(self.context) is None)
+        get_other_active_dag_runs_mock.return_value = [self.dag_run]
+        _skip_or_schedule_mock.return_value = 'SCHEDULED'
+        self.assertTrue(self.singleton.execute(self.context) is None)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following:
  - https://issues.apache.org/jira/browse/AIRFLOW-3902

### Description

- [x] Here are some details about my PR:
  - Checks for downstream tasks from previous DagRuns in unfinished state
  - Skips downstream tasks from execution if it finds a downstream task in running state from previous DagRuns

### Tests

- [x] My PR adds the following unit tests:
  - test__skip_or_schedule (tests.operators.test_singleton_operator.SingletonOperatorTest)
  - test_execute_schedule (tests.operators.test_singleton_operator.SingletonOperatorTest)
  - test_execute_skip (tests.operators.test_singleton_operator.SingletonOperatorTest)
  - test_get_other_active_dag_runs (tests.operators.test_singleton_operator.SingletonOperatorTest)
  - test_task_count (tests.operators.test_singleton_operator.SingletonOperatorTest)
  - test_unfinished_tasks (tests.operators.test_singleton_operator.SingletonOperatorTest)

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`