### PR TITLE
[AIRFLOW-3939] Add Google Cloud Translate operator

### DIFF
--- a/airflow/contrib/example_dags/example_gcp_translate.py
+++ b/airflow/contrib/example_dags/example_gcp_translate.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Example Airflow DAG that translates text in Google Cloud Translate
+service in the Google Cloud Platform.
+
+"""
+import airflow
+from airflow import models
+
+from airflow.contrib.operators.gcp_translate_operator import CloudTranslateTextOperator
+from airflow.operators.bash_operator import BashOperator
+
+default_args = {'start_date': airflow.utils.dates.days_ago(1)}
+
+with models.DAG(
+    'example_gcp_translate', default_args=default_args, schedule_interval=None  # Override to match your needs
+) as dag:
+    # [START howto_operator_translate_text]
+    product_set_create = CloudTranslateTextOperator(
+        task_id='translate',
+        values=['zażółć gęślą jaźń'],
+        target_language='en',
+        format_='text',
+        source_language=None,
+        model='base',
+    )
+    # [END howto_operator_translate_text]
+    # [START howto_operator_translate_access]
+    translation_access = BashOperator(
+        task_id='access',
+        bash_command="echo '{{ task_instance.xcom_pull(\"translate\")[0] }}'"
+    )
+    product_set_create >> translation_access
+    # [END howto_operator_translate_access]

--- a/airflow/contrib/hooks/gcp_translate_hook.py
+++ b/airflow/contrib/hooks/gcp_translate_hook.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from google.cloud.translate_v2 import Client
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+
+
+class CloudTranslateHook(GoogleCloudBaseHook):
+    """
+    Hook for Google Cloud translate APIs.
+    """
+
+    _client = None
+
+    def __init__(self, gcp_conn_id='google_cloud_default'):
+        super(CloudTranslateHook, self).__init__(gcp_conn_id)
+
+    def get_conn(self):
+        """
+        Retrieves connection to Cloud Translate
+
+        :return: Google Cloud Translate client object.
+        :rtype: Client
+        """
+        if not self._client:
+            self._client = Client(credentials=self._get_credentials())
+        return self._client
+
+    def translate(
+        self, values, target_language, format_=None, source_language=None, model=None
+    ):
+        """Translate a string or list of strings.
+
+        See https://cloud.google.com/translate/docs/translating-text
+
+        :type values: str or list
+        :param values: String or list of strings to translate.
+
+        :type target_language: str
+        :param target_language: The language to translate results into. This
+                                is required by the API and defaults to
+                                the target language of the current instance.
+
+        :type format_: str
+        :param format_: (Optional) One of ``text`` or ``html``, to specify
+                        if the input text is plain text or HTML.
+
+        :type source_language: str or None
+        :param source_language: (Optional) The language of the text to
+                                be translated.
+
+        :type model: str or None
+        :param model: (Optional) The model used to translate the text, such
+                      as ``'base'`` or ``'nmt'``.
+
+        :rtype: str or list
+        :returns: A list of dictionaries for each queried value. Each
+                  dictionary typically contains three keys (though not
+                  all will be present in all cases)
+
+                  * ``detectedSourceLanguage``: The detected language (as an
+                    ISO 639-1 language code) of the text.
+                  * ``translatedText``: The translation of the text into the
+                    target language.
+                  * ``input``: The corresponding input value.
+                  * ``model``: The model used to translate the text.
+
+                  If only a single value is passed, then only a single
+                  dictionary will be returned.
+        :raises: :class:`~exceptions.ValueError` if the number of
+                 values and translations differ.
+        """
+        client = self.get_conn()
+
+        return client.translate(
+            values=values,
+            target_language=target_language,
+            format_=format_,
+            source_language=source_language,
+            model=model,
+        )

--- a/airflow/contrib/operators/gcp_translate_operator.py
+++ b/airflow/contrib/operators/gcp_translate_operator.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow import AirflowException
+from airflow.contrib.hooks.gcp_translate_hook import CloudTranslateHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class CloudTranslateTextOperator(BaseOperator):
+    """
+    Translate a string or list of strings.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudTranslateTextOperator`
+
+    See https://cloud.google.com/translate/docs/translating-text
+
+    Execute method returns str or list.
+
+    This is a list of dictionaries for each queried value. Each
+    dictionary typically contains three keys (though not
+    all will be present in all cases).
+
+    * ``detectedSourceLanguage``: The detected language (as an
+      ISO 639-1 language code) of the text.
+    * ``translatedText``: The translation of the text into the
+      target language.
+    * ``input``: The corresponding input value.
+    * ``model``: The model used to translate the text.
+
+    If only a single value is passed, then only a single
+    dictionary is set as XCom return value.
+
+    :type values: str or list
+    :param values: String or list of strings to translate.
+
+    :type target_language: str
+    :param target_language: The language to translate results into. This
+      is required by the API and defaults to
+      the target language of the current instance.
+
+    :type format_: str or None
+    :param format_: (Optional) One of ``text`` or ``html``, to specify
+      if the input text is plain text or HTML.
+
+    :type source_language: str or None
+    :param source_language: (Optional) The language of the text to
+      be translated.
+
+    :type model: str or None
+    :param model: (Optional) The model used to translate the text, such
+      as ``'base'`` or ``'nmt'``.
+
+    """
+
+    # [START translate_template_fields]
+    template_fields = ('values', 'target_language', 'format_', 'source_language', 'model', 'gcp_conn_id')
+    # [END translate_template_fields]
+
+    @apply_defaults
+    def __init__(
+        self,
+        values,
+        target_language,
+        format_,
+        source_language,
+        model,
+        gcp_conn_id='google_cloud_default',
+        *args,
+        **kwargs
+    ):
+        super(CloudTranslateTextOperator, self).__init__(*args, **kwargs)
+        self.values = values
+        self.target_language = target_language
+        self.format_ = format_
+        self.source_language = source_language
+        self.model = model
+        self.gcp_conn_id = gcp_conn_id
+
+    def execute(self, context):
+        _hook = CloudTranslateHook(gcp_conn_id=self.gcp_conn_id)
+        try:
+            translation = _hook.translate(
+                values=self.values,
+                target_language=self.target_language,
+                format_=self.format_,
+                source_language=self.source_language,
+                model=self.model,
+            )
+            self.log.debug("Translation %s", translation)
+            return translation
+        except ValueError as e:
+            self.log.error('An error has been thrown from translate method:')
+            self.log.error(e)
+            raise AirflowException(e)

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -208,6 +208,7 @@ Operators
 .. autoclass:: airflow.contrib.operators.gcp_compute_operator.GceSetMachineTypeOperator
 .. autoclass:: airflow.contrib.operators.gcp_function_operator.GcfFunctionDeleteOperator
 .. autoclass:: airflow.contrib.operators.gcp_function_operator.GcfFunctionDeployOperator
+.. autoclass:: airflow.contrib.operators.gcp_translate_operator.CloudTranslateTextOperator
 .. autoclass:: airflow.contrib.operators.gcp_vision_operator.CloudVisionProductCreateOperator
 .. autoclass:: airflow.contrib.operators.gcp_vision_operator.CloudVisionProductDeleteOperator
 .. autoclass:: airflow.contrib.operators.gcp_vision_operator.CloudVisionProductGetOperator
@@ -509,6 +510,7 @@ Community contributed hooks
 .. autoclass:: airflow.contrib.hooks.gcp_function_hook.GcfHook
 .. autoclass:: airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook
 .. autoclass:: airflow.contrib.hooks.gcp_kms_hook.GoogleCloudKMSHook
+.. autoclass:: airflow.contrib.hooks.gcp_translate_hook.CloudTranslateHook
 .. autoclass:: airflow.contrib.hooks.gcs_hook.GoogleCloudStorageHook
 .. autoclass:: airflow.contrib.hooks.grpc_hook.GrpcHook
 .. autoclass:: airflow.contrib.hooks.imap_hook.ImapHook

--- a/docs/howto/operator/gcp/translate.rst
+++ b/docs/howto/operator/gcp/translate.rst
@@ -1,0 +1,68 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Google Cloud Translate Operators
+--------------------------------
+
+.. contents::
+  :depth: 1
+  :local:
+
+.. _howto/operator:CloudTranslateTextOperator:
+
+CloudTranslateTextOperator
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Translate a string or list of strings.
+
+For parameter definition, take a look at
+:class:`~airflow.contrib.operators.gcp_translate_operator.CloudTranslateTextOperator`
+
+Using the operator
+""""""""""""""""""
+
+Basic usage of the operator:
+
+.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_translate.py
+      :language: python
+      :dedent: 4
+      :start-after: [START howto_operator_translate_text]
+      :end-before: [END howto_operator_translate_text]
+
+The result of translation is available as dictionary or array of dictionaries accessible via the usual
+XCom mechanisms of Airflow:
+
+.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_translate.py
+      :language: python
+      :dedent: 4
+      :start-after: [START howto_operator_translate_access]
+      :end-before: [END howto_operator_translate_access]
+
+
+Templating
+""""""""""
+
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_translate_operator.py
+    :language: python
+    :dedent: 4
+    :start-after: [START translate_template_fields]
+    :end-before: [END translate_template_fields]
+
+More information
+""""""""""""""""
+
+See `Google Cloud Translate documentation <https://cloud.google.com/translate/docs/translating-text>`_.

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -618,6 +618,16 @@ Cloud Vision Product Search Operators
 
 They also use :class:`airflow.contrib.hooks.gcp_vision_hook.CloudVisionHook` to communicate with Google Cloud Platform.
 
