### PR TITLE
[AIRFLOW-4063] - fix exception string in BigQueryHook

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1261,8 +1261,8 @@ class BigQueryBaseCursor(LoggingMixin):
                     time.sleep(5)
                 else:
                     raise Exception(
-                        'BigQuery job status check failed. Final error was: %s',
-                        err.resp.status)
+                        'BigQuery job status check failed. Final error was: {}'.
+                        format(err.resp.status))
 
         return self.running_job_id
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4063
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description
The `%s` in the current string isn't replaced with the error code:


Before:
```
Python 3.6.7 (default, Oct 21 2018, 04:56:05)
Type "help", "copyright", "credits" or "license" for more information.
>>> raise Exception( 'BigQuery job status check failed. Final error was: %s', 404)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
Exception: ('BigQuery job status check failed. Final error was: %s', 404)
```

After:
```
>>> raise Exception( 'BigQuery job status check failed. Final error was: {}'.format( 404))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
Exception: BigQuery job status check failed. Final error was: 404
```


