### PR TITLE
[AIRFLOW-3841] Remove DagBag from /tree

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -2574,21 +2574,20 @@ class BaseOperator(LoggingMixin):
 
         return count
 
-    def get_task_instances(self, start_date=None, end_date=None):
+    @provide_session
+    def get_task_instances(self, start_date=None, end_date=None, session=None):
         """
         Get a set of task instance related to this task for a specific date
         range.
         """
         end_date = end_date or timezone.utcnow()
-        with create_session() as session:
-            results = session.query(TaskInstance)\
-                .filter(TaskInstance.dag_id == self.dag_id)\
-                .filter(TaskInstance.task_id == self.task_id)\
-                .filter(TaskInstance.execution_date >= start_date)\
-                .filter(TaskInstance.execution_date <= end_date)\
-                .order_by(TaskInstance.execution_date)\
-                .all()
-        return results
+        return session.query(TaskInstance)\
+            .filter(TaskInstance.dag_id == self.dag_id)\
+            .filter(TaskInstance.task_id == self.task_id)\
+            .filter(TaskInstance.execution_date >= start_date)\
+            .filter(TaskInstance.execution_date <= end_date)\
+            .order_by(TaskInstance.execution_date)\
+            .all()
 
     def get_flat_relative_ids(self, upstream=False, found_descendants=None):
         """
@@ -3509,24 +3508,23 @@ class DAG(BaseDag, LoggingMixin):
         self.get_task(upstream_task_id).set_downstream(
             self.get_task(downstream_task_id))
 
+    @provide_session
     def get_task_instances(
-            self, start_date=None, end_date=None, state=None):
-        TI = TaskInstance
+            self, start_date=None, end_date=None, state=None, session=None):
         if not start_date:
             start_date = (timezone.utcnow() - timedelta(30)).date()
             start_date = timezone.make_aware(
                 datetime.combine(start_date, datetime.min.time()))
         end_date = end_date or timezone.utcnow()
-        with create_session() as session:
-            tis = session.query(TaskInstance).filter(
-                TaskInstance.dag_id == self.dag_id,
-                TaskInstance.execution_date >= start_date,
-                TaskInstance.execution_date <= end_date,
-                TaskInstance.task_id.in_([t.task_id for t in self.tasks]),
-            )
-            if state:
-                tis = tis.filter(TI.state == state)
-            tis = tis.order_by(TI.execution_date).all()
+        tis = session.query(TaskInstance).filter(
+            TaskInstance.dag_id == self.dag_id,
+            TaskInstance.execution_date >= start_date,
+            TaskInstance.execution_date <= end_date,
+            TaskInstance.task_id.in_([t.task_id for t in self.tasks]),
+        )
+        if state:
+            tis = tis.filter(TaskInstance.state == state)
+        tis = tis.order_by(TaskInstance.execution_date).all()
         return tis
 
     @property
@@ -4428,26 +4426,25 @@ class DagRun(Base, LoggingMixin):
         """
         Returns the task instances for this dag run
         """
-        TI = TaskInstance
-        tis = session.query(TI).filter(
-            TI.dag_id == self.dag_id,
-            TI.execution_date == self.execution_date,
+        tis = session.query(TaskInstance).filter(
+            TaskInstance.dag_id == self.dag_id,
+            TaskInstance.execution_date == self.execution_date,
         )
         if state:
             if isinstance(state, six.string_types):
-                tis = tis.filter(TI.state == state)
+                tis = tis.filter(TaskInstance.state == state)
             else:
                 # this is required to deal with NULL values
                 if None in state:
                     tis = tis.filter(
-                        or_(TI.state.in_(state),
-                            TI.state.is_(None))
+                        or_(TaskInstance.state.in_(state),
+                            TaskInstance.state.is_(None))
                     )
                 else:
-                    tis = tis.filter(TI.state.in_(state))
+                    tis = tis.filter(TaskInstance.state.in_(state))
 
         if self.dag and self.dag.partial:
-            tis = tis.filter(TI.task_id.in_(self.dag.task_ids))
+            tis = tis.filter(TaskInstance.task_id.in_(self.dag.task_ids))
 
         return tis.all()
 

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -2581,12 +2581,13 @@ class BaseOperator(LoggingMixin):
         """
         end_date = end_date or timezone.utcnow()
         with create_session() as session:
