### PR TITLE
[AIRFLOW-3370] Add stdout output options to Elasticsearch task log handler

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -594,8 +594,8 @@ log_filename_template = {{{{ ti.dag_id }}}}/{{{{ ti.task_id }}}}/{{{{ ts }}}}/{{
 log_processor_filename_template = {{{{ filename }}}}.log
 
 [elasticsearch]
-elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
-elasticsearch_end_of_log_mark = end_of_log
+log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+end_of_log_mark = end_of_log
 ```
 
 The previous setting of `log_task_reader` is not needed in many cases now when using the default logging config with remote storages. (Previously it needed to be set to `s3.task` or similar. This is not needed with the default config anymore)

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,10 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Changes in writing Logs to Elasticsearch
+
+The `elasticsearch_` prefix has been removed from all config items under the `[elasticsearch]` section. For example `elasticsearch_host` is now just `host`.
+
 ### Removal of Mesos Executor
 The Mesos Executor is removed from the code base as it was not widely used and not maintained. [Mailing List Discussion on deleting it](https://lists.apache.org/list.html?dev@airflow.apache.org:lte=1M:mesos).
 
@@ -594,8 +598,8 @@ log_filename_template = {{{{ ti.dag_id }}}}/{{{{ ti.task_id }}}}/{{{{ ts }}}}/{{
 log_processor_filename_template = {{{{ filename }}}}.log
 
 [elasticsearch]
-log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
-end_of_log_mark = end_of_log
+elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+elasticsearch_end_of_log_mark = end_of_log
 ```
 
 The previous setting of `log_task_reader` is not needed in many cases now when using the default logging config with remote storages. (Previously it needed to be set to `s3.task` or similar. This is not needed with the default config anymore)

--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -22,6 +22,7 @@ from typing import Dict, Any
 
 from airflow import configuration as conf
 from airflow.utils.file import mkdirs
+from airflow.utils.log.json_formatter import create_formatter
 
 # TODO: Logging format and level should be configured
 # in this file instead of from airflow.cfg. Currently
@@ -56,9 +57,16 @@ REMOTE_BASE_LOG_FOLDER = conf.get('core', 'REMOTE_BASE_LOG_FOLDER')
 
 ELASTICSEARCH_HOST = conf.get('elasticsearch', 'ELASTICSEARCH_HOST')
 
-LOG_ID_TEMPLATE = conf.get('elasticsearch', 'ELASTICSEARCH_LOG_ID_TEMPLATE')
+ELASTICSEARCH_LOG_ID_TEMPLATE = conf.get('elasticsearch', 'ELASTICSEARCH_LOG_ID_TEMPLATE')
 
-END_OF_LOG_MARK = conf.get('elasticsearch', 'ELASTICSEARCH_END_OF_LOG_MARK')
+ELASTICSEARCH_END_OF_LOG_MARK = conf.get('elasticsearch', 'ELASTICSEARCH_END_OF_LOG_MARK')
+
+ELASTICSEARCH_WRITE_STDOUT = conf.get('elasticsearch', 'ELASTICSEARCH_WRITE_STDOUT')
+
+ELASTICSEARCH_JSON_FORMAT = conf.get('elasticsearch', 'ELASTICSEARCH_JSON_FORMAT')
+
+ELASTICSEARCH_RECORD_LABELS = conf.get('elasticsearch', 'ELASTICSEARCH_RECORD_LABELS')
+
 
 DEFAULT_LOGGING_CONFIG = {
     'version': 1,
@@ -67,6 +75,10 @@ DEFAULT_LOGGING_CONFIG = {
         'airflow': {
             'format': LOG_FORMAT,
         },
+        'json': {
+            '()': create_formatter,
+            'record_labels': ['created', 'filename', 'lineno', 'levelname', 'msg'],
+        }
     },
     'handlers': {
         'console': {
@@ -165,10 +177,13 @@ REMOTE_HANDLERS = {
             'class': 'airflow.utils.log.es_task_handler.ElasticsearchTaskHandler',
             'formatter': 'airflow',
             'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
-            'log_id_template': LOG_ID_TEMPLATE,
+            'log_id_template': ELASTICSEARCH_LOG_ID_TEMPLATE,
             'filename_template': FILENAME_TEMPLATE,
-            'end_of_log_mark': END_OF_LOG_MARK,
+            'end_of_log_mark': ELASTICSEARCH_END_OF_LOG_MARK,
             'host': ELASTICSEARCH_HOST,
+            'write_stdout': ELASTICSEARCH_WRITE_STDOUT,
+            'json_format': ELASTICSEARCH_JSON_FORMAT,
+            'record_labels': ELASTICSEARCH_RECORD_LABELS
         },
     },
 }

--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -54,17 +54,17 @@ PROCESSOR_FILENAME_TEMPLATE = conf.get('core', 'LOG_PROCESSOR_FILENAME_TEMPLATE'
 # just to help Airflow select correct handler
 REMOTE_BASE_LOG_FOLDER = conf.get('core', 'REMOTE_BASE_LOG_FOLDER')
 
-ELASTICSEARCH_HOST = conf.get('elasticsearch', 'ELASTICSEARCH_HOST')
+ELASTICSEARCH_HOST = conf.get('elasticsearch', 'HOST')
 
-ELASTICSEARCH_LOG_ID_TEMPLATE = conf.get('elasticsearch', 'ELASTICSEARCH_LOG_ID_TEMPLATE')
+ELASTICSEARCH_LOG_ID_TEMPLATE = conf.get('elasticsearch', 'LOG_ID_TEMPLATE')
 
-ELASTICSEARCH_END_OF_LOG_MARK = conf.get('elasticsearch', 'ELASTICSEARCH_END_OF_LOG_MARK')
+ELASTICSEARCH_END_OF_LOG_MARK = conf.get('elasticsearch', 'END_OF_LOG_MARK')
 
-ELASTICSEARCH_WRITE_STDOUT = conf.get('elasticsearch', 'ELASTICSEARCH_WRITE_STDOUT')
+ELASTICSEARCH_WRITE_STDOUT = conf.get('elasticsearch', 'WRITE_STDOUT')
 
-ELASTICSEARCH_JSON_FORMAT = conf.get('elasticsearch', 'ELASTICSEARCH_JSON_FORMAT')
+ELASTICSEARCH_JSON_FORMAT = conf.get('elasticsearch', 'JSON_FORMAT')
 
-ELASTICSEARCH_JSON_FIELDS = conf.get('elasticsearch', 'ELASTICSEARCH_JSON_FIELDS')
+ELASTICSEARCH_JSON_FIELDS = conf.get('elasticsearch', 'JSON_FIELDS')
 
 
 DEFAULT_LOGGING_CONFIG = {

--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -22,7 +22,6 @@ from typing import Dict, Any
 
 from airflow import configuration as conf
 from airflow.utils.file import mkdirs
-from airflow.utils.log.json_formatter import create_formatter
 
 # TODO: Logging format and level should be configured
 # in this file instead of from airflow.cfg. Currently
@@ -65,7 +64,7 @@ ELASTICSEARCH_WRITE_STDOUT = conf.get('elasticsearch', 'ELASTICSEARCH_WRITE_STDO
 
 ELASTICSEARCH_JSON_FORMAT = conf.get('elasticsearch', 'ELASTICSEARCH_JSON_FORMAT')
 
-ELASTICSEARCH_RECORD_LABELS = conf.get('elasticsearch', 'ELASTICSEARCH_RECORD_LABELS')
+ELASTICSEARCH_JSON_FIELDS = conf.get('elasticsearch', 'ELASTICSEARCH_JSON_FIELDS')
 
 
 DEFAULT_LOGGING_CONFIG = {
@@ -75,10 +74,6 @@ DEFAULT_LOGGING_CONFIG = {
         'airflow': {
             'format': LOG_FORMAT,
         },
-        'json': {
-            '()': create_formatter,
-            'record_labels': ['created', 'filename', 'lineno', 'levelname', 'msg'],
-        }
     },
     'handlers': {
         'console': {
@@ -183,7 +178,7 @@ REMOTE_HANDLERS = {
             'host': ELASTICSEARCH_HOST,
             'write_stdout': ELASTICSEARCH_WRITE_STDOUT,
             'json_format': ELASTICSEARCH_JSON_FORMAT,
-            'record_labels': ELASTICSEARCH_RECORD_LABELS
+            'json_fields': ELASTICSEARCH_JSON_FIELDS
         },
     },
 }

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -564,6 +564,9 @@ hide_sensitive_variable_fields = True
 elasticsearch_host =
 elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
 elasticsearch_end_of_log_mark = end_of_log
+elasticsearch_write_stdout =
+elasticsearch_json_format =
+elasticsearch_record_labels =
 # Qualified URL for an elasticsearch frontend (like Kibana) with a template argument for log_id
 # Code will construct log_id using the log_id template from the argument above.
 # NOTE: The code will prefix the https:// automatically, don't include that here.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -710,6 +710,25 @@ affinity =
 #   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#toleration-v1-core
 tolerations =
 
+# **kwargs parameters to pass while calling a kubernetes client core_v1_api methods from Kubernetes Executor
+# provided as a single line formatted JSON dictionary string.
+# List of supported params in **kwargs are similar for all core_v1_apis, hence a single config variable for all apis
+# See:
+#   https://raw.githubusercontent.com/kubernetes-client/python/master/kubernetes/client/apis/core_v1_api.py
+kube_client_request_args =
+
+# Worker pods security context options
+# See:
+#   https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+
+# Specifies the uid to run the first process of the worker pods containers as
+run_as_user =
+
+# Specifies a gid to associate with all containers in the worker pods
+# if using a git_ssh_key_secret_name use an fs_group
+# that allows for the key to be read, e.g. 65533
+fs_group =
+
 [kubernetes_node_selectors]
 # The Key-value pairs to be given to worker pods.
 # The worker pods will be scheduled to the nodes of the specified key-value pairs.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -562,21 +562,21 @@ hide_sensitive_variable_fields = True
 
 [elasticsearch]
 # Elasticsearch host
-elasticsearch_host =
+host =
 # Format of the log_id, which is used to query for a given tasks logs
-elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
 # Used to mark the end of a log stream for a task
-elasticsearch_end_of_log_mark = end_of_log
+end_of_log_mark = end_of_log
 # Qualified URL for an elasticsearch frontend (like Kibana) with a template argument for log_id
 # Code will construct log_id using the log_id template from the argument above.
 # NOTE: The code will prefix the https:// automatically, don't include that here.
-elasticsearch_frontend =
+frontend =
 # Write the task logs to the stdout of the worker, rather than the default files
-elasticsearch_write_stdout = False
+write_stdout = False
 # Instead of the default log formatter, write the log lines as JSON
-elasticsearch_json_format = False
+json_format = False
 # Log fields to also attach to the json output, if enabled
-elasticsearch_json_fields = asctime, filename, lineno, levelname, message
+json_fields = asctime, filename, lineno, levelname, message
 
 [kubernetes]
 # The repository, tag and imagePullPolicy of the Kubernetes Image for the Worker to Run

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -564,13 +564,13 @@ hide_sensitive_variable_fields = True
 elasticsearch_host =
 elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
 elasticsearch_end_of_log_mark = end_of_log
-elasticsearch_write_stdout =
-elasticsearch_json_format =
-elasticsearch_record_labels =
 # Qualified URL for an elasticsearch frontend (like Kibana) with a template argument for log_id
 # Code will construct log_id using the log_id template from the argument above.
 # NOTE: The code will prefix the https:// automatically, don't include that here.
 elasticsearch_frontend =
+elasticsearch_write_stdout = False
+elasticsearch_json_format = False
+elasticsearch_json_fields = asctime, filename, lineno, levelname, message
 
 [kubernetes]
 # The repository, tag and imagePullPolicy of the Kubernetes Image for the Worker to Run
@@ -703,25 +703,6 @@ affinity =
 # See:
 #   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#toleration-v1-core
 tolerations =
-
-# **kwargs parameters to pass while calling a kubernetes client core_v1_api methods from Kubernetes Executor
-# provided as a single line formatted JSON dictionary string.
-# List of supported params in **kwargs are similar for all core_v1_apis, hence a single config variable for all apis
-# See:
-#   https://raw.githubusercontent.com/kubernetes-client/python/master/kubernetes/client/apis/core_v1_api.py
-kube_client_request_args =
-
-# Worker pods security context options
-# See:
-#   https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-
-# Specifies the uid to run the first process of the worker pods containers as
-run_as_user =
-
-# Specifies a gid to associate with all containers in the worker pods
-# if using a git_ssh_key_secret_name use an fs_group
-# that allows for the key to be read, e.g. 65533
-fs_group =
 
 [kubernetes_node_selectors]
 # The Key-value pairs to be given to worker pods.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -561,15 +561,21 @@ api_rev = v3
 hide_sensitive_variable_fields = True
 
 [elasticsearch]
+# Elasticsearch host
 elasticsearch_host =
+# Format of the log_id, which is used to query for a given tasks logs
 elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+# Used to mark the end of a log stream for a task
 elasticsearch_end_of_log_mark = end_of_log
 # Qualified URL for an elasticsearch frontend (like Kibana) with a template argument for log_id
 # Code will construct log_id using the log_id template from the argument above.
 # NOTE: The code will prefix the https:// automatically, don't include that here.
 elasticsearch_frontend =
+# Write the task logs to the stdout of the worker, rather than the default files
 elasticsearch_write_stdout = False
+# Instead of the default log formatter, write the log lines as JSON
 elasticsearch_json_format = False
+# Log fields to also attach to the json output, if enabled
 elasticsearch_json_fields = asctime, filename, lineno, levelname, message
 
 [kubernetes]

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -113,9 +113,9 @@ max_tis_per_query = 512
 hide_sensitive_variable_fields = True
 
 [elasticsearch]
-elasticsearch_host =
-elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
-elasticsearch_end_of_log_mark = end_of_log
+host =
+log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+end_of_log_mark = end_of_log
 
 [kubernetes]
 dags_volume_claim = default

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -131,6 +131,13 @@ class AirflowConfigParser(ConfigParser):
             'ssl_active': 'celery_ssl_active',
             'ssl_cert': 'celery_ssl_cert',
             'ssl_key': 'celery_ssl_key',
+            'elasticsearch_host': 'host',
+            'elasticsearch_log_id_template': 'log_id_template',
+            'elasticsearch_end_of_log_mark': 'end_of_log_mark',
+            'elasticsearch_frontend': 'frontend',
+            'elasticsearch_write_stdout': 'write_stdout',
+            'elasticsearch_json_format': 'json_format',
+            'elasticsearch_json_fields': 'json_fields'
         }
     }
 

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -101,7 +101,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
         # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters
         :param execution_date: execution date of the dag run.
         """
-        return re.sub(r"[\+\-\:\.]", "", execution_date.isoformat())
+        return execution_date.strftime("%Y_%m_%dT%H_%I_%S_%f")
 
     def _read(self, ti, try_number, metadata=None):
         """

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -124,7 +124,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
 
         next_offset = offset if not logs else logs[-1].offset
 
-        # Ensure a string here. Large offset numbers will get JSON.parsed incorretly
+        # Ensure a string here. Large offset numbers will get JSON.parsed incorrectly
         # on the client. Sending as a string prevents this issue.
         # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
         metadata['offset'] = str(next_offset)

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -27,8 +27,8 @@ from elasticsearch_dsl import Search
 from airflow.utils import timezone
 from airflow.utils.helpers import parse_template_string
 from airflow.utils.log.file_task_handler import FileTaskHandler
+from airflow.utils.log.json_formatter import JSONFormatter
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.log.json_formatter import create_formatter
 
 
 class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -20,7 +20,6 @@
 # Using `from elasticsearch import *` would break elasticsearch mocking used in unit test.
 import elasticsearch
 import logging
-import re
 import sys
 import pendulum
 from elasticsearch_dsl import Search

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -32,20 +32,6 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.json_formatter import create_formatter
 
 
-class ParentStdout():
-    """
-    Keep track of the ParentStdout stdout context in child process
-    """
-    def __init__(self):
-        self.closed = False
-
-    def write(self, string):
-        sys.__stdout__.write(string)
-
-    def close(self):
-        self.closed = True
-
-
 class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
     PAGE = 0
     MAX_LINE_PER_PAGE = 1000
@@ -198,10 +184,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
         self.mark_end_on_close = not ti.raw
 
         if self.write_stdout:
-            self.writer = ParentStdout()
-            sys.stdout = self.writer
-
-            self.handler = logging.StreamHandler(stream=sys.stdout)
+            self.handler = logging.StreamHandler(stream=sys.__stdout__)
             self.handler.setLevel(self.level)
             if self.json_format and not ti.raw:
                 self.handler.setFormatter(create_formatter(self.record_labels, {

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -74,7 +74,6 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
         self.write_stdout = write_stdout
         self.json_format = json_format
         self.record_labels = [label.strip() for label in record_labels.split(",")]
-
         self.handler = None
 
     def _render_log_id(self, ti, try_number):

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -84,13 +84,17 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
             jinja_context['try_number'] = try_number
             return self.log_id_jinja_template.render(**jinja_context)
 
-        execution_date = self._clean_execution_date(ti.execution_date)
+        if self.json_format:
+            execution_date = self._clean_execution_date(ti.execution_date)
+        else:
+            execution_date = ti.execution_date.isoformat()
         return self.log_id_template.format(dag_id=ti.dag_id,
                                            task_id=ti.task_id,
                                            execution_date=execution_date,
                                            try_number=try_number)
 
-    def _clean_execution_date(self, execution_date):
+    @staticmethod
+    def _clean_execution_date(execution_date):
         """
         Clean up an execution date so that it is safe to query in elasticsearch
         by removing reserved characters.

--- a/airflow/utils/log/json_formatter.py
+++ b/airflow/utils/log/json_formatter.py
@@ -17,24 +17,36 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""
+json_formatter module stores all related to ElasticSearch specific logger classes
+"""
+
 import logging
 import json
 
 
+def merge_dicts(d1, d2):
+    merged = d1.copy()
+    merged.update(d2)
+    return merged
+
+
 class JSONFormatter(logging.Formatter):
-    def __init__(self, fmt=None, datefmt=None, style='%', json_fields=[], extras={}):
+    """
+    JSONFormatter instances are used to convert a log record to json.
+    """
+    def __init__(self, fmt=None, datefmt=None, style='%', json_fields=None, extras=None):
         super(JSONFormatter, self).__init__(fmt, datefmt, style)
+        if extras is None:
+            extras = {}
+        if json_fields is None:
+            json_fields = []
         self.json_fields = json_fields
         self.extras = extras
-
-    def _merge_dicts(self, d1, d2):
-        merged = d1.copy()
-        merged.update(d2)
-        return merged
 
     def format(self, record):
         super(JSONFormatter, self).format(record)
         record_dict = {label: getattr(record, label, None)
                        for label in self.json_fields}
-        merged_record = self._merge_dicts(record_dict, self.extras)
+        merged_record = merge_dicts(record_dict, self.extras)
         return json.dumps(merged_record)

--- a/airflow/utils/log/json_formatter.py
+++ b/airflow/utils/log/json_formatter.py
@@ -26,6 +26,9 @@ import json
 
 
 def merge_dicts(d1, d2):
+    """
+    Merge two dicts
+    """
     merged = d1.copy()
     merged.update(d2)
     return merged

--- a/airflow/utils/log/json_formatter.py
+++ b/airflow/utils/log/json_formatter.py
@@ -2,10 +2,10 @@ import logging
 import json
 
 
-class JsonFormatter(logging.Formatter):
-    def __init__(self, record_labels, extras={}):
-        super(JsonFormatter, self).__init__()
-        self.record_labels = record_labels
+class JSONFormatter(logging.Formatter):
+    def __init__(self, fmt=None, datefmt=None, style='%', json_fields=[], extras={}):
+        super(JSONFormatter, self).__init__(fmt, datefmt, style)
+        self.json_fields = json_fields
         self.extras = extras
 
     def _merge_dicts(self, d1, d2):
@@ -14,11 +14,8 @@ class JsonFormatter(logging.Formatter):
         return merged
 
     def format(self, record):
-        record_dict = {label: getattr(record, label)
-                       for label in self.record_labels}
+        super(JSONFormatter, self).format(record)
+        record_dict = {label: getattr(record, label, None)
+                       for label in self.json_fields}
         merged_record = self._merge_dicts(record_dict, self.extras)
         return json.dumps(merged_record)
-
-
-def create_formatter(record_labels, extras={}):
-    return JsonFormatter(record_labels, extras)

--- a/airflow/utils/log/json_formatter.py
+++ b/airflow/utils/log/json_formatter.py
@@ -1,0 +1,24 @@
+import logging
+import json
+
+
+class JsonFormatter(logging.Formatter):
+    def __init__(self, record_labels, extras={}):
+        super(JsonFormatter, self).__init__()
+        self.record_labels = record_labels
+        self.extras = extras
+
+    def _merge_dicts(self, d1, d2):
+        merged = d1.copy()
+        merged.update(d2)
+        return merged
+
+    def format(self, record):
+        record_dict = {label: getattr(record, label)
+                       for label in self.record_labels}
+        merged_record = self._merge_dicts(record_dict, self.extras)
+        return json.dumps(merged_record)
+
+
+def create_formatter(record_labels, extras={}):
+    return JsonFormatter(record_labels, extras)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -629,8 +629,8 @@ class Airflow(AirflowBaseView):
         task_id = request.args.get('task_id')
         execution_date = request.args.get('execution_date')
         try_number = request.args.get('try_number', 1)
-        elasticsearch_frontend = conf.get('elasticsearch', 'elasticsearch_frontend')
-        log_id_template = conf.get('elasticsearch', 'elasticsearch_log_id_template')
+        elasticsearch_frontend = conf.get('elasticsearch', 'frontend')
+        log_id_template = conf.get('elasticsearch', 'log_id_template')
         log_id = log_id_template.format(
             dag_id=dag_id, task_id=task_id,
             execution_date=execution_date, try_number=try_number)
@@ -1294,7 +1294,7 @@ class Airflow(AirflowBaseView):
 
         form = DateTimeWithNumRunsForm(data={'base_date': max_date,
                                              'num_runs': num_runs})
-        external_logs = conf.get('elasticsearch', 'elasticsearch_frontend')
+        external_logs = conf.get('elasticsearch', 'frontend')
         return self.render_template(
             'airflow/tree.html',
             operators=sorted({op.__class__ for op in dag.tasks}, key=lambda x: x.__name__),
@@ -1384,7 +1384,7 @@ class Airflow(AirflowBaseView):
         doc_md = markdown.markdown(dag.doc_md) \
             if hasattr(dag, 'doc_md') and dag.doc_md else ''
 
-        external_logs = conf.get('elasticsearch', 'elasticsearch_frontend')
+        external_logs = conf.get('elasticsearch', 'frontend')
         return self.render_template(
             'airflow/graph.html',
             dag=dag,

--- a/docs/howto/write-logs.rst
+++ b/docs/howto/write-logs.rst
@@ -137,3 +137,50 @@ example:
   [2017-10-03 21:57:51,306] {base_task_runner.py:98} INFO - Subtask: [2017-10-03 21:57:51,306] {models.py:186} INFO - Filling up the DagBag from /airflow/dags/example_dags/example_bash_operator.py
 
 **Note** that the path to the remote log file is listed on the first line.
+
+.. _write-logs-elasticsearch:
+
+Writing Logs to Elasticsearch
+------------------------------------
+
+Airflow can be configured to read task logs from Elasticsearch and optionally write logs to stdout in standard or json format. These logs can later be collected and forwarded to the Elasticsearch cluster using tools like fluentd, logstash or others.
+
+You can choose to have all task logs from workers output to the highest parent level process, instead of the standard file locations. This allows for some additional flexibility in container environments like Kubernetes, where container stdout is already being logged to the host nodes. From there a log shipping tool can be used to forward them along to Elasticsearch. To use this feature, set the ``elasticsearch_write_stdout`` option in ``airflow.cfg``.
+You can also choose to have the logs output in a JSON format, using the ``elasticsearch_json_format`` option. Airflow uses the standard Python logging module and JSON fields are directly extracted from the LogRecord object. To use this feature, set the ``elasticsearch_json_fields`` option in ``airflow.cfg``. Add the fields to the comma-delimited string that you want collected for the logs. These fields are from the LogRecord object in the ``logging`` module. `Documentation on different attributes can be found here <https://docs.python.org/3/library/logging.html#logrecord-objects/>`_.
+
+First, to use the handler, airflow.cfg must be configured as follows:
+
+.. code-block:: bash
+
+    [core]
+    # Airflow can store logs remotely in AWS S3, Google Cloud Storage or Elastic Search.
+    # Users must supply an Airflow connection id that provides access to the storage
+    # location. If remote_logging is set to true, see UPDATING.md for additional
+    # configuration requirements.
+    remote_logging = True
+
+    [elasticsearch]
+    elasticsearch_host = {{ host }}:{{ port }}
+    elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+    elasticsearch_end_of_log_mark = end_of_log
+    elasticsearch_write_stdout =
+    elasticsearch_json_fields =
+
+To output task logs to stdout in JSON format, the following config could be used:
+
+.. code-block:: bash
+
+    [core]
+    # Airflow can store logs remotely in AWS S3, Google Cloud Storage or Elastic Search.
+    # Users must supply an Airflow connection id that provides access to the storage
+    # location. If remote_logging is set to true, see UPDATING.md for additional
+    # configuration requirements.
+    remote_logging = True
+
+    [elasticsearch]
+    elasticsearch_host = {{ host }}:{{ port }}
+    elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+    elasticsearch_end_of_log_mark = end_of_log
+    elasticsearch_write_stdout = True
+    elasticsearch_json_format = True
+    elasticsearch_json_fields = asctime, filename, lineno, levelname, message

--- a/docs/howto/write-logs.rst
+++ b/docs/howto/write-logs.rst
@@ -145,8 +145,8 @@ Writing Logs to Elasticsearch
 
 Airflow can be configured to read task logs from Elasticsearch and optionally write logs to stdout in standard or json format. These logs can later be collected and forwarded to the Elasticsearch cluster using tools like fluentd, logstash or others.
 
-You can choose to have all task logs from workers output to the highest parent level process, instead of the standard file locations. This allows for some additional flexibility in container environments like Kubernetes, where container stdout is already being logged to the host nodes. From there a log shipping tool can be used to forward them along to Elasticsearch. To use this feature, set the ``elasticsearch_write_stdout`` option in ``airflow.cfg``.
-You can also choose to have the logs output in a JSON format, using the ``elasticsearch_json_format`` option. Airflow uses the standard Python logging module and JSON fields are directly extracted from the LogRecord object. To use this feature, set the ``elasticsearch_json_fields`` option in ``airflow.cfg``. Add the fields to the comma-delimited string that you want collected for the logs. These fields are from the LogRecord object in the ``logging`` module. `Documentation on different attributes can be found here <https://docs.python.org/3/library/logging.html#logrecord-objects/>`_.
+You can choose to have all task logs from workers output to the highest parent level process, instead of the standard file locations. This allows for some additional flexibility in container environments like Kubernetes, where container stdout is already being logged to the host nodes. From there a log shipping tool can be used to forward them along to Elasticsearch. To use this feature, set the ``write_stdout`` option in ``airflow.cfg``.
+You can also choose to have the logs output in a JSON format, using the ``json_format`` option. Airflow uses the standard Python logging module and JSON fields are directly extracted from the LogRecord object. To use this feature, set the ``json_fields`` option in ``airflow.cfg``. Add the fields to the comma-delimited string that you want collected for the logs. These fields are from the LogRecord object in the ``logging`` module. `Documentation on different attributes can be found here <https://docs.python.org/3/library/logging.html#logrecord-objects/>`_.
 
 First, to use the handler, airflow.cfg must be configured as follows:
 
@@ -160,10 +160,10 @@ First, to use the handler, airflow.cfg must be configured as follows:
     remote_logging = True
 
     [elasticsearch]
-    elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
-    elasticsearch_end_of_log_mark = end_of_log
-    elasticsearch_write_stdout =
-    elasticsearch_json_fields =
+    log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+    end_of_log_mark = end_of_log
+    write_stdout =
+    json_fields =
 
 To output task logs to stdout in JSON format, the following config could be used:
 
@@ -177,9 +177,9 @@ To output task logs to stdout in JSON format, the following config could be used
     remote_logging = True
 
     [elasticsearch]
-    elasticsearch_host = {{ host }}:{{ port }}
-    elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
-    elasticsearch_end_of_log_mark = end_of_log
-    elasticsearch_write_stdout = True
-    elasticsearch_json_format = True
-    elasticsearch_json_fields = asctime, filename, lineno, levelname, message
+    host = {{ host }}:{{ port }}
+    log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+    end_of_log_mark = end_of_log
+    write_stdout = True
+    json_format = True
+    json_fields = asctime, filename, lineno, levelname, message

--- a/docs/howto/write-logs.rst
+++ b/docs/howto/write-logs.rst
@@ -160,7 +160,6 @@ First, to use the handler, airflow.cfg must be configured as follows:
     remote_logging = True
 
     [elasticsearch]
-    elasticsearch_host = {{ host }}:{{ port }}
     elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
     elasticsearch_end_of_log_mark = end_of_log
     elasticsearch_write_stdout =

--- a/docs/howto/write-logs.rst
+++ b/docs/howto/write-logs.rst
@@ -177,7 +177,6 @@ To output task logs to stdout in JSON format, the following config could be used
     remote_logging = True
 
     [elasticsearch]
-    host = {{ host }}:{{ port }}
     log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
     end_of_log_mark = end_of_log
     write_stdout = True

--- a/scripts/ci/kubernetes/kube/templates/configmaps.template.yaml
+++ b/scripts/ci/kubernetes/kube/templates/configmaps.template.yaml
@@ -323,4 +323,4 @@ data:
     hide_sensitive_variable_fields = True
 
     [elasticsearch]
-    elasticsearch_host =
+    host =

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -48,11 +48,17 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.filename_template = '{try_number}.log'
         self.log_id_template = '{dag_id}-{task_id}-{execution_date}-{try_number}'
         self.end_of_log_mark = 'end_of_log\n'
+        self.write_stdout = False
+        self.json_format = False
+        self.json_fields = 'asctime,filename,lineno,levelname,message'
         self.es_task_handler = ElasticsearchTaskHandler(
             self.local_log_location,
             self.filename_template,
             self.log_id_template,
-            self.end_of_log_mark
+            self.end_of_log_mark,
+            self.write_stdout,
+            self.json_format,
+            self.json_fields
         )
 
         self.es = elasticsearch.Elasticsearch(hosts=[{'host': 'localhost', 'port': 9200}])
@@ -86,20 +92,21 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
                                                     {'offset': 0,
                                                      'last_log_timestamp': str(ts),
                                                      'end_of_log': False})
+
         self.assertEqual(1, len(logs))
         self.assertEqual(len(logs), len(metadatas))
         self.assertEqual(self.test_message, logs[0])
         self.assertFalse(metadatas[0]['end_of_log'])
-        self.assertEqual(1, metadatas[0]['offset'])
+        self.assertEqual('1', metadatas[0]['offset'])
         self.assertTrue(timezone.parse(metadatas[0]['last_log_timestamp']) > ts)
 
     def test_read_with_match_phrase_query(self):
-        simiar_log_id = '{task_id}-{dag_id}-2016-01-01T00:00:00+00:00-1'.format(
+        similar_log_id = '{task_id}-{dag_id}-2016-01-01T00:00:00+00:00-1'.format(
             dag_id=TestElasticsearchTaskHandler.DAG_ID,
             task_id=TestElasticsearchTaskHandler.TASK_ID)
         another_test_message = 'another message'
 
-        another_body = {'message': another_test_message, 'log_id': simiar_log_id, 'offset': 1}
+        another_body = {'message': another_test_message, 'log_id': similar_log_id, 'offset': 1}
         self.es.index(index=self.index_name, doc_type=self.doc_type,
                       body=another_body, id=1)
 
@@ -115,7 +122,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.assertNotEqual(another_test_message, logs[0])
 
         self.assertFalse(metadatas[0]['end_of_log'])
-        self.assertEqual(1, metadatas[0]['offset'])
+        self.assertEqual('1', metadatas[0]['offset'])
         self.assertTrue(timezone.parse(metadatas[0]['last_log_timestamp']) > ts)
 
     def test_read_with_none_meatadata(self):
@@ -124,7 +131,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.assertEqual(len(logs), len(metadatas))
         self.assertEqual(self.test_message, logs[0])
         self.assertFalse(metadatas[0]['end_of_log'])
-        self.assertEqual(1, metadatas[0]['offset'])
+        self.assertEqual('1', metadatas[0]['offset'])
         self.assertTrue(
             timezone.parse(metadatas[0]['last_log_timestamp']) < pendulum.now())
 
@@ -143,7 +150,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.assertEqual(len(logs), len(metadatas))
         self.assertEqual([''], logs)
         self.assertFalse(metadatas[0]['end_of_log'])
-        self.assertEqual(0, metadatas[0]['offset'])
+        self.assertEqual('0', metadatas[0]['offset'])
         # last_log_timestamp won't change if no log lines read.
         self.assertTrue(timezone.parse(metadatas[0]['last_log_timestamp']) == ts)
 
@@ -155,7 +162,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.assertEqual(self.test_message, logs[0])
         self.assertFalse(metadatas[0]['end_of_log'])
         # offset should be initialized to 0 if not provided.
-        self.assertEqual(1, metadatas[0]['offset'])
+        self.assertEqual('1', metadatas[0]['offset'])
         # last_log_timestamp will be initialized using log reading time
         # if not last_log_timestamp is provided.
         self.assertTrue(timezone.parse(metadatas[0]['last_log_timestamp']) > ts)
@@ -168,7 +175,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.assertEqual([''], logs)
         self.assertFalse(metadatas[0]['end_of_log'])
         # offset should be initialized to 0 if not provided.
-        self.assertEqual(0, metadatas[0]['offset'])
+        self.assertEqual('0', metadatas[0]['offset'])
         # last_log_timestamp will be initialized using log reading time
         # if not last_log_timestamp is provided.
         self.assertTrue(timezone.parse(metadatas[0]['last_log_timestamp']) > ts)
@@ -187,7 +194,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.assertEqual([''], logs)
         self.assertTrue(metadatas[0]['end_of_log'])
         # offset should be initialized to 0 if not provided.
-        self.assertEqual(0, metadatas[0]['offset'])
+        self.assertEqual('0', metadatas[0]['offset'])
         self.assertTrue(timezone.parse(metadatas[0]['last_log_timestamp']) == ts)
 
     def test_read_as_download_logs(self):
@@ -219,7 +226,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.assertEqual(len(logs), len(metadatas))
         self.assertEqual([''], logs)
         self.assertFalse(metadatas[0]['end_of_log'])
-        self.assertEqual(0, metadatas[0]['offset'])
+        self.assertEqual('0', metadatas[0]['offset'])
 
     def test_set_context(self):
         self.es_task_handler.set_context(self.ti)
@@ -293,7 +300,10 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
             self.local_log_location,
             self.filename_template,
             '{{ ti.dag_id }}-{{ ti.task_id }}-{{ ts }}-{{ try_number }}',
-            self.end_of_log_mark
+            self.end_of_log_mark,
+            self.write_stdout,
+            self.json_format,
+            self.json_fields
         )
         log_id = self.es_task_handler._render_log_id(self.ti, 1)
         self.assertEqual(expected_log_id, log_id)

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -210,7 +210,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.assertEqual(self.test_message, logs[0])
         self.assertFalse(metadatas[0]['end_of_log'])
         self.assertTrue(metadatas[0]['download_logs'])
-        self.assertEqual(1, metadatas[0]['offset'])
+        self.assertEqual('1', metadatas[0]['offset'])
         self.assertTrue(timezone.parse(metadatas[0]['last_log_timestamp']) > ts)
 
     def test_read_raises(self):

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -307,3 +307,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         )
         log_id = self.es_task_handler._render_log_id(self.ti, 1)
         self.assertEqual(expected_log_id, log_id)
+
+    def test_clean_execution_date(self):
+        clean_execution_date = self.es_task_handler._clean_execution_date(self.EXECUTION_DATE)
+        self.assertEqual('2016_01_01T00_12_00_000000', clean_execution_date)

--- a/tests/utils/log/test_json_formatter.py
+++ b/tests/utils/log/test_json_formatter.py
@@ -16,25 +16,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import unittest
+from logging import makeLogRecord
 
-import logging
-import json
+from airflow.utils.log.json_formatter import JSONFormatter
 
 
-class JSONFormatter(logging.Formatter):
-    def __init__(self, fmt=None, datefmt=None, style='%', json_fields=[], extras={}):
-        super(JSONFormatter, self).__init__(fmt, datefmt, style)
-        self.json_fields = json_fields
-        self.extras = extras
+class TestJSONFormatter(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
 
-    def _merge_dicts(self, d1, d2):
-        merged = d1.copy()
-        merged.update(d2)
-        return merged
+    def test_json_formatter_is_not_none(self):
+        json_fmt = JSONFormatter()
+        self.assertIsNotNone(json_fmt)
 
-    def format(self, record):
-        super(JSONFormatter, self).format(record)
-        record_dict = {label: getattr(record, label, None)
-                       for label in self.json_fields}
-        merged_record = self._merge_dicts(record_dict, self.extras)
-        return json.dumps(merged_record)
+    def test_format(self):
+        log_record = makeLogRecord({"label": "value"})
+        json_fmt = JSONFormatter(json_fields=["label"])
+        self.assertEqual(json_fmt.format(log_record), {"label": "value"})

--- a/tests/utils/log/test_json_formatter.py
+++ b/tests/utils/log/test_json_formatter.py
@@ -20,7 +20,7 @@
 """
 Module for all tests airflow.utils.log.json_formatter.JSONFormatter
 """
-
+import json
 import unittest
 from logging import makeLogRecord
 
@@ -61,4 +61,6 @@ class TestJSONFormatter(unittest.TestCase):
         """
         log_record = makeLogRecord({"label": "value"})
         json_fmt = JSONFormatter(json_fields=["label"], extras={'pod_extra': 'useful_message'})
-        self.assertEqual(json_fmt.format(log_record), '{"label": "value", "pod_extra": "useful_message"}')
+        # compare as a dicts to not fail on sorting errors
+        self.assertDictEqual(json.loads(json_fmt.format(log_record)),
+                             {"label": "value", "pod_extra": "useful_message"})

--- a/tests/utils/log/test_json_formatter.py
+++ b/tests/utils/log/test_json_formatter.py
@@ -16,33 +16,49 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+"""
+Module for all tests airflow.utils.log.json_formatter.JSONFormatter
+"""
+
 import unittest
 from logging import makeLogRecord
 
-from airflow.utils.log.json_formatter import JSONFormatter
+from airflow.utils.log.json_formatter import JSONFormatter, merge_dicts
 
 
 class TestJSONFormatter(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
-
+    """
+    TestJSONFormatter class combine all tests for JSONFormatter
+    """
     def test_json_formatter_is_not_none(self):
+        """
+        JSONFormatter instance  should return not none
+        """
         json_fmt = JSONFormatter()
         self.assertIsNotNone(json_fmt)
 
-    def test__merge_dicts(self):
-        d1 = {'a': 1, 'b': 2, 'c': 3}
-        d2 = {'a': 1, 'b': 3, 'd': 42}
-        json_fmt = JSONFormatter()
-        merged = json_fmt._merge_dicts(d1, d2)
+    def test_merge_dicts(self):
+        """
+        Test _merge method from JSONFormatter
+        """
+        dict1 = {'a': 1, 'b': 2, 'c': 3}
+        dict2 = {'a': 1, 'b': 3, 'd': 42}
+        merged = merge_dicts(dict1, dict2)
         self.assertDictEqual(merged, {'a': 1, 'b': 3, 'c': 3, 'd': 42})
 
     def test_format(self):
+        """
+        Test format method from JSONFormatter
+        """
         log_record = makeLogRecord({"label": "value"})
         json_fmt = JSONFormatter(json_fields=["label"])
         self.assertEqual(json_fmt.format(log_record), '{"label": "value"}')
 
     def test_format_with_extras(self):
+        """
+        Test format with extras method from JSONFormatter
+        """
         log_record = makeLogRecord({"label": "value"})
         json_fmt = JSONFormatter(json_fields=["label"], extras={'pod_extra': 'useful_message'})
         self.assertEqual(json_fmt.format(log_record), '{"label": "value", "pod_extra": "useful_message"}')

--- a/tests/utils/log/test_json_formatter.py
+++ b/tests/utils/log/test_json_formatter.py
@@ -30,7 +30,19 @@ class TestJSONFormatter(unittest.TestCase):
         json_fmt = JSONFormatter()
         self.assertIsNotNone(json_fmt)
 
+    def test__merge_dicts(self):
+        d1 = {'a': 1, 'b': 2, 'c': 3}
+        d2 = {'a': 1, 'b': 3, 'd': 42}
+        json_fmt = JSONFormatter()
+        merged = json_fmt._merge_dicts(d1, d2)
+        self.assertDictEqual(merged, {'a': 1, 'b': 3, 'c': 3, 'd': 42})
+
     def test_format(self):
         log_record = makeLogRecord({"label": "value"})
         json_fmt = JSONFormatter(json_fields=["label"])
         self.assertEqual(json_fmt.format(log_record), '{"label": "value"}')
+
+    def test_format_with_extras(self):
+        log_record = makeLogRecord({"label": "value"})
+        json_fmt = JSONFormatter(json_fields=["label"], extras={'pod_extra': 'useful_message'})
+        self.assertEqual(json_fmt.format(log_record), '{"label": "value", "pod_extra": "useful_message"}')

--- a/tests/utils/log/test_json_formatter.py
+++ b/tests/utils/log/test_json_formatter.py
@@ -33,4 +33,4 @@ class TestJSONFormatter(unittest.TestCase):
     def test_format(self):
         log_record = makeLogRecord({"label": "value"})
         json_fmt = JSONFormatter(json_fields=["label"])
-        self.assertEqual(json_fmt.format(log_record), {"label": "value"})
+        self.assertEqual(json_fmt.format(log_record), '{"label": "value"}')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] [AIRFLOW-3370](https://issues.apache.org/jira/browse/AIRFLOW-3370/)

### Description

- [x] Add stdout output options to Elasticsearch task log handler

### Tests

- [x] My PR adds the following unit tests

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
