### PR TITLE
[AIRFLOW-3932] Update unit tests and documentation for safe mode flag.

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -52,8 +52,10 @@ the ``DAG`` objects. You can have as many DAGs as you want, each describing an
 arbitrary number of tasks. In general, each one should correspond to a single
 logical workflow.
 
-.. note:: When searching for DAGs, Airflow will only consider files where the string
-   "airflow" and "DAG" both appear in the contents of the ``.py`` file.
+.. note:: When searching for DAGs, Airflow only considers python files
+   that contain the strings "airflow" and "DAG" by default. To consider
+   all python files instead, disable the ``DAG_DISCOVERY_SAFE_MODE``
+   configuration flag.
 
 Scope
 -----


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In #4746, we introduced the `DAG_DISCOVERY_SAFE_MODE` flag. Taking another look at the diffs, it looks like I neglected to pass the `safe_mode` flag to all necessary methods. This patch fixes the use of `safe_mode`, backfills unit tests, and updates documentation about the new flag.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
