### PR TITLE
[AIRFLOW_3982] Update DagRun state based on its tasks rather than DAG's

### DIFF
--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -45,7 +45,6 @@ default_args = {
     # 'end_date': datetime(2016, 1, 1),
     # 'wait_for_downstream': False,
     # 'dag': dag,
-    # 'adhoc':False,
     # 'sla': timedelta(hours=2),
     # 'execution_timeout': timedelta(seconds=300),
     # 'on_failure_callback': some_function,

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -953,10 +953,6 @@ class SchedulerJob(BaseJob):
                 # fixme: ti.task is transient but needs to be set
                 ti.task = task
 
-                # future: remove adhoc
-                if task.adhoc:
-                    continue
-
                 if ti.are_dependencies_met(
                         dep_context=DepContext(flag_upstream_failed=True),
                         session=session):

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -2069,7 +2069,6 @@ class BaseOperator(LoggingMixin):
             dag=None,
             params=None,
             default_args=None,
-            adhoc=False,
             priority_weight=1,
             weight_rule=WeightRule.DOWNSTREAM,
             queue=configuration.conf.get('celery', 'default_queue'),
@@ -2155,7 +2154,6 @@ class BaseOperator(LoggingMixin):
         self.retry_exponential_backoff = retry_exponential_backoff
         self.max_retry_delay = max_retry_delay
         self.params = params or {}  # Available in templates!
-        self.adhoc = adhoc
         self.priority_weight = priority_weight
         if not WeightRule.is_valid(weight_rule):
             raise AirflowException(
@@ -2216,7 +2214,6 @@ class BaseOperator(LoggingMixin):
             'schedule_interval',
             'depends_on_past',
             'wait_for_downstream',
-            'adhoc',
             'priority_weight',
             'sla',
             'execution_timeout',
@@ -3309,14 +3306,6 @@ class DAG(BaseDag, LoggingMixin):
     @property
     def task_ids(self):
         return list(self.task_dict.keys())
-
-    @property
-    def active_task_ids(self):
-        return list(k for k, v in self.task_dict.items() if not v.adhoc)
-
-    @property
-    def active_tasks(self):
-        return [t for t in self.tasks if not t.adhoc]
 
     @property
     def filepath(self):
@@ -4505,7 +4494,6 @@ class DagRun(Base, LoggingMixin):
         dag = self.get_dag()
 
         tis = self.get_task_instances(session=session)
-
         self.log.debug("Updating state for %s considering %s task(s)", self, len(tis))
 
         for ti in list(tis):
@@ -4546,37 +4534,35 @@ class DagRun(Base, LoggingMixin):
         duration = (timezone.utcnow() - start_dttm).total_seconds() * 1000
         Stats.timing("dagrun.dependency-check.{}".format(self.dag_id), duration)
 
-        # future: remove the check on adhoc tasks (=active_tasks)
-        if len(tis) == len(dag.active_tasks):
-            root_ids = [t.task_id for t in dag.roots]
-            roots = [t for t in tis if t.task_id in root_ids]
+        root_ids = [t.task_id for t in dag.roots]
+        roots = [t for t in tis if t.task_id in root_ids]
 
-            # if all roots finished and at least one failed, the run failed
-            if (not unfinished_tasks and
-                    any(r.state in (State.FAILED, State.UPSTREAM_FAILED) for r in roots)):
-                self.log.info('Marking run %s failed', self)
-                self.set_state(State.FAILED)
-                dag.handle_callback(self, success=False, reason='task_failure',
-                                    session=session)
+        # if all roots finished and at least one failed, the run failed
+        if (not unfinished_tasks and
+                any(r.state in (State.FAILED, State.UPSTREAM_FAILED) for r in roots)):
+            self.log.info('Marking run %s failed', self)
+            self.set_state(State.FAILED)
+            dag.handle_callback(self, success=False, reason='task_failure',
+                                session=session)
 
-            # if all roots succeeded and no unfinished tasks, the run succeeded
-            elif not unfinished_tasks and all(r.state in (State.SUCCESS, State.SKIPPED)
-                                              for r in roots):
-                self.log.info('Marking run %s successful', self)
-                self.set_state(State.SUCCESS)
-                dag.handle_callback(self, success=True, reason='success', session=session)
+        # if all roots succeeded and no unfinished tasks, the run succeeded
+        elif not unfinished_tasks and all(r.state in (State.SUCCESS, State.SKIPPED)
+                                          for r in roots):
+            self.log.info('Marking run %s successful', self)
+            self.set_state(State.SUCCESS)
+            dag.handle_callback(self, success=True, reason='success', session=session)
 
-            # if *all tasks* are deadlocked, the run failed
-            elif (unfinished_tasks and none_depends_on_past and
-                  none_task_concurrency and no_dependencies_met):
-                self.log.info('Deadlock; marking run %s failed', self)
-                self.set_state(State.FAILED)
-                dag.handle_callback(self, success=False, reason='all_tasks_deadlocked',
-                                    session=session)
+        # if *all tasks* are deadlocked, the run failed
+        elif (unfinished_tasks and none_depends_on_past and
+              none_task_concurrency and no_dependencies_met):
+            self.log.info('Deadlock; marking run %s failed', self)
+            self.set_state(State.FAILED)
+            dag.handle_callback(self, success=False, reason='all_tasks_deadlocked',
+                                session=session)
 
-            # finally, if the roots aren't done, the dag is still running
-            else:
-                self.set_state(State.RUNNING)
+        # finally, if the roots aren't done, the dag is still running
+        else:
+            self.set_state(State.RUNNING)
 
         # todo: determine we want to use with_for_update to make sure to lock the run
         session.merge(self)
@@ -4620,8 +4606,6 @@ class DagRun(Base, LoggingMixin):
 
         # check for missing tasks
         for task in six.itervalues(dag.task_dict):
-            if task.adhoc:
-                continue
             if task.start_date > self.execution_date and not self.is_backfill:
                 continue
 

--- a/tests/dags/test_issue_1225.py
+++ b/tests/dags/test_issue_1225.py
@@ -23,7 +23,7 @@ DAG designed to test what happens when a DAG with pooled tasks is run
 by a BackfillJob.
 Addresses issue #1225.
 """
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
@@ -149,4 +149,16 @@ dag8_task2 = PythonOperator(
     task_id='test_dagrun_fail',
     dag=dag8,
     python_callable=fail,
+)
+
+# DAG tests that a Dag run that completes but has a root in the future is marked as success
+dag9 = DAG(dag_id='test_dagrun_states_root_future', default_args=default_args)
+dag9_task1 = DummyOperator(
+    task_id='current',
+    dag=dag9,
+)
+dag8_task2 = DummyOperator(
+    task_id='future',
+    dag=dag9,
+    start_date=DEFAULT_DATE + timedelta(days=1),
 )

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -2428,6 +2428,24 @@ class SchedulerJobTest(unittest.TestCase):
         dr_state = dr.update_state()
         self.assertEqual(dr_state, State.RUNNING)
 
+    def test_dagrun_root_after_dagrun_unfinished(self):
+        """
+        DagRuns with one successful and one future root task -> SUCCESS
+        """
+        dag_id = 'test_dagrun_states_root_future'
+        dag = self.dagbag.get_dag(dag_id)
+        dag.clear()
+        scheduler = SchedulerJob(dag_id, num_runs=2)
+        # we can't use dag.run or evaluate_dagrun because it uses BackfillJob
+        # instead of SchedulerJob and BackfillJobs are allowed to not respect start dates
+        scheduler.run()
+
+        first_run = DagRun.find(dag_id=dag_id, execution_date=DEFAULT_DATE)[0]
+        ti_ids = [(ti.task_id, ti.state) for ti in first_run.get_task_instances()]
+
+        self.assertEqual(ti_ids, [('current', State.SUCCESS)])
+        self.assertEqual(first_run.state, State.SUCCESS)
+
     def test_dagrun_deadlock_ignore_depends_on_past_advance_ex_date(self):
         """
         DagRun is marked a success if ignore_first_depends_on_past=True


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3982

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
If a DagRun does not have the same tasks as its DAG (e.g. a task is added or removed later), it should update its state based on its tasks rather than the DAG's.

This is probably mostly relevant when (a) adding a task to a DAG with a different start date and then (b) clearing a past DAG Run.

Note that this CR also removes the adhoc task references.  The code path that led to this bug is attempting to exclude adhoc tasks, which don't exist anymore as of https://github.com/apache/airflow/pull/1667.  I've removed other references for consistency.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
SchedulerJobTest.test_dagrun_root_after_dagrun_unfinished

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] Passes `flake8`
