### PR TITLE
[AIRFLOW-4046] Added validations for poke_interval & timeout for Airflow Sensor

### DIFF
--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -74,9 +74,9 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         self.soft_fail = soft_fail
         self.timeout = timeout
         self.mode = mode
-        self.validate_inputs()
+        self._validate_input_values()
 
-    def validate_inputs(self):
+    def _validate_input_values(self):
         if not isinstance(self.poke_interval, (int, float)) or self.poke_interval < 0:
             raise AirflowException(
                 "The poke_interval must be a non-negative number")

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -70,11 +70,11 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                  *args,
                  **kwargs):
         super(BaseSensorOperator, self).__init__(*args, **kwargs)
-        if isinstance(poke_interval, str) or poke_interval < 0:
+        if poke_interval < 0:
             raise AirflowException(
                 "The poke_interval must be a non-negative number"
                 )
-        if isinstance(timeout, str) or timeout < 0:
+        if timeout < 0:
             raise AirflowException(
                 "The timeout must be a non-negative number"
                 )

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -20,6 +20,7 @@
 
 from time import sleep
 from datetime import timedelta
+from numbers import Number
 
 from airflow.exceptions import AirflowException, AirflowSensorTimeout, \
     AirflowSkipException, AirflowRescheduleException
@@ -70,10 +71,10 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                  *args,
                  **kwargs):
         super(BaseSensorOperator, self).__init__(*args, **kwargs)
-        if not isinstance(poke_interval, int) or poke_interval < 0:
+        if not isinstance(poke_interval, Number) or poke_interval < 0:
             raise AirflowException(
                 "The poke_interval must be a non-negative integer")
-        if not isinstance(timeout, int) or timeout < 0:
+        if not isinstance(timeout, Number) or timeout < 0:
             raise AirflowException(
                 "The timeout must be a non-negative integer")
         self.poke_interval = poke_interval

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -73,10 +73,10 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         super(BaseSensorOperator, self).__init__(*args, **kwargs)
         if not isinstance(poke_interval, Number) or poke_interval < 0:
             raise AirflowException(
-                "The poke_interval must be a non-negative integer")
+                "The poke_interval must be a non-negative number")
         if not isinstance(timeout, Number) or timeout < 0:
             raise AirflowException(
-                "The timeout must be a non-negative integer")
+                "The timeout must be a non-negative number")
         self.poke_interval = poke_interval
         self.soft_fail = soft_fail
         self.timeout = timeout

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -72,12 +72,10 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         super(BaseSensorOperator, self).__init__(*args, **kwargs)
         if poke_interval < 0:
             raise AirflowException(
-                "The poke_interval must be a non-negative number"
-                )
+                "The poke_interval must be a non-negative number")
         if timeout < 0:
             raise AirflowException(
-                "The timeout must be a non-negative number"
-                )
+                "The timeout must be a non-negative number")
         self.poke_interval = poke_interval
         self.soft_fail = soft_fail
         self.timeout = timeout

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -70,6 +70,14 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                  *args,
                  **kwargs):
         super(BaseSensorOperator, self).__init__(*args, **kwargs)
+        if isinstance(poke_interval, str) or poke_interval < 0:
+             raise AirflowException(
+                "The poke_interval must be a non-negative number"
+                )
+        if isinstance(timeout, str) or timeout < 0:
+             raise AirflowException(
+                "The timeout must be a non-negative number"
+                )
         self.poke_interval = poke_interval
         self.soft_fail = soft_fail
         self.timeout = timeout

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -71,11 +71,11 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                  **kwargs):
         super(BaseSensorOperator, self).__init__(*args, **kwargs)
         if isinstance(poke_interval, str) or poke_interval < 0:
