### PR TITLE
[AIRFLOW-4045] Fix hard-coded URLs in FAB UI when base_url is set

### DIFF
--- a/airflow/www/blueprints.py
+++ b/airflow/www/blueprints.py
@@ -17,11 +17,11 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from flask import Blueprint, redirect
+from flask import Blueprint, redirect, url_for
 
 routes = Blueprint('routes', __name__)
 
 
 @routes.route('/')
 def index():
-    return redirect('/home')
+    return redirect(url_for('Airflow.index'))

--- a/airflow/www/static_config.py
+++ b/airflow/www/static_config.py
@@ -18,9 +18,11 @@
 # under the License.
 from __future__ import print_function
 
-import os
 import json
+import os
 from typing import Dict
+
+from flask import url_for
 
 manifest = dict()  # type: Dict[str, str]
 
@@ -40,6 +42,9 @@ def configure_manifest_files(app):
                                          'static/dist/manifest.json')
             with open(manifest_file, 'r') as f:
                 manifest.update(json.load(f))
+
+                for k in manifest.keys():
+                    manifest[k] = os.path.join("dist", manifest[k])
         except Exception:
             print("Please make sure to build the frontend in "
                   "static/ directory and restart the server")
@@ -48,7 +53,7 @@ def configure_manifest_files(app):
     def get_asset_url(filename):
         if app.debug:
             parse_manifest_json()
-        return '/static/dist/{}'.format(manifest.get(filename, ''))
+        return url_for('static', filename=manifest.get(filename, ''))
 
     parse_manifest_json()
 

--- a/airflow/www/templates/airflow/dag_details.html
+++ b/airflow/www/templates/airflow/dag_details.html
@@ -29,7 +29,7 @@
       <a
           class="btn"
           style="border: none; background-color:{{ State.color(state)}}; color: {{ State.color_fg(state) }};"
-          href="/taskinstance/list/?_flt_3_dag_id={{ dag.dag_id }}&_flt_3_state={{ state }}">
+          href="{{ url_for('TaskInstanceModelView.list', _flt_3_dag_id=dag.dag_id, _flt_3_state=state) }}">
         {{ state }} <span class="badge">{{ count }}</span>
       </a>
       {% endfor %}

--- a/airflow/www/templates/appbuilder/navbar_menu.html
+++ b/airflow/www/templates/appbuilder/navbar_menu.html
@@ -23,7 +23,7 @@
     {{_(item.label)}}</a>
 {% endmacro %}
 
-<li class="dropdown"><a href="/">DAGs</a></li>
+<li class="dropdown"><a href="{{ url_for('Airflow.index') }}">DAGs</a></li>
 
 {% for item1 in menu.get_list() %}
     {% if item1 | is_menu_visible %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -641,7 +641,7 @@ class Airflow(AirflowBaseView):
                 "Task [{}.{}] doesn't seem to exist"
                 " at the moment".format(dag_id, task_id),
                 "error")
-            return redirect('/')
+            return redirect(url_for('Airflow.index'))
         task = copy.copy(dag.get_task(task_id))
         task.resolve_template_files()
         ti = TI(task=task, execution_date=dttm)
@@ -723,7 +723,7 @@ class Airflow(AirflowBaseView):
                 "Task [{}.{}] doesn't seem to exist"
                 " at the moment".format(dag_id, task_id),
                 "error")
