### PR TITLE
AIRFLOW-4218 Support to Provide http args to K8executor while calling…

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -725,6 +725,13 @@ affinity =
 #   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#toleration-v1-core
 tolerations =
 
+# **kwargs parameters to pass while calling a kubernetes client core_v1_api methods from Kubernetes Executor
+# provided as a single line formatted JSON dictionary string.
+# List of supported params in **kwargs are similar for all core_v1_apis, hence a single config variable for all apis
+# See:
+#   https://raw.githubusercontent.com/kubernetes-client/python/master/kubernetes/client/apis/core_v1_api.py
+kube_client_request_args =
+
 # Worker pods security context options
 # See:
 #   https://kubernetes.io/docs/tasks/configure-pod-container/security-context/

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -252,6 +252,15 @@ class KubeConfig:
         else:
             self.kube_tolerations = None
 
+        kube_client_request_args = conf.get(self.kubernetes_section, 'kube_client_request_args')
+        if kube_client_request_args:
+            self.kube_client_request_args = json.loads(kube_client_request_args)
+            if self.kube_client_request_args['_request_timeout'] and \
+                    isinstance(self.kube_client_request_args['_request_timeout'], list):
+                self.kube_client_request_args['_request_timeout'] = \
+                    tuple(self.kube_client_request_args['_request_timeout'])
+        else:
+            self.kube_client_request_args = {}
         self._validate()
 
     def _validate(self):
@@ -278,19 +287,20 @@ class KubeConfig:
 
 
 class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin, object):
-    def __init__(self, namespace, watcher_queue, resource_version, worker_uuid):
+    def __init__(self, namespace, watcher_queue, resource_version, worker_uuid, kube_config):
         multiprocessing.Process.__init__(self)
         self.namespace = namespace
         self.worker_uuid = worker_uuid
         self.watcher_queue = watcher_queue
         self.resource_version = resource_version
+        self.kube_config = kube_config
 
     def run(self):
         kube_client = get_kube_client()
         while True:
             try:
                 self.resource_version = self._run(kube_client, self.resource_version,
-                                                  self.worker_uuid)
+                                                  self.worker_uuid, self.kube_config)
             except Exception:
                 self.log.exception('Unknown error in KubernetesJobWatcher. Failing')
                 raise
@@ -298,7 +308,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin, object):
                 self.log.warn('Watch died gracefully, starting back up with: '
                               'last resource_version: %s', self.resource_version)
 
-    def _run(self, kube_client, resource_version, worker_uuid):
+    def _run(self, kube_client, resource_version, worker_uuid, kube_config):
         self.log.info(
             'Event: and now my watch begins starting at resource_version: %s',
             resource_version
@@ -308,6 +318,9 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin, object):
         kwargs = {'label_selector': 'airflow-worker={}'.format(worker_uuid)}
         if resource_version:
             kwargs['resource_version'] = resource_version
+        if kube_config.kube_client_request_args:
+            for key, value in kube_config.kube_client_request_args.iteritems():
+                kwargs[key] = value
 
         last_resource_version = None
         for event in watcher.stream(kube_client.list_namespaced_pod, self.namespace,
@@ -381,7 +394,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
     def _make_kube_watcher(self):
         resource_version = KubeResourceVersion.get_current_resource_version()
         watcher = KubernetesJobWatcher(self.namespace, self.watcher_queue,
-                                       resource_version, self.worker_uuid)
+                                       resource_version, self.worker_uuid, self.kube_config)
         watcher.start()
         return watcher
 
@@ -417,14 +430,15 @@ class AirflowKubernetesScheduler(LoggingMixin):
             airflow_command=command, kube_executor_config=kube_executor_config
         )
         # the watcher will monitor pods, so we do not block.
-        self.launcher.run_pod_async(pod)
+        self.launcher.run_pod_async(pod, **self.kube_config.kube_client_request_args)
         self.log.debug("Kubernetes Job created!")
 
     def delete_pod(self, pod_id):
         if self.kube_config.delete_worker_pods:
             try:
                 self.kube_client.delete_namespaced_pod(
-                    pod_id, self.namespace, body=client.V1DeleteOptions())
+                    pod_id, self.namespace, body=client.V1DeleteOptions(),
+                    **self.kube_config.kube_client_request_args)
             except ApiException as e:
                 # If the pod is already deleted
                 if e.status != 404:
@@ -639,6 +653,9 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
                 )
             )
             kwargs = dict(label_selector=dict_string)
+            if self.kube_config.kube_client_request_args:
+                for key, value in self.kube_config.kube_client_request_args.iteritems():
+                    kwargs[key] = value
             pod_list = self.kube_client.list_namespaced_pod(
                 self.kube_config.kube_namespace, **kwargs)
             if len(pod_list.items) == 0:
@@ -659,7 +676,8 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
                     self.kube_config.executor_namespace, kubernetes.client.V1Secret(
                         data={
                             'key.json': base64.b64encode(open(secret_path, 'r').read())},
-                        metadata=kubernetes.client.V1ObjectMeta(name=secret_name)))
+                        metadata=kubernetes.client.V1ObjectMeta(name=secret_name)),
+                    **self.kube_config.kube_client_request_args)
             except ApiException as e:
                 if e.status == 409:
                     return self.kube_client.replace_namespaced_secret(
@@ -667,7 +685,8 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
                         kubernetes.client.V1Secret(
                             data={'key.json': base64.b64encode(
                                 open(secret_path, 'r').read())},
-                            metadata=kubernetes.client.V1ObjectMeta(name=secret_name)))
+                            metadata=kubernetes.client.V1ObjectMeta(name=secret_name)),
+                        **self.kube_config.kube_client_request_args)
                 self.log.exception(
                     'Exception while trying to inject secret. '
                     'Secret name: %s, error details: %s',

--- a/airflow/contrib/kubernetes/pod_launcher.py
+++ b/airflow/contrib/kubernetes/pod_launcher.py
@@ -50,11 +50,11 @@ class PodLauncher(LoggingMixin):
         self.kube_req_factory = pod_factory.ExtractXcomPodRequestFactory(
         ) if extract_xcom else pod_factory.SimplePodRequestFactory()
 
-    def run_pod_async(self, pod):
+    def run_pod_async(self, pod, **kwargs):
         req = self.kube_req_factory.create(pod)
         self.log.debug('Pod Creation Request: \n%s', json.dumps(req, indent=2))
         try:
-            resp = self._client.create_namespaced_pod(body=req, namespace=pod.namespace)
+            resp = self._client.create_namespaced_pod(body=req, namespace=pod.namespace, **kwargs)
             self.log.debug('Pod Creation Response: %s', resp)
         except ApiException:
             self.log.exception('Exception when attempting to create Namespaced Pod.')

--- a/tests/contrib/executors/test_kubernetes_executor.py
+++ b/tests/contrib/executors/test_kubernetes_executor.py
@@ -211,6 +211,8 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
                     return '/usr/local/airflow/dags'
                 if(args[1] == 'delete_worker_pods'):
                     return True
+                if(args[1] == 'kube_client_request_args'):
+                    return '{"_request_timeout" : [60,360] }'
                 return '1'
             return None
 


### PR DESCRIPTION
… k8 python client lib apis

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following 
  - https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-4218
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Kubernetes Python client corev1 apis supports passing arguments like timeouts, async, etc. - https://github.com/kubernetes-client/python/blob/master/kubernetes/client/apis/core_v1_api.py
I would want to pass these arguments when using K8Executor mode by specifying args in kubernetes section of airflow.cfg as single line json dict string.

PS. args only used in K8executor and not in K8PodOperator.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
