### PR TITLE
[AIRFLOW-4108] Load autocomplete data asynchronously

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -215,6 +215,7 @@
   <script>
 
       const DAGS_INDEX = "{{ url_for('Airflow.index') }}";
+      const DAGS_AUTOCOMPLETE = "{{ url_for('Airflow.dags_autocomplete') }}";
       const ENTER_KEY_CODE = 13;
 
       $('#dag_query').on('keypress', function (e) {
@@ -256,17 +257,21 @@
       });
 
       var $input = $(".typeahead");
-      unique_options_search = new Set([
-          {% for token in auto_complete_data %}
-            "{{token}}",
-          {% endfor %}
-        ]);
 
       $input.typeahead({
-        source: [...unique_options_search],
+        source: function(query, success, error) {
+          $.ajax({
+            url: DAGS_AUTOCOMPLETE,
+            data: {search: query, limit: 8}
+          }).done(function(data) {
+            success(data.items)
+          }).fail(function() {
+            error()
+          });
+        },
         autoSelect: false,
         afterSelect: function(value) {
-          search_query = value.trim()
+          var search_query = value.trim()
           if (search_query) {
             window.location = DAGS_INDEX + "?search="+ encodeURI(search_query);
           }

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -407,6 +407,29 @@ class TestAirflowBaseViews(TestBase):
         resp = self.client.get('home', follow_redirects=True)
         self.check_content_in_response('DAGs', resp)
 
+    def test_autocomplete(self):
+        search = 'example_branch_dop_operator_v3'
+        url = 'dags_autocomplete?search={}'.format(search)
+        resp_json = json.loads(self.client.get(url, follow_redirects=True).data.decode('utf-8'))
+
+        self.assertEqual(resp_json['items'], ['example_branch_dop_operator_v3'])
+
+    def test_autocomplete_like(self):
+        search = 'branch'
+        url = 'dags_autocomplete?search={}'.format(search)
+        resp_json = json.loads(self.client.get(url, follow_redirects=True).data.decode('utf-8'))
+
+        self.assertEqual(
+            resp_json['items'], ['example_branch_dop_operator_v3', 'example_branch_operator']
+        )
+
+    def test_autocomplete_limit(self):
+        search = 'branch'
+        url = 'dags_autocomplete?search={}&limit=1'.format(search)
+        resp_json = json.loads(self.client.get(url, follow_redirects=True).data.decode('utf-8'))
+
+        self.assertEqual(resp_json['items'], ['example_branch_dop_operator_v3'])
+
     def test_task(self):
         url = ('task?task_id=runme_0&dag_id=example_bash_operator&execution_date={}'
                .format(self.percent_encode(self.EXAMPLE_DAG_DEFAULT_DATE)))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

This PR introduces changes:
- loading data into typeahead in an asynchronous way
- add sorting 
- fixes searching by the owner field

CC: @astahlman 

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
