### PR TITLE
[AIRFLOW-4083] Add tests for link generation utils

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -225,5 +225,5 @@ def cached_app(config=None, session=None, testing=False):
 
 def cached_appbuilder(config=None, testing=False):
     global appbuilder
-    cached_app(config, testing)
+    cached_app(config=config, testing=testing)
     return appbuilder

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -24,7 +24,6 @@ import inspect
 import json
 import time
 import wtforms
-import bleach
 import markdown
 import re
 import zipfile
@@ -235,8 +234,8 @@ def make_cache_key(*args, **kwargs):
 
 
 def task_instance_link(attr):
-    dag_id = bleach.clean(attr.get('dag_id')) if attr.get('dag_id') else None
-    task_id = bleach.clean(attr.get('task_id')) if attr.get('task_id') else None
+    dag_id = attr.get('dag_id')
+    task_id = attr.get('task_id')
     execution_date = attr.get('execution_date')
     url = url_for(
         'Airflow.task',
@@ -257,14 +256,14 @@ def task_instance_link(attr):
             aria-hidden="true"></span>
         </a>
         </span>
-        """.format(**locals()))
+        """).format(**locals())
 
 
 def state_token(state):
     color = State.color(state)
     return Markup(
         '<span class="label" style="background-color:{color};">'
-        '{state}</span>'.format(**locals()))
+        '{state}</span>').format(**locals())
 
 
 def state_f(attr):
@@ -275,7 +274,7 @@ def state_f(attr):
 def nobr_f(attr_name):
     def nobr(attr):
         f = attr.get(attr_name)
-        return Markup("<nobr>{}</nobr>".format(f))
+        return Markup("<nobr>{}</nobr>").format(f)
     return nobr
 
 
@@ -285,24 +284,24 @@ def datetime_f(attr_name):
         f = f.isoformat() if f else ''
         if timezone.utcnow().isoformat()[:4] == f[:4]:
             f = f[5:]
-        return Markup("<nobr>{}</nobr>".format(f))
+        return Markup("<nobr>{}</nobr>").format(f)
     return dt
 
 
 def dag_link(attr):
-    dag_id = bleach.clean(attr.get('dag_id')) if attr.get('dag_id') else None
+    dag_id = attr.get('dag_id')
     execution_date = attr.get('execution_date')
     url = url_for(
         'Airflow.graph',
         dag_id=dag_id,
         execution_date=execution_date)
     return Markup(
-        '<a href="{}">{}</a>'.format(url, dag_id))
+        '<a href="{}">{}</a>').format(url, dag_id)
 
 
 def dag_run_link(attr):
-    dag_id = bleach.clean(attr.get('dag_id')) if attr.get('dag_id') else None
-    run_id = bleach.clean(attr.get('run_id')) if attr.get('run_id') else None
+    dag_id = attr.get('dag_id')
+    run_id = attr.get('run_id')
     execution_date = attr.get('execution_date')
     url = url_for(
         'Airflow.graph',
@@ -310,7 +309,7 @@ def dag_run_link(attr):
         run_id=run_id,
         execution_date=execution_date)
     return Markup(
-        '<a href="{url}">{run_id}</a>'.format(**locals()))
+        '<a href="{url}">{run_id}</a>').format(**locals())
 
 
 def pygment_html_render(s, lexer=lexers.TextLexer):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -35,7 +35,7 @@ import pendulum
 import sqlalchemy as sqla
 from flask import (
     redirect, request, Markup, Response, render_template,
-    make_response, flash, jsonify, send_file, escape, url_for)
+    make_response, flash, jsonify, send_file, url_for)
 from flask._compat import PY2
 from flask_appbuilder import BaseView, ModelView, expose, has_access
 from flask_appbuilder.actions import action
@@ -2000,8 +2000,7 @@ class PoolModelView(AirflowModelView):
         pool_id = attr.get('pool')
         if pool_id is not None:
             url = url_for('TaskInstanceModelView.list', _flt_3_pool=pool_id)
-            pool_id = escape(pool_id)
-            return Markup("<a href='{url}'>{pool_id}</a>".format(**locals()))
+            return Markup("<a href='{url}'>{pool_id}</a>").format(**locals())
         else:
             return Markup('<span class="label label-danger">Invalid</span>')
 
@@ -2010,7 +2009,7 @@ class PoolModelView(AirflowModelView):
         used_slots = attr.get('used_slots')
         if pool_id is not None and used_slots is not None:
             url = url_for('TaskInstanceModelView.list', _flt_3_pool=pool_id, _flt_3_state='running')
-            return Markup("<a href='{url}'>{used_slots}</a>".format(**locals()))
+            return Markup("<a href='{url}'>{used_slots}</a>").format(**locals())
         else:
             return Markup('<span class="label label-danger">Invalid</span>')
 
@@ -2019,7 +2018,7 @@ class PoolModelView(AirflowModelView):
         queued_slots = attr.get('queued_slots')
         if pool_id is not None and queued_slots is not None:
             url = url_for('TaskInstanceModelView.list', _flt_3_pool=pool_id, _flt_3_state='queued')
-            return Markup("<a href='{url}'>{queued_slots}</a>".format(**locals()))
+            return Markup("<a href='{url}'>{queued_slots}</a>").format(**locals())
         else:
             return Markup('<span class="label label-danger">Invalid</span>')
 

--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,6 @@ def do_setup():
         scripts=['airflow/bin/airflow'],
         install_requires=[
             'alembic>=0.9, <1.0',
-            'bleach~=2.1.3',
             'configparser>=3.5.0, <3.6.0',
             'croniter>=0.3.17, <0.4',
             'dill>=0.2.2, <0.3',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira
https://issues.apache.org/jira/browse/AIRFLOW-4083
 
### Description

We were making use of the "bleach" module or jinja.escape function to
clean parameters when it wasn't needed - we could simply call .format on
the Markup object and it will handle escaping for us. (format the
object, not format the string passed to the constructor)

This removes the (direct?) dependency on bleach - one less thing to
depend on is a good thing too.

### Tests

- [x] Tests added to tests/www/test_utils.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
