### PR TITLE
[AIRFLOW-3761] Fix `DROP TABLE user` migration for upgrades.

### DIFF
--- a/airflow/migrations/versions/cf5dc11e79ad_drop_user_and_chart.py
+++ b/airflow/migrations/versions/cf5dc11e79ad_drop_user_and_chart.py
@@ -24,6 +24,7 @@ Create Date: 2019-01-24 15:30:35.834740
 """
 from alembic import op
 from sqlalchemy.dialects import mysql
+from sqlalchemy.engine.reflection import Inspector
 import sqlalchemy as sa
 
 
@@ -35,6 +36,18 @@ depends_on = None
 
 
 def upgrade():
+    # We previously had a KnownEvent's table, but we deleted the table without
+    # a down migration to remove it (so we didn't delete anyone's data if they
+    # were happing to use the feature.
+    #
+    # But before we can delete the users table we need to drop the FK
+
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+
+    if 'known_event' in inspector.get_table_names():
+        op.drop_constraint('known_event_user_id_fkey', 'known_event')
+
     op.drop_table("chart")
     op.drop_table("users")
 


### PR DESCRIPTION
If you are upgrading an old install you will likely have rows in the
user and known_event tables. We dropped the KnownEvent without a
migration to remove it (on purpose) in [AIRFLOW-3468] (#4421) but this
means if we have any rows in there we won't be able to drop the USER
table:

> sqlalchemy.exc.InternalError: (psycopg2.InternalError) cannot drop table users because other objects depend on it
> DETAIL:  constraint known_event_user_id_fkey on table known_event depends on table users

So we need to drop that FK constraint first (if the table exists, which
it won't on a fresh install, as the create migration has been deleted.)

cc @Fokko @XD-DENG 

### Jira

https://issues.apache.org/jira/browse/AIRFLOW-3761
