### PR TITLE
[AIRFLOW-3962] Added graceful handling for creation of dag_run of a dag which doesn't have any task

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -865,8 +865,8 @@ class SchedulerJob(BaseJob):
                     dag.start_date, next_run_date
                 )
 
-            # don't ever schedule in the future
-            if next_run_date > timezone.utcnow():
+            # don't ever schedule in the future or if next_run_date is None
+            if not next_run_date or next_run_date > timezone.utcnow():
                 return
 
             # this structure is necessary to avoid a TypeError from concatenating

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -2673,11 +2673,11 @@ class SchedulerJobTest(unittest.TestCase):
         with create_session() as session:
             orm_dag = DagModel(dag_id=dag.dag_id)
             session.merge(orm_dag)
-        scheduler = SchedulerJob()
-        dag.clear()
-        dag.start_date = None
-        dr = scheduler.create_dag_run(dag)
-        self.assertIsNone(dr)
+            scheduler = SchedulerJob()
+            dag.clear(session=session)
+            dag.start_date = None
+            dr = scheduler.create_dag_run(dag, session=session)
+            self.assertIsNone(dr)
 
     def test_scheduler_do_not_run_finished(self):
         dag = DAG(

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -2673,8 +2673,6 @@ class SchedulerJobTest(unittest.TestCase):
         with create_session() as session:
             orm_dag = DagModel(dag_id=dag.dag_id)
             session.merge(orm_dag)
-            session.commit()
-            session.close()
         scheduler = SchedulerJob()
         dag.clear()
         dag.start_date = None

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -2670,11 +2670,11 @@ class SchedulerJobTest(unittest.TestCase):
             dag_id='test_scheduler_do_not_schedule_without_tasks',
             start_date=DEFAULT_DATE)
 
-        session = settings.Session()
-        orm_dag = DagModel(dag_id=dag.dag_id)
-        session.merge(orm_dag)
-        session.commit()
-        session.close()
+        with create_session() as session:
+            orm_dag = DagModel(dag_id=dag.dag_id)
+            session.merge(orm_dag)
+            session.commit()
+            session.close()
         scheduler = SchedulerJob()
         dag.clear()
         dag.start_date = None

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -2665,6 +2665,22 @@ class SchedulerJobTest(unittest.TestCase):
 
         queue.put.assert_not_called()
 
+    def test_scheduler_do_not_schedule_without_tasks(self):
+        dag = DAG(
+            dag_id='test_scheduler_do_not_schedule_without_tasks',
+            start_date=DEFAULT_DATE)
+
+        session = settings.Session()
+        orm_dag = DagModel(dag_id=dag.dag_id)
+        session.merge(orm_dag)
+        session.commit()
+        session.close()
+        scheduler = SchedulerJob()
+        dag.clear()
+        dag.start_date = None
+        dr = scheduler.create_dag_run(dag)
+        self.assertIsNone(dr)
+
     def test_scheduler_do_not_run_finished(self):
         dag = DAG(
             dag_id='test_scheduler_do_not_run_finished',


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3962
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Scheduler throwing an exception while creating dag_run for a dag which doesn't contain any task, this PR includes graceful Han doing by adding a check.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`