### PR TITLE
[AIRFLOW-3984] Add tests for WinRMHook

### DIFF
--- a/tests/contrib/hooks/test_winrm_hook.py
+++ b/tests/contrib/hooks/test_winrm_hook.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+
+from mock import patch
+
+from airflow import AirflowException
+from airflow.contrib.hooks.winrm_hook import WinRMHook
+from airflow.models.connection import Connection
+
+
+class TestWinRMHook(unittest.TestCase):
+
+    @patch('airflow.contrib.hooks.winrm_hook.Protocol')
+    def test_get_conn_exists(self, mock_protocol):
+        winrm_hook = WinRMHook()
+        winrm_hook.client = mock_protocol.return_value.open_shell.return_value
+
+        conn = winrm_hook.get_conn()
+
+        self.assertEqual(conn, winrm_hook.client)
+
+    def test_get_conn_missing_remote_host(self):
+        with self.assertRaises(AirflowException):
+            WinRMHook().get_conn()
+
+    @patch('airflow.contrib.hooks.winrm_hook.Protocol')
+    def test_get_conn_error(self, mock_protocol):
+        mock_protocol.side_effect = Exception('Error')
+
+        with self.assertRaises(AirflowException):
+            WinRMHook(remote_host='host').get_conn()
+
+    @patch('airflow.contrib.hooks.winrm_hook.Protocol')
+    @patch('airflow.contrib.hooks.winrm_hook.WinRMHook.get_connection',
+           return_value=Connection(
+               login='username',
+               password='password',
+               host='remote_host',
+               extra="""{
+                   "endpoint": "endpoint",
+                   "remote_port": 123,
+                   "transport": "transport",
+                   "service": "service",
+                   "keytab": "keytab",
+                   "ca_trust_path": "ca_trust_path",
+                   "cert_pem": "cert_pem",
+                   "cert_key_pem": "cert_key_pem",
+                   "server_cert_validation": "server_cert_validation",
+                   "kerberos_delegation": "true",
+                   "read_timeout_sec": 123,
+                   "operation_timeout_sec": 123,
+                   "kerberos_hostname_override": "kerberos_hostname_override",
+                   "message_encryption": "message_encryption",
+                   "credssp_disable_tlsv1_2": "true",
+                   "send_cbt": "false"
+               }"""
+           ))
+    def test_get_conn_from_connection(self, mock_get_connection, mock_protocol):
+        connection = mock_get_connection.return_value
+        winrm_hook = WinRMHook(ssh_conn_id='conn_id')
+
+        winrm_hook.get_conn()
+
+        mock_get_connection.assert_called_once_with(winrm_hook.ssh_conn_id)
+        mock_protocol.assert_called_once_with(
+            endpoint=str(connection.extra_dejson['endpoint']),
+            transport=str(connection.extra_dejson['transport']),
+            username=connection.login,
+            password=connection.password,
+            service=str(connection.extra_dejson['service']),
+            keytab=str(connection.extra_dejson['keytab']),
+            ca_trust_path=str(connection.extra_dejson['ca_trust_path']),
+            cert_pem=str(connection.extra_dejson['cert_pem']),
+            cert_key_pem=str(connection.extra_dejson['cert_key_pem']),
+            server_cert_validation=str(connection.extra_dejson['server_cert_validation']),
+            kerberos_delegation=str(connection.extra_dejson['kerberos_delegation']).lower() == 'true',
+            read_timeout_sec=int(connection.extra_dejson['read_timeout_sec']),
+            operation_timeout_sec=int(connection.extra_dejson['operation_timeout_sec']),
+            kerberos_hostname_override=str(connection.extra_dejson['kerberos_hostname_override']),
+            message_encryption=str(connection.extra_dejson['message_encryption']),
+            credssp_disable_tlsv1_2=str(connection.extra_dejson['credssp_disable_tlsv1_2']).lower() == 'true',
+            send_cbt=str(connection.extra_dejson['send_cbt']).lower() == 'true'
+        )
+
+    @patch('airflow.contrib.hooks.winrm_hook.getpass.getuser', return_value='user')
+    @patch('airflow.contrib.hooks.winrm_hook.Protocol')
+    def test_get_conn_no_username(self, mock_protocol, mock_getuser):
+        winrm_hook = WinRMHook(remote_host='host', password='password')
+
+        winrm_hook.get_conn()
+
+        self.assertEqual(mock_getuser.return_value, winrm_hook.username)
+
+    @patch('airflow.contrib.hooks.winrm_hook.Protocol')
+    def test_get_conn_no_endpoint(self, mock_protocol):
+        winrm_hook = WinRMHook(remote_host='host', password='password')
+
+        winrm_hook.get_conn()
+
+        self.assertEqual('http://{0}:{1}/wsman'.format(winrm_hook.remote_host, winrm_hook.remote_port),
+                         winrm_hook.endpoint)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3984
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

- fix docs
- refactoring code

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Add tests for
* test_get_conn_exists
* test_get_conn_missing_remote_host
* test_get_conn_error
* test_get_conn_from_connection
* test_get_conn_no_username
* test_get_conn_no_endpoint

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
