### PR TITLE
[AIRFLOW-XXX] Use Py3.7 on readthedocs to fix OOM

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,18 +16,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+version: 2
+formats: []
 python:
-    pip_install: true
-    extra_requirements:
-        - all_dbs
-        - databricks
-        - doc
-        - docker
-        - emr
-        - gcp
-        - s3
-        - salesforce
-        - sendgrid
-        - ssh
-        - slack
-        - qds
+    version: 3.7
+    install:
+      - method: pip
+        path: .
+        extra_requirements:
+            - doc
+    system_packages: true


### PR DESCRIPTION
### Jira

- [x] No Jira

### Description

- [x] Previous builds were failing with "Command killed due to excessive
memory consumption".

This updated the RTD config, removes the un-needed extras (which we have
mocked for a while now), switches to building on Py3.7. This seems to
help the docs build again

