### PR TITLE
[AIRFLOW-3924] Fix try number for alert emails

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -1718,10 +1718,12 @@ class TaskInstance(Base, LoggingMixin):
     def email_alert(self, exception):
         exception_html = str(exception).replace('\n', '<br>')
         jinja_context = self.get_template_context()
+        # This function is called after changing the state
+        # from State.RUNNING so need to subtract 1 from self.try_number.
         jinja_context.update(dict(
             exception=exception,
             exception_html=exception_html,
-            try_number=self.try_number,
+            try_number=self.try_number - 1,
             max_tries=self.max_tries))
 
         jinja_env = self.task.get_template_env()

--- a/tests/models.py
+++ b/tests/models.py
@@ -2819,6 +2819,7 @@ class TaskInstanceTest(unittest.TestCase):
         self.assertEqual(email, 'to')
         self.assertIn('test_email_alert', title)
         self.assertIn('test_email_alert', body)
+        self.assertIn('Try 1', body)
 
     @patch('airflow.models.send_email')
     def test_email_alert_with_config(self, mock_send_email):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3924

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Fix for alert emails sent via email_alert() to have the correct try number
in the body of the text.

Alert emails are being sent after the state of the Task Instance
is changed from State.RUNNING. This causes self.try_number to be
incremented for the alert email and the first email being sent with
`Try 2 of 1`.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Add a test to ensure the first email sent says `Try 1`.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
