### PR TITLE
[AIRFLOW-3971] Add Google Cloud Natural Language operators

### DIFF
--- a/airflow/contrib/example_dags/example_gcp_natural_language.py
+++ b/airflow/contrib/example_dags/example_gcp_natural_language.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Example Airflow DAG for Google Cloud Natural Language service
+"""
+
+
+from google.cloud.language_v1.proto.language_service_pb2 import Document
+
+import airflow
+from airflow import models
+from airflow.contrib.operators.gcp_natural_language_operator import (
+    CloudLanguageAnalyzeEntitiesOperator,
+    CloudLanguageAnalyzeEntitySentimentOperator,
+    CloudLanguageAnalyzeSentimentOperator,
+    CloudLanguageClassifyTextOperator,
+)
+from airflow.operators.bash_operator import BashOperator
+
+# [START howto_operator_gcp_natural_language_document_text]
+TEXT = """
+Airflow is a platform to programmatically author, schedule and monitor workflows.
+
+Use Airflow to author workflows as Directed Acyclic Graphs (DAGs) of tasks. The Airflow scheduler executes
+ your tasks on an array of workers while following the specified dependencies. Rich command line utilities
+ make performing complex surgeries on DAGs a snap. The rich user interface makes it easy to visualize
+ pipelines running in production, monitor progress, and troubleshoot issues when needed.
+"""
+document = Document(content=TEXT, type="PLAIN_TEXT")
+# [END howto_operator_gcp_natural_language_document_text]
+
+# [START howto_operator_gcp_natural_language_document_gcs]
+GCS_CONTENT_URI = "gs://my-text-bucket/sentiment-me.txt"
+document_gcs = Document(gcs_content_uri=GCS_CONTENT_URI, type="PLAIN_TEXT")
+# [END howto_operator_gcp_natural_language_document_gcs]
+
+
+default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+
+with models.DAG(
+    "example_gcp_natural_language",
+    default_args=default_args,
+    schedule_interval=None,  # Override to match your needs
+) as dag:
+
+    # [START howto_operator_gcp_natural_language_analyze_entities]
+    analyze_entities = CloudLanguageAnalyzeEntitiesOperator(document=document, task_id="analyze_entities")
+    # [END howto_operator_gcp_natural_language_analyze_entities]
+
+    # [START howto_operator_gcp_natural_language_analyze_entities_result]
+    analyze_entities_result = BashOperator(
+        bash_command="echo \"{{ task_instance.xcom_pull('analyze_entities') }}\"",
+        task_id="analyze_entities_result",
+    )
+    # [END howto_operator_gcp_natural_language_analyze_entities_result]
+
+    # [START howto_operator_gcp_natural_language_analyze_entity_sentiment]
+    analyze_entity_sentiment = CloudLanguageAnalyzeEntitySentimentOperator(
+        document=document, task_id="analyze_entity_sentiment"
+    )
+    # [END howto_operator_gcp_natural_language_analyze_entity_sentiment]
+
+    # [START howto_operator_gcp_natural_language_analyze_entity_sentiment_result]
+    analyze_entity_sentiment_result = BashOperator(
+        bash_command="echo \"{{ task_instance.xcom_pull('analyze_entity_sentiment') }}\"",
+        task_id="analyze_entity_sentiment_result",
+    )
+    # [END howto_operator_gcp_natural_language_analyze_entity_sentiment_result]
+
+    # [START howto_operator_gcp_natural_language_analyze_sentiment]
+    analyze_sentiment = CloudLanguageAnalyzeSentimentOperator(document=document, task_id="analyze_sentiment")
+    # [END howto_operator_gcp_natural_language_analyze_sentiment]
+
+    # [START howto_operator_gcp_natural_language_analyze_sentiment_result]
+    analyze_sentiment_result = BashOperator(
+        bash_command="echo \"{{ task_instance.xcom_pull('analyze_sentiment') }}\"",
+        task_id="analyze_sentiment_result",
+    )
+    # [END howto_operator_gcp_natural_language_analyze_sentiment_result]
+
+    # [START howto_operator_gcp_natural_language_analyze_classify_text]
+    analyze_classify_text = CloudLanguageClassifyTextOperator(
+        document=document, task_id="analyze_classify_text"
+    )
+    # [END howto_operator_gcp_natural_language_analyze_classify_text]
+
+    # [START howto_operator_gcp_natural_language_analyze_classify_text_result]
+    analyze_classify_text_result = BashOperator(
+        bash_command="echo \"{{ task_instance.xcom_pull('analyze_classify_text') }}\"",
+        task_id="analyze_classify_text_result",
+    )
+    # [END howto_operator_gcp_natural_language_analyze_classify_text_result]
+
+    analyze_entities >> analyze_entities_result
+    analyze_entity_sentiment >> analyze_entity_sentiment_result
+    analyze_sentiment >> analyze_sentiment_result
+    analyze_classify_text >> analyze_classify_text_result

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -168,6 +168,7 @@ class GoogleCloudBaseHook(BaseHook):
         Function decorator that intercepts HTTP Errors and raises AirflowException
         with more informative message.
         """
+
         @functools.wraps(func)
         def wrapper_decorator(self, *args, **kwargs):
             try:
@@ -187,6 +188,7 @@ class GoogleCloudBaseHook(BaseHook):
             except HttpError as e:
                 self.log.error('The request failed:\n%s', str(e))
                 raise AirflowException(e)
+
         return wrapper_decorator
 
     @staticmethod

--- a/airflow/contrib/hooks/gcp_natural_language_hook.py
+++ b/airflow/contrib/hooks/gcp_natural_language_hook.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from google.cloud.language_v1 import LanguageServiceClient
+
+
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+
+
+# noinspection PyAbstractClass
+class CloudNaturalLanguageHook(GoogleCloudBaseHook):
+    """
+    Hook for Google Cloud Natural Language Service.
+
+    :param gcp_conn_id: The connection ID to use when fetching connection info.
+    :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    """
+
+    _conn = None
+
+    def __init__(self, gcp_conn_id="google_cloud_default", delegate_to=None):
+        super(CloudNaturalLanguageHook, self).__init__(gcp_conn_id, delegate_to)
+
+    def get_conn(self):
+        """
+        Retrieves connection to Cloud Natural Language service.
+
+        :return: Cloud Natural Language service object
+        :rtype: google.cloud.language_v1.LanguageServiceClient
+        """
+        if not self._conn:
+            self._conn = LanguageServiceClient(credentials=self._get_credentials())
+        return self._conn
+
+    @GoogleCloudBaseHook.catch_http_exception
+    def analyze_entities(self, document, encoding_type=None, retry=None, timeout=None, metadata=None):
+        """
+        Finds named entities in the text along with entity types,
+        salience, mentions for each entity, and other properties.
+
+        :param document: Input document.
+            If a dict is provided, it must be of the same form as the protobuf message Document
+        :type document: dict or class google.cloud.language_v1.types.Document
+        :param encoding_type: The encoding type used by the API to calculate offsets.
+        :type encoding_type: google.cloud.language_v1.types.EncodingType
+        :param retry: A retry object used to retry requests. If None is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            retry is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: sequence[tuple[str, str]]]
+        :rtype: google.cloud.language_v1.types.AnalyzeEntitiesResponse
+        """
+        client = self.get_conn()
+
+        return client.analyze_entities(
+            document=document, encoding_type=encoding_type, retry=retry, timeout=timeout, metadata=metadata
+        )
+
+    @GoogleCloudBaseHook.catch_http_exception
+    def analyze_entity_sentiment(self, document, encoding_type=None, retry=None, timeout=None, metadata=None):
+        """
+        Finds entities, similar to AnalyzeEntities in the text and analyzes sentiment associated with each
+        entity and its mentions.
+
+        :param document: Input document.
+            If a dict is provided, it must be of the same form as the protobuf message Document
+        :type document: dict or class google.cloud.language_v1.types.Document
+        :param encoding_type: The encoding type used by the API to calculate offsets.
+        :type encoding_type: google.cloud.language_v1.types.EncodingType
+        :param retry: A retry object used to retry requests. If None is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            retry is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: sequence[tuple[str, str]]]
+        :rtype: google.cloud.language_v1.types.AnalyzeEntitiesResponse
+        """
+        client = self.get_conn()
+
+        return client.analyze_entity_sentiment(
+            document=document, encoding_type=encoding_type, retry=retry, timeout=timeout, metadata=metadata
+        )
+
+    @GoogleCloudBaseHook.catch_http_exception
+    def analyze_sentiment(self, document, encoding_type=None, retry=None, timeout=None, metadata=None):
+        """
+        Analyzes the sentiment of the provided text.
+
+        :param document: Input document.
+            If a dict is provided, it must be of the same form as the protobuf message Document
+        :type document: dict or class google.cloud.language_v1.types.Document
+        :param encoding_type: The encoding type used by the API to calculate offsets.
+        :type encoding_type: google.cloud.language_v1.types.EncodingType
+        :param retry: A retry object used to retry requests. If None is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            retry is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: sequence[tuple[str, str]]]
+        :rtype: google.cloud.language_v1.types.AnalyzeEntitiesResponse
+        """
+        client = self.get_conn()
+
+        return client.analyze_sentiment(
+            document=document, encoding_type=encoding_type, retry=retry, timeout=timeout, metadata=metadata
+        )
+
+    @GoogleCloudBaseHook.catch_http_exception
+    def analyze_syntax(self, document, encoding_type=None, retry=None, timeout=None, metadata=None):
+        """
+        Analyzes the syntax of the text and provides sentence boundaries and tokenization along with part
+        of speech tags, dependency trees, and other properties.
+
+        :param document: Input document.
+            If a dict is provided, it must be of the same form as the protobuf message Document
+        :type document: dict or class google.cloud.language_v1.types.Document#
+        :param encoding_type: The encoding type used by the API to calculate offsets.
+        :type encoding_type: google.cloud.language_v1.types.EncodingType
+        :param retry: A retry object used to retry requests. If None is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            retry is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: sequence[tuple[str, str]]]
+        :rtype: google.cloud.language_v1.types.AnalyzeSyntaxResponse
+        """
+        client = self.get_conn()
+
+        return client.analyze_syntax(
+            document=document, encoding_type=encoding_type, retry=retry, timeout=timeout, metadata=metadata
+        )
+
+    @GoogleCloudBaseHook.catch_http_exception
+    def annotate_text(self, document, features, encoding_type=None, retry=None, timeout=None, metadata=None):
+        """
+        A convenience method that provides all the features that analyzeSentiment,
+        analyzeEntities, and analyzeSyntax provide in one call.
+
+        :param document: Input document.
+            If a dict is provided, it must be of the same form as the protobuf message Document
+        :type document: dict or google.cloud.language_v1.types.Document
+        :param features: The enabled features.
+            If a dict is provided, it must be of the same form as the protobuf message Features
+        :type features: dict or google.cloud.language_v1.enums.Features
+        :param encoding_type: The encoding type used by the API to calculate offsets.
+        :type encoding_type: google.cloud.language_v1.types.EncodingType
+        :param retry: A retry object used to retry requests. If None is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            retry is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: sequence[tuple[str, str]]]
+        :rtype: google.cloud.language_v1.types.AnnotateTextResponse
+        """
+        client = self.get_conn()
+
+        return client.annotate_text(
+            document=document,
+            features=features,
+            encoding_type=encoding_type,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+
+    @GoogleCloudBaseHook.catch_http_exception
+    def classify_text(self, document, retry=None, timeout=None, metadata=None):
+        """
+        Classifies a document into categories.
+
+        :param document: Input document.
+            If a dict is provided, it must be of the same form as the protobuf message Document
+        :type document: dict or class google.cloud.language_v1.types.Document
+        :param retry: A retry object used to retry requests. If None is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            retry is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: sequence[tuple[str, str]]]
+        :rtype: google.cloud.language_v1.types.AnalyzeEntitiesResponse
+        """
+        client = self.get_conn()
+
+        return client.classify_text(document=document, retry=retry, timeout=timeout, metadata=metadata)

--- a/airflow/contrib/operators/gcp_natural_language_operator.py
+++ b/airflow/contrib/operators/gcp_natural_language_operator.py
@@ -1,0 +1,262 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from google.protobuf.json_format import MessageToDict
+
+from airflow.contrib.hooks.gcp_natural_language_hook import CloudNaturalLanguageHook
+from airflow.models import BaseOperator
+
+
+class CloudLanguageAnalyzeEntitiesOperator(BaseOperator):
+    """
+    Finds named entities in the text along with entity types,
+    salience, mentions for each entity, and other properties.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudLanguageAnalyzeEntitiesOperator`
+
+    :param document: Input document.
+        If a dict is provided, it must be of the same form as the protobuf message Document
+    :type document: dict or google.cloud.language_v1.types.Document
+    :param encoding_type: The encoding type used by the API to calculate offsets.
+    :type encoding_type: google.cloud.language_v1.types.EncodingType
+    :param retry: A retry object used to retry requests. If None is specified, requests will not be
+        retried.
+    :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+        retry is specified, the timeout applies to each individual attempt.
+    :type timeout: float
+    :param metadata: Additional metadata that is provided to the method.
+    :type metadata: seq[tuple[str, str]]]
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
+    :type gcp_conn_id: str
+    """
+
+    # [START natural_langauge_analyze_entities_template_fields]
+    template_fields = ("document", "gcp_conn_id")
+    # [END natural_langauge_analyze_entities_template_fields]
+
+    def __init__(
+        self,
+        document,
+        encoding_type=None,
+        retry=None,
+        timeout=None,
+        metadata=None,
+        gcp_conn_id="google_cloud_default",
+        *args,
+        **kwargs
+    ):
+        super(CloudLanguageAnalyzeEntitiesOperator, self).__init__(*args, **kwargs)
+        self.document = document
+        self.encoding_type = encoding_type
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+
+    def execute(self, context):
+        hook = CloudNaturalLanguageHook(gcp_conn_id=self.gcp_conn_id)
+
+        self.log.info("Start analyzing entities")
+        response = hook.analyze_entities(
+            document=self.document, retry=self.retry, timeout=self.timeout, metadata=self.metadata
+        )
+        self.log.info("Finished analyzing entities")
+
+        return MessageToDict(response)
+
+
+class CloudLanguageAnalyzeEntitySentimentOperator(BaseOperator):
+    """
+    Finds entities, similar to AnalyzeEntities in the text and analyzes sentiment associated with each
+    entity and its mentions.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudLanguageAnalyzeEntitySentimentOperator`
+
+    :param document: Input document.
+        If a dict is provided, it must be of the same form as the protobuf message Document
+    :type document: dict or google.cloud.language_v1.types.Document
+    :param encoding_type: The encoding type used by the API to calculate offsets.
+    :type encoding_type: google.cloud.language_v1.types.EncodingType
+    :param retry: A retry object used to retry requests. If None is specified, requests will not be
+        retried.
+    :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+        retry is specified, the timeout applies to each individual attempt.
+    :type timeout: float
+    :param metadata: Additional metadata that is provided to the method.
+    :type metadata: seq[tuple[str, str]]]
+    :rtype: google.cloud.language_v1.types.AnalyzeEntitiesResponse
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
+    :type gcp_conn_id: str
+    """
+
+    # [START natural_langauge_analyze_entity_sentiment_template_fields]
+    template_fields = ("document", "gcp_conn_id")
+    # [END natural_langauge_analyze_entity_sentiment_template_fields]
+
+    def __init__(
+        self,
+        document,
+        encoding_type=None,
+        retry=None,
+        timeout=None,
+        metadata=None,
+        gcp_conn_id="google_cloud_default",
+        *args,
+        **kwargs
+    ):
+        super(CloudLanguageAnalyzeEntitySentimentOperator, self).__init__(*args, **kwargs)
+        self.document = document
+        self.encoding_type = encoding_type
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+
+    def execute(self, context):
+        hook = CloudNaturalLanguageHook(gcp_conn_id=self.gcp_conn_id)
+
+        self.log.info("Start entity sentiment analyze")
+        response = hook.analyze_entity_sentiment(
+            document=self.document,
+            encoding_type=self.encoding_type,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )
+        self.log.info("Finished entity sentiment analyze")
+
+        return MessageToDict(response)
+
+
+class CloudLanguageAnalyzeSentimentOperator(BaseOperator):
+    """
+    Analyzes the sentiment of the provided text.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudLanguageAnalyzeSentimentOperator`
+
+    :param document: Input document.
+        If a dict is provided, it must be of the same form as the protobuf message Document
+    :type document: dict or google.cloud.language_v1.types.Document
+    :param encoding_type: The encoding type used by the API to calculate offsets.
+    :type encoding_type: google.cloud.language_v1.types.EncodingType
+    :param retry: A retry object used to retry requests. If None is specified, requests will not be
+        retried.
+    :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+        retry is specified, the timeout applies to each individual attempt.
+    :type timeout: float
+    :param metadata: Additional metadata that is provided to the method.
+    :type metadata: sequence[tuple[str, str]]]
+    :rtype: google.cloud.language_v1.types.AnalyzeEntitiesResponse
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
+    :type gcp_conn_id: str
+    """
+
+    # [START natural_langauge_analyze_sentiment_template_fields]
+    template_fields = ("document", "gcp_conn_id")
+    # [END natural_langauge_analyze_sentiment_template_fields]
+
+    def __init__(
+        self,
+        document,
+        encoding_type=None,
+        retry=None,
+        timeout=None,
+        metadata=None,
+        gcp_conn_id="google_cloud_default",
+        *args,
+        **kwargs
+    ):
+        super(CloudLanguageAnalyzeSentimentOperator, self).__init__(*args, **kwargs)
+        self.document = document
+        self.encoding_type = encoding_type
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+
+    def execute(self, context):
+        hook = CloudNaturalLanguageHook(gcp_conn_id=self.gcp_conn_id)
+
+        self.log.info("Start sentiment analyze")
+        response = hook.analyze_sentiment(
+            document=self.document, retry=self.retry, timeout=self.timeout, metadata=self.metadata
+        )
+        self.log.info("Finished sentiment analyze")
+
+        return MessageToDict(response)
+
+
+class CloudLanguageClassifyTextOperator(BaseOperator):
+    """
+    Classifies a document into categories.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudLanguageClassifyTextOperator`
+
+    :param document: Input document.
+        If a dict is provided, it must be of the same form as the protobuf message Document
+    :type document: dict or google.cloud.language_v1.types.Document
+    :param retry: A retry object used to retry requests. If None is specified, requests will not be
+        retried.
+    :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+        retry is specified, the timeout applies to each individual attempt.
+    :type timeout: float
+    :param metadata: Additional metadata that is provided to the method.
+    :type metadata: sequence[tuple[str, str]]]
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
+    :type gcp_conn_id: str
+    """
+
+    # [START natural_langauge_classify_text_template_fields]
+    template_fields = ("document", "gcp_conn_id")
+    # [END natural_langauge_classify_text_template_fields]
+
+    def __init__(
+        self,
+        document,
+        retry=None,
+        timeout=None,
+        metadata=None,
+        gcp_conn_id="google_cloud_default",
+        *args,
+        **kwargs
+    ):
+        super(CloudLanguageClassifyTextOperator, self).__init__(*args, **kwargs)
+        self.document = document
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+
+    def execute(self, context):
+        hook = CloudNaturalLanguageHook(gcp_conn_id=self.gcp_conn_id)
+
+        self.log.info("Start text classify")
+        response = hook.classify_text(
+            document=self.document, retry=self.retry, timeout=self.timeout, metadata=self.metadata
+        )
+        self.log.info("Finished text classify")
+
+        return MessageToDict(response)

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -437,6 +437,8 @@ could take thousands of tasks without a problem), or from an environment
 perspective (you want a worker running from within the Spark cluster
 itself because it needs a very specific environment and security rights).
 
