### PR TITLE
[AIRFLOW-3968][2/3] Refactor base GCP hook

### DIFF
--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -17,28 +17,114 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import json
 import functools
-
-import httplib2
-import google.auth
-import google_auth_httplib2
-import google.oauth2.service_account
+import json
 import os
 import tempfile
 
+import httplib2
 from google.api_core.exceptions import GoogleAPICallError, AlreadyExists, RetryError
+import google.auth
+from google.auth.environment_vars import CREDENTIALS
+import google.oauth2.service_account
 from googleapiclient.errors import HttpError
+import google_auth_httplib2
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 
 
 _DEFAULT_SCOPES = ('https://www.googleapis.com/auth/cloud-platform',)
-# The name of the environment variable that Google Authentication library uses
-# to get service account key location. Read more:
-# https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable
-_G_APP_CRED_ENV_VAR = "GOOGLE_APPLICATION_CREDENTIALS"
+
+
+def fallback_to_default_project_id(func):
+    """
+    Decorator that provides fallback for Google Cloud Platform project id. If
+    the project is None it will be replaced with the project_id from the
+    service account the Hook is authenticated with. Project id can be specified
+    either via project_id kwarg or via first parameter in positional args.
+
+    :param func: function to wrap
+    :return: result of the function call
+    """
+
+    @functools.wraps(func)
+    def inner_wrapper(self, *args, **kwargs):
+        if len(args) > 0:
+            raise AirflowException("You must use keyword arguments in this methods rather than positional")
+
+        kwargs['project_id'] = kwargs.get('project_id') or self.project_id
+
+        if not kwargs['project_id']:
+            raise AirflowException(
+                "The project id must be passed either as keyword project_id parameter or as project_id extra "
+                "in GCP connection definition. Both are not set!"
+            )
+        return func(self, *args, **kwargs)
+
+    return inner_wrapper
+
+
+def provide_gcp_credential_file(func):
+    """
+    Function decorator that provides a GOOGLE_APPLICATION_CREDENTIALS
+    environment variable, pointing to file path of a JSON file of service
+    account key.
+    """
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        with tempfile.NamedTemporaryFile(mode='w+t') as conf_file:
+            key_path = self._get_field('key_path', False)
+            keyfile_dict = self._get_field('keyfile_dict', False)
+            current_env_state = os.environ.get(CREDENTIALS)
+            try:
+                if key_path:
+                    if key_path.endswith('.p12'):
+                        raise AirflowException('Legacy P12 key file are not supported, use a JSON key file.')
+                    os.environ[CREDENTIALS] = key_path
+                elif keyfile_dict:
+                    conf_file.write(keyfile_dict)
+                    conf_file.flush()
+                    os.environ[CREDENTIALS] = conf_file.name
+                return func(self, *args, **kwargs)
+            finally:
+                if current_env_state is None:
+                    if CREDENTIALS in os.environ:
+                        del os.environ[CREDENTIALS]
+                else:
+                    os.environ[CREDENTIALS] = current_env_state
+
+    return wrapper
+
+
+def catch_http_exception(func):
+    """
+    Function decorator that intercepts HTTP Errors and raises AirflowException
+    with more informative message.
+    """
+
+    @functools.wraps(func)
+    def wrapper_decorator(self, *args, **kwargs):
+        try:
+            return func(self, *args, **kwargs)
+        except GoogleAPICallError as e:
+            if isinstance(e, AlreadyExists):
+                raise e
+            else:
+                self.log.error('The request failed:\n%s', str(e))
+                raise AirflowException(e)
+        except RetryError as e:
+            self.log.error('The request failed due to a retryable error and retry attempts failed.')
+            raise AirflowException(e)
+        except ValueError as e:
+            self.log.error('The request failed, the parameters are invalid.')
+            raise AirflowException(e)
+        except HttpError as e:
+            self.log.error('The request failed:\n%s', str(e))
+            raise AirflowException(e)
+
+    return wrapper_decorator
 
 
 class GoogleCloudBaseHook(BaseHook):
