### PR TITLE
[AIRFLOW-4293] Fix downgrade of d4ecb8fbee3_add_schedule_interval

### DIFF
--- a/airflow/migrations/versions/dd4ecb8fbee3_add_schedule_interval_to_dag.py
+++ b/airflow/migrations/versions/dd4ecb8fbee3_add_schedule_interval_to_dag.py
@@ -39,4 +39,4 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_column('dag', sa.Column('schedule_interval', sa.Text(), nullable=True))
+    op.drop_column('dag', 'schedule_interval')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4293

### Description

- [x] The down migration introduced in #4390 was broken, as reported https://github.com/apache/airflow/pull/4390#issuecomment-481828025

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
