### PR TITLE
[AIRFLOW-3795] provide_context param is now used

### DIFF
--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -229,6 +229,12 @@ class PythonVirtualenvOperator(PythonOperator):
     :type op_kwargs: list
     :param op_kwargs: A dict of keyword arguments to pass to python_callable.
     :type op_kwargs: dict
+    :param provide_context: if set to true, Airflow will pass a set of
+        keyword arguments that can be used in your function. This set of
+        kwargs correspond exactly to what you can use in your jinja
+        templates. For this to work, you need to define `**kwargs` in your
+        function header.
+    :type provide_context: bool
     :param string_args: Strings that are present in the global var virtualenv_string_args,
         available to python_callable at runtime as a list[str]. Note that args are split
         by newline.
@@ -247,15 +253,16 @@ class PythonVirtualenvOperator(PythonOperator):
                  requirements=None,
                  python_version=None, use_dill=False,
                  system_site_packages=True,
-                 op_args=None, op_kwargs=None, string_args=None,
-                 templates_dict=None, templates_exts=None, *args, **kwargs):
+                 op_args=None, op_kwargs=None, provide_context=False,
+                 string_args=None, templates_dict=None, templates_exts=None,
+                 *args, **kwargs):
         super(PythonVirtualenvOperator, self).__init__(
             python_callable=python_callable,
             op_args=op_args,
             op_kwargs=op_kwargs,
             templates_dict=templates_dict,
             templates_exts=templates_exts,
-            provide_context=False,
+            provide_context=provide_context,
             *args,
             **kwargs)
         self.requirements = requirements or []

--- a/tests/operators/test_virtualenv_operator.py
+++ b/tests/operators/test_virtualenv_operator.py
@@ -205,3 +205,14 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
         def f(**kwargs):
             return kwargs['templates_dict']['ds']
         self._run_as_operator(f, templates_dict={'ds': '{{ ds }}'})
+
+    def test_provide_context(self):
+        operator = PythonVirtualenvOperator(
+            python_callable=lambda x: 4,
+            task_id='task',
+            dag=self.dag,
+            provide_context=True
+        )
+        self.assertTrue(
+            operator.provide_context
+        )

--- a/tests/operators/test_virtualenv_operator.py
+++ b/tests/operators/test_virtualenv_operator.py
@@ -207,12 +207,15 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
         self._run_as_operator(f, templates_dict={'ds': '{{ ds }}'})
 
     def test_provide_context(self):
-        operator = PythonVirtualenvOperator(
-            python_callable=lambda x: 4,
+        def fn():
+            pass
+        task = PythonVirtualenvOperator(
+            python_callable=fn,
+            python_version=sys.version_info[0],
             task_id='task',
             dag=self.dag,
-            provide_context=True
+            provide_context=True,
         )
         self.assertTrue(
-            operator.provide_context
+            task.provide_context
         )


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3795

### Description

- [ ] Here are some details about my PR:

For a `PythonOperator`, I can set `provide_context=True`. For a `PythonVirtualenvOperator`, I am not able to set `provide_context=True`, and `provide_context=False` gets passed to the super function. I do not see why this is hardcoded, and I would like to be able to use the context with a `PythonVirtualenvOperator`.

See:
https://github.com/apache/airflow/blob/83cb9c3acdd3b4eeadf1cab3cb45d644c3e9ede0/airflow/operators/python_operator.py#L242

### Tests

- [ x ] My PR adds the following unit tests.

### Commits

- [ x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ x] Passes `flake8`
