### PR TITLE
[AIRFLOW-4124] add get_table and get_table_location in aws_glue_hook and tests

### DIFF
--- a/airflow/contrib/hooks/aws_glue_catalog_hook.py
+++ b/airflow/contrib/hooks/aws_glue_catalog_hook.py
@@ -132,11 +132,7 @@ class AwsGlueCatalogHook(AwsHook):
         >>> r['Name'] = 'table_foo'
         """
 
-        try:
-            result = self.get_conn().get_table(
-                DatabaseName=database_name, Name=table_name)
-        except Exception as e:
-            raise e
+        result = self.get_conn().get_table(DatabaseName=database_name, Name=table_name)
 
         return result['Table']
 

--- a/airflow/contrib/hooks/aws_glue_catalog_hook.py
+++ b/airflow/contrib/hooks/aws_glue_catalog_hook.py
@@ -116,3 +116,41 @@ class AwsGlueCatalogHook(AwsHook):
             return True
         else:
             return False
+
+    def get_table(self, database_name, table_name):
+        """
+        Get the information of the table
+
+        :param database_name: Name of hive database (schema) @table belongs to
+        :type database_name: str
+        :param table_name: Name of hive table
+        :type table_name: str
+        :rtype: dict
+
+        >>> hook = AwsGlueCatalogHook()
+        >>> r = hook.get_table('db', 'table_foo')
+        >>> r['Name'] = 'table_foo'
+        """
+
+        try:
+            result = self.get_conn().get_table(
+                DatabaseName=database_name, Name=table_name)
+        except Exception as e:
+            raise e
+
+        return result['Table']
+
+    def get_table_location(self, database_name, table_name):
+        """
+        Get the physical location of the table
+
+        :param database_name: Name of hive database (schema) @table belongs to
+        :type database_name: str
+        :param table_name: Name of hive table
+        :type table_name: str
+        :return: str
+        """
+
+        table = self.get_table(database_name, table_name)
+
+        return table['StorageDescriptor']['Location']


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-4124\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4124
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-4124\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
