### PR TITLE
[AIRFLOW-3978] - Add TIME, BINARY, VARBINARY to MySqlToGoogleCloudStorageOperator

### DIFF
--- a/airflow/contrib/operators/mysql_to_gcs.py
+++ b/airflow/contrib/operators/mysql_to_gcs.py
@@ -273,6 +273,8 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
         d = {
             FIELD_TYPE.INT24: 'INTEGER',
             FIELD_TYPE.TINY: 'INTEGER',
+            FIELD_TYPE.BINARY: 'BINARY',
+            FIELD_TYPE.VARBINARY: 'BINARY',
             FIELD_TYPE.BIT: 'INTEGER',
             FIELD_TYPE.DATETIME: 'TIMESTAMP',
             FIELD_TYPE.DATE: 'TIMESTAMP',
@@ -283,6 +285,7 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
             FIELD_TYPE.LONG: 'INTEGER',
             FIELD_TYPE.LONGLONG: 'INTEGER',
             FIELD_TYPE.SHORT: 'INTEGER',
+            FIELD_TYPE.TIME: 'TIME',
             FIELD_TYPE.TIMESTAMP: 'TIMESTAMP',
             FIELD_TYPE.YEAR: 'INTEGER',
         }


### PR DESCRIPTION
### Jira
https://issues.apache.org/jira/browse/AIRFLOW-3978

### Description

Add missing types for mapping TIME, BINARY , VARBINARY
Info about Types:
http://www.mysqltutorial.org/mysql-data-types.aspx
https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
