### PR TITLE
[AIRFLOW-4123] Add Exception handling for _change_state method in K8 …

### DIFF
--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -660,7 +660,12 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
             key, state, pod_id, resource_version = results
             last_resource_version = resource_version
             self.log.info('Changing state of %s to %s', results, state)
-            self._change_state(key, state, pod_id)
+            try:
+                self._change_state(key, state, pod_id)
+            except Exception as e:
+                self.log.exception('Exception: %s when attempting ' +
+                                   'to change state of %s to %s, re-queueing.', e, results, state)
+                self.result_queue.put(results)
 
         KubeResourceVersion.checkpoint_resource_version(last_resource_version)
 


### PR DESCRIPTION
…Executor

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4123) issues and references them in the PR title.
  "\[AIRFLOW-4123\] Add Exception handling for _change_state method in K8 Executor"
  - https://issues.apache.org/jira/browse/AIRFLOW-4123
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
  
   Failure to delete pod, causes multiple issue, like-

     1. The completed pod remains in the cluster forever,

     2. The taskInstance states are not updated in DB.

I want to retry _change_state in case of any failures. I am handling a generic exception, since APIException from kubernetes python client method delete_namespaced_pod does not encompass timeout exceptions like ReadTimeoutError or SocketError.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
