### PR TITLE
[AIRFLOW-4200][AIP-3-subtask-4] Remove all __future__ imports

### DIFF
--- a/airflow/_vendor/nvd3/NVD3Chart.py
+++ b/airflow/_vendor/nvd3/NVD3Chart.py
@@ -9,7 +9,6 @@ for d3.js without taking away the power that d3.js gives you.
 Project location : https://github.com/areski/python-nvd3
 """
 
-from __future__ import unicode_literals
 from optparse import OptionParser
 from jinja2 import Environment, PackageLoader
 from airflow._vendor.slugify import slugify

--- a/airflow/api/__init__.py
+++ b/airflow/api/__init__.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
-
 from typing import Any
 
 from airflow.exceptions import AirflowException

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -18,7 +18,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
 import importlib
 import logging
 

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -16,11 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from base64 import b64encode
 from builtins import str

--- a/airflow/contrib/auth/backends/password_auth.py
+++ b/airflow/contrib/auth/backends/password_auth.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import unicode_literals
-
 from sys import version_info
 
 import base64

--- a/airflow/contrib/example_dags/example_kubernetes_executor.py
+++ b/airflow/contrib/example_dags/example_kubernetes_executor.py
@@ -16,7 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import print_function
+
 import airflow
 from airflow.operators.python_operator import PythonOperator
 from airflow.models import DAG

--- a/airflow/contrib/example_dags/example_kubernetes_executor_config.py
+++ b/airflow/contrib/example_dags/example_kubernetes_executor_config.py
@@ -16,7 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import print_function
+
 import airflow
 from airflow.operators.python_operator import PythonOperator
 from libs.helper import print_stuff

--- a/airflow/contrib/example_dags/example_pubsub_flow.py
+++ b/airflow/contrib/example_dags/example_pubsub_flow.py
@@ -24,7 +24,7 @@ can be used to trigger dependant tasks upon receipt of a Pub/Sub message.
 NOTE: project_id must be updated to a GCP project ID accessible with the
       Google Default Credentials on the machine running the workflow
 """
-from __future__ import unicode_literals
+
 from base64 import b64encode
 
 import datetime

--- a/airflow/contrib/operators/cassandra_to_gcs.py
+++ b/airflow/contrib/operators/cassandra_to_gcs.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import unicode_literals
-
 import json
 from builtins import str
 from base64 import b64encode

--- a/airflow/contrib/sensors/celery_queue_sensor.py
+++ b/airflow/contrib/sensors/celery_queue_sensor.py
@@ -16,7 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import absolute_import
 
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults

--- a/airflow/contrib/utils/mlengine_prediction_summary.py
+++ b/airflow/contrib/utils/mlengine_prediction_summary.py
@@ -89,9 +89,6 @@ subprocess.check_call(["python",
                        ])
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import argparse
 import base64

--- a/airflow/contrib/utils/sendgrid.py
+++ b/airflow/contrib/utils/sendgrid.py
@@ -17,11 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import base64
 import mimetypes
 import os

--- a/airflow/dag/base_dag.py
+++ b/airflow/dag/base_dag.py
@@ -17,11 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from abc import ABCMeta, abstractmethod, abstractproperty
 
 

