### PR TITLE
[AIRFLOW-3720] Add prefix to file match in GCS_TO_S3 operator to avoid missmatch

### DIFF
--- a/airflow/contrib/operators/gcs_to_s3.py
+++ b/airflow/contrib/operators/gcs_to_s3.py
@@ -58,6 +58,14 @@ class GoogleCloudStorageToS3Operator(GoogleCloudStorageListOperator):
                  You can specify this argument if you want to use a different
                  CA cert bundle than the one used by botocore.
     :type dest_verify: bool or str
+    :param replace: Whether or not to verify the existence of the files in the
+        destination bucket.
+        By default is set to False
+        If set to True, will upload all the files replacing the existing ones in
+        the destination bucket.
+        If set to False, will upload only the files that are in the origin but not
+        in the destination bucket.
+    :type replace: bool
     """
     template_fields = ('bucket', 'prefix', 'delimiter', 'dest_s3_key')
     ui_color = '#f0eee4'
@@ -99,8 +107,14 @@ class GoogleCloudStorageToS3Operator(GoogleCloudStorageListOperator):
             # if we are not replacing -> list all files in the S3 bucket
             # and only keep those files which are present in
             # Google Cloud Storage and not in S3
-            bucket_name, _ = S3Hook.parse_s3_url(self.dest_s3_key)
-            existing_files = s3_hook.list_keys(bucket_name)
+            bucket_name, prefix = S3Hook.parse_s3_url(self.dest_s3_key)
+            # look for the bucket and the prefix to avoid look into
+            # parent directories/keys
+            existing_files = s3_hook.list_keys(bucket_name, prefix=prefix)
+            # in case that no files exists, return an empty array to avoid errors
+            existing_files = existing_files if existing_files is not None else []
+            # remove the prefix for the existing files to allow the match
+            existing_files = [file.replace(prefix, '', 1) for file in existing_files]
             files = list(set(files) - set(existing_files))
 
         if files:

--- a/tests/contrib/operators/test_gcs_to_s3_operator.py
+++ b/tests/contrib/operators/test_gcs_to_s3_operator.py
@@ -45,6 +45,67 @@ MOCK_FILES = ["TEST1.csv", "TEST2.csv", "TEST3.csv"]
 
 class GoogleCloudStorageToS3OperatorTest(unittest.TestCase):
 
+    # Test1: incremental behaviour (just some files missing)
+    @mock_s3
+    @mock.patch('airflow.contrib.operators.gcs_list_operator.GoogleCloudStorageHook')
+    @mock.patch('airflow.contrib.operators.gcs_to_s3.GoogleCloudStorageHook')
+    def test_execute_incremental(self, mock_hook, mock_hook2):
+        mock_hook.return_value.list.return_value = MOCK_FILES
+        mock_hook.return_value.download.return_value = b"testing"
+        mock_hook2.return_value.list.return_value = MOCK_FILES
+
+        operator = GoogleCloudStorageToS3Operator(task_id=TASK_ID,
+                                                  bucket=GCS_BUCKET,
+                                                  prefix=PREFIX,
+                                                  delimiter=DELIMITER,
+                                                  dest_aws_conn_id=None,
+                                                  dest_s3_key=S3_BUCKET,
+                                                  replace=False)
+        # create dest bucket
+        hook = S3Hook(aws_conn_id=None)
+        b = hook.get_bucket('bucket')
+        b.create()
+        b.put_object(Key=MOCK_FILES[0], Body=b'testing')
+
+        # we expect all except first file in MOCK_FILES to be uploaded
+        # and all the MOCK_FILES to be present at the S3 bucket
+        uploaded_files = operator.execute(None)
+        self.assertEqual(sorted(MOCK_FILES[1:]),
+                         sorted(uploaded_files))
+        self.assertEqual(sorted(MOCK_FILES),
+                         sorted(hook.list_keys('bucket', delimiter='/')))
+
+    # Test2: All the files are already in origin and destination without replace
+    @mock_s3
+    @mock.patch('airflow.contrib.operators.gcs_list_operator.GoogleCloudStorageHook')
+    @mock.patch('airflow.contrib.operators.gcs_to_s3.GoogleCloudStorageHook')
+    def test_execute_without_replace(self, mock_hook, mock_hook2):
+        mock_hook.return_value.list.return_value = MOCK_FILES
+        mock_hook.return_value.download.return_value = b"testing"
+        mock_hook2.return_value.list.return_value = MOCK_FILES
+
+        operator = GoogleCloudStorageToS3Operator(task_id=TASK_ID,
+                                                  bucket=GCS_BUCKET,
+                                                  prefix=PREFIX,
+                                                  delimiter=DELIMITER,
+                                                  dest_aws_conn_id=None,
+                                                  dest_s3_key=S3_BUCKET,
+                                                  replace=False)
+        # create dest bucket with all the files
+        hook = S3Hook(aws_conn_id=None)
+        b = hook.get_bucket('bucket')
+        b.create()
+        [b.put_object(Key=MOCK_FILE, Body=b'testing') for MOCK_FILE in MOCK_FILES]
+
+        # we expect nothing to be uploaded
+        # and all the MOCK_FILES to be present at the S3 bucket
+        uploaded_files = operator.execute(None)
+        self.assertEqual([],
+                         uploaded_files)
+        self.assertEqual(sorted(MOCK_FILES),
+                         sorted(hook.list_keys('bucket', delimiter='/')))
+
+    # Test3: There are no files in destination bucket
     @mock_s3
     @mock.patch('airflow.contrib.operators.gcs_list_operator.GoogleCloudStorageHook')
     @mock.patch('airflow.contrib.operators.gcs_to_s3.GoogleCloudStorageHook')
@@ -58,17 +119,77 @@ class GoogleCloudStorageToS3OperatorTest(unittest.TestCase):
                                                   prefix=PREFIX,
                                                   delimiter=DELIMITER,
                                                   dest_aws_conn_id=None,
-                                                  dest_s3_key=S3_BUCKET)
-        # create dest bucket
+                                                  dest_s3_key=S3_BUCKET,
+                                                  replace=False)
+        # create dest bucket without files
         hook = S3Hook(aws_conn_id=None)
         b = hook.get_bucket('bucket')
         b.create()
-        b.put_object(Key=MOCK_FILES[0], Body=b'testing')
 
-        # we expect MOCK_FILES[1:] to be uploaded
+        # we expect all MOCK_FILES to be uploaded
         # and all MOCK_FILES to be present at the S3 bucket
         uploaded_files = operator.execute(None)
-        self.assertEqual(sorted(MOCK_FILES[1:]),
+        self.assertEqual(sorted(MOCK_FILES),
+                         sorted(uploaded_files))
+        self.assertEqual(sorted(MOCK_FILES),
+                         sorted(hook.list_keys('bucket', delimiter='/')))
+
+    # Test4: Destination and Origin are in sync but replace all files in destination
+    @mock_s3
+    @mock.patch('airflow.contrib.operators.gcs_list_operator.GoogleCloudStorageHook')
+    @mock.patch('airflow.contrib.operators.gcs_to_s3.GoogleCloudStorageHook')
+    def test_execute_with_replace(self, mock_hook, mock_hook2):
+        mock_hook.return_value.list.return_value = MOCK_FILES
+        mock_hook.return_value.download.return_value = b"testing"
+        mock_hook2.return_value.list.return_value = MOCK_FILES
+
+        operator = GoogleCloudStorageToS3Operator(task_id=TASK_ID,
+                                                  bucket=GCS_BUCKET,
+                                                  prefix=PREFIX,
+                                                  delimiter=DELIMITER,
+                                                  dest_aws_conn_id=None,
+                                                  dest_s3_key=S3_BUCKET,
+                                                  replace=True)
+        # create dest bucket with all the files
+        hook = S3Hook(aws_conn_id=None)
+        b = hook.get_bucket('bucket')
+        b.create()
+        [b.put_object(Key=MOCK_FILE, Body=b'testing') for MOCK_FILE in MOCK_FILES]
+
+        # we expect all MOCK_FILES to be uploaded and replace the existing ones
+        # and all MOCK_FILES to be present at the S3 bucket
+        uploaded_files = operator.execute(None)
+        self.assertEqual(sorted(MOCK_FILES),
+                         sorted(uploaded_files))
+        self.assertEqual(sorted(MOCK_FILES),
+                         sorted(hook.list_keys('bucket', delimiter='/')))
+
+    # Test5: Incremental sync with replace
+    @mock_s3
+    @mock.patch('airflow.contrib.operators.gcs_list_operator.GoogleCloudStorageHook')
+    @mock.patch('airflow.contrib.operators.gcs_to_s3.GoogleCloudStorageHook')
+    def test_execute_incremental_with_replace(self, mock_hook, mock_hook2):
+        mock_hook.return_value.list.return_value = MOCK_FILES
+        mock_hook.return_value.download.return_value = b"testing"
+        mock_hook2.return_value.list.return_value = MOCK_FILES
+
+        operator = GoogleCloudStorageToS3Operator(task_id=TASK_ID,
+                                                  bucket=GCS_BUCKET,
+                                                  prefix=PREFIX,
+                                                  delimiter=DELIMITER,
+                                                  dest_aws_conn_id=None,
+                                                  dest_s3_key=S3_BUCKET,
+                                                  replace=True)
+        # create dest bucket with just two files (the first two files in MOCK_FILES)
+        hook = S3Hook(aws_conn_id=None)
+        b = hook.get_bucket('bucket')
+        b.create()
+        [b.put_object(Key=MOCK_FILE, Body=b'testing') for MOCK_FILE in MOCK_FILES[:2]]
+
+        # we expect all the MOCK_FILES to be uploaded and replace the existing ones
+        # and all MOCK_FILES to be present at the S3 bucket
+        uploaded_files = operator.execute(None)
+        self.assertEqual(sorted(MOCK_FILES),
                          sorted(uploaded_files))
         self.assertEqual(sorted(MOCK_FILES),
                          sorted(hook.list_keys('bucket', delimiter='/')))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira
  - https://issues.apache.org/jira/browse/AIRFLOW-3720

### Description

- While using the GCS_TO_S3 operator, if the `replace` flag is set to False and the destination bucket have to many sub-directories it will look for the entire bucket instead of, only look into the destination directory set in the prefix

### Tests

- Added Unit test with the replace Flag

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
