### PR TITLE
[AIRFLOW-4052] Allow filtering using "event" and "owner" in "Log" view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2277,7 +2277,7 @@ class LogModelView(AirflowModelView):
 
     list_columns = ['id', 'dttm', 'dag_id', 'task_id', 'event', 'execution_date',
                     'owner', 'extra']
-    search_columns = ['dag_id', 'task_id', 'execution_date', 'extra']
+    search_columns = ['dag_id', 'task_id', 'event', 'execution_date', 'owner', 'extra']
 
     base_order = ('dttm', 'desc')
 


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-4052

### Description

In the RBAC UI, users can check Logs ("Browse" -> "Logs"). But they could only use "dag_id", "task_id", "execution_date", or "extra" to filter.

**Before This Change:**
![screen shot 2019-03-08 at 5 50 58 pm](https://user-images.githubusercontent.com/11539188/54032356-52474300-41ec-11e9-8f07-adb1d4836822.png)

However, filtering using "event" and "owner" will be very useful (to allow users to check specific events that happened, or check what a specific user did).

In this PR, "event" and "owner" are added into `search_columns`.

**After This Change:**
<img width="1184" alt="screen shot 2019-03-08 at 10 00 26 pm" src="https://user-images.githubusercontent.com/11539188/54032855-ba4a5900-41ed-11e9-8ed4-8dcbc587e664.png">

