### PR TITLE
[AIRFLOW-1526] Add dingding hook and operator

### DIFF
--- a/airflow/contrib/example_dags/example_dingding_operator.py
+++ b/airflow/contrib/example_dags/example_dingding_operator.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import timedelta
+
+import airflow
+from airflow.contrib.operators.dingding_operator import DingdingOperator
+from airflow.models import DAG
+
+args = {
+    'owner': 'airflow',
+    'retries': 3,
+    'start_date': airflow.utils.dates.days_ago(2),
+}
+
+
+# [START howto_operator_dingding_failure_callback]
+def failure_callback(context):
+    message = 'AIRFLOW TASK FAILURE TIPS:\n' \
+              'DAG:    {}\n' \
+              'TASKS:  {}\n' \
+              'Reason: {}\n' \
+        .format(context['task_instance'].dag_id,
+                context['task_instance'].task_id,
+                context['exception'])
+    return DingdingOperator(
+        task_id='dingding_success_callback',
+        dingding_conn_id='dingding_default',
+        message_type='text',
+        message=message,
+        at_all=True,
+    ).execute(context)
+
+
+args['on_failure_callback'] = failure_callback
+# [END howto_operator_dingding_failure_callback]
+
+dag = DAG(
+    dag_id='example_dingding_operator',
+    default_args=args,
+    schedule_interval='@once',
+    dagrun_timeout=timedelta(minutes=60),
+)
+
+# [START howto_operator_dingding]
+text_msg_remind_none = DingdingOperator(
+    task_id='text_msg_remind_none',
+    dingding_conn_id='dingding_default',
+    message_type='text',
+    message='Airflow dingding text message remind none',
+    at_mobiles=None,
+    at_all=False,
+    dag=dag,
+)
+# [END howto_operator_dingding]
+
+text_msg_remind_specific = DingdingOperator(
+    task_id='text_msg_remind_specific',
+    dingding_conn_id='dingding_default',
+    message_type='text',
+    message='Airflow dingding text message remind specific users',
+    at_mobiles=['156XXXXXXXX', '130XXXXXXXX'],
+    at_all=False,
+    dag=dag,
+)
+
+text_msg_remind_include_invalid = DingdingOperator(
+    task_id='text_msg_remind_include_invalid',
+    dingding_conn_id='dingding_default',
+    message_type='text',
+    message='Airflow dingding text message remind users including invalid',
+    # 123 is invalid user or user not in the group
+    at_mobiles=['156XXXXXXXX', '123'],
+    at_all=False,
+    dag=dag,
+)
+
+# [START howto_operator_dingding_remind_users]
+text_msg_remind_all = DingdingOperator(
+    task_id='text_msg_remind_all',
+    dingding_conn_id='dingding_default',
+    message_type='text',
+    message='Airflow dingding text message remind all users in group',
+    # list of user phone/email here in the group
+    # when at_all is specific will cover at_mobiles
+    at_mobiles=['156XXXXXXXX', '130XXXXXXXX'],
+    at_all=True,
+    dag=dag,
+)
+# [END howto_operator_dingding_remind_users]
+
+link_msg = DingdingOperator(
+    task_id='link_msg',
+    dingding_conn_id='dingding_default',
+    message_type='link',
+    message={
+        'title': 'Airflow dingding link message',
+        'text': 'Airflow official documentation link',
+        'messageUrl': 'http://airflow.apache.org',
+        'picURL': 'http://airflow.apache.org/_images/pin_large.png'
+    },
+    dag=dag,
+)
+
+# [START howto_operator_dingding_rich_text]
+markdown_msg = DingdingOperator(
+    task_id='markdown_msg',
+    dingding_conn_id='dingding_default',
+    message_type='markdown',
+    message={
+        'title': 'Airflow dingding markdown message',
+        'text': '# Markdown message title\n'
+                'content content .. \n'
+                '### sub-title\n'
+                '![logo](http://airflow.apache.org/_images/pin_large.png)'
+    },
+    at_mobiles=['156XXXXXXXX'],
+    at_all=False,
+    dag=dag,
+)
+# [END howto_operator_dingding_rich_text]
+
+single_action_card_msg = DingdingOperator(
+    task_id='single_action_card_msg',
+    dingding_conn_id='dingding_default',
+    message_type='actionCard',
+    message={
+        'title': 'Airflow dingding single actionCard message',
+        'text': 'Airflow dingding single actionCard message\n'
+                '![logo](http://airflow.apache.org/_images/pin_large.png)\n'
+                'This is a official logo in Airflow website.',
+        'hideAvatar': '0',
+        'btnOrientation': '0',
+        'singleTitle': 'read more',
+        'singleURL': 'http://airflow.apache.org'
+    },
+    dag=dag,
+)
+
+multi_action_card_msg = DingdingOperator(
+    task_id='multi_action_card_msg',
+    dingding_conn_id='dingding_default',
+    message_type='actionCard',
+    message={
+        'title': 'Airflow dingding multi actionCard message',
+        'text': 'Airflow dingding multi actionCard message\n'
+                '![logo](http://airflow.apache.org/_images/pin_large.png)\n'
+                'Airflow documentation and github',
+        'hideAvatar': '0',
+        'btnOrientation': '0',
+        'btns': [
+            {
+                'title': 'Airflow Documentation',
+                'actionURL': 'http://airflow.apache.org'
+            },
+            {
+                'title': 'Airflow Github',
+                'actionURL': 'https://github.com/apache/airflow'
+            }
+        ]
+    },
+    dag=dag,
+)
+
+feed_card_msg = DingdingOperator(
+    task_id='feed_card_msg',
+    dingding_conn_id='dingding_default',
+    message_type='feedCard',
+    message={
+        "links": [
+            {
+                "title": "Airflow DAG feed card",
+                "messageURL": "https://airflow.readthedocs.io/en/latest/ui.html",
+                "picURL": "http://airflow.apache.org/_images/dags.png"
+            },
+            {
+                "title": "Airflow tree feed card",
+                "messageURL": "https://airflow.readthedocs.io/en/latest/ui.html",
+                "picURL": "http://airflow.apache.org/_images/tree.png"
+            },
+            {
+                "title": "Airflow graph feed card",
+                "messageURL": "https://airflow.readthedocs.io/en/latest/ui.html",
+                "picURL": "http://airflow.apache.org/_images/graph.png"
+            }
+        ]
+    },
+    dag=dag,
+)
+
+msg_failure_callback = DingdingOperator(
+    task_id='msg_failure_callback',
+    dingding_conn_id='dingding_default',
+    message_type='not_support_msg_type',
+    message="",
+    dag=dag,
+)
+
+[
+    text_msg_remind_none,
+    text_msg_remind_specific,
+    text_msg_remind_include_invalid,
+    text_msg_remind_all
+] >> link_msg >> markdown_msg >> [
+    single_action_card_msg,
+    multi_action_card_msg
+] >> feed_card_msg >> msg_failure_callback

