### PR TITLE
[AIRFLOW-796] Config options for processor_poll_interval and num_runs

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1995,7 +1995,7 @@ class CLIFactory(object):
         'dag_id_opt': Arg(("-d", "--dag_id"), help="The id of the dag to run"),
         'num_runs': Arg(
             ("-n", "--num_runs"),
-            default=-1, type=int,
+            default=conf.getint('scheduler', 'num_runs'), type=int,
             help="Set the number of runs to execute before exiting"),
         # worker
         'do_pickle': Arg(

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -448,6 +448,13 @@ job_heartbeat_sec = 5
 # how often the scheduler should run (in seconds).
 scheduler_heartbeat_sec = 5
 
+# The number of times to try to schedule each DAG file
+# -1 indicates unlimited number
+num_runs = -1
+
+# The number of seconds to wait between consecutive DAG file processing
+processor_poll_interval = 1
+
 # after how much time (seconds) a new DAGs should be picked up from the filesystem
 min_file_process_interval = 0
 

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -548,8 +548,8 @@ class SchedulerJob(BaseJob):
             dag_id=None,
             dag_ids=None,
             subdir=settings.DAGS_FOLDER,
-            num_runs=-1,
-            processor_poll_interval=1.0,
+            num_runs=conf.getint('scheduler', 'num_runs'),
+            processor_poll_interval=conf.getfloat('scheduler', 'processor_poll_interval'),
             do_pickle=False,
             log=None,
             *args, **kwargs):


### PR DESCRIPTION
Follow up from https://github.com/apache/airflow/pull/2014 after syncing with latest master and omitting the already merged `log_level` and removed `run_duration` settings.

Jira: https://jira.apache.org/jira/browse/AIRFLOW-796