### PR TITLE
[AIRFLOW-4037] Log response in SimpleHttpOperator even if the response check fails

### DIFF
--- a/airflow/operators/http_operator.py
+++ b/airflow/operators/http_operator.py
@@ -86,9 +86,9 @@ class SimpleHttpOperator(BaseOperator):
                             self.data,
                             self.headers,
                             self.extra_options)
+        if self.log_response:
+            self.log.info(response.text)
         if self.response_check:
             if not self.response_check(response):
                 raise AirflowException("Response check returned False.")
-        if self.log_response:
-            self.log.info(response.text)
         return response.text

--- a/tests/operators/test_http_operator.py
+++ b/tests/operators/test_http_operator.py
@@ -22,6 +22,8 @@ import unittest
 
 import requests_mock
 from airflow.operators.http_operator import SimpleHttpOperator
+from airflow.exceptions import AirflowException
+
 
 try:
     from unittest import mock
@@ -52,3 +54,27 @@ class SimpleHttpOpTests(unittest.TestCase):
         with mock.patch.object(operator.log, 'info') as mock_info:
             operator.execute(None)
             mock_info.assert_called_with('Example.com fake response')
+
+    @requests_mock.mock()
+    def test_response_in_logs_after_failed_check(self, m):
+        """
+        Test that when using SimpleHttpOperator with log_response=True,
+        the reponse is logged even if request_check fails
+        """
+
+        def response_check(response):
+            return response.text != 'invalid response'
+
+        m.get('http://www.example.com', text='invalid response')
+        operator = SimpleHttpOperator(
+            task_id='test_HTTP_op',
+            method='GET',
+            endpoint='/',
+            http_conn_id='HTTP_EXAMPLE',
+            log_response=True,
+            response_check=response_check
+        )
+
+        with mock.patch.object(operator.log, 'info') as mock_info:
+            self.assertRaises(AirflowException, operator.execute, None)
+            mock_info.assert_called_with('invalid response')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [AIRFLOW-4037](https://issues.apache.org/jira/browse/AIRFLOW-4037)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

I changed the order of response_check and response_log so in case of response_check failing response would be still logged. Usually if we want to log responses it would be extra useful with failing responses. Previously response_check fail raises error which causes execute function to exit.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

tests/operators/test_http_operator.py::test_response_in_logs_after_failed_check

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
