### PR TITLE
[AIRFLOW-4296][AIP-3-subtask-18] Remove py2 in ci process

### DIFF
--- a/scripts/ci/docker-compose.yml
+++ b/scripts/ci/docker-compose.yml
@@ -74,7 +74,6 @@ services:
       - INSIDE_DOCKER_CONTAINER=true
       - ADDITIONAL_PATH=~/.local/bin
       - TOX_ENV
-      - PYTHON_VERSION
       - CI
       - TRAVIS
       - TRAVIS_BRANCH

--- a/scripts/ci/kubernetes/docker/Dockerfile
+++ b/scripts/ci/kubernetes/docker/Dockerfile
@@ -15,15 +15,12 @@
 #  specific language governing permissions and limitations      *
 #  under the License.                                           *
 
-FROM ubuntu:16.04
+FROM python:3.6-slim
 
 # install deps
 RUN apt-get update -y && apt-get install -y \
         wget \
-        python-dev \
-        python-pip \
         libczmq-dev \
-        libcurlpp-dev \
         curl \
         libssl-dev \
         git \
@@ -31,6 +28,7 @@ RUN apt-get update -y && apt-get install -y \
         bind9utils \
         zip \
         unzip \
+        gcc \
     && apt-get clean
 
 RUN pip install --upgrade pip

--- a/scripts/ci/kubernetes/docker/airflow-test-env-init.sh
+++ b/scripts/ci/kubernetes/docker/airflow-test-env-init.sh
@@ -19,7 +19,7 @@
 
 set -x
 
-cd /usr/local/lib/python2.7/dist-packages/airflow && \
+cd /usr/local/lib/python3.6/site-packages/airflow && \
 cp -R example_dags/* /root/airflow/dags/ && \
 cp -R contrib/example_dags/example_kubernetes_*.py /root/airflow/dags/ && \
 cp -a contrib/example_dags/libs /root/airflow/dags/ && \

--- a/scripts/ci/kubernetes/docker/build.sh
+++ b/scripts/ci/kubernetes/docker/build.sh
@@ -21,6 +21,7 @@ IMAGE=${IMAGE:-airflow}
 TAG=${TAG:-latest}
 DIRNAME=$(cd "$(dirname "$0")"; pwd)
 AIRFLOW_ROOT="$DIRNAME/../../../.."
+PYTHON_DOCKER_IMAGE=python:3.6-slim
 
 set -e
 
@@ -33,12 +34,6 @@ fi
 
 echo "Airflow directory $AIRFLOW_ROOT"
 echo "Airflow Docker directory $DIRNAME"
-
-if [[ ${PYTHON_VERSION} == '3' ]]; then
-  PYTHON_DOCKER_IMAGE=python:3.6-slim
-else
-  PYTHON_DOCKER_IMAGE=python:2.7-slim
-fi
 
 cd $AIRFLOW_ROOT
 docker run -ti --rm -v ${AIRFLOW_ROOT}:/airflow \

--- a/scripts/ci/run-ci.sh
+++ b/scripts/ci/run-ci.sh
@@ -30,16 +30,10 @@ if [ -d $HOME/.minikube ]; then
     sudo chown -R airflow.airflow $HOME/.kube $HOME/.minikube
 fi
 
-if [[ $PYTHON_VERSION == '3' ]]; then
-  PIP=pip3
-else
-  PIP=pip2
-fi
+sudo -H pip3 install --upgrade pip
+sudo -H pip3 install tox
 
-sudo -H $PIP install --upgrade pip
-sudo -H $PIP install tox
-
-cd $AIRFLOW_ROOT && $PIP --version && tox --version
+cd $AIRFLOW_ROOT && pip3 --version && tox --version
 
 if [ -z "$KUBERNETES_VERSION" ];
 then


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4296

### Description

My PR https://github.com/apache/airflow/pull/5020 CI failed, and the sample log https://api.travis-ci.org/v3/job/519213992/log.txt

```sh
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 21, in <module>
    from airflow import configuration
  File "/usr/local/lib/python2.7/dist-packages/airflow/__init__.py", line 36, in <module>
    from airflow import settings, configuration as conf
  File "/usr/local/lib/python2.7/dist-packages/airflow/settings.py", line 32, in <module>
    from airflow.utils.sqlalchemy import setup_event_handlers
  File "/usr/local/lib/python2.7/dist-packages/airflow/utils/sqlalchemy.py", line 22, in <module>
    import json
  File "/usr/local/lib/python2.7/dist-packages/airflow/utils/json.py", line 27, in <module>
    class AirflowJsonEncoder(json.JSONEncoder):
AttributeError: 'module' object has no attribute 'JSONEncoder'
```

And I found out we ci process still have py2, So remove `from __future__ import absolute_import` will cause error. This PR are try to fix this.

### Code Quality

- [x] Passes `flake8`
