### PR TITLE
[AIRFLOW-4092] Add gRPCOperator, unit test and added to auto doc

### DIFF
--- a/airflow/contrib/operators/grpc_operator.py
+++ b/airflow/contrib/operators/grpc_operator.py
@@ -34,27 +34,22 @@ class GrpcOperator(BaseOperator):
     :type grpc_conn_id: str
     :param data: The data to pass to the rpc call
     :type data: A dict with key value pairs as kwargs of the call_func
-    :param auth_type: The auth_type
-    :type grpc_conn_id: str
     :param interceptors: A list of gRPC interceptor objects to be used on the channel
     :type interceptors: A list of gRPC interceptor objects, has to be initialized
     :param custom_connection_func: The customized connection function to return channel object
     :type custom_connection_func: A python function that returns channel object, take in
         a connection object, can be a partial function
+    :param streaming: A flag to indicate if the call is a streaming call
+    :type streaming: boolean
     :param response_callback: The callback function to process the response from gRPC call
     :type response_callback: A python function that process the response from gRPC call,
         takes in response object and context object, context object can be used to perform
         push xcom or other after task actions
-    :param streaming: A flag to indicate if the call is a streaming call
-    :type streaming: boolean
     :param log_response: A flag to indicate if we need to log the response
     :type log_response: boolean
     """
 
     template_fields = ('stub_class', 'call_func', 'data')
-    # hook dispatcher dict, dispatch based on auth_type other than the ones
-    # support in the base hook
-    hook_dispatchers = {}
 
     @apply_defaults
     def __init__(self,
@@ -62,7 +57,6 @@ class GrpcOperator(BaseOperator):
                  call_func,
                  grpc_conn_id="grpc_default",
                  data=None,
-                 auth_type="NO_AUTH",
                  interceptors=None,
                  custom_connection_func=None,
                  streaming=False,
@@ -74,19 +68,13 @@ class GrpcOperator(BaseOperator):
         self.call_func = call_func
         self.grpc_conn_id = grpc_conn_id
         self.data = data or {}
-        self.auth_type = auth_type
         self.interceptors = interceptors
         self.custom_connection_func = custom_connection_func
         self.streaming = streaming
         self.log_response = log_response
         self.response_callback = response_callback
-        self.hook = self._get_grpc_hook()
 
     def _get_grpc_hook(self):
-        if self.auth_type in self.hook_dispatchers:
-            hook_class = self.hook_dispatchers.get(self.auth_type)
-            return hook_class(self.grpc_conn_id)
-
         return GrpcHook(
             self.grpc_conn_id,
             interceptors=self.interceptors,
@@ -94,10 +82,11 @@ class GrpcOperator(BaseOperator):
         )
 
     def execute(self, context):
+        hook = self._get_grpc_hook()
         self.log.info("Calling gRPC service")
 
         # grpc hook always yield
-        responses = self.hook.run(self.stub_class, self.call_func, streaming=self.streaming, data=self.data)
+        responses = hook.run(self.stub_class, self.call_func, streaming=self.streaming, data=self.data)
 
         for response in responses:
             self._handle_response(response, context)

--- a/airflow/contrib/operators/grpc_operator.py
+++ b/airflow/contrib/operators/grpc_operator.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.contrib.hooks.grpc_hook import GrpcHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class GrpcOperator(BaseOperator):
+    """
+    Calls a gRPC endpoint to execute an action
+    """
+    template_fields = ('stub_class', 'call_func', 'data')
+    # hook dispatcher dict, dispatch based on auth_type other than the ones
+    # support in the base hook
+    hook_dispatchers = {}
+
+    @apply_defaults
+    def __init__(self,
+                 stub_class,
+                 call_func,
+                 grpc_conn_id="grpc_default",
+                 data=None,
+                 auth_type="NO_AUTH",
+                 interceptors=None,
+                 custom_connection_func=None,
+                 streaming=False,
+                 response_callback=None,
+                 log_response=False,
+                 *args, **kwargs):
+        """
+        :param stub_class: The stub client to use for this gRPC call
+        :type stub_class: gRPC stub class generated from proto file
+        :param call_func: The client function name to call the gRPC endpoint
+        :type call_func: gRPC client function name for the endpoint generated from proto file, str
+        :param grpc_conn_id: The connection to run the operator against
+        :type grpc_conn_id: str
+        :param data: The data to pass to the rpc call
+        :type data: A dict with key value pairs as kwargs of the call_func
+        :param auth_type: The auth_type
+        :type grpc_conn_id: str
+        :param interceptors: A list of gRPC interceptor objects to be used on the channel
+        :type interceptors: A list of gRPC interceptor objects, has to be initialized
+        :param custom_connection_func: The customized connection function to return channel object
+        :type custom_connection_func: A python function that returns channel object, take in
+            a connection object, can be a partial function
+        :param response_callback: The callback function to process the response from gRPC call
+        :type response_callback: A python function that process the response from gRPC call,
+            takes in response object and context object, context object can be used to perform
+            push xcom or other after task actions
+        :param streaming: A flag to indicate if the call is a streaming call
+        :type streaming: boolean
+        :param log_response: A flag to indicate if we need to log the response
+        :type log_response: boolean
+        """
+        super(GrpcOperator, self).__init__(*args, **kwargs)
+        self.stub_class = stub_class
+        self.call_func = call_func
+        self.grpc_conn_id = grpc_conn_id
+        self.data = data or {}
+        self.auth_type = auth_type
+        self.interceptors = interceptors
+        self.custom_connection_func = custom_connection_func
+        self.streaming = streaming
+        self.log_response = log_response
+        self.response_callback = response_callback
+        self.hook = self._get_grpc_hook()
+
+    def _get_grpc_hook(self):
+        if self.auth_type in self.hook_dispatchers:
+            hook_class = self.hook_dispatchers.get(self.auth_type)
+            return hook_class(self.grpc_conn_id)
+
+        return GrpcHook(
+            self.grpc_conn_id,
+            interceptors=self.interceptors,
+            custom_connection_func=self.custom_connection_func
+        )
+
+    def execute(self, context):
+        self.log.info("Calling gRPC service")
+
+        # grpc hook always yield
+        responses = self.hook.run(self.stub_class, self.call_func, streaming=self.streaming, data=self.data)
+
+        for response in responses:
+            self._handle_response(response, context)
+
+    def _handle_response(self, response, context):
+        if self.log_response:
+            self.log.info(repr(response))
+        if self.response_callback:
+            self.response_callback(response, context)

--- a/airflow/contrib/operators/grpc_operator.py
+++ b/airflow/contrib/operators/grpc_operator.py
@@ -25,7 +25,32 @@ from airflow.utils.decorators import apply_defaults
 class GrpcOperator(BaseOperator):
     """
     Calls a gRPC endpoint to execute an action
