### PR TITLE
[AIRFLOW-3937] KubernetesPodOperator support for envFrom configMapRef…

### DIFF
--- a/airflow/contrib/kubernetes/pod.py
+++ b/airflow/contrib/kubernetes/pod.py
@@ -66,6 +66,9 @@ class Pod:
     :type tolerations: list
     :param security_context: A dict containing the security context for the pod
     :type security_context: dict
+    :param configmaps: A list containing names of configmaps object
+        mounting env variables to the pod
+    :type configmaps: list[str]
     """
     def __init__(
             self,
@@ -91,6 +94,7 @@ class Pod:
             hostnetwork=False,
             tolerations=None,
             security_context=None,
+            configmaps=None
     ):
         self.image = image
         self.envs = envs or {}
@@ -114,3 +118,4 @@ class Pod:
         self.hostnetwork = hostnetwork or False
         self.tolerations = tolerations or []
         self.security_context = security_context
+        self.configmaps = configmaps or []

--- a/airflow/contrib/kubernetes/secret.py
+++ b/airflow/contrib/kubernetes/secret.py
@@ -14,28 +14,41 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from airflow.exceptions import AirflowConfigException
 
 
 class Secret:
     """Defines Kubernetes Secret Volume"""
 
-    def __init__(self, deploy_type, deploy_target, secret, key):
+    def __init__(self, deploy_type, deploy_target, secret, key=None):
         """Initialize a Kubernetes Secret Object. Used to track requested secrets from
         the user.
         :param deploy_type: The type of secret deploy in Kubernetes, either `env` or
             `volume`
         :type deploy_type: str
         :param deploy_target: The environment variable when `deploy_type` `env` or
-            file path when `deploy_type` `volume` where expose secret
+            file path when `deploy_type` `volume` where expose secret.
+            If `key` is not provided deploy target should be None.
         :type deploy_target: str
         :param secret: Name of the secrets object in Kubernetes
         :type secret: str
-        :param key: Key of the secret within the Kubernetes Secret
-        :type key: str
+        :param key: (Optional) Key of the secret within the Kubernetes Secret
+            if not provided in `deploy_type` `env` it will mount all secrets in object
+        :type key: str or None
         """
         self.deploy_type = deploy_type
-        self.deploy_target = deploy_target.upper()
+
+        if deploy_target:
+            self.deploy_target = deploy_target.upper()
+
         if deploy_type == 'volume':
             self.deploy_target = deploy_target
+
+        if not deploy_type == 'env' and key is None:
+            raise AirflowConfigException(
+                'In deploy_type different than `env` parameter `key` is mandatory'
+            )
+
         self.secret = secret
-        self.key = key
+        if key:
+            self.key = key

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -88,6 +88,9 @@ class KubernetesPodOperator(BaseOperator):
     :type hostnetwork: bool
     :param tolerations: A list of kubernetes tolerations
     :type tolerations: list tolerations
+    :param configmaps: A list of configmap names objects that we
+        want mount as env variables
+    :type configmaps: list[str]
     """
     template_fields = ('cmds', 'arguments', 'env_vars', 'config_file')
 
@@ -123,6 +126,7 @@ class KubernetesPodOperator(BaseOperator):
             pod.node_selectors = self.node_selectors
             pod.hostnetwork = self.hostnetwork
             pod.tolerations = self.tolerations
+            pod.configmaps = self.configmaps
 
             launcher = pod_launcher.PodLauncher(kube_client=client,
                                                 extract_xcom=self.do_xcom_push)
@@ -172,6 +176,7 @@ class KubernetesPodOperator(BaseOperator):
                  is_delete_operator_pod=False,
                  hostnetwork=False,
                  tolerations=None,
+                 configmaps=None,
                  *args,
                  **kwargs):
         super(KubernetesPodOperator, self).__init__(*args, **kwargs)
