### PR TITLE
[AIRFLOW-3950] Improve AirflowSecurityManager.update_admin_perm_view

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -443,11 +443,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         pvms = [p for p in pvms if p.permission and p.view_menu]
 
         admin = self.find_role('Admin')
-        existing_perms_vms = set(admin.permissions)
-        for p in pvms:
-            if p not in existing_perms_vms:
-                existing_perms_vms.add(p)
-        admin.permissions = list(existing_perms_vms)
+        admin.permissions = list(set(admin.permissions) | set(pvms))
 
         self.get_session.commit()
 


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3950


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR helps improve `AirflowSecurityManager.update_admin_perm_view` by 
- Simplifying the implementation: avoid unnecessary for-loop by using set.
- Improving the performance (especially when there are many DAGs)

Regarding performance improvement, please refer to this simple toy benchmarking:

```python
def fun1(a, b):
    a=set(a)

    for i in b:
        if i not in a:
            a.add(i)

    list(a)

def fun2(a, b):
    list(set(a) | set(b))


if __name__ == '__main__':
    import timeit
    print("-Test.1-")
    print(timeit.timeit("fun1([1,2,3], range(100))", setup="from __main__ import fun1"))
    print(timeit.timeit("fun2([1,2,3], range(100))", setup="from __main__ import fun2"))
    print("-Test.2-")
    print(timeit.timeit("fun1([1,2,3], range(500))", setup="from __main__ import fun1"))
    print(timeit.timeit("fun2([1,2,3], range(500))", setup="from __main__ import fun2"))
```

**Result:**
```
-Test.1-
12.912254190000112
5.487735479000094
-Test.2-
62.42928877399936
21.93449944399981
```