--- a/airflow/contrib/hooks/dingding_hook.py
+++ b/airflow/contrib/hooks/dingding_hook.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+
+import requests
+
+from airflow import AirflowException
+from airflow.hooks.http_hook import HttpHook
+
+
+class DingdingHook(HttpHook):
+    """
+    This hook allows you send Dingding message using Dingding custom bot.
+    Get Dingding token from conn_id.password. And prefer set domain to
+    conn_id.host, if not will use default ``https://oapi.dingtalk.com``.
+
+    For more detail message in
+    `Dingding custom bot <https://open-doc.dingtalk.com/microapp/serverapi2/qf2nxq>`_
+
+    :param dingding_conn_id: The name of the Dingding connection to use
+    :type dingding_conn_id: str
+    :param message_type: Message type you want to send to Dingding, support five type so far
+        including text, link, markdown, actionCard, feedCard
+    :type message_type: str
+    :param message: The message send to Dingding chat group
+    :type message: str or dict
+    :param at_mobiles: Remind specific users with this message
+    :type at_mobiles: list[str]
+    :param at_all: Remind all people in group or not. If True, will overwrite ``at_mobiles``
+    :type at_all: bool
+    """
+
+    def __init__(self,
+                 dingding_conn_id='dingding_default',
+                 message_type='text',
+                 message=None,
+                 at_mobiles=None,
+                 at_all=False,
+                 *args,
+                 **kwargs
+                 ):
+        super(DingdingHook, self).__init__(http_conn_id=dingding_conn_id, *args, **kwargs)
+        self.message_type = message_type
+        self.message = message
+        self.at_mobiles = at_mobiles
+        self.at_all = at_all
+
+    def _get_endpoint(self):
+        """
+        Get Dingding endpoint for sending message.
+        """
+        conn = self.get_connection(self.http_conn_id)
+        token = conn.password
+        if not token:
+            raise AirflowException('Dingding token is requests but get nothing, '
+                                   'check you conn_id configuration.')
+        return 'robot/send?access_token={}'.format(token)
+
+    def _build_message(self):
+        """
+        Build different type of Dingding message
+        As most commonly used type, text message just need post message content
+        rather than a dict like ``{'content': 'message'}``
+        """
+        if self.message_type in ['text', 'markdown']:
+            data = {
+                'msgtype': self.message_type,
+                self.message_type: {
+                    'content': self.message
+                } if self.message_type == 'text' else self.message,
+                'at': {
+                    'atMobiles': self.at_mobiles,
+                    'isAtAll': self.at_all
+                }
+            }
+        else:
+            data = {
+                'msgtype': self.message_type,
+                self.message_type: self.message
+            }
+        return json.dumps(data)
+
+    def get_conn(self, headers=None):
+        """
+        Overwrite HttpHook get_conn because just need base_url and headers and
+        not don't need generic params
+        :param headers: additional headers to be passed through as a dictionary
+        :type headers: dict
+        """
+        conn = self.get_connection(self.http_conn_id)
+        self.base_url = conn.host if conn.host else 'https://oapi.dingtalk.com'
+        session = requests.Session()
+        if headers:
+            session.headers.update(headers)
+        return session
+
+    def send(self):
+        """
+        Send Dingding message
+        """
+        support_type = ['text', 'link', 'markdown', 'actionCard', 'feedCard']
+        if self.message_type not in support_type:
+            raise ValueError('DingdingWebhookHook only support {} '
+                             'so far, but receive {}'.format(support_type, self.message_type))
+
+        data = self._build_message()
+        self.log.info('Sending Dingding type %s message %s', self.message_type, data)
+        resp = self.run(endpoint=self._get_endpoint(),
+                        data=data,
+                        headers={'Content-Type': 'application/json'})
+
+        # Dingding success send message will with errcode equal to 0
+        if int(resp.json().get('errcode')) != 0:
+            raise AirflowException('Send Dingding message failed, receive error '
+                                   'message %s', resp.text)
+        self.log.info('Success Send Dingding message')