@@ -85,27 +171,20 @@ class GoogleCloudBaseHook(BaseHook):
         """
         key_path = self._get_field('key_path', False)
         keyfile_dict = self._get_field('keyfile_dict', False)
-        scope = self._get_field('scope', None)
-        if scope:
-            scopes = [s.strip() for s in scope.split(',')]
-        else:
-            scopes = _DEFAULT_SCOPES
-
         if not key_path and not keyfile_dict:
-            self.log.info('Getting connection using `google.auth.default()` '
-                          'since no key file is defined for hook.')
-            credentials, _ = google.auth.default(scopes=scopes)
+            self.log.info(
+                'Getting connection using `google.auth.default() since no key file is defined for hook.'
+            )
+            credentials, _ = google.auth.default(scopes=self.scopes)
         elif key_path:
             # Get credentials from a JSON file.
             if key_path.endswith('.json'):
-                self.log.debug('Getting connection using JSON key file %s' % key_path)
-                credentials = (
-                    google.oauth2.service_account.Credentials.from_service_account_file(
-                        key_path, scopes=scopes)
+                self.log.debug('Getting connection using JSON key file %s', key_path)
+                credentials = google.oauth2.service_account.Credentials.from_service_account_file(
+                    key_path, scopes=self.scopes
                 )
             elif key_path.endswith('.p12'):
-                raise AirflowException('Legacy P12 key file are not supported, '
-                                       'use a JSON key file.')
+                raise AirflowException('Legacy P12 key file are not supported, use a JSON key file.')
             else:
                 raise AirflowException('Unrecognised extension for key file.')
         else:
@@ -115,18 +194,15 @@ class GoogleCloudBaseHook(BaseHook):
 
                 # Depending on how the JSON was formatted, it may contain
                 # escaped newlines. Convert those to actual newlines.
-                keyfile_dict['private_key'] = keyfile_dict['private_key'].replace(
-                    '\\n', '\n')
+                keyfile_dict['private_key'] = keyfile_dict['private_key'].replace('\\n', '\n')
 
-                credentials = (
-                    google.oauth2.service_account.Credentials.from_service_account_info(
-                        keyfile_dict, scopes=scopes)
+                credentials = google.oauth2.service_account.Credentials.from_service_account_info(
+                    keyfile_dict, scopes=self.scopes
                 )
             except json.decoder.JSONDecodeError:
                 raise AirflowException('Invalid key JSON.')
 
-        return credentials.with_subject(self.delegate_to) \
-            if self.delegate_to else credentials
+        return credentials.with_subject(self.delegate_to) if self.delegate_to else credentials
 
     def _get_access_token(self):
         """
@@ -141,8 +217,7 @@ class GoogleCloudBaseHook(BaseHook):
         """
         credentials = self._get_credentials()
         http = httplib2.Http()
-        authed_http = google_auth_httplib2.AuthorizedHttp(
-            credentials, http=http)
+        authed_http = google_auth_httplib2.AuthorizedHttp(credentials, http=http)
         return authed_http
 
     def _get_field(self, f, default=None):
@@ -162,96 +237,9 @@ class GoogleCloudBaseHook(BaseHook):
     def project_id(self):
         return self._get_field('project')
 
-    @staticmethod
-    def catch_http_exception(func):
-        """
-        Function decorator that intercepts HTTP Errors and raises AirflowException
-        with more informative message.
-        """
-        @functools.wraps(func)
-        def wrapper_decorator(self, *args, **kwargs):
-            try:
-                return func(self, *args, **kwargs)
-            except GoogleAPICallError as e:
-                if isinstance(e, AlreadyExists):
-                    raise e
-                else:
-                    self.log.error('The request failed:\n%s', str(e))
-                    raise AirflowException(e)
-            except RetryError as e:
-                self.log.error('The request failed due to a retryable error and retry attempts failed.')
-                raise AirflowException(e)
-            except ValueError as e:
-                self.log.error('The request failed, the parameters are invalid.')
-                raise AirflowException(e)
-            except HttpError as e:
-                self.log.error('The request failed:\n%s', str(e))
-                raise AirflowException(e)
-        return wrapper_decorator
-
-    @staticmethod
-    def fallback_to_default_project_id(func):
-        """
-        Decorator that provides fallback for Google Cloud Platform project id. If
-        the project is None it will be replaced with the project_id from the
-        service account the Hook is authenticated with. Project id can be specified
-        either via project_id kwarg or via first parameter in positional args.
-
-        :param func: function to wrap
-        :return: result of the function call
-        """
-        @functools.wraps(func)
-        def inner_wrapper(self, *args, **kwargs):
-            if len(args) > 0:
-                raise AirflowException(
-                    "You must use keyword arguments in this methods rather than"
-                    " positional")
-            if 'project_id' in kwargs:
-                kwargs['project_id'] = self._get_project_id(kwargs['project_id'])
-            else:
-                kwargs['project_id'] = self._get_project_id(None)
-            if not kwargs['project_id']:
-                raise AirflowException("The project id must be passed either as "
-                                       "keyword project_id parameter or as project_id extra "
-                                       "in GCP connection definition. Both are not set!")
-            return func(self, *args, **kwargs)
-        return inner_wrapper
-
-    def _get_project_id(self, project_id):
-        """
-        In case project_id is None, overrides it with default project_id from
-        the service account that is authorized.
-
-        :param project_id: project id to
-        :type project_id: str
-        :return: the project_id specified or default project id if project_id is None
-        """
-        return project_id if project_id else self.project_id
-
-    class _Decorators(object):
-        """A private inner class for keeping all decorator methods."""
-
-        @staticmethod
-        def provide_gcp_credential_file(func):
-            """
-            Function decorator that provides a GOOGLE_APPLICATION_CREDENTIALS
-            environment variable, pointing to file path of a JSON file of service
-            account key.
-            """
-            @functools.wraps(func)
-            def wrapper(self, *args, **kwargs):
-                with tempfile.NamedTemporaryFile(mode='w+t') as conf_file:
-                    key_path = self._get_field('key_path', False)
-                    keyfile_dict = self._get_field('keyfile_dict', False)
-                    if key_path:
-                        if key_path.endswith('.p12'):
-                            raise AirflowException(
-                                'Legacy P12 key file are not supported, '
-                                'use a JSON key file.')
-                        os.environ[_G_APP_CRED_ENV_VAR] = key_path
-                    elif keyfile_dict:
-                        conf_file.write(keyfile_dict)
-                        conf_file.flush()
-                        os.environ[_G_APP_CRED_ENV_VAR] = conf_file.name
-                    return func(self, *args, **kwargs)
-            return wrapper
+    @property
+    def scopes(self):
+        scope = self._get_field('scope', None)
+        if not scope:
+            return _DEFAULT_SCOPES
+        return [s.strip() for s in scope.split(',')]

--- a/airflow/contrib/hooks/gcp_bigtable_hook.py
+++ b/airflow/contrib/hooks/gcp_bigtable_hook.py
@@ -22,7 +22,7 @@ from google.cloud.bigtable.cluster import Cluster
 from google.cloud.bigtable.instance import Instance
 from google.cloud.bigtable.table import Table
 from google.cloud.bigtable_admin_v2 import enums
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, fallback_to_default_project_id
 
 
 class BigtableHook(GoogleCloudBaseHook):
@@ -46,7 +46,7 @@ class BigtableHook(GoogleCloudBaseHook):
                                   admin=True)
         return self._client
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_instance(self, instance_id, project_id=None):
         """
         Retrieves and returns the specified Cloud Bigtable instance if it exists.
