### PR TITLE
[AIRFLOW-3925] Don't pull docker-images on pretest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,13 +44,16 @@ jobs:
   include:
     - name: Flake8
       stage: pre-test
-      script: pip install flake8 && flake8
+      install: pip install flake8
+      script: flake8
     - name: Check license header
       stage: pre-test
+      install: skip
       script: scripts/ci/6-check-license.sh
     - name: Check docs
       stage: pre-test
-      script: pip install -e .[doc] && docs/build.sh
+      install: pip install -e .[doc]
+      script: docs/build.sh
 
 cache:
   directories:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3925

### Description

We do not need a docker in pretest, so we should not pull images.
The problem has previously been discussed:
https://github.com/apache/airflow/pull/4685#issuecomment-464285412

### Tests

No applicable 

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

No applicable 

### Code Quality

No applicable 
