### PR TITLE
[AIRFLOW-3967] Extract Jinja directive from Javascript

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -273,3 +273,10 @@ div.square {
 .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
 .s2 { color: #BA2121 } /* Literal.String.Double */
 .s1 { color: #BA2121 } /* Literal.String.Single */
+
+.highlight--demo-mode .s,
+.highlight--demo-mode .s1,
+.highlight--demo-mode .s2 {
+  text-shadow: 0px 0px 10px red;
+  color: transparent;
+}

--- a/airflow/www/static/js/base.js
+++ b/airflow/www/static/js/base.js
@@ -21,11 +21,8 @@ import {defaultFormatWithTZ, moment} from './datetime-utils';
 
 function displayTime() {
   let utcTime = moment().utc().format(defaultFormatWithTZ);
-  $('#clock')
-    .attr("data-original-title", function() {
-      return hostName
-    })
-    .html(utcTime);
+
+  $('#clock').html(utcTime);
 
   setTimeout(displayTime, 1000);
 }
@@ -73,11 +70,13 @@ window.postAsForm = postAsForm;
 
 $(document).ready(function () {
   displayTime();
+  const CSRF_TOKEN = getMetaValue('csrf-token');
+
   $('span').tooltip();
   $.ajaxSetup({
     beforeSend: function(xhr, settings) {
       if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) && !this.crossDomain) {
-        xhr.setRequestHeader("X-CSRFToken", csrfToken);
+        xhr.setRequestHeader("X-CSRFToken", CSRF_TOKEN);
       }
     }
   });

--- a/airflow/www/static/js/datetime-utils.js
+++ b/airflow/www/static/js/datetime-utils.js
@@ -20,7 +20,7 @@
 export const moment = require('moment-timezone');
 export const defaultFormat = 'YYYY-MM-DD, HH:mm:ss';
 export const defaultFormatWithTZ = 'YYYY-MM-DD, HH:mm:ss z';
-
+const dagTZ = getMetaValue('dag-timezone');
 
 const makeDateTimeHTML = (start, end) => {
   return (

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -20,6 +20,8 @@
 import { generateTooltipDateTime, converAndFormatUTC, secondsToString } from './datetime-utils';
 import { escapeHtml } from './base';
 
+var dagTZ = getMetaValue('dag-timezone');
+
 // Assigning css classes based on state to nodes
 // Initiating the tooltips
 function update_nodes_states(task_instances) {
@@ -44,7 +46,7 @@ function update_nodes_states(task_instances) {
         tt += "Operator: " + escapeHtml(task.task_type) + "<br>";
         tt += "Duration: " + escapeHtml(ti.duration) + "<br>";
         tt += "Started: " + escapeHtml(ti.start_date) + "<br>";
-        tt += generateTooltipDateTime(ti.start_date, ti.end_date, dagTZ); // dagTZ has been defined in dag.html
+        tt += generateTooltipDateTime(ti.start_date, ti.end_date, dagTZ);
         return tt;
       });
   });

--- a/airflow/www/static/js/utils.js
+++ b/airflow/www/static/js/utils.js
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function getMetaValue(name) {
+  const el = document.querySelector('meta[name="' + name + '"]')
+  if (!el) {
+    return
+  }
+  return el.getAttribute("content")
+}
+
+global.getMetaValue = getMetaValue

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -22,6 +22,11 @@
 {% block head_css %}
   {{ super() }}
   <link href="{{ url_for_asset('bootstrap-toggle.min.css') }}" rel="stylesheet" type="text/css">
+  <meta name="dag-id" content="{{ dag.dag_id }}">
+  <meta name="dag-timezone" content="{{ dag.timezone.name }}">
+  <meta name="base-url-get-logs-with-metadata" content="{{ url_for('Airflow.get_logs_with_metadata') }}">
+  <meta name="base-url-paused" content="{{ url_for('Airflow.paused') }}">
+  <meta name="base-url-extra-links" content="{{ url_for('Airflow.extra_links') }}">
 {% endblock %}
 
 {% block content %}
@@ -322,6 +327,7 @@
 {% endblock %}
 {% block tail %}
   {{ super() }}
+  <script src="{{ url_for_asset('utils.js') }}"></script>
   <script src="{{ url_for_asset('bootstrap-toggle.min.js') }}"></script>
   <script>
 function updateQueryStringParameter(uri, key, value) {
@@ -342,11 +348,11 @@ function updateQueryStringParameter(uri, key, value) {
     });
 
     var id = '';
-    var dag_id = '{{ dag.dag_id }}';
-    var dagTZ = '{{ dag.timezone.name }}'; // Being used in datetime-utils.js
+    var dag_id = getMetaValue('dag-id');
     var task_id = '';
     var exection_date = '';
     var subdag_id = '';
+    const base_url_paused = getMetaValue('base-url-paused')
 
     var buttons = Array.from(document.querySelectorAll('a[id^="btn_"][data-base-url]')).reduce(function(obj, elm) {
       obj[elm.id.replace('btn_', '')] = elm;
@@ -420,9 +426,10 @@ function updateQueryStringParameter(uri, key, value) {
       updateModalUrls();
 
       $("#try_index > li").remove();
+      const base_url_get_logs = getMetaValue('base-url-get-logs-with-metadata')
       var startIndex = (try_numbers > 2 ? 0 : 1)
       for (var index = startIndex; index <  try_numbers; index++) {
-        var url = "{{ url_for('Airflow.get_logs_with_metadata') }}" +
+        var url = base_url_get_logs +
           "?dag_id=" + encodeURIComponent(dag_id) +
           "&task_id=" + encodeURIComponent(task_id) +
           "&execution_date=" + encodeURIComponent(execution_date) +
@@ -444,9 +451,9 @@ function updateQueryStringParameter(uri, key, value) {
 
       if (extra_links && extra_links.length > 0){
         var markupArr = [];
-
+        var baseUrlExtraLinks = getMetaValue('base-url-extra-links');
         $.each(extra_links, function(i, link){
-          var url = "{{ url_for('Airflow.extra_links') }}" +
+          var url = baseUrlExtraLinks +
                   "?task_id=" + encodeURIComponent(task_id) +
                   "&dag_id=" + encodeURIComponent(dag_id) +
                   "&execution_date=" + encodeURIComponent(execution_date) +
@@ -527,7 +534,8 @@ function updateQueryStringParameter(uri, key, value) {
       } else {
         is_paused = 'false'
       }
-      url = "{{ url_for('Airflow.paused') }}" + '?is_paused=' + is_paused + '&dag_id=' + encodeURIComponent(dag_id);
+
+      url = base_url_paused + '?is_paused=' + is_paused + '&dag_id=' + encodeURIComponent(dag_id);
       $.post(url);
     });
 

--- a/airflow/www/templates/airflow/dag_code.html
+++ b/airflow/www/templates/airflow/dag_code.html
@@ -23,18 +23,3 @@
     <h4>{{ title }}</h4>
     {{ html_code|safe }}
 {% endblock %}
-
-{% block tail %}
-    {{ super() }}
-    <script>
-      // We blur task_ids in demo mode
-    $( document ).ready(function() {
-      if ("{{ demo_mode }}" == "True") {
-          $("pre span.s").css({
-              'text-shadow': '0px 0px 10px red',
-              'color': 'transparent',
-          });
-      }
-    });
-    </script>
-{% endblock %}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -23,6 +23,13 @@
 {{ super() }}
 <link href="{{ url_for_asset('dataTables.bootstrap.min.css') }}" rel="stylesheet" type="text/css" >
 <link href="{{ url_for_asset('bootstrap-toggle.min.css') }}" rel="stylesheet" type="text/css">
+<meta name="base-url-index" content="{{ url_for('Airflow.index') }}"/>
+<meta name="base-url-blocked" content="{{ url_for('Airflow.blocked') }}"/>
+<meta name="base-url-dag-stats" content="{{ url_for('Airflow.dag_stats') }}"/>
+<meta name="base-url-dag-run-list" content="{{ url_for('DagRunModelView.list') }}" />
+<meta name="base-url-task-stats" content="{{ url_for('Airflow.task_stats') }}" />
+<meta name="base-url-task-instance-list" content="{{ url_for('TaskInstanceModelView.list') }}" />
+<meta name="tokens" content="{{ auto_complete_data | join(',') }}"/>
 {% endblock %}
 
 {% block content %}
@@ -207,6 +214,7 @@
 
 {% block tail %}
   {{ super() }}
+  <script src="{{ url_for_asset('utils.js') }}"></script>
   <script src="{{ url_for_asset('d3.min.js') }}"></script>
   <script src="{{ url_for_asset('jquery.dataTables.min.js') }}"></script>
   <script src="{{ url_for_asset('dataTables.bootstrap.min.js') }}"></script>
@@ -214,7 +222,13 @@
   <script src="{{ url_for_asset('bootstrap3-typeahead.min.js') }}"></script>
   <script>
 
-      const DAGS_INDEX = "{{ url_for('Airflow.index') }}";
+      const DAGS_INDEX = getMetaValue('base-url-index');
+      const BASE_URL_BLOCKED = getMetaValue('base-url-blocked');
+      const BASE_URL_DAG_STATS = getMetaValue("base-url-dag-stats");
+      const BASE_URL_DAG_RUN_LIST = getMetaValue('base-url-dag-run-list');
+      const BASE_URL_TASK_STATS = getMetaValue('base-url-task-stats');
+      const BASE_URL_TASK_INSTANCES_LIST = getMetaValue('base-url-task-instance-list');
+
       const ENTER_KEY_CODE = 13;
 
       $('#dag_query').on('keypress', function (e) {
@@ -263,11 +277,7 @@
       });
 
       var $input = $(".typeahead");
-      unique_options_search = new Set([
-          {% for token in auto_complete_data %}
-            "{{token}}",
-          {% endfor %}
-        ]);
+      unique_options_search = new Set(getMetaValue('tokens').split(','));
 
       $input.typeahead({
         source: [...unique_options_search],
@@ -298,7 +308,7 @@
       circle_margin = 4;
       stroke_width = 2;
       stroke_width_hover = 6;
-      d3.json("{{ url_for('Airflow.blocked') }}", function(error, json) {
+      d3.json(BASE_URL_BLOCKED, function(error, json) {
         $.each(json, function() {
           $('.label.schedule.' + this.dag_id)
           .attr('title', this.active_dag_run + '/' + this.max_active_runs + ' active dag runs')
@@ -309,7 +319,7 @@
           }
         });
       });
-      d3.json("{{ url_for('Airflow.dag_stats') }}", function(error, json) {
+      d3.json(BASE_URL_DAG_STATS, function(error, json) {
         for(var dag_id in json) {
             states = json[dag_id];
             g = d3.select('svg#dag-run-' + dag_id)
@@ -357,7 +367,9 @@
               })
               .on('click', function(d, i) {
                   if (d.count > 0)
-                    window.location = "{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id=" + d.dag_id + "&_flt_3_state=" + d.state;
+                    window.location = BASE_URL_DAG_RUN_LIST +
+                      "?_flt_3_dag_id=" + encodeUriComponent(d.dag_id) +
+                      "&_flt_3_state=" + encodeUriComponent(d.state);
               })
               .on('mouseover', function(d, i) {
                 if (d.count > 0) {
@@ -388,7 +400,7 @@
           container: "body",
         });
       });
-      d3.json("{{ url_for('Airflow.task_stats') }}", function(error, json) {
+      d3.json(BASE_URL_TASK_STATS, function(error, json) {
         for(var dag_id in json) {
             states = json[dag_id];
             g = d3.select('svg#task-run-' + dag_id)
@@ -436,7 +448,9 @@
               })
               .on('click', function(d, i) {
                   if (d.count > 0)
-                    window.location = "{{ url_for('TaskInstanceModelView.list') }}?_flt_3_dag_id=" + d.dag_id + "&_flt_3_state=" + d.state;
+                    window.location = BASE_URL_TASK_INSTANCES_LIST +
+                      "?_flt_3_dag_id=" + encodeUriComponent(d.dag_id) +
+                      "&_flt_3_state=" + encodeUriComponent(d.state);
               })
               .on('mouseover', function(d, i) {
                 if (d.count > 0) {

--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -23,6 +23,8 @@
     href="{{url_for('appbuilder.static',filename='datepicker/bootstrap-datepicker.css')}}" >
 <link type="text/css" href="{{ url_for('static', filename='css/gantt.css') }}" rel="stylesheet" />
 <link type="text/css" href="{{ url_for('static', filename='css/tree.css') }}" rel="stylesheet" />
+<meta name="dag-id" content="{{ dag.dag_id }}">
+<meta name="data" content="{{ data | tojson | forceescape }}">
 {% endblock %}
 
 {% block content %}
@@ -46,16 +48,15 @@
 
 {% block tail %}
 {{ super() }}
+<script src="{{ url_for_asset('utils.js') }}"></script>
 <script src="{{ url_for('appbuilder.static',filename='datepicker/bootstrap-datepicker.js') }}"></script>
 <script src="{{ url_for_asset('d3.min.js') }}"></script>
 <script src="{{ url_for_asset('d3-tip.js') }}"></script>/
 <script src="{{ url_for_asset('ganttChartD3v2.js') }}"></script>
 <script>
   $( document ).ready(function() {
-    var dag_id = '{{ dag.dag_id }}';
-    var task_id = '';
-    var exection_date = '';
-    data = {{ data |tojson|safe }};
+    var dag_id = getMetaValue('dag-id');
+    var data = JSON.parse(getMetaValue('data'));
     var gantt = d3.gantt()
       .taskTypes(data.taskNames)
       .taskStatus(data.taskStatus)

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -22,6 +22,16 @@
 {% block head_css %}
 {{ super() }}
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/graph.css') }}">
+<meta name="nodes" content="{{ nodes | tojson | forceescape }}">
+<meta name="edges" content="{{ edges | tojson | forceescape }}">
+<meta name="execution-date" content="{{ execution_date }}">
+<meta name="arrange" content="{{ arrange }}">
+<meta name="tasks" content="{{ tasks | tojson | forceescape}}">
+<meta name="task-instances" content="{{ task_instances | tojson | forceescape }}">
+<meta name="base-task-instance-url" content="{{ url_for('Airflow.task_instances') }}">
+{% if blur %}
+  <meta name="blur" content="true"/>
+{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -92,7 +102,7 @@
 
 {% block tail %}
 {{ super() }}
-
+<script src="{{ url_for_asset('utils.js') }}"></script>
 <script src="{{ url_for_asset('d3.min.js') }}"></script>
 <script src="{{ url_for_asset('dagre-d3.min.js') }}"></script>
 <script>
@@ -103,15 +113,16 @@
     var initialStrokeWidth = '3px';
     var highlightStrokeWidth = '5px';
 
-    var nodes = {{ nodes|tojson|safe }};
-    var edges = {{ edges|tojson|safe }};
-    var execution_date = "{{ execution_date }}";
-    var arrange = "{{ arrange }}";
+    var nodes = JSON.parse(getMetaValue('nodes'));
+    var edges = JSON.parse(getMetaValue('edges'));
+    var execution_date = getMetaValue('execution-date');
+    var arrange = getMetaValue('arrange');
+    var tasks = JSON.parse(getMetaValue('tasks'));
+    var task_instances =  JSON.parse(getMetaValue('task-instances'));
+    var base_task_instance_url = getMetaValue('base-task-instance-url');
 
     // Below variables are being used in dag.js
-    var tasks = {{ tasks|tojson|safe }};
-    var task_instances = {{ task_instances|tojson|safe }};
-    var getTaskInstanceURL = "{{ url_for('Airflow.task_instances') }}" +
+    var getTaskInstanceURL = base_task_instance_url +
       "?dag_id=" + encodeURIComponent(dag_id) + "&execution_date=" +
       encodeURIComponent(execution_date);
 
@@ -195,10 +206,9 @@
         highlight_nodes(g.successors(d), null)
     });
 
-
-    {% if blur %}
-    d3.selectAll("text").attr("class", "blur");
-    {% endif %}
+    if(getMetaValue('blur')) {
+      d3.selectAll("text").attr("class", "blur");
+    }
 
     $("g.node").tooltip({
       html: true,

--- a/airflow/www/templates/airflow/task_instance.html
+++ b/airflow/www/templates/airflow/task_instance.html
@@ -22,6 +22,7 @@
 
 {% block head_css %}
 {{ super() }}
+<meta name="execution-date" content="{{ execution_date }}">
 <link rel="stylesheet" type="text/css"
     href="{{ url_for('appbuilder.static',filename='datepicker/bootstrap-datepicker.css')}}" >
 {% endblock %}
@@ -60,13 +61,15 @@
 {% endblock %}
 {% block tail %}
   {{ super() }}
+  <script src="{{ url_for_asset('utils.js') }}"></script>
   <script src="{{ url_for('appbuilder.static',filename='datepicker/bootstrap-datepicker.js')}}"></script>
   <script>
+    const EXECUTION_DATE = getMetaValue('execution-date');
     $( document ).ready(function() {
       function date_change(){
           execution_date = $("input#execution_date").val().replace(' ', 'T');
           loc = decodeURIComponent(window.location.href);
-          loc = loc.replace('{{ execution_date }}', execution_date);
+          loc = loc.replace(EXECUTION_DATE, execution_date);
           window.location = loc;
       }
       $("input#execution_date").on("change.daterangepicker", function(){

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -18,6 +18,16 @@ limitations under the License.
 {% extends "airflow/task_instance.html" %}
 {% block title %}Airflow - DAGs{% endblock %}
 
+{% block head_css %}
+  {{ super() }}
+  <meta name="total-attempts" content="{{ logs|length }}">
+  <meta name="dag-id" content="{{ dag_id }}">
+  <meta name="task-id" content="{{ task_id }}">
+  <meta name="execution-date" content="{{ execution_date }}">
+  <meta name="task-id" content="{{ task_id }}">
+  <meta name="base-url-get-logs-with-metadata" content="{{ url_for("Airflow.get_logs_with_metadata") }}">
+{% endblock %}
+
 {% block content %}
 {{ super() }}
 <h4>{{ title }}</h4>
@@ -42,7 +52,9 @@ limitations under the License.
 {% endblock %}
 {% block tail %}
 {{ super() }}
+<script src="{{ url_for_asset('utils.js') }}"></script>
 <script>
+(function() {
     // TODO: make those constants configurable.
     // Time interval to wait before next log fetching. Default 2s.
     const DELAY = 2e3;
@@ -51,7 +63,11 @@ limitations under the License.
     // Animation speed for auto tailing log display.
     const ANIMATION_SPEED = 1000;
     // Total number of tabs to show.
-    const TOTAL_ATTEMPTS = "{{ logs|length }}";
+    const TOTAL_ATTEMPTS = getMetaValue('total-attempts');
+    const EXECUTION_DATE = getMetaValue('execution-date');
+    const DAG_ID = getMetaValue('dag-id');
+    const TASK_ID = getMetaValue('task-id');
+    const BASE_URL_GET_LOGS = getMetaValue('base-url-get-logs-with-metadata');
 
     // Recursively fetch logs from flask endpoint.
     function recurse(delay=DELAY) {
@@ -72,16 +88,15 @@ limitations under the License.
 
     // Streaming log with auto-tailing.
     function autoTailingLog(try_number, metadata=null, auto_tailing=false) {
-      console.debug("Auto-tailing log for dag_id: {{ dag_id }}, task_id: {{ task_id }}, \
-       execution_date: {{ execution_date }}, try_number: " + try_number + ", metadata: " + JSON.stringify(metadata));
+      console.debug(`Auto-tailing log for dag_id: ${DAG_ID}, task_id: ${TASK_ID}, execution_date: ${EXECUTION_DATE},  try_number,  ${try_number}, metadata: ${JSON.stringify(metadata)}`);
 
       return Promise.resolve(
         $.ajax({
-          url: "{{ url_for("Airflow.get_logs_with_metadata") }}",
+          url: BASE_URL_GET_LOGS,
           data: {
-            dag_id: "{{ dag_id }}",
-            task_id: "{{ task_id }}",
-            execution_date: "{{ execution_date }}",
+            dag_id: DAG_ID,
+            task_id: TASK_ID,
+            execution_date: EXECUTION_DATE,
             try_number: try_number,
             metadata: JSON.stringify(metadata),
           },
@@ -135,6 +150,6 @@ limitations under the License.
         autoTailingLog(i, null, auto_tailing=(i == TOTAL_ATTEMPTS));
       }
     });
-
+})()
 </script>
 {% endblock %}

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -23,6 +23,10 @@
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/tree.css') }}">
 <link rel="stylesheet" type="text/css"
       href="{{ url_for('appbuilder.static',filename='datepicker/bootstrap-datepicker.css') }}">
+<meta name="data" content="{{ data | tojson | forceescape }}"/>
+{% if blur %}
+  <meta name="blur" content="true"/>
+{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -76,11 +80,12 @@
 
 {% block tail %}
 {{ super() }}
+<script src="{{ url_for_asset('utils.js') }}"></script>
 <script src="{{ url_for_asset('d3.min.js') }}"></script>
 <script>
 $('span.status_square').tooltip({html: true});
 
-var data = {{ data|tojson|safe }};
+var data = JSON.parse(getMetaValue('data'));
 var barHeight = 20;
 var axisHeight = 40;
 var square_x = 500;
@@ -114,10 +119,11 @@ var svg = d3.select("svg")
     data.x0 = 0;
     data.y0 = 0;
 
+  var base_mode;
   if (nodes.length == 1)
-    var base_node = nodes[0];
+    base_node = nodes[0];
   else
-    var base_node = nodes[1];
+    base_node = nodes[1];
 
   var num_square = base_node.instances.length;
   var extent = d3.extent(base_node.instances, function(d,i) {
@@ -220,9 +226,11 @@ function update(source) {
       .attr("dy", 3.5)
       .attr("dx", barHeight/2)
       .text(function(d) { return d.name; });
-  {% if blur %}
-  text.attr("class", "blur");
-  {% endif %}
+
+  if(getMetaValue('blur')) {
+    text.attr("class", "blur");
+  }
+
 
   nodeEnter.append('g')
       .attr("class", "stateboxes")

--- a/airflow/www/templates/appbuilder/baselayout.html
+++ b/airflow/www/templates/appbuilder/baselayout.html
@@ -27,8 +27,9 @@
     <link href="{{ url_for_asset('airflowDefaultTheme.css') }}" rel="stylesheet">
   {% endif %}
   <link href="{{ url_for_asset('main.css') }}" rel="stylesheet">
-
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='pin_30.png') }}">
+  <meta name="host-name" content="{{ hostname }}"/>
+  <meta name="csrf-token" content="{{ csrf_token() }}"/>
 {% endblock %}
 
 
@@ -66,10 +67,6 @@
 
 {% block tail_js %}
 {{ super() }}
-<script type="text/javascript">
-  // below variables are used in base.js
-  var hostName = '{{ hostname }}';
-  var csrfToken = '{{ csrf_token() }}';
-</script>
+<script src="{{ url_for_asset('utils.js') }}"></script>
 <script src="{{ url_for_asset('base.js') }}" type="text/javascript"></script>
 {% endblock %}

--- a/airflow/www/templates/appbuilder/navbar_right.html
+++ b/airflow/www/templates/appbuilder/navbar_right.html
@@ -45,7 +45,7 @@
 {% endmacro %}
 
 <!-- clock -->
-<li><a id="clock"></a></li>
+<li><a id="clock" data-original-title="{{ hostname }}"></a></li>
 
 {% if not current_user.is_anonymous %}
     <li class="dropdown">

--- a/airflow/www/webpack.config.js
+++ b/airflow/www/webpack.config.js
@@ -34,6 +34,7 @@ const BUILD_DIR = path.resolve(__dirname, './static/dist');
 
 const config = {
   entry: {
+    utils: `${STATIC_DIR}/js/utils.js`,
     connectionForm: `${STATIC_DIR}/js/connection_form.js`,
     base: `${STATIC_DIR}/js/base.js`,
     graph: `${STATIC_DIR}/js/graph.js`,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3967
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

The current state is unexpected because:

* When Javascript is generated by the template engine, we do metaprogramming, which raises the complexity of the problems.
* It does not allow testing the code in isolation.
* Jinja is a HTML Template Engine. Using it to the JS code may cause a security risk.

As a next step, I would like to:
* move the JS code to separate file
* introduce linting for all JS/HTML files. 
* extract inlined CSS  to separate file

For a long-term goal, I would like to 
* introduce visual regression and snapshot testing. If the JS code will be in separate files then it will be relatively simple. 
* update a dependency - Bootstrap 4 including dropping glyphicons

@jmcarp  I saw that you changed HTML / JS files recently. What do you think about the change and plans for the future? Does what I want to do in the future make sense for you?

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
