### PR TITLE
[AIRFLOW-XXX] Build a universal wheel with LICNESE files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,13 @@ description-file = README.md
 author = Apache Airflow PMC
 author-email = dev@airflow.apache.org
 license = Apache License, Version 2.0
+license_files =
+  LICENSE
+  licenses/*
+  NOTICE
+
+[bdist_wheel]
+universal=1
 
 [files]
 packages = airflow


### PR DESCRIPTION
These settings enable us to run `setup.py sdist bdist_wheel` and have
that wheel contian all the license files that we ship in the other dist
formats.

A wheel is a "binary" package for python that is quicker to install than
a tar.gz -- with one important difference: setup.py isn't "run" on the
installing machine.

Make sure you have checked _all_ steps below.

### Jira

- [x] No Jira

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