--- a/airflow/example_dags/docker_copy_data.py
+++ b/airflow/example_dags/docker_copy_data.py
@@ -26,7 +26,6 @@ TODO: Review the workflow, change it accordingly to
       your environment & enable the code.
 """
 
-# from __future__ import print_function
 #
 # from airflow import DAG
 # import airflow

--- a/airflow/example_dags/example_python_operator.py
+++ b/airflow/example_dags/example_python_operator.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
-
 import time
 from builtins import range
 from pprint import pprint

--- a/airflow/example_dags/example_xcom.py
+++ b/airflow/example_dags/example_xcom.py
@@ -16,7 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import print_function
 
 import airflow
 from airflow import DAG

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -17,11 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 import random
 from typing import Iterable

--- a/airflow/hooks/druid_hook.py
+++ b/airflow/hooks/druid_hook.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
-
 import requests
 import time
 

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function, unicode_literals
-
 import contextlib
 import os
 import re

--- a/airflow/hooks/pig_hook.py
+++ b/airflow/hooks/pig_hook.py
@@ -17,7 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
 import subprocess
 from tempfile import NamedTemporaryFile
 

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -16,11 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import getpass
 import logging

--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -17,7 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import absolute_import
 from datetime import datetime, timedelta
 import dateutil # noqa
 from random import random # noqa

--- a/airflow/migrations/env.py
+++ b/airflow/migrations/env.py
@@ -17,7 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import with_statement
 from alembic import context
 from logging.config import fileConfig
 

--- a/airflow/operators/hive_operator.py
+++ b/airflow/operators/hive_operator.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import unicode_literals
-
 import re
 
 from airflow.hooks.hive_hooks import HiveCliHook

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -16,11 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from builtins import object
 import imp

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -16,11 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import atexit
 import logging

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import unicode_literals
-
 import getpass
 import os
 import subprocess

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -20,7 +20,6 @@
 """
 Utilities module for cli
 """
-from __future__ import absolute_import
 
 import functools
 import getpass

--- a/airflow/utils/cli_action_loggers.py
+++ b/airflow/utils/cli_action_loggers.py
@@ -21,7 +21,6 @@
 An Action Logger module. Singleton pattern has been applied into this module
 so that registered callbacks can be used all through the same python process.
 """
-from __future__ import absolute_import
 
 import logging
 from typing import List, Callable

--- a/airflow/utils/configuration.py
+++ b/airflow/utils/configuration.py
@@ -16,8 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import unicode_literals
-from __future__ import absolute_import
 
 import os
 import json

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -16,11 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import logging
 import multiprocessing

--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -16,11 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from airflow.utils import timezone
 from datetime import datetime, timedelta

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -16,11 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from functools import wraps
 

--- a/airflow/utils/email.py
+++ b/airflow/utils/email.py
@@ -17,11 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from past.builtins import basestring
 
 import importlib

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -16,9 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import errno
 import os

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -16,11 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import errno
 

--- a/airflow/utils/json.py
+++ b/airflow/utils/json.py
@@ -16,11 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from datetime import datetime, date
 import json

--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -16,11 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import logging
 import sys

--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -16,11 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import datetime
 import os

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -16,8 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import unicode_literals
 
 from builtins import object
 

--- a/airflow/utils/timeout.py
+++ b/airflow/utils/timeout.py
@@ -16,11 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import signal
 import os

--- a/airflow/utils/trigger_rule.py
+++ b/airflow/utils/trigger_rule.py
@@ -16,8 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import unicode_literals
 
 from builtins import object
 from typing import Set

--- a/airflow/utils/weight_rule.py
+++ b/airflow/utils/weight_rule.py
@@ -16,8 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import unicode_literals
 
 from builtins import object
 from typing import Set

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -16,11 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from airflow.models import Connection
 from airflow.utils import timezone

--- a/airflow/www/static_config.py
+++ b/airflow/www/static_config.py
@@ -16,7 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import print_function
 
 import json
 import os

--- a/dev/airflow-jira
+++ b/dev/airflow-jira
@@ -29,8 +29,6 @@
 # This tool is based on the Spark merge_spark_pr script:
 # https://github.com/apache/spark/blob/master/dev/merge_spark_pr.py
 
-from __future__ import print_function
-
 import jira
 import re
 import sys

--- a/dev/airflow-license
+++ b/dev/airflow-license
@@ -15,8 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-from __future__ import print_function
 
 import os
 import re

--- a/dev/airflow-pr
+++ b/dev/airflow-pr
@@ -29,7 +29,6 @@
 # This tool is based on the Spark merge_spark_pr script:
 # https://github.com/apache/spark/blob/master/dev/merge_spark_pr.py
 
-from __future__ import print_function
 import json
 import os
 import re

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,7 +19,5 @@
 
 # flake8: noqa
 
-from __future__ import absolute_import
-
 from .api import *  # type: ignore
 from .core import *  # type: ignore

