### PR TITLE
[AIRFLOW-3833] Remove DagBag from /get_logs_with_metadata.

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -541,7 +541,7 @@ class Airflow(AirflowBaseView):
             models.TaskInstance.execution_date == execution_date).first()
 
         if ti is None:
-            logs = ["*** Task instance did not exist in the DB\n"]
+            logs = ["*** Task instance does not not exist in the database\n"]
             metadata['end_of_log'] = True
         else:
             dag_model = DagModel.get_dagmodel(dag_id)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"

  - https://issues.apache.org/jira/browse/AIRFLOW-3833

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

- Removes dependency on dagbag in the get_logs_with_metadata endpoint, similar to earlier PR's such as #4831. 
- Fixes issue with missing metadata argument (json.loads fails on None)
- Refactors function to make try/except around handler.read more explicit.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Covered by existing tests.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.

Not applicable.

### Code Quality

- [X] Passes `flake8`
