### PR TITLE
[AIRFLOW-3800] run a dag at the beginning of the scheduled interval

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -2031,6 +2031,9 @@ class BaseOperator(LoggingMixin):
     :param do_xcom_push: if True, an XCom is pushed containing the Operator's
         result
     :type do_xcom_push: bool
+    :param run_at_beginning: if True, dag will be scheduled at the
+        beginning of the interval
+    :type run_at_beginning: bool
     """
 
     # For derived classes to define which fields will get jinjaified
@@ -2088,6 +2091,7 @@ class BaseOperator(LoggingMixin):
             do_xcom_push=True,
             inlets=None,
             outlets=None,
+            run_at_beginning=False,
             *args,
             **kwargs):
 
@@ -2171,6 +2175,7 @@ class BaseOperator(LoggingMixin):
         self.task_concurrency = task_concurrency
         self.executor_config = executor_config or {}
         self.do_xcom_push = do_xcom_push
+        self.run_at_beginning = run_at_beginning
 
         # Private attributes
         self._upstream_task_ids = set()

--- a/airflow/sensors/time_delta_sensor.py
+++ b/airflow/sensors/time_delta_sensor.py
@@ -40,7 +40,10 @@ class TimeDeltaSensor(BaseSensorOperator):
 
     def poke(self, context):
         dag = context['dag']
-        target_dttm = dag.following_schedule(context['execution_date'])
+        if dag.run_at_beginning:
+            target_dttm = context['execution_date']
+        else:
+            target_dttm = dag.following_schedule(context['execution_date'])
         target_dttm += self.delta
         self.log.info('Checking if the time (%s) has come', target_dttm)
         return timezone.utcnow() > target_dttm


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3800) issue and references them in the PR title. 

### Description

Traditionally, Airflow runs a dag at the end of each interval, since it was designed to run ETL jobs. This differs from cron and causes some confusion and limitation. Specifically when a job is intended to run at an exact time. This is an attempt to add a flag to have Airflow run a dag at exactly the scheduled time. For exam ple, if the a cron string such as `0 0 * * 1-5` is used, the Friday's job is executed on Sunday morning.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
