### PR TITLE
[AIRFLOW-4187] SlackWebhookOperator do not pass http_conn_id to its parent class

### DIFF
--- a/airflow/contrib/hooks/slack_webhook_hook.py
+++ b/airflow/contrib/hooks/slack_webhook_hook.py
@@ -66,7 +66,7 @@ class SlackWebhookHook(HttpHook):
                  *args,
                  **kwargs
                  ):
-        super(SlackWebhookHook, self).__init__(*args, **kwargs)
+        super(SlackWebhookHook, self).__init__(http_conn_id=http_conn_id, *args, **kwargs)
         self.webhook_token = self._get_token(webhook_token, http_conn_id)
         self.message = message
         self.attachments = attachments
@@ -94,6 +94,12 @@ class SlackWebhookHook(HttpHook):
         else:
             raise AirflowException('Cannot get token: No valid Slack '
                                    'webhook token nor conn_id supplied')
+
+    def _get_base_url(self):
+        """
+        :return: base url (str)
+        """
+        return self.base_url
 
     def _build_slack_message(self):
         """

--- a/airflow/contrib/hooks/slack_webhook_hook.py
+++ b/airflow/contrib/hooks/slack_webhook_hook.py
@@ -95,12 +95,6 @@ class SlackWebhookHook(HttpHook):
             raise AirflowException('Cannot get token: No valid Slack '
                                    'webhook token nor conn_id supplied')
 
-    def _get_base_url(self):
-        """
-        :return: base url (str)
-        """
-        return self.base_url
-
     def _build_slack_message(self):
         """
         Construct the Slack message. All relevant parameters are combined here to a valid

--- a/tests/contrib/hooks/test_slack_webhook_hook.py
+++ b/tests/contrib/hooks/test_slack_webhook_hook.py
@@ -21,6 +21,7 @@ import json
 import unittest
 
 from airflow import configuration
+from airflow.exceptions import AirflowException
 from airflow.models.connection import Connection
 from airflow.utils import db
 
@@ -90,6 +91,16 @@ class TestSlackWebhookHook(unittest.TestCase):
 
         # Then
         self.assertEqual(self.expected_message, message)
+
+    def test_get_base_url_default(self):
+        hook = SlackWebhookHook(http_conn_id='http_default')
+        hook.get_conn()
+
+        self.assertEqual(hook._get_base_url(), 'https://www.google.com/')
+
+    def test_conn_id_is_not_defined_error(self):
+        with self.assertRaises(AirflowException):
+            SlackWebhookHook(http_conn_id='fake_conn_id')
 
 
 if __name__ == '__main__':

--- a/tests/contrib/hooks/test_slack_webhook_hook.py
+++ b/tests/contrib/hooks/test_slack_webhook_hook.py
@@ -96,7 +96,7 @@ class TestSlackWebhookHook(unittest.TestCase):
         hook = SlackWebhookHook(http_conn_id='http_default')
         hook.get_conn()
 
-        self.assertEqual(hook._get_base_url(), 'https://www.google.com/')
+        self.assertEqual(hook.base_url, 'https://www.google.com/')
 
     def test_conn_id_is_not_defined_error(self):
         with self.assertRaises(AirflowException):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-4187\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4187
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
