### PR TITLE
[AIRFLOW-3918] Add ssh private-key support to git-sync for KubernetesExecutor

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -640,18 +640,23 @@ logs_volume_host =
 # Git credentials and repository for DAGs mounted via Git (mutually exclusive with volume claim)
 git_repo =
 git_branch =
+git_subpath =
+# Use git_user and git_password for user authentication or git_ssh_key_secret_name and git_ssh_key_secret_key
+# for SSH authentication
 git_user =
 git_password =
-git_subpath =
 git_sync_root = /git
 git_sync_dest = repo
 # Mount point of the volume if git-sync is being used.
 # i.e. {AIRFLOW_HOME}/dags
 git_dags_folder_mount_point =
+# Kubernetes secret name and secret key where the SSH key is stored
+git_ssh_key_secret_name =
+git_ssh_key_secret_key =
 
 # For cloning DAGs from git repositories into volumes: https://github.com/kubernetes/git-sync
-git_sync_container_repository = gcr.io/google-containers/git-sync-amd64
-git_sync_container_tag = v2.0.5
+git_sync_container_repository = k8s.gcr.io/git-sync
+git_sync_container_tag = v3.1.1
 git_sync_init_container_name = git-sync-clone
 
 # The name of the Kubernetes service account to be associated with airflow workers, if any.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -650,9 +650,34 @@ git_sync_dest = repo
 # Mount point of the volume if git-sync is being used.
 # i.e. {AIRFLOW_HOME}/dags
 git_dags_folder_mount_point =
-# Kubernetes secret name and secret key where the SSH key is stored
-git_ssh_key_secret_name =
-git_ssh_key_secret_key =
+
+# To get Git-sync SSH authentication set up follow this format
+#
+# airflow-secrets.yaml:
+# ---
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: airflow-secrets
+# data:
+#   # key needs to be gitSshKey
+#   gitSshKey: <base64_encoded_data>
+# ---
+# airflow-configmap.yaml:
+# apiVersion: v1
+# kind: ConfigMap
+# metadata:
+#   name: airflow-configmap
+# data:
+#   known_hosts: |
+#       github.com ssh-rsa <...>
+#   airflow.cfg: |
+#       ...
+#
+# git_ssh_secret_name = airflow-secrets
+# git_ssh_known_hosts_configmap_name = airflow-configmap
+git_ssh_secret_name =
+git_ssh_known_hosts_configmap_name =
 
 # For cloning DAGs from git repositories into volumes: https://github.com/kubernetes/git-sync
 git_sync_container_repository = k8s.gcr.io/git-sync

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -674,9 +674,9 @@ git_dags_folder_mount_point =
 #   airflow.cfg: |
 #       ...
 #
-# git_ssh_secret_name = airflow-secrets
+# git_ssh_key_secret_name = airflow-secrets
 # git_ssh_known_hosts_configmap_name = airflow-configmap
-git_ssh_secret_name =
+git_ssh_key_secret_name =
 git_ssh_known_hosts_configmap_name =
 
 # For cloning DAGs from git repositories into volumes: https://github.com/kubernetes/git-sync

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -164,10 +164,12 @@ class KubeConfig:
                                                     'git_dags_folder_mount_point')
 
         # Optionally a user may supply a (`git_user` AND `git_password`) OR
-        # (`git_ssh_secret_name` AND `git_ssh_key_secret_key`) for private repositories
+        # (`git_ssh_key_secret_name` AND `git_ssh_key_secret_key`) for private repositories
         self.git_user = conf.get(self.kubernetes_section, 'git_user')
         self.git_password = conf.get(self.kubernetes_section, 'git_password')
-        self.git_ssh_secret_name = conf.get(self.kubernetes_section, 'git_ssh_secret_name')
+        self.git_ssh_key_secret_name = conf.get(self.kubernetes_section, 'git_ssh_key_secret_name')
+        self.git_ssh_known_hosts_configmap_name = conf.get(self.kubernetes_section,
+                                                           'git_ssh_known_hosts_configmap_name')
 
         # NOTE: The user may optionally use a volume claim to mount a PV containing
         # DAGs directly
