### PR TITLE
[AIRFLOW-4155] Allow Public role access to /home

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -28,6 +28,17 @@
 {% block content %}
   <h2>DAGs</h2>
 
+{% if not is_user_logged_in %}
+<div class="alert alert-warning" role="alert">
+  Note: Some DAGs may not be visible until you <a href="/login/">log in</a>.
+</div>
+{% elif is_public_user %}
+<div class="alert alert-warning" role="alert">
+  Note: Some DAGs may not be visible because you do not have sufficient privileges.
+</div>
+{% endif %}
+
+
   <div id="main_content">
     <div class="row">
       <div class="col-sm-2">

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -267,8 +267,13 @@ class Airflow(AirflowBaseView):
             auto_complete_data.add(row.dag_id)
             auto_complete_data.add(row.owners)
 
+        is_user_logged_in = appbuilder.sm.is_user_logged_in()
+        is_public_user = appbuilder.sm.is_public_user()
+
         return self.render(
             'airflow/dags.html',
+            is_user_logged_in=is_user_logged_in,
+            is_public_user=is_public_user,
             dags=dags,
             hide_paused=hide_paused,
             current_page=current_page,

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -308,3 +308,26 @@ class TestSecurity(unittest.TestCase):
         test_security_manager = TestSecurityManager(appbuilder=self.appbuilder)
         self.assertEqual(len(test_security_manager.VIEWER_VMS), 1)
         self.assertEqual(test_security_manager.VIEWER_VMS, {'Airflow'})
+
+    def test_is_user_logged_in_returns_false_if_not_authenticated(self):
+        user = mock.MagicMock()
+        user.is_authenticated = False
+        self.assertFalse(self.security_manager.is_user_logged_in(user))
+
+    def test_is_user_logged_in_returns_true_if_authenticated(self):
+        user = mock.MagicMock()
+        user.is_authenticated = True
+        self.assertTrue(self.security_manager.is_user_logged_in(user))
+
+    def test_unauthenticated_user_is_public(self):
+        user = mock.MagicMock()
+        user.is_authenticated = False
+        self.assertTrue(self.security_manager.is_public_user(user))
+
+    def test_user_in_public_role_only_is_public(self):
+        self.expect_user_is_in_role(self.user, rolename='Public')
+        self.assertTrue(self.security_manager.is_public_user(self.user))
+
+    def test_user_with_any_non_public_role_is_not_public(self):
+        self.expect_user_is_in_role(self.user, rolename='team-a')
+        self.assertFalse(self.security_manager.is_public_user(self.user))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4155
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:

    Problem: After a user registers in the PUBLIC_AUTH_ROLE they are
    redirected to /home. But a user in the Public role still doesn't have
    view privileges on /home, so they are immediately
    redirected *back* to the /login page, which creates an endless redirect
    cycle.

    This PR change grants the Public role view access to the index page.
    Because the Public user doesn't have any other read permission, they
    won't see any DAGs.

    If the user is not logged in, we add a banner at the top of the page
    with a link to the login page. If the user is logged in but belongs only
    to the Public role, then the banner displays a message warning the user
    that they don't have sufficient privileges to view the DAGs.

#### Before logging in 
![Screen Shot 2019-03-25 at 9 38 05 AM](https://user-images.githubusercontent.com/1173394/54939277-675aec00-4ee5-11e9-8dda-0526e5fe0d18.png)

#### After logging in as user in Public role
![Screen Shot 2019-03-25 at 9 38 30 AM](https://user-images.githubusercontent.com/1173394/54939275-64f89200-4ee5-11e9-9e6c-347814b33ac6.png)


### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ X ] Passes `flake8`
