### PR TITLE
[AIRFLOW-XXX] Update SlackWebhookOperator and SlackWebhookHook docstring

### DIFF
--- a/airflow/contrib/hooks/slack_webhook_hook.py
+++ b/airflow/contrib/hooks/slack_webhook_hook.py
@@ -28,7 +28,7 @@ class SlackWebhookHook(HttpHook):
     This hook allows you to post messages to Slack using incoming webhooks.
     Takes both Slack webhook token directly and connection that has Slack webhook token.
     If both supplied, http_conn_id will be used as base_url,
-    and webhook_token will be taken as endpoint.
+    and webhook_token will be taken as endpoint, the relative path of the url.
 
     Each Slack webhook token can be pre-configured to use a specific channel, username and
     icon. You can override these defaults in this hook.

--- a/airflow/contrib/operators/slack_webhook_operator.py
+++ b/airflow/contrib/operators/slack_webhook_operator.py
@@ -26,7 +26,8 @@ class SlackWebhookOperator(SimpleHttpOperator):
     """
     This operator allows you to post messages to Slack using incoming webhooks.
     Takes both Slack webhook token directly and connection that has Slack webhook token.
-    If both supplied, Slack webhook token will be used.
+    If both supplied, http_conn_id will be used as base_url,
+    and webhook_token will be taken as endpoint, the relative path of the url.
 
     Each Slack webhook token can be pre-configured to use a specific channel, username and
     icon. You can override these defaults in this hook.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] No Jira. Updating documentation.

### Description

- [X] If both Slack webhook token and http_conn_id is provided, SlackWebhookOperator and SlackWebhookHook will not take token as the absolute path, but use http_conn_id as base_url and webhook token as relative path. This is in line with SlackWebhookHook's superclass HttpHook's design idea. https://github.com/apache/airflow/blob/7ac82196b2a2eac43feb3060cffb4e6092a3afb7/airflow/hooks/http_hook.py#L64-L72
https://github.com/apache/airflow/blob/7ac82196b2a2eac43feb3060cffb4e6092a3afb7/airflow/hooks/http_hook.py#L103-L108
