### PR TITLE
[AIRFLOW-3965] Fixing GoogleCloudStorageToBigQueryOperator failing for jobs outside US and EU

### DIFF
--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -122,6 +122,8 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         by one or more columns. This is only available in conjunction with
         time_partitioning. The order of columns given determines the sort order.
         Not applicable for external tables.
+    :param location: The geographic location of the job. See details at
+    https://cloud.google.com/bigquery/docs/locations#specifying_your_location
     :type cluster_fields: list[str]
     """
     template_fields = ('bucket', 'source_objects',
@@ -157,6 +159,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                  time_partitioning=None,
                  cluster_fields=None,
                  autodetect=False,
+                 location=None,
                  *args, **kwargs):
 
         super(GoogleCloudStorageToBigQueryOperator, self).__init__(*args, **kwargs)
@@ -196,10 +199,16 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         self.time_partitioning = time_partitioning
         self.cluster_fields = cluster_fields
         self.autodetect = autodetect
+        self.location = location
 
     def execute(self, context):
-        bq_hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
-                               delegate_to=self.delegate_to)
+        bq_hook_params = {
+            'bigquery_conn_id': self.bigquery_conn_id,
+            'delegate_to': self.delegate_to
+        }
+        if self.location:
+            bq_hook_params['location'] = self.location
+        bq_hook = BigQueryHook(**bq_hook_params)
 
         if not self.schema_fields:
             if self.schema_object and self.source_format != 'DATASTORE_BACKUP':


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira
Reported on https://issues.apache.org/jira/browse/AIRFLOW-3965
### Description

GoogleCloudStorageToBigQueryOperator class does not accept "location" parameter and for jobs that are not "US", "EU" will fail.

To be more precise, the BigQuery job itself will still work, however the task instance will mark as error because it isn't able to fetch the job status (HTTP 404). Setting the location parameter will fix this problem.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Does not need testing, as the same parameter is already used by many other GCP connection classes.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