--- a/airflow/contrib/operators/dingding_operator.py
+++ b/airflow/contrib/operators/dingding_operator.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.contrib.hooks.dingding_hook import DingdingHook
+from airflow.operators.bash_operator import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class DingdingOperator(BaseOperator):
+    """
+    This operator allows you send Dingding message using Dingding custom bot.
+    Get Dingding token from conn_id.password. And prefer set domain to
+    conn_id.host, if not will use default ``https://oapi.dingtalk.com``.
+
+    For more detail message in
+    `Dingding custom bot <https://open-doc.dingtalk.com/microapp/serverapi2/qf2nxq>`_
+
+    :param dingding_conn_id: The name of the Dingding connection to use
+    :type dingding_conn_id: str
+    :param message_type: Message type you want to send to Dingding, support five type so far
+        including text, link, markdown, actionCard, feedCard
+    :type message_type: str
+    :param message: The message send to Dingding chat group
+    :type message: str or dict
+    :param at_mobiles: Remind specific users with this message
+    :type at_mobiles: list[str]
+    :param at_all: Remind all people in group or not. If True, will overwrite ``at_mobiles``
+    :type at_all: bool
+    """
+    template_fields = ('message',)
+    ui_color = '#4ea4d4'  # Dingding icon color
+
+    @apply_defaults
+    def __init__(self,
+                 dingding_conn_id='dingding_default',
+                 message_type='text',
+                 message=None,
+                 at_mobiles=None,
+                 at_all=False,
+                 *args,
+                 **kwargs):
+        super(DingdingOperator, self).__init__(*args, **kwargs)
+        self.dingding_conn_id = dingding_conn_id
+        self.message_type = message_type
+        self.message = message
+        self.at_mobiles = at_mobiles
+        self.at_all = at_all
+
+    def execute(self, context):
+        self.log.info('Sending Dingding message.')
+        hook = DingdingHook(
+            self.dingding_conn_id,
+            self.message_type,
+            self.message,
+            self.at_mobiles,
+            self.at_all
+        )
+        hook.send()

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -278,6 +278,10 @@ def initdb():
         Connection(
             conn_id='cassandra_default', conn_type='cassandra',
             host='cassandra', port=9042))
