### PR TITLE
[AIRFLOW-2224] Add support CSV files in MySqlToGoogleCloudStorageOperator

### DIFF
--- a/airflow/contrib/operators/mysql_to_gcs.py
+++ b/airflow/contrib/operators/mysql_to_gcs.py
@@ -31,13 +31,18 @@ from decimal import Decimal
 from MySQLdb.constants import FIELD_TYPE
 from tempfile import NamedTemporaryFile
 from six import string_types
+import unicodecsv as csv
 
 PY3 = sys.version_info[0] == 3
 
 
 class MySqlToGoogleCloudStorageOperator(BaseOperator):
-    """
-    Copy data from MySQL to Google cloud storage in JSON format.
+    """Copy data from MySQL to Google cloud storage in JSON or CSV format.
+
+    The JSON data files generated are newline-delimited to enable them to be
+    loaded into BigQuery.
+    Reference: https://cloud.google.com/bigquery/docs/
+    loading-data-cloud-storage-json#limitations
 
     :param sql: The SQL to execute on the MySQL table.
     :type sql: str
@@ -72,6 +77,10 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
         work, the service account making the request must have domain-wide
         delegation enabled.
     :type delegate_to: str
+    :param export_format: Desired format of files to be exported.
+    :type export_format: str
+    :param field_delimiter: The delimiter to be used for CSV files.
+    :type field_delimiter: str
     """
     template_fields = ('sql', 'bucket', 'filename', 'schema_filename', 'schema')
     template_ext = ('.sql',)
@@ -88,6 +97,8 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
                  google_cloud_storage_conn_id='google_cloud_default',
                  schema=None,
                  delegate_to=None,
+                 export_format='json',
+                 field_delimiter=',',
                  *args,
                  **kwargs):
         super(MySqlToGoogleCloudStorageOperator, self).__init__(*args, **kwargs)
@@ -100,6 +111,8 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
         self.schema = schema
         self.delegate_to = delegate_to
+        self.export_format = export_format.lower()
+        self.field_delimiter = field_delimiter
 
     def execute(self, context):
         cursor = self._query_mysql()
@@ -107,17 +120,19 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
 
         # If a schema is set, create a BQ schema JSON file.
         if self.schema_filename:
-            files_to_upload.update(self._write_local_schema_file(cursor))
+            files_to_upload.append(self._write_local_schema_file(cursor))
 
         # Flush all files before uploading.
-        for file_handle in files_to_upload.values():
-            file_handle.flush()
+        for tmp_file in files_to_upload:
+            tmp_file_handle = tmp_file.get('file_handle')
+            tmp_file_handle.flush()
 
         self._upload_to_gcs(files_to_upload)
 
         # Close all temp file handles.
-        for file_handle in files_to_upload.values():
-            file_handle.close()
+        for tmp_file in files_to_upload:
+            tmp_file_handle = tmp_file.get('file_handle')
+            tmp_file_handle.close()
 
     def _query_mysql(self):
         """
@@ -141,41 +156,73 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
         col_type_dict = self._get_col_type_dict()
         file_no = 0
         tmp_file_handle = NamedTemporaryFile(delete=True)
-        tmp_file_handles = {self.filename.format(file_no): tmp_file_handle}
+        if self.export_format == 'csv':
+            file_mime_type = 'text/csv'
+        else:
+            file_mime_type = 'application/json'
+        files_to_upload = [{
+            'file_name': self.filename.format(file_no),
+            'file_handle': tmp_file_handle,
+            'file_mime_type': file_mime_type
+        }]
+
+        if self.export_format == 'csv':
+            csv_writer = self._configure_csv_file(tmp_file_handle, schema)
 
         for row in cursor:
             # Convert datetime objects to utc seconds, and decimals to floats.
             # Convert binary type object to string encoded with base64.
             row = self._convert_types(schema, col_type_dict, row)
-            row_dict = dict(zip(schema, row))
 