@@ -65,7 +65,7 @@ class BigtableHook(GoogleCloudBaseHook):
             return None
         return instance
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def delete_instance(self, instance_id, project_id=None):
         """
         Deletes the specified Cloud Bigtable instance.
@@ -86,7 +86,7 @@ class BigtableHook(GoogleCloudBaseHook):
             self.log.info("The instance '%s' does not exist in project '%s'. Exiting", instance_id,
                           project_id)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def create_instance(self,
                         instance_id,
                         main_cluster_id,
@@ -195,7 +195,7 @@ class BigtableHook(GoogleCloudBaseHook):
         table = Table(table_id, instance)
         table.create(initial_split_keys, column_families)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def delete_table(self, instance_id, table_id, project_id=None):
         """
         Deletes the specified table in Cloud Bigtable.

--- a/airflow/contrib/hooks/gcp_compute_hook.py
+++ b/airflow/contrib/hooks/gcp_compute_hook.py
@@ -21,7 +21,7 @@ import time
 from googleapiclient.discovery import build
 
 from airflow import AirflowException
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, fallback_to_default_project_id
 
 # Number of retries - used by googleapiclient method calls to perform retries
 # For requests that are "retriable"
@@ -68,7 +68,7 @@ class GceHook(GoogleCloudBaseHook):
                                http=http_authorized, cache_discovery=False)
         return self._conn
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def start_instance(self, zone, resource_id, project_id=None):
         """
         Starts an existing instance defined by project_id, zone and resource_id.
@@ -99,7 +99,7 @@ class GceHook(GoogleCloudBaseHook):
                                              operation_name=operation_name,
                                              zone=zone)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def stop_instance(self, zone, resource_id, project_id=None):
         """
         Stops an instance defined by project_id, zone and resource_id
@@ -130,7 +130,7 @@ class GceHook(GoogleCloudBaseHook):
                                              operation_name=operation_name,
                                              zone=zone)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def set_machine_type(self, zone, resource_id, body, project_id=None):
         """
         Sets machine type of an instance defined by project_id, zone and resource_id.
@@ -166,7 +166,7 @@ class GceHook(GoogleCloudBaseHook):
             project=project_id, zone=zone, instance=resource_id, body=body)\
             .execute(num_retries=NUM_RETRIES)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_instance_template(self, resource_id, project_id=None):
         """
         Retrieves instance template by project_id and resource_id.
@@ -188,7 +188,7 @@ class GceHook(GoogleCloudBaseHook):
         ).execute(num_retries=NUM_RETRIES)
         return response
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def insert_instance_template(self, body, request_id=None, project_id=None):
         """
         Inserts instance template using body specified
@@ -222,7 +222,7 @@ class GceHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_instance_group_manager(self, zone, resource_id, project_id=None):
         """
         Retrieves Instance Group Manager by project_id, zone and resource_id.
