### PR TITLE
[AIRFLOW-3153] Send DAG processing stats to statsd

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -47,7 +47,7 @@ from airflow import configuration as conf
 from airflow.dag.base_dag import BaseDag, BaseDagBag
 from airflow.exceptions import AirflowException
 from airflow.models import errors
-from airflow.settings import logging_class_path
+from airflow.settings import logging_class_path, Stats
 from airflow.utils import timezone
 from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -966,11 +966,25 @@ class DagFileProcessorManager(LoggingMixin):
         rows = []
         for file_path in known_file_paths:
             last_runtime = self.get_last_runtime(file_path)
+            file_name = os.path.basename(file_path)
+            file_name = os.path.splitext(file_name)[0].replace(os.sep, '.')
+            if last_runtime:
+                Stats.gauge(
+                    'dag_processing.last_runtime.{}'.format(file_name),
+                    last_runtime
+                )
+
             processor_pid = self.get_pid(file_path)
             processor_start_time = self.get_start_time(file_path)
             runtime = ((timezone.utcnow() - processor_start_time).total_seconds()
                        if processor_start_time else None)
             last_run = self.get_last_finish_time(file_path)
+            if last_run:
+                seconds_ago = (timezone.utcnow() - last_run).total_seconds()
+                Stats.gauge(
+                    'dag_processing.last_run.seconds_ago.{}'.format(file_name),
+                    seconds_ago
+                )
 
             rows.append((file_path,
                          processor_pid,

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -49,13 +49,15 @@ scheduler_heartbeat                 Scheduler heartbeats
 Gauges
 ------
 
-===================== =====================================
-Name                  Description
-===================== =====================================
-collect_dags          Seconds taken to scan and import DAGs
-dagbag_import_errors  DAG import errors
-dagbag_size           DAG bag size
-===================== =====================================
+=============================================== ========================================================================
+Name                                            Description
+=============================================== ========================================================================
+collect_dags                                    Seconds taken to scan and import DAGs
+dagbag_import_errors                            DAG import errors
+dagbag_size                                     DAG bag size
+dag_processing.last_runtime.<dag_file>          Seconds spent processing <dag_file> (in most recent iteration)
+dag_processing.last_run.seconds_ago.<dag_file>  Seconds since <dag_file> was last processed
+=============================================== ========================================================================
 
 Timers
 ------


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3153
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:

Add 3 stats under the `airflow.dag_processing` namespace. The metric
names follow the template: `dag_processing.<metric>.<dag_file>`, where
`<dag_file>` is the name of a file in the dag_folder (without the
extension) and `<metric>` is one of the following:

- `last_runtime`: the number of seconds it took to process the DAG file
  on the most recent iteration
- `last_run.unixtime`: the Unix epoch time (in seconds) at which the DAG
  file was last processed
- `last_run.seconds_ago`: the number of seconds that have elapsed since
  the DAG file was last processed

### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I've verified the logging by running the scheduler on the examples DAGs
and logging the value of the gauges with netcat:

    $ nc -u -l -p 8125 | tr '|' '\n' | grep dag_processing
      gairflow.dag_processing.last_runtime.example_docker_operator:2.002253
      gairflow.dag_processing.last_run.unixtime.example_docker_operator:1550717832
      gairflow.dag_processing.last_run.seconds_ago.example_docker_operator:18.066831
      gairflow.dag_processing.last_runtime.tutorial:2.001403
      gairflow.dag_processing.last_run.unixtime.tutorial:1550717814
      gairflow.dag_processing.last_run.seconds_ago.tutorial:36.114995
      gairflow.dag_processing.last_runtime.docker_copy_data:2.003188
      gairflow.dag_processing.last_run.unixtime.docker_copy_data:1550717822
      gairflow.dag_processing.last_run.seconds_ago.docker_copy_data:28.097275

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ X ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ X ] Passes `flake8`
