### PR TITLE
[AIRFLOW-3945] Stop inserting row when permission views unchanged

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -428,7 +428,8 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
                 update_perm_views.append({'permission_view_id': perm_view_id,
                                           'role_id': role.id})
 
-        self.get_session.execute(ab_perm_view_role.insert(), update_perm_views)
+        if update_perm_views:
+            self.get_session.execute(ab_perm_view_role.insert(), update_perm_views)
         self.get_session.commit()
 
     def update_admin_perm_view(self):

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -26,6 +26,7 @@ import mock
 from flask import Flask
 from flask_appbuilder import AppBuilder, SQLA, Model, has_access, expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface
+from flask_appbuilder.security.sqla import models as sqla_models
 from flask_appbuilder.views import ModelView, BaseView
 
 from sqlalchemy import Column, Integer, String, Date, Float
@@ -260,6 +261,15 @@ class TestSecurity(unittest.TestCase):
             perms=['can_dag_edit'],
             dag_id='access_control_test',
         )
+
+    def test_no_additional_dag_permission_views_created(self):
+        ab_perm_view_role = sqla_models.assoc_permissionview_role
+
+        self.security_manager.sync_roles()
+        num_pv_before = self.db.session().query(ab_perm_view_role).count()
+        self.security_manager.sync_roles()
+        num_pv_after = self.db.session().query(ab_perm_view_role).count()
+        self.assertEqual(num_pv_before, num_pv_after)
 
     def expect_user_is_in_role(self, user, rolename):
         self.security_manager.init_role(rolename, [], [])


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3945

### Description

When creating new permission views in AirflowSecurityManager.create_custom_dag_permission_view in the file airflow/www/security.py, the list of permission views to update might be empty because everything is still up to date. In that case, a row in which only the id is not NULL will still be inserted in table ab_permission_view_role every time.

This is a minor bug when using PostgreSQL. When using a SQL Server backend, this causes the webserver to crash as SQL Server disallows multiple NULLs in a unique constraint (by default).

My PR
  * Fixes this bug
  * Adds a test for it

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
I added a test which checks that the number of records in table ab_permission_view_role remains the same when running sync_roles() twice in succession. It fails before my changes and passes after my changes.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`

### Unanswered Question

What to do about the existing records in table ab_permission_view_role?

If you restarted the webserver a lot then you will have lots of empty rows in your database (empty apart from the id column). I tried adding an Alembic migration to delete these rows, but that won't work on new installations since the ab_* tables are not created yet when Alembic runs its migrations for the first time. We could decide to leave it, but I'm not sure that won't cause problems down the line.