@@ -247,7 +247,7 @@ class GceHook(GoogleCloudBaseHook):
         ).execute(num_retries=NUM_RETRIES)
         return response
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def patch_instance_group_manager(self, zone, resource_id,
                                      body, request_id=None, project_id=None):
         """

--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -25,7 +25,7 @@ import uuid
 
 from googleapiclient.discovery import build
 
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, provide_gcp_credential_file
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 # This is the default location
@@ -190,7 +190,7 @@ class DataFlowHook(GoogleCloudBaseHook):
         return build(
             'dataflow', 'v1b3', http=http_authorized, cache_discovery=False)
 
-    @GoogleCloudBaseHook._Decorators.provide_gcp_credential_file
+    @provide_gcp_credential_file
     def _start_dataflow(self, variables, name, command_prefix, label_formatter):
         variables = self._set_variables(variables)
         cmd = command_prefix + self._build_cmd(variables, label_formatter)

--- a/airflow/contrib/hooks/gcp_function_hook.py
+++ b/airflow/contrib/hooks/gcp_function_hook.py
@@ -22,7 +22,7 @@ import requests
 from googleapiclient.discovery import build
 
 from airflow import AirflowException
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, fallback_to_default_project_id
 
 # Number of retries - used by googleapiclient method calls to perform retries
 # For requests that are "retriable"
@@ -88,7 +88,7 @@ class GcfHook(GoogleCloudBaseHook):
         return self.get_conn().projects().locations().functions().get(
             name=name).execute(num_retries=NUM_RETRIES)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def create_new_function(self, location, body, project_id=None):
         """
         Creates a new function in Cloud Function in the location specified in the body.
@@ -129,7 +129,7 @@ class GcfHook(GoogleCloudBaseHook):
         operation_name = response["name"]
         self._wait_for_operation_to_complete(operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def upload_function_zip(self, location, zip_path, project_id=None):
         """
         Uploads zip file with sources.

--- a/airflow/contrib/hooks/gcp_spanner_hook.py
+++ b/airflow/contrib/hooks/gcp_spanner_hook.py
@@ -21,7 +21,7 @@ from google.cloud.spanner_v1.client import Client
 from google.longrunning.operations_grpc_pb2 import Operation  # noqa: F401
 
 from airflow import AirflowException
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, fallback_to_default_project_id
 
 
 class CloudSpannerHook(GoogleCloudBaseHook):
@@ -51,7 +51,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
             self._client = Client(project=project_id, credentials=self._get_credentials())
         return self._client
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_instance(self, instance_id, project_id=None):
         """
         Gets information about a particular instance.
@@ -105,7 +105,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
             result = operation.result()
             self.log.info(result)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def create_instance(self, instance_id, configuration_name, node_count,
                         display_name, project_id=None):
         """
@@ -132,7 +132,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
         self._apply_to_instance(project_id, instance_id, configuration_name,
                                 node_count, display_name, lambda x: x.create())
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def update_instance(self, instance_id, configuration_name, node_count,
                         display_name, project_id=None):
         """
@@ -159,7 +159,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
         return self._apply_to_instance(project_id, instance_id, configuration_name,
                                        node_count, display_name, lambda x: x.update())
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def delete_instance(self, instance_id, project_id=None):
         """
         Deletes an existing Cloud Spanner instance.
@@ -180,7 +180,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
             self.log.error('An error occurred: %s. Exiting.', e.message)
             raise e
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_database(self, instance_id, database_id, project_id=None):
         """
         Retrieves a database in Cloud Spanner. If the database does not exist
@@ -208,7 +208,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
         else:
             return database
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def create_database(self, instance_id, database_id, ddl_statements, project_id=None):
         """
         Creates a new database in Cloud Spanner.
@@ -243,7 +243,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
             self.log.info(result)
         return
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def update_database(self, instance_id, database_id, ddl_statements,
                         project_id=None,
                         operation_id=None):
@@ -287,7 +287,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
             self.log.error('An error occurred: %s. Exiting.', e.message)
             raise e
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def delete_database(self, instance_id, database_id, project_id=None):
         """
         Drops a database in Cloud Spanner.
@@ -324,7 +324,7 @@ class CloudSpannerHook(GoogleCloudBaseHook):
             self.log.info(result)
         return
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def execute_dml(self, instance_id, database_id, queries, project_id=None):
         """
         Executes an arbitrary DML query (INSERT, UPDATE, DELETE).

--- a/airflow/contrib/hooks/gcp_sql_hook.py
+++ b/airflow/contrib/hooks/gcp_sql_hook.py
@@ -39,7 +39,7 @@ import requests
 from googleapiclient.discovery import build
 
 from airflow import AirflowException, LoggingMixin
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, fallback_to_default_project_id
 
 # Number of retries - used by googleapiclient method calls to perform retries
 # For requests that are "retriable"
@@ -94,7 +94,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
                                http=http_authorized, cache_discovery=False)
         return self._conn
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_instance(self, instance, project_id=None):
         """
         Retrieves a resource containing information about a Cloud SQL instance.
@@ -112,7 +112,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
             instance=instance
         ).execute(num_retries=NUM_RETRIES)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def create_instance(self, body, project_id=None):
         """
         Creates a new Cloud SQL instance.
@@ -133,7 +133,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def patch_instance(self, body, instance, project_id=None):
         """
         Updates settings of a Cloud SQL instance.
