### PR TITLE
[AIRFLOW-3767] Correct bulk insert function

### DIFF
--- a/airflow/hooks/oracle_hook.py
+++ b/airflow/hooks/oracle_hook.py
@@ -203,17 +203,11 @@ class OracleHook(DbApiHook):
             raise ValueError("parameter rows could not be None or empty iterable")
         conn = self.get_conn()
         cursor = conn.cursor()
-        if target_fields:
-            columns = ', '.join(target_fields)
-            columns = '({})'.format(columns)
-            values = ', '.join(':%s' % i for i in range(1, len(target_fields) + 1))
-        else:
-            columns = ''
-            values = ', '.join(':%s' % i for i in range(1, len(rows[0]) + 1))
+        values_base = target_fields if target_fields else rows[0]
         prepared_stm = 'insert into {tablename} {columns} values ({values})'.format(
             tablename=table,
-            columns=columns,
-            values=values,
+            columns='({})'.format(', '.join(target_fields)) if target_fields else '',
+            values=', '.join(':%s' % i for i in range(1, len(values_base) + 1)),
         )
         row_count = 0
         # Chunk the rows

--- a/airflow/hooks/oracle_hook.py
+++ b/airflow/hooks/oracle_hook.py
@@ -199,12 +199,20 @@ class OracleHook(DbApiHook):
             Default 5000. Set greater than 0. Set 1 to insert each row in each transaction
         :type commit_every: int
         """
+        if not rows:
+            raise ValueError("parameter rows could not be None or empty iterable")
         conn = self.get_conn()
         cursor = conn.cursor()
-        values = ', '.join(':%s' % i for i in range(1, len(target_fields) + 1))
-        prepared_stm = 'insert into {tablename} ({columns}) values ({values})'.format(
+        if target_fields:
+            columns = ', '.join(target_fields)
+            columns = '({})'.format(columns)
+            values = ', '.join(':%s' % i for i in range(1, len(target_fields) + 1))
+        else:
+            columns = ''
+            values = ', '.join(':%s' % i for i in range(1, len(rows[0]) + 1))
+        prepared_stm = 'insert into {tablename} {columns} values ({values})'.format(
             tablename=table,
-            columns=', '.join(target_fields),
+            columns=columns,
             values=values,
         )
         row_count = 0

--- a/tests/hooks/test_oracle_hook.py
+++ b/tests/hooks/test_oracle_hook.py
@@ -240,3 +240,14 @@ class TestOracleHook(unittest.TestCase):
         self.cur.prepare.assert_called_with(
             "insert into table (col1, col2, col3) values (:1, :2, :3)")
         self.cur.executemany.assert_called_with(None, rows[2:])
+
+    def test_bulk_insert_rows_without_fields(self):
+        rows = [(1, 2, 3), (4, 5, 6), (7, 8, 9)]
+        self.db_hook.bulk_insert_rows('table', rows)
+        self.cur.prepare.assert_called_once_with(
+            "insert into table  values (:1, :2, :3)")
+        self.cur.executemany.assert_called_once_with(None, rows)
+
+    def test_bulk_insert_rows_no_rows(self):
+        rows = []
+        self.assertRaises(ValueError, self.db_hook.bulk_insert_rows, 'table', rows)


### PR DESCRIPTION
Fix Oracle hook bulk_insert bug when
`target_fields` is None or `rows` is
empty iterable

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3767

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Fix Oracle_hook bulk_insert_rows while param `target_fields` is None and `rows` is empty iterable.

### Tests

- [x] My PR adds the following unit tests :

`test/hooks/test_oracle_hook.py` function `test_bulk_insert_rows_without_fields` and `test_bulk_insert_rows_no_rows`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] not a new functionality

### Code Quality

- [x] Passes `flake8`
