### PR TITLE
[AIRFLOW-4173] Improve scheduler performance by avoid unnecessary actions in SchedulerJob.process_file()

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1725,13 +1725,12 @@ class SchedulerJob(BaseJob):
 
         # Pickle the DAGs (if necessary) and put them into a SimpleDag
         for dag_id in dagbag.dags:
-            dag = dagbag.get_dag(dag_id)
-            pickle_id = None
-            if pickle_dags:
-                pickle_id = dag.pickle(session).id
-
             # Only return DAGs that are not paused
             if dag_id not in paused_dag_ids:
+                dag = dagbag.get_dag(dag_id)
+                pickle_id = None
+                if pickle_dags:
+                    pickle_id = dag.pickle(session).id
                 simple_dags.append(SimpleDag(dag, pickle_id=pickle_id))
 
         if len(self.dag_ids) > 0:


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-4173

### Description

In current implementation of `SchedulerJob.process_file()` https://github.com/apache/airflow/blob/068ded96cd279dcd51f5b6d1e96f09205ecf40c8/airflow/jobs.py#L1722-L1734, action `dag = dagbag.get_dag(dag_id)` is to be done no matter if dag_id is pointing to a paused DAG. However, the result will not be used later if that DAG is paused. This is causing inefficiency.

We can do the `if dag_id not in paused_dag_ids:` check first, before we invoke `dag = dagbag.get_dag(dag_id)`.

This change may bring considerable improvement (running `dag = dagbag.get_dag(dag_id)` for 1000 dag_ids is taking ~8 seconds in my environment). 

