### PR TITLE
[AIRFLOW-3540] Warn if old airflow.cfg file is found

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -578,6 +578,18 @@ if conf.has_option('core', 'AIRFLOW_HOME'):
         AIRFLOW_HOME = conf.get('core', 'airflow_home')
         warnings.warn(msg, category=DeprecationWarning)
 
+# Warn about old config file. We used to read ~/airflow/airflow.cfg even if
+# that AIRFLOW_HOME was set to something else
+_old_config_file = os.path.expanduser("~/airflow/airflow.cfg")
+if _old_config_file != AIRFLOW_CONFIG and os.path.isfile(_old_config_file):
+    warnings.warn(
+        'You have two airflow.cfg files: {old} and {new}. Airflow used to look '
+        'at ~/airflow/airflow.cfg, even when AIRFLOW_HOME was set to a different '
+        'value. Airflow will now only read {new}, and you should remove the '
+        'other file'.format(old=_old_config_file, new=AIRFLOW_CONFIG),
+        category=DeprecationWarning,
+    )
+
 
 WEBSERVER_CONFIG = AIRFLOW_HOME + '/webserver_config.py'
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-3540

### Description

- [x] People might have been caught by this situation of having (a dual config file) without even knowning it. To make it obvious for those people we should _say_ if we found the old config file even if we don't read from it.

  **Note:** Against v1-10-stable branch, not master.

  A DeprecationWarning may not actually be the right thing here, as we aren't reading from it. Anyone have any thoughts?

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: tested manually.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
