### PR TITLE
[AIRFLOW-4027] Make experimental tests more stateless

### DIFF
--- a/tests/api/common/experimental/test_mark_tasks.py
+++ b/tests/api/common/experimental/test_mark_tasks.py
@@ -30,6 +30,7 @@ from airflow.utils.db import create_session, provide_session
 from airflow.utils.dates import days_ago
 from airflow.utils.state import State
 from airflow.models import DagRun
+from tests.test_utils.db import clear_db_runs
 
 DEV_NULL = "/dev/null"
 
@@ -38,13 +39,17 @@ configuration.load_test_config()
 
 class TestMarkTasks(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        dagbag = models.DagBag(include_examples=True)
+        cls.dag1 = dagbag.dags['example_bash_operator']
+        cls.dag1.sync_to_db()
+        cls.dag2 = dagbag.dags['example_subdag_operator']
+        cls.dag2.sync_to_db()
+        cls.execution_dates = [days_ago(2), days_ago(1)]
+
     def setUp(self):
-        self.dagbag = models.DagBag(include_examples=True)
-        self.dag1 = self.dagbag.dags['example_bash_operator']
-        self.dag2 = self.dagbag.dags['example_subdag_operator']
-
-        self.execution_dates = [days_ago(2), days_ago(1)]
-
+        clear_db_runs()
         drs = _create_dagruns(self.dag1, self.execution_dates,
                               state=State.RUNNING,
                               run_id_template="scheduled__{}")
@@ -62,13 +67,7 @@ class TestMarkTasks(unittest.TestCase):
             dr.verify_integrity()
 
     def tearDown(self):
-        self.dag1.clear()
-        self.dag2.clear()
-
-        # just to make sure we are fully cleaned up
-        with create_session() as session:
-            session.query(models.DagRun).delete()
-            session.query(models.TaskInstance).delete()
+        clear_db_runs()
 
     @staticmethod
     def snapshot_state(dag, execution_dates):
@@ -216,11 +215,18 @@ class TestMarkTasks(unittest.TestCase):
 
 
 class TestMarkDAGRun(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        dagbag = models.DagBag(include_examples=True)
+        cls.dag1 = dagbag.dags['example_bash_operator']
+        cls.dag1.sync_to_db()
+        cls.dag2 = dagbag.dags['example_subdag_operator']
+        cls.dag2.sync_to_db()
+        cls.execution_dates = [days_ago(2), days_ago(1), days_ago(0)]
+
     def setUp(self):
-        self.dagbag = models.DagBag(include_examples=True)
-        self.dag1 = self.dagbag.dags['example_bash_operator']
-        self.dag2 = self.dagbag.dags['example_subdag_operator']
-        self.execution_dates = [days_ago(2), days_ago(1), days_ago(0)]
+        clear_db_runs()
 
     def _set_default_task_instance_states(self, dr):
         # success task

--- a/tests/api/common/experimental/test_pool.py
+++ b/tests/api/common/experimental/test_pool.py
@@ -20,15 +20,15 @@
 import unittest
 
 from airflow import models
-from airflow import settings
 from airflow.api.common.experimental import pool as pool_api
 from airflow.exceptions import AirflowBadRequest, PoolNotFound
+from airflow.utils.db import create_session
+from tests.test_utils.db import clear_db_pools
 
 
 class TestPool(unittest.TestCase):
 
     def setUp(self):
-        self.session = settings.Session()
         self.pools = []
         for i in range(2):
             name = 'experimental_%s' % (i + 1)
@@ -37,36 +37,32 @@ class TestPool(unittest.TestCase):
                 slots=i,
                 description=name,
             )
-            self.session.add(pool)
             self.pools.append(pool)
-        self.session.commit()
+        with create_session() as session:
+            session.add_all(self.pools)
 
     def tearDown(self):
-        self.session.query(models.Pool).delete()
-        self.session.commit()
-        self.session.close()
+        clear_db_pools()
 
     def test_get_pool(self):
-        pool = pool_api.get_pool(name=self.pools[0].pool, session=self.session)
+        pool = pool_api.get_pool(name=self.pools[0].pool)
         self.assertEqual(pool.pool, self.pools[0].pool)
 
     def test_get_pool_non_existing(self):
         self.assertRaisesRegexp(PoolNotFound,
                                 "^Pool 'test' doesn't exist$",
                                 pool_api.get_pool,
-                                name='test',
-                                session=self.session)
+                                name='test')
 
     def test_get_pool_bad_name(self):
         for name in ('', '    '):
             self.assertRaisesRegexp(AirflowBadRequest,
                                     "^Pool name shouldn't be empty$",
                                     pool_api.get_pool,
-                                    name=name,
-                                    session=self.session)
+                                    name=name)
 
     def test_get_pools(self):