--- a/tests/contrib/hooks/test_gcp_kms_hook.py
+++ b/tests/contrib/hooks/test_gcp_kms_hook.py
@@ -16,9 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-
-from __future__ import unicode_literals
 
 import unittest
 from base64 import b64encode

--- a/tests/contrib/hooks/test_gcp_pubsub_hook.py
+++ b/tests/contrib/hooks/test_gcp_pubsub_hook.py
@@ -16,9 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-
-from __future__ import unicode_literals
 
 from base64 import b64encode as b64e
 import unittest

--- a/tests/contrib/hooks/test_sftp_hook.py
+++ b/tests/contrib/hooks/test_sftp_hook.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
-
 import mock
 import unittest
 import shutil

--- a/tests/contrib/operators/test_cassandra_to_gcs_operator.py
+++ b/tests/contrib/operators/test_cassandra_to_gcs_operator.py
@@ -16,7 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import unicode_literals
 
 import unittest
 import mock

--- a/tests/contrib/operators/test_mlengine_operator.py
+++ b/tests/contrib/operators/test_mlengine_operator.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import absolute_import, division, print_function
-
 import copy
 import datetime
 import unittest

--- a/tests/contrib/operators/test_postgres_to_gcs_operator.py
+++ b/tests/contrib/operators/test_postgres_to_gcs_operator.py
@@ -16,11 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import unittest
 

--- a/tests/contrib/operators/test_pubsub_operator.py
+++ b/tests/contrib/operators/test_pubsub_operator.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import unicode_literals
-
 from base64 import b64encode as b64e
 import unittest
 

--- a/tests/contrib/operators/test_snowflake_operator.py
+++ b/tests/contrib/operators/test_snowflake_operator.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
-
 import unittest
 
 from airflow import DAG, configuration

--- a/tests/contrib/sensors/test_celery_queue_sensor.py
+++ b/tests/contrib/sensors/test_celery_queue_sensor.py
@@ -16,7 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import absolute_import
 
 import unittest
 from mock import patch

--- a/tests/contrib/sensors/test_pubsub_sensor.py
+++ b/tests/contrib/sensors/test_pubsub_sensor.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import unicode_literals
-
 import unittest
 
 from base64 import b64encode as b64e

--- a/tests/contrib/utils/test_mlengine_operator_utils.py
+++ b/tests/contrib/utils/test_mlengine_operator_utils.py
@@ -15,10 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import datetime
 import unittest
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
-
 import json
 import unittest
 

--- a/tests/operators/test_email_operator.py
+++ b/tests/operators/test_email_operator.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function, unicode_literals
-
 import datetime
 import mock
 import unittest

--- a/tests/operators/test_hive_operator.py
+++ b/tests/operators/test_hive_operator.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
-
 import datetime
 import os
 import unittest

--- a/tests/operators/test_latest_only_operator.py
+++ b/tests/operators/test_latest_only_operator.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function, unicode_literals
-
 import datetime
 import unittest
 

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
-
 from airflow import DAG, configuration, operators
 from airflow.utils import timezone
 

--- a/tests/operators/test_python_operator.py
+++ b/tests/operators/test_python_operator.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function, unicode_literals
-
 import copy
 import logging
 import os

--- a/tests/operators/test_virtualenv_operator.py
+++ b/tests/operators/test_virtualenv_operator.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function, unicode_literals
-
 import datetime
 
 import funcsigs

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -17,11 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import unittest
 
 

--- a/tests/task/__init__.py
+++ b/tests/task/__init__.py
@@ -19,5 +19,4 @@
 
 # flake8: noqa
 
-from __future__ import absolute_import
 from .task_runner import *

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -17,9 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import contextlib
 import os
 import warnings

--- a/tests/test_impersonation.py
+++ b/tests/test_impersonation.py
@@ -16,7 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# from __future__ import print_function
+
 import errno
 import os
 import subprocess

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -17,11 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import datetime
 import json
 import logging

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
-
 import unittest
 import logging
 import mock


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4200
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

### Code Quality

- [x] Passes `flake8`
