### PR TITLE
[AIRFLOW-4129] Escape HTML in generated tooltips (#4944)

### DIFF
--- a/airflow/www/templates/admin/master.html
+++ b/airflow/www/templates/admin/master.html
@@ -45,6 +45,13 @@
         }
       }
     });
+
+var el = document.createElement("span");
+
+export function escapeHtml(text) {
+  el.textContent = text;
+  return el.innerHTML;
+}
 </script>
 {% endblock %}
 

--- a/airflow/www/templates/admin/master.html
+++ b/airflow/www/templates/admin/master.html
@@ -48,7 +48,7 @@
 
 var el = document.createElement("span");
 
-export function escapeHtml(text) {
+function escapeHtml(text) {
   el.textContent = text;
   return el.innerHTML;
 }

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -280,16 +280,19 @@
             .attr("data-original-title", function(d) {
               // Tooltip
               task = tasks[task_id];
-              tt =  "Task_id: " + ti.task_id + "<br>";
-              tt += "Run: " + ti.execution_date + "<br>";
-              if(ti.run_id != undefined){
-                tt += "run_id: <nobr>" + ti.run_id + "</nobr><br>";
+              tt = "";
+              if(ti.task_id != undefined){
+                tt +=  "Task_id: " + escapeHtml(ti.task_id) + "<br>";
               }
-              tt += "Operator: " + task.task_type + "<br>";
-              tt += "Started: " + ti.start_date + "<br>";
-              tt += "Ended: " + ti.end_date + "<br>";
-              tt += "Duration: " + ti.duration + "<br>";
-              tt += "State: " + ti.state + "<br>";
+              tt += "Run: " + escapeHtml(ti.execution_date) + "<br>";
+              if(ti.run_id != undefined){
+                tt += "run_id: <nobr>" + escapeHtml(ti.run_id) + "</nobr><br>";
+              }
+              tt += "Operator: " + escapeHtml(task.task_type) + "<br>";
+              tt += "Started: " + escapeHtml(ti.start_date) + "<br>";
+              tt += "Ended: " + escapeHtml(ti.end_date) + "<br>";
+              tt += "Duration: " + escapeHtml(ti.duration) + "<br>";
+              tt += "State: " + escapeHtml(ti.state) + "<br>";
               return tt;
             });
         });

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -197,13 +197,15 @@ function update(source) {
       .attr("title", function(d){
         var tt = "";
         if (d.operator != undefined) {
-          tt += "operator: " + d.operator + "<br/>";
-          tt += "depends_on_past: " + d.depends_on_past + "<br/>";
-          tt += "upstream: " + d.num_dep + "<br/>";
-          tt += "retries: " + d.retries + "<br/>";
-          tt += "owner: " + d.owner + "<br/>";
-          tt += "start_date: " + d.start_date + "<br/>";
-          tt += "end_date: " + d.end_date + "<br/>";
+          if (d.operator != undefined) {
+            tt += "operator: " + escapeHtml(d.operator) + "<br/>";
+          }
+          tt += "depends_on_past: " + escapeHtml(d.depends_on_past) + "<br/>";
+          tt += "upstream: " + escapeHtml(d.num_dep) + "<br/>";
+          tt += "retries: " + escapeHtml(d.retries) + "<br/>";
+          tt += "owner: " + escapeHtml(d.owner) + "<br/>";
+          tt += "start_date: " + escapeHtml(d.start_date) + "<br/>";
+          tt += "end_date: " + escapeHtml(d.end_date) + "<br/>";
         }
         return tt;
       })
@@ -244,17 +246,24 @@ function update(source) {
       .style("stroke-width", function(d) {return (d.run_id != undefined)? "2": "1"})
       .style("stroke-opacity", function(d) {return d.external_trigger ? "0": "1"})
       .attr("title", function(d){
-        s =  "Task_id: " + d.task_id + "<br>";
-        s += "Run: " + d.execution_date + "<br>";
-        if(d.run_id != undefined){
-          s += "run_id: <nobr>" + d.run_id + "</nobr><br>";
+        var s = "";
+        if (d.task_id != undefined ) {
+          s += "Task_id: " + escapeHtml(d.task_id) + "<br>";
         }
-        s += "Operator: " + d.operator + "<br>"
+        s += "Run: " + escapeHtml(d.execution_date) + "<br>";
+        if(d.run_id != undefined){
+          s += "run_id: <nobr>" + escapeHtml(d.run_id) + "</nobr><br>";
+        }
+        if (d.operator != undefined) {
+          s += "Operator: " + escapeHtml(d.operator) + "<br>"
+        }
         if(d.start_date != undefined){
-          s += "Started: " + d.start_date + "<br>";
-          s += "Ended: " + d.end_date + "<br>";
-          s += "Duration: " + d.duration + "<br>";
-          s += "State: " + d.state + "<br>";
+          s += "Started: " + escapeHtml(d.start_date) + "<br>";
+          s += "Ended: " + escapeHtml(d.end_date) + "<br>";
+          if (d.duration != undefined) {
+            s += "Duration: " + escapeHtml(d.duration) + "<br>";
+          }
+          s += "State: " + escapeHtml(d.state) + "<br>";
         }
         return s;
       })

--- a/airflow/www_rbac/static/js/base.js
+++ b/airflow/www_rbac/static/js/base.js
@@ -30,6 +30,15 @@ function displayTime() {
   setTimeout(displayTime, 1000);
 }
 
+var el = document.createElement("span");
+
+export function escapeHtml(text) {
+  el.textContent = text;
+  return el.innerHTML;
+}
+
+window.escapeHtml = escapeHtml;
+
 $(document).ready(function () {
   displayTime();
   $('span').tooltip();

--- a/airflow/www_rbac/static/js/graph.js
+++ b/airflow/www_rbac/static/js/graph.js
@@ -18,6 +18,7 @@
  */
 
 import { generateTooltipDateTime, converAndFormatUTC } from './datetime-utils';
+import { escapeHtml } from './base';
 
 // Assigning css classes based on state to nodes
 // Initiating the tooltips
@@ -32,14 +33,17 @@ function update_nodes_states(task_instances) {
       .attr("data-original-title", function (d) {
         // Tooltip
         const task = tasks[task_id];
-        let tt = "Task_id: " + ti.task_id + "<br>";
-        tt += "Run: " + converAndFormatUTC(ti.execution_date) + "<br>";
-        if (ti.run_id != undefined) {
-          tt += "run_id: <nobr>" + ti.run_id + "</nobr><br>";
+        let tt = "";
+        if(ti.task_id != undefined) {
+          tt +=  "Task_id: " + escapeHtml(task.task_id) + "<br>";
         }
-        tt += "Operator: " + task.task_type + "<br>";
-        tt += "Duration: " + ti.duration + "<br>";
-        tt += "State: " + ti.state + "<br>";
+        tt += "Run: " + converAndFormatUTC(task.execution_date) + "<br>";
+        if(ti.run_id != undefined) {
+          tt += "run_id: <nobr>" + escapeHtml(task.run_id) + "</nobr><br>";
+        }
+        tt += "Operator: " + escapeHtml(task.task_type) + "<br>";
+        tt += "Duration: " + escapeHtml(task.duration) + "<br>";
+        tt += "Started: " + escapeHtml(ti.start_date) + "<br>";
         tt += generateTooltipDateTime(ti.start_date, ti.end_date, dagTZ); // dagTZ has been defined in dag.html
         return tt;
       });

--- a/airflow/www_rbac/templates/airflow/tree.html
+++ b/airflow/www_rbac/templates/airflow/tree.html
@@ -199,13 +199,15 @@ function update(source) {
       .attr("title", function(d){
         var tt = "";
         if (d.operator != undefined) {
-          tt += "operator: " + d.operator + "<br/>";
-          tt += "depends_on_past: " + d.depends_on_past + "<br/>";
-          tt += "upstream: " + d.num_dep + "<br/>";
-          tt += "retries: " + d.retries + "<br/>";
-          tt += "owner: " + d.owner + "<br/>";
-          tt += "start_date: " + d.start_date + "<br/>";
-          tt += "end_date: " + d.end_date + "<br/>";
+          if (d.operator != undefined) {
+            tt += "operator: " + escapeHtml(d.operator) + "<br/>";
+          }
+          tt += "depends_on_past: " + escapeHtml(d.depends_on_past) + "<br/>";
+          tt += "upstream: " + escapeHtml(d.num_dep) + "<br/>";
+          tt += "retries: " + escapeHtml(d.retries) + "<br/>";
+          tt += "owner: " + escapeHtml(d.owner) + "<br/>";
+          tt += "start_date: " + escapeHtml(d.start_date) + "<br/>";
+          tt += "end_date: " + escapeHtml(d.end_date) + "<br/>";
         }
         return tt;
       })
@@ -246,17 +248,24 @@ function update(source) {
       .style("stroke-width", function(d) {return (d.run_id != undefined)? "2": "1"})
       .style("stroke-opacity", function(d) {return d.external_trigger ? "0": "1"})
       .attr("title", function(d){
-        s =  "Task_id: " + d.task_id + "<br>";
-        s += "Run: " + d.execution_date + "<br>";
-        if(d.run_id != undefined){
-          s += "run_id: <nobr>" + d.run_id + "</nobr><br>";
+        var s = "";
+        if (d.task_id != undefined) {
+          s += "Task_id: " + escapeHtml(d.task_id) + "<br>";
         }
-        s += "Operator: " + d.operator + "<br>"
+        s += "Run: " + escapeHtml(d.execution_date) + "<br>";
+        if(d.run_id != undefined){
+          s += "run_id: <nobr>" + escapeHtml(d.run_id) + "</nobr><br>";
+        }
+        if (d.operator != undefined) {
+          s += "Operator: " + escapeHtml(d.operator) + "<br>"
+        }
         if(d.start_date != undefined){
-          s += "Started: " + d.start_date + "<br>";
-          s += "Ended: " + d.end_date + "<br>";
-          s += "Duration: " + d.duration + "<br>";
-          s += "State: " + d.state + "<br>";
+          s += "Started: " + escapeHtml(d.start_date) + "<br>";
+          s += "Ended: " + escapeHtml(d.end_date) + "<br>";
+          if (d.duration != undefined) {
+            s += "Duration: " + escapeHtml(d.duration) + "<br>";
+          }
+          s += "State: " + escapeHtml(d.state) + "<br>";
         }
         return s;
       })


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira
https://issues.apache.org/jira/browse/AIRFLOW-4129

### Description

Escape anything that we expect to be plain text when building tooltips.

Many of these properties aren't user generated, but it is better to be
safe.

This is a back-port of #4944 to 1.10 branch on the RBAC and classic UI,
both of which are slightly different code layout to current master
Many of these properties aren't user generated, but it is better to be
safe

### Tests


### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