-             raise AirflowException(
+            raise AirflowException(
                 "The poke_interval must be a non-negative number"
                 )
         if isinstance(timeout, str) or timeout < 0:
-             raise AirflowException(
+            raise AirflowException(
                 "The timeout must be a non-negative number"
                 )
         self.poke_interval = poke_interval

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -77,17 +77,17 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         self._validate_inputs()
 
     def _validate_inputs(self):
-            if not isinstance(self.poke_interval, (int, float)) or self.poke_interval < 0:
-                raise AirflowException(
-                    "The poke_interval must be a non-negative number")
-            if not isinstance(self.timeout, (int, float)) or self.timeout < 0:
-                raise AirflowException(
-                    "The timeout must be a non-negative number")
-            if self.mode not in self.valid_modes:
-                raise AirflowException(
-                    "The mode must be one of {valid_modes},"
-                    "'{d}.{t}'; received '{m}'."
-                    .format(valid_modes=self.valid_modes,
+        if not isinstance(self.poke_interval, (int, float)) or self.poke_interval < 0:
+            raise AirflowException(
+                "The poke_interval must be a non-negative number")
+        if not isinstance(self.timeout, (int, float)) or self.timeout < 0:
+            raise AirflowException(
+                "The timeout must be a non-negative number")
+        if self.mode not in self.valid_modes:
+            raise AirflowException(
+                "The mode must be one of {valid_modes},"
+                "'{d}.{t}'; received '{m}'."
+                .format(valid_modes=self.valid_modes,
                         d=self.dag.dag_id if self.dag else "",
                         t=self.task_id, m=self.mode))
 

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -20,7 +20,6 @@
 
 from time import sleep
 from datetime import timedelta
-from numbers import Number
 
 from airflow.exceptions import AirflowException, AirflowSensorTimeout, \
     AirflowSkipException, AirflowRescheduleException
@@ -71,10 +70,10 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                  *args,
                  **kwargs):
         super(BaseSensorOperator, self).__init__(*args, **kwargs)
-        if not isinstance(poke_interval, Number) or poke_interval < 0:
+        if not isinstance(poke_interval, (int, float)) or poke_interval < 0:
             raise AirflowException(
                 "The poke_interval must be a non-negative number")
-        if not isinstance(timeout, Number) or timeout < 0:
+        if not isinstance(timeout, (int, float)) or timeout < 0:
             raise AirflowException(
                 "The timeout must be a non-negative number")
         self.poke_interval = poke_interval

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -70,23 +70,26 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                  *args,
                  **kwargs):
         super(BaseSensorOperator, self).__init__(*args, **kwargs)
-        if not isinstance(poke_interval, (int, float)) or poke_interval < 0:
-            raise AirflowException(
-                "The poke_interval must be a non-negative number")
-        if not isinstance(timeout, (int, float)) or timeout < 0:
-            raise AirflowException(
-                "The timeout must be a non-negative number")
         self.poke_interval = poke_interval
         self.soft_fail = soft_fail
         self.timeout = timeout
-        if mode not in self.valid_modes:
-            raise AirflowException(
-                "The mode must be one of {valid_modes},"
-                "'{d}.{t}'; received '{m}'."
-                .format(valid_modes=self.valid_modes,
-                        d=self.dag.dag_id if self.dag else "",
-                        t=self.task_id, m=mode))
         self.mode = mode
+        self._validate_inputs()
+
+    def _validate_inputs(self):
+            if not isinstance(self.poke_interval, (int, float)) or self.poke_interval < 0:
+                raise AirflowException(
+                    "The poke_interval must be a non-negative number")
+            if not isinstance(self.timeout, (int, float)) or self.timeout < 0:
+                raise AirflowException(
+                    "The timeout must be a non-negative number")
+            if self.mode not in self.valid_modes:
+                raise AirflowException(
+                    "The mode must be one of {valid_modes},"
+                    "'{d}.{t}'; received '{m}'."
+                    .format(valid_modes=self.valid_modes,
+                        d=self.dag.dag_id if self.dag else "",
+                        t=self.task_id, m=self.mode))
 
     def poke(self, context):
         """

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -74,9 +74,9 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         self.soft_fail = soft_fail
         self.timeout = timeout
         self.mode = mode
-        self._validate_inputs()
+        self.validate_inputs()
 
-    def _validate_inputs(self):
+    def validate_inputs(self):
         if not isinstance(self.poke_interval, (int, float)) or self.poke_interval < 0:
             raise AirflowException(
                 "The poke_interval must be a non-negative number")

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -70,12 +70,12 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                  *args,
                  **kwargs):
         super(BaseSensorOperator, self).__init__(*args, **kwargs)
-        if poke_interval < 0:
+        if not isinstance(poke_interval, int) or poke_interval < 0:
             raise AirflowException(
-                "The poke_interval must be a non-negative number")
-        if timeout < 0:
+                "The poke_interval must be a non-negative integer")
+        if not isinstance(timeout, int) or timeout < 0:
             raise AirflowException(
-                "The timeout must be a non-negative number")
+                "The timeout must be a non-negative integer")
         self.poke_interval = poke_interval
         self.soft_fail = soft_fail
         self.timeout = timeout

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -470,12 +470,12 @@ class BaseSensorTest(unittest.TestCase):
         non_number_poke_interval = "abcd"
         positive_poke_interval = 10
         with self.assertRaises(AirflowException):
-            sensor = self._make_sensor(
+            self._make_sensor(
                 return_value=None,
                 poke_interval=negative_poke_interval,
                 timeout=25)
 
-            sensor = self._make_sensor(
+            self._make_sensor(
                 return_value=None,
                 poke_interval=non_number_poke_interval,
                 timeout=25)
@@ -490,12 +490,12 @@ class BaseSensorTest(unittest.TestCase):
         non_number_timeout = "abcd"
         positive_timeout = 25
         with self.assertRaises(AirflowException):
-            sensor = self._make_sensor(
+            self._make_sensor(
                 return_value=None,
                 poke_interval=10,
                 timeout=negative_timeout)
 
-            sensor = self._make_sensor(
+            self._make_sensor(
                 return_value=None,
                 poke_interval=10,
                 timeout=non_number_timeout)

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -484,6 +484,7 @@ class BaseSensorTest(unittest.TestCase):
             return_value=None,
             poke_interval=positive_poke_interval,
             timeout=25)
+        del sensor
 
     def test_sensor_with_invalid_timeout(self):
         negative_timeout = -25
@@ -504,3 +505,4 @@ class BaseSensorTest(unittest.TestCase):
             return_value=None,
             poke_interval=10,
             timeout=positive_timeout)
+        del sensor

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -475,6 +475,7 @@ class BaseSensorTest(unittest.TestCase):
                 poke_interval=negative_poke_interval,
                 timeout=25)
 
+        with self.assertRaises(AirflowException):
             self._make_sensor(
                 return_value=None,
                 poke_interval=non_number_poke_interval,
@@ -495,6 +496,7 @@ class BaseSensorTest(unittest.TestCase):
                 poke_interval=10,
                 timeout=negative_timeout)
 
+        with self.assertRaises(AirflowException):
             self._make_sensor(
                 return_value=None,
                 poke_interval=10,

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -465,30 +465,42 @@ class BaseSensorTest(unittest.TestCase):
             if ti.task_id == DUMMY_OP:
                 self.assertEqual(ti.state, State.NONE)
 
-    def test_sensor_with_negetive_poke_interval(self):
+    def test_sensor_with_invalid_poke_interval(self):
         negative_poke_interval = -10
+        non_number_poke_interval = "abcd"
         positive_poke_interval = 10
         with self.assertRaises(AirflowException):
             sensor = self._make_sensor(
                 return_value=None,
                 poke_interval=negative_poke_interval,
                 timeout=25)
+
+            sensor = self._make_sensor(
+                return_value=None,
+                poke_interval=non_number_poke_interval,
+                timeout=25)
+
         sensor = self._make_sensor(
             return_value=None,
             poke_interval=positive_poke_interval,
             timeout=25)
-        self.assertEqual(sensor.poke_interval, positive_poke_interval)
 
-    def test_sensor_with_negetive_timeout(self):
+    def test_sensor_with_invalid_timeout(self):
         negative_timeout = -25
+        non_number_timeout = "abcd"
         positive_timeout = 25
         with self.assertRaises(AirflowException):
             sensor = self._make_sensor(
                 return_value=None,
                 poke_interval=10,
                 timeout=negative_timeout)
+
+            sensor = self._make_sensor(
+                return_value=None,
+                poke_interval=10,
+                timeout=non_number_timeout)
+
         sensor = self._make_sensor(
             return_value=None,
             poke_interval=10,
             timeout=positive_timeout)
-        self.assertEqual(sensor.timeout, positive_timeout)

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -474,9 +474,9 @@ class BaseSensorTest(unittest.TestCase):
                 poke_interval=negative_poke_interval,
                 timeout=25)
         sensor = self._make_sensor(
-                return_value=None,
-                poke_interval=positive_poke_interval,
-                timeout=25)
+            return_value=None,
+            poke_interval=positive_poke_interval,
+            timeout=25)
         self.assertEqual(sensor.poke_interval, positive_poke_interval)
 
     def test_sensor_with_negetive_timeout(self):
@@ -488,7 +488,7 @@ class BaseSensorTest(unittest.TestCase):
                 poke_interval=10,
                 timeout=negative_timeout)
         sensor = self._make_sensor(
-                return_value=None,
-                poke_interval=10,
-                timeout=positive_timeout)
+            return_value=None,
+            poke_interval=10,
+            timeout=positive_timeout)
         self.assertEqual(sensor.timeout, positive_timeout)

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -480,11 +480,10 @@ class BaseSensorTest(unittest.TestCase):
                 poke_interval=non_number_poke_interval,
                 timeout=25)
 
-        sensor = self._make_sensor(
+        self._make_sensor(
             return_value=None,
             poke_interval=positive_poke_interval,
             timeout=25)
-        del sensor
 
     def test_sensor_with_invalid_timeout(self):
         negative_timeout = -25
@@ -501,8 +500,7 @@ class BaseSensorTest(unittest.TestCase):
                 poke_interval=10,
                 timeout=non_number_timeout)
 
-        sensor = self._make_sensor(
+        self._make_sensor(
             return_value=None,
             poke_interval=10,
             timeout=positive_timeout)
-        del sensor

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -464,3 +464,31 @@ class BaseSensorTest(unittest.TestCase):
                 self.assertEqual(len(task_reschedules), 0)
             if ti.task_id == DUMMY_OP:
                 self.assertEqual(ti.state, State.NONE)
+
+    def test_sensor_with_negetive_poke_interval(self):
+        negative_poke_interval = -10
+        positive_poke_interval = 10
+        with self.assertRaises(AirflowException):
+            sensor = self._make_sensor(
+                return_value=None,
+                poke_interval=negative_poke_interval,
+                timeout=25)
+        sensor = self._make_sensor(
+                return_value=None,
+                poke_interval=positive_poke_interval,
+                timeout=25)
+        self.assertEqual(sensor.poke_interval, positive_poke_interval)
+
+    def test_sensor_with_negetive_timeout(self):
+        negative_timeout = -25
+        positive_timeout = 25
+        with self.assertRaises(AirflowException):
+            sensor = self._make_sensor(
+                return_value=None,
+                poke_interval=10,
+                timeout=negative_timeout)
+        sensor = self._make_sensor(
+                return_value=None,
+                poke_interval=10,
+                timeout=positive_timeout)
+        self.assertEqual(sensor.timeout, positive_timeout)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4046
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`