### PR TITLE
[AIRFLOW-XXX] pin sphix to <2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ doc = [
     'sphinx-autoapi>=0.7.1',
     'Sphinx-PyPI-upload>=0.2.1',
     'sphinx-rtd-theme>=0.1.6',
-    'sphinx>=1.2.3',
+    'sphinx>=1.2.3,<2.0.0',
     'sphinxcontrib-httpdomain>=1.7.0',
 ]
 docker = ['docker~=3.0']


### PR DESCRIPTION
`sphinx` release 2.0.0 yesterday (https://pypi.org/project/Sphinx/#history), and it's breaking our pre-test `Check docs`.

Examples:
- https://travis-ci.org/apache/airflow/builds/512503808
- https://travis-ci.org/apache/airflow/builds/512568417
- https://travis-ci.org/apache/airflow/builds/512431284

Before we address it properly/completely, let's pin `sphinx` to `<2.0.0` first.