### PR TITLE
[AIRFLOW-XXX] 1-setup-env.sh should only run in docker

### DIFF
--- a/scripts/ci/1-setup-env.sh
+++ b/scripts/ci/1-setup-env.sh
@@ -20,6 +20,14 @@
 
 set -exuo pipefail
 
+if [[ ${INSIDE_DOCKER_CONTAINER:-} != true ]]; then
+    echo "You are not inside a docker container!"
+    echo "You should only run this script in the docker container as it may override your files."
+    echo "Learn more about how we develop and test airflow in:"
+    echo "https://github.com/apache/airflow/blob/master/CONTRIBUTING.md#development-and-testing"
+    exit 1
+fi
+
 # Start MiniCluster
 java -cp "/tmp/minicluster-1.1-SNAPSHOT/*" com.ing.minicluster.MiniCluster > /dev/null &
 

--- a/scripts/ci/docker-compose.yml
+++ b/scripts/ci/docker-compose.yml
@@ -70,6 +70,7 @@ services:
     init: true
     environment:
       - USER=airflow
+      - INSIDE_DOCKER_CONTAINER=true
       - ADDITIONAL_PATH=~/.local/bin
       - TOX_ENV
       - PYTHON_VERSION


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

`1-setup-env.sh` should only be ran inside the docker container as it override files.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Modified the CI bash script should not need unit test I guess?

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
