### PR TITLE
[AIRFLOW-4053] Fix KubePodOperator Xcom on Kube 1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 sudo: true
-dist: trusty
+dist: xenial
 language: python
 python:
   - "3.6"
@@ -33,7 +33,7 @@ env:
     - TOX_ENV=py35-backend_sqlite-env_docker PYTHON_VERSION=3
     - TOX_ENV=py35-backend_postgres-env_docker PYTHON_VERSION=3
     - TOX_ENV=py27-backend_postgres-env_kubernetes KUBERNETES_VERSION=v1.9.0
-    - TOX_ENV=py35-backend_postgres-env_kubernetes KUBERNETES_VERSION=v1.10.0 PYTHON_VERSION=3
+    - TOX_ENV=py35-backend_postgres-env_kubernetes KUBERNETES_VERSION=v1.13.0 PYTHON_VERSION=3
 
 stages:
   - pre-test

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
@@ -89,7 +89,16 @@ spec:
           mountPath: {xcomMountPath}
     - name: {sidecarContainerName}
       image: python:3.5-alpine
-      command: ["python", "-m", "http.server"]
+      command:
+        - python
+        - -c
+        - |
+            import time
+            while True:
+                try:
+                    time.sleep(3600)
+                except KeyboardInterrupt:
+                    exit(0)
       volumeMounts:
         - name: xcom
           mountPath: {xcomMountPath}

--- a/scripts/ci/kubernetes/minikube/start_minikube.sh
+++ b/scripts/ci/kubernetes/minikube/start_minikube.sh
@@ -25,7 +25,7 @@ _MY_SCRIPT="${BASH_SOURCE[0]}"
 _MY_DIR=$(cd "$(dirname "$_MY_SCRIPT")" && pwd)
 # Avoids 1.7.x because of https://github.com/kubernetes/minikube/issues/2240
 _KUBERNETES_VERSION="${KUBERNETES_VERSION}"
-_MINIKUBE_VERSION="${MINIKUBE_VERSION:-v0.28.2}"
+_MINIKUBE_VERSION="${MINIKUBE_VERSION:-v0.34.1}"
 
 echo "setting up kubernetes ${_KUBERNETES_VERSION}, using minikube ${_MINIKUBE_VERSION}"
 
@@ -105,9 +105,12 @@ echo "your path is ${PATH}"
 
 _MINIKUBE="sudo -E PATH=$PATH minikube"
 
-$_MINIKUBE config set bootstrapper localkube
 $_MINIKUBE start --kubernetes-version=${_KUBERNETES_VERSION} --vm-driver=${_VM_DRIVER}
 $_MINIKUBE update-context
+
+if [[ "${TRAVIS}" == true ]]; then
+  sudo chown -R travis.travis $HOME/.kube $HOME/.minikube
+fi
 
 # Wait for Kubernetes to be up and ready.
 k8s_single_node_ready

--- a/scripts/ci/kubernetes/minikube/stop_minikube.sh
+++ b/scripts/ci/kubernetes/minikube/stop_minikube.sh
@@ -34,6 +34,9 @@ sudo minikube status
 if [[ $? = 0 ]]; then
   sudo minikube delete
   sudo rm -rf HOME/.kube $HOME/.minikube
+  if [[ "${TRAVIS}" == true ]]; then
+    sudo rm -rf /etc/kubernetes/*.conf
+  fi
 fi
 
 sudo chown -R travis.travis .


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### Jira
https://issues.apache.org/jira/browse/AIRFLOW-4053

### Description

Newer versions of Kube return "failed" events for the side car container
when the ^C causes the python process to exit with 1

Kube 1.13 runs a different number of kube-dns pods (2 by default, 1.9
and 1.10 ran only 1) so the setup scripts needed changing a little bit.

To get a Kube 1.13 cluster I had to upgrade minikube, and it no longer
works on a dist without systemd installed (#systemdsucks) so I had to
update the travis dist to xenial which is no bad thing!

(This version of minikube doesn't need the localkube bootstrapper set
anymore, it handles driver=none much more gracefully)


### Tests

- [x] Existing tests good enough, and still pass

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- None

### Code Quality

- [x] Passes `flake8`
