### PR TITLE
[AIRFLOW-4158] Prefix and delimiter support for S3CopyObjectOperator & S3DeleteObjectsOperator

### DIFF
--- a/airflow/contrib/operators/s3_copy_object_operator.py
+++ b/airflow/contrib/operators/s3_copy_object_operator.py
@@ -29,17 +29,6 @@ class S3CopyObjectOperator(BaseOperator):
     Note: the S3 connection used here needs to have access to both
     source and destination buckets.
 
-    :param source_bucket_key: The list of source object keys. (templated)
-        It can be either str or list of str, 
-        Keys must be relative path from root level.
-        Full s3:// url will returns a error.
-    :type source_bucket_key: str or list
-
-    :param dest_bucket_key: The key of the object to copy to. (templated)
-        You can only specify a single key. 
-        If there are multiple sources only first file will be copied.
-    :type dest_bucket_key: str
-    
     :param source_bucket_name: Name of the S3 bucket where the source object is in. (templated)
         It is a required field.
     :type source_bucket_name: str
@@ -47,9 +36,20 @@ class S3CopyObjectOperator(BaseOperator):
     :param dest_bucket_name: Name of the S3 bucket to where the object is copied. (templated)
         It is a required field.
     :type dest_bucket_name: str
-    
+
+    :param source_bucket_key: The list of source object keys. (templated)
+        It can be either str or list of str,
+        Keys must be relative path from root level.
+        Full s3:// url will returns a error.
+    :type source_bucket_key: str or list
+
+    :param dest_bucket_key: The key of the object to copy to. (templated)
+        You can only specify a single key.
+        If there are multiple sources only first file will be copied.
+    :type dest_bucket_key: str
+
     :param source_bucket_prefix: prifix of source object keys. (templated)
-        default prefix is empty string which will accept all files from the source bucket, 
+        default prefix is empty string which will accept all files from the source bucket,
         prefix will only execute if source_bucket_key is not specified.
     :type source_bucket_prefix: str
 
@@ -91,10 +91,10 @@ class S3CopyObjectOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            source_bucket_key=None,
-            dest_bucket_key=None,
             source_bucket_name,
             dest_bucket_name,
+            source_bucket_key=None,
+            dest_bucket_key=None,
             source_bucket_prefix='',
             source_bucket_delimiter='',
             dest_bucket_path=None,
@@ -125,64 +125,72 @@ class S3CopyObjectOperator(BaseOperator):
             )
 
             self.source_bucket_key = s3_hook.list_keys(
-                    bucket_name=self.source_bucket_name,
-                    prefix=self.source_bucket_prefix,
-                    delimiter=self.source_bucket_delimiter)
-        
-        elif not isinstance(self.source_bucket_key,list):
+                bucket_name=self.source_bucket_name,
+                prefix=self.source_bucket_prefix,
+                delimiter=self.source_bucket_delimiter)
+
+        elif not isinstance(self.source_bucket_key, list):
             self.source_bucket_key = [self.source_bucket_key]
 
         if self.source_bucket_key is None:
             self.log.info(
                 "No files to copy!"
             )
-        
+
         elif(self.dest_bucket_key is not None):
             self.log.info(
                 'Copying file: s3://%s/%s to s3://%s/%s',
-                self.source_bucket_name, self.source_bucket_key[0], 
+                self.source_bucket_name, self.source_bucket_key[0],
                 self.dest_bucket_name, self.dest_bucket_key
             )
-        
-            s3_hook.copy_object(self.source_bucket_key[0], self.dest_bucket_key,
-                self.source_bucket_name, self.dest_bucket_name,
+
+            s3_hook.copy_object(
+                self.source_bucket_key[0],
+                self.dest_bucket_key,
+                self.source_bucket_name,
+                self.dest_bucket_name,
                 self.source_version_id)
 
             self.log.info(
                 'All done, 1 file Copied successfully!',
             )
-                    
+
         elif(self.dest_bucket_path is None):
             for key in self.source_bucket_key:
                 self.log.info(
                     'Copying file: s3://%s/%s to s3://%s/%s',
                     self.source_bucket_name, key, self.dest_bucket_name, key
                 )
-            
-                s3_hook.copy_object(key, key,
-                                self.source_bucket_name, self.dest_bucket_name,
-                                self.source_version_id)
+
+                s3_hook.copy_object(
+                    key,
+                    key,
+                    self.source_bucket_name,
+                    self.dest_bucket_name,
+                    self.source_version_id)
 
             self.log.info(
                 'All done, %d file(s) Copied successfully!', len(self.source_bucket_key)
-            )   
+            )
 
         else:
