### PR TITLE
[AIRFLOW-4057] Fix bug in stat name validation

### DIFF
--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -73,7 +73,7 @@ def stat_name_default_handler(stat_name, max_length=250):
 
 def validate_stat(f):
     @wraps(f)
-    def wrapper(stat, *args, **kwargs):
+    def wrapper(_self, stat, *args, **kwargs):
         try:
             from airflow.plugins_manager import stat_name_handler
             if stat_name_handler:
@@ -81,10 +81,10 @@ def validate_stat(f):
             else:
                 handle_stat_name_func = stat_name_default_handler
             stat_name = handle_stat_name_func(stat)
-        except Exception as err:
-            log.warning('Invalid stat name: {stat}.'.format(stat=stat), err)
+        except InvalidStatsNameException:
+            log.warning('Invalid stat name: {}.'.format(stat), exc_info=True)
             return
-        return f(stat_name, *args, **kwargs)
+        return f(_self, stat_name, *args, **kwargs)
 
     return wrapper
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -212,7 +212,7 @@ definitions in Airflow.
         flask_blueprints = [bp]
         appbuilder_views = [v_appbuilder_package]
         appbuilder_menu_items = [appbuilder_mitem]
-        stat_name_handler = stat_name_dummy_handler
+        stat_name_handler = staticmethod(stat_name_dummy_handler)
 
 
 Note on role based views

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -99,7 +99,7 @@ class AirflowTestPlugin(AirflowPlugin):
     flask_blueprints = [bp]
     appbuilder_views = [v_appbuilder_package]
     appbuilder_menu_items = [appbuilder_mitem]
-    stat_name_handler = stat_name_dummy_handler
+    stat_name_handler = staticmethod(stat_name_dummy_handler)
 
 
 class MockPluginA(AirflowPlugin):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4057
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:

The `@validate_stats` wrapper is wrapping an instance method, so it's first
argument is actually an instance of `SafeStatsdLogger`, not the stat_name.
Here's the backtrace that shows up in the webserver logs without the fix:

      File "/Users/andrewstahlman/src/incubator-airflow/airflow/www/views.py", line 86, in <module>
	dagbag = models.DagBag(os.devnull, include_examples=False)
      File "/Users/andrewstahlman/src/incubator-airflow/airflow/models/__init__.py", line 312, in __init__
	safe_mode=safe_mode)
      File "/Users/andrewstahlman/src/incubator-airflow/airflow/models/__init__.py", line 594, in collect_dags
	'collect_dags', (timezone.utcnow() - start_dttm).total_seconds(), 1)
      File "/Users/andrewstahlman/src/incubator-airflow/airflow/stats.py", line 85, in wrapper
	log.warning('Invalid stat name: {stat}.'.format(stat=stat), err)
    Message: 'Invalid stat name: <airflow.stats.SafeStatsdLogger object at 0x10bf194a8>.'
    Arguments: (InvalidStatsNameException('The stat_name has to be a string'),)


### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I've verified the fix by updating the unit tests to exercise the "public"
methods rather than testing the internal validation logic directly.

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ X ] Passes `flake8`
