### PR TITLE
[AIRFLOW-4048] HttpSensor provide-context to response_check

### DIFF
--- a/airflow/sensors/http_sensor.py
+++ b/airflow/sensors/http_sensor.py
@@ -31,6 +31,15 @@ class HttpSensor(BaseSensorOperator):
     HTTP Error codes other than 404 (like 403) or Connection Refused Error
     would fail the sensor itself directly (no more poking).
 
+    The response check can access the template context by passing ``provide_context=True`` to the operator::
+
+        def response_check(response, **context):
+            # Can look at context['ti'] etc.
+            return True
+
+        HttpSensor(task_id='my_http_sensor', ..., provide_context=True, response_check=response_check)
+
+
     :param http_conn_id: The connection to run the sensor against
     :type http_conn_id: str
     :param method: The HTTP request method to use
@@ -41,6 +50,12 @@ class HttpSensor(BaseSensorOperator):
     :type request_params: a dictionary of string key/value pairs
     :param headers: The HTTP headers to be added to the GET request
     :type headers: a dictionary of string key/value pairs
+    :param provide_context: if set to true, Airflow will pass a set of
+        keyword arguments that can be used in your function. This set of
+        kwargs correspond exactly to what you can use in your jinja
+        templates. For this to work, you need to define context in your
+        function header.
+    :type provide_context: bool
     :param response_check: A check against the 'requests' response object.
         Returns True for 'pass' and False otherwise.
     :type response_check: A lambda or defined function.
@@ -60,6 +75,7 @@ class HttpSensor(BaseSensorOperator):
                  request_params=None,
                  headers=None,
                  response_check=None,
+                 provide_context=False,
                  extra_options=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.endpoint = endpoint
@@ -68,6 +84,7 @@ class HttpSensor(BaseSensorOperator):
         self.headers = headers or {}
         self.extra_options = extra_options or {}
         self.response_check = response_check
+        self.provide_context = provide_context
 
         self.hook = HttpHook(
             method=method,
@@ -81,8 +98,10 @@ class HttpSensor(BaseSensorOperator):
                                      headers=self.headers,
                                      extra_options=self.extra_options)
             if self.response_check:
-                # run content check on response
-                return self.response_check(response)
+                if self.provide_context:
+                    return self.response_check(response, **context)
+                else:
+                    return self.response_check(response)
         except AirflowException as ae:
             if str(ae).startswith("404"):
                 return False


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4048

### Description

- The httpSensor do not make any use of the context inside the poke function , also sensors frequently  need execution context to evaluate the response inside the response_check function.

By example a HttpSensor looking for availability of data thank to an API , is going to need the context["execution_date"] to compare the date of data availability.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
