### PR TITLE
[AIRFLOW-4044] The documentation of `query_params` in `BigQueryOperator` is wrong. 

### DIFF
--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -80,9 +80,13 @@ class BigQueryOperator(BaseOperator):
     :param schema_update_options: Allows the schema of the destination
         table to be updated as a side effect of the load job.
     :type schema_update_options: tuple
-    :param query_params: a dictionary containing query parameter types and
-        values, passed to BigQuery.
-    :type query_params: dict
+    :param query_params: a list of dictionary containing query parameter types and
+        values, passed to BigQuery. The structure of dictionary should look like 
+        'queryParameters' in Google BigQuery Jobs API:
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs. 
+        For example, [{ 'name': 'corpus', 'parameterType': { 'type': 'STRING' }, 
+        'parameterValue': { 'value': 'romeoandjuliet' } }].
+    :type query_params: list
     :param labels: a dictionary containing labels for the job/query,
         passed to BigQuery
     :type labels: dict

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -81,10 +81,10 @@ class BigQueryOperator(BaseOperator):
         table to be updated as a side effect of the load job.
     :type schema_update_options: tuple
     :param query_params: a list of dictionary containing query parameter types and
-        values, passed to BigQuery. The structure of dictionary should look like 
+        values, passed to BigQuery. The structure of dictionary should look like
         'queryParameters' in Google BigQuery Jobs API:
-        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs. 
-        For example, [{ 'name': 'corpus', 'parameterType': { 'type': 'STRING' }, 
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs.
+        For example, [{ 'name': 'corpus', 'parameterType': { 'type': 'STRING' },
         'parameterValue': { 'value': 'romeoandjuliet' } }].
     :type query_params: list
     :param labels: a dictionary containing labels for the job/query,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [AIRFLOW-4044](https://issues.apache.org/jira/browse/AIRFLOW-4044) 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently, the doc (https://airflow.apache.org/code.html?highlight=query_params) says: 

```
query_params (dict) - a dictionary containing query parameter types and values, passed to BigQuery. 
```

However, in BigQueryBaseCursor (https://github.com/apache/airflow/blob/0c797a830e3370bd6e39f5fcfc128a8fd776912e/airflow/contrib/hooks/bigquery_hook.py#L694-L696), the doc indicates that this parameter should be a list of `dict`. Also, it is unclear how this `query_params` look like and no examples are available. 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Updating the documentation and there are no code changes. 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