@@ -254,12 +256,12 @@ class KubeConfig:
                 'or `git_repo and git_branch and git_dags_folder_mount_point`')
         if self.git_repo \
            and (self.git_user or self.git_password) \
-           and self.git_ssh_secret_name:
+           and self.git_ssh_key_secret_name:
             raise AirflowConfigException(
                 'In kubernetes mode, using `git_repo` to pull the DAGs: '
                 'for private repositories, either `git_user` and `git_password` '
                 'must be set for authentication through user credentials; '
-                'or `git_ssh_secret_name` must be set for authentication '
+                'or `git_ssh_key_secret_name` must be set for authentication '
                 'through ssh key, but not both')
 
 

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -163,10 +163,13 @@ class KubeConfig:
         self.git_dags_folder_mount_point = conf.get(self.kubernetes_section,
                                                     'git_dags_folder_mount_point')
 
-        # Optionally a user may supply a `git_user` and `git_password` for private
-        # repositories
+        # Optionally a user may supply a (`git_user` AND `git_password`) OR
+        # (`git_ssh_key_secret_name` AND `git_ssh_key_secret_key`) for
+        # private repositories
         self.git_user = conf.get(self.kubernetes_section, 'git_user')
         self.git_password = conf.get(self.kubernetes_section, 'git_password')
+        self.git_ssh_key_secret_name = conf.get(self.kubernetes_section, 'git_ssh_key_secret_name')
+        self.git_ssh_key_secret_key = conf.get(self.kubernetes_section, 'git_ssh_key_secret_key')
 
         # NOTE: The user may optionally use a volume claim to mount a PV containing
         # DAGs directly
@@ -251,6 +254,15 @@ class KubeConfig:
                 'or `dags_volume_host` '
                 'or `dags_in_image` '
                 'or `git_repo and git_branch and git_dags_folder_mount_point`')
+        if self.git_repo \
+           and (self.git_user or self.git_password) \
+           and (self.git_ssh_key_secret_name or self.git_ssh_key_secret_key):
+            raise AirflowConfigException(
+                'In kubernetes mode, using `git_repo` to pull the DAGs: '
+                'for private repositories, either `git_user` and `git_password` '
+                'must be set for authentication through user credentials; '
+                'or `git_ssh_key_secret_name` and git_ssh_key_secret_key '
+                'must be set for authentication through ssh key, but not both')
 
 
 class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin, object):

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -164,12 +164,10 @@ class KubeConfig:
                                                     'git_dags_folder_mount_point')
 
         # Optionally a user may supply a (`git_user` AND `git_password`) OR
-        # (`git_ssh_key_secret_name` AND `git_ssh_key_secret_key`) for
-        # private repositories
+        # (`git_ssh_secret_name` AND `git_ssh_key_secret_key`) for private repositories
         self.git_user = conf.get(self.kubernetes_section, 'git_user')
         self.git_password = conf.get(self.kubernetes_section, 'git_password')
-        self.git_ssh_key_secret_name = conf.get(self.kubernetes_section, 'git_ssh_key_secret_name')
-        self.git_ssh_key_secret_key = conf.get(self.kubernetes_section, 'git_ssh_key_secret_key')
+        self.git_ssh_secret_name = conf.get(self.kubernetes_section, 'git_ssh_secret_name')
 
         # NOTE: The user may optionally use a volume claim to mount a PV containing
         # DAGs directly
@@ -256,13 +254,13 @@ class KubeConfig:
                 'or `git_repo and git_branch and git_dags_folder_mount_point`')
         if self.git_repo \
            and (self.git_user or self.git_password) \