+    merge_conn(
+        Connection(
+            conn_id='dingding_default', conn_type='http',
+            host='', password=''))
 
     dagbag = models.DagBag()
     # Save individual DAGs in the ORM

--- a/docs/howto/operator/dingding.rst
+++ b/docs/howto/operator/dingding.rst
@@ -1,0 +1,91 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Dingding Operators
+==================
+
+
+Prerequisite Tasks
+^^^^^^^^^^^^^^^^^^
+
+To use this operators, you must do a few things:
+
+  * Add custom robot to Dingding group which you want to send Dingding message.
+  * Get the webhook token from Dingding custom robot.
+  * Put the Dingding custom robot token in the password field of the ``dingding_default``
+    Connection. Notice that you just need token rather than the whole webhook string.
+
+Basic Usage
+^^^^^^^^^^^
+
+Use the :class:`~airflow/contrib/operators/dingding_operator.DingdingOperator`
+to send Dingding message:
+
+.. literalinclude:: ../../../airflow/contrib/example_dags/example_dingding_operator.py
+    :language: python
+    :start-after: [START howto_operator_dingding]
+    :end-before: [END howto_operator_dingding]
+
+
+Remind users in message
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Use parameters ``at_mobiles`` and ``at_all`` to remind specific users when you send message,
+``at_mobiles`` will be ignored When ``at_all`` is set to ``True``:
+
+.. literalinclude:: ../../../airflow/contrib/example_dags/example_dingding_operator.py
+    :language: python
+    :start-after: [START howto_operator_dingding_remind_users]
+    :end-before: [END howto_operator_dingding_remind_users]
+
+
+Send rich text message
+^^^^^^^^^^^^^^^^^^^^^^
+
+The Dingding operator can send rich text messages including link, markdown, actionCard and feedCard.
+A rich text message can not remind specific users except by using markdown type message:
+
+.. literalinclude:: ../../../airflow/contrib/example_dags/example_dingding_operator.py
+    :language: python
+    :start-after: [START howto_operator_dingding_rich_text]
+    :end-before: [END howto_operator_dingding_rich_text]
+
+
+Sending messages from a Task callback
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Dingding operator could handle task callback by writing a function wrapper dingding operators
+and then pass the function to ``sla_miss_callback``, ``on_success_callback``, ``on_failure_callback``,
+or ``on_retry_callback``. Here we use ``on_failure_callback`` as an example:
+
+.. literalinclude:: ../../../airflow/contrib/example_dags/example_dingding_operator.py
+    :language: python
+    :start-after: [START howto_operator_dingding_failure_callback]
+    :end-before: [END howto_operator_dingding_failure_callback]
+
+
+Changing connection host if you need
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The Dingding operator post http requests using default host ``https://oapi.dingtalk.com``,
+if you need to change the host used you can set the host field of the connection.
+
+
+More information
+^^^^^^^^^^^^^^^^
+
+See Dingding documentation on how to `custom robot
+<https://open-doc.dingtalk.com/microapp/serverapi2/qf2nxq>`_.

