### PR TITLE
[AIRFLOW-3975] Handle null inputs in attribute renderers.

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -337,11 +337,15 @@ def render(obj, lexer):
 
 
 def wrapped_markdown(s):
-    return '<div class="rich_doc">' + markdown.markdown(s) + "</div>"
+    return (
+        '<div class="rich_doc">' + markdown.markdown(s) + "</div>"
+        if s is not None
+        else None
+    )
 
 
 def get_attr_renderer():
-    attr_renderer = {
+    return {
         'bash_command': lambda x: render(x, lexers.BashLexer),
         'hql': lambda x: render(x, lexers.SqlLexer),
         'sql': lambda x: render(x, lexers.SqlLexer),
@@ -351,9 +355,8 @@ def get_attr_renderer():
         'doc_yaml': lambda x: render(x, lexers.YamlLexer),
         'doc_md': wrapped_markdown,
         'python_callable': lambda x: render(
-            inspect.getsource(x), lexers.PythonLexer),
+            inspect.getsource(x) if x is not None else None, lexers.PythonLexer),
     }
-    return attr_renderer
 
 
 def recurse_tasks(tasks, task_ids, dag_ids, task_id_to_dag):

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -149,5 +149,27 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual('deep/path/to/file.txt', args[0])
 
 
-if __name__ == '__main__':
-    unittest.main()
+class AttrRendererTest(unittest.TestCase):
+
+    def setUp(self):
+        self.attr_renderer = utils.get_attr_renderer()
+
+    def test_python_callable(self):
+        def example_callable(self):
+            print("example")
+        rendered = self.attr_renderer["python_callable"](example_callable)
+        self.assertIn('&quot;example&quot;', rendered)
+
+    def test_python_callable_none(self):
+        rendered = self.attr_renderer["python_callable"](None)
+        self.assertEqual("", rendered)
+
+    def test_markdown(self):
+        markdown = "* foo\n* bar"
+        rendered = self.attr_renderer["doc_md"](markdown)
+        self.assertIn("<li>foo</li>", rendered)
+        self.assertIn("<li>bar</li>", rendered)
+
+    def test_markdown_none(self):
+        rendered = self.attr_renderer["python_callable"](None)
+        self.assertEqual("", rendered)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3975
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
