### PR TITLE
[AIRFLOW-3481] Add SFTP in connection type

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -72,6 +72,7 @@ class Connection(Base, LoggingMixin):
         ('samba', 'Samba',),
         ('sqlite', 'Sqlite',),
         ('ssh', 'SSH',),
+        ('sftp', 'SFTP',),
         ('cloudant', 'IBM Cloudant',),
         ('mssql', 'Microsoft SQL Server'),
         ('mesos_framework-id', 'Mesos Framework ID'),


### PR DESCRIPTION


Resolves: https://issues.apache.org/jira/browse/AIRFLOW-3481

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3481) 

### Description

SFTPHook is different from SSHHook. It would be better having an individual conn type. For example, a factory method is able to choose hook by its conn type.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
