### PR TITLE
[AIRFLOW-XXX] Fix CI for broken lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ cgroups = [
 ]
 # major update coming soon, clamp to 0.x
 cloudant = ['cloudant>=0.5.9,<2.0']
-crypto = ['cryptography>=0.9.3']
+crypto = ['cryptography>=0.9.3,<2.6']
 dask = [
     'distributed>=1.17.1, <2'
 ]


### PR DESCRIPTION
It seems cryptograph 2.6 is broken in python 3 which broke our CI (issue could be found in https://github.com/pyca/cryptography/issues/4789)