-            results = session.query(TaskInstance).filter(
-                TaskInstance.dag_id == self.dag_id,
-                TaskInstance.task_id == self.task_id,
-                TaskInstance.execution_date >= start_date,
-                TaskInstance.execution_date <= end_date,
-                ).order_by(TaskInstance.execution_date).all()
+            results = session.query(TaskInstance)\
+                .filter(TaskInstance.dag_id == self.dag_id)\
+                .filter(TaskInstance.task_id == self.task_id)\
+                .filter(TaskInstance.execution_date >= start_date)\
+                .filter(TaskInstance.execution_date <= end_date)\
+                .order_by(TaskInstance.execution_date)\
+                .all()
         return results
 
     def get_flat_relative_ids(self, upstream=False, found_descendants=None):

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -23,8 +23,9 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import copy
-from collections import defaultdict, namedtuple, OrderedDict
 from builtins import ImportError as BuiltinImportError, bytes, object, str
+from collections import defaultdict, namedtuple, OrderedDict
+
 from future.standard_library import install_aliases
 
 from airflow.models.base import Base, ID_LEN
@@ -95,7 +96,7 @@ from airflow.ti_deps.dep_context import DepContext, QUEUE_DEPS, RUN_DEPS
 from airflow.utils import timezone
 from airflow.utils.dag_processing import list_py_file_paths
 from airflow.utils.dates import cron_presets, date_range as utils_date_range
-from airflow.utils.db import provide_session, create_session
+from airflow.utils.db import provide_session
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.email import send_email
 from airflow.utils.helpers import is_container, validate_key, pprinttable

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1165,10 +1165,10 @@ class Airflow(AirflowBaseView):
         dag_id = request.args.get('dag_id')
         blur = conf.getboolean('webserver', 'demo_mode')
         dag_model = DagModel.get_dagmodel(dag_id)
-        dag = dag_model.get_dag()
-        if dag_id not in dagbag.dags:
-            flash('DAG "{0}" seems to be missing.'.format(dag_id), "error")
+        if not dag_model:
+            flash('DAG "{0}" seems to be missing in database.'.format(dag_id), "error")
             return redirect('/')
+        dag = dag_model.get_dag()
 
         root = request.args.get('root')
         if root:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1159,8 +1159,7 @@ class Airflow(AirflowBaseView):
     @has_access
     @gzipped
     @action_logging
-    @provide_session
-    def tree(self, session=None):
+    def tree(self):
         default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
         blur = conf.getboolean('webserver', 'demo_mode')

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1203,8 +1203,7 @@ class Airflow(AirflowBaseView):
         max_date = max(dates) if dates else None
         min_date = min(dates) if dates else None
 
-        tis = dag.get_task_instances(
-            session, start_date=min_date, end_date=base_date)
+        tis = dag.get_task_instances(start_date=min_date, end_date=base_date)
         task_instances = {}
         for ti in tis:
             tid = alchemy_to_dict(ti)
