### PR TITLE
[DRAFT] [AIRFLOW-3891] Make the Graph View time-zone aware

### DIFF
--- a/airflow/www/static/js/base.js
+++ b/airflow/www/static/js/base.js
@@ -17,21 +17,48 @@
  * under the License.
  */
 
-import {defaultFormatWithTZ, moment} from './datetime-utils';
+import { defaultFormatWithTZ, formatDateStr, moment } from './datetime-utils';
+
+
+const getSelectedTimeZone = () => {
+  return $('#clock').data('selected-tz')
+};
+
+export const formatInSelectedTz = (dateString) => {
+  let tz = getSelectedTimeZone();
+  return formatDateStr(dateString, tz);
+};
 
 function displayTime() {
-  let utcTime = moment().utc().format(defaultFormatWithTZ);
-  $('#clock')
+  let $clock = $('#clock');
+  let tz = $clock.data('selected-tz');
+  $clock
     .attr("data-original-title", function() {
       return hostName
     })
-    .html(utcTime);
+    .text(moment().tz(tz).format(defaultFormatWithTZ));
 
   setTimeout(displayTime, 1000);
 }
 
 $(document).ready(function () {
-  displayTime();
+  $("#tz-picker li").click(function(e) {
+    let tz = $(this).text() == 'Local' ? moment.tz.guess() : 'UTC';
+    $('.tz-aware').each(function() {
+      $(this).trigger('tz-changed', tz);
+    })
+  });
+
+  $('#clock').on('tz-changed', function(event, tz) {
+    $(this).data('selected-tz', tz);
+    displayTime();
+  });
+
+  // Initialize default time zone and start clock
+  $('.tz-aware').each(function() {
+    $(this).trigger('tz-changed', 'UTC');
+  })
+
   $('span').tooltip();
   $.ajaxSetup({
     beforeSend: function(xhr, settings) {

--- a/airflow/www/static/js/datetime-utils.js
+++ b/airflow/www/static/js/datetime-utils.js
@@ -52,15 +52,13 @@ export const generateTooltipDateTime = (startDate, endDate, dagTZ) => {
   return tooltipHTML
 };
 
-
-export const converAndFormatUTC = (datetime, tz) => {
-  let dateTimeObj = moment.utc(datetime);
-  if (tz) dateTimeObj = dateTimeObj.tz(tz);
+export const formatDateStr = (dateString, tz) => {
+  let dateTimeObj = moment(dateString).tz(tz);
   return dateTimeObj.format(defaultFormatWithTZ)
-}
+};
 
 export const secondsToString = (seconds) => {
-  let numdays    = Math.floor((seconds % 31536000) / 86400); 
+  let numdays    = Math.floor((seconds % 31536000) / 86400);
   let numhours   = Math.floor(((seconds % 31536000) % 86400) / 3600);
   let numminutes = Math.floor((((seconds % 31536000) % 86400) % 3600) / 60);
   let numseconds = Math.floor((((seconds % 31536000) % 86400) % 3600) % 60);
@@ -68,4 +66,4 @@ export const secondsToString = (seconds) => {
          (numhours > 0   ? numhours   + (numhours   === 1 ? " hour "   : " hours ")   : "") +
          (numminutes > 0 ? numminutes + (numminutes === 1 ? " minute " : " minutes ") : "") +
          (numseconds > 0 ? numseconds + (numseconds === 1 ? " second"  : " seconds")  : "");
-}
+};

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -17,11 +17,11 @@
  * under the License.
  */
 
-import { generateTooltipDateTime, converAndFormatUTC, secondsToString } from './datetime-utils';
+import { generateTooltipDateTime, moment, formatDateStr, secondsToString } from './datetime-utils';
 
 // Assigning css classes based on state to nodes
 // Initiating the tooltips
-function update_nodes_states(task_instances) {
+export const update_nodes_states = (task_instances, dag_tz) => {
   $.each(task_instances, function (task_id, ti) {
     $('tspan').filter(function (index) {
       return $(this).text() === task_id;
@@ -33,20 +33,20 @@ function update_nodes_states(task_instances) {
         // Tooltip
         const task = tasks[task_id];
         let tt = "Task_id: " + ti.task_id + "<br>";
-        tt += "Run: " + converAndFormatUTC(ti.execution_date) + "<br>";
+        tt += "Run: " + formatDateStr(ti.execution_date, 'UTC') + "<br>";
         if (ti.run_id != undefined) {
           tt += "run_id: <nobr>" + ti.run_id + "</nobr><br>";
         }
         tt += "Operator: " + task.task_type + "<br>";
         tt += "Duration: " + secondsToString(ti.duration) + "<br>";
         tt += "State: " + ti.state + "<br>";
-        tt += generateTooltipDateTime(ti.start_date, ti.end_date, dagTZ); // dagTZ has been defined in dag.html
+        tt += generateTooltipDateTime(ti.start_date, ti.end_date, dag_tz);
         return tt;
       });
   });
 }
 
-function initRefreshButton() {
+export const initRefreshButton = (dagTz) => {
   d3.select("#refresh_button").on("click",
     function () {
       $("#loading").css("display", "block");
@@ -54,21 +54,79 @@ function initRefreshButton() {
       $.get(getTaskInstanceURL)
         .done(
           function (task_instances) {
-            update_nodes_states(JSON.parse(task_instances));
+            update_nodes_states(JSON.parse(task_instances), dagTz);
             $("#loading").hide();
             $("div#svg_container").css("opacity", "1");
             $('#error').hide();
           }
         ).fail(function (jqxhr, textStatus, err) {
-        $('#error_msg').html(textStatus + ': ' + err);
-        $('#error').show();
-        $('#loading').hide();
-        $('#chart_section').hide(1000);
-        $('#datatable_section').hide(1000);
-      });
+          $('#error_msg').html(textStatus + ': ' + err);
+          $('#error').show();
+          $('#loading').hide();
+          $('#chart_section').hide(1000);
+          $('#datatable_section').hide(1000);
+        });
     }
   );
 }
 
-initRefreshButton();
-update_nodes_states(task_instances);
+const localizeExecutionDate = (option, tz) => {
+  let ts = moment(option.val()).tz(tz);
+  const prefixes = ["scheduled__", "backfill_", "manual__"];
+  prefixes.forEach(function(prefix) {
+    if (option.text().startsWith(prefix)) {
+      option.text(prefix + ts.format());
+    }
+  });
+}
+
+const getNaiveDateString = (picker) => {
+  return moment(picker.getDate()).utc().format('YYYY-MM-DD HH:mm');
+}
+
+const getSelectedTz = () => {
+  return $('#datetimepicker').data('current-tz');
+}
+
+const getBaseDateInUtc = () => {
+  let picker = $('#datetimepicker').data('datetimepicker');
+  let dateString = getNaiveDateString(picker);
+  let utcTime = moment.tz(dateString, getSelectedTz()).utc();
+  return utcTime;
+}
+
+$(document).ready(function () {
+  let queryParams = new URLSearchParams(window.location.search)
+  let baseDateString = queryParams.get('base_date');
+  let baseDate = baseDateString ? moment.tz(baseDateString, 'UTC') : moment().utc();
+  $('#datetimepicker')
+    .data('current-tz', 'UTC')
+    .datetimepicker('setDate', baseDate.toDate());
+
+  $('select#execution_date').on('tz-changed', function(event, tz) {
+    $(this).children('option').each(function (i) {
+      localizeExecutionDate($(this), tz);
+    });
+  });
+
+  $('#datetimepicker')
+    .addClass('tz-aware')
+    .on('tz-changed', function(event, tz) {
+      let oldTz = $(this).data('current-tz') || 'UTC';
+      $(this).data('current-tz', tz);
+
+      let picker = $(this).data('datetimepicker');
+      let inTargetTz = moment.tz(getNaiveDateString(picker), oldTz).tz(tz);
+      let naiveDateStrInTargetTz = inTargetTz.format('YYYY-MM-DD HH:mm');
+
+      let actualDate = moment.tz(naiveDateStrInTargetTz, tz);
+      let adjustedDisplayDate = moment.tz(naiveDateStrInTargetTz, 'UTC');
+      $(this).data('utc-time', actualDate.utc());
+
+      picker.setDate(adjustedDisplayDate);
+    });
+
+  $("form").on('submit', function(event) {
+    $('#base_date').val(getBaseDateInUtc().format());
+  });
+});

--- a/airflow/www/static/js/index.js
+++ b/airflow/www/static/js/index.js
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { formatInSelectedTz } from './base';
+export { initRefreshButton, update_nodes_states } from './graph';

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -291,6 +291,7 @@
 {% block tail %}
   {{ super() }}
   <script src="{{ url_for_asset('bootstrap-toggle.min.js') }}"></script>
+  <script src="{{ url_for_asset('index.js') }}"></script>
   <script>
 function updateQueryStringParameter(uri, key, value) {
   var re = new RegExp("([?&])" + key + "=.*?(&|$)", "i");
@@ -311,7 +312,6 @@ function updateQueryStringParameter(uri, key, value) {
 
     var id = '';
     var dag_id = '{{ dag.dag_id }}';
-    var dagTZ = '{{ dag.timezone.name }}'; // Being used in datetime-utils.js
     var task_id = '';
     var exection_date = '';
     var subdag_id = '';
@@ -435,7 +435,8 @@ function updateQueryStringParameter(uri, key, value) {
       subdag_id = sd;
       execution_date = d;
       $('#task_id').html(t);
-      $('#execution_date').html(d);
+      let in_selected_tz = AirflowUI.formatInSelectedTz(d);
+      $('#execution_date').html(in_selected_tz);
       $('#myModal').modal({});
       $("#myModal").css("margin-top","0px")
       if (subdag_id === undefined)

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -32,10 +32,10 @@
 <div class="form-inline">
   <form method="get" style="float:left;">
     {{ state_token }}
-    Base date: {{ form.base_date(class_="form-control") }}
+    Base date: {{ form.base_date(class_="form-control tz-aware") }}
     Number of runs: {{ form.num_runs(class_="form-control") }}
     Run:
-    {{ form.execution_date(class_="form-control") | safe }}
+    {{ form.execution_date(class_="form-control tz-aware") | safe }}
     Layout:
     {{ form.arrange(class_="form-control") | safe }}
     <input type="hidden" name="root" value="{{ root }}">
@@ -362,6 +362,15 @@
 
 </script>
 <script src="{{ url_for_asset('graph.js') }}"></script>
+<script src="{{ url_for_asset('index.js') }}"></script>
+<script type="text/javascript">
+  let dagTz = '{{ dag.timezone.name }}';
+
+  window.onload = function() {
+      AirflowUI.initRefreshButton(dagTz);
+      AirflowUI.update_nodes_states(task_instances, dagTz);
+  }
+</script>
 
 
 {% endblock %}

--- a/airflow/www/templates/appbuilder/navbar_right.html
+++ b/airflow/www/templates/appbuilder/navbar_right.html
@@ -45,7 +45,17 @@
 {% endmacro %}
 
 <!-- clock -->
-<li><a id="clock"></a></li>
+<li class="dropdown">
+    <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+        <text id="clock" class="tz-aware"></text><b class="caret"></b>
+    </a>
+
+    <ul id="tz-picker" class="dropdown-menu">
+      <li>UTC</li>
+      <li>Local</li>
+    </ul>
+</li>
+
 
 {% if not current_user.is_anonymous %}
     <li class="dropdown">

--- a/airflow/www/webpack.config.js
+++ b/airflow/www/webpack.config.js
@@ -38,6 +38,7 @@ const config = {
     base: `${STATIC_DIR}/js/base.js`,
     graph: `${STATIC_DIR}/js/graph.js`,
     ganttChartD3v2: `${STATIC_DIR}/js/gantt-chart-d3v2.js`,
+    index: `${STATIC_DIR}/js/index.js`,
     main: `${STATIC_DIR}/css/main.css`,
     airflowDefaultTheme: `${STATIC_DIR}/css/bootstrap-theme.css`,
   },
@@ -45,6 +46,7 @@ const config = {
     path: BUILD_DIR,
     filename: '[name].[chunkhash].js',
     chunkFilename: '[name].[chunkhash].js',
+    library: 'AirflowUI',
   },
   resolve: {
     extensions: [


### PR DESCRIPTION
Note: this PR isn't fit to be merged, as it only addresses the Graph
view page. I'm sharing this for early review to make sure it's on the
right track. If there are no major objections to this approach, then
I'll apply similar changes to the other views.

Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3891
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:


The clock element in the navbar is now a drop-down that allows time-zone
selection from two options: 'UTC' or 'Local' (the browser default). The
default is UTC, and this selection does not persist across page
refreshes. I'm open to suggestions here on whether the time-zone
selection should be "sticky", and if so, what's the right way to make it
so.

The `Base date:` datetimepicker requires a bit of hackery, since the
datetimepicker element bundled with Flask-AppBuilder doesn't seem to
have time zone support (see [1]). To work around this, we have to add an
offset to the (UTC) value in the picker so that the date string
displayed in the picker appears to be in the selected time zone, then
subtract the offset when we read the actual (UTC) value from the picker.

[1] https://github.com/dpgaspar/Flask-AppBuilder/issues/920


### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Front-end changes only

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ X ] Passes `flake8`