--- a/docs/howto/operator/index.rst
+++ b/docs/howto/operator/index.rst
@@ -28,6 +28,7 @@ information.
 .. toctree::
     :maxdepth: 2
 
-    python
     bash
+    dingding
     gcp/index
+    python

--- a/tests/contrib/hooks/test_dingding_hook.py
+++ b/tests/contrib/hooks/test_dingding_hook.py
@@ -1,0 +1,278 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+import unittest
+
+from airflow.utils import db
+
+from airflow import configuration
+
+from airflow.contrib.hooks.dingding_hook import DingdingHook
+from airflow.models.connection import Connection
+
+
+class TestDingdingHook(unittest.TestCase):
+    conn_id = 'dingding_conn_id_test'
+
+    def setUp(self):
+        configuration.load_test_config()
+        db.merge_conn(
+            Connection(
+                conn_id=self.conn_id,
+                conn_type='http',
+                host='https://oapi.dingtalk.com',
+                password='you_token_here'))
+
+    def test_get_endpoint_conn_id(self):
+        hook = DingdingHook(dingding_conn_id=self.conn_id)
+        endpoint = hook._get_endpoint()
+        self.assertEqual('robot/send?access_token=you_token_here', endpoint)
+
+    def test_build_text_message_not_remind(self):
+        config = {
+            'dingding_conn_id': self.conn_id,
+            'message_type': 'text',
+            'message': 'Airflow dingding text message remind no one',
+            'at_mobiles': False,
+            'at_all': False,
+        }
+        expect = {
+            'msgtype': 'text',
+            'text': {
+                'content': 'Airflow dingding text message remind no one'
+            },
+            'at': {
+                'atMobiles': False,
+                'isAtAll': False
+            }
+        }
+        hook = DingdingHook(**config)
+        message = hook._build_message()
+        self.assertEqual(json.dumps(expect), message)
+
+    def test_build_text_message_remind_specific(self):
+        config = {
+            'dingding_conn_id': self.conn_id,
+            'message_type': 'text',
+            'message': 'Airflow dingding text message remind specific users',
+            'at_mobiles': ['1234', '5768'],
+            'at_all': False,
+        }
+        expect = {
+            'msgtype': 'text',
+            'text': {
+                'content': 'Airflow dingding text message remind specific users'
+            },
+            'at': {
+                'atMobiles': ['1234', '5768'],
+                'isAtAll': False
+            }
+        }
+        hook = DingdingHook(**config)
+        message = hook._build_message()
+        self.assertEqual(json.dumps(expect), message)
+
+    def test_build_text_message_remind_all(self):
+        config = {
+            'dingding_conn_id': self.conn_id,
+            'message_type': 'text',
+            'message': 'Airflow dingding text message remind all user in group',
+            'at_all': True,
+        }
+        expect = {
+            'msgtype': 'text',
+            'text': {
+                'content': 'Airflow dingding text message remind all user in group'
+            },
+            'at': {
+                'atMobiles': None,
+                'isAtAll': True
+            }
+        }
+        hook = DingdingHook(**config)
+        message = hook._build_message()
+        self.assertEqual(json.dumps(expect), message)
+
+    def test_build_markdown_message_remind_specific(self):
+        msg = {
+            'title': 'Airflow dingding markdown message',
+            'text': '# Markdown message title\ncontent content .. \n### sub-title\n'
+                    '![logo](http://airflow.apache.org/_images/pin_large.png)'
+        }
+        config = {
+            'dingding_conn_id': self.conn_id,
+            'message_type': 'markdown',
+            'message': msg,
+            'at_mobiles': ['1234', '5678'],
+            'at_all': False,
+        }
+        expect = {
+            'msgtype': 'markdown',
+            'markdown': msg,
+            'at': {
+                'atMobiles': ['1234', '5678'],
+                'isAtAll': False
+            }
+        }
+        hook = DingdingHook(**config)
+        message = hook._build_message()
+        self.assertEqual(json.dumps(expect), message)
+
+    def test_build_markdown_message_remind_all(self):
+        msg = {
+            'title': 'Airflow dingding markdown message',
+            'text': '# Markdown message title\ncontent content .. \n### sub-title\n'
+                    '![logo](http://airflow.apache.org/_images/pin_large.png)'
+        }
+        config = {
+            'dingding_conn_id': self.conn_id,
+            'message_type': 'markdown',
+            'message': msg,
+            'at_all': True,
+        }
+        expect = {
+            'msgtype': 'markdown',
+            'markdown': msg,
+            'at': {
+                'atMobiles': None,
+                'isAtAll': True
+            }
+        }
+        hook = DingdingHook(**config)
+        message = hook._build_message()
+        self.assertEqual(json.dumps(expect), message)
+
+    def test_build_link_message(self):
+        msg = {
+            'title': 'Airflow dingding link message',
+            'text': 'Airflow official documentation link',
+            'messageUrl': 'http://airflow.apache.org',
+            'picURL': 'http://airflow.apache.org/_images/pin_large.png'
+        }
+        config = {
+            'dingding_conn_id': self.conn_id,
+            'message_type': 'link',
+            'message': msg
+        }
+        expect = {
+            'msgtype': 'link',
+            'link': msg
+        }
+        hook = DingdingHook(**config)
+        message = hook._build_message()
+        self.assertEqual(json.dumps(expect), message)
+
+    def test_build_single_action_card_message(self):
+        msg = {
+            'title': 'Airflow dingding single actionCard message',
+            'text': 'Airflow dingding single actionCard message\n'
+                    '![logo](http://airflow.apache.org/_images/pin_large.png)\n'
+                    'This is a official logo in Airflow website.',
+            'hideAvatar': '0',
+            'btnOrientation': '0',
+            'singleTitle': 'read more',
+            'singleURL': 'http://airflow.apache.org'
+        }
+        config = {
+            'dingding_conn_id': self.conn_id,
+            'message_type': 'actionCard',
+            'message': msg
+        }
+        expect = {
+            'msgtype': 'actionCard',
+            'actionCard': msg
+        }
+        hook = DingdingHook(**config)
+        message = hook._build_message()
+        self.assertEqual(json.dumps(expect), message)
+
+    def test_build_multi_action_card_message(self):
+        msg = {
+            'title': 'Airflow dingding multi actionCard message',
+            'text': 'Airflow dingding multi actionCard message\n'
+                    '![logo](http://airflow.apache.org/_images/pin_large.png)\n'
+                    'Airflow documentation and github',
+            'hideAvatar': '0',
+            'btnOrientation': '0',
+            'btns': [
+                {
+                    'title': 'Airflow Documentation',
+                    'actionURL': 'http://airflow.apache.org'
+                },
+                {
+                    'title': 'Airflow Github',
+                    'actionURL': 'https://github.com/apache/airflow'
+                }
+            ]
+        }
+        config = {
+            'dingding_conn_id': self.conn_id,
+            'message_type': 'actionCard',
+            'message': msg
+        }
+        expect = {
+            'msgtype': 'actionCard',
+            'actionCard': msg
+        }
+        hook = DingdingHook(**config)
+        message = hook._build_message()
+        self.assertEqual(json.dumps(expect), message)
+
+    def test_build_feed_card_message(self):
+        msg = {
+            "links": [
+                {
+                    "title": "Airflow DAG feed card",
+                    "messageURL": "https://airflow.readthedocs.io/en/latest/ui.html",
+                    "picURL": "http://airflow.apache.org/_images/dags.png"
+                },
+                {
+                    "title": "Airflow tree feed card",
+                    "messageURL": "https://airflow.readthedocs.io/en/latest/ui.html",
+                    "picURL": "http://airflow.apache.org/_images/tree.png"
+                },
+                {
+                    "title": "Airflow graph feed card",
+                    "messageURL": "https://airflow.readthedocs.io/en/latest/ui.html",
+                    "picURL": "http://airflow.apache.org/_images/graph.png"
+                }
+            ]
+        }
+        config = {
+            'dingding_conn_id': self.conn_id,
+            'message_type': 'feedCard',
+            'message': msg
+        }
+        expect = {
+            'msgtype': 'feedCard',
+            'feedCard': msg
+        }
+        hook = DingdingHook(**config)
+        message = hook._build_message()
+        self.assertEqual(json.dumps(expect), message)
+
+    def test_send_not_support_type(self):
+        config = {
+            'dingding_conn_id': self.conn_id,
+            'message_type': 'not_support_type',
+            'message': 'Airflow dingding text message remind no one'
+        }
+        hook = DingdingHook(**config)
+        self.assertRaises(ValueError, hook.send)

