### PR TITLE
[AIRFLOW-4028] Avoid Adding DAG_PERMS of All DAGs to Admin Role

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -445,10 +445,13 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         :return: None.
         """
         pvms = self.get_session.query(sqla_models.PermissionView).all()
-        pvms = [p for p in pvms if p.permission and p.view_menu]
+        pvms = {p for p in pvms
+                if p.permission and
+                p.view_menu and
+                not (p.permission.name in DAG_PERMS and p.view_menu.name != 'all_dags')}
 
         admin = self.find_role('Admin')
-        admin.permissions = list(set(admin.permissions) | set(pvms))
+        admin.permissions = list(set(admin.permissions) | pvms)
 
         self.get_session.commit()
 


### PR DESCRIPTION

### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-4028

### Description

Currently Admin’s permissions will always be updated so it has ALL permissions, including each DAG’s “can_dag_view” and “can_dag_edit”.

Let’s say we have 1000 DAGs now: then 2000 permissions will be added to Admin role in DB, and all of them will also be shown in UI if we go to Security->Roles.

This may not be necessary as Admin role already has “can_dag_view” and “can_dag_edit” on special view “all_dags”.