@@ -160,7 +160,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def delete_instance(self, instance, project_id=None):
         """
         Deletes a Cloud SQL instance.
@@ -180,7 +180,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def get_database(self, instance, database, project_id=None):
         """
         Retrieves a database resource from a Cloud SQL instance.
@@ -202,7 +202,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
             database=database
         ).execute(num_retries=NUM_RETRIES)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def create_database(self, instance, body, project_id=None):
         """
         Creates a new database inside a Cloud SQL instance.
@@ -226,7 +226,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def patch_database(self, instance, database, body, project_id=None):
         """
         Updates a database resource inside a Cloud SQL instance.
@@ -256,7 +256,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def delete_database(self, instance, database, project_id=None):
         """
         Deletes a database from a Cloud SQL instance.
@@ -279,7 +279,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id,
                                              operation_name=operation_name)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def export_instance(self, instance, body, project_id=None):
         """
         Exports data from a Cloud SQL instance to a Cloud Storage bucket as a SQL dump
@@ -310,7 +310,7 @@ class CloudSqlHook(GoogleCloudBaseHook):
                 'Exporting instance {} failed: {}'.format(instance, ex.content)
             )
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @fallback_to_default_project_id
     def import_instance(self, instance, body, project_id=None):
         """
         Imports data into a Cloud SQL instance from a SQL dump or CSV file in

--- a/airflow/contrib/hooks/gcp_transfer_hook.py
+++ b/airflow/contrib/hooks/gcp_transfer_hook.py
@@ -25,7 +25,8 @@ import six
 from googleapiclient.discovery import build
 
 from airflow.exceptions import AirflowException
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, catch_http_exception, \
+    fallback_to_default_project_id
 
 # Time to sleep between active checks of the operation results
 TIME_TO_SLEEP_IN_SECONDS = 10
@@ -118,7 +119,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
             )
         return self._conn
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @catch_http_exception
     def create_transfer_job(self, body):
         """
         Creates a transfer job that runs periodically.
@@ -134,8 +135,8 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
         body = self._inject_project_id(body, BODY, PROJECT_ID)
         return self.get_conn().transferJobs().create(body=body).execute(num_retries=NUM_RETRIES)
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
-    @GoogleCloudBaseHook.catch_http_exception
+    @fallback_to_default_project_id
+    @catch_http_exception
     def get_transfer_job(self, job_name, project_id=None):
         """
         Gets the latest state of a long-running operation in Google Storage
@@ -181,7 +182,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
 
         return jobs
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @catch_http_exception
     def update_transfer_job(self, job_name, body):
         """
         Updates a transfer job that runs periodically.
@@ -199,8 +200,8 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
             self.get_conn().transferJobs().patch(jobName=job_name, body=body).execute(num_retries=NUM_RETRIES)
         )
 
-    @GoogleCloudBaseHook.fallback_to_default_project_id
-    @GoogleCloudBaseHook.catch_http_exception
+    @fallback_to_default_project_id
+    @catch_http_exception
     def delete_transfer_job(self, job_name, project_id):
         """
         Deletes a transfer job. This is a soft delete. After a transfer job is
@@ -231,7 +232,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
             .execute(num_retries=NUM_RETRIES)
         )
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @catch_http_exception
     def cancel_transfer_operation(self, operation_name):
         """
         Cancels an transfer operation in Google Storage Transfer Service.
@@ -242,7 +243,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
         """
         self.get_conn().transferOperations().cancel(name=operation_name).execute(num_retries=NUM_RETRIES)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @catch_http_exception
     def get_transfer_operation(self, operation_name):
         """
         Gets an transfer operation in Google Storage Transfer Service.
@@ -256,7 +257,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
         """
         return self.get_conn().transferOperations().get(name=operation_name).execute(num_retries=NUM_RETRIES)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @catch_http_exception
     def list_transfer_operations(self, filter):
         """
         Gets an transfer operation in Google Storage Transfer Service.
