### PR TITLE
[AIRFLOW-3970] Pull out the action buttons from the tabs

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -26,24 +26,52 @@
 
 {% block content %}
 <div>
-    <h3 class="pull-left">
-      {% if dag.parent_dag is defined and dag.parent_dag %}
-        <span style='color:#AAA;'>SUBDAG: </span> <span> {{ dag.dag_id }}</span>
-      {% else %}
-        <input id="pause_resume" dag_id="{{ dag.dag_id }}" type="checkbox" {{ "checked" if not dag.is_paused else "" }} data-toggle="toggle" data-size="mini" method="post">
-        <span style='color:#AAA;'>DAG: </span> <span> {{ dag.dag_id }}</span> <small class="text-muted"> {{ dag.description }} </small>
-      {% endif %}
-      {% if root %}
-        <span style='color:#AAA;'>ROOT: </span> <span> {{ root }}</span>
-      {% endif %}
-    </h3>
-    <h4 class="pull-right">
-      <a class="label label-default" href="{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id={{ dag.dag_id }}">
-        schedule: {{ dag.schedule_interval }}
-      </a>
-    </h4>
+  <div class="clearfix">
+    <div class="pull-right">
+      <div class="btn-group">
+        <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=request.base_url ) }}"
+           onclick="return confirmTriggerDag('{{ dag.safe_dag_id }}')"
+           class="btn btn-primary"
+        >
+          <span class="glyphicon glyphicon-play-circle" aria-hidden="true"></span>
+          Trigger DAG
+        </a>
+        <a href="{{ url_for('Airflow.refresh', dag_id=dag.dag_id) }}"
+           class="btn btn-primary"
+        >
+          <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
+          Refresh
+        </a>
+        <a href="{{ url_for('Airflow.delete', dag_id=dag.dag_id) }}"
+           onclick="return confirmDeleteDag('{{ dag.safe_dag_id }}')"
+           class="btn btn-danger"
+        >
+          <span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span>
+          Delete
+        </a>
+      </div>
+    </div>
+    <div style="display: flex; align-items: center;">
+      <h2>
+        {% if dag.parent_dag is defined and dag.parent_dag %}
+          <span style='color:#AAA;'>SUBDAG: </span> <span> {{ dag.dag_id }}</span>
+        {% else %}
+          <input id="pause_resume" dag_id="{{ dag.dag_id }}" type="checkbox" {{ "checked" if not dag.is_paused else "" }} data-toggle="toggle" data-size="mini" method="post">
+          <span style='color:#AAA;'>DAG: </span> <span> {{ dag.dag_id }}</span> <small class="text-muted"> {{ dag.description }} </small>
+        {% endif %}
+        {% if root %}
+          <span style='color:#AAA;'>ROOT: </span> <span> {{ root }}</span>
+        {% endif %}
+      </h2>
+      <h4 style="padding-left: 16px">
+        <a class="label label-default" href="{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id={{ dag.dag_id }}">
+          schedule: {{ dag.schedule_interval }}
+        </a>
+      </h4>
+    </div>
+
   </div>
-  <div class="clearfix"></div>
+
   <div>
     {% set base_date_arg = request.args.get('base_date') %}
     {% set num_runs_arg = request.args.get('num_runs') %}
@@ -92,26 +120,6 @@
         <a href="{{ url_for('Airflow.code', dag_id=dag.dag_id, root=root) }}">
           <span class="glyphicon glyphicon-file" aria-hidden="true"></span>
           Code
-        </a>
-      </li>
-      <li>
-        <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=request.base_url ) }}"
-          onclick="return confirmTriggerDag('{{ dag.safe_dag_id }}')">
-          <span class="glyphicon glyphicon-play-circle" aria-hidden="true"></span>
-          Trigger DAG
-        </a>
-      </li>
-      <li>
-        <a href="{{ url_for('Airflow.refresh', dag_id=dag.dag_id) }}" title="Refresh">
-          <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
-          Refresh
-        </a>
-      </li>
-      <li>
-        <a href="{{ url_for('Airflow.delete', dag_id=dag.dag_id) }}"
-          onclick="return confirmDeleteDag('{{ dag.safe_dag_id }}')">
-          <span class="glyphicon glyphicon-remove-circle" style="color:red" aria-hidden="true"></span>
-          Delete
         </a>
       </li>
     </ul>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3970

### Description

Assigning actions to a tab element is misleading.Now, tabs are used only for browsing and  buttons are used to perform action.

Before:
![localhost_8004_tree_dag_id example_gcp_vision 1](https://user-images.githubusercontent.com/12058428/53496242-e81ef780-3aa1-11e9-8082-4d57463e135a.png)

After:
![localhost_8004_tree_dag_id example_gcp_vision](https://user-images.githubusercontent.com/12058428/53496105-9aa28a80-3aa1-11e9-87c1-3574b0f4badc.png)

@ashb Can you look at it?

### Tests

No applicable

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
