### PR TITLE
[AIRFLOW-4020] Remove viewer DAG edit permissions

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,8 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Viewer won't have edit permissions on DAG view.
+
 ### RedisPy dependency updated to v3 series
 
 If you are using the Redis Sensor or Hook you may have to update your code. See

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -129,10 +129,15 @@ DAG_VMS = {
     'all_dags'
 }
 
-DAG_PERMS = {
-    'can_dag_read',
+WRITE_DAG_PERMS = {
     'can_dag_edit',
 }
+
+READ_DAG_PERMS = {
+    'can_dag_read',
+}
+
+DAG_PERMS = WRITE_DAG_PERMS | READ_DAG_PERMS
 
 ###########################################################################
 #                     DEFAULT ROLE CONFIGURATIONS
@@ -141,7 +146,7 @@ DAG_PERMS = {
 ROLE_CONFIGS = [
     {
         'role': 'Viewer',
-        'perms': VIEWER_PERMS | DAG_PERMS,
+        'perms': VIEWER_PERMS | READ_DAG_PERMS,
         'vms': VIEWER_VMS | DAG_VMS
     },
     {

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -1060,7 +1060,7 @@ class TestDagACLView(TestBase):
                 role=role_user,
                 password='test_user')
 
-        role_viewer = self.appbuilder.sm.find_role('User')
+        role_viewer = self.appbuilder.sm.find_role('Viewer')
         test_viewer = self.appbuilder.sm.find_user(username='test_viewer')
         if not test_viewer:
             self.appbuilder.sm.add_user(
@@ -1565,6 +1565,14 @@ class TestDagACLView(TestBase):
         url = 'tree?dag_id=example_bash_operator'
         resp = self.client.get(url, follow_redirects=True)
         self.check_content_in_response('runme_1', resp)
+
+    def test_refresh_failure_for_viewer(self):
+        # viewer role can't refresh
+        self.logout()
+        self.login(username='test_viewer',
+                   password='test_viewer')
+        resp = self.client.get('refresh?dag_id=example_bash_operator')
+        self.check_content_in_response('Redirecting', resp, resp_code=302)
 
 
 class TestTaskInstanceView(TestBase):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4020
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Viewer shouldn't be able to have write/edit access on DAG View-menu

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
