### PR TITLE
AIRFLOW-3736: SqoopOperator Numeric `extra_import_options` value

### DIFF
--- a/airflow/contrib/hooks/sqoop_hook.py
+++ b/airflow/contrib/hooks/sqoop_hook.py
@@ -195,7 +195,7 @@ class SqoopHook(BaseHook):
             for key, value in extra_import_options.items():
                 cmd += ['--{}'.format(key)]
                 if value:
-                    cmd += [value]
+                    cmd += [str(value)]
 
         return cmd
 
@@ -304,7 +304,7 @@ class SqoopHook(BaseHook):
             for key, value in extra_export_options.items():
                 cmd += ['--{}'.format(key)]
                 if value:
-                    cmd += [value]
+                    cmd += [str(value)]
 
         # The required option
         cmd += ["--table", table]

--- a/tests/contrib/hooks/test_sqoop_hook.py
+++ b/tests/contrib/hooks/test_sqoop_hook.py
@@ -60,7 +60,8 @@ class TestSqoopHook(unittest.TestCase):
         'relaxed_isolation': True,
         'extra_export_options': collections.OrderedDict([
             ('update-key', 'id'),
-            ('update-mode', 'allowinsert')
+            ('update-mode', 'allowinsert'),
+            ('fetch-size', 1)
         ])
     }
     _config_import = {
@@ -72,7 +73,8 @@ class TestSqoopHook(unittest.TestCase):
         'driver': 'com.microsoft.jdbc.sqlserver.SQLServerDriver',
         'extra_import_options': {
             'hcatalog-storage-stanza': "\"stored as orcfile\"",
-            'show': ''
+            'show': '',
+            'fetch-size': 1
         }
     }
 
@@ -130,6 +132,7 @@ class TestSqoopHook(unittest.TestCase):
              '--export-dir', self._config_export['export_dir'],
              '--update-key', 'id',
              '--update-mode', 'allowinsert',
+             '--fetch-size', str(self._config_export['extra_export_options'].get('fetch-size')),
              '--table', self._config_export['table']], stderr=-2, stdout=-1))
 
     def test_submit_none_mappers(self):
@@ -250,6 +253,11 @@ class TestSqoopHook(unittest.TestCase):
         if self._config_export['relaxed_isolation']:
             self.assertIn("--relaxed-isolation", cmd)
 
+        if self._config_export['extra_export_options']:
+            self.assertIn("--update-key", cmd)
+            self.assertIn("--update-mode", cmd)
+            self.assertIn("--fetch-size", cmd)
+
     def test_import_cmd(self):
         """
         Tests to verify the hook import command is building correct Sqoop import command.
@@ -300,6 +308,7 @@ class TestSqoopHook(unittest.TestCase):
         # these checks are from the extra import options
         self.assertIn('--show', cmd)
         self.assertIn('hcatalog-storage-stanza \"stored as orcfile\"', cmd)
+        self.assertIn('--fetch-size', cmd)
 
     def test_get_export_format_argument(self):
         """

--- a/tests/contrib/operators/test_sqoop_operator.py
+++ b/tests/contrib/operators/test_sqoop_operator.py
@@ -64,7 +64,8 @@ class TestSqoopOperator(unittest.TestCase):
         },
         'extra_export_options': {
             'update-key': 'id',
-            'update-mode': 'allowinsert'
+            'update-mode': 'allowinsert',
+            'fetch-size': 1
         }
     }
 
@@ -154,7 +155,9 @@ class TestSqoopOperator(unittest.TestCase):
             extra_import_options={
                 'hcatalog-storage-stanza': "\"stored as orcfile\"",
                 'hive-partition-key': 'day',
-                'hive-partition-value': '2017-10-18'},
+                'hive-partition-value': '2017-10-18',
+                'fetch-size': 1
+            },
             dag=self.dag
         )
 


### PR DESCRIPTION
### Jira
- My PR addresses the following [Airflow-3736](https://issues.apache.org/jira/browse/AIRFLOW-3736)

### Description
- SqoopOperator would throw an error when an integer value was passed inside `extra_import_options`.

### Tests
- Modified existing SqoopHook tests to include the new functionality.
- Added {'fetch-size': 1} to SqoopOperator execution test to ensure no failures
