### PR TITLE
[AIRFLOW-XXX] Pin psycopg2 due to breaking change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,7 @@ password = [
     'flask-bcrypt>=0.7.1',
 ]
 pinot = ['pinotdb==0.1.1']
-postgres = ['psycopg2>=2.7.4']
+postgres = ['psycopg2>=2.7.4,<2.8']
 qds = ['qds-sdk>=1.10.4']
 rabbitmq = ['librabbitmq>=1.6.1']
 redis = ['redis~=3.2']


### PR DESCRIPTION
psycopg2 releases 2.8 a few hours ago (https://pypi.org/project/psycopg2/#history), and it's causing issue in our CI.

Example: https://travis-ci.org/XD-DENG/incubator-airflow/jobs/515704617
```
Collecting psycopg2>=2.7.4 (from apache-airflow===2.0.0.dev0-)
  Downloading https://files.pythonhosted.org/packages/c7/ca/75236b17f1b951950ffc55d657c5aa408d3d0327a1b6c4c0f7cb16ef7e7b/psycopg2-2.8.tar.gz (367kB)
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    
    Error: pg_config executable not found.
    
    pg_config is required to build psycopg2 from source.  Please add the directory
    containing pg_config to the $PATH or specify the full executable path with the
    option:
    
        python setup.py build_ext --pg-config /path/to/pg_config build ...
    
    or with the pg_config option in 'setup.cfg'.
    
    If you prefer to avoid building psycopg2 from source, please install the PyPI
    'psycopg2-binary' package instead.
    
    For further information please check the 'doc/src/install.rst' file (also at
    <http://initd.org/psycopg/docs/install.html>).
```