### PR TITLE
AIRFLOW-2511 - Investigation to mitigate Deadlocking

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -2275,7 +2275,13 @@ class BackfillJob(BaseJob):
                                     cfg_path=cfg_path)
                                 ti_status.running[key] = ti
                                 ti_status.to_run.pop(key)
-                        session.commit()
+                        try:
+                            session.commit()
+                        except OperationalError as e:
+                            self.log.warning(
+                                'Rolling Back as sqlalchemy OperationalError was raised: {}'.format(e)
+                            )
+                            session.rollback()
                         continue
 
                     if ti.state == State.UPSTREAM_FAILED:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-2511/) issues and references them in the PR title. For example, "\[AIRFLOW-2511\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-2511
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

In 1.10.2, when running Subdags using the k8s executor (and possibly
others) a common problem which can arrise is an issue of Deadlocks
around a transactional update to the database when updating the task
state.

As a measure to mitigate this, we have implemented a catch to swallow
the OperationalError (if raised) and automatically perform a
session.rollback().  By doing this, we can continue with the Sundag.

I'm aware that this isn't the most ideal solution to this issue, and we
are being quite general in regards to rolling back on an
OperationalError exception, but as sqlalchemy doesn't give a specific
error code relating to the specifics of a Deadlock, and as Postgresql
and MySQL return a different error code and string when faced with the
same error, it could lead to some fairly db-specific exception catches
in the code.

We did also toy with the idea of using a retry loop, and utilising the
session.begin_nested() function to create a SAVEPOINT, but this is not
supported by all setups, so may lead to further unwanted complications
depending on setup.

I'm open to ideas/suggestions on further investigations of this issue,
and whether we should be handling this error elswehere.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Other than manually creating a deadlock within the airflow meta database, and the infrequent occurance of this issue, we've not implemented a method to test this.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X] Passes `flake8`
