### PR TITLE
[AIRFLOW-3419] S3_hook.select_key is broken on Python3

### DIFF
--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -272,7 +272,7 @@ class S3Hook(AwsHook):
             InputSerialization=input_serialization,
             OutputSerialization=output_serialization)
 
-        return ''.join(event['Records']['Payload']
+        return ''.join(event['Records']['Payload'].decode('utf-8')
                        for event in response['Payload']
                        if 'Records' in event)
 

--- a/tests/hooks/test_s3_hook.py
+++ b/tests/hooks/test_s3_hook.py
@@ -211,7 +211,7 @@ class TestS3Hook(unittest.TestCase):
     @mock.patch('airflow.contrib.hooks.aws_hook.AwsHook.get_client_type')
     def test_select_key(self, mock_get_client_type):
         mock_get_client_type.return_value.select_object_content.return_value = \
-            {'Payload': [{'Records': {'Payload': u'Contént'}}]}
+            {'Payload': [{'Records': {'Payload': b'Cont\xC3\xA9nt'}}]}
         hook = S3Hook(aws_conn_id=None)
         self.assertEqual(hook.select_key('my_key', 'mybucket'), u'Contént')
 


### PR DESCRIPTION
Fix actual return type of select_key function

Re-opening  #4571 after I messed up trying to rebase OP's branch. I have preserved the original author and commit time.

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3419

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Fixes S3_hook.select_key return type to str instead of bytes

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
original test changed to match actual types

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [X] Passes `flake8`