@@ -1353,7 +1352,7 @@ class Airflow(AirflowBaseView):
 
         task_instances = {
             ti.task_id: alchemy_to_dict(ti)
-            for ti in dag.get_task_instances(session, dttm, dttm)}
+            for ti in dag.get_task_instances(dttm, dttm)}
         tasks = {
             t.task_id: {
                 'dag_id': t.dag_id,
@@ -1429,8 +1428,7 @@ class Airflow(AirflowBaseView):
         x = defaultdict(list)
         cum_y = defaultdict(list)
 
-        tis = dag.get_task_instances(
-            session, start_date=min_date, end_date=base_date)
+        tis = dag.get_task_instances(start_date=min_date, end_date=base_date)
         TF = TaskFail
         ti_fails = (
             session.query(TF)
@@ -1535,16 +1533,14 @@ class Airflow(AirflowBaseView):
         for task in dag.tasks:
             y = []
             x = []
-            for ti in task.get_task_instances(session, start_date=min_date,
-                                              end_date=base_date):
+            for ti in task.get_task_instances(start_date=min_date, end_date=base_date):
                 dttm = wwwutils.epoch(ti.execution_date)
                 x.append(dttm)
                 y.append(ti.try_number)
             if x:
                 chart.add_serie(name=task.task_id, x=x, y=y)
 
-        tis = dag.get_task_instances(
-            session, start_date=min_date, end_date=base_date)
+        tis = dag.get_task_instances(start_date=min_date, end_date=base_date)
         tries = sorted(list({ti.try_number for ti in tis}))
         max_date = max([ti.execution_date for ti in tis]) if tries else None
 
@@ -1600,8 +1596,7 @@ class Airflow(AirflowBaseView):
         for task in dag.tasks:
             y[task.task_id] = []
             x[task.task_id] = []
-            for ti in task.get_task_instances(session, start_date=min_date,
-                                              end_date=base_date):
+            for ti in task.get_task_instances(start_date=min_date, end_date=base_date):
                 ts = ti.execution_date
                 if dag.schedule_interval and dag.following_schedule(ts):
                     ts = dag.following_schedule(ts)
@@ -1623,8 +1618,7 @@ class Airflow(AirflowBaseView):
                 chart.add_serie(name=task.task_id, x=x[task.task_id],
                                 y=scale_time_units(y[task.task_id], y_unit))
 
-        tis = dag.get_task_instances(
-            session, start_date=min_date, end_date=base_date)
+        tis = dag.get_task_instances(start_date=min_date, end_date=base_date)
         dates = sorted(list({ti.execution_date for ti in tis}))
         max_date = max([ti.execution_date for ti in tis]) if dates else None
 
@@ -1723,7 +1717,7 @@ class Airflow(AirflowBaseView):
         form.execution_date.choices = dt_nr_dr_data['dr_choices']
 
         tis = [
-            ti for ti in dag.get_task_instances(session, dttm, dttm)
+            ti for ti in dag.get_task_instances(dttm, dttm)
             if ti.start_date]
         tis = sorted(tis, key=lambda ti: ti.start_date)
         TF = TaskFail
@@ -1799,7 +1793,7 @@ class Airflow(AirflowBaseView):
 
         task_instances = {
             ti.task_id: alchemy_to_dict(ti)
-            for ti in dag.get_task_instances(session, dttm, dttm)}
+            for ti in dag.get_task_instances(dttm, dttm)}
 
         return json.dumps(task_instances)
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -2593,7 +2593,7 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertIsNotNone(dr)
 
         with create_session() as session:
-            tis = dr.get_task_instances(session=session)
+            tis = dr.get_task_instances()
             for ti in tis:
                 ti.state = state
                 ti.start_date = start_date
@@ -2696,7 +2696,7 @@ class SchedulerJobTest(unittest.TestCase):
         dr = scheduler.create_dag_run(dag)
         self.assertIsNotNone(dr)
 
-        tis = dr.get_task_instances(session=session)
+        tis = dr.get_task_instances()
         for ti in tis:
             ti.state = State.SUCCESS
 
@@ -3625,7 +3625,7 @@ class SchedulerJobTest(unittest.TestCase):
         session = settings.Session()
 
         dr1 = scheduler.create_dag_run(dag, session=session)
-        ti = dr1.get_task_instances(session=session)[0]
+        ti = dr1.get_task_instances()[0]
         dr1.state = State.RUNNING
         ti.state = State.SCHEDULED
         dr1.external_trigger = True
@@ -3646,7 +3646,7 @@ class SchedulerJobTest(unittest.TestCase):
         session = settings.Session()
 
         dr1 = scheduler.create_dag_run(dag, session=session)
-        ti = dr1.get_task_instances(session=session)[0]
+        ti = dr1.get_task_instances()[0]
         ti.state = State.SCHEDULED
         dr1.state = State.RUNNING
         dr1.run_id = BackfillJob.ID_PREFIX + '_sdfsfdfsd'
@@ -3671,8 +3671,8 @@ class SchedulerJobTest(unittest.TestCase):
         dr2 = scheduler.create_dag_run(dag)
         dr1.state = State.SUCCESS
         dr2.state = State.RUNNING
-        ti1 = dr1.get_task_instances(session=session)[0]
-        ti2 = dr2.get_task_instances(session=session)[0]
+        ti1 = dr1.get_task_instances()[0]
+        ti2 = dr2.get_task_instances()[0]
         ti1.state = State.SCHEDULED
         ti2.state = State.SCHEDULED
 
@@ -3721,7 +3721,7 @@ class SchedulerJobTest(unittest.TestCase):
 
         dr1 = scheduler.create_dag_run(dag)
         dr1.state = State.RUNNING
-        tis = dr1.get_task_instances(session=session)
+        tis = dr1.get_task_instances()
         tis[0].state = State.RUNNING
         session.merge(dr1)
         session.merge(tis[0])
@@ -3743,7 +3743,7 @@ class SchedulerJobTest(unittest.TestCase):
 
         dr1 = scheduler.create_dag_run(dag)
         dr1.state = State.SUCCESS
-        tis = dr1.get_task_instances(session=session)
+        tis = dr1.get_task_instances()
         self.assertEqual(1, len(tis))
         tis[0].state = State.SCHEDULED
         session.merge(dr1)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -2593,7 +2593,7 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertIsNotNone(dr)
 
         with create_session() as session:
-            tis = dr.get_task_instances()
+            tis = dr.get_task_instances(session=session)
             for ti in tis:
                 ti.state = state
                 ti.start_date = start_date
@@ -2696,7 +2696,7 @@ class SchedulerJobTest(unittest.TestCase):
         dr = scheduler.create_dag_run(dag)
         self.assertIsNotNone(dr)
 
-        tis = dr.get_task_instances()
+        tis = dr.get_task_instances(session=session)
         for ti in tis:
             ti.state = State.SUCCESS
 
@@ -3625,7 +3625,7 @@ class SchedulerJobTest(unittest.TestCase):
         session = settings.Session()
 
         dr1 = scheduler.create_dag_run(dag, session=session)
-        ti = dr1.get_task_instances()[0]
+        ti = dr1.get_task_instances(session=session)[0]
         dr1.state = State.RUNNING
         ti.state = State.SCHEDULED
         dr1.external_trigger = True
@@ -3646,7 +3646,7 @@ class SchedulerJobTest(unittest.TestCase):
         session = settings.Session()
 
         dr1 = scheduler.create_dag_run(dag, session=session)
-        ti = dr1.get_task_instances()[0]
+        ti = dr1.get_task_instances(session=session)[0]
         ti.state = State.SCHEDULED
         dr1.state = State.RUNNING
         dr1.run_id = BackfillJob.ID_PREFIX + '_sdfsfdfsd'
@@ -3671,8 +3671,8 @@ class SchedulerJobTest(unittest.TestCase):
         dr2 = scheduler.create_dag_run(dag)
         dr1.state = State.SUCCESS
         dr2.state = State.RUNNING
-        ti1 = dr1.get_task_instances()[0]
-        ti2 = dr2.get_task_instances()[0]
+        ti1 = dr1.get_task_instances(session=session)[0]
+        ti2 = dr2.get_task_instances(session=session)[0]
         ti1.state = State.SCHEDULED
         ti2.state = State.SCHEDULED
 
@@ -3721,7 +3721,7 @@ class SchedulerJobTest(unittest.TestCase):
 
         dr1 = scheduler.create_dag_run(dag)
         dr1.state = State.RUNNING
-        tis = dr1.get_task_instances()
+        tis = dr1.get_task_instances(session=session)
         tis[0].state = State.RUNNING
         session.merge(dr1)
         session.merge(tis[0])
@@ -3743,7 +3743,7 @@ class SchedulerJobTest(unittest.TestCase):
 
         dr1 = scheduler.create_dag_run(dag)
         dr1.state = State.SUCCESS
-        tis = dr1.get_task_instances()
+        tis = dr1.get_task_instances(session=session)
         self.assertEqual(1, len(tis))
         tis[0].state = State.SCHEDULED
         session.merge(dr1)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3841

### Description

Remove DagBag from /tree to make the webserver more stateless

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`