### PR TITLE
[AIRFLOW-4061] Remove incubator in CI process

### DIFF
--- a/scripts/ci/docker-compose.yml
+++ b/scripts/ci/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     domainname: example.com
 
   airflow-testing:
-    image: airflowci/incubator-airflow-ci:latest
+    image: airflowci/airflow-ci:latest
     init: true
     environment:
       - USER=airflow


### PR DESCRIPTION
Remove incubator as Airflow is Top-Level project.
[ci skip]

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-4061\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We still use `airflowci/incubator-airflow-ci:latest` in our ci docker-compose, should change it to `airflowci/airflow-ci:latest`, in this case we have to change [airflow-ci](https://github.com/apache/airflow-ci) setting in [docker-hub](https://hub.docker.com/r/airflowci/incubator-airflow-ci/), let `airflowci/airflow-ci:latest` work.
