### PR TITLE
[AIRFLOW-4163] IntervalCheckOperator supports relative diff

### DIFF
--- a/tests/operators/test_check_operator.py
+++ b/tests/operators/test_check_operator.py
@@ -21,7 +21,8 @@ import unittest
 from datetime import datetime
 from airflow.models import DAG
 from airflow.exceptions import AirflowException
-from airflow.operators.check_operator import ValueCheckOperator
+
+from airflow.operators.check_operator import IntervalCheckOperator, ValueCheckOperator
 from tests.compat import mock
 
 
@@ -85,4 +86,125 @@ class ValueCheckOperatorTest(unittest.TestCase):
         operator = self.__construct_operator('select value from tab1 limit 1;', 5, 1)
 
         with self.assertRaisesRegexp(AirflowException, 'Tolerance:100.0%'):
+            operator.execute()
+
+
+class IntervalCheckOperatorTest(unittest.TestCase):
+
+    def _construct_operator(self, table, metric_thresholds,
+                            ratio_formula, ignore_zero):
+        return IntervalCheckOperator(
+            task_id='test_task',
+            table=table,
+            metrics_thresholds=metric_thresholds,
+            ratio_formula=ratio_formula,
+            ignore_zero=ignore_zero,
+        )
+
+    def test_invalid_ratio_formula(self):
+        with self.assertRaisesRegexp(AirflowException, 'Invalid diff_method'):
+            self._construct_operator(
+                table='test_table',
+                metric_thresholds={
+                    'f1': 1,
+                },
+                ratio_formula='abs',
+                ignore_zero=False,
+            )
+
+    @mock.patch.object(IntervalCheckOperator, 'get_db_hook')
+    def test_execute_not_ignore_zero(self, mock_get_db_hook):
+        mock_hook = mock.Mock()
+        mock_hook.get_first.return_value = [0]
+        mock_get_db_hook.return_value = mock_hook
+
+        operator = self._construct_operator(
+            table='test_table',
+            metric_thresholds={
+                'f1': 1,
+            },
+            ratio_formula='max_over_min',
+            ignore_zero=False,
+        )
+
+        with self.assertRaises(AirflowException):
+            operator.execute()
+
+    @mock.patch.object(IntervalCheckOperator, 'get_db_hook')
+    def test_execute_ignore_zero(self, mock_get_db_hook):
+        mock_hook = mock.Mock()
+        mock_hook.get_first.return_value = [0]
+        mock_get_db_hook.return_value = mock_hook
+
+        operator = self._construct_operator(
+            table='test_table',
+            metric_thresholds={
+                'f1': 1,
+            },
+            ratio_formula='max_over_min',
+            ignore_zero=True,
+        )
+
+        operator.execute()
+
+    @mock.patch.object(IntervalCheckOperator, 'get_db_hook')
+    def test_execute_min_max(self, mock_get_db_hook):
+        mock_hook = mock.Mock()
+
+        def returned_row():
+            rows = [
+                [2, 2, 2, 2],  # reference
+                [1, 1, 1, 1],  # current
+            ]
+
+            for r in rows:
+                yield r
+
+        mock_hook.get_first.side_effect = returned_row()
+        mock_get_db_hook.return_value = mock_hook
+
+        operator = self._construct_operator(
+            table='test_table',
+            metric_thresholds={
+                'f0': 1.0,
+                'f1': 1.5,
+                'f2': 2.0,
+                'f3': 2.5,
+            },
+            ratio_formula='max_over_min',
+            ignore_zero=True,
+        )
+
+        with self.assertRaisesRegexp(AirflowException, "f0, f1, f2"):
+            operator.execute()
+
+    @mock.patch.object(IntervalCheckOperator, 'get_db_hook')
+    def test_execute_diff(self, mock_get_db_hook):
+        mock_hook = mock.Mock()
+
+        def returned_row():
+            rows = [
+                [3, 3, 3, 3],  # reference
+                [1, 1, 1, 1],  # current
+            ]
+
+            for r in rows:
+                yield r
+
+        mock_hook.get_first.side_effect = returned_row()
+        mock_get_db_hook.return_value = mock_hook
+
+        operator = self._construct_operator(
+            table='test_table',
+            metric_thresholds={
+                'f0': 0.5,
+                'f1': 0.6,
+                'f2': 0.7,
+                'f3': 0.8,
+            },
+            ratio_formula='relative_diff',
+            ignore_zero=True,
+        )
+
+        with self.assertRaisesRegexp(AirflowException, "f0, f1"):
             operator.execute()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira]
  - https://issues.apache.org/jira/browse/AIRFLOW-4163

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Make `IntervalCheckOperator` supports calculating ratio with relative difference. And also add an option to not ignore zero values in metric.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
