### PR TITLE
[AIRFLOW-4232] Add `none_skipped` trigger rule

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -2008,7 +2008,7 @@ class BaseOperator(LoggingMixin):
     :param trigger_rule: defines the rule by which dependencies are applied
         for the task to get triggered. Options are:
         ``{ all_success | all_failed | all_done | one_success |
-        one_failed | none_failed | dummy}``
+        one_failed | none_failed | none_skipped | dummy}``
         default is ``all_success``. Options can be set as string or
         using the constants defined in the static class
         ``airflow.utils.TriggerRule``

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -157,6 +157,9 @@ class TriggerRuleDep(BaseTIDep):
                     ti.set_state(State.UPSTREAM_FAILED, session)
                 elif skipped == upstream:
                     ti.set_state(State.SKIPPED, session)
+            elif tr == TR.NONE_SKIPPED:
+                if skipped:
+                    ti.set_state(State.SKIPPED, session)
 
         if tr == TR.ONE_SUCCESS:
             if successes <= 0:
@@ -207,6 +210,14 @@ class TriggerRuleDep(BaseTIDep):
                     "tasks to have succeeded or been skipped, but found {1} non-success(es). "
                     "upstream_tasks_state={2}, upstream_task_ids={3}"
                     .format(tr, num_failures, upstream_tasks_state,
+                            task.upstream_task_ids))
+        elif tr == TR.NONE_SKIPPED:
+            if skipped > 0:
+                yield self._failing_status(
+                    reason="Task's trigger rule '{0}' requires all upstream "
+                    "tasks to not have been skipped, but found {1} task(s) skipped. "
+                    "upstream_tasks_state={2}, upstream_task_ids={3}"
+                    .format(tr, skipped, upstream_tasks_state,
                             task.upstream_task_ids))
         else:
             yield self._failing_status(

--- a/airflow/utils/trigger_rule.py
+++ b/airflow/utils/trigger_rule.py
@@ -29,8 +29,9 @@ class TriggerRule(object):
     ALL_DONE = 'all_done'
     ONE_SUCCESS = 'one_success'
     ONE_FAILED = 'one_failed'
-    DUMMY = 'dummy'
     NONE_FAILED = 'none_failed'
+    NONE_SKIPPED = 'none_skipped'
+    DUMMY = 'dummy'
 
     _ALL_TRIGGER_RULES = set()  # type: Set[str]
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -741,6 +741,7 @@ while creating tasks:
 * ``one_failed``: fires as soon as at least one parent has failed, it does not wait for all parents to be done
 * ``one_success``: fires as soon as at least one parent succeeds, it does not wait for all parents to be done
 * ``none_failed``: all parents have not failed (``failed`` or ``upstream_failed``) i.e. all parents have succeeded or been skipped
+* ``none_skipped``: no parent is in a ``skipped`` state, i.e. all parents are in a ``success``, ``failed``, or ``upstream_failed`` state
 * ``dummy``: dependencies are just for show, trigger at will
 
 Note that these can be used in conjunction with ``depends_on_past`` (boolean)
@@ -750,7 +751,7 @@ previous schedule for the task hasn't succeeded.
 One must be aware of the interaction between trigger rules and skipped tasks
 in schedule level. Skipped tasks will cascade through trigger rules 
 ``all_success`` and ``all_failed`` but not ``all_done``, ``one_failed``, ``one_success``,
-``none_failed`` and ``dummy``. 
+``none_failed``, ``none_skipped`` and ``dummy``.
 
 For example, consider the following DAG:
 

--- a/tests/utils/test_trigger_rule.py
+++ b/tests/utils/test_trigger_rule.py
@@ -30,5 +30,6 @@ class TestTriggerRule(unittest.TestCase):
         self.assertTrue(TriggerRule.is_valid(TriggerRule.ONE_SUCCESS))
         self.assertTrue(TriggerRule.is_valid(TriggerRule.ONE_FAILED))
         self.assertTrue(TriggerRule.is_valid(TriggerRule.NONE_FAILED))
+        self.assertTrue(TriggerRule.is_valid(TriggerRule.NONE_SKIPPED))
         self.assertTrue(TriggerRule.is_valid(TriggerRule.DUMMY))
-        self.assertEqual(len(TriggerRule.all_triggers()), 7)
+        self.assertEqual(len(TriggerRule.all_triggers()), 8)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4232) issues and references them in the PR title.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add a "none_skipped" trigger rule so that downstream tasks will only run if all their upstream tasks have succeeded or failed.

##### Example:
* Task 1 is a transform task that creates a temp table.
* Task 2 is a cleanup task that drops the temp table.

Task 1 >> Task 2

If Task 1 succeeds or fails, Task 2 should drop the temp table as cleanup. However if the task never runs, we should just skip it.

Or perhaps Task 2 is a logging task that only logs successes and failures, but doesn't log skips to cut down on noise.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
