### PR TITLE
[AIRFLOW-4014] Change DatastoreHook and add tests

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,11 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Changes to DatastoreHook
+
+* removed argument `version` from `get_conn` function and added it to the hook's `__init__` function instead and renamed it to `api_version`
+* renamed the `partialKeys` argument of function `allocate_ids` to `partial_keys`
+
 #### Unify default conn_id for Google Cloud Platform
 
 Previously not all hooks and operators related to Google Cloud Platform use

--- a/airflow/contrib/hooks/datastore_hook.py
+++ b/airflow/contrib/hooks/datastore_hook.py
@@ -19,58 +19,77 @@
 #
 
 import time
+
 from googleapiclient.discovery import build
+
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 
 
 class DatastoreHook(GoogleCloudBaseHook):
     """
-    Interact with Google Cloud Datastore. This hook uses the Google Cloud Platform
-    connection.
+    Interact with Google Cloud Datastore. This hook uses the Google Cloud Platform connection.
 
     This object is not threads safe. If you want to make multiple requests
     simultaneously, you will need to create a hook per thread.
+
+    :param api_version: The version of the API it is going to connect to.
+    :type api_version: str
     """
 
     def __init__(self,
                  datastore_conn_id='google_cloud_default',
-                 delegate_to=None):
+                 delegate_to=None,
+                 api_version='v1'):
         super(DatastoreHook, self).__init__(datastore_conn_id, delegate_to)
-        self.connection = self.get_conn()
-        self.admin_connection = self.get_conn('v1beta1')
+        self.connection = None
+        self.api_version = api_version
 
-    def get_conn(self, version='v1'):
+    def get_conn(self):
         """
-        Returns a Google Cloud Datastore service object.
-        """
-        http_authorized = self._authorize()
-        return build(
-            'datastore', version, http=http_authorized, cache_discovery=False)
+        Establishes a connection to the Google API.
 
-    def allocate_ids(self, partialKeys):
+        :return: a Google Cloud Datastore service object.
+        :rtype: Resource
+        """
+        if not self.connection:
+            http_authorized = self._authorize()
+            self.connection = build('datastore', self.api_version, http=http_authorized,
+                                    cache_discovery=False)
+
+        return self.connection
+
+    def allocate_ids(self, partial_keys):
         """
         Allocate IDs for incomplete keys.
-        see https://cloud.google.com/datastore/docs/reference/rest/v1/projects/allocateIds
 
-        :param partialKeys: a list of partial keys
+        .. seealso::
+            https://cloud.google.com/datastore/docs/reference/rest/v1/projects/allocateIds
+
+        :param partial_keys: a list of partial keys.
+        :type partial_keys: list
         :return: a list of full keys.
+        :rtype: list
         """
-        resp = self.connection.projects().allocateIds(
-            projectId=self.project_id, body={'keys': partialKeys}
-        ).execute()
+        conn = self.get_conn()
+
+        resp = conn.projects().allocateIds(projectId=self.project_id, body={'keys': partial_keys}).execute()
+
         return resp['keys']
 
     def begin_transaction(self):
         """
-        Get a new transaction handle
+        Begins a new transaction.
 
-            .. seealso::
-                https://cloud.google.com/datastore/docs/reference/rest/v1/projects/beginTransaction
+        .. seealso::
+            https://cloud.google.com/datastore/docs/reference/rest/v1/projects/beginTransaction
 
-        :return: a transaction handle
+        :return: a transaction handle.
+        :rtype: str
         """
-        resp = self.connection.projects().beginTransaction(
-            projectId=self.project_id, body={}).execute()
+        conn = self.get_conn()
+
+        resp = conn.projects().beginTransaction(projectId=self.project_id, body={}).execute()
+
         return resp['transaction']
 
     def commit(self, body):
@@ -80,46 +99,58 @@ class DatastoreHook(GoogleCloudBaseHook):
         .. seealso::
             https://cloud.google.com/datastore/docs/reference/rest/v1/projects/commit
 
-        :param body: the body of the commit request
-        :return: the response body of the commit request
+        :param body: the body of the commit request.
+        :type body: dict
+        :return: the response body of the commit request.
+        :rtype: dict
         """
