### PR TITLE
[AIRFLOW-3991] Retrieve configs from commands in environment

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -36,7 +36,7 @@ import subprocess
 import sys
 import warnings
 
-from backports.configparser import ConfigParser, _UNSET, NoOptionError
+from backports.configparser import ConfigParser, _UNSET, NoOptionError, NoSectionError
 from zope.deprecation import deprecated
 
 from airflow.exceptions import AirflowConfigException
@@ -181,10 +181,8 @@ class AirflowConfigParser(ConfigParser):
         fallback_key = key + '_cmd'
         # if this is a valid command key...
         if (section, key) in self.as_command_stdout:
-            if super(AirflowConfigParser, self) \
-                    .has_option(section, fallback_key):
-                command = super(AirflowConfigParser, self) \
-                    .get(section, fallback_key)
+            if self.has_option(section, fallback_key):
+                command = self.get(section, fallback_key)
                 return run_command(command)
 
     def get(self, section, key, **kwargs):
@@ -276,6 +274,8 @@ class AirflowConfigParser(ConfigParser):
             # UNSET to avoid logging a warning about missing values
             self.get(section, option, fallback=_UNSET)
             return True
+        except NoSectionError:
+            return False
         except NoOptionError:
             return False
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -185,6 +185,15 @@ key6 = value6
         self.assertEqual('cmd_result', cfg_dict['test']['key2'])
         self.assertNotIn('key2_cmd', cfg_dict['test'])
 
+    def test_command_from_env(self):
+        test_conf = AirflowConfigParser()
+        test_conf.as_command_stdout = test_conf.as_command_stdout | {
+            ('test', 'key'),
+        }
+        os.environ['AIRFLOW__TEST__KEY_CMD'] = 'printf correct_value'
+        self.assertEqual('correct_value', test_conf.get('test', 'key'))
+        os.environ.pop('AIRFLOW__TEST__KEY_CMD')
+
     def test_getboolean(self):
         """Test AirflowConfigParser.getboolean"""
         TEST_CONFIG = """


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AIRFLOW-3991

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
When looking for configurations via commands, airflow can now look at environment variables to find the command.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
test_command_from_env

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