-            # TODO validate that row isn't > 2MB. BQ enforces a hard row size of 2MB.
-            s = json.dumps(row_dict)
-            if PY3:
-                s = s.encode('utf-8')
-            tmp_file_handle.write(s)
+            if self.export_format == 'csv':
+                csv_writer.writerow(row)
+            else:
+                row_dict = dict(zip(schema, row))
 
-            # Append newline to make dumps BigQuery compatible.
-            tmp_file_handle.write(b'\n')
+                # TODO validate that row isn't > 2MB. BQ enforces a hard row size of 2MB.
+                s = json.dumps(row_dict, sort_keys=True)
+                if PY3:
+                    s = s.encode('utf-8')
+                tmp_file_handle.write(s)
+
+                # Append newline to make dumps BigQuery compatible.
+                tmp_file_handle.write(b'\n')
 
             # Stop if the file exceeds the file size limit.
             if tmp_file_handle.tell() >= self.approx_max_file_size_bytes:
                 file_no += 1
                 tmp_file_handle = NamedTemporaryFile(delete=True)
-                tmp_file_handles[self.filename.format(file_no)] = tmp_file_handle
+                files_to_upload.append({
+                    'file_name': self.filename.format(file_no),
+                    'file_handle': tmp_file_handle,
+                    'file_mime_type': file_mime_type
+                })
 
-        return tmp_file_handles
+                if self.export_format == 'csv':
+                    csv_writer = self._configure_csv_file(tmp_file_handle, schema)
+
+        return files_to_upload
+
+    def _configure_csv_file(self, file_handle, schema):
+        """Configure a csv writer with the file_handle and write schema
+        as headers for the new file.
+        """
+        csv_writer = csv.writer(file_handle, encoding='utf-8',
+                                delimiter=self.field_delimiter)
+        csv_writer.writerow(schema)
+        return csv_writer
 
     def _write_local_schema_file(self, cursor):
         """
-        Takes a cursor, and writes the BigQuery schema for the results to a
-        local file system.
+        Takes a cursor, and writes the BigQuery schema in .json format for the
+        results to a local file system.
 
         :return: A dictionary where key is a filename to be used as an object
             name in GCS, and values are file handles to local files that
             contains the BigQuery schema fields in .json format.
         """
         schema_str = None
+        schema_file_mime_type = 'application/json'
         tmp_schema_file_handle = NamedTemporaryFile(delete=True)
         if self.schema is not None and isinstance(self.schema, string_types):
             schema_str = self.schema
@@ -199,13 +246,18 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
                     'type': field_type,
                     'mode': field_mode,
                 })
-            schema_str = json.dumps(schema)
+            schema_str = json.dumps(schema, sort_keys=True)
         if PY3:
             schema_str = schema_str.encode('utf-8')
         tmp_schema_file_handle.write(schema_str)
 
         self.log.info('Using schema for %s: %s', self.schema_filename, schema_str)