-        resp = self.connection.projects().commit(
-            projectId=self.project_id, body=body).execute()
+        conn = self.get_conn()
+
+        resp = conn.projects().commit(projectId=self.project_id, body=body).execute()
+
         return resp
 
     def lookup(self, keys, read_consistency=None, transaction=None):
         """
-        Lookup some entities by key
+        Lookup some entities by key.
 
         .. seealso::
             https://cloud.google.com/datastore/docs/reference/rest/v1/projects/lookup
 
-        :param keys: the keys to lookup
+        :param keys: the keys to lookup.
+        :type keys: list
         :param read_consistency: the read consistency to use. default, strong or eventual.
-                Cannot be used with a transaction.
+                                 Cannot be used with a transaction.
+        :type read_consistency: str
         :param transaction: the transaction to use, if any.
+        :type transaction: str
         :return: the response body of the lookup request.
+        :rtype: dict
         """
+        conn = self.get_conn()
+
         body = {'keys': keys}
         if read_consistency:
             body['readConsistency'] = read_consistency
         if transaction:
             body['transaction'] = transaction
-        return self.connection.projects().lookup(
-            projectId=self.project_id, body=body).execute()
+        resp = conn.projects().lookup(projectId=self.project_id, body=body).execute()
+
+        return resp
 
     def rollback(self, transaction):
         """
-        Roll back a transaction
+        Roll back a transaction.
 
         .. seealso::
             https://cloud.google.com/datastore/docs/reference/rest/v1/projects/rollback
 
-        :param transaction: the transaction to roll back
+        :param transaction: the transaction to roll back.
+        :type transaction: str
         """
-        self.connection.projects().rollback(
-            projectId=self.project_id, body={'transaction': transaction})\
-            .execute()
+        conn = self.get_conn()
+
+        conn.projects().rollback(projectId=self.project_id, body={'transaction': transaction}).execute()
 
     def run_query(self, body):
         """
@@ -128,37 +159,67 @@ class DatastoreHook(GoogleCloudBaseHook):
         .. seealso::
             https://cloud.google.com/datastore/docs/reference/rest/v1/projects/runQuery
 
-        :param body: the body of the query request
+        :param body: the body of the query request.
+        :type body: dict
         :return: the batch of query results.
+        :rtype: dict
         """
-        resp = self.connection.projects().runQuery(
-            projectId=self.project_id, body=body).execute()
+        conn = self.get_conn()
+
+        resp = conn.projects().runQuery(projectId=self.project_id, body=body).execute()
+
         return resp['batch']
 
     def get_operation(self, name):
         """
-        Gets the latest state of a long-running operation
+        Gets the latest state of a long-running operation.
 
-        :param name: the name of the operation resource
+        .. seealso::
+            https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects.operations/get
+
+        :param name: the name of the operation resource.
+        :type name: str
+        :return: a resource operation instance.
+        :rtype: dict
         """
-        resp = self.connection.projects().operations().get(name=name).execute()
+        conn = self.get_conn()
+
+        resp = conn.projects().operations().get(name=name).execute()
+
         return resp
 
     def delete_operation(self, name):
         """
-        Deletes the long-running operation
+        Deletes the long-running operation.
 
-        :param name: the name of the operation resource
+        .. seealso::
+            https://cloud.google.com/datastore/docs/reference/data/rest/v1/projects.operations/delete
+
+        :param name: the name of the operation resource.
+        :type name: str
+        :return: none if successful.
+        :rtype: dict
         """
-        resp = self.connection.projects().operations().delete(name=name).execute()
+        conn = self.get_conn()
+
+        resp = conn.projects().operations().delete(name=name).execute()
+
         return resp
 
     def poll_operation_until_done(self, name, polling_interval_in_seconds):
         """
-        Poll backup operation state until it's completed
+        Poll backup operation state until it's completed.
+
+        :param name: the name of the operation resource
+        :type name: str
+        :param polling_interval_in_seconds: The number of seconds to wait before calling another request.
+        :type polling_interval_in_seconds: int
+        :return: a resource operation instance.
+        :rtype: dict
         """
         while True:
             result = self.get_operation(name)