+.. _concepts:xcom:
+
 XComs
 =====
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,6 +119,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'autoapi.extension',
     'exampleinclude',
+    'docroles'
 ]
 
 autodoc_default_flags = ['show-inheritance', 'members']
@@ -196,8 +197,8 @@ exclude_patterns = [
     '_api/airflow/version',
     '_api/airflow/www',
     '_api/main',
-    '_build',
     'autoapi_templates',
+    'howto/operator/gcp/_partials',
 ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/docs/exts/docroles.py
+++ b/docs/exts/docroles.py
@@ -1,0 +1,95 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from docutils import nodes, utils
+from sphinx.ext.autodoc.importer import import_module, mock
+from functools import partial
+
+
+class RoleException(Exception):
+    pass
+
+
+def get_template_field(env, fullname):
+    """
+    Gets template fields for specific operator class.
+
+    :param fullname: Full path to operator class.
+        For example: ``airflow.contrib.operators.gcp_vision_operator.CloudVisionProductSetCreateOperator``
+    :return: List of template field
+    :rtype: list[str]
+    """
+    modname, classname = fullname.rsplit(".", 1)
+
+    try:
+        with mock(env.config.autodoc_mock_imports):
+            mod = import_module(modname)
+    except ImportError:
+        raise RoleException("Error loading %s module." % (modname, ))
+
+    clazz = getattr(mod, classname)
+    if not clazz:
+        raise RoleException("Error finding %s class in %s module." % (classname, modname))
+
+    template_fields = getattr(clazz, "template_fields")
+
+    if not template_fields:
+        raise RoleException(
+            "Could not find the template fields for %s class in %s module." % (classname, modname)
+        )
+
+    return list(template_fields)
+
+
+def template_field_role(app, typ, rawtext, text, lineno, inliner, options={}, content=[]):
+    """
+    A role that allows you to include a list of template fields in the middle of the text. This is especially
+    useful when writing guides describing how to use the operator.
+    The result is a list of fields where each field is shorted in the literal block.
+
+    Sample usage::
+
+    :template-fields:`airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageAnalyzeSentimentOperator`
+
+    For further information look at:
+
+    * [http://docutils.sourceforge.net/docs/howto/rst-roles.html](Creating reStructuredText Interpreted
+      Text Roles)
+    """
+    text = utils.unescape(text)
+
+    try:
+        template_fields = get_template_field(app.env, text)
+    except RoleException as e:
+        msg = inliner.reporter.error("invalid class name %s \n%s" % (text, e, ), line=lineno)
+        prb = inliner.problematic(rawtext, rawtext, msg)
+        return [prb], [msg]
+
+    node = nodes.inline(rawtext=rawtext)
+    for i, field in enumerate(template_fields):
+        if i != 0:
+            node += nodes.Text(", ")
+        node += nodes.literal(field, "", nodes.Text(field))
+
+    return [node], []
+
+
+def setup(app):
+    from docutils.parsers.rst import roles
+    roles.register_local_role("template-fields", partial(template_field_role, app))
+
+    return {"version": "builtin", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/howto/operator/gcp/_partials/prerequisite_tasks.rst
+++ b/docs/howto/operator/gcp/_partials/prerequisite_tasks.rst
@@ -1,0 +1,31 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+To use these operators, you must do a few things:
+
+  * Select or create a Cloud Platform project using `Cloud Console <https://console.cloud.google.com/project>`__.
+  * Enable billing for your project, as described in `Google Cloud documentation <https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project>`__.
+  * Enable API, as described in `Cloud Console documentation <https://cloud.google.com/apis/docs/enable-disable-apis>`__.
+  * Install API libraries via **pip**.
+
+    .. code-block:: bash
+
+      pip install 'apache-airflow[gcp]'
+
+    Detailed information is available :doc:`../../../../installation`
+
+  * :doc:`Setup Connection <../../connection/gcp>`.

--- a/docs/howto/operator/gcp/natural_language.rst
+++ b/docs/howto/operator/gcp/natural_language.rst
@@ -1,0 +1,180 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Google Cloud Natural Language Operators
+=======================================
+
+The `Google Cloud Natural Language <https://cloud.google.com/natural-language/>`__
+can be used to reveal the structure and meaning of text via powerful machine
+learning models. You can use it to extract information about people, places,
+events and much more, mentioned in text documents, news articles or blog posts.
+You can use it to understand sentiment about your product on social media or
+parse intent from customer conversations happening in a call center or a
+messaging app.
+
+.. contents::
+  :depth: 1
+  :local:
+
+Prerequisite Tasks
+^^^^^^^^^^^^^^^^^^
+
+.. include:: _partials/prerequisite_tasks.rst
+
+
+.. _howto/operator:CloudNaturalLanguageDocuments:
+
+Documents
+^^^^^^^^^
+
+Each operator uses a :class:`~google.cloud.language_v1.types.Document` for
+representing text.
+
+Here is an example of document with text provided as a string:
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_natural_language.py
+    :language: python
+    :start-after: [START howto_operator_gcp_natural_language_document_text]
+    :end-before: [END howto_operator_gcp_natural_language_document_text]
+
+In addition to supplying string, a document can refer to content stored in Google Cloud Storage.
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_natural_language.py
+    :language: python
+    :start-after: [START howto_operator_gcp_natural_language_document_gcs]
+    :end-before: [END howto_operator_gcp_natural_language_document_gcs]
+
+.. _howto/operator:CloudLanguageAnalyzeEntitiesOperator:
+
+Analyzing Entities
+^^^^^^^^^^^^^^^^^^
+
+Entity Analysis inspects the given text for known entities (proper nouns such as
+public figures, landmarks, etc.), and returns information about those entities.
+Entity analysis is performed with the
+:class:`~airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageAnalyzeEntitiesOperator` operator.
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_natural_language.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcp_natural_language_analyze_entities]
+    :end-before: [END howto_operator_gcp_natural_language_analyze_entities]
+
+You can use :ref:`Jinja templating <jinja-templating>` with
+:template-fields:`airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageAnalyzeEntitiesOperator`
+parameters which allows you to dynamically determine values. The result is saved to :ref:`XCom <concepts:xcom>`, which allows it
+to be used by other operators.
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_natural_language.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcp_natural_language_analyze_entities_result]
+    :end-before: [END howto_operator_gcp_natural_language_analyze_entities_result]
+
+.. _howto/operator:CloudLanguageAnalyzeEntitySentimentOperator:
+
+Analyzing Entity Sentiment
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sentiment Analysis inspects the given text and identifies the prevailing
+emotional opinion within the text, especially to determine a writer's attitude
+as positive, negative, or neutral. Sentiment analysis is performed through
+the :class:`~airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageAnalyzeEntitySentimentOperator`
+operator.
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_natural_language.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcp_natural_language_analyze_entity_sentiment]
+    :end-before: [END howto_operator_gcp_natural_language_analyze_entity_sentiment]
+
+You can use :ref:`Jinja templating <jinja-templating>` with
+:template-fields:`airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageAnalyzeEntitiesOperator`
+parameters which allows you to dynamically determine values. The result is saved to :ref:`XCom <concepts:xcom>`, which allows it
+to be used by other operators.
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_natural_language.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcp_natural_language_analyze_entity_sentiment_result]
+    :end-before: [END howto_operator_gcp_natural_language_analyze_entity_sentiment_result]
+
+.. _howto/operator:CloudLanguageAnalyzeSentimentOperator:
+
+Analyzing Sentiment
+^^^^^^^^^^^^^^^^^^^
+
+Sentiment Analysis inspects the given text and identifies the prevailing
+emotional opinion within the text, especially to determine a writer's
+attitude as positive, negative, or neutral. Sentiment analysis is performed
+through the
+:class:`~airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageAnalyzeSentimentOperator`
+operator.
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_natural_language.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcp_natural_language_analyze_sentiment]
+    :end-before: [END howto_operator_gcp_natural_language_analyze_sentiment]
+
+You can use :ref:`Jinja templating <jinja-templating>` with
+:template-fields:`airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageAnalyzeSentimentOperator`
+parameters which allows you to dynamically determine values. The result is saved to :ref:`XCom <concepts:xcom>`, which allows it
+to be used by other operators.
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_natural_language.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcp_natural_language_analyze_sentiment_result]
+    :end-before: [END howto_operator_gcp_natural_language_analyze_sentiment_result]
+
+.. _howto/operator:CloudLanguageClassifyTextOperator:
+
+Classifying Content
+^^^^^^^^^^^^^^^^^^^
+
+Content Classification analyzes a document and returns a list of content
+categories that apply to the text found in the document. To classify the
+content in a document, use the
+:class:`~airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageClassifyTextOperator`
+operator.
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_natural_language.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcp_natural_language_analyze_classify_text]
+    :end-before: [END howto_operator_gcp_natural_language_analyze_classify_text]
+
+You can use :ref:`Jinja templating <jinja-templating>` with
+:template-fields:`airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageClassifyTextOperator`
+parameters which allows you to dynamically determine values. The result is saved to :ref:`XCom <concepts:xcom>`, which allows it
+to be used by other operators.
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_natural_language.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcp_natural_language_analyze_classify_text_result]
+    :end-before: [END howto_operator_gcp_natural_language_analyze_classify_text_result]
+
+
+Reference
+^^^^^^^^^
+
+For further information, look at:
+
+* `Client Library Documentation <https://googleapis.github.io/google-cloud-python/latest/language/index.html>`__
+* `Product Documentation <https://cloud.google.com/natural-language/docs/>`__

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -691,6 +691,26 @@ Google Kubernetes Engine
 They also use :class:`airflow.contrib.hooks.gcp_container_hook.GKEClusterHook` to communicate with Google Cloud Platform.
 
 
