### PR TITLE
[AIRFLOW-4054] Fix assertEqualIgnoreMultipleSpaces util and add tests

### DIFF
--- a/tests/utils/test_tests.py
+++ b/tests/utils/test_tests.py
@@ -17,23 +17,32 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import re
 import unittest
+from airflow.utils.tests import assertEqualIgnoreMultipleSpaces
+from contextlib import contextmanager
 
 
-def skipUnlessImported(module, obj):
-    import importlib
-    try:
-        m = importlib.import_module(module)
-    except ImportError:
-        m = None
-    return unittest.skipUnless(
-        obj in dir(m),
-        "Skipping test because {} could not be imported from {}".format(
-            obj, module))
+class UtilsTestsTest(unittest.TestCase):
 
+    @contextmanager
+    def assertNotRaises(self, error_type):
+        try:
+            yield None
+        except error_type:
+            raise self.failureException('{} raised'.format(error_type.__name__))
 
-def assertEqualIgnoreMultipleSpaces(case, first, second, msg=None):
-    def _trim(s):
-        return re.sub(r"\s+", " ", s.strip())
-    return case.assertEqual(_trim(first), _trim(second), msg)
+    def test_assertEqualIgnoreMultipleSpaces_raises(self):
+        str1 = 'w oo f'
+        str2 = 'meow'
+
+        self.assertRaises(AssertionError, lambda: assertEqualIgnoreMultipleSpaces(self, str1, str2))
+
+    def test_assertEqualIgnoreMultipleSpaces_passes(self):
+        str1 = 'w oo f'
+        str2 = """
+            w
+            oo    f
+        """
+
+        with self.assertNotRaises(AssertionError):
+            assertEqualIgnoreMultipleSpaces(self, str1, str2)

--- a/tests/utils/test_tests.py
+++ b/tests/utils/test_tests.py
@@ -19,17 +19,9 @@
 
 import unittest
 from airflow.utils.tests import assertEqualIgnoreMultipleSpaces
-from contextlib import contextmanager
 
 
 class UtilsTestsTest(unittest.TestCase):
-
-    @contextmanager
-    def assertNotRaises(self, error_type):
-        try:
-            yield None
-        except error_type:
-            raise self.failureException('{} raised'.format(error_type.__name__))
 
     def test_assertEqualIgnoreMultipleSpaces_raises(self):
         str1 = 'w oo f'
@@ -44,5 +36,4 @@ class UtilsTestsTest(unittest.TestCase):
             oo    f
         """
 
-        with self.assertNotRaises(AssertionError):
-            assertEqualIgnoreMultipleSpaces(self, str1, str2)
+        assertEqualIgnoreMultipleSpaces(self, str1, str2)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4054
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description

`assertEqualIgnoreMultipleSpaces` util doesn't have tests, but is used in multiple tests: https://github.com/apache/airflow/search?q=assertEqualIgnoreMultipleSpaces&unscoped_q=assertEqualIgnoreMultipleSpaces

It compares two strings after trimming white spaces. Currently assertion passes even when strings are different. Reason is that `_trim(s)` method doesn't have a return statement, therefore returning `None` for both first and second trimmed strings.

```
def assertEqualIgnoreMultipleSpaces(case, first, second, msg=None):
	def _trim(s):
	        re.sub(r"\s+", " ", s.strip())
	return case.assertEqual(_trim(first), _trim(second), msg)
 ```

Is causes `assertEqual` compare `None` with `None`, therefore forcing assertion `assertEqualIgnoreMultipleSpaces` to pass.

Code change is:

```
def assertEqualIgnoreMultipleSpaces(case, first, second, msg=None):
	def _trim(s):
	        return re.sub(r"\s+", " ", s.strip())
	return case.assertEqual(_trim(first), _trim(second), msg)
 ```

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

* Test that `assertEqualIgnoreMultipleSpaces` passes when strings are equal after trimming white space
* Test that `assertEqualIgnoreMultipleSpaces` throws `AssertionError` when strings are not equal after trimming white space

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
