### PR TITLE
Remove verbose test on nosetests

### DIFF
--- a/scripts/ci/5-run-tests.sh
+++ b/scripts/ci/5-run-tests.sh
@@ -77,7 +77,7 @@ if [ -z "$nose_args" ]; then
   --with-ignore-docstrings \
   --rednose \
   --with-timer \
-  --logging-level=DEBUG"
+  -v
 fi
 
 if [ -z "$KUBERNETES_VERSION" ]; then

--- a/scripts/ci/5-run-tests.sh
+++ b/scripts/ci/5-run-tests.sh
@@ -77,7 +77,6 @@ if [ -z "$nose_args" ]; then
   --with-ignore-docstrings \
   --rednose \
   --with-timer \
-  -v \
   --logging-level=DEBUG"
 fi
 

--- a/scripts/ci/5-run-tests.sh
+++ b/scripts/ci/5-run-tests.sh
@@ -77,7 +77,8 @@ if [ -z "$nose_args" ]; then
   --with-ignore-docstrings \
   --rednose \
   --with-timer \
-  -v"
+  -v \
+  --logging-level=INFO"
 fi
 
 if [ -z "$KUBERNETES_VERSION" ]; then

--- a/scripts/ci/5-run-tests.sh
+++ b/scripts/ci/5-run-tests.sh
@@ -77,7 +77,7 @@ if [ -z "$nose_args" ]; then
   --with-ignore-docstrings \
   --rednose \
   --with-timer \
-  -v
+  -v"
 fi
 
 if [ -z "$KUBERNETES_VERSION" ]; then

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -78,7 +78,7 @@ class CeleryExecutorTest(unittest.TestCase):
             executor = celery_executor.CeleryExecutor()
             executor.start()
 
-            with start_worker(app=app, logfile=sys.stdout, loglevel='debug'):
+            with start_worker(app=app, logfile=sys.stdout, loglevel='info'):
                 success_command = ['true', 'some_parameter']
                 fail_command = ['false', 'some_parameter']
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example,
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX

### Description

Making tests less verbose

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
