### PR TITLE
[AIRFLOW-4019] Fix AWS Athena Sensor object has no attribute 'mode'

### DIFF
--- a/airflow/contrib/sensors/aws_athena_sensor.py
+++ b/airflow/contrib/sensors/aws_athena_sensor.py
@@ -56,7 +56,7 @@ class AthenaSensor(BaseSensorOperator):
                  aws_conn_id='aws_default',
                  sleep_time=10,
                  *args, **kwargs):
-        super(BaseSensorOperator, self).__init__(*args, **kwargs)
+        super(AthenaSensor, self).__init__(*args, **kwargs)
         self.aws_conn_id = aws_conn_id
         self.query_execution_id = query_execution_id
         self.hook = None


### PR DESCRIPTION

### Jira

- [x] My PR addresses this jira ticket [AIRFLOW-4019](https://issues.apache.org/jira/browse/AIRFLOW-4019) . 
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When airflow runs the AthenaSensor, I get the following error. The following update to the first argument of `super()` would fix this.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/airflow/models.py", line 1657, in _run_raw_task
    result = task_copy.execute(context=context)
  File "/usr/local/lib/python3.6/site-packages/airflow/sensors/base_sensor_operator.py", line 92, in execute
    if self.reschedule:
  File "/usr/local/lib/python3.6/site-packages/airflow/sensors/base_sensor_operator.py", line 123, in reschedule
    return self.mode == 'reschedule'
AttributeError: 'AthenaSensor' object has no attribute 'mode'
```

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

not applicable. 

### Code Quality

- [x] Passes `flake8`