+
             state = result['metadata']['common']['state']
             if state == 'PROCESSING':
                 self.log.info('Operation is processing. Re-polling state in {} seconds'
@@ -167,11 +228,29 @@ class DatastoreHook(GoogleCloudBaseHook):
             else:
                 return result
 
-    def export_to_storage_bucket(self, bucket, namespace=None,
-                                 entity_filter=None, labels=None):
+    def export_to_storage_bucket(self, bucket, namespace=None, entity_filter=None, labels=None):
         """
-        Export entities from Cloud Datastore to Cloud Storage for backup
+        Export entities from Cloud Datastore to Cloud Storage for backup.
+
+        .. note::
+            Keep in mind that this requests the Admin API not the Data API.
+
+        .. seealso::
+            https://cloud.google.com/datastore/docs/reference/admin/rest/v1/projects/export
+
+        :param bucket: The name of the Cloud Storage bucket.
+        :type bucket: str
+        :param namespace: The Cloud Storage namespace path.
+        :type namespace: str
+        :param entity_filter: Description of what data from the project is included in the export.
+        :type entity_filter: dict
+        :param labels: Client-assigned labels.
+        :type labels: dict of str
+        :return: a resource operation instance.
+        :rtype: dict
         """
+        admin_conn = self.get_conn()
+
         output_uri_prefix = 'gs://' + '/'.join(filter(None, [bucket, namespace]))
         if not entity_filter:
             entity_filter = {}
@@ -182,15 +261,35 @@ class DatastoreHook(GoogleCloudBaseHook):
             'entityFilter': entity_filter,
             'labels': labels,
         }
-        resp = self.admin_connection.projects().export(
-            projectId=self.project_id, body=body).execute()
+        resp = admin_conn.projects().export(projectId=self.project_id, body=body).execute()
+
         return resp
 
-    def import_from_storage_bucket(self, bucket, file,
-                                   namespace=None, entity_filter=None, labels=None):
+    def import_from_storage_bucket(self, bucket, file, namespace=None, entity_filter=None, labels=None):
         """
-        Import a backup from Cloud Storage to Cloud Datastore
+        Import a backup from Cloud Storage to Cloud Datastore.
+
+        .. note::
+            Keep in mind that this requests the Admin API not the Data API.
+
+        .. seealso::
+            https://cloud.google.com/datastore/docs/reference/admin/rest/v1/projects/import
+
+        :param bucket: The name of the Cloud Storage bucket.
+        :type bucket: str
+        :param file: the metadata file written by the projects.export operation.
+        :type file: str
+        :param namespace: The Cloud Storage namespace path.
+        :type namespace: str
+        :param entity_filter: specify which kinds/namespaces are to be imported.
+        :type entity_filter: dict
+        :param labels: Client-assigned labels.
+        :type labels: dict of str
+        :return: a resource operation instance.
+        :rtype: dict
         """
+        admin_conn = self.get_conn()
+
         input_url = 'gs://' + '/'.join(filter(None, [bucket, namespace, file]))
         if not entity_filter:
             entity_filter = {}
@@ -201,6 +300,6 @@ class DatastoreHook(GoogleCloudBaseHook):
             'entityFilter': entity_filter,
             'labels': labels,
         }
-        resp = self.admin_connection.projects().import_(
-            projectId=self.project_id, body=body).execute()
+        resp = admin_conn.projects().import_(projectId=self.project_id, body=body).execute()
+
         return resp

