### PR TITLE
[AIRFLOW-4262] Ensure SlackWebhookHook can take either http_conn_id or webhook_token, or both

### DIFF
--- a/airflow/contrib/hooks/slack_webhook_hook.py
+++ b/airflow/contrib/hooks/slack_webhook_hook.py
@@ -27,7 +27,8 @@ class SlackWebhookHook(HttpHook):
     """
     This hook allows you to post messages to Slack using incoming webhooks.
     Takes both Slack webhook token directly and connection that has Slack webhook token.
-    If both supplied, Slack webhook token will be used.
+    If both supplied, http_conn_id will be used as base_url,
+    and webhook_token will be taken as endpoint.
 
     Each Slack webhook token can be pre-configured to use a specific channel, username and
     icon. You can override these defaults in this hook.

--- a/airflow/contrib/hooks/slack_webhook_hook.py
+++ b/airflow/contrib/hooks/slack_webhook_hook.py
@@ -66,7 +66,7 @@ class SlackWebhookHook(HttpHook):
                  *args,
                  **kwargs
                  ):
-        super(SlackWebhookHook, self).__init__(*args, **kwargs)
+        super(SlackWebhookHook, self).__init__(http_conn_id=http_conn_id, *args, **kwargs)
         self.webhook_token = self._get_token(webhook_token, http_conn_id)
         self.message = message
         self.attachments = attachments

--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -57,25 +57,26 @@ class HttpHook(BaseHook):
         :param headers: additional headers to be passed through as a dictionary
         :type headers: dict
         """
-        conn = self.get_connection(self.http_conn_id)
         session = requests.Session()
+        if self.http_conn_id:
+            conn = self.get_connection(self.http_conn_id)
 
-        if "://" in conn.host:
-            self.base_url = conn.host
-        else:
-            # schema defaults to HTTP
-            schema = conn.schema if conn.schema else "http"
-            self.base_url = schema + "://" + conn.host
+            if "://" in conn.host:
+                self.base_url = conn.host
+            else:
+                # schema defaults to HTTP
+                schema = conn.schema if conn.schema else "http"
+                self.base_url = schema + "://" + conn.host
 
-        if conn.port:
-            self.base_url = self.base_url + ":" + str(conn.port)
-        if conn.login:
-            session.auth = (conn.login, conn.password)
-        if conn.extra:
-            try:
-                session.headers.update(conn.extra_dejson)
-            except TypeError:
-                self.log.warn('Connection to %s has invalid extra field.', conn.host)
+            if conn.port:
+                self.base_url = self.base_url + ":" + str(conn.port)
+            if conn.login:
+                session.auth = (conn.login, conn.password)
+            if conn.extra:
+                try:
+                    session.headers.update(conn.extra_dejson)
+                except TypeError:
+                    self.log.warn('Connection to %s has invalid extra field.', conn.host)
         if headers:
             session.headers.update(headers)
 
@@ -100,10 +101,11 @@ class HttpHook(BaseHook):
 
         session = self.get_conn(headers)
 
-        if not self.base_url.endswith('/') and not endpoint.startswith('/'):
+        if self.base_url and not self.base_url.endswith('/') and \
+           endpoint and not endpoint.startswith('/'):
             url = self.base_url + '/' + endpoint
         else:
-            url = self.base_url + endpoint
+            url = (self.base_url or '') + (endpoint or '')
 
         req = None
         if self.method == 'GET':


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [AIRFLOW-4262](https://issues.apache.org/jira/browse/AIRFLOW-4262) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4262
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
This PR is to fix SlackWebhookHook malfunction. It ensures that SlackWebhookHook can take either `http_conn_id` or `webhook_token`, or both, to POST messages into a slack channel, as said in the [docstring](https://github.com/apache/airflow/blob/4d34632fafe2f0bb8fcd67bb0964315eeb5c4fa9/airflow/contrib/hooks/slack_webhook_hook.py#L28-L30)

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  1. My PR adds test to ensure correct url and http method is hit by SlackWebhookHook if only `http_conn_id` is supplied.
  2. My PR adds test to ensure correct url and http method is hit by SlackWebhookHook if only `webhook_token` is supplied.
  3. My PR adds test to ensure correct url and http method is hit by SlackWebhookHook if both `http_conn_id` and `webhook_token` is supplied.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