-            if(self.dest_bucket_path is not "" and not self.dest_bucket_path.endswith("/")):
-                self.dest_bucket_path=self.dest_bucket_path+"/"
+            if(self.dest_bucket_path == "" and not self.dest_bucket_path.endswith("/")):
+                self.dest_bucket_path = self.dest_bucket_path + "/"
 
             for key in self.source_bucket_key:
                 dest = self.dest_bucket_path + key[key.rfind('/') + 1:]
- 
+
                 self.log.info(
                     'Copying file: s3://%s/%s to s3://%s/%s',
                     self.source_bucket_name, key, self.dest_bucket_name, dest
                 )
-            
-                s3_hook.copy_object(key, dest,
-                                self.source_bucket_name, self.dest_bucket_name,
-                                self.source_version_id)
-            
+
+                s3_hook.copy_object(
+                    key,
+                    dest,
+                    self.source_bucket_name,
+                    self.dest_bucket_name,
+                    self.source_version_id)
 
             self.log.info(
                 'All done,%d file(s) Copied successfully!', len(self.source_bucket_key)

--- a/airflow/contrib/operators/s3_copy_object_operator.py
+++ b/airflow/contrib/operators/s3_copy_object_operator.py
@@ -24,33 +24,51 @@ from airflow.utils.decorators import apply_defaults
 
 class S3CopyObjectOperator(BaseOperator):
     """
-    Creates a copy of an object that is already stored in S3.
+    Create copy of objects from S3 to S3.
 
     Note: the S3 connection used here needs to have access to both
-    source and destination bucket/key.
+    source and destination buckets.
 
-    :param source_bucket_key: The key of the source object. (templated)
+    :param source_bucket_key: The list of source object keys. (templated)
+        It can be either str or list of str, 
+        Keys must be relative path from root level.
+        Full s3:// url will returns a error.
+    :type source_bucket_key: str or list
 
-        It can be either full s3:// style url or relative path from root level.
-
-        When it's specified as a full s3:// url, please omit source_bucket_name.
-    :type source_bucket_key: str
     :param dest_bucket_key: The key of the object to copy to. (templated)
-
-        The convention to specify `dest_bucket_key` is the same as `source_bucket_key`.
+        You can only specify a single key. 
+        If there are multiple sources only first file will be copied.
     :type dest_bucket_key: str
+    
     :param source_bucket_name: Name of the S3 bucket where the source object is in. (templated)
-
-        It should be omitted when `source_bucket_key` is provided as a full s3:// url.
+        It is a required field.
     :type source_bucket_name: str
-    :param dest_bucket_name: Name of the S3 bucket to where the object is copied. (templated)
 
-        It should be omitted when `dest_bucket_key` is provided as a full s3:// url.
+    :param dest_bucket_name: Name of the S3 bucket to where the object is copied. (templated)
+        It is a required field.
     :type dest_bucket_name: str
+    
+    :param source_bucket_prefix: prifix of source object keys. (templated)
+        default prefix is empty string which will accept all files from the source bucket, 
+        prefix will only execute if source_bucket_key is not specified.
+    :type source_bucket_prefix: str
+
+    :param source_bucket_delimiter:delimiter of source object keys. (templated)
+        The convention to specify `source_bucket_delimiter` is the same as `source_bucket_prefix`.
+    :type source_bucket_delimiter: str
+
+    :param dest_bucket_path: destination path where to copy. (templated)
+        Destination path must be relative path from root level.
+        Uses same file name as source.
+        For same path as source please omit dest_bucket_path along with source_bucket_key.
+    :type source_bucket_path: str
+
     :param source_version_id: Version ID of the source object (OPTIONAL)
     :type source_version_id: str
+
     :param aws_conn_id: Connection id of the S3 connection to use
     :type aws_conn_id: str
+
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
 
@@ -66,15 +84,20 @@ class S3CopyObjectOperator(BaseOperator):
     """
 
     template_fields = ('source_bucket_key', 'dest_bucket_key',
-                       'source_bucket_name', 'dest_bucket_name')
+                       'source_bucket_name', 'dest_bucket_name',
+                       'source_bucket_prefix', 'source_bucket_delimiter',
+                       'dest_bucket_path')
 
     @apply_defaults
     def __init__(
             self,
-            source_bucket_key,
-            dest_bucket_key,
-            source_bucket_name=None,
-            dest_bucket_name=None,
+            source_bucket_key=None,
+            dest_bucket_key=None,
+            source_bucket_name,
+            dest_bucket_name,
+            source_bucket_prefix='',
+            source_bucket_delimiter='',
+            dest_bucket_path=None,
             source_version_id=None,
             aws_conn_id='aws_default',
             verify=None,
@@ -85,12 +108,82 @@ class S3CopyObjectOperator(BaseOperator):
         self.dest_bucket_key = dest_bucket_key
         self.source_bucket_name = source_bucket_name
         self.dest_bucket_name = dest_bucket_name
+        self.source_bucket_prefix = source_bucket_prefix
+        self.source_bucket_delimiter = source_bucket_delimiter
+        self.dest_bucket_path = dest_bucket_path
         self.source_version_id = source_version_id
         self.aws_conn_id = aws_conn_id
         self.verify = verify
 
     def execute(self, context):
         s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
-        s3_hook.copy_object(self.source_bucket_key, self.dest_bucket_key,
-                            self.source_bucket_name, self.dest_bucket_name,
-                            self.source_version_id)
+
+        if self.source_bucket_key is None:
+            self.log.info(
+                'Getting the list of files from bucket: %s in prefix: %s (Delimiter %s)',
+                self.source_bucket_name, self.source_bucket_prefix, self.source_bucket_delimiter
+            )
+
+            self.source_bucket_key = s3_hook.list_keys(
+                    bucket_name=self.source_bucket_name,
+                    prefix=self.source_bucket_prefix,
+                    delimiter=self.source_bucket_delimiter)
+        
+        elif not isinstance(self.source_bucket_key,list):
+            self.source_bucket_key = [self.source_bucket_key]
+
+        if self.source_bucket_key is None:
+            self.log.info(
+                "No files to copy!"
+            )
+        
+        elif(self.dest_bucket_key is not None):
+            self.log.info(
+                'Copying file: s3://%s/%s to s3://%s/%s',
+                self.source_bucket_name, self.source_bucket_key[0], 
+                self.dest_bucket_name, self.dest_bucket_key
+            )
+        
+            s3_hook.copy_object(self.source_bucket_key[0], self.dest_bucket_key,
+                self.source_bucket_name, self.dest_bucket_name,
+                self.source_version_id)
+
+            self.log.info(
+                'All done, 1 file Copied successfully!',
+            )
+                    
+        elif(self.dest_bucket_path is None):
+            for key in self.source_bucket_key:
+                self.log.info(
+                    'Copying file: s3://%s/%s to s3://%s/%s',
+                    self.source_bucket_name, key, self.dest_bucket_name, key
+                )
+            
+                s3_hook.copy_object(key, key,
+                                self.source_bucket_name, self.dest_bucket_name,
+                                self.source_version_id)
+
+            self.log.info(
+                'All done, %d file(s) Copied successfully!', len(self.source_bucket_key)
+            )   
+
+        else:
+            if(self.dest_bucket_path is not "" and not self.dest_bucket_path.endswith("/")):
+                self.dest_bucket_path=self.dest_bucket_path+"/"
+
+            for key in self.source_bucket_key:
+                dest = self.dest_bucket_path + key[key.rfind('/') + 1:]
+ 
+                self.log.info(
+                    'Copying file: s3://%s/%s to s3://%s/%s',
+                    self.source_bucket_name, key, self.dest_bucket_name, dest
+                )
+            
+                s3_hook.copy_object(key, dest,
+                                self.source_bucket_name, self.dest_bucket_name,
+                                self.source_version_id)
+            
+
+            self.log.info(
+                'All done,%d file(s) Copied successfully!', len(self.source_bucket_key)
+            )

--- a/airflow/contrib/operators/s3_delete_objects_operator.py
+++ b/airflow/contrib/operators/s3_delete_objects_operator.py
@@ -32,7 +32,7 @@ class S3DeleteObjectsOperator(BaseOperator):
 
     :param bucket: Name of the bucket in which you are going to delete object(s). (templated)
     :type bucket: str
-    
+
     :param keys: The key(s) to delete from S3 bucket. (templated)
 
         When ``keys`` is a string, it's supposed to be the key name of
@@ -45,7 +45,7 @@ class S3DeleteObjectsOperator(BaseOperator):
     :type keys: str or list
 
     :param prefix: prefix of source object keys. (templated)
-        Either keys or prefix must be specified, 
+        Either keys or prefix must be specified,
         To delete all files in a bucket use empty prefix.
     :type source_bucket_prefix: str
 
@@ -99,9 +99,9 @@ class S3DeleteObjectsOperator(BaseOperator):
             )
 
             self.keys = s3_hook.list_keys(
-                    bucket_name=self.bucket,
-                    prefix=self.prefix,
-                    delimiter=self.delimiter)
+                bucket_name=self.bucket,
+                prefix=self.prefix,
+                delimiter=self.delimiter)
 
         if self.keys is None:
             self.log.info(


### PR DESCRIPTION
### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4158

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

In S3DeleteObjectsOperator and S3CopyObjectOperator, it only supports the exact key of the file, there is no feature to copy or delete using prefix and delimiter. 
By this change, we can either use key or prefix and/or delimiter with S3DeleteObjectsOperator and S3CopyObjectOperator, if we use prefix and/or delimiter we can delete/copy all files with the same prefix. It is equivalent to --recursive option of aws command.
### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  
### Code Quality

- [ ] Passes `flake8`
