### PR TITLE
[AIRFLOW-833] New `airflow default_config` command

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1119,6 +1119,16 @@ def worker(args):
         sp.kill()
 
 
+def default_config(args):
+    if os.path.isfile(args.filename):
+        if args.overwrite:
+            os.unlink(args.filename)
+        else:
+            raise AirflowException('{} already exists; pass --overwrite to '
+                                   'overwrite it'.format(args.filename))
+    conf.save_config_file(args.filename, conf.DEFAULT_CONFIG)
+
+
 def initdb(args):
     print("DB: " + repr(settings.engine.url))
     db.initdb()
@@ -1727,6 +1737,15 @@ class CLIFactory(object):
             "store_true",
             default=False),
 
+        # default_config
+        'filename': Arg(
+            ("-f", "--filename"),
+            "File to write the default config to",
+            default=conf.AIRFLOW_CONFIG),
+        'overwrite': Arg(
+            ("-o", "--overwrite"),
+            "Overwrite file if it exists", "store_true"),
+
         # list_dag_runs
         'no_backfill': Arg(
             ("--no_backfill",),
@@ -2192,6 +2211,10 @@ class CLIFactory(object):
     }
     subparsers = (
         {
+            'func': default_config,
+            'help': "Write the default config file",
+            'args': ('filename', 'overwrite'),
+        }, {
             'func': backfill,
             'help': "Run subsections of a DAG for a specified date range. "
                     "If reset_dag_run option is used,"

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -546,11 +546,12 @@ if conf.has_option('core', 'AIRFLOW_HOME'):
 
 WEBSERVER_CONFIG = os.path.join(AIRFLOW_HOME, 'webserver_config.py')
 
-if not os.path.isfile(WEBSERVER_CONFIG):
-    log.info('Creating new FAB webserver config file in: %s', WEBSERVER_CONFIG)
-    DEFAULT_WEBSERVER_CONFIG = _read_default_config_file('default_webserver_config.py')
-    with open(WEBSERVER_CONFIG, 'w') as f:
-        f.write(DEFAULT_WEBSERVER_CONFIG)
+
+def save_webserver_config(config_file):
+    log.info('Creating new FAB webserver config file in: %s', config_file)
+    with open(config_file, 'w') as f:
+        f.write(_read_default_config_file('default_webserver_config.py'))
+
 
 if conf.getboolean('core', 'unit_test_mode'):
     TEST_CONFIG = _read_default_config_file('default_test.cfg')

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -471,7 +471,6 @@ def get_airflow_config(airflow_home):
 
 AIRFLOW_HOME = get_airflow_home()
 AIRFLOW_CONFIG = get_airflow_config(AIRFLOW_HOME)
-mkdir_p(AIRFLOW_HOME)
 
 
 # Set up dags folder for unit tests

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -28,6 +28,7 @@ import os
 import contextlib
 
 from airflow import settings
+from airflow import configuration as conf
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 log = LoggingMixin().log
@@ -292,6 +293,10 @@ def initdb():
 
     from flask_appbuilder.models.sqla import Base
     Base.metadata.create_all(settings.engine)
+
+    # save the default airflow.cfg if it doesn't exist
+    if not os.path.isfile(conf.AIRFLOW_CONFIG):
+        conf.save_config_file(conf.AIRFLOW_CONFIG, conf.DEFAULT_CONFIG)
 
 
 def upgradedb():

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -87,6 +87,10 @@ def merge_conn(conn, session=None):
 def initdb():
     from airflow import models
     from airflow.models.connection import Connection
+
+    if settings.engine.name == 'sqlite':
+        conf.mkdir_p(os.path.dirname(settings.engine.url.database))
+
     upgradedb()
 
     merge_conn(

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -51,6 +51,8 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
         app.wsgi_app = ProxyFix(app.wsgi_app)
     app.secret_key = conf.get('webserver', 'SECRET_KEY')
 
+    if not os.path.isfile(settings.WEBSERVER_CONFIG):
+        conf.save_webserver_config(settings.WEBSERVER_CONFIG)
     app.config.from_pyfile(settings.WEBSERVER_CONFIG, silent=True)
     app.config['APP_NAME'] = app_name
     app.config['TESTING'] = testing

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1819,8 +1819,12 @@ class ConfigurationView(AirflowBaseView):
         subtitle = conf.AIRFLOW_CONFIG
         # Don't show config when expose_config variable is False in airflow config
         if conf.getboolean("webserver", "expose_config"):
-            with open(conf.AIRFLOW_CONFIG, 'r') as f:
-                config = f.read()
+            if os.path.isfile(conf.AIRFLOW_CONFIG):
+                with open(conf.AIRFLOW_CONFIG, 'r') as f:
+                    config = f.read()
+            else:
+                config = conf.parameterized_config(conf.DEFAULT_CONFIG)
+                subtitle = None
             table = [(section, key, value, source)
                      for section, parameters in conf.as_dict(True, True).items()
                      for key, (value, source) in parameters.items()]

--- a/docs/howto/set-config.rst
+++ b/docs/howto/set-config.rst
@@ -18,7 +18,7 @@
 Setting Configuration Options
 =============================
 
-The first time you run Airflow, it will create a file called ``airflow.cfg`` in
+The first time you run ``airflow initdb``, it will create a file called ``airflow.cfg`` in
 your ``$AIRFLOW_HOME`` directory (``~/airflow`` by default). This file contains Airflow's configuration and you
 can edit it to change any of the settings. You can also set options with environment variables by using this format:
 ``$AIRFLOW__{SECTION}__{KEY}`` (note the double underscores).

--- a/tests/utils/log/test_file_processor_handler.py
+++ b/tests/utils/log/test_file_processor_handler.py
@@ -42,10 +42,11 @@ class TestFileProcessorHandler(unittest.TestCase):
         handler.dag_dir = self.dag_dir
 
         path = os.path.join(self.base_log_folder, "latest")
-        self.assertTrue(os.path.islink(path))
-        self.assertEqual(os.path.basename(os.readlink(path)), date)
+        self.assertFalse(os.path.islink(path))
 
         handler.set_context(filename=os.path.join(self.dag_dir, "logfile"))
+        self.assertTrue(os.path.islink(path))
+        self.assertEqual(os.path.basename(os.readlink(path)), date)
         self.assertTrue(os.path.exists(os.path.join(path, "logfile")))
 
     def test_template(self):
@@ -55,10 +56,11 @@ class TestFileProcessorHandler(unittest.TestCase):
         handler.dag_dir = self.dag_dir
 
         path = os.path.join(self.base_log_folder, "latest")
-        self.assertTrue(os.path.islink(path))
-        self.assertEqual(os.path.basename(os.readlink(path)), date)
+        self.assertFalse(os.path.islink(path))
 
         handler.set_context(filename=os.path.join(self.dag_dir, "logfile"))
+        self.assertTrue(os.path.islink(path))
+        self.assertEqual(os.path.basename(os.readlink(path)), date)
         self.assertTrue(os.path.exists(os.path.join(path, "logfile.log")))
 
     def test_symlink_latest_log_directory(self):


### PR DESCRIPTION
Follow up from #2052  after syncing with latest master. In addition to the new command, this PR defers the dir/file creation that takes place at import time (`airflow.cfg`, `unittests.cfg`, `webserver_config.py`, `airflow.db`, `logs/`) 