-           and (self.git_ssh_key_secret_name or self.git_ssh_key_secret_key):
+           and self.git_ssh_secret_name:
             raise AirflowConfigException(
                 'In kubernetes mode, using `git_repo` to pull the DAGs: '
                 'for private repositories, either `git_user` and `git_password` '
                 'must be set for authentication through user credentials; '
-                'or `git_ssh_key_secret_name` and git_ssh_key_secret_key '
-                'must be set for authentication through ssh key, but not both')
+                'or `git_ssh_secret_name` must be set for authentication '
+                'through ssh key, but not both')
 
 
 class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin, object):

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -191,3 +191,8 @@ class KubernetesRequestFactory:
     def extract_tolerations(pod, req):
         if pod.tolerations:
             req['spec']['tolerations'] = pod.tolerations
+
+    @staticmethod
+    def extract_security_context(pod, req):
+        if pod.security_context:
+            req['spec']['securityContext'] = pod.security_context

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
@@ -62,6 +62,7 @@ spec:
         self.extract_affinity(pod, req)
         self.extract_hostnetwork(pod, req)
         self.extract_tolerations(pod, req)
+        self.extract_security_context(pod, req)
         return req
 
 

--- a/airflow/contrib/kubernetes/pod.py
+++ b/airflow/contrib/kubernetes/pod.py
@@ -64,6 +64,8 @@ class Pod:
     :type hostnetwork: bool
     :param tolerations: A list of kubernetes tolerations
     :type tolerations: list
