### PR TITLE
[AIRFLOW-3946] Deprecate utils.file.TemporaryDirectory

### DIFF
--- a/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.py
+++ b/airflow/contrib/operators/oracle_to_azure_data_lake_transfer.py
@@ -17,11 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from tempfile import TemporaryDirectory
+
 from airflow.hooks.oracle_hook import OracleHook
 from airflow.contrib.hooks.azure_data_lake_hook import AzureDataLakeHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
-from airflow.utils.file import TemporaryDirectory
 
 import unicodecsv as csv
 import os

--- a/airflow/contrib/sensors/bash_sensor.py
+++ b/airflow/contrib/sensors/bash_sensor.py
@@ -19,10 +19,9 @@
 
 import os
 from subprocess import Popen, STDOUT, PIPE
-from tempfile import gettempdir, NamedTemporaryFile
+from tempfile import gettempdir, NamedTemporaryFile, TemporaryDirectory
 from airflow.utils.decorators import apply_defaults
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
-from airflow.utils.file import TemporaryDirectory
 
 
 class BashSensor(BaseSensorOperator):

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -24,7 +24,7 @@ import subprocess
 import time
 import socket
 from collections import OrderedDict
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import unicodecsv as csv
 from six.moves import zip
@@ -33,7 +33,6 @@ from airflow import configuration
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 from airflow.security import utils
-from airflow.utils.file import TemporaryDirectory
 from airflow.utils.helpers import as_flattened_list
 from airflow.utils.operator_helpers import AIRFLOW_VAR_NAME_FORMAT_MAPPING
 

--- a/airflow/hooks/pig_hook.py
+++ b/airflow/hooks/pig_hook.py
@@ -18,11 +18,10 @@
 # under the License.
 
 import subprocess
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
-from airflow.utils.file import TemporaryDirectory
 
 
 class PigCliHook(BaseHook):

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -21,12 +21,11 @@
 import os
 import signal
 from subprocess import Popen, STDOUT, PIPE
-from tempfile import gettempdir, NamedTemporaryFile
+from tempfile import gettempdir, NamedTemporaryFile, TemporaryDirectory
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
-from airflow.utils.file import TemporaryDirectory
 from airflow.utils.operator_helpers import context_to_airflow_vars
 
 

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -18,12 +18,12 @@
 # under the License.
 
 import json
+from tempfile import TemporaryDirectory
 
 from airflow.hooks.docker_hook import DockerHook
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
-from airflow.utils.file import TemporaryDirectory
 from docker import APIClient, tls
 import ast
 

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -23,6 +23,7 @@ import pickle
 import subprocess
 import sys
 import types
+from tempfile import TemporaryDirectory
 from textwrap import dedent
 from typing import Optional, Iterable, Dict, Callable
 
@@ -32,7 +33,6 @@ import six
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, SkipMixin
 from airflow.utils.decorators import apply_defaults
-from airflow.utils.file import TemporaryDirectory
 from airflow.utils.operator_helpers import context_to_airflow_vars
 
 

--- a/airflow/operators/s3_to_hive_operator.py
+++ b/airflow/operators/s3_to_hive_operator.py
@@ -17,8 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from tempfile import NamedTemporaryFile
-from airflow.utils.file import TemporaryDirectory
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 import gzip
 import bz2
 import tempfile

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -23,8 +23,12 @@ import shutil
 from tempfile import mkdtemp
 
 from contextlib import contextmanager
+from zope import deprecation
 
 
+@deprecation.deprecate(msg="This function will be removed in Airflow 2.0. "
+                           "tempfile.TemporaryDirectory (Python >=3.2) provides the "
+                           "same functionality.")
 @contextmanager
 def TemporaryDirectory(suffix='', prefix=None, dir=None):
     name = mkdtemp(suffix=suffix, prefix=prefix, dir=dir)

--- a/tests/contrib/operators/test_oracle_to_azure_data_lake_transfer.py
+++ b/tests/contrib/operators/test_oracle_to_azure_data_lake_transfer.py
@@ -18,9 +18,10 @@
 # under the License.
 
 import unittest
+from tempfile import TemporaryDirectory
+
 from airflow.contrib.operators.oracle_to_azure_data_lake_transfer \
     import OracleToAzureDataLakeTransfer
-from airflow.utils.file import TemporaryDirectory
 import unicodecsv as csv
 import os
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3946
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR deprecates `utils.file.TemporaryDirectory`.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
