### PR TITLE
[AIRFLOW-3552] Fix encoding issue in ImapAttachmentToS3Operator

### DIFF
--- a/airflow/contrib/operators/imap_attachment_to_s3_operator.py
+++ b/airflow/contrib/operators/imap_attachment_to_s3_operator.py
@@ -85,4 +85,4 @@ class ImapAttachmentToS3Operator(BaseOperator):
             )
 
         s3_hook = S3Hook(aws_conn_id=self.s3_conn_id)
-        s3_hook.load_string(string_data=imap_mail_attachments[0][1], key=self.s3_key)
+        s3_hook.load_bytes(bytes_data=imap_mail_attachments[0][1], key=self.s3_key)

--- a/tests/contrib/operators/test_imap_attachment_to_s3_operator.py
+++ b/tests/contrib/operators/test_imap_attachment_to_s3_operator.py
@@ -51,7 +51,7 @@ class TestImapAttachmentToS3Operator(unittest.TestCase):
             check_regex=self.kwargs['imap_check_regex'],
             latest_only=True
         )
-        mock_s3_hook.return_value.load_string.assert_called_once_with(
-            string_data=mock_imap_hook.return_value.retrieve_mail_attachments.return_value[0][1],
+        mock_s3_hook.return_value.load_bytes.assert_called_once_with(
+            bytes_data=mock_imap_hook.return_value.retrieve_mail_attachments.return_value[0][1],
             key=self.kwargs['s3_key']
         )


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3552
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

- change method to upload data to s3 from load_string to load_bytes

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
