### PR TITLE
[AIRFLOW-3706] Fix tooltip max-width by correcting ordering of CSS files

### DIFF
--- a/airflow/www/templates/appbuilder/baselayout.html
+++ b/airflow/www/templates/appbuilder/baselayout.html
@@ -21,12 +21,12 @@
 {% block head_css %}
   {{ super() }}
 
-  <link href="{{ url_for_asset('main.css') }}" rel="stylesheet">
 
   {% if not appbuilder.app_theme %}
     {# airflowDefaultTheme.css file contains the styles from local bootstrap-theme.css #}
     <link href="{{ url_for_asset('airflowDefaultTheme.css') }}" rel="stylesheet">
   {% endif %}
+  <link href="{{ url_for_asset('main.css') }}" rel="stylesheet">
 
   <link rel="icon" type="image/png" href="{{ url_for('static', filename='pin_30.png') }}">
 {% endblock %}


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### Jira
 https://issues.apache.org/jira/browse/AIRFLOW-3706

### Description

The "airflowDefaultTheme.css" file is created by webpack out of
bootstrap-theme.css, which is a "base" file. But this was loaded _after_
Airflow's main.css, meaning the `max-width` we set on `.tooltip-inner`
was being replaced by the default from bootstrap.

/cc @verdan 

### Tests

**Before**:
![Screen Shot 2019-03-19 at 23 20 43](https://user-images.githubusercontent.com/34150/54648340-c6f86800-4a9d-11e9-8983-dc882b32e7a1.png)


**After**:

![Screen Shot 2019-03-19 at 23 19 08](https://user-images.githubusercontent.com/34150/54648344-ccee4900-4a9d-11e9-8f7d-f23761660040.png)

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- x] Passes `flake8`