--- a/tests/contrib/operators/test_dingding_operator.py
+++ b/tests/contrib/operators/test_dingding_operator.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import mock
+
+from airflow import DAG, configuration
+from airflow.contrib.operators.dingding_operator import DingdingOperator
+from airflow.utils import timezone
+
+DEFAULT_DATE = timezone.datetime(2017, 1, 1)
+
+
+class TestDingdingOperator(unittest.TestCase):
+    _config = {
+        'dingding_conn_id': 'dingding_default',
+        'message_type': 'text',
+        'message': 'Airflow dingding webhook test',
+        'at_mobiles': ['123', '456'],
+        'at_all': False
+    }
+
+    def setUp(self):
+        configuration.load_test_config()
+        args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE
+        }
+        self.dag = DAG('test_dag_id', default_args=args)
+
+    @mock.patch('airflow.contrib.operators.dingding_operator.DingdingHook')
+    def test_execute(self, mock_hook):
+        operator = DingdingOperator(
+            task_id='dingding_task',
+            dag=self.dag,
+            **self._config
+        )
+
+        self.assertIsNotNone(operator)
+        self.assertEqual(self._config['dingding_conn_id'], operator.dingding_conn_id)
+        self.assertEqual(self._config['message_type'], operator.message_type)
+        self.assertEqual(self._config['message'], operator.message)
+        self.assertEqual(self._config['at_mobiles'], operator.at_mobiles)
+        self.assertEqual(self._config['at_all'], operator.at_all)
+
+        operator.execute(None)
+        mock_hook.assert_called_once_with(
+            self._config['dingding_conn_id'],
+            self._config['message_type'],
+            self._config['message'],
+            self._config['at_mobiles'],
+            self._config['at_all']
+        )
+        mock_hook.return_value.send.assert_called_once()


### PR DESCRIPTION
Dingding is popular team collaboration tools talk
just like Slack. This PR is add it to master, could
help us easy send message to Dingding.

Change db.py add conn dingding_webhook_default, could
easy configure dingding message due the host is constant

Add how to operator dingding section tell users
how to send different kind of dingding message or
how to use dingding as callback funtion in DAG
and add example to show how to use.

Set operator UI color as dingding icon color

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - https://issues.apache.org/jira/browse/AIRFLOW-1526
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add dingding (popular team collaboration tools in China) hook and operator to master,

### Tests

- [x] My PR adds the following unit tests :

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
