### PR TITLE
[AIRFLOW-4127] _get_instance_view returns instance view

### DIFF
--- a/airflow/contrib/hooks/azure_container_instance_hook.py
+++ b/airflow/contrib/hooks/azure_container_instance_hook.py
@@ -113,7 +113,7 @@ class AzureContainerInstanceHook(BaseHook):
         response = self.connection.container_groups.get(resource_group,
                                                         name,
                                                         raw=False)
-        return response.containers[0].instance_view.current_state
+        return response.containers[0].instance_view
 
     def get_messages(self, resource_group, name):
         """


### PR DESCRIPTION
### Jira

https://issues.apache.org/jira/browse/AIRFLOW-4127

### Description

Simple bugfix for method `_get_instance_view` that returned `current_view` instead of an `instance_view`

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