-        pools = sorted(pool_api.get_pools(session=self.session),
+        pools = sorted(pool_api.get_pools(),
                        key=lambda p: p.pool)
         self.assertEqual(pools[0].pool, self.pools[0].pool)
         self.assertEqual(pools[1].pool, self.pools[1].pool)
@@ -74,22 +70,22 @@ class TestPool(unittest.TestCase):
     def test_create_pool(self):
         pool = pool_api.create_pool(name='foo',
                                     slots=5,
-                                    description='',
-                                    session=self.session)
+                                    description='')
         self.assertEqual(pool.pool, 'foo')
         self.assertEqual(pool.slots, 5)
         self.assertEqual(pool.description, '')
-        self.assertEqual(self.session.query(models.Pool).count(), 3)
+        with create_session() as session:
+            self.assertEqual(session.query(models.Pool).count(), 3)
 
     def test_create_pool_existing(self):
         pool = pool_api.create_pool(name=self.pools[0].pool,
                                     slots=5,
-                                    description='',
-                                    session=self.session)
+                                    description='')
         self.assertEqual(pool.pool, self.pools[0].pool)
         self.assertEqual(pool.slots, 5)
         self.assertEqual(pool.description, '')
-        self.assertEqual(self.session.query(models.Pool).count(), 2)
+        with create_session() as session:
+            self.assertEqual(session.query(models.Pool).count(), 2)
 
     def test_create_pool_bad_name(self):
         for name in ('', '    '):
@@ -98,8 +94,7 @@ class TestPool(unittest.TestCase):
                                     pool_api.create_pool,
                                     name=name,
                                     slots=5,
-                                    description='',
-                                    session=self.session)
+                                    description='')
 
     def test_create_pool_bad_slots(self):
         self.assertRaisesRegexp(AirflowBadRequest,
@@ -107,29 +102,26 @@ class TestPool(unittest.TestCase):
                                 pool_api.create_pool,
                                 name='foo',
                                 slots='foo',
-                                description='',
-                                session=self.session)
+                                description='')
 
     def test_delete_pool(self):
-        pool = pool_api.delete_pool(name=self.pools[0].pool,
-                                    session=self.session)
+        pool = pool_api.delete_pool(name=self.pools[0].pool)
         self.assertEqual(pool.pool, self.pools[0].pool)
-        self.assertEqual(self.session.query(models.Pool).count(), 1)
+        with create_session() as session:
+            self.assertEqual(session.query(models.Pool).count(), 1)
 
     def test_delete_pool_non_existing(self):
         self.assertRaisesRegexp(pool_api.PoolNotFound,
                                 "^Pool 'test' doesn't exist$",
                                 pool_api.delete_pool,
-                                name='test',
-                                session=self.session)
+                                name='test')
 
     def test_delete_pool_bad_name(self):
         for name in ('', '    '):
             self.assertRaisesRegexp(AirflowBadRequest,
                                     "^Pool name shouldn't be empty$",
                                     pool_api.delete_pool,
-                                    name=name,
-                                    session=self.session)
+                                    name=name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-4027

### Description

Make api tests more stateless

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`