@@ -292,7 +293,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
 
         return operations
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @catch_http_exception
     def pause_transfer_operation(self, operation_name):
         """
         Pauses an transfer operation in Google Storage Transfer Service.
@@ -303,7 +304,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
         """
         self.get_conn().transferOperations().pause(name=operation_name).execute(num_retries=NUM_RETRIES)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @catch_http_exception
     def resume_transfer_operation(self, operation_name):
         """
         Resumes an transfer operation in Google Storage Transfer Service.
@@ -314,7 +315,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
         """
         self.get_conn().transferOperations().resume(name=operation_name).execute(num_retries=NUM_RETRIES)
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @catch_http_exception
     def wait_for_transfer_job(self, job, expected_statuses=(GcpTransferOperationStatus.SUCCESS,), timeout=60):
         """
         Waits until the job reaches the expected state.

--- a/airflow/contrib/hooks/gcp_vision_hook.py
+++ b/airflow/contrib/hooks/gcp_vision_hook.py
@@ -22,7 +22,8 @@ from google.cloud.vision_v1 import ProductSearchClient, ImageAnnotatorClient
 from google.protobuf.json_format import MessageToDict
 
 from airflow import AirflowException
-from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook, fallback_to_default_project_id, \
+    catch_http_exception
 from airflow.utils.decorators import cached_property
 
 
@@ -118,8 +119,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
     def annotator_client(self):
         return ImageAnnotatorClient(credentials=self._get_credentials())
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @catch_http_exception
+    @fallback_to_default_project_id
     def create_product_set(
         self,
         location,
@@ -155,8 +156,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         return product_set_id
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @catch_http_exception
+    @fallback_to_default_project_id
     def get_product_set(
         self, location, product_set_id, project_id=None, retry=None, timeout=None, metadata=None
     ):
@@ -172,8 +173,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
         self.log.debug('ProductSet retrieved:\n%s', response)
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @catch_http_exception
+    @fallback_to_default_project_id
     def update_product_set(
         self,
         product_set,
@@ -201,8 +202,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
         self.log.debug('ProductSet updated:\n%s', response)
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @catch_http_exception
+    @fallback_to_default_project_id
     def delete_product_set(
         self, location, product_set_id, project_id=None, retry=None, timeout=None, metadata=None
     ):
@@ -216,8 +217,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
         client.delete_product_set(name=name, retry=retry, timeout=timeout, metadata=metadata)
         self.log.info('ProductSet with the name [%s] deleted.', name)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @catch_http_exception
+    @fallback_to_default_project_id
     def create_product(
         self, location, product, project_id=None, product_id=None, retry=None, timeout=None, metadata=None
     ):
@@ -246,8 +247,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         return product_id
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @catch_http_exception
+    @fallback_to_default_project_id
     def get_product(self, location, product_id, project_id=None, retry=None, timeout=None, metadata=None):
         """
         For the documentation see:
