### PR TITLE
[AIRFLOW-4063] - fix exception string in BigQueryHook [2/2]

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1285,8 +1285,8 @@ class BigQueryBaseCursor(LoggingMixin):
                     err.resp.status, job_id)
             else:
                 raise Exception(
-                    'BigQuery job status check failed. Final error was: %s',
-                    err.resp.status)
+                    'BigQuery job status check failed. Final error was: {}'.
+                    format(err.resp.status))
         return False
 
     def cancel_query(self):


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/AIRFLOW-4063
follow to PR https://github.com/apache/airflow/pull/4899