### PR TITLE
[AIRFLOW-XXX] Fix flaky test - test_execution_unlimited_parallelism

### DIFF
--- a/tests/executors/test_local_executor.py
+++ b/tests/executors/test_local_executor.py
@@ -50,7 +50,7 @@ class LocalExecutorTest(unittest.TestCase):
         executor.running['fail'] = True
 
         if parallelism == 0:
-            with timeout(seconds=5):
+            with timeout(seconds=10):
                 executor.end()
         else:
             executor.end()


### PR DESCRIPTION
I noticed that test `test_execution_unlimited_parallelism` (`tests.executors.test_local_executor.LocalExecutorTest`) fails () frequently with no obvious reason.

Error:
```
41) ERROR: test_execution_unlimited_parallelism (tests.executors.test_local_executor.LocalExecutorTest)
----------------------------------------------------------------------
   Traceback (most recent call last):
    tests/executors/test_local_executor.py line 71 in test_execution_unlimited_parallelism
      self.execution_parallelism(parallelism=0)
    tests/executors/test_local_executor.py line 54 in execution_parallelism
      executor.end()
    airflow/executors/local_executor.py line 230 in end
      self.impl.end()
    airflow/executors/local_executor.py line 167 in end
      time.sleep(0.5)
    airflow/utils/timeout.py line 43 in handle_timeout
      raise AirflowTaskTimeout(self.error_message)
   AirflowTaskTimeout: Timeout, PID: 217
```

Examples:
- https://travis-ci.org/apache/airflow/jobs/511931793
- https://travis-ci.org/apache/airflow/jobs/511914002

I'm not sure if the original timeout length (5 seconds) is from some sort of careful calculation/consideration. If not, let's adjust it to a slightly bigger value, to avoid flaky test error.