### PR TITLE
[AIRFLOW-4254] Create a PrestoOperator

### DIFF
--- a/airflow/contrib/operators/presto_operator.py
+++ b/airflow/contrib/operators/presto_operator.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+from airflow.hooks.presto_hook import PrestoHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class PrestoOperator(BaseOperator):
+    """
+    Runs HQL query on Presto.
+
+    :param hql: HQL query to execute on Presto. (templated)
+    :type hql: str
+    :param conn_id: presto connection id
+    :type conn_id: str
+    """
+
+    template_fields = ('hql',)
+    template_ext = ('.hql',)
+
+    @apply_defaults
+    def __init__(self,
+                 hql,  # type: str
+                 conn_id='presto_default',  # type: str
+                 *args,
+                 **kwargs):
+        super(PrestoOperator, self).__init__(*args, **kwargs)
+        self.hql = hql
+        self.conn_id = conn_id
+
+    def execute(self, context):
+        presto_hook = PrestoHook(presto_conn_id=self.conn_id)
+        self.log.info("Executing hql: %s", self.hql)
+        presto_hook.run(self.hql)
+        self.log.info("Finished!")

--- a/tests/contrib/operators/test_presto_operator.py
+++ b/tests/contrib/operators/test_presto_operator.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from mock import patch
+import unittest
+
+from airflow.contrib.operators.presto_operator import PrestoOperator
+
+
+class TestPrestoOperator(unittest.TestCase):
+
+    @patch('airflow.contrib.operators.presto_operator.PrestoHook')
+    def test_presto_operator(self, mock_presto_hook):
+        hql = 'select 1'
+        presto_operator = PrestoOperator(hql=hql, task_id='test_presto_operator')
+
+        presto_operator.execute(context=None)
+
+        mock_presto_hook.return_value.run.assert_called_once_with(hql)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