--- a/tests/contrib/hooks/test_datastore_hook.py
+++ b/tests/contrib/hooks/test_datastore_hook.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+
+from mock import patch, call
+
+from airflow.contrib.hooks.datastore_hook import DatastoreHook
+
+
+def mock_init(self, gcp_conn_id, delegate_to=None):
+    pass
+
+
+class TestDatastoreHook(unittest.TestCase):
+
+    def setUp(self):
+        with patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__', new=mock_init):
+            self.datastore_hook = DatastoreHook()
+
+    @patch('airflow.contrib.hooks.datastore_hook.DatastoreHook._authorize')
+    @patch('airflow.contrib.hooks.datastore_hook.build')
+    def test_get_conn(self, mock_build, mock_authorize):
+        conn = self.datastore_hook.get_conn()
+
+        mock_build.assert_called_once_with('datastore', 'v1', http=mock_authorize.return_value,
+                                           cache_discovery=False)
+        self.assertEqual(conn, mock_build.return_value)
+        self.assertEqual(conn, self.datastore_hook.connection)
+
+    @patch('airflow.contrib.hooks.datastore_hook.DatastoreHook.get_conn')
+    def test_allocate_ids(self, mock_get_conn):
+        self.datastore_hook.connection = mock_get_conn.return_value
+        partial_keys = []
+
+        keys = self.datastore_hook.allocate_ids(partial_keys)
+
+        projects = self.datastore_hook.connection.projects
+        projects.assert_called_once_with()
+        allocate_ids = projects.return_value.allocateIds
+        allocate_ids.assert_called_once_with(projectId=self.datastore_hook.project_id,
+                                             body={'keys': partial_keys})
+        execute = allocate_ids.return_value.execute
+        execute.assert_called_once_with()
+        self.assertEqual(keys, execute.return_value['keys'])
+
+    @patch('airflow.contrib.hooks.datastore_hook.DatastoreHook.get_conn')
+    def test_begin_transaction(self, mock_get_conn):
+        self.datastore_hook.connection = mock_get_conn.return_value
+
+        transaction = self.datastore_hook.begin_transaction()
+
+        projects = self.datastore_hook.connection.projects
+        projects.assert_called_once_with()
+        begin_transaction = projects.return_value.beginTransaction
+        begin_transaction.assert_called_once_with(projectId=self.datastore_hook.project_id, body={})
+        execute = begin_transaction.return_value.execute
+        execute.assert_called_once_with()
+        self.assertEqual(transaction, execute.return_value['transaction'])
+
+    @patch('airflow.contrib.hooks.datastore_hook.DatastoreHook.get_conn')
+    def test_commit(self, mock_get_conn):
+        self.datastore_hook.connection = mock_get_conn.return_value
+        body = {'item': 'a'}
+
+        resp = self.datastore_hook.commit(body)
+
+        projects = self.datastore_hook.connection.projects
+        projects.assert_called_once_with()
+        commit = projects.return_value.commit
+        commit.assert_called_once_with(projectId=self.datastore_hook.project_id, body=body)
+        execute = commit.return_value.execute
+        execute.assert_called_once_with()
+        self.assertEqual(resp, execute.return_value)
+
+    @patch('airflow.contrib.hooks.datastore_hook.DatastoreHook.get_conn')
+    def test_lookup(self, mock_get_conn):
+        self.datastore_hook.connection = mock_get_conn.return_value
+        keys = []
+        read_consistency = 'ENUM'
+        transaction = 'transaction'
+
+        resp = self.datastore_hook.lookup(keys, read_consistency, transaction)
+
+        projects = self.datastore_hook.connection.projects
+        projects.assert_called_once_with()
+        lookup = projects.return_value.lookup
+        lookup.assert_called_once_with(projectId=self.datastore_hook.project_id,
+                                       body={
+                                           'keys': keys,
+                                           'readConsistency': read_consistency,
+                                           'transaction': transaction
+                                       })
+        execute = lookup.return_value.execute
+        execute.assert_called_once_with()
+        self.assertEqual(resp, execute.return_value)
+
+    @patch('airflow.contrib.hooks.datastore_hook.DatastoreHook.get_conn')
+    def test_rollback(self, mock_get_conn):
+        self.datastore_hook.connection = mock_get_conn.return_value
+        transaction = 'transaction'
+
+        self.datastore_hook.rollback(transaction)
+
+        projects = self.datastore_hook.connection.projects
+        projects.assert_called_once_with()
+        rollback = projects.return_value.rollback
+        rollback.assert_called_once_with(projectId=self.datastore_hook.project_id,
+                                         body={'transaction': transaction})
+        execute = rollback.return_value.execute
+        execute.assert_called_once_with()
+
+    @patch('airflow.contrib.hooks.datastore_hook.DatastoreHook.get_conn')
+    def test_run_query(self, mock_get_conn):
+        self.datastore_hook.connection = mock_get_conn.return_value
+        body = {'item': 'a'}
+
+        resp = self.datastore_hook.run_query(body)
+
+        projects = self.datastore_hook.connection.projects
+        projects.assert_called_once_with()
+        run_query = projects.return_value.runQuery
+        run_query.assert_called_once_with(projectId=self.datastore_hook.project_id, body=body)
+        execute = run_query.return_value.execute
+        execute.assert_called_once_with()
+        self.assertEqual(resp, execute.return_value['batch'])
+
+    @patch('airflow.contrib.hooks.datastore_hook.DatastoreHook.get_conn')
+    def test_get_operation(self, mock_get_conn):
+        self.datastore_hook.connection = mock_get_conn.return_value
+        name = 'name'
+
+        resp = self.datastore_hook.get_operation(name)
+
+        projects = self.datastore_hook.connection.projects
+        projects.assert_called_once_with()
+        operations = projects.return_value.operations
+        operations.assert_called_once_with()
+        get = operations.return_value.get
+        get.assert_called_once_with(name=name)
+        execute = get.return_value.execute
+        execute.assert_called_once_with()
+        self.assertEqual(resp, execute.return_value)
+
+    @patch('airflow.contrib.hooks.datastore_hook.DatastoreHook.get_conn')
+    def test_delete_operation(self, mock_get_conn):
+        self.datastore_hook.connection = mock_get_conn.return_value
+        name = 'name'
+
+        resp = self.datastore_hook.delete_operation(name)
+
+        projects = self.datastore_hook.connection.projects
+        projects.assert_called_once_with()
+        operations = projects.return_value.operations
+        operations.assert_called_once_with()
+        delete = operations.return_value.delete
+        delete.assert_called_once_with(name=name)
+        execute = delete.return_value.execute
+        execute.assert_called_once_with()
+        self.assertEqual(resp, execute.return_value)
+
+    @patch('airflow.contrib.hooks.datastore_hook.time.sleep')
+    @patch('airflow.contrib.hooks.datastore_hook.DatastoreHook.get_operation',
+           side_effect=[
+               {'metadata': {'common': {'state': 'PROCESSING'}}},
+               {'metadata': {'common': {'state': 'NOT PROCESSING'}}}
+           ])
+    def test_poll_operation_until_done(self, mock_get_operation, mock_time_sleep):
+        name = 'name'
+        polling_interval_in_seconds = 10
+
+        result = self.datastore_hook.poll_operation_until_done(name, polling_interval_in_seconds)
+
+        mock_get_operation.assert_has_calls([call(name), call(name)])
+        mock_time_sleep.assert_called_once_with(polling_interval_in_seconds)
+        self.assertEqual(result, {'metadata': {'common': {'state': 'NOT PROCESSING'}}})
+
+    @patch('airflow.contrib.hooks.datastore_hook.DatastoreHook.get_conn')
+    def test_export_to_storage_bucket(self, mock_get_conn):
+        self.datastore_hook.admin_connection = mock_get_conn.return_value
+        bucket = 'bucket'
+        namespace = None
+        entity_filter = {}
+        labels = {}
+
+        resp = self.datastore_hook.export_to_storage_bucket(bucket, namespace, entity_filter, labels)
+
+        projects = self.datastore_hook.admin_connection.projects
+        projects.assert_called_once_with()
+        export = projects.return_value.export
+        export.assert_called_once_with(projectId=self.datastore_hook.project_id,
+                                       body={
+                                           'outputUrlPrefix': 'gs://' + '/'.join(
+                                               filter(None, [bucket, namespace])
+                                           ),
+                                           'entityFilter': entity_filter,
+                                           'labels': labels,
+                                       })
+        execute = export.return_value.execute
+        execute.assert_called_once_with()
+        self.assertEqual(resp, execute.return_value)
+
+    @patch('airflow.contrib.hooks.datastore_hook.DatastoreHook.get_conn')
+    def test_import_from_storage_bucket(self, mock_get_conn):
+        self.datastore_hook.admin_connection = mock_get_conn.return_value
+        bucket = 'bucket'
+        file = 'file'
+        namespace = None
+        entity_filter = {}
+        labels = {}
+
+        resp = self.datastore_hook.import_from_storage_bucket(bucket, file, namespace, entity_filter, labels)
+
+        projects = self.datastore_hook.admin_connection.projects
+        projects.assert_called_once_with()
+        import_ = projects.return_value.import_
+        import_.assert_called_once_with(projectId=self.datastore_hook.project_id,
+                                        body={
+                                            'inputUrl': 'gs://' + '/'.join(
+                                                filter(None, [bucket, namespace, file])
+                                            ),
+                                            'entityFilter': entity_filter,
+                                            'labels': labels,
+                                        })
+        execute = import_.return_value.execute
+        execute.assert_called_once_with()
+        self.assertEqual(resp, execute.return_value)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4014
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

- move the establishment of the connection to the function calls instead of the hook init
- remove argument `version` from `get_conn` function
- add `version` argument to the `__init__` function
- rename the `partialKeys` argument of function `allocate_ids` to `partial_keys`.
- add tests
- update docs
- refactor code

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