+Google Natural Language
+'''''''''''''''''''''''
+
+:class:`airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageAnalyzeEntities`
+    Finds named entities (currently proper names and common nouns) in the text along with entity types,
+    salience, mentions for each entity, and other properties.
+
+:class:`airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageAnalyzeEntitySentiment`
+    Finds entities, similar to AnalyzeEntities in the text and analyzes sentiment associated with each
+    entity and its mentions.
+
+:class:`airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageAnalyzeSentiment`
+    Analyzes the sentiment of the provided text.
+
+:class:`airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageClassifyTextOperator`
+    Classifies a document into categories.
+
+They also use :class:`airflow.contrib.hooks.gcp_natural_language_operator.CloudNaturalLanguageHook` to communicate with Google Cloud Platform.
+
+
 .. _Qubole:
 
 Qubole

--- a/setup.py
+++ b/setup.py
@@ -174,20 +174,21 @@ elasticsearch = [
     'elasticsearch-dsl>=5.0.0,<6.0.0'
 ]
 gcp = [
-    'httplib2>=0.9.2',
     'google-api-python-client>=1.6.0, <2.0.0dev',
-    'google-auth>=1.0.0, <2.0.0dev',
     'google-auth-httplib2>=0.0.1',
-    'google-cloud-container>=0.1.1',
+    'google-auth>=1.0.0, <2.0.0dev',
     'google-cloud-bigtable==0.31.0',
+    'google-cloud-container>=0.1.1',
+    'google-cloud-language>=1.1.1',
     'google-cloud-spanner>=1.7.1',
     'google-cloud-translate>=1.3.3',
     'google-cloud-vision>=0.35.2',
     'google-cloud-texttospeech>=0.4.0',
     'google-cloud-speech>=0.36.3',
     'grpcio-gcp>=0.2.2',
+    'httplib2~=0.9.2',
+    'pandas-gbq',
     'PyOpenSSL',
-    'pandas-gbq'
 ]
 github_enterprise = ['Flask-OAuthlib>=0.9.1']
 grpc = ['grpcio>=1.15.0']

--- a/tests/contrib/hooks/test_gcp_natural_language_hook.py
+++ b/tests/contrib/hooks/test_gcp_natural_language_hook.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import unittest
+from typing import Dict, Any
+
+from google.cloud.language_v1.proto.language_service_pb2 import Document
+
+from airflow.contrib.hooks.gcp_natural_language_hook import CloudNaturalLanguageHook
+from tests.compat import mock
+from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id
+
+
+API_RESPONSE = {}  # type: Dict[Any, Any]
+DOCUMENT = Document(
+    content="Airflow is a platform to programmatically author, schedule and monitor workflows."
+)
+ENCODING_TYPE = "UTF32"
+
+
+class TestCloudNaturalLanguageHook(unittest.TestCase):
+    def setUp(self):
+        with mock.patch(
+            "airflow.contrib.hooks." "gcp_api_base_hook.GoogleCloudBaseHook.__init__",
+            new=mock_base_gcp_hook_no_default_project_id,
+        ):
+            self.hook = CloudNaturalLanguageHook(gcp_conn_id="test")
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_natural_language_hook.CloudNaturalLanguageHook.get_conn",
+        **{"return_value.analyze_entities.return_value": API_RESPONSE}  # type: ignore
+    )
+    def test_analyze_entities(self, get_conn):
+        result = self.hook.analyze_entities(document=DOCUMENT, encoding_type=ENCODING_TYPE)
+
+        self.assertIs(result, API_RESPONSE)
+
+        get_conn.return_value.analyze_entities.assert_called_once_with(
+            document=DOCUMENT, encoding_type=ENCODING_TYPE, retry=None, timeout=None, metadata=None
+        )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_natural_language_hook.CloudNaturalLanguageHook.get_conn",
+        **{"return_value.analyze_entity_sentiment.return_value": API_RESPONSE}
+    )
+    def test_analyze_entity_sentiment(self, get_conn):
+        result = self.hook.analyze_entity_sentiment(document=DOCUMENT, encoding_type=ENCODING_TYPE)
+
+        self.assertIs(result, API_RESPONSE)
+
+        get_conn.return_value.analyze_entity_sentiment.assert_called_once_with(
+            document=DOCUMENT, encoding_type=ENCODING_TYPE, retry=None, timeout=None, metadata=None
+        )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_natural_language_hook.CloudNaturalLanguageHook.get_conn",
+        **{"return_value.analyze_sentiment.return_value": API_RESPONSE}
+    )
+    def test_analyze_sentiment(self, get_conn):
+        result = self.hook.analyze_sentiment(document=DOCUMENT, encoding_type=ENCODING_TYPE)
+
+        self.assertIs(result, API_RESPONSE)
+
+        get_conn.return_value.analyze_sentiment.assert_called_once_with(
+            document=DOCUMENT, encoding_type=ENCODING_TYPE, retry=None, timeout=None, metadata=None
+        )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_natural_language_hook.CloudNaturalLanguageHook.get_conn",
+        **{"return_value.analyze_syntax.return_value": API_RESPONSE}
+    )
+    def test_analyze_syntax(self, get_conn):
+        result = self.hook.analyze_syntax(document=DOCUMENT, encoding_type=ENCODING_TYPE)
+
+        self.assertIs(result, API_RESPONSE)
+
+        get_conn.return_value.analyze_syntax.assert_called_once_with(
+            document=DOCUMENT, encoding_type=ENCODING_TYPE, retry=None, timeout=None, metadata=None
+        )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_natural_language_hook.CloudNaturalLanguageHook.get_conn",
+        **{"return_value.annotate_text.return_value": API_RESPONSE}
+    )
+    def test_annotate_text(self, get_conn):
+        result = self.hook.annotate_text(document=DOCUMENT, encoding_type=ENCODING_TYPE, features=None)
+
+        self.assertIs(result, API_RESPONSE)
+
+        get_conn.return_value.annotate_text.assert_called_once_with(
+            document=DOCUMENT,
+            encoding_type=ENCODING_TYPE,
+            features=None,
+            retry=None,
+            timeout=None,
+            metadata=None,
+        )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_natural_language_hook.CloudNaturalLanguageHook.get_conn",
+        **{"return_value.classify_text.return_value": API_RESPONSE}
+    )
+    def test_classify_text(self, get_conn):
+        result = self.hook.classify_text(document=DOCUMENT)
+
+        self.assertIs(result, API_RESPONSE)
+
+        get_conn.return_value.classify_text.assert_called_once_with(
+            document=DOCUMENT, retry=None, timeout=None, metadata=None
+        )

--- a/tests/contrib/operators/test_gcp_natural_language_operator.py
+++ b/tests/contrib/operators/test_gcp_natural_language_operator.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import unittest
+
+from google.cloud.language_v1.proto.language_service_pb2 import (
+    AnalyzeEntitiesResponse,
+    AnalyzeEntitySentimentResponse,
+    AnalyzeSentimentResponse,
+    ClassifyTextResponse,
+    Document,
+)
+
+from airflow.contrib.operators.gcp_natural_language_operator import (
+    CloudLanguageAnalyzeEntitiesOperator,
+    CloudLanguageAnalyzeEntitySentimentOperator,
+    CloudLanguageAnalyzeSentimentOperator,
+    CloudLanguageClassifyTextOperator,
+)
+from tests.compat import patch
+
+
+DOCUMENT = Document(
+    content="Airflow is a platform to programmatically author, schedule and monitor workflows."
+)
+
+CLASSIFY_TEXT_RRESPONSE = ClassifyTextResponse()
+ANALYZE_ENTITIES_RESPONSE = AnalyzeEntitiesResponse()
+ANALYZE_ENTITY_SENTIMENT_RESPONSE = AnalyzeEntitySentimentResponse()
+ANALYZE_SENTIMENT_RESPONSE = AnalyzeSentimentResponse()
+
+ENCODING_TYPE = "UTF32"
+
+
+class CloudLanguageAnalyzeEntitiesOperatorTestCase(unittest.TestCase):
+    @patch("airflow.contrib.operators.gcp_natural_language_operator.CloudNaturalLanguageHook")
+    def test_minimal_green_path(self, hook_mock):
+        hook_mock.return_value.analyze_entities.return_value = ANALYZE_ENTITIES_RESPONSE
+        op = CloudLanguageAnalyzeEntitiesOperator(task_id="task-id", document=DOCUMENT)
+        resp = op.execute({})
+        self.assertEquals(resp, {})
+
+
+class CloudLanguageAnalyzeEntitySentimentOperatorTestCase(unittest.TestCase):
+    @patch("airflow.contrib.operators.gcp_natural_language_operator.CloudNaturalLanguageHook")
+    def test_minimal_green_path(self, hook_mock):
+        hook_mock.return_value.analyze_entity_sentiment.return_value = ANALYZE_ENTITY_SENTIMENT_RESPONSE
+        op = CloudLanguageAnalyzeEntitySentimentOperator(task_id="task-id", document=DOCUMENT)
+        resp = op.execute({})
+        self.assertEquals(resp, {})
+
+
+class CloudLanguageAnalyzeSentimentOperatorTestCase(unittest.TestCase):
+    @patch("airflow.contrib.operators.gcp_natural_language_operator.CloudNaturalLanguageHook")
+    def test_minimal_green_path(self, hook_mock):
+        hook_mock.return_value.analyze_sentiment.return_value = ANALYZE_SENTIMENT_RESPONSE
+        op = CloudLanguageAnalyzeSentimentOperator(task_id="task-id", document=DOCUMENT)
+        resp = op.execute({})
+        self.assertEquals(resp, {})
+
+
+class CloudLanguageClassifyTextOperatorTestCase(unittest.TestCase):
+    @patch("airflow.contrib.operators.gcp_natural_language_operator.CloudNaturalLanguageHook")
+    def test_minimal_green_path(self, hook_mock):
+        hook_mock.return_value.classify_text.return_value = CLASSIFY_TEXT_RRESPONSE
+        op = CloudLanguageClassifyTextOperator(task_id="task-id", document=DOCUMENT)
+        resp = op.execute({})
+        self.assertEquals(resp, {})

--- a/tests/contrib/operators/test_gcp_natural_language_operator_system.py
+++ b/tests/contrib/operators/test_gcp_natural_language_operator_system.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest
+
+from tests.contrib.utils.base_gcp_system_test_case import SKIP_TEST_WARNING, DagGcpSystemTestCase
+from tests.contrib.utils.gcp_authenticator import GCP_AI_KEY
+
+
+@unittest.skipIf(DagGcpSystemTestCase.skip_check(GCP_AI_KEY), SKIP_TEST_WARNING)
+class CloudNaturalLanguageExampleDagsTest(DagGcpSystemTestCase):
+    def __init__(self, method_name="runTest"):
+        super(CloudNaturalLanguageExampleDagsTest, self).__init__(
+            method_name, dag_id="example_gcp_natural_language", gcp_key=GCP_AI_KEY
+        )
+
+    def test_run_example_dagr(self):
+        self._run_dag()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-3971

### Description

Hello,

I would like to create operators for Google Natural Language:

* CloudLanguageAnalyzeEntitiesOperator
* CloudLanguageAnalyzeEntitySentimentOperator
* CloudLanguageAnalyzeSentimentOperator
* CloudLanguageClassifyTextOperator

### Tests

- [X] Unit tests for hook
- [X] Unit tests for operators
- [X] System test

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

* How-to Guide
* Integratio.rst
* API Reference

### Code Quality

- [X] Passes `flake8`
