### PR TITLE
[AIRFLOW-4269] Minor acceleration of jobs._process_task_instances()

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -919,7 +919,7 @@ class SchedulerJob(BaseJob):
                 continue
 
             if len(active_dag_runs) >= dag.max_active_runs:
-                self.log.info("Active dag runs > max_active_run.")
+                self.log.info("Number of active dag runs reached max_active_run.")
                 break
 
             # skip backfill dagruns for now as long as they are not really scheduled

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -920,7 +920,7 @@ class SchedulerJob(BaseJob):
 
             if len(active_dag_runs) >= dag.max_active_runs:
                 self.log.info("Active dag runs > max_active_run.")
-                continue
+                break
 
             # skip backfill dagruns for now as long as they are not really scheduled
             if run.is_backfill:


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-4269


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

**Item-1:**
`continue` here should be a `break`.

When `len(active_dag_runs) >= dag.max_active_runs`, the following part of the for-loop will give the same result and result in a `continue` again and again, while doing nothing. We should use a `break` here.

**Item-2:**
Changed the log.info here a bit to make it more precise.