-        return {self.schema_filename: tmp_schema_file_handle}
+        schema_file_to_upload = {
+            'file_name': self.schema_filename,
+            'file_handle': tmp_schema_file_handle,
+            'file_mime_type': schema_file_mime_type
+        }
+        return schema_file_to_upload
 
     def _upload_to_gcs(self, files_to_upload):
         """
@@ -215,8 +267,10 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
         hook = GoogleCloudStorageHook(
             google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
             delegate_to=self.delegate_to)
-        for object, tmp_file_handle in files_to_upload.items():
-            hook.upload(self.bucket, object, tmp_file_handle.name, 'application/json')
+        for tmp_file in files_to_upload:
+            hook.upload(self.bucket, tmp_file.get('file_name'),
+                        tmp_file.get('file_handle').name,
+                        mime_type=tmp_file.get('file_mime_type'))
 
     @staticmethod
     def _convert_types(schema, col_type_dict, row):

--- a/tests/contrib/operators/test_mysql_to_gcs_operator.py
+++ b/tests/contrib/operators/test_mysql_to_gcs_operator.py
@@ -17,45 +17,226 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import sys
 import unittest
-import json
-from mock import MagicMock
 
 from airflow.contrib.operators.mysql_to_gcs import \
     MySqlToGoogleCloudStorageOperator
 
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+PY3 = sys.version_info[0] == 3
+
+TASK_ID = 'test-mysql-to-gcs'
+MYSQL_CONN_ID = 'mysql_conn_test'
+SQL = 'select 1'
+BUCKET = 'gs://test'
+JSON_FILENAME = 'test_{}.ndjson'
+CSV_FILENAME = 'test_{}.csv'
+
+ROWS = [
+    ('mock_row_content_1', 42),
+    ('mock_row_content_2', 43),
+    ('mock_row_content_3', 44)
+]
+CURSOR_DESCRIPTION = (
+    ('some_str', 0, 0, 0, 0, 0, False),
+    ('some_num', 1005, 0, 0, 0, 0, False)
+)
+NDJSON_LINES = [
+    b'{"some_num": 42, "some_str": "mock_row_content_1"}\n',
+    b'{"some_num": 43, "some_str": "mock_row_content_2"}\n',
+    b'{"some_num": 44, "some_str": "mock_row_content_3"}\n'
+]
+CSV_LINES = [
+    b'some_str,some_num\r\n'
+    b'mock_row_content_1,42\r\n',
+    b'mock_row_content_2,43\r\n',
+    b'mock_row_content_3,44\r\n'
+]
+CSV_LINES_PIPE_DELIMITED = [
+    b'some_str|some_num\r\n'
+    b'mock_row_content_1|42\r\n',
+    b'mock_row_content_2|43\r\n',
+    b'mock_row_content_3|44\r\n'
+]
+SCHEMA_FILENAME = 'schema_test.json'
+SCHEMA_JSON = [
+    b'[{"mode": "REQUIRED", "name": "some_str", "type": "FLOAT"}, ',
+    b'{"mode": "REQUIRED", "name": "some_num", "type": "STRING"}]'
+]
+
 
 class MySqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
 
-    @staticmethod
-    def test_write_local_data_files():
+    def test_init(self):
+        """Test MySqlToGoogleCloudStorageOperator instance is properly initialized."""
+        op = MySqlToGoogleCloudStorageOperator(
+            task_id=TASK_ID, sql=SQL, bucket=BUCKET, filename=JSON_FILENAME,
+            export_format='CSV', field_delimiter='|')
+        self.assertEqual(op.task_id, TASK_ID)
+        self.assertEqual(op.sql, SQL)
+        self.assertEqual(op.bucket, BUCKET)
+        self.assertEqual(op.filename, JSON_FILENAME)
+        self.assertEqual(op.export_format, 'csv')
+        self.assertEqual(op.field_delimiter, '|')
 
-        # Configure
-        task_id = "some_test_id"
-        sql = "some_sql"
-        bucket = "some_bucket"
-        filename = "some_filename"
-        row_iter = [[1, b'byte_str_1'], [2, b'byte_str_2']]
-        schema = [{
-            'name': 'location',
-            'type': 'STRING',
-            'mode': 'nullable',
-        }, {
-            'name': 'uuid',
-            'type': 'BYTES',
-            'mode': 'nullable',
-        }]
-        schema_str = json.dumps(schema)
+    @mock.patch('airflow.contrib.operators.mysql_to_gcs.MySqlHook')
+    @mock.patch('airflow.contrib.operators.mysql_to_gcs.GoogleCloudStorageHook')
+    def test_exec_success_json(self, gcs_hook_mock_class, mysql_hook_mock_class):
+        """Test successful run of execute function for JSON"""
+        op = MySqlToGoogleCloudStorageOperator(
+            task_id=TASK_ID,
+            mysql_conn_id=MYSQL_CONN_ID,
+            sql=SQL,
+            bucket=BUCKET,
+            filename=JSON_FILENAME)
+
+        mysql_hook_mock = mysql_hook_mock_class.return_value
+        mysql_hook_mock.get_conn().cursor().__iter__.return_value = iter(ROWS)
+        mysql_hook_mock.get_conn().cursor().description = CURSOR_DESCRIPTION
+
+        gcs_hook_mock = gcs_hook_mock_class.return_value
+
+        def _assert_upload(bucket, obj, tmp_filename, mime_type=None):
+            self.assertEqual(BUCKET, bucket)
+            self.assertEqual(JSON_FILENAME.format(0), obj)
+            self.assertEqual('application/json', mime_type)
+            with open(tmp_filename, 'rb') as f:
+                self.assertEqual(b''.join(NDJSON_LINES), f.read())
+
+        gcs_hook_mock.upload.side_effect = _assert_upload
+
+        op.execute(None)
+
+        mysql_hook_mock_class.assert_called_once_with(mysql_conn_id=MYSQL_CONN_ID)
+        mysql_hook_mock.get_conn().cursor().execute.assert_called_once_with(SQL)
+
+    @mock.patch('airflow.contrib.operators.mysql_to_gcs.MySqlHook')
+    @mock.patch('airflow.contrib.operators.mysql_to_gcs.GoogleCloudStorageHook')
+    def test_exec_success_csv(self, gcs_hook_mock_class, mysql_hook_mock_class):
+        """Test successful run of execute function for CSV"""
+        op = MySqlToGoogleCloudStorageOperator(
+            task_id=TASK_ID,
+            mysql_conn_id=MYSQL_CONN_ID,
+            sql=SQL,
+            export_format='CSV',
+            bucket=BUCKET,
+            filename=CSV_FILENAME)
+
+        mysql_hook_mock = mysql_hook_mock_class.return_value
+        mysql_hook_mock.get_conn().cursor().__iter__.return_value = iter(ROWS)
+        mysql_hook_mock.get_conn().cursor().description = CURSOR_DESCRIPTION
+
+        gcs_hook_mock = gcs_hook_mock_class.return_value
+
+        def _assert_upload(bucket, obj, tmp_filename, mime_type=None):
+            self.assertEqual(BUCKET, bucket)
+            self.assertEqual(CSV_FILENAME.format(0), obj)
+            self.assertEqual('text/csv', mime_type)
+            with open(tmp_filename, 'rb') as f:
+                self.assertEqual(b''.join(CSV_LINES), f.read())
+
+        gcs_hook_mock.upload.side_effect = _assert_upload
+
+        op.execute(None)
+
+        mysql_hook_mock_class.assert_called_once_with(mysql_conn_id=MYSQL_CONN_ID)
+        mysql_hook_mock.get_conn().cursor().execute.assert_called_once_with(SQL)
+
+    @mock.patch('airflow.contrib.operators.mysql_to_gcs.MySqlHook')
+    @mock.patch('airflow.contrib.operators.mysql_to_gcs.GoogleCloudStorageHook')
+    def test_exec_success_csv_with_delimiter(self, gcs_hook_mock_class, mysql_hook_mock_class):
+        """Test successful run of execute function for CSV with a field delimiter"""
+        op = MySqlToGoogleCloudStorageOperator(
+            task_id=TASK_ID,
+            mysql_conn_id=MYSQL_CONN_ID,
+            sql=SQL,
+            export_format='csv',
+            field_delimiter='|',
+            bucket=BUCKET,
+            filename=CSV_FILENAME)
+
+        mysql_hook_mock = mysql_hook_mock_class.return_value
+        mysql_hook_mock.get_conn().cursor().__iter__.return_value = iter(ROWS)
+        mysql_hook_mock.get_conn().cursor().description = CURSOR_DESCRIPTION
+
+        gcs_hook_mock = gcs_hook_mock_class.return_value
+
+        def _assert_upload(bucket, obj, tmp_filename, mime_type=None):
+            self.assertEqual(BUCKET, bucket)
+            self.assertEqual(CSV_FILENAME.format(0), obj)
+            self.assertEqual('text/csv', mime_type)
+            with open(tmp_filename, 'rb') as f:
+                self.assertEqual(b''.join(CSV_LINES_PIPE_DELIMITED), f.read())
+
+        gcs_hook_mock.upload.side_effect = _assert_upload
+
+        op.execute(None)
+
+        mysql_hook_mock_class.assert_called_once_with(mysql_conn_id=MYSQL_CONN_ID)
+        mysql_hook_mock.get_conn().cursor().execute.assert_called_once_with(SQL)
+
+    @mock.patch('airflow.contrib.operators.mysql_to_gcs.MySqlHook')
+    @mock.patch('airflow.contrib.operators.mysql_to_gcs.GoogleCloudStorageHook')
+    def test_file_splitting(self, gcs_hook_mock_class, mysql_hook_mock_class):
+        """Test that ndjson is split by approx_max_file_size_bytes param."""
+        mysql_hook_mock = mysql_hook_mock_class.return_value
+        mysql_hook_mock.get_conn().cursor().__iter__.return_value = iter(ROWS)
+        mysql_hook_mock.get_conn().cursor().description = CURSOR_DESCRIPTION
+
+        gcs_hook_mock = gcs_hook_mock_class.return_value
+        expected_upload = {
+            JSON_FILENAME.format(0): b''.join(NDJSON_LINES[:2]),
+            JSON_FILENAME.format(1): NDJSON_LINES[2],
+        }
+
+        def _assert_upload(bucket, obj, tmp_filename, mime_type=None):
+            self.assertEqual(BUCKET, bucket)
+            self.assertEqual('application/json', mime_type)
+            with open(tmp_filename, 'rb') as f:
+                self.assertEqual(expected_upload[obj], f.read())
+
+        gcs_hook_mock.upload.side_effect = _assert_upload
 
         op = MySqlToGoogleCloudStorageOperator(
-            task_id=task_id,
-            sql=sql,
-            bucket=bucket,
-            filename=filename,
-            schema=schema_str)
+            task_id=TASK_ID,
+            sql=SQL,
+            bucket=BUCKET,
+            filename=JSON_FILENAME,
+            approx_max_file_size_bytes=len(expected_upload[JSON_FILENAME.format(0)]))
+        op.execute(None)
 
-        cursor_mock = MagicMock()
-        cursor_mock.__iter__.return_value = row_iter
+    @mock.patch('airflow.contrib.operators.mysql_to_gcs.MySqlHook')
+    @mock.patch('airflow.contrib.operators.mysql_to_gcs.GoogleCloudStorageHook')
+    def test_schema_file(self, gcs_hook_mock_class, mysql_hook_mock_class):
+        """Test writing schema files."""
+        mysql_hook_mock = mysql_hook_mock_class.return_value
+        mysql_hook_mock.get_conn().cursor().__iter__.return_value = iter(ROWS)
+        mysql_hook_mock.get_conn().cursor().description = CURSOR_DESCRIPTION
 
-        # Run
-        op._write_local_data_files(cursor_mock)
+        gcs_hook_mock = gcs_hook_mock_class.return_value
+
+        def _assert_upload(bucket, obj, tmp_filename, mime_type):
+            if obj == SCHEMA_FILENAME:
+                with open(tmp_filename, 'rb') as f:
+                    self.assertEqual(b''.join(SCHEMA_JSON), f.read())
+
+        gcs_hook_mock.upload.side_effect = _assert_upload
+
+        op = MySqlToGoogleCloudStorageOperator(
+            task_id=TASK_ID,
+            sql=SQL,
+            bucket=BUCKET,
+            filename=JSON_FILENAME,
+            schema_filename=SCHEMA_FILENAME)
+        op.execute(None)
+
+        # once for the file and once for the schema
+        self.assertEqual(2, gcs_hook_mock.upload.call_count)


### PR DESCRIPTION
MySqlToGoogleCloudStorageOperator supported export from MySQL in newline-delimited JSON format only. 

Added support for export in CSV format with the option of specifying a field delimiter.

Thanks to Bernardo Najlis(@bnajlis) for the original PR(#3139).
I made some changes to the the original PR.

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2224
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added tests:
 * test_init
 * test_exec_success_json
 * test_exec_success_csv
 * test_exec_success_csv_with_delimiter
 * test_file_splitting
 * test_schema_file
Replaced the pre-existing test with the one @bnajlis wrote as those tests covered that case too.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
