### PR TITLE
[AIRFLOW-4112] Remove beeline_default in default connection

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -95,11 +95,6 @@ def initdb():
             schema='airflow'))
     merge_conn(
         Connection(
-            conn_id='beeline_default', conn_type='beeline', port=10000,
-            host='localhost', extra="{\"use_beeline\": true, \"auth\": \"\"}",
-            schema='default'))
-    merge_conn(
-        Connection(
             conn_id='bigquery_default', conn_type='google_cloud_platform',
             schema='default'))
     merge_conn(
@@ -118,7 +113,8 @@ def initdb():
             schema='default',))
     merge_conn(
         Connection(
-            conn_id='hive_cli_default', conn_type='hive_cli',
+            conn_id='hive_cli_default', conn_type='hive_cli', port=10000,
+            host='localhost', extra='{"use_beeline": true, "auth": ""}',
             schema='default',))
     merge_conn(
         Connection(

--- a/tests/core.py
+++ b/tests/core.py
@@ -1435,7 +1435,7 @@ class CliTests(unittest.TestCase):
         # Assert that some of the connections are present in the output as
         # expected:
         self.assertIn(['aws_default', 'aws'], conns)
-        self.assertIn(['beeline_default', 'beeline'], conns)
+        self.assertIn(['hive_cli_default', 'hive_cli'], conns)
         self.assertIn(['emr_default', 'emr'], conns)
         self.assertIn(['mssql_default', 'mssql'], conns)
         self.assertIn(['mysql_default', 'mysql'], conns)

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -79,7 +79,7 @@ class HiveEnvironmentTest(unittest.TestCase):
                 'table': self.table,
                 'partition_by': self.partition_by
             },
-            hive_cli_conn_id='beeline_default',
+            hive_cli_conn_id='hive_cli_default',
             hql=self.hql, dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE,
               ignore_ti_state=True)
@@ -389,7 +389,7 @@ class TestHiveServer2Hook(unittest.TestCase):
                 'table': self.table,
                 'csv_path': self.local_path
             },
-            hive_cli_conn_id='beeline_default',
+            hive_cli_conn_id='hive_cli_default',
             hql=self.hql, dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE,
               ignore_ti_state=True)

--- a/tests/operators/test_hive_operator.py
+++ b/tests/operators/test_hive_operator.py
@@ -163,7 +163,7 @@ if 'AIRFLOW_RUNALL_TESTS' in os.environ:
 
         def test_beeline(self):
             t = HiveOperator(
-                task_id='beeline_hql', hive_cli_conn_id='beeline_default',
+                task_id='beeline_hql', hive_cli_conn_id='hive_cli_default',
                 hql=self.hql, dag=self.dag)
             t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE,
                   ignore_ti_state=True)

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -391,7 +391,7 @@ class TransferTests(unittest.TestCase):
         sql = "SELECT * FROM baby_names LIMIT 1000;"
         t = MySqlToHiveTransfer(
             task_id='test_m2h',
-            hive_cli_conn_id='beeline_default',
+            hive_cli_conn_id='hive_cli_default',
             sql=sql,
             hive_table='test_mysql_to_hive',
             recreate=True,
@@ -406,7 +406,7 @@ class TransferTests(unittest.TestCase):
         sql = "SELECT * FROM baby_names LIMIT 1000;"
         t = MySqlToHiveTransfer(
             task_id='test_m2h',
-            hive_cli_conn_id='beeline_default',
+            hive_cli_conn_id='hive_cli_default',
             sql=sql,
             hive_table='test_mysql_to_hive_part',
             partition={'ds': DEFAULT_DATE_DS},
@@ -423,7 +423,7 @@ class TransferTests(unittest.TestCase):
         sql = "SELECT * FROM baby_names LIMIT 1000;"
         t = MySqlToHiveTransfer(
             task_id='test_m2h',
-            hive_cli_conn_id='beeline_default',
+            hive_cli_conn_id='hive_cli_default',
             sql=sql,
             hive_table='test_mysql_to_hive',
             recreate=True,
@@ -458,7 +458,7 @@ class TransferTests(unittest.TestCase):
             from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
             t = MySqlToHiveTransfer(
                 task_id='test_m2h',
-                hive_cli_conn_id='beeline_default',
+                hive_cli_conn_id='hive_cli_default',
                 sql="SELECT * FROM {}".format(mysql_table),
                 hive_table='test_mysql_to_hive',
                 dag=self.dag)
@@ -525,7 +525,7 @@ class TransferTests(unittest.TestCase):
             from airflow.operators.mysql_to_hive import MySqlToHiveTransfer
             t = MySqlToHiveTransfer(
                 task_id='test_m2h',
-                hive_cli_conn_id='beeline_default',
+                hive_cli_conn_id='hive_cli_default',
                 sql="SELECT * FROM {}".format(mysql_table),
                 hive_table=hive_table,
                 recreate=True,

--- a/tests/sensors/test_named_hive_partition_sensor.py
+++ b/tests/sensors/test_named_hive_partition_sensor.py
@@ -64,7 +64,7 @@ class NamedHivePartitionSensorTests(unittest.TestCase):
                 'table': self.table,
                 'partition_by': self.partition_by
             },
-            hive_cli_conn_id='beeline_default',
+            hive_cli_conn_id='hive_cli_default',
             hql=self.hql, dag=self.dag)
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE,
               ignore_ti_state=True)


### PR DESCRIPTION
We use both `beeline_default` and `hive_cli_default`
as our default when we run `airflow initdb`. But in
airflow source folder we only use `hive_cli_default`
as conn_id in hive related hook/operator and only
use `beeline_default` in airflow test folder for
test hive hook/operator. That why I think we should
merge then as one default connection

And in [Hive doc](https://cwiki.apache.org/confluence/
display/Hive/LanguageManual+Cli#
LanguageManualCli-DeprecationinfavorofBeelineCLI) could
know that hive cli will be deprecation in favor of
Beeline. In this situation I think we should remove
`beeline_default` and change `hive_cli_default` as
same configure as `beeline_default`

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-4112\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR:

We use both `beeline_default` and `hive_cli_default`
as our default when we run `airflow initdb`. But in
airflow source folder we only use `hive_cli_default`
as conn_id in hive related hook/operator and only
use `beeline_default` in airflow test folder for
test hive hook/operator. That why I think we should
merge then as one default connection

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

monir change, not need.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
