### PR TITLE
[AIRFLOW-XXX] Unpin cryptography (2.6.1 fixes issue in 2.6)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ cgroups = [
 ]
 # major update coming soon, clamp to 0.x
 cloudant = ['cloudant>=0.5.9,<2.0']
-crypto = ['cryptography>=0.9.3,<2.6']
+crypto = ['cryptography>=0.9.3']
 dask = [
     'distributed>=1.17.1, <2'
 ]


### PR DESCRIPTION
There was issue in `cryptography` 2.6, and https://github.com/apache/airflow/pull/4800 (https://github.com/apache/airflow/commit/2ade9126588cef252cc7406a4729976f95e1c66e) helped pin version of it to avoid the issue.

`cryptography` 2.6.1 was released very fast though to fix this issue. So we can remove the pin on `cryptography`.