### PR TITLE
[AIRFLOW-XXX] Ignore python files under node_modules when building docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -418,9 +418,13 @@ autoapi_template_dir = 'autoapi_templates'
 
 # A list of patterns to ignore when finding files
 autoapi_ignore = [
-    os.path.abspath('../airflow/contrib/operators/s3_to_gcs_transfer_operator.py'),
-    os.path.abspath('../airflow/contrib/operators/gcs_to_gcs_transfer_operator.py'),
-    os.path.abspath('../airflow/contrib/operators/gcs_to_gcs_transfer_operator.py'),
+    # These modules are backcompat shims, don't build docs for them
+    '*/airflow/contrib/operators/s3_to_gcs_transfer_operator.py',
+    '*/airflow/contrib/operators/gcs_to_gcs_transfer_operator.py',
+    '*/airflow/contrib/operators/gcs_to_gcs_transfer_operator.py',
+
+    '*/node_modules/*',
+    '*/migrations/*',
 ]
 # Keep the AutoAPI generated files on the filesystem after the run.
 # Useful for debugging.


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [x] No Jira

### Description

- [x] Some node modules ship .py files which we don't want in our docs.

Without this change if you attempt to build docs locally on a tree which
you have already compiled the www assets it will fail.

/cc @mik-laj 