-            return redirect('/')
+            return redirect(url_for('Airflow.index'))
 
         xcomlist = session.query(XCom).filter(
             XCom.dag_id == dag_id, XCom.task_id == task_id,
@@ -821,7 +821,7 @@ class Airflow(AirflowBaseView):
         from airflow.exceptions import DagNotFound, DagFileExists
 
         dag_id = request.args.get('dag_id')
-        origin = request.args.get('origin') or "/"
+        origin = request.args.get('origin') or url_for('Airflow.index')
 
         try:
             delete_dag.delete_dag(dag_id)
@@ -847,7 +847,7 @@ class Airflow(AirflowBaseView):
     @provide_session
     def trigger(self, session=None):
         dag_id = request.args.get('dag_id')
-        origin = request.args.get('origin') or "/"
+        origin = request.args.get('origin') or url_for('Airflow.index')
         dag = session.query(models.DagModel).filter(models.DagModel.dag_id == dag_id).first()
         if not dag:
             flash("Cannot find dag {}".format(dag_id))
@@ -1163,7 +1163,7 @@ class Airflow(AirflowBaseView):
         dag_model = DagModel.get_dagmodel(dag_id)
         if not dag_model:
             flash('DAG "{0}" seems to be missing in database.'.format(dag_id), "error")
-            return redirect('/')
+            return redirect(url_for('Airflow.index'))
         dag = dag_model.get_dag()
 
         root = request.args.get('root')
@@ -1293,7 +1293,7 @@ class Airflow(AirflowBaseView):
         dag = dagbag.get_dag(dag_id)
         if dag_id not in dagbag.dags:
             flash('DAG "{0}" seems to be missing.'.format(dag_id), "error")
-            return redirect('/')
+            return redirect(url_for('Airflow.index'))
 
         root = request.args.get('root')
         if root:
@@ -1397,7 +1397,7 @@ class Airflow(AirflowBaseView):
 
         if dag is None:
             flash('DAG "{0}" seems to be missing.'.format(dag_id), "error")
-            return redirect('/')
+            return redirect(url_for('Airflow.index'))
 
         if base_date:
             base_date = pendulum.parse(base_date)
@@ -1681,7 +1681,7 @@ class Airflow(AirflowBaseView):
         for dag_id, dag in dagbag.dags.items():
             appbuilder.sm.sync_perm_for_dag(dag_id, dag.access_control)
         flash("All DAGs are now up to date")
-        return redirect('/')
+        return redirect(url_for('Airflow.index'))
 
     @expose('/gantt')
     @has_dag_access(can_dag_read=True)
@@ -2210,7 +2210,7 @@ class DagRunModelView(AirflowModelView):
         except Exception as ex:
             flash(str(ex), 'error')
             flash('Failed to set state', 'error')
-        return redirect(self.route_base + '/list')
+        return redirect(self.get_default_url())
 
     @action('set_failed', "Set state to 'failed'",
             "All running task instances would also be marked as failed, are you sure?",
@@ -2237,7 +2237,7 @@ class DagRunModelView(AirflowModelView):
                 "were set to failed".format(**locals()))
         except Exception:
             flash('Failed to set state', 'error')
-        return redirect(self.route_base + '/list')
+        return redirect(self.get_default_url())
 
     @action('set_success', "Set state to 'success'",
             "All task instances would also be marked as success, are you sure?",
@@ -2264,7 +2264,7 @@ class DagRunModelView(AirflowModelView):
                 "were set to success".format(**locals()))
         except Exception:
             flash('Failed to set state', 'error')
-        return redirect(self.route_base + '/list')
+        return redirect(self.get_default_url())
 
 
 class LogModelView(AirflowModelView):

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -276,7 +276,7 @@ class TestMountPoint(unittest.TestCase):
         application.app = None
         application.appbuilder = None
         conf.load_test_config()
-        conf.set("webserver", "base_url", "http://localhost:8080/test")
+        conf.set("webserver", "base_url", "http://localhost/test")
         app = application.cached_app(config={'WTF_CSRF_ENABLED': False}, session=Session, testing=True)
         cls.client = Client(app, BaseResponse)
 
@@ -294,6 +294,11 @@ class TestMountPoint(unittest.TestCase):
     def test_not_found(self):
         resp = self.client.get('/', follow_redirects=True)
         self.assertEqual(resp.status_code, 404)
+
+    def test_index(self):
+        resp = self.client.get('/test/')
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers['Location'], 'http://localhost/test/home')
 
 
 class TestAirflowBaseViews(TestBase):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira
https://issues.apache.org/jira/browse/AIRFLOW-4045

### Description

There were a few places that had hard-coded URLs in the FAB ui that meant various parts don't work when base_url was set:
- the redirect from / to /home
- any compiled static assets
- a couple of the redirects.

I've tried to grep through the app, but I might not have gotten all of them.

### Tests

- [x] Added :)

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
