### PR TITLE
[AIRFLOW-4198] Remove all try/import compatibility imports

### DIFF
--- a/airflow/contrib/hooks/qubole_check_hook.py
+++ b/airflow/contrib/hooks/qubole_check_hook.py
@@ -17,15 +17,13 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
+from io import StringIO
+
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.contrib.hooks.qubole_hook import QuboleHook
 from airflow.exceptions import AirflowException
 from qds_sdk.commands import Command
-
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 
 COL_DELIM = '\t'

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -17,22 +17,17 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import os
 
-# inspect.signature is only available in Python 3. funcsigs.signature is
-# a backport.
-try:
-    import inspect
-    signature = inspect.signature
-except AttributeError:
-    import funcsigs
-    signature = funcsigs.signature
+import inspect
+import os
 
 from copy import copy
 from functools import wraps
 
 from airflow import settings
 from airflow.exceptions import AirflowException
+
+signature = inspect.signature
 
 
 def apply_defaults(func):

--- a/dev/airflow-pr
+++ b/dev/airflow-pr
@@ -35,12 +35,7 @@ import re
 import subprocess
 import sys
 import textwrap
-
-# Python 3 compatibility
-try:
-    import urllib2 as urllib
-except ImportError:
-    import urllib.request as urllib
+import urllib.request as urllib
 
 try:
     import click

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -16,10 +16,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-try:
-    from unittest import mock  # noqa: F401
-except ImportError:
-    import mock  # type: ignore  # noqa: F401
+
+from unittest import mock  # noqa: F401
 
 patch = mock.patch
 Mock = mock.Mock

--- a/tests/contrib/hooks/test_gcp_api_base_hook.py
+++ b/tests/contrib/hooks/test_gcp_api_base_hook.py
@@ -20,6 +20,7 @@
 
 import os
 import unittest
+from io import StringIO
 
 from parameterized import parameterized
 from google.api_core.exceptions import RetryError, AlreadyExists
@@ -35,11 +36,6 @@ from google.auth.exceptions import GoogleAuthError
 
 from airflow.hooks.base_hook import BaseHook
 from tests.compat import mock
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 
 default_creds_available = True

--- a/tests/contrib/hooks/test_grpc_hook.py
+++ b/tests/contrib/hooks/test_grpc_hook.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 
 from airflow import configuration
 from airflow.exceptions import AirflowConfigException

--- a/tests/core.py
+++ b/tests/core.py
@@ -24,6 +24,7 @@ import doctest
 import mock
 import multiprocessing
 import os
+import pickle  # type: ignore
 import re
 import signal
 import sqlalchemy
@@ -74,12 +75,6 @@ DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
 DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
 TEST_DAG_ID = 'unit_tests'
 EXAMPLE_DAG_DEFAULT_DATE = days_ago(2)
-
-try:
-    import cPickle as pickle
-except ImportError:
-    # Python 3
-    import pickle  # type: ignore
 
 
 class OperatorSubclass(BaseOperator):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4198
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
