### PR TITLE
[AIRFLOW-4248] Fix 'FileExistsError' makedirs() race condition

### DIFF
--- a/airflow/utils/log/file_processor_handler.py
+++ b/airflow/utils/log/file_processor_handler.py
@@ -17,7 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import errno
 import logging
 import os
 
@@ -49,9 +48,9 @@ class FileProcessorHandler(logging.Handler):
         if not os.path.exists(self._get_log_directory()):
             try:
                 os.makedirs(self._get_log_directory())
-            except OSError as e:
+            except OSError:
                 # only ignore case where the directory already exist
-                if e.errno != errno.EEXIST:
+                if not os.path.isdir(self._get_log_directory()):
                     raise
 
                 logging.warning("%s already exists", self._get_log_directory())
@@ -138,7 +137,11 @@ class FileProcessorHandler(logging.Handler):
         directory = os.path.dirname(full_path)
 
         if not os.path.exists(directory):
-            os.makedirs(directory)
+            try:
+                os.makedirs(directory)
+            except OSError:
+                if not os.path.isdir(directory):
+                    raise
 
         if not os.path.exists(full_path):
             open(full_path, "a").close()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4248
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

The `FileProcessorHandler`'s `_init_file` method can trigger an unhandled exception due to a race condition when multiple processes attempt to create the same directory on a shared filesystem.  When this occurs a `FileExistsError` is raised, and if it is the scheduler process, can prevent tasks from starting until the scheduler is restarted.

This PR catches the exception and handles it similarly to how it's done when using the `exists_ok=True` argument of Python v3.2's `os.makedirs` function , which does an `isdir()` call instead of checking for the `EEXIST` error code (comments in `os.makedirs` state that checking for this error code is unreliable because the OS can return other error codes instead).  This PR also replaces the existing `EEXIST` check in the `FileProcessorHandler.__init__` method to instead use `isdir()`.

Note: It'd be slightly nicer to just use the `os.makdirs(exists_ok=True)` parameter instead, which can be done if this PR becomes dependent upon `AIP-3`.

### Tests

- [] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [N/A] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