@@ -204,3 +209,4 @@ class KubernetesPodOperator(BaseOperator):
         self.is_delete_operator_pod = is_delete_operator_pod
         self.hostnetwork = hostnetwork
         self.tolerations = tolerations or []
+        self.configmaps = configmaps or []

--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -53,10 +53,13 @@ Kubernetes Operator
 
     secret_file = Secret('volume', '/etc/sql_conn', 'airflow-secrets', 'sql_alchemy_conn')
     secret_env  = Secret('env', 'SQL_CONN', 'airflow-secrets', 'sql_alchemy_conn')
+    secret_all_keys  = Secret('env', None, 'airflow-secrets-2')
     volume_mount = VolumeMount('test-volume',
                                 mount_path='/root/mount_file',
                                 sub_path=None,
                                 read_only=True)
+
+    configmaps = ['test-configmap-1', 'test-configmap-2']
 
     volume_config= {
         'persistentVolumeClaim':
@@ -128,7 +131,7 @@ Kubernetes Operator
                               cmds=["bash", "-cx"],
                               arguments=["echo", "10"],
                               labels={"foo": "bar"},
-                              secrets=[secret_file,secret_env]
+                              secrets=[secret_file, secret_env, secret_all_keys],
                               volumes=[volume],
                               volume_mounts=[volume_mount]
                               name="test",
@@ -136,7 +139,8 @@ Kubernetes Operator
                               affinity=affinity,
                               is_delete_operator_pod=True,
                               hostnetwork=False,
-                              tolerations=tolerations
+                              tolerations=tolerations,
+                              configmaps=configmaps
                               )
 
 

--- a/tests/contrib/minikube/test_kubernetes_pod_operator.py
+++ b/tests/contrib/minikube/test_kubernetes_pod_operator.py
@@ -19,6 +19,7 @@ import unittest
 import os
 import shutil
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.contrib.kubernetes.secret import Secret
 from airflow import AirflowException
 from kubernetes.client.rest import ApiException
 from subprocess import check_call
@@ -325,6 +326,50 @@ class KubernetesPodOperatorTest(unittest.TestCase):
             do_xcom_push=True
         )
         self.assertEqual(k.execute(None), json.loads(return_value))
+
+    @mock.patch("airflow.contrib.kubernetes.pod_launcher.PodLauncher.run_pod")
+    @mock.patch("airflow.contrib.kubernetes.kube_client.get_kube_client")
+    def test_envs_from_configmaps(self, client_mock, launcher_mock):
+        # GIVEN
+        from airflow.utils.state import State
+        configmaps = ['test-configmap']
+        # WHEN
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            configmaps=configmaps
+        )
+        # THEN
+        launcher_mock.return_value = (State.SUCCESS, None)
+        k.execute(None)
+        self.assertEqual(launcher_mock.call_args[0][0].configmaps, configmaps)
+
+    @mock.patch("airflow.contrib.kubernetes.pod_launcher.PodLauncher.run_pod")
+    @mock.patch("airflow.contrib.kubernetes.kube_client.get_kube_client")
+    def test_envs_from_secrets(self, client_mock, launcher_mock):
+        # GIVEN
+        from airflow.utils.state import State
+        secrets = [Secret('env', None, "secret_name")]
+        # WHEN
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            secrets=secrets,
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+        )
+        # THEN
+        launcher_mock.return_value = (State.SUCCESS, None)
+        k.execute(None)
+        self.assertEqual(launcher_mock.call_args[0][0].secrets, secrets)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
… and secretRef

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [AIRFLOW-3937](https://issues.apache.org/jira/browse/AIRFLOW-3937/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-3937/
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-3937\], code changes always need a Jira issue.

### Description

- [X] Here are some details about my PR:
* My PR add support for envFrom in k8s from ConfigMap and Secret

### Tests

- [X] My PR adds the following unit tests:
* test_envs_from_secrets
* test_envs_from_configmaps

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