@@ -261,8 +262,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
         self.log.debug('Product retrieved:\n%s', response)
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @catch_http_exception
+    @fallback_to_default_project_id
     def update_product(
         self,
         product,
@@ -288,8 +289,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
         self.log.debug('Product updated:\n%s', response)
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @catch_http_exception
+    @fallback_to_default_project_id
     def delete_product(self, location, product_id, project_id=None, retry=None, timeout=None, metadata=None):
         """
         For the documentation see:
@@ -301,8 +302,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
         client.delete_product(name=name, retry=retry, timeout=timeout, metadata=metadata)
         self.log.info('Product with the name [%s] deleted:', name)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @catch_http_exception
+    @fallback_to_default_project_id
     def create_reference_image(
         self,
         location,
@@ -343,8 +344,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         return reference_image_id
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @catch_http_exception
+    @fallback_to_default_project_id
     def delete_reference_image(
         self,
         location,
@@ -369,8 +370,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         return MessageToDict(response)
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @catch_http_exception
+    @fallback_to_default_project_id
     def add_product_to_product_set(
         self,
         product_set_id,
@@ -398,8 +399,8 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         self.log.info('Product added to Product Set')
 
-    @GoogleCloudBaseHook.catch_http_exception
-    @GoogleCloudBaseHook.fallback_to_default_project_id
+    @catch_http_exception
+    @fallback_to_default_project_id
     def remove_product_from_product_set(
         self,
         product_set_id,
@@ -427,7 +428,7 @@ class CloudVisionHook(GoogleCloudBaseHook):
 
         self.log.info('Product removed from Product Set')
 
-    @GoogleCloudBaseHook.catch_http_exception
+    @catch_http_exception
     def annotate_image(self, request, retry=None, timeout=None):
         """
         For the documentation see:

--- a/tests/contrib/hooks/test_gcp_container_hook.py
+++ b/tests/contrib/hooks/test_gcp_container_hook.py
@@ -22,7 +22,7 @@ import unittest
 
 from airflow import AirflowException
 from airflow.contrib.hooks.gcp_container_hook import GKEClusterHook
-
+from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 
 TASK_ID = 'test-gke-cluster-operator'
 CLUSTER_NAME = 'test-cluster'
@@ -32,12 +32,15 @@ GKE_ZONE = 'test-zone'
 
 class GKEClusterHookDeleteTest(unittest.TestCase):
     def setUp(self):
-        self.gke_hook = GKEClusterHook(location=GKE_ZONE)
+        with mock.patch(
+            'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+            new=mock_base_gcp_hook_default_project_id
+        ):
+            self.gke_hook = GKEClusterHook(location=GKE_ZONE)
         self.gke_hook._client = mock.Mock()
 
     @mock.patch("airflow.contrib.hooks.gcp_container_hook.GKEClusterHook._dict_to_proto")
-    @mock.patch(
-        "airflow.contrib.hooks.gcp_container_hook.GKEClusterHook.wait_for_operation")
+    @mock.patch("airflow.contrib.hooks.gcp_container_hook.GKEClusterHook.wait_for_operation")
     def test_delete_cluster(self, wait_mock, convert_mock):
         retry_mock, timeout_mock = mock.Mock(), mock.Mock()
 
@@ -86,7 +89,11 @@ class GKEClusterHookDeleteTest(unittest.TestCase):
 
 class GKEClusterHookCreateTest(unittest.TestCase):
     def setUp(self):
-        self.gke_hook = GKEClusterHook(location=GKE_ZONE)
+        with mock.patch(
+            'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+            new=mock_base_gcp_hook_default_project_id
+        ):
+            self.gke_hook = GKEClusterHook(location=GKE_ZONE)
         self.gke_hook._client = mock.Mock()
 
     @mock.patch("airflow.contrib.hooks.gcp_container_hook.GKEClusterHook._dict_to_proto")
@@ -167,7 +174,11 @@ class GKEClusterHookCreateTest(unittest.TestCase):
 
 class GKEClusterHookGetTest(unittest.TestCase):
     def setUp(self):
-        self.gke_hook = GKEClusterHook(location=GKE_ZONE)
+        with mock.patch(
+            'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+            new=mock_base_gcp_hook_default_project_id
+        ):
+            self.gke_hook = GKEClusterHook(location=GKE_ZONE)
         self.gke_hook._client = mock.Mock()
 
     def test_get_cluster(self):
@@ -189,7 +200,11 @@ class GKEClusterHookGetTest(unittest.TestCase):
 class GKEClusterHookTest(unittest.TestCase):
 
     def setUp(self):
-        self.gke_hook = GKEClusterHook(location=GKE_ZONE)
+        with mock.patch(
+            'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+            new=mock_base_gcp_hook_default_project_id
+        ):
+            self.gke_hook = GKEClusterHook(location=GKE_ZONE)
         self.gke_hook._client = mock.Mock()
 
     @mock.patch('airflow.contrib.hooks.gcp_container_hook.container_v1.'

--- a/tests/contrib/hooks/test_gcp_mlengine_hook.py
+++ b/tests/contrib/hooks/test_gcp_mlengine_hook.py
@@ -28,13 +28,12 @@ from airflow.contrib.hooks import gcp_mlengine_hook as hook
 from googleapiclient.errors import HttpError
 from googleapiclient.discovery import build_from_document
 from googleapiclient.http import HttpMockSequence
-from google.auth.exceptions import GoogleAuthError
 import requests
 
 cml_available = True
 try:
     hook.MLEngineHook().get_conn()
-except GoogleAuthError:
+except Exception:
     cml_available = False
 
 

--- a/tests/contrib/operators/test_gcp_compute_operator.py
+++ b/tests/contrib/operators/test_gcp_compute_operator.py
@@ -29,6 +29,7 @@ from airflow.contrib.operators.gcp_compute_operator import GceInstanceStartOpera
     GceInstanceGroupManagerUpdateTemplateOperator
 from airflow.models import TaskInstance, DAG
 from airflow.utils import timezone
+from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 
 try:
     # noinspection PyProtectedMember
@@ -404,6 +405,8 @@ class GceInstanceSetMachineTypeTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.gcp_compute_operator.GceHook'
                 '._execute_set_machine_type')
     @mock.patch('airflow.contrib.operators.gcp_compute_operator.GceHook.get_conn')
+    @mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+                new=mock_base_gcp_hook_default_project_id)
     def test_set_machine_type_should_handle_and_trim_gce_error(
             self, get_conn, _execute_set_machine_type, _check_zone_operation_status):
         get_conn.return_value = {}

--- a/tests/contrib/operators/test_gcp_vision_operator.py
+++ b/tests/contrib/operators/test_gcp_vision_operator.py
@@ -76,11 +76,9 @@ class CloudVisionProductSetCreateTest(unittest.TestCase):
             metadata=None,
         )
 
