### PR TITLE
[AIRFLOW-4251] Instrument DagRun schedule delay

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1440,6 +1440,12 @@ class SchedulerJob(BaseJob):
 
             dag_run = self.create_dag_run(dag)
             if dag_run:
+                expected_start_date = dag.following_schedule(dag_run.execution_date)
+                if expected_start_date:
+                    schedule_delay = dag_run.start_date - expected_start_date
+                    Stats.timing(
+                        'dagrun.schedule_delay.{dag_id}'.format(dag_id=dag.dag_id),
+                        schedule_delay)
                 self.log.info("Created %s", dag_run)
             self._process_task_instances(dag, tis_out)
             self.manage_slas(dag)

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -82,4 +82,6 @@ dagrun.dependency-check.<dag_id>  Seconds taken to check DAG dependencies
 dag.<dag_id>.<task_id>.duration   Seconds taken to finish a task
 dagrun.duration.success.<dag_id>  Seconds taken for a DagRun to reach success state
 dagrun.duration.failed.<dag_id>   Seconds taken for a DagRun to reach failed state
+dagrun.schedule_delay.<dag_id>    Seconds of delay between the scheduled DagRun
+                                  start date and the actual DagRun start date
 ================================= =================================================


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW4251

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Instrument DagRun schedule delay - time between expected DagRun start date and the actual DagRun start date.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Tests not required as we did not change any airflow logic

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