+
+    :param stub_class: The stub client to use for this gRPC call
+    :type stub_class: gRPC stub class generated from proto file
+    :param call_func: The client function name to call the gRPC endpoint
+    :type call_func: gRPC client function name for the endpoint generated from proto file, str
+    :param grpc_conn_id: The connection to run the operator against
+    :type grpc_conn_id: str
+    :param data: The data to pass to the rpc call
+    :type data: A dict with key value pairs as kwargs of the call_func
+    :param auth_type: The auth_type
+    :type grpc_conn_id: str
+    :param interceptors: A list of gRPC interceptor objects to be used on the channel
+    :type interceptors: A list of gRPC interceptor objects, has to be initialized
+    :param custom_connection_func: The customized connection function to return channel object
+    :type custom_connection_func: A python function that returns channel object, take in
+        a connection object, can be a partial function
+    :param response_callback: The callback function to process the response from gRPC call
+    :type response_callback: A python function that process the response from gRPC call,
+        takes in response object and context object, context object can be used to perform
+        push xcom or other after task actions
+    :param streaming: A flag to indicate if the call is a streaming call
+    :type streaming: boolean
+    :param log_response: A flag to indicate if we need to log the response
+    :type log_response: boolean
     """
+
     template_fields = ('stub_class', 'call_func', 'data')
     # hook dispatcher dict, dispatch based on auth_type other than the ones
     # support in the base hook
@@ -44,31 +69,6 @@ class GrpcOperator(BaseOperator):
                  response_callback=None,
                  log_response=False,
                  *args, **kwargs):
-        """
-        :param stub_class: The stub client to use for this gRPC call
-        :type stub_class: gRPC stub class generated from proto file
-        :param call_func: The client function name to call the gRPC endpoint
-        :type call_func: gRPC client function name for the endpoint generated from proto file, str
-        :param grpc_conn_id: The connection to run the operator against
-        :type grpc_conn_id: str
-        :param data: The data to pass to the rpc call
-        :type data: A dict with key value pairs as kwargs of the call_func
-        :param auth_type: The auth_type
-        :type grpc_conn_id: str
-        :param interceptors: A list of gRPC interceptor objects to be used on the channel
-        :type interceptors: A list of gRPC interceptor objects, has to be initialized
-        :param custom_connection_func: The customized connection function to return channel object
-        :type custom_connection_func: A python function that returns channel object, take in
-            a connection object, can be a partial function
-        :param response_callback: The callback function to process the response from gRPC call
-        :type response_callback: A python function that process the response from gRPC call,
-            takes in response object and context object, context object can be used to perform
-            push xcom or other after task actions
-        :param streaming: A flag to indicate if the call is a streaming call
-        :type streaming: boolean
-        :param log_response: A flag to indicate if we need to log the response
-        :type log_response: boolean
-        """
         super(GrpcOperator, self).__init__(*args, **kwargs)
         self.stub_class = stub_class
         self.call_func = call_func

--- a/tests/contrib/operators/test_grpc_operator.py
+++ b/tests/contrib/operators/test_grpc_operator.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from airflow import configuration
+from airflow.contrib.operators.grpc_operator import GrpcOperator
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+
+class StubClass(object):
+    def __init__(self, channel):
+        pass
+
+    def stream_call(self, data):
+        pass
+
+
+class TestGrpcOperator(unittest.TestCase):
+    def setUp(self):
+        configuration.load_test_config()
+
+    def custom_conn_func(self, connection):
+        pass
+
+    @mock.patch('airflow.contrib.operators.grpc_operator.GrpcHook')
+    def test_with_interceptors(self, mock_hook):
+        mocked_hook = mock.Mock()
+        mock_hook.return_value = mocked_hook
+        GrpcOperator(
+            stub_class=StubClass,
+            call_func="stream_call",
+            interceptors=[],
+            task_id="test_grpc",
+        )
+
+        mock_hook.assert_called_once_with("grpc_default", interceptors=[], custom_connection_func=None)
+
+    @mock.patch('airflow.contrib.operators.grpc_operator.GrpcHook')
+    def test_with_custom_connection_func(self, mock_hook):
+        mocked_hook = mock.Mock()
+        mock_hook.return_value = mocked_hook
+        GrpcOperator(
+            stub_class=StubClass,
+            call_func="stream_call",
+            custom_connection_func=self.custom_conn_func,
+            task_id="test_grpc",
+        )
+
+        mock_hook.assert_called_once_with(
+            "grpc_default", interceptors=None, custom_connection_func=self.custom_conn_func)
+
+    @mock.patch('airflow.contrib.operators.grpc_operator.GrpcHook')
+    def test_execute_with_log(self, mock_hook):
+        mocked_hook = mock.Mock()
+        mock_hook.return_value = mocked_hook
+        mocked_hook.configure_mock(**{'run.return_value': ["value1", "value2"]})
+        operator = GrpcOperator(
+            stub_class=StubClass,
+            call_func="stream_call",
+            log_response=True,
+            task_id="test_grpc",
+        )
+
+        with mock.patch.object(operator.log, 'info') as mock_info:
+            operator.execute({})
+
+            mock_hook.assert_called_once_with("grpc_default", interceptors=None, custom_connection_func=None)
+            mocked_hook.run.assert_called_once_with(StubClass, "stream_call", data={}, streaming=False)
+            mock_info.assert_any_call("Calling gRPC service")
+            mock_info.assert_any_call("'value1'")
+            mock_info.assert_any_call("'value2'")
+
+    @mock.patch('airflow.contrib.operators.grpc_operator.GrpcHook')
+    def test_execute_with_callback(self, mock_hook):
+        mocked_hook = mock.Mock()
+        callback = mock.Mock()
+        mock_hook.return_value = mocked_hook
+        mocked_hook.configure_mock(**{'run.return_value': ["value1", "value2"]})
+        operator = GrpcOperator(
+            stub_class=StubClass,
+            call_func="stream_call",
+            task_id="test_grpc",
+            response_callback=callback
+        )
+
+        with mock.patch.object(operator.log, 'info') as mock_info:
+            operator.execute({})
+            mock_hook.assert_called_once_with("grpc_default", interceptors=None, custom_connection_func=None)
+            mocked_hook.run.assert_called_once_with(StubClass, "stream_call", data={}, streaming=False)
+            self.assertTrue(("'value1'", "'value2'") not in mock_info.call_args_list)
+            mock_info.assert_any_call("Calling gRPC service")
+            callback.assert_any_call("value1", {})
+            callback.assert_any_call("value2", {})

--- a/tests/contrib/operators/test_grpc_operator.py
+++ b/tests/contrib/operators/test_grpc_operator.py
@@ -16,13 +16,7 @@ import unittest
 from airflow import configuration
 from airflow.contrib.operators.grpc_operator import GrpcOperator
 
-try:
-    from unittest import mock
-except ImportError:
-    try:
-        import mock
-    except ImportError:
-        mock = None
+from tests.compat import mock
 
 
 class StubClass(object):
@@ -42,28 +36,26 @@ class TestGrpcOperator(unittest.TestCase):
 
     @mock.patch('airflow.contrib.operators.grpc_operator.GrpcHook')
     def test_with_interceptors(self, mock_hook):
-        mocked_hook = mock.Mock()
-        mock_hook.return_value = mocked_hook
-        GrpcOperator(
+        operator = GrpcOperator(
             stub_class=StubClass,
             call_func="stream_call",
             interceptors=[],
             task_id="test_grpc",
         )
 
+        operator.execute({})
         mock_hook.assert_called_once_with("grpc_default", interceptors=[], custom_connection_func=None)
 
     @mock.patch('airflow.contrib.operators.grpc_operator.GrpcHook')
     def test_with_custom_connection_func(self, mock_hook):
-        mocked_hook = mock.Mock()
-        mock_hook.return_value = mocked_hook
-        GrpcOperator(
+        operator = GrpcOperator(
             stub_class=StubClass,
             call_func="stream_call",
             custom_connection_func=self.custom_conn_func,
             task_id="test_grpc",
         )
 
+        operator.execute({})
         mock_hook.assert_called_once_with(
             "grpc_default", interceptors=None, custom_connection_func=self.custom_conn_func)
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [AIRFLOW-4092](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-4092
  
### Description

- [x] Added gRPCOperator using gRPCHook to call gRPC service from airflow, added docs

### Tests

- [x] My PR adds the following unit tests :
tests/contrib/operators/test_grpc_operator.py

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
