### PR TITLE
[AIRFLOW-4160] Fix redirecting of 'Trigger Dag' Button in DAG Page

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -95,7 +95,7 @@
         </a>
       </li>
       <li>
-        <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=request.base_url ) }}"
+        <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=url_for('Airflow.tree', dag_id=dag.dag_id)) }}"
           onclick="return confirmTriggerDag('{{ dag.safe_dag_id }}')">
           <span class="glyphicon glyphicon-play-circle" aria-hidden="true"></span>
           Trigger DAG


### PR DESCRIPTION


### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-4160


### Description

"Trigger Dag" Button in DAG Page was added in https://github.com/apache/airflow/pull/4373 

but it was broken by https://github.com/apache/airflow/pull/4643 

This issue is found in the testing process of 1.10.3b1 .

### Tests

Tested locally and the fix is working