### PR TITLE
[AIRFLOW-4287] location support for BigQueryGetDataOperator

### DIFF
--- a/airflow/contrib/operators/bigquery_get_data.py
+++ b/airflow/contrib/operators/bigquery_get_data.py
@@ -66,6 +66,10 @@ class BigQueryGetDataOperator(BaseOperator):
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
     :type delegate_to: str
+    :param location: The geographic location of the BigQuery job.
+        Required except for US and EU. See details at
+        https://cloud.google.com/bigquery/docs/locations#specifying_your_location
+    :type location: str
     """
     template_fields = ('dataset_id', 'table_id', 'max_results')
     ui_color = '#e4f0e8'
@@ -78,6 +82,7 @@ class BigQueryGetDataOperator(BaseOperator):
                  selected_fields=None,
                  bigquery_conn_id='google_cloud_default',
                  delegate_to=None,
+                 location=None,
                  *args,
                  **kwargs):
         super(BigQueryGetDataOperator, self).__init__(*args, **kwargs)
@@ -87,6 +92,7 @@ class BigQueryGetDataOperator(BaseOperator):
         self.selected_fields = selected_fields
         self.bigquery_conn_id = bigquery_conn_id
         self.delegate_to = delegate_to
+        self.location = location
 
     def execute(self, context):
         self.log.info('Fetching Data from:')
@@ -94,7 +100,8 @@ class BigQueryGetDataOperator(BaseOperator):
                       self.dataset_id, self.table_id, self.max_results)
 
         hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
-                            delegate_to=self.delegate_to)
+                            delegate_to=self.delegate_to,
+                            location=self.location)
 
         conn = hook.get_conn()
         cursor = conn.cursor()

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -512,6 +512,30 @@ class TestTableOperations(unittest.TestCase):
             body=body
         )
 
+    def test_get_tabledata(self):
+        project_id = 'bq_project'
+        dataset_id = 'bq_dataset'
+        table_id = 'bq_table'
+        location = 'asia-northeast1'
+        max_results = 'max_results'
+        selected_fields = 'selected_fields'
+        page_token = 'page_token'
+        start_index = 'start_index'
+
+         mock_service = mock.Mock()
+        method = mock_service.tabledata.return_value.list
+        cursor = hook.BigQueryBaseCursor(mock_service, project_id, location=location)
+        cursor.get_tabledata(dataset_id, table_id, max_results, selected_fields, page_token, start_index)
+        method.assert_called_once_with(
+            projectId=project_id,
+            datasetId=dataset_id,
+            tableId=table_id,
+            maxResults=max_results,
+            selectedFields=selected_fields,
+            pageToken=page_token,
+            startIndex=start_index,
+            location=location)
+
     def test_create_empty_table_succeed(self):
         project_id = 'bq-project'
         dataset_id = 'bq_dataset'

--- a/tests/contrib/operators/test_bigquery_get_data.py
+++ b/tests/contrib/operators/test_bigquery_get_data.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from datetime import datetime
+
+from airflow.contrib.operators.bigquery_get_data import BigQueryGetDataOperator
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+TASK_ID = 'test-bq-create-table-operator'
+TEST_DATASET = 'test-dataset'
+TEST_GCP_PROJECT_ID = 'test-project'
+TEST_TABLE_ID = 'test-table-id'
+TEST_GCS_BUCKET = 'test-bucket'
+TEST_GCS_DATA = ['dir1/*.csv']
+TEST_SOURCE_FORMAT = 'CSV'
+DEFAULT_DATE = datetime(2015, 1, 1)
+TEST_DAG_ID = 'test-bigquery-operators'
+TEST_LOCATION = 'ap-northeast-1'
+TEST_MAX_RESULT = 100
+TEST_SELECTED_FIELDS = 'a'
+
+
+class BigQueryGetDataOperatorTest(unittest.TestCase):
+
+    @mock.patch('airflow.contrib.operators.bigquery_operator.BigQueryHook')
+    def test_execute(self, mock_hook):
+        operator = BigQueryGetDataOperator(task_id=TASK_ID,
+                                           dataset_id=TEST_DATASET,
+                                           project_id=TEST_GCP_PROJECT_ID,
+                                           table_id=TEST_TABLE_ID,
+                                           max_results=TEST_MAX_RESULT,
+                                           selected_fields=TEST_SELECTED_FIELDS,
+                                           location=TEST_LOCATION)
+
+        operator.execute(None)
+        mock_hook.return_value \
+            .get_conn() \
+            .cursor() \
+            .get_tabledata \
+            .assert_called_once_with(
+                dataset_id=TEST_DATASET,
+                table_id=TEST_TABLE_ID,
+                max_results=TEST_MAX_RESULT,
+                selected_fields=TEST_SELECTED_FIELDS
+            )


### PR DESCRIPTION
### Jira
- [x]  https://issues.apache.org/jira/browse/AIRFLOW-4287
- This is 1/10 operators needs to be fixed to support location. See here for full list https://issues.apache.org/jira/browse/AIRFLOW-3601

### Description
- [x] Add location support to BigQueryGetDataOperator. location is required if you run this operator in the region except US and EU.

### Tests

- [x] My PR adds the following unit tests
 - tests/contrib/hooks/test_bigquery_hook.py
 - tests/contrib/operators/test_bigquery_get_data.py

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
