### PR TITLE
[AIRFLOW-3958] List tasks upstream work in chain

### DIFF
--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -24,6 +24,7 @@ import psutil
 from builtins import input
 from datetime import datetime
 from functools import reduce
+from collections import Iterable
 import os
 import re
 import signal
@@ -150,19 +151,50 @@ def as_flattened_list(iterable):
 
 
 def chain(*tasks):
-    """
+    r"""
     Given a number of tasks, builds a dependency chain.
+    Support mix airflow.models.BaseOperator and List[airflow.models.BaseOperator].
+    If you want to chain between two List[airflow.models.BaseOperator], have to
+    make sure they have same length.
 
-    chain(task_1, task_2, task_3, task_4)
+    chain(t1, [t2, t3], [t4, t5], t6)
 
     is equivalent to
 
-    task_1.set_downstream(task_2)
-    task_2.set_downstream(task_3)
-    task_3.set_downstream(task_4)
+      / -> t2 -> t4 \
+    t1               -> t6
+      \ -> t3 -> t5 /
+
+    t1.set_downstream(t2)
+    t1.set_downstream(t3)
+    t2.set_downstream(t4)
+    t3.set_downstream(t5)
+    t4.set_downstream(t6)
+    t5.set_downstream(t6)
+
+    :param tasks: List of tasks or List[airflow.models.BaseOperator] to set dependencies
+    :type tasks: List[airflow.models.BaseOperator] or airflow.models.BaseOperator
     """
-    for up_task, down_task in zip(tasks[:-1], tasks[1:]):
-        up_task.set_downstream(down_task)
+    from airflow.models import BaseOperator
+
+    for index, up_task in enumerate(tasks[:-1]):
+        down_task = tasks[index + 1]
+        if isinstance(up_task, BaseOperator):
+            up_task.set_downstream(down_task)
+        elif isinstance(down_task, BaseOperator):
+            down_task.set_upstream(up_task)
+        else:
+            if not isinstance(up_task, Iterable) or not isinstance(down_task, Iterable):
+                raise TypeError(
+                    'Chain not supported between instances of {up_type} and {down_type}'.format(
+                        up_type=type(up_task), down_type=type(down_task)))
+            elif len(up_task) != len(down_task):
+                raise AirflowException(
+                    'Chain not supported different length Iterable but get {up_len} and {down_len}'.format(
+                        up_len=len(up_task), down_len=len(down_task)))
+            else:
+                for up, down in zip(up_task, down_task):
+                    up.set_downstream(down)
 
 
 def cross_downstream(from_tasks, to_tasks):


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3958

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

For now on, `airflow.utils.helpers.chain` only support list as downstream, but not upstream. This ticket is to support list as upstream.

Only support

```markdown
task_1 --> task_2 --> task_3 --> task_4

or
                  /--> task_3
task_1 --> task_2 
                  \--> task_4
```

This improvement to be support

```markdown
                  /--> task_3 \
task_1 --> task_2              --> task_5
                  \--> task_4 /
```

### Tests

- [x] My PR adds the following unit tests :

* airflow/tests/utils/helpers/test_chain

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
