### PR TITLE
[AIRFLOW-3935] answer a TODO in airflow/executors/local_executor.py

### DIFF
--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -88,8 +88,6 @@ class LocalWorker(multiprocessing.Process, LoggingMixin):
         except subprocess.CalledProcessError as e:
             state = State.FAILED
             self.log.error("Failed to execute task %s.", str(e))
-            # TODO: Why is this commented out?
-            # raise e
         self.result_queue.put((key, state))
 
     def run(self):


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3935


### Description

The TODO cleared in this PR actually was asking a question, why 'raise e' was commented.

To answer why 'raise e' was commented:
1. This `try-except` is inside method `execute_work()` & there are other operations after the try-except as well as after invoking this method. Raising exception here will prevent all following steps from taking place properly.
2. The exception itself is already marked properly by labelling state to be FAILED, and the exception is printed out using `self.log.error()`.

