### PR TITLE
[AIRFLOW-4095] Add template_fields for S3CopyObjectOperator & S3DeleteObjectsOperator

### DIFF
--- a/airflow/contrib/operators/s3_copy_object_operator.py
+++ b/airflow/contrib/operators/s3_copy_object_operator.py
@@ -29,21 +29,21 @@ class S3CopyObjectOperator(BaseOperator):
     Note: the S3 connection used here needs to have access to both
     source and destination bucket/key.
 
-    :param source_bucket_key: The key of the source object.
+    :param source_bucket_key: The key of the source object. (templated)
 
         It can be either full s3:// style url or relative path from root level.
 
         When it's specified as a full s3:// url, please omit source_bucket_name.
     :type source_bucket_key: str
-    :param dest_bucket_key: The key of the object to copy to.
+    :param dest_bucket_key: The key of the object to copy to. (templated)
 
         The convention to specify `dest_bucket_key` is the same as `source_bucket_key`.
     :type dest_bucket_key: str
-    :param source_bucket_name: Name of the S3 bucket where the source object is in.
+    :param source_bucket_name: Name of the S3 bucket where the source object is in. (templated)
 
         It should be omitted when `source_bucket_key` is provided as a full s3:// url.
     :type source_bucket_name: str
-    :param dest_bucket_name: Name of the S3 bucket to where the object is copied.
+    :param dest_bucket_name: Name of the S3 bucket to where the object is copied. (templated)
 
         It should be omitted when `dest_bucket_key` is provided as a full s3:// url.
     :type dest_bucket_name: str
@@ -65,6 +65,9 @@ class S3CopyObjectOperator(BaseOperator):
     :type verify: bool or str
     """
 
+    template_fields = ('source_bucket_key', 'dest_bucket_key',
+                       'source_bucket_name', 'dest_bucket_name')
+    
     @apply_defaults
     def __init__(
             self,

--- a/airflow/contrib/operators/s3_copy_object_operator.py
+++ b/airflow/contrib/operators/s3_copy_object_operator.py
@@ -67,7 +67,7 @@ class S3CopyObjectOperator(BaseOperator):
 
     template_fields = ('source_bucket_key', 'dest_bucket_key',
                        'source_bucket_name', 'dest_bucket_name')
-    
+
     @apply_defaults
     def __init__(
             self,

--- a/airflow/contrib/operators/s3_delete_objects_operator.py
+++ b/airflow/contrib/operators/s3_delete_objects_operator.py
@@ -30,9 +30,9 @@ class S3DeleteObjectsOperator(BaseOperator):
 
     Users may specify up to 1000 keys to delete.
 
-    :param bucket: Name of the bucket in which you are going to delete object(s)
+    :param bucket: Name of the bucket in which you are going to delete object(s). (templated)
     :type bucket: str
-    :param keys: The key(s) to delete from S3 bucket.
+    :param keys: The key(s) to delete from S3 bucket. (templated)
 
         When ``keys`` is a string, it's supposed to be the key name of
         the single object to delete.
@@ -58,6 +58,8 @@ class S3DeleteObjectsOperator(BaseOperator):
     :type verify: bool or str
     """
 
+    template_fields = ('keys', 'bucket')
+    
     @apply_defaults
     def __init__(
             self,

--- a/airflow/contrib/operators/s3_delete_objects_operator.py
+++ b/airflow/contrib/operators/s3_delete_objects_operator.py
@@ -59,7 +59,7 @@ class S3DeleteObjectsOperator(BaseOperator):
     """
 
     template_fields = ('keys', 'bucket')
-    
+
     @apply_defaults
     def __init__(
             self,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira
- [x] My PR addresses the following [Airflow 4095](https://issues.apache.org/jira/browse/AIRFLOW-4095) issue
### Description
Added below attributes as template_fields, now those params will accept Jinja template and values will changes in run time

S3DeleteObjectsOperator
1. keys
2. bucket 

S3CopyObjectOperator
1. source_bucket_key
2. dest_bucket_key
3. source_bucket_name
4. dest_bucket_name

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