-    @mock.patch('airflow.contrib.operators.gcp_vision_operator.CloudVisionHook.get_conn')
-    @mock.patch('airflow.contrib.operators.gcp_vision_operator.CloudVisionHook.create_product_set')
-    def test_already_exists(self, create_product_set_mock, get_conn):
-        get_conn.return_value = {}
-        create_product_set_mock.side_effect = AlreadyExists(message='')
+    @mock.patch('airflow.contrib.operators.gcp_vision_operator.CloudVisionHook')
+    def test_already_exists(self, hock_mock):
+        hock_mock.return_value.create_product_set.side_effect = AlreadyExists(message='')
         # Exception AlreadyExists not raised, caught in the operator's execute() - idempotence
         op = CloudVisionProductSetCreateOperator(
             location=LOCATION_TEST,
@@ -169,11 +167,9 @@ class CloudVisionProductCreateTest(unittest.TestCase):
             metadata=None,
         )
 
-    @mock.patch('airflow.contrib.operators.gcp_vision_operator.CloudVisionHook.get_conn')
-    @mock.patch('airflow.contrib.operators.gcp_vision_operator.CloudVisionHook.create_product')
-    def test_already_exists(self, create_product_mock, get_conn):
-        get_conn.return_value = {}
-        create_product_mock.side_effect = AlreadyExists(message='')
+    @mock.patch('airflow.contrib.operators.gcp_vision_operator.CloudVisionHook')
+    def test_already_exists(self, hook_mock):
+        hook_mock.return_value.create_product.side_effect = AlreadyExists(message='')
         # Exception AlreadyExists not raised, caught in the operator's execute() - idempotence
         op = CloudVisionProductCreateOperator(
             location=LOCATION_TEST,

--- a/tests/contrib/utils/base_gcp_mock.py
+++ b/tests/contrib/utils/base_gcp_mock.py
@@ -23,7 +23,7 @@ import mock
 GCP_PROJECT_ID_HOOK_UNIT_TEST = 'example-project'
 
 
-def mock_base_gcp_hook_default_project_id(self, gcp_conn_id, delegate_to=None):
+def mock_base_gcp_hook_default_project_id(self, gcp_conn_id='google_cloud_default', delegate_to=None):
     self.extras = {
         'extra__google_cloud_platform__project': GCP_PROJECT_ID_HOOK_UNIT_TEST
     }
@@ -31,7 +31,7 @@ def mock_base_gcp_hook_default_project_id(self, gcp_conn_id, delegate_to=None):
     self.delegate_to = delegate_to
 
 
-def mock_base_gcp_hook_no_default_project_id(self, gcp_conn_id, delegate_to=None):
+def mock_base_gcp_hook_no_default_project_id(self, gcp_conn_id='google_cloud_default', delegate_to=None):
     self.extras = {
     }
     self._conn = gcp_conn_id


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3968

### Description

This is one of the PR series aimed to add automatically API Reference.

- [AIRFLOW-XXX][1/3] Syntax docs improvements - https://github.com/apache/airflow/pull/4789
- [AIRFLOW-3968][2/3] Refactor base GCP hook -  https://github.com/apache/airflow/pull/4790
- [AIRFLOW-3811][3/3] Add automatic generation of API Reference  - https://github.com/apache/airflow/pull/4788

I would ask you to accept changes in order.

Documentation preview with all changes is available: 
http://neighborly-sun.surge.sh/autoapi/index.html

The proposed PR introduces various changes related to GoogleCloudBaseHook:

- Move all decorators to top-level of module.  
   There were two ways to place decorations in the file: 
  1. as a static method on GoogleCloudBaseHook
  2. as a static method on nested class _Decorators in class GoogleCloudBaseHook. 

  In my opinion, the applied level of nesting is unjustified.
  This is also indicated in Google's code style guide: http://google.github.io/styleguide/pyguide.html#217-function-and-method-decorators
- Create property `scope` to separate complex logic from the `get_credentials` method. 
  This allows us to test the code in isolation. Tests have been added.
- Simplify logic of `fallback_to_default_project_id`. 
  The logic of the method has been unnecessarily complicated.  The helper method used was used deleted. There have been added tests to check the code's logic.
- Some code fragment did not follow the line width rule.
- Use `@decoractor` syntax. 
The old syntax is not supported by [autoapi](https://lists.apache.org/list.html?dev@airflow.apache.org:lte=5M:).
- preserve the state of the environment variable after execution of `provide_gcp_credential_file` decorator.
- remove constant `_G_APP_CRED_ENV_VAR`
- some tests were dependent on the database. I added a mock. In the future I will try to fix the constructor. It should not connect to the database

CC: @kaxil @fenglu-g

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
