### PR TITLE
[AIRFLOW-XXX] Change allowed version of Jinja2 to fix CVE-2019-10906

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,7 @@ def do_setup():
             'gunicorn>=19.5.0, <20.0',
             'iso8601>=0.1.12',
             'json-merge-patch==0.2',
-            'jinja2>=2.7.3, <=2.10.0',
+            'jinja2>=2.10.1, <2.11.0',
             'markdown>=2.5.2, <3.0',
             'pandas>=0.17.1, <1.0.0',
             'pendulum==1.4.4',


### PR DESCRIPTION
To change allowed version of Jinja2 to fix CVE-2019-10906 (high severity)

Ref: https://nvd.nist.gov/vuln/detail/CVE-2019-10906