### PR TITLE
[AIRFLOW-3948] Operator list as templated field issue 

### DIFF
--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -23,6 +23,7 @@ from airflow.contrib.hooks.bigquery_hook import BigQueryHook
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook, _parse_gcs_url
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.helpers import get_templated_list
 
 
 class BigQueryOperator(BaseOperator):
@@ -480,8 +481,9 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         else:
             schema_fields = self.schema_fields
 
+        source_objects = get_templated_list(self.source_objects)
         source_uris = ['gs://{}/{}'.format(self.bucket, source_object)
-                       for source_object in self.source_objects]
+                       for source_object in source_objects]
         conn = bq_hook.get_conn()
         cursor = conn.cursor()
 

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -481,9 +481,9 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         else:
             schema_fields = self.schema_fields
 
-        source_objects = get_templated_list(self.source_objects)
+        self.source_objects = get_templated_list(self.source_objects)
         source_uris = ['gs://{}/{}'.format(self.bucket, source_object)
-                       for source_object in source_objects]
+                       for source_object in self.source_objects]
         conn = bq_hook.get_conn()
         cursor = conn.cursor()
 

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -33,6 +33,7 @@ from airflow.utils.decorators import apply_defaults
 from airflow.version import version
 from googleapiclient.errors import HttpError
 from airflow.utils import timezone
+from airflow.utils.helpers import get_templated_list
 
 
 class DataprocClusterCreateOperator(BaseOperator):
@@ -782,6 +783,8 @@ class DataProcPigOperator(BaseOperator):
         else:
             job.add_query(self.query)
         job.add_variables(self.variables)
+
+        self.dataproc_jars = get_templated_list(self.dataproc_jars)
         job.add_jar_file_uris(self.dataproc_jars)
         job.set_job_name(self.job_name)
 
@@ -880,6 +883,8 @@ class DataProcHiveOperator(BaseOperator):
         else:
             job.add_query(self.query)
         job.add_variables(self.variables)
+
+        self.dataproc_jars = get_templated_list(self.dataproc_jars)
         job.add_jar_file_uris(self.dataproc_jars)
         job.set_job_name(self.job_name)
 
@@ -979,6 +984,8 @@ class DataProcSparkSqlOperator(BaseOperator):
         else:
             job.add_query(self.query)
         job.add_variables(self.variables)
+
+        self.dataproc_jars = get_templated_list(self.dataproc_jars)
         job.add_jar_file_uris(self.dataproc_jars)
         job.set_job_name(self.job_name)
 
@@ -1084,7 +1091,11 @@ class DataProcSparkOperator(BaseOperator):
                                        self.dataproc_properties)
 
         job.set_main(self.main_jar, self.main_class)
+
+        self.arguments = get_templated_list(self.arguments)
         job.add_args(self.arguments)
+
+        self.dataproc_jars = get_templated_list(self.dataproc_jars)
         job.add_jar_file_uris(self.dataproc_jars)
         job.add_archive_uris(self.archives)
         job.add_file_uris(self.files)
@@ -1192,7 +1203,11 @@ class DataProcHadoopOperator(BaseOperator):
                                        self.dataproc_properties)
 
         job.set_main(self.main_jar, self.main_class)
+
+        self.arguments = get_templated_list(self.arguments)
         job.add_args(self.arguments)
+
+        self.dataproc_jars = get_templated_list(self.dataproc_jars)
         job.add_jar_file_uris(self.dataproc_jars)
         job.add_archive_uris(self.archives)
         job.add_file_uris(self.files)
@@ -1339,7 +1354,10 @@ class DataProcPySparkOperator(BaseOperator):
             self.main = self._upload_file_temp(bucket, self.main)
         job.set_python_main(self.main)
 
+        self.arguments = get_templated_list(self.arguments)
         job.add_args(self.arguments)
+
+        self.dataproc_jars = get_templated_list(self.dataproc_jars)
         job.add_jar_file_uris(self.dataproc_jars)
         job.add_archive_uris(self.archives)
         job.add_file_uris(self.files)

--- a/airflow/contrib/operators/emr_add_steps_operator.py
+++ b/airflow/contrib/operators/emr_add_steps_operator.py
@@ -16,10 +16,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from airflow.contrib.hooks.emr_hook import EmrHook
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
-from airflow.exceptions import AirflowException
-from airflow.contrib.hooks.emr_hook import EmrHook
+from airflow.utils.helpers import get_templated_list
 
 
 class EmrAddStepsOperator(BaseOperator):
@@ -54,6 +55,8 @@ class EmrAddStepsOperator(BaseOperator):
         emr = EmrHook(aws_conn_id=self.aws_conn_id).get_conn()
 
         self.log.info('Adding steps to %s', self.job_flow_id)
+
+        self.steps = get_templated_list(self.steps)
         response = emr.add_job_flow_steps(JobFlowId=self.job_flow_id, Steps=self.steps)
 
         if not response['ResponseMetadata']['HTTPStatusCode'] == 200:

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -219,9 +219,9 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         else:
             schema_fields = get_templated_list(self.schema_fields)
 
-        source_objects = get_templated_list(self.source_objects)
+        self.source_objects = get_templated_list(self.source_objects)
         source_uris = ['gs://{}/{}'.format(self.bucket, source_object)
-                       for source_object in source_objects]
+                       for source_object in self.source_objects]
         conn = bq_hook.get_conn()
         cursor = conn.cursor()
 

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -19,10 +19,11 @@
 
 import json
 
-from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.contrib.hooks.bigquery_hook import BigQueryHook
+from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.helpers import get_templated_list
 
 
 class GoogleCloudStorageToBigQueryOperator(BaseOperator):
@@ -216,10 +217,11 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                 schema_fields = None
 
         else:
-            schema_fields = self.schema_fields
+            schema_fields = get_templated_list(self.schema_fields)
 
+        source_objects = get_templated_list(self.source_objects)
         source_uris = ['gs://{}/{}'.format(self.bucket, source_object)
-                       for source_object in self.source_objects]
+                       for source_object in source_objects]
         conn = bq_hook.get_conn()
         cursor = conn.cursor()
 

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -24,6 +24,7 @@ from airflow.utils.state import State
 from airflow.contrib.kubernetes.volume_mount import VolumeMount  # noqa
 from airflow.contrib.kubernetes.volume import Volume  # noqa
 from airflow.contrib.kubernetes.secret import Secret  # noqa
+from airflow.utils.helpers import get_templated_list
 
 template_fields = ('templates_dict',)
 template_ext = tuple()
@@ -102,6 +103,9 @@ class KubernetesPodOperator(BaseOperator):
                 gen.add_mount(mount)
             for volume in self.volumes:
                 gen.add_volume(volume)
+
+            self.cmds = get_templated_list(self.cmds)
+            self.arguments = get_templated_list(self.arguments)
 
             pod = gen.make_pod(
                 namespace=self.namespace,

--- a/airflow/contrib/operators/mlengine_operator.py
+++ b/airflow/contrib/operators/mlengine_operator.py
@@ -21,6 +21,7 @@ from airflow.contrib.hooks.gcp_mlengine_hook import MLEngineHook
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.helpers import get_templated_list
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 log = LoggingMixin().log
@@ -222,6 +223,8 @@ class MLEngineBatchPredictionOperator(BaseOperator):
 
     def execute(self, context):
         job_id = _normalize_mlengine_job_id(self._job_id)
+
+        self._input_paths = get_templated_list(self._input_paths)
         prediction_request = {
             'jobId': job_id,
             'predictionInput': {

--- a/airflow/contrib/operators/pubsub_operator.py
+++ b/airflow/contrib/operators/pubsub_operator.py
@@ -20,6 +20,7 @@
 from airflow.contrib.hooks.gcp_pubsub_hook import PubSubHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.helpers import get_templated_list
 
 
 class PubSubTopicCreateOperator(BaseOperator):
@@ -430,4 +431,6 @@ class PubSubPublishOperator(BaseOperator):
     def execute(self, context):
         hook = PubSubHook(gcp_conn_id=self.gcp_conn_id,
                           delegate_to=self.delegate_to)
+
+        self.messages = get_templated_list(self.messages)
         hook.publish(self.project, self.topic, self.messages)

--- a/airflow/contrib/operators/spark_submit_operator.py
+++ b/airflow/contrib/operators/spark_submit_operator.py
@@ -21,6 +21,7 @@ from airflow.contrib.hooks.spark_submit_hook import SparkSubmitHook
 from airflow.models import BaseOperator
 from airflow.settings import WEB_COLORS
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.helpers import get_templated_list
 
 
 class SparkSubmitOperator(BaseOperator):
@@ -148,6 +149,8 @@ class SparkSubmitOperator(BaseOperator):
         """
         Call the SparkSubmitHook to run the provided spark job
         """
+
+        self._application_args = get_templated_list(self._application_args)
         self._hook = SparkSubmitHook(
             conf=self._conf,
             conn_id=self._conn_id,

--- a/airflow/operators/hive_to_druid.py
+++ b/airflow/operators/hive_to_druid.py
@@ -21,6 +21,7 @@ from airflow.hooks.hive_hooks import HiveCliHook, HiveMetastoreHook
 from airflow.hooks.druid_hook import DruidHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.helpers import get_templated_list
 
 LOAD_CHECK_INTERVAL = 5
 DEFAULT_TARGET_PARTITION_SIZE = 5000000
@@ -180,6 +181,8 @@ class HiveToDruidTransfer(BaseOperator):
         # Take all the columns, which are not the time dimension
         # or a metric, as the dimension columns
         dimensions = [c for c in columns if c not in metric_names and c != self.ts_dim]
+
+        self.intervals = get_templated_list(self.intervals)
 
         ingest_query_dict = {
             "type": "index_hadoop",

--- a/airflow/operators/hive_to_druid.py
+++ b/airflow/operators/hive_to_druid.py
@@ -21,7 +21,6 @@ from airflow.hooks.hive_hooks import HiveCliHook, HiveMetastoreHook
 from airflow.hooks.druid_hook import DruidHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
-from airflow.utils.helpers import get_templated_list
 
 LOAD_CHECK_INTERVAL = 5
 DEFAULT_TARGET_PARTITION_SIZE = 5000000
@@ -181,8 +180,6 @@ class HiveToDruidTransfer(BaseOperator):
         # Take all the columns, which are not the time dimension
         # or a metric, as the dimension columns
         dimensions = [c for c in columns if c not in metric_names and c != self.ts_dim]
-
-        self.intervals = get_templated_list(self.intervals)
 
         ingest_query_dict = {
             "type": "index_hadoop",

--- a/airflow/sensors/named_hive_partition_sensor.py
+++ b/airflow/sensors/named_hive_partition_sensor.py
@@ -21,6 +21,7 @@ from past.builtins import basestring
 
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.helpers import get_templated_list
 
 
 class NamedHivePartitionSensor(BaseSensorOperator):
@@ -96,7 +97,7 @@ class NamedHivePartitionSensor(BaseSensorOperator):
             schema, table, partition)
 
     def poke(self, context):
-
+        self.partition_names = get_templated_list(self.partition_names)
         self.partition_names = [
             partition_name for partition_name in self.partition_names
             if not self.poke_partition(partition_name)

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -333,6 +333,5 @@ def get_templated_list(elements):
                 elements_list = ast.literal_eval(elements)
             except (ValueError, SyntaxError):
                 elements_list = [elements]
-
         return elements_list
     return elements

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -17,27 +17,24 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
+import ast
 import errno
-
-import psutil
-
-from builtins import input
-from past.builtins import basestring
-from datetime import datetime
-from functools import reduce
 import os
 import re
 import signal
+from builtins import input
+from datetime import datetime
+from functools import reduce
 
-from jinja2 import Template
-
+import psutil
 from airflow import configuration
 from airflow.exceptions import AirflowException
+from jinja2 import Template
+from past.builtins import basestring
+from six import string_types
 
 # When killing processes, time to wait after issuing a SIGTERM before issuing a
 # SIGKILL.
@@ -321,3 +318,21 @@ def render_log_filename(ti, try_number, filename_template):
                                     task_id=ti.task_id,
                                     execution_date=ti.execution_date.isoformat(),
                                     try_number=try_number)
+
+
+def get_templated_list(elements):
+    if isinstance(elements, string_types):
+        if "," in elements:
+            elements_list = ast.literal_eval(elements)
+            elements_list = [
+                element.strip() if isinstance(element, string_types) else element
+                for element in elements_list
+            ]
+        else:
+            try:
+                elements_list = ast.literal_eval(elements)
+            except (ValueError, SyntaxError):
+                elements_list = [elements]
+
+        return elements_list
+    return elements


### PR DESCRIPTION
Operator list as templated field

This is a global fix for #4770 

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [AIRFLOW-3948](https://issues.apache.org/jira/browse/AIRFLOW-3948) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