+Cloud Translate
+'''''''''''''''
+
+Cloud Translate Text Operators
+""""""""""""""""""""""""""""""
+
+:class:`airflow.contrib.operators.gcp_translate_operator.CloudTranslateTextOperator`
+    Translate a string or list of strings.
+
+
 Google Kubernetes Engine
 ''''''''''''''''''''''''
 

--- a/setup.py
+++ b/setup.py
@@ -180,6 +180,7 @@ gcp = [
     'google-cloud-container>=0.1.1',
     'google-cloud-bigtable==0.31.0',
     'google-cloud-spanner>=1.7.1',
+    'google-cloud-translate>=1.3.3',
     'google-cloud-vision>=0.35.2',
     'grpcio-gcp>=0.2.2',
     'PyOpenSSL',

--- a/tests/contrib/hooks/test_gcp_translate_hook.py
+++ b/tests/contrib/hooks/test_gcp_translate_hook.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow.contrib.hooks.gcp_translate_hook import CloudTranslateHook
+from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+PROJECT_ID_TEST = 'project-id'
+
+
+class TestCloudTranslateHook(unittest.TestCase):
+    def setUp(self):
+        with mock.patch(
+            'airflow.contrib.hooks.gcp_translate_hook.CloudTranslateHook.__init__',
+            new=mock_base_gcp_hook_default_project_id,
+        ):
+            self.hook = CloudTranslateHook(gcp_conn_id='test')
+
+    @mock.patch('airflow.contrib.hooks.gcp_translate_hook.CloudTranslateHook.get_conn')
+    def test_translate_called(self, get_conn):
+        # Given
+        translate_method = get_conn.return_value.translate
+        translate_method.return_value = {
+            'translatedText': 'Yellowing self Gęśle',
+            'detectedSourceLanguage': 'pl',
+            'model': 'base',
+            'input': 'zażółć gęślą jaźń',
+        }
+        # When
+        result = self.hook.translate(
+            values=['zażółć gęślą jaźń'],
+            target_language='en',
+            format_='text',
+            source_language=None,
+            model='base',
+        )
+        # Then
+        self.assertEqual(
+            result,
+            {
+                'translatedText': 'Yellowing self Gęśle',
+                'detectedSourceLanguage': 'pl',
+                'model': 'base',
+                'input': 'zażółć gęślą jaźń',
+            },
+        )
+        translate_method.assert_called_once_with(
+            values=['zażółć gęślą jaźń'],
+            target_language='en',
+            format_='text',
+            source_language=None,
+            model='base',
+        )

--- a/tests/contrib/operators/test_gcp_translate_operator.py
+++ b/tests/contrib/operators/test_gcp_translate_operator.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow.contrib.operators.gcp_translate_operator import CloudTranslateTextOperator
+
+try:
+    # noinspection PyProtectedMember
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+GCP_CONN_ID = 'google_cloud_default'
+
+
+class CloudTranslateTest(unittest.TestCase):
+    @mock.patch('airflow.contrib.operators.gcp_translate_operator.CloudTranslateHook')
+    def test_minimal_green_path(self, mock_hook):
+        mock_hook.return_value.translate.return_value = [
+            {
+                'translatedText': 'Yellowing self Gęśle',
+                'detectedSourceLanguage': 'pl',
+                'model': 'base',
+                'input': 'zażółć gęślą jaźń',
+            }
+        ]
+        op = CloudTranslateTextOperator(
+            values=['zażółć gęślą jaźń'],
+            target_language='en',
+            format_='text',
+            source_language=None,
+            model='base',
+            gcp_conn_id=GCP_CONN_ID,
+            task_id='id',
+        )
+        return_value = op.execute(context=None)
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.return_value.translate.assert_called_once_with(
+            values=['zażółć gęślą jaźń'],
+            target_language='en',
+            format_='text',
+            source_language=None,
+            model='base',
+        )
+        self.assertEqual(
+            [
+                {
+                    'translatedText': 'Yellowing self Gęśle',
+                    'detectedSourceLanguage': 'pl',
+                    'model': 'base',
+                    'input': 'zażółć gęślą jaźń',
+                }
+            ],
+            return_value,
+        )

--- a/tests/contrib/operators/test_gcp_translate_operator_system.py
+++ b/tests/contrib/operators/test_gcp_translate_operator_system.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from tests.contrib.utils.base_gcp_system_test_case import DagGcpSystemTestCase, SKIP_TEST_WARNING
+from tests.contrib.utils.gcp_authenticator import GCP_AI_KEY
+
+
+@unittest.skipIf(DagGcpSystemTestCase.skip_check(GCP_AI_KEY), SKIP_TEST_WARNING)
+class CloudTranslateExampleDagsSystemTest(DagGcpSystemTestCase):
+    def __init__(self, method_name='runTest'):
+        super(CloudTranslateExampleDagsSystemTest, self).__init__(
+            method_name, dag_id='example_gcp_translate', gcp_key=GCP_AI_KEY
+        )
+
+    def test_run_example_dag_function(self):
+        self._run_dag()

--- a/tests/contrib/utils/gcp_authenticator.py
+++ b/tests/contrib/utils/gcp_authenticator.py
@@ -38,9 +38,9 @@ KEYFILE_DICT_EXTRA = 'extra__google_cloud_platform__keyfile_dict'
 SCOPE_EXTRA = 'extra__google_cloud_platform__scope'
 PROJECT_EXTRA = 'extra__google_cloud_platform__project'
 
-AIRFLOW_MAIN_FOLDER = os.path.realpath(os.path.join(
-    os.path.dirname(os.path.realpath(__file__)),
-    os.pardir, os.pardir, os.pardir))
+AIRFLOW_MAIN_FOLDER = os.path.realpath(
+    os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir, os.pardir)
+)
 
 
 class GcpAuthenticator(LoggingCommandExecutor):
@@ -48,6 +48,7 @@ class GcpAuthenticator(LoggingCommandExecutor):
     Manages authentication to Google Cloud Platform. It helps to manage
     connection - it can authenticate with the gcp key name specified
     """
+
     original_account = None
 
     def __init__(self, gcp_key, project_extra=None):
@@ -77,15 +78,13 @@ class GcpAuthenticator(LoggingCommandExecutor):
         """
         session = settings.Session()
         try:
-            conn = session.query(Connection).filter(
-                Connection.conn_id == 'google_cloud_default')[0]
+            conn = session.query(Connection).filter(Connection.conn_id == 'google_cloud_default')[0]
             extras = conn.extra_dejson
             extras[KEYPATH_EXTRA] = self.full_key_path
             if extras.get(KEYFILE_DICT_EXTRA):
                 del extras[KEYFILE_DICT_EXTRA]
             extras[SCOPE_EXTRA] = 'https://www.googleapis.com/auth/cloud-platform'
-            extras[PROJECT_EXTRA] = self.project_extra if self.project_extra else \
-                self.project_id
+            extras[PROJECT_EXTRA] = self.project_extra if self.project_extra else self.project_id
             conn.extra = json.dumps(extras)
             session.commit()
         except BaseException as ex:
@@ -103,8 +102,7 @@ class GcpAuthenticator(LoggingCommandExecutor):
         """
         session = settings.Session()
         try:
-            conn = session.query(Connection).filter(
-                Connection.conn_id == 'google_cloud_default')[0]
+            conn = session.query(Connection).filter(Connection.conn_id == 'google_cloud_default')[0]
             extras = conn.extra_dejson
             with open(self.full_key_path, "r") as path_file:
                 content = json.load(path_file)
@@ -135,9 +133,7 @@ class GcpAuthenticator(LoggingCommandExecutor):
         if "GCP_CONFIG_DIR" in os.environ:
             gcp_config_dir = os.environ["GCP_CONFIG_DIR"]
         else:
-            gcp_config_dir = os.path.join(AIRFLOW_MAIN_FOLDER,
-                                          os.pardir,
-                                          "config")
+            gcp_config_dir = os.path.join(AIRFLOW_MAIN_FOLDER, os.pardir, "config")
         if not os.path.isdir(gcp_config_dir):
             self.log.info("The {} is not a directory".format(gcp_config_dir))
         key_dir = os.path.join(gcp_config_dir, "keys")
@@ -154,8 +150,10 @@ class GcpAuthenticator(LoggingCommandExecutor):
             raise AirflowException("The gcp_key is not set!")
         if not os.path.isfile(self.full_key_path):
             raise AirflowException(
-                "The key {} could not be found. Please copy it to the {} path.".
-                format(self.gcp_key, self.full_key_path))
+                "The key {} could not be found. Please copy it to the {} path.".format(
+                    self.gcp_key, self.full_key_path
+                )
+            )
 
     def gcp_authenticate(self):
         """
@@ -165,9 +163,14 @@ class GcpAuthenticator(LoggingCommandExecutor):
         self.log.info("Setting the GCP key to {}".format(self.full_key_path))
         # Checking if we can authenticate using service account credentials provided
         self.execute_cmd(
-            ['gcloud', 'auth', 'activate-service-account',
-             '--key-file={}'.format(self.full_key_path),
-             '--project={}'.format(self.project_id)])
+            [
+                'gcloud',
+                'auth',
+                'activate-service-account',
+                '--key-file={}'.format(self.full_key_path),
+                '--project={}'.format(self.project_id),
+            ]
+        )
         self.set_key_path_in_airflow_connection()
 
     def gcp_revoke_authentication(self):
@@ -176,11 +179,10 @@ class GcpAuthenticator(LoggingCommandExecutor):
         """
         self._validate_key_set()
         self.log.info("Revoking authentication - setting it to none")
+        self.execute_cmd(['gcloud', 'config', 'get-value', 'account', '--project={}'.format(self.project_id)])
         self.execute_cmd(
-            ['gcloud', 'config', 'get-value', 'account',
-             '--project={}'.format(self.project_id)])
-        self.execute_cmd(['gcloud', 'config', 'set', 'account', 'none',
-                          '--project={}'.format(self.project_id)])
+            ['gcloud', 'config', 'set', 'account', 'none', '--project={}'.format(self.project_id)]
+        )
 
     def gcp_store_authentication(self):
         """
@@ -190,10 +192,9 @@ class GcpAuthenticator(LoggingCommandExecutor):
         self._validate_key_set()
         if not GcpAuthenticator.original_account:
             GcpAuthenticator.original_account = self.check_output(
-                ['gcloud', 'config', 'get-value', 'account',
-                 '--project={}'.format(self.project_id)]).decode('utf-8')
-            self.log.info("Storing account: to restore it later {}".format(
-                GcpAuthenticator.original_account))
+                ['gcloud', 'config', 'get-value', 'account', '--project={}'.format(self.project_id)]
+            ).decode('utf-8')
+            self.log.info("Storing account: to restore it later {}".format(GcpAuthenticator.original_account))
 
     def gcp_restore_authentication(self):
         """
@@ -201,10 +202,16 @@ class GcpAuthenticator(LoggingCommandExecutor):
         """
         self._validate_key_set()
         if GcpAuthenticator.original_account:
-            self.log.info("Restoring original account stored: {}".
-                          format(GcpAuthenticator.original_account))
-            subprocess.call(['gcloud', 'config', 'set', 'account',
-                             GcpAuthenticator.original_account,
-                             '--project={}'.format(self.project_id)])
+            self.log.info("Restoring original account stored: {}".format(GcpAuthenticator.original_account))
+            subprocess.call(
+                [
+                    'gcloud',
+                    'config',
+                    'set',
+                    'account',
+                    GcpAuthenticator.original_account,
+                    '--project={}'.format(self.project_id),
+                ]
+            )
         else:
             self.log.info("Not restoring the original GCP account: it is not set")


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-3939

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Add Google Cloud Translate operator

### Tests

- [x] My PR adds the following unit tests
* TestCloudTranslateHook
* CloudTranslateTest
* CloudTranslateExampleDagsSystemTest

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
