### PR TITLE
[AIRFLOW-4100] Correctly JSON escape data for tree/graph views

### DIFF
--- a/airflow/utils/json.py
+++ b/airflow/utils/json.py
@@ -29,15 +29,6 @@ import numpy as np
 
 # Dates and JSON encoding/decoding
 
-def json_ser(obj):
-    """json serializer that deals with dates.
-
-    usage: json.dumps(object, default=utils.json.json_ser)
-    """
-    if isinstance(obj, (datetime, date)):
-        return obj.isoformat()
-
-
 class AirflowJsonEncoder(json.JSONEncoder):
 
     def default(self, obj):

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -33,6 +33,7 @@ from airflow import settings
 from airflow import configuration as conf
 from airflow.logging_config import configure_logging
 from airflow.www.static_config import configure_manifest_files
+from airflow.utils.json import AirflowJsonEncoder
 
 app = None
 appbuilder = None
@@ -61,6 +62,9 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
 
     if config:
         app.config.from_mapping(config)
+
+    # Configure the JSON encoder used by `|tojson` filter from Flask
+    app.json_encoder = AirflowJsonEncoder
 
     csrf.init_app(app)
 

--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -55,7 +55,7 @@
     var dag_id = '{{ dag.dag_id }}';
     var task_id = '';
     var exection_date = '';
-    data = {{ data |safe }};
+    data = {{ data |tojson|safe }};
     var gantt = d3.gantt()
       .taskTypes(data.taskNames)
       .taskStatus(data.taskStatus)

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -103,14 +103,14 @@
     var initialStrokeWidth = '3px';
     var highlightStrokeWidth = '5px';
 
-    var nodes = {{ nodes|safe }};
-    var edges = {{ edges|safe }};
+    var nodes = {{ nodes|tojson|safe }};
+    var edges = {{ edges|tojson|safe }};
     var execution_date = "{{ execution_date }}";
     var arrange = "{{ arrange }}";
 
     // Below variables are being used in dag.js
-    var tasks = {{ tasks|safe }};
-    var task_instances = {{ task_instances|safe }};
+    var tasks = {{ tasks|tojson|safe }};
+    var task_instances = {{ task_instances|tojson|safe }};
     var getTaskInstanceURL = "{{ url_for('Airflow.task_instances') }}" +
       "?dag_id=" + encodeURIComponent(dag_id) + "&execution_date=" +
       encodeURIComponent(execution_date);

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -80,7 +80,7 @@
 <script>
 $('span.status_square').tooltip({html: true});
 
-var data = {{ data|safe }};
+var data = {{ data|tojson|safe }};
 var barHeight = 20;
 var axisHeight = 40;
 var square_x = 500;

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -64,7 +64,6 @@ from airflow.utils import timezone
 from airflow.utils.dates import infer_time_unit, scale_time_units
 from airflow.utils.db import provide_session, create_session
 from airflow.utils.helpers import alchemy_to_dict, render_log_filename
-from airflow.utils.json import json_ser
 from airflow.utils.state import State
 from airflow._vendor import nvd3
 from airflow.www import utils as wwwutils
@@ -1265,8 +1264,6 @@ class Airflow(AirflowBaseView):
                 for d in dates],
         }
 
-        # minimize whitespace as this can be huge for bigger dags
-        data = json.dumps(data, default=json_ser, separators=(',', ':'))
         session.commit()
 
         form = DateTimeWithNumRunsForm(data={'base_date': max_date,
@@ -1377,10 +1374,10 @@ class Airflow(AirflowBaseView):
             ),
             blur=blur,
             root=root or '',
-            task_instances=json.dumps(task_instances, indent=2),
-            tasks=json.dumps(tasks, indent=2),
-            nodes=json.dumps(nodes, indent=2),
-            edges=json.dumps(edges, indent=2), )
+            task_instances=task_instances,
+            tasks=tasks,
+            nodes=nodes,
+            edges=edges)
 
     @expose('/duration')
     @has_dag_access(can_dag_read=True)
@@ -1760,7 +1757,7 @@ class Airflow(AirflowBaseView):
             dag=dag,
             execution_date=dttm.isoformat(),
             form=form,
-            data=json.dumps(data, indent=2),
+            data=data,
             base_date='',
             demo_mode=demo_mode,
             root=root,

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -26,22 +26,6 @@ import numpy as np
 from airflow.utils import json as utils_json
 
 
-class TestJsonSer(unittest.TestCase):
-
-    def test_json_ser_datetime(self):
-        obj = datetime.strptime('2017-05-21 00:00:00', '%Y-%m-%d %H:%M:%S')
-        self.assertEqual(
-            json.dumps(obj, default=utils_json.json_ser),
-            '"2017-05-21T00:00:00"',
-        )
-
-    def test_json_ser_date(self):
-        self.assertEqual(
-            json.dumps(date(2017, 5, 21), default=utils_json.json_ser),
-            '"2017-05-21"',
-        )
-
-
 class TestAirflowJsonEncoder(unittest.TestCase):
 
     def test_encode_datetime(self):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

https://issues.apache.org/jira/browse/AIRFLOW-4100
  
### Description

It was possible to end up with invalid JS-in-script if you created
certain structures. This fixes it.

`|tojson|safe` is the method recommended by Flask of dealing with this
sort of case: http://flask.pocoo.org/docs/1.0/templating/#standard-filters

### Tests

- [x] I haven't currently added any tests for this - maybe I should. What to people think?

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
