### PR TITLE
[AIRFLOW-4330] - Change _create_or_update_secret to work with python3

### DIFF
--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -657,7 +657,7 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
                 return self.kube_client.create_namespaced_secret(
                     self.kube_config.executor_namespace, kubernetes.client.V1Secret(
                         data={
-                            'key.json': base64.b64encode(open(secret_path, 'r').read())},
+                            'key.json': base64.b64encode(open(secret_path, 'rb').read()).decode('UTF-8')},
                         metadata=kubernetes.client.V1ObjectMeta(name=secret_name)))
             except ApiException as e:
                 if e.status == 409:
@@ -665,7 +665,7 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
                         secret_name, self.kube_config.executor_namespace,
                         kubernetes.client.V1Secret(
                             data={'key.json': base64.b64encode(
-                                open(secret_path, 'r').read())},
+                                open(secret_path, 'rb').read()).decode('UTF-8')},
                             metadata=kubernetes.client.V1ObjectMeta(name=secret_name)))
                 self.log.exception(
                     'Exception while trying to inject secret. '


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4330

### Description

- [x] changes to the way that the secrets are created from the gcp_service_account_keys to allow for use with python 3 as the base64 encoder now requires a buffer

### Tests

- [] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
- covered by preexisting tests

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
