### PR TITLE
[AIRFLOW-4252] Remove the unused sessions

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -3408,7 +3408,6 @@ class DAG(BaseDag, LoggingMixin):
             context.update({'reason': reason})
             callback(context)
 
-    @provide_session
     def get_active_runs(self):
         """
         Returns a list of dag run execution dates currently running
@@ -3839,7 +3838,6 @@ class DAG(BaseDag, LoggingMixin):
             return self.task_dict[task_id]
         raise AirflowException("Task {task_id} not found".format(task_id=task_id))
 
-    @provide_session
     def pickle_info(self):
         d = dict()
         d['is_picklable'] = True

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -3409,11 +3409,10 @@ class DAG(BaseDag, LoggingMixin):
             callback(context)
 
     @provide_session
-    def get_active_runs(self, session=None):
+    def get_active_runs(self):
         """
         Returns a list of dag run execution dates currently running
 
-        :param session:
         :return: List of execution dates
         """
         runs = DagRun.find(dag_id=self.dag_id, state=State.RUNNING)
@@ -3841,7 +3840,7 @@ class DAG(BaseDag, LoggingMixin):
         raise AirflowException("Task {task_id} not found".format(task_id=task_id))
 
     @provide_session
-    def pickle_info(self, session=None):
+    def pickle_info(self):
         d = dict()
         d['is_picklable'] = True
         try:


### PR DESCRIPTION
Some housekeeping

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-4252\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4252
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