+    :param security_context: A dict containing the security context for the pod
+    :type security_context: dict
     """
     def __init__(
             self,
@@ -88,6 +90,7 @@ class Pod:
             affinity=None,
             hostnetwork=False,
             tolerations=None,
+            security_context=None,
     ):
         self.image = image
         self.envs = envs or {}
@@ -110,3 +113,4 @@ class Pod:
         self.affinity = affinity or {}
         self.hostnetwork = hostnetwork or False
         self.tolerations = tolerations or []
+        self.security_context = security_context

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -15,11 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import copy
 import os
 import six
 
-from airflow import AirflowException
 from airflow.configuration import conf
 from airflow.contrib.kubernetes.pod import Pod, Resources
 from airflow.contrib.kubernetes.secret import Secret
@@ -37,10 +35,14 @@ class WorkerConfiguration(LoggingMixin):
 
         self.dags_volume_name = 'airflow-dags'
         self.logs_volume_name = 'airflow-logs'
+        self.git_sync_ssh_secret_volume_name = 'git-sync-ssh-key'
+        self.git_ssh_key_secret_key = 'gitSshKey'
+        self.git_sync_ssh_known_hosts_volume_name = 'git-sync-known-hosts'
+        self.git_ssh_known_hosts_configmap_key = 'known_hosts'
 
         super(WorkerConfiguration, self).__init__()
 
-    def _get_init_containers(self, volume_mounts):
+    def _get_init_containers(self):
         """When using git to retrieve the DAGs, use the GitSync Init Container"""
         # If we're using volume claims to mount the dags, no init container is needed
         if self.kube_config.dags_volume_claim or \
@@ -78,19 +80,54 @@ class WorkerConfiguration(LoggingMixin):
                 'value': self.kube_config.git_password
             })
 
-        if self.dags_volume_name not in volume_mounts:
-            raise AirflowException(
-                "GitSync enabled but volume %s is not defined." % self.dags_volume_name)
-
-        volume_mounts[self.dags_volume_name]['mountPath'] = self.kube_config.git_sync_root
-        volume_mounts[self.dags_volume_name]['readOnly'] = False
+        volume_mounts = [{
+            'mountPath': self.kube_config.git_sync_root,
+            'name': self.dags_volume_name,
+            'readOnly': False
+        }]
+        if self.kube_config.git_ssh_key_secret_name:
+            volume_mounts.append({
+                'name': self.git_sync_ssh_secret_volume_name,
+                'mountPath': '/etc/git-secret/ssh',
+                'subPath': 'ssh'
+            })
+            init_environment.extend([
+                {
+                    'name': 'GIT_SSH_KEY_FILE',
+                    'value': '/etc/git-secret/ssh'
+                },
+                {
+                    'name': 'GIT_SYNC_SSH',
+                    'value': 'true'
+                }])
+            if self.kube_config.git_ssh_known_hosts_configmap_name:
+                volume_mounts.append({
+                    'name': self.git_sync_ssh_known_hosts_volume_name,
+                    'mountPath': '/etc/git-secret/known_hosts',
+                    'subPath': 'known_hosts'
+                })
+                init_environment.extend([
+                    {
+                        'name': 'GIT_KNOWN_HOSTS',
+                        'value': 'true'
+                    },
+                    {
+                        'name': 'GIT_SSH_KNOWN_HOSTS_FILE',
+                        'value': '/etc/git-secret/known_hosts'
+                    }
+                ])
+            else:
+                init_environment.append({
+                    'name': 'GIT_KNOWN_HOSTS',
+                    'value': 'false'
+                })
 
         return [{
             'name': self.kube_config.git_sync_init_container_name,
             'image': self.kube_config.git_sync_container,
-            'securityContext': {'runAsUser': 0},
+            'securityContext': {'runAsUser': 65533},  # git-sync user
             'env': init_environment,
-            'volumeMounts': [value for value in volume_mounts.values()]
+            'volumeMounts': volume_mounts
         }]
 
     def _get_environment(self):
@@ -129,6 +166,15 @@ class WorkerConfiguration(LoggingMixin):
         if not self.kube_config.image_pull_secrets:
             return []
         return self.kube_config.image_pull_secrets.split(',')
+
+    def _get_security_context(self):
+        """Defines the security context"""
+        if self.kube_config.git_ssh_key_secret_name:
+            return {
+                'fsGroup': 65533  # to make SSH key readable
+            }
+        else:
+            return None
 
     def init_volumes_and_mounts(self):
         def _construct_volume(name, claim, host):
@@ -183,6 +229,28 @@ class WorkerConfiguration(LoggingMixin):
             del volumes[self.dags_volume_name]
             del volume_mounts[self.dags_volume_name]
 
+        # Get the SSH key from secrets as a volume
+        if self.kube_config.git_ssh_key_secret_name:
+            volumes[self.git_sync_ssh_secret_volume_name] = {
+                'name': self.git_sync_ssh_secret_volume_name,
+                'secret': {
+                    'secretName': self.kube_config.git_ssh_key_secret_name,
+                    'items': [{
+                        'key': self.kube_config.git_ssh_key_secret_key,
+                        'path': 'ssh',
+                        'mode': 288
+                    }]
+                }
+            }
+            if self.kube_config.git_ssh_known_hosts_configmap_name:
+                volumes[self.git_sync_ssh_known_hosts_volume_name] = {
+                    'name': self.git_sync_ssh_known_hosts_volume_name,
+                    'configMap': {
+                        'name': self.kube_config.git_ssh_known_hosts_configmap_name
+                    },
+                    'mode': 288
+                }
+
         # Mount the airflow.cfg file via a configmap the user has specified
         if self.kube_config.airflow_configmap:
             config_volume_name = 'airflow-config'
@@ -213,8 +281,7 @@ class WorkerConfiguration(LoggingMixin):
     def make_pod(self, namespace, worker_uuid, pod_id, dag_id, task_id, execution_date,
                  try_number, airflow_command, kube_executor_config):
         volumes_dict, volume_mounts_dict = self.init_volumes_and_mounts()
-        worker_init_container_spec = self._get_init_containers(
-            copy.deepcopy(volume_mounts_dict))
+        worker_init_container_spec = self._get_init_containers()
         resources = Resources(
             request_memory=kube_executor_config.request_memory,
             request_cpu=kube_executor_config.request_cpu,
@@ -258,5 +325,6 @@ class WorkerConfiguration(LoggingMixin):
             node_selectors=(kube_executor_config.node_selectors or
                             self.kube_config.kube_node_selectors),
             affinity=affinity,
-            tolerations=tolerations
+            tolerations=tolerations,
+            security_context=self._get_security_context(),
         )

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -236,7 +236,7 @@ class WorkerConfiguration(LoggingMixin):
                 'secret': {
                     'secretName': self.kube_config.git_ssh_key_secret_name,
                     'items': [{
-                        'key': self.kube_config.git_ssh_key_secret_key,
+                        'key': self.git_ssh_key_secret_key,
                         'path': 'ssh',
                         'mode': 288
                     }]

--- a/tests/contrib/executors/test_kubernetes_executor.py
+++ b/tests/contrib/executors/test_kubernetes_executor.py
@@ -25,15 +25,20 @@ import mock
 import re
 import string
 import random
+from os import path
 from urllib3 import HTTPResponse
 from datetime import datetime
 
 try:
     from kubernetes.client.rest import ApiException
+    from airflow import configuration
+    from airflow.configuration import conf
     from airflow.contrib.executors.kubernetes_executor import AirflowKubernetesScheduler
     from airflow.contrib.executors.kubernetes_executor import KubernetesExecutor
+    from airflow.contrib.executors.kubernetes_executor import KubeConfig
     from airflow.contrib.executors.kubernetes_executor import KubernetesExecutorConfig
     from airflow.contrib.kubernetes.worker_configuration import WorkerConfiguration
+    from airflow.exceptions import AirflowConfigException
 except ImportError:
     AirflowKubernetesScheduler = None
 
@@ -161,6 +166,39 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
                     "subPath shouldn't be defined"
                 )
 
+    @mock.patch.object(conf, 'get')
+    @mock.patch.object(configuration, 'as_dict')
+    def test_worker_configuration_auth_both_ssh_and_user(self, mock_config_as_dict, mock_conf_get):
+        def get_conf(*args, **kwargs):
+            if(args[0] == 'core'):
+                return '1'
+            if(args[0] == 'kubernetes'):
+                if(args[1] == 'airflow_configmap'):
+                    return 'airflow-configmap'
+                if(args[1] == 'git_ssh_key_secret_name'):
+                    return 'airflow-secrets'
+                if(args[1] == 'git_ssh_key_secret_key'):
+                    return 'gitSshKey'
+                if(args[1] == 'git_user'):
+                    return 'some-user'
+                if(args[1] == 'git_password'):
+                    return 'some-password'
+                if(args[1] == 'git_repo'):
+                    return 'git@github.com:apache/airflow.git'
+                if(args[1] == 'git_branch'):
+                    return 'master'
+                if(args[1] == 'git_dags_folder_mount_point'):
+                    return '/usr/local/airflow/dags'
+                if(args[1] == 'delete_worker_pods'):
+                    return True
+                return '1'
+            return None
+
+        mock_conf_get.side_effect = get_conf
+        mock_config_as_dict.return_value = {'core': ''}
+        with self.assertRaises(AirflowConfigException):
+            KubeConfig()
+
     def test_worker_with_subpaths(self):
         self.kube_config.dags_volume_subpath = 'dags'
         self.kube_config.logs_volume_subpath = 'logs'
@@ -236,6 +274,62 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
 
         self.assertEqual(dags_folder, env['AIRFLOW__CORE__DAGS_FOLDER'])
 
+    def test_init_environment_using_git_sync_ssh(self):
+        # Tests the init environment created with git-sync SSH authentication option is correct
+        self.kube_config.airflow_configmap = 'airflow-configmap'
+        self.kube_config.git_ssh_key_secret_name = 'airflow-secrets'
+        self.kube_config.git_ssh_key_secret_key = 'gitSshKey'
+        self.kube_config.dags_volume_claim = None
+        self.kube_config.dags_volume_host = None
+        self.kube_config.dags_in_image = None
+
+        worker_config = WorkerConfiguration(self.kube_config)
+        init_containers = worker_config._get_init_containers()
+
+        self.assertTrue(init_containers)  # check not empty
+        env = init_containers[0]['env']
+
+        self.assertTrue({'name': 'GIT_SSH_KEY_FILE', 'value': '/etc/git-secret/ssh'} in env)
+        self.assertTrue({'name': 'GIT_KNOWN_HOSTS', 'value': 'false'} in env)
+        self.assertTrue({'name': 'GIT_SYNC_SSH', 'value': 'true'} in env)
+
+    def test_make_pod_git_sync_ssh(self):
+        # Tests the pod created with git-sync SSH authentication option is correct
+        self.kube_config.airflow_configmap = 'airflow-configmap'
+        self.kube_config.git_ssh_key_secret_name = 'airflow-secrets'
+        self.kube_config.git_ssh_key_secret_key = 'gitSshKey'
+        self.kube_config.dags_volume_claim = None
+        self.kube_config.dags_volume_host = None
+        self.kube_config.dags_in_image = None
+        self.kube_config.git_sync_ssh_secret_volume_name = 'dags-repo-secret'
+
+        worker_config = WorkerConfiguration(self.kube_config)
+        kube_executor_config = KubernetesExecutorConfig(annotations=[],
+                                                        volumes=[],
+                                                        volume_mounts=[])
+
+        pod = worker_config.make_pod("default", str(uuid.uuid4()), "test_pod_id", "test_dag_id",
+                                     "test_task_id", str(datetime.utcnow()), 1, "bash -c 'ls /'",
+                                     kube_executor_config)
+        pod_git_sync_secret_volume = next((x for x in pod.volumes
+                                          if x['name'] == self.kube_config.git_sync_ssh_secret_volume_name),
+                                          None)
+
+        init_containers = worker_config._get_init_containers()
+        git_ssh_key_file = next((x['value'] for x in init_containers[0]['env']
+                                if x['name'] == 'GIT_SSH_KEY_FILE'), None)
+        volume_mount_ssh_key = next((x['mountPath'] for x in init_containers[0]['volumeMounts']
+                                    if x['name'] == self.kube_config.git_sync_ssh_secret_volume_name),
+                                    None)
+        self.assertTrue(git_ssh_key_file)
+        self.assertTrue(volume_mount_ssh_key)
+        self.assertEqual({'fsGroup': 65533}, pod.security_context)
+        self.assertEqual(git_ssh_key_file,
+                         path.join(volume_mount_ssh_key,
+                                   pod_git_sync_secret_volume['secret']['items'][0]['path']),
+                         ('The location where the git ssh secret is mounted'
+                          ' needs to be the same as the GIT_SSH_KEY_FILE path'))
+
     def test_make_pod_with_empty_executor_config(self):
         self.kube_config.kube_affinity = self.affinity_config
         self.kube_config.kube_tolerations = self.tolerations_config
@@ -292,7 +386,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         worker_config = WorkerConfiguration(self.kube_config)
         volumes, volume_mounts = worker_config.init_volumes_and_mounts()
 
-        init_containers = worker_config._get_init_containers(volume_mounts)
+        init_containers = worker_config._get_init_containers()
 
         dag_volume = [volume for volume in volumes.values() if volume['name'] == 'airflow-dags']
         dag_volume_mount = [mount for mount in volume_mounts.values() if mount['name'] == 'airflow-dags']
@@ -327,7 +421,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         self.assertEqual(self.kube_config.git_dags_folder_mount_point, dag_volume_mount[0]['mountPath'])
         self.assertTrue(dag_volume_mount[0]['readOnly'])
 
-        init_container = worker_config._get_init_containers(volume_mounts)[0]
+        init_container = worker_config._get_init_containers()[0]
         init_container_volume_mount = [mount for mount in init_container['volumeMounts']
                                        if mount['name'] == 'airflow-dags']
 
@@ -346,7 +440,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         dag_volume = [volume for volume in volumes.values() if volume['name'] == 'airflow-dags']
         dag_volume_mount = [mount for mount in volume_mounts.values() if mount['name'] == 'airflow-dags']
 
-        init_containers = worker_config._get_init_containers(volume_mounts)
+        init_containers = worker_config._get_init_containers()
 
         self.assertEqual(0, len(dag_volume))
         self.assertEqual(0, len(dag_volume_mount))

--- a/tests/contrib/executors/test_kubernetes_executor.py
+++ b/tests/contrib/executors/test_kubernetes_executor.py
@@ -25,7 +25,6 @@ import mock
 import re
 import string
 import random
-from os import path
 from urllib3 import HTTPResponse
 from datetime import datetime
 
@@ -274,11 +273,12 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
 
         self.assertEqual(dags_folder, env['AIRFLOW__CORE__DAGS_FOLDER'])
 
-    def test_init_environment_using_git_sync_ssh(self):
+    def test_init_environment_using_git_sync_ssh_without_known_hosts(self):
         # Tests the init environment created with git-sync SSH authentication option is correct
+        # without known hosts file
         self.kube_config.airflow_configmap = 'airflow-configmap'
-        self.kube_config.git_ssh_key_secret_name = 'airflow-secrets'
-        self.kube_config.git_ssh_key_secret_key = 'gitSshKey'
+        self.kube_config.git_ssh_secret_name = 'airflow-secrets'
+        self.kube_config.git_ssh_known_hosts_configmap_name = None
         self.kube_config.dags_volume_claim = None
         self.kube_config.dags_volume_host = None
         self.kube_config.dags_in_image = None
@@ -293,15 +293,34 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         self.assertTrue({'name': 'GIT_KNOWN_HOSTS', 'value': 'false'} in env)
         self.assertTrue({'name': 'GIT_SYNC_SSH', 'value': 'true'} in env)
 
-    def test_make_pod_git_sync_ssh(self):
-        # Tests the pod created with git-sync SSH authentication option is correct
+    def test_init_environment_using_git_sync_ssh_with_known_hosts(self):
+        # Tests the init environment created with git-sync SSH authentication option is correct
+        # with known hosts file
         self.kube_config.airflow_configmap = 'airflow-configmap'
         self.kube_config.git_ssh_key_secret_name = 'airflow-secrets'
-        self.kube_config.git_ssh_key_secret_key = 'gitSshKey'
         self.kube_config.dags_volume_claim = None
         self.kube_config.dags_volume_host = None
         self.kube_config.dags_in_image = None
-        self.kube_config.git_sync_ssh_secret_volume_name = 'dags-repo-secret'
+
+        worker_config = WorkerConfiguration(self.kube_config)
+        init_containers = worker_config._get_init_containers()
+
+        self.assertTrue(init_containers)  # check not empty
+        env = init_containers[0]['env']
+
+        self.assertTrue({'name': 'GIT_SSH_KEY_FILE', 'value': '/etc/git-secret/ssh'} in env)
+        self.assertTrue({'name': 'GIT_KNOWN_HOSTS', 'value': 'true'} in env)
+        self.assertTrue({'name': 'GIT_SSH_KNOWN_HOSTS_FILE',
+                        'value': '/etc/git-secret/known_hosts'} in env)
+        self.assertTrue({'name': 'GIT_SYNC_SSH', 'value': 'true'} in env)
+
+    def test_make_pod_git_sync_ssh_without_known_hosts(self):
+        # Tests the pod created with git-sync SSH authentication option is correct without known hosts
+        self.kube_config.airflow_configmap = 'airflow-configmap'
+        self.kube_config.git_ssh_key_secret_name = 'airflow-secrets'
+        self.kube_config.dags_volume_claim = None
+        self.kube_config.dags_volume_host = None
+        self.kube_config.dags_in_image = None
 
         worker_config = WorkerConfiguration(self.kube_config)
         kube_executor_config = KubernetesExecutorConfig(annotations=[],
@@ -311,24 +330,45 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         pod = worker_config.make_pod("default", str(uuid.uuid4()), "test_pod_id", "test_dag_id",
                                      "test_task_id", str(datetime.utcnow()), 1, "bash -c 'ls /'",
                                      kube_executor_config)
-        pod_git_sync_secret_volume = next((x for x in pod.volumes
-                                          if x['name'] == self.kube_config.git_sync_ssh_secret_volume_name),
-                                          None)
 
         init_containers = worker_config._get_init_containers()
         git_ssh_key_file = next((x['value'] for x in init_containers[0]['env']
                                 if x['name'] == 'GIT_SSH_KEY_FILE'), None)
         volume_mount_ssh_key = next((x['mountPath'] for x in init_containers[0]['volumeMounts']
-                                    if x['name'] == self.kube_config.git_sync_ssh_secret_volume_name),
+                                    if x['name'] == worker_config.git_sync_ssh_secret_volume_name),
                                     None)
         self.assertTrue(git_ssh_key_file)
         self.assertTrue(volume_mount_ssh_key)
         self.assertEqual({'fsGroup': 65533}, pod.security_context)
         self.assertEqual(git_ssh_key_file,
-                         path.join(volume_mount_ssh_key,
-                                   pod_git_sync_secret_volume['secret']['items'][0]['path']),
+                         volume_mount_ssh_key,
                          ('The location where the git ssh secret is mounted'
                           ' needs to be the same as the GIT_SSH_KEY_FILE path'))
+
+    def test_make_pod_git_sync_ssh_with_known_hosts(self):
+        # Tests the pod created with git-sync SSH authentication option is correct with known hosts
+        self.kube_config.airflow_configmap = 'airflow-configmap'
+        self.kube_config.git_ssh_secret_name = 'airflow-secrets'
+        self.kube_config.dags_volume_claim = None
+        self.kube_config.dags_volume_host = None
+        self.kube_config.dags_in_image = None
+
+        worker_config = WorkerConfiguration(self.kube_config)
+
+        init_containers = worker_config._get_init_containers()
+        git_ssh_known_hosts_file = next((x['value'] for x in init_containers[0]['env']
+                                         if x['name'] == 'GIT_SSH_KNOWN_HOSTS_FILE'), None)
+        print(init_containers[0]['volumeMounts'])
+        volume_mount_ssh_known_hosts_file = next(
+            (x['mountPath'] for x in init_containers[0]['volumeMounts']
+             if x['name'] == worker_config.git_sync_ssh_known_hosts_volume_name),
+            None)
+        self.assertTrue(git_ssh_known_hosts_file)
+        self.assertTrue(volume_mount_ssh_known_hosts_file)
+        self.assertEqual(git_ssh_known_hosts_file,
+                         volume_mount_ssh_known_hosts_file,
+                         ('The location where the git known hosts file is mounted'
+                          ' needs to be the same as the GIT_SSH_KNOWN_HOSTS_FILE path'))
 
     def test_make_pod_with_empty_executor_config(self):
         self.kube_config.kube_affinity = self.affinity_config


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

> - [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
>  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
>  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

https://issues.apache.org/jira/browse/AIRFLOW-3918

### Description

> - [X] Here are some details about my PR, including screenshots of any UI changes:

This PR adds support for Git Sync authentication through SSH key (e.g. a GitHub deployment read-only key)

### Tests

> - [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

* test_worker_configuration_auth_both_ssh_and_user: tests that configuration validation throws an exception when both user authentication and SSH authentication are configured
* test_init_environment_using_git_sync_ssh: tests that the environment is correctly set up for the init pod when using SSH auth
* test_make_pod_git_sync_ssh: tests that the make_pod function correctly generates the config for the pod, covers security_context test

Additionally tested at HBC on our cluster

### Commits

> - [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
>  1. Subject is separated from body by a blank line
>  1. Subject is limited to 50 characters (not including Jira issue reference)
>  1. Subject does not end with a period
>  1. Subject uses the imperative mood ("add", not "adding")
>  1. Body wraps at 72 characters
>  1. Body explains "what" and "why", not "how"

### Documentation

> - [X] In case of new functionality, my PR adds documentation that describes how to use it.
>  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
>  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

> - [X] Passes `flake8`
