### PR TITLE
[AIRFLOW-3997] Add getter to Variable that returns None instead of throwing

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -203,12 +203,16 @@ See [AIRFLOW-3249](https://jira.apache.org/jira/browse/AIRFLOW-3249) to check if
 
 ### Changed behaviour of using default value when accessing variables
 It's now possible to use `None` as a default value with the `default_var` parameter when getting a variable, e.g.
-```
+
+```python
 foo = Variable.get("foo", default_var=None)
-    if foo is None:
-        handle_missing_foo()
+if foo is None:
+    handle_missing_foo()
 ```
-This changes the behaviour if you previously explicitly provided `None` as a default value. If your code expects a `KeyError` to be thrown, simply don't pass the `default_var` parameter. 
+
+(Note: there is already `Variable.setdefault()` which me be helpful in some cases.)
+
+This changes the behaviour if you previously explicitly provided `None` as a default value. If your code expects a `KeyError` to be thrown, then don't pass the `default_var` argument. 
 
 
 ## Airflow 1.10.2

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -201,6 +201,15 @@ The `do_xcom_push` flag (a switch to push the result of an operator to xcom or n
 
 See [AIRFLOW-3249](https://jira.apache.org/jira/browse/AIRFLOW-3249) to check if your operator was affected.
 
+### Changed behaviour of using default value when accessing variables
+It's now possible to use `None` as a default value with the `default_var` parameter when getting a variable, e.g.
+```
+foo = Variable.get("foo", default_var=None)
+    if foo is None:
+        handle_missing_foo()
+```
+This changes the behaviour if you previously explicitly provided `None` as a default value. If your code expects a `KeyError` to be thrown, simply don't pass the `default_var` parameter. 
+
 
 ## Airflow 1.10.2
 

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -4200,6 +4200,7 @@ class DAG(BaseDag, LoggingMixin):
 
 class Variable(Base, LoggingMixin):
     __tablename__ = "variable"
+    __NO_DEFAULT_SENTINEL = object()
 
     id = Column(Integer, primary_key=True)
     key = Column(String(ID_LEN), unique=True)
@@ -4253,10 +4254,9 @@ class Variable(Base, LoggingMixin):
             and un-encode it when retrieving a value
         :return: Mixed
         """
-        default_sentinel = object()
-        obj = Variable.get(key, default_var=default_sentinel,
+        obj = Variable.get(key, default_var=None,
                            deserialize_json=deserialize_json)
-        if obj is default_sentinel:
+        if obj is None:
             if default is not None:
                 Variable.set(key, default, serialize_json=deserialize_json)
                 return default
@@ -4267,10 +4267,10 @@ class Variable(Base, LoggingMixin):
 
     @classmethod
     @provide_session
-    def get(cls, key, default_var=None, deserialize_json=False, session=None):
+    def get(cls, key, default_var=__NO_DEFAULT_SENTINEL, deserialize_json=False, session=None):
         obj = session.query(cls).filter(cls.key == key).first()
         if obj is None:
-            if default_var is not None:
+            if default_var is not cls.__NO_DEFAULT_SENTINEL:
                 return default_var
             else:
                 raise KeyError('Variable {} does not exist'.format(key))

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -503,10 +503,14 @@ accessible and modifiable through the UI.
     from airflow.models import Variable
     foo = Variable.get("foo")
     bar = Variable.get("bar", deserialize_json=True)
+    baz = Variable.get("baz", default_var=None)
 
 The second call assumes ``json`` content and will be deserialized into
 ``bar``. Note that ``Variable`` is a sqlalchemy model and can be used
-as such.
+as such. The third call uses the ``default_var`` parameter with the value
+``None``, which either returns an existing value or ``None`` if the variable
+isn't defined. The get function will throw a ``KeyError`` if the variable
+doesn't exist and no default is provided.
 
 You can use a variable from a jinja template with the syntax :
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -711,6 +711,13 @@ class CoreTest(unittest.TestCase):
         self.assertEqual(default_value, Variable.get("thisIdDoesNotExist",
                                                      default_var=default_value))
 
+    def test_get_non_existing_var_should_raise_key_error(self):
+        with self.assertRaises(KeyError):
+            Variable.get("thisIdDoesNotExist")
+
+    def test_get_non_existing_var_with_none_default_should_return_none(self):
+        self.assertIsNone(Variable.get("thisIdDoesNotExist", default_var=None))
+
     def test_get_non_existing_var_should_not_deserialize_json_default(self):
         default_value = "}{ this is a non JSON default }{"
         self.assertEqual(default_value, Variable.get("thisIdDoesNotExist",


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3997
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Fix default so `None` works as default value for the get method. 

This will not change existing regular functions in the `Variable` class (unless the redundant `default_var=None` is used). If
variable `foo` doesn't exist:
```
foo = Variable.get("foo")
    -> KeyError
```

For passing `default_var=None` to get, `None` is returned instead:
```
foo = Variable.get("foo", default_var=None)
if foo is None:
    handle_missing_foo()
```


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

* Test `None` as default, and throw when no default is provided
* Test the current behaviour for missing variables for the `get` function to raise a `KeyError`
* Use `None` as default value in the `setdefault` method

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

Describe the default_var parameter with a `None` value in the doc, in the get variable examples section. Also describe the current behaviour for `get` raising an error when a variable is missing.

### Code Quality

- [x] Passes `flake8`
