### PR TITLE
[AIRFLOW-4031] Allow for key pair auth in snowflake hook

### DIFF
--- a/airflow/contrib/hooks/snowflake_hook.py
+++ b/airflow/contrib/hooks/snowflake_hook.py
@@ -18,6 +18,8 @@
 # under the License.
 
 import snowflake.connector
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
 
 from airflow.hooks.dbapi_hook import DbApiHook
 
@@ -64,6 +66,33 @@ class SnowflakeHook(DbApiHook):
             "region": self.region or region or '',
             "role": self.role or role or '',
         }
+
+        """
+        If private_key_file is specified in the extra json, load the contents of the file as a private
+        key and specify that in the connection configuration. The connection password then becomes the
+        passphrase for the private key. If your private key file is not encrypted (not recommended), then
+        leave the password empty.
+        """
+        private_key_file = conn.extra_dejson.get('private_key_file', None)
+        if private_key_file is not None:
+            with open(private_key_file, "rb") as key:
+                passphrase = None
+                if conn.password is not None and conn.password.strip() != '':
+                    passphrase = conn.password.strip().encode()
+
+                p_key = serialization.load_pem_private_key(
+                    key.read(),
+                    password=passphrase,
+                    backend=default_backend()
+                )
+
+            pkb = p_key.private_bytes(encoding=serialization.Encoding.DER,
+                                      format=serialization.PrivateFormat.PKCS8,
+                                      encryption_algorithm=serialization.NoEncryption())
+
+            conn_config['private_key'] = pkb
+            conn_config.pop('password', None)
+
         return conn_config
 
     def get_uri(self):

--- a/airflow/contrib/hooks/snowflake_hook.py
+++ b/airflow/contrib/hooks/snowflake_hook.py
@@ -74,10 +74,10 @@ class SnowflakeHook(DbApiHook):
         leave the password empty.
         """
         private_key_file = conn.extra_dejson.get('private_key_file', None)
-        if private_key_file is not None:
+        if private_key_file:
             with open(private_key_file, "rb") as key:
                 passphrase = None
-                if conn.password is not None and conn.password.strip() != '':
+                if conn.password:
                     passphrase = conn.password.strip().encode()
 
                 p_key = serialization.load_pem_private_key(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ autodoc_mock_imports = [
     'cassandra',
     'celery',
     'cloudant',
+    'cryptography',
     'cx_Oracle',
     'datadog',
     'distributed',

--- a/tests/contrib/hooks/test_snowflake_hook.py
+++ b/tests/contrib/hooks/test_snowflake_hook.py
@@ -115,7 +115,7 @@ class TestSnowflakeHook(unittest.TestCase):
                                   'warehouse': 'af_wh',
                                   'region': 'af_region',
                                   'role': 'af_role',
-                                  'private_key_file': '/tmp/test_key.p8'}
+                                  'private_key_file': self.encryptedPrivateKey}
 
         params = self.db_hook._get_conn_params()
         self.assertTrue('private_key' in params)
@@ -126,7 +126,7 @@ class TestSnowflakeHook(unittest.TestCase):
                                   'warehouse': 'af_wh',
                                   'region': 'af_region',
                                   'role': 'af_role',
-                                  'private_key_file': '/tmp/test_key.pem'}
+                                  'private_key_file': self.nonEncryptedPrivateKey}
 
         self.conn.password = ''
         params = self.db_hook._get_conn_params()

--- a/tests/contrib/hooks/test_snowflake_hook.py
+++ b/tests/contrib/hooks/test_snowflake_hook.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 #
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -18,9 +17,14 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+import os
 
 import mock
 import unittest
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from airflow.contrib.hooks.snowflake_hook import SnowflakeHook
 
@@ -54,6 +58,39 @@ class TestSnowflakeHook(unittest.TestCase):
 
         self.db_hook = UnitTestSnowflakeHook()
 
+        self.nonEncryptedPrivateKey = "/tmp/test_key.pem"
+        self.encryptedPrivateKey = "/tmp/test_key.p8"
+
+        # Write some temporary private keys. First is not encrypted, second is with a passphrase.
+        key = rsa.generate_private_key(
+            backend=default_backend(),
+            public_exponent=65537,
+            key_size=2048
+        )
+        private_key = key.private_bytes(serialization.Encoding.PEM,
+                                        serialization.PrivateFormat.PKCS8,
+                                        serialization.NoEncryption())
+
+        with open(self.nonEncryptedPrivateKey, "wb") as f:
+            f.write(private_key)
+
+        key = rsa.generate_private_key(
+            backend=default_backend(),
+            public_exponent=65537,
+            key_size=2048
+        )
+        private_key = key.private_bytes(serialization.Encoding.PEM,
+                                        serialization.PrivateFormat.PKCS8,
+                                        encryption_algorithm=serialization.BestAvailableEncryption(
+                                            self.conn.password.encode()))
+
+        with open(self.encryptedPrivateKey, "wb") as f:
+            f.write(private_key)
+
+    def tearDown(self):
+        os.remove(self.encryptedPrivateKey)
+        os.remove(self.nonEncryptedPrivateKey)
+
     def test_get_uri(self):
         uri_shouldbe = 'snowflake://user:pw@airflow/db/public?warehouse=af_wh&role=af_role'
         self.assertEqual(uri_shouldbe, self.db_hook.get_uri())
@@ -71,3 +108,30 @@ class TestSnowflakeHook(unittest.TestCase):
 
     def test_get_conn(self):
         self.assertEqual(self.db_hook.get_conn(), self.conn)
+
+    def test_key_pair_auth_encrypted(self):
+        self.conn.extra_dejson = {'database': 'db',
+                                  'account': 'airflow',
+                                  'warehouse': 'af_wh',
+                                  'region': 'af_region',
+                                  'role': 'af_role',
+                                  'private_key_file': '/tmp/test_key.p8'}
+
+        params = self.db_hook._get_conn_params()
+        self.assertTrue('private_key' in params)
+
+    def test_key_pair_auth_not_encrypted(self):
+        self.conn.extra_dejson = {'database': 'db',
+                                  'account': 'airflow',
+                                  'warehouse': 'af_wh',
+                                  'region': 'af_region',
+                                  'role': 'af_role',
+                                  'private_key_file': '/tmp/test_key.pem'}
+
+        self.conn.password = ''
+        params = self.db_hook._get_conn_params()
+        self.assertTrue('private_key' in params)
+
+        self.conn.password = None
+        params = self.db_hook._get_conn_params()
+        self.assertTrue('private_key' in params)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-4031](https://issues.apache.org/jira/browse/AIRFLOW-4031)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR adds the ability to use key pair authentication to the SnowflakeHook.
In your snowflake connection extra json, you would add 'private_key_file': '/location/to/file'. This points to the private key that will be used for authentication. If there is a passphrase on the private key, you would specify it in the connection password. If there is no passphrase, you leave the password field blank.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I have added unit tests that create a private key file with no passphrase and one with, verifies they are each read properly by the hook and then removes the files.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

It appears there is no current documentation for this operator/hook.

### Code Quality

- [x] Passes `flake8`
