### PR TITLE
[AIRFLOW-3973] Commit after each alembic migration

### DIFF
--- a/airflow/migrations/env.py
+++ b/airflow/migrations/env.py
@@ -78,6 +78,7 @@ def run_migrations_online():
     with connectable.connect() as connection:
         context.configure(
             connection=connection,
+            transaction_per_migration=True,
             target_metadata=target_metadata,
             compare_type=COMPARE_TYPE,
         )


### PR DESCRIPTION
### Jira
https://issues.apache.org/jira/browse/AIRFLOW-3973

### Description
If `Variable`s are used in DAGs, and Postgres is used for the internal database, a fresh `$ airflow initdb` (or `$ airflow resetdb`) spams the logs with error messages (but does not fail).

This commit corrects this by running each migration in a separate transaction.

See Jira ticket for more details.

I have tested this change with the default SQLite database and, of course, with Postgres.
### Tests

No tests included as this is a one line change which adds no functionality whatsoever.