### PR TITLE
[AIRFLOW-3926] Remove references to Flask-Admin

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -35,7 +35,6 @@ import sys
 # flake8: noqa: F401
 from airflow import settings, configuration as conf
 from airflow.models import DAG
-from flask_admin import BaseView
 from importlib import import_module
 from airflow.exceptions import AirflowException
 
@@ -70,10 +69,6 @@ def load_login():
         )
         if conf.getboolean('webserver', 'AUTHENTICATE'):
             raise AirflowException("Failed to import authentication backend")
-
-
-class AirflowViewPlugin(BaseView):
-    pass
 
 
 class AirflowMacroPlugin(object):

--- a/airflow/contrib/plugins/metastore_browser/main.py
+++ b/airflow/contrib/plugins/metastore_browser/main.py
@@ -43,7 +43,7 @@ TABLE_SELECTOR_LIMIT = 2000
 pd.set_option('display.max_colwidth', -1)
 
 
-# Creating a flask admin BaseView
+# Creating a Flask-AppBuilder BaseView
 class MetastoreBrowserView(BaseView):
 
     default_view = 'index'

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2411,18 +2411,6 @@ class TaskInstanceModelView(AirflowModelView):
         self.update_redirect()
         return redirect(self.get_redirect())
 
-    def get_one(self, id):
-        """
-        As a workaround for AIRFLOW-252, this method overrides Flask-Admin's
-        ModelView.get_one().
-
-        TODO: this method should be removed once the below bug is fixed on
-        Flask-Admin side. https://github.com/flask-admin/flask-admin/issues/1226
-        """
-        task_id, dag_id, execution_date = iterdecode(id)  # noqa
-        execution_date = pendulum.parse(execution_date)
-        return self.session.query(self.model).get((task_id, dag_id, execution_date))
-
 
 class DagModelView(AirflowModelView):
     route_base = '/dagmodel'

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -86,13 +86,8 @@ looks like:
         executors = []
         # A list of references to inject into the macros namespace
         macros = []
-        # A list of objects created from a class derived
-        # from flask_admin.BaseView
-        admin_views = []
-        # A list of Blueprint object created from flask.Blueprint. For use with the flask_admin based GUI
+        # A list of Blueprint object created from flask.Blueprint. For use with the flask_appbuilder based GUI
         flask_blueprints = []
-        # A list of menu links (flask_admin.base.MenuLink). For use with the flask_admin based GUI
-        menu_links = []
         # A list of dictionaries containing FlaskAppBuilder BaseView object and some metadata. See example below
         appbuilder_views = []
         # A list of dictionaries containing FlaskAppBuilder BaseView object and some metadata. See example below
@@ -142,9 +137,7 @@ definitions in Airflow.
     from airflow.plugins_manager import AirflowPlugin
 
     from flask import Blueprint
-    from flask_admin import BaseView, expose
-    from flask_admin.base import MenuLink
-    from flask_appbuilder import BaseView as AppBuilderBaseView
+    from flask_appbuilder import expose, BaseView as AppBuilderBaseView
 
     # Importing base classes that we need to derive
     from airflow.hooks.base_hook import BaseHook
@@ -172,25 +165,12 @@ definitions in Airflow.
     def plugin_macro():
         pass
 
-    # Creating a flask admin BaseView
-    class TestView(BaseView):
-        @expose('/')
-        def test(self):
-            # in this example, put your test_plugin/test.html template at airflow/plugins/templates/test_plugin/test.html
-            return self.render("test_plugin/test.html", content="Hello galaxy!")
-    v = TestView(category="Test Plugin", name="Test View")
-
     # Creating a flask blueprint to integrate the templates and static folder
     bp = Blueprint(
         "test_plugin", __name__,
         template_folder='templates', # registers airflow/plugins/templates as a Jinja template folder
         static_folder='static',
         static_url_path='/static/test_plugin')
-
-    ml = MenuLink(
-        category='Test Plugin',
-        name='Test Menu Link',
-        url='https://airflow.apache.org/')
 
     # Creating a flask appbuilder BaseView
     class TestAppBuilderBaseView(AppBuilderBaseView):
@@ -199,6 +179,7 @@ definitions in Airflow.
         @expose("/")
         def test(self):
             return self.render("test_plugin/test.html", content="Hello galaxy!")
+
     v_appbuilder_view = TestAppBuilderBaseView()
     v_appbuilder_package = {"name": "Test View",
                             "category": "Test Plugin",
@@ -218,9 +199,7 @@ definitions in Airflow.
         hooks = [PluginHook]
         executors = [PluginExecutor]
         macros = [plugin_macro]
-        admin_views = [v]
         flask_blueprints = [bp]
-        menu_links = [ml]
         appbuilder_views = [v_appbuilder_package]
         appbuilder_menu_items = [appbuilder_mitem]
 

--- a/setup.py
+++ b/setup.py
@@ -295,7 +295,6 @@ def do_setup():
             'enum34~=1.1.6;python_version<"3.4"',
             'flask>=1.0, <2.0',
             'flask-appbuilder==1.12.3',
-            'flask-admin==1.5.3',
             'flask-caching>=1.3.3, <1.4.0',
             'flask-login>=0.3, <0.5',
             'flask-swagger==0.2.13',

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -21,9 +21,7 @@
 from airflow.plugins_manager import AirflowPlugin
 
 from flask import Blueprint
-from flask_admin import BaseView, expose
-from flask_admin.base import MenuLink
-from flask_appbuilder import BaseView as AppBuilderBaseView
+from flask_appbuilder import expose, BaseView as AppBuilderBaseView
 
 # Importing base classes that we need to derive
 from airflow.hooks.base_hook import BaseHook
@@ -57,18 +55,6 @@ def plugin_macro():
     pass
 
 
-# Creating a flask admin BaseView
-class PluginTestView(BaseView):
-    @expose('/')
-    def test(self):
-        # in this example, put your test_plugin/test.html
-        # template at airflow/plugins/templates/test_plugin/test.html
-        return self.render("test_plugin/test.html", content="Hello galaxy!")
-
-
-v = PluginTestView(category="Test Plugin", name="Test View")
-
-
 # Creating a flask appbuilder BaseView
 class PluginTestAppBuilderBaseView(AppBuilderBaseView):
     default_view = "test"
@@ -98,12 +84,6 @@ bp = Blueprint(
     static_url_path='/static/test_plugin')
 
 
-ml = MenuLink(
-    category='Test Plugin',
-    name="Test Menu Link",
-    url="https://airflow.apache.org/")
-
-
 # Defining the plugin class
 class AirflowTestPlugin(AirflowPlugin):
     name = "test_plugin"
@@ -112,9 +92,7 @@ class AirflowTestPlugin(AirflowPlugin):
     hooks = [PluginHook]
     executors = [PluginExecutor]
     macros = [plugin_macro]
-    admin_views = [v]
     flask_blueprints = [bp]
-    menu_links = [ml]
     appbuilder_views = [v_appbuilder_package]
     appbuilder_menu_items = [appbuilder_mitem]
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3926
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:

Remove all remaining references to Flask-Admin and remove it as a
dependency. This should be the final step in the deprecation of
Flask-Admin in favor of Flask-AppBuilder.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ X ] Passes `flake8`
