### PR TITLE
[AIRFLOW-4265] Lineage backend did not work normally

### DIFF
--- a/airflow/lineage/__init__.py
+++ b/airflow/lineage/__init__.py
@@ -54,8 +54,8 @@ def apply_lineage(func):
 
     @wraps(func)
     def wrapper(self, context, *args, **kwargs):
-        self.log.debug("Lineage called with inlets: %s, outlets: %s",
-                       self.inlets, self.outlets)
+        self.log.debug("Backend: %s, Lineage called with inlets: %s, outlets: %s",
+                       backend, self.inlets, self.outlets)
         ret_val = func(self, context, *args, **kwargs)
 
         outlets = [x.as_dict() for x in self.outlets]

--- a/airflow/lineage/backend/atlas/__init__.py
+++ b/airflow/lineage/backend/atlas/__init__.py
@@ -35,7 +35,8 @@ _host = conf.get("atlas", "host")
 
 
 class AtlasBackend(LineageBackend):
-    def send_lineage(self, operator, inlets, outlets, context):
+    @staticmethod
+    def send_lineage(operator, inlets, outlets, context):
         client = Atlas(_host, port=_port, username=_username, password=_password)
         try:
             client.typedefs.create(data=operator_typedef)

--- a/docs/lineage.rst
+++ b/docs/lineage.rst
@@ -99,7 +99,7 @@ properly, e.g. in your ``airflow.cfg``:
 .. code:: python
 
     [lineage]
-    backend = airflow.lineage.backend.atlas
+    backend = airflow.lineage.backend.atlas.AtlasBackend
 
     [atlas]
     username = my_username


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4265
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
