### PR TITLE
[AIRFLOW-3362] [WIP]Template to support jinja2 native python types

### DIFF
--- a/airflow/lineage/datasets.py
+++ b/airflow/lineage/datasets.py
@@ -18,7 +18,10 @@
 # under the License.
 import six
 
-from jinja2 import Environment
+try:
+    from jinja2.nativetypes import NativeEnvironment as Environment
+except ImportError:
+    from jinja2 import Environment
 
 
 def _inherited(cls):

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -44,6 +44,10 @@ import imp
 import importlib
 import zipfile
 import jinja2
+try:
+    from jinja2.nativetypes import NativeEnvironment as Environment
+except ImportError:
+    from jinja2 import Environment
 import json
 import logging
 import os
@@ -2482,7 +2486,7 @@ class BaseOperator(LoggingMixin):
     def get_template_env(self):
         return self.dag.get_template_env() \
             if hasattr(self, 'dag') \
-            else jinja2.Environment(cache_size=0)
+            else Environment(cache_size=0)
 
     def prepare_template(self):
         """
@@ -3483,7 +3487,7 @@ class DAG(BaseDag, LoggingMixin):
         if self.template_searchpath:
             searchpath += self.template_searchpath
 
-        env = jinja2.Environment(
+        env = Environment(
             loader=jinja2.FileSystemLoader(searchpath),
             extensions=["jinja2.ext.do"],
             cache_size=0)

--- a/tests/contrib/operators/test_databricks_operator.py
+++ b/tests/contrib/operators/test_databricks_operator.py
@@ -173,6 +173,7 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
         dag = DAG('test', start_date=datetime.now())
         op = DatabricksSubmitRunOperator(dag=dag, task_id=TASK_ID, json=json)
         op.json = op.render_template('json', op.json, {'ds': DATE})
+        op.json = databricks_operator._deep_string_coerce(op.json)
         expected = databricks_operator._deep_string_coerce({
             'new_cluster': NEW_CLUSTER,
             'notebook_task': RENDERED_TEMPLATED_NOTEBOOK_TASK,
@@ -340,6 +341,7 @@ class DatabricksRunNowOperatorTest(unittest.TestCase):
         dag = DAG('test', start_date=datetime.now())
         op = DatabricksRunNowOperator(dag=dag, task_id=TASK_ID, job_id=JOB_ID, json=json)
         op.json = op.render_template('json', op.json, {'ds': DATE})
+        op.json = databricks_operator._deep_string_coerce(op.json)
         expected = databricks_operator._deep_string_coerce({
             'notebook_params': NOTEBOOK_PARAMS,
             'jar_params': RENDERED_TEMPLATED_JAR_PARAMS,

--- a/tests/core.py
+++ b/tests/core.py
@@ -85,6 +85,11 @@ except ImportError:
     # Python 3
     import pickle
 
+try:
+    from jinja2.nativetypes import NativeEnvironment
+except ImportError:
+    NativeEnvironment = None
+
 
 class OperatorSubclass(BaseOperator):
     """
@@ -615,8 +620,16 @@ class CoreTest(unittest.TestCase):
         Variable.set("a_variable", val['test_value'], serialize_json=True)
 
         def verify_templated_field(context):
-            self.assertEqual(context['ti'].task.some_templated_field,
-                             u'{"foo": "bar"}')
+            if NativeEnvironment:
+                self.assertEqual(
+                    context['ti'].task.some_templated_field,
+                    {"foo": "bar"}
+                )
+            else:
+                self.assertEqual(
+                    context['ti'].task.some_templated_field,
+                    u'{"foo": "bar"}'
+                )
 
         t = OperatorSubclass(
             task_id='test_complex_template',

--- a/tests/operators/test_check_operator.py
+++ b/tests/operators/test_check_operator.py
@@ -31,6 +31,11 @@ except ImportError:
     except ImportError:
         mock = None
 
+try:
+    from jinja2.nativetypes import NativeEnvironment
+except ImportError:
+    NativeEnvironment = None
+
 
 class ValueCheckOperatorTest(unittest.TestCase):
 
@@ -65,7 +70,10 @@ class ValueCheckOperatorTest(unittest.TestCase):
         result = operator.render_template('pass_value', operator.pass_value, {})
 
         self.assertEqual(operator.task_id, self.task_id)
-        self.assertEqual(result, str(pass_value_float))
+        if NativeEnvironment:
+            self.assertEqual(result, pass_value_float)
+        else:
+            self.assertEqual(result, str(pass_value_float))
 
     @mock.patch.object(ValueCheckOperator, 'get_db_hook')
     def test_execute_pass(self, mock_get_db_hook):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow-3362](https://issues.apache.org/jira/browse/AIRFLOW-3362) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
