### PR TITLE
[AIRFLOW-4306] Global operator extra links

### DIFF
--- a/airflow/contrib/operators/qubole_operator.py
+++ b/airflow/contrib/operators/qubole_operator.py
@@ -26,6 +26,8 @@ from airflow.contrib.hooks.qubole_hook import QuboleHook, COMMAND_ARGS, HYPHEN_A
 
 class QDSLink(BaseOperatorLink):
 
+    name = 'Go to QDS'
+
     def get_link(self, operator, dttm):
         return operator.get_hook().get_extra_links(operator, dttm)
 
@@ -155,9 +157,9 @@ class QuboleOperator(BaseOperator):
     ui_fgcolor = '#fff'
     qubole_hook_allowed_args_list = ['command_type', 'qubole_conn_id', 'fetch_logs']
 
-    operator_extra_link_dict = {
-        'Go to QDS': QDSLink(),
-    }
+    operator_extra_links = (
+        QDSLink(),
+    )
 
     @apply_defaults
     def __init__(self, qubole_conn_id="qubole_default", *args, **kwargs):

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -26,6 +26,7 @@ import pkg_resources
 from typing import List, Any
 
 from airflow import settings
+from airflow.models.baseoperator import BaseOperatorLink
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 log = LoggingMixin().log
@@ -55,7 +56,8 @@ class AirflowPlugin(object):
     #
     # The function should have the following signature:
     # def func_name(stat_name: str) -> str:
-    stat_name_handler = None  # type:Any
+    stat_name_handler = None  # type: Any
+    global_operator_extra_links = []  # type: List[BaseOperatorLink]
 
     @classmethod
     def validate(cls):
@@ -176,6 +178,7 @@ menu_links = []  # type: List[Any]
 flask_appbuilder_views = []  # type: List[Any]
 flask_appbuilder_menu_links = []  # type: List[Any]
 stat_name_handler = None  # type: Any
+global_operator_extra_links = []  # type: List[Any]
 
 stat_name_handlers = []
 for p in plugins:
@@ -199,6 +202,7 @@ for p in plugins:
     } for bp in p.flask_blueprints])
     if p.stat_name_handler:
         stat_name_handlers.append(p.stat_name_handler)
+    global_operator_extra_links.extend(p.global_operator_extra_links)
 
 if len(stat_name_handlers) > 1:
     raise AirflowPluginException(

--- a/docs/howto/define_extra_link.rst
+++ b/docs/howto/define_extra_link.rst
@@ -50,3 +50,8 @@ The following code shows how to add extra links to an operator:
 
         def execute(self, context):
             self.log.info("Hello World!")
+
+You can also add a global operator extra link that will be available to
+all the operators through airflow plugin. Learn more about it in the
+:ref:`plugin example <plugin-example>`.
+

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -106,6 +106,13 @@ looks like:
            # ... perform Plugin boot actions
            pass
 
+        # A list of global operator extra links that can redirect users to
+        # external systems. These extra links will be available on the
+        # task page in the form of buttons.
+        #
+        # Note: the global operator extra link can be overridden at each
+        # operator level.
+        global_operator_extra_links = []
 
 
 
@@ -131,6 +138,8 @@ For example,
 Make sure you restart the webserver and scheduler after making changes to plugins so that they take effect.
 
 
+.. _plugin-example:
+
 Example
 -------
 
@@ -148,6 +157,7 @@ definitions in Airflow.
     # Importing base classes that we need to derive
     from airflow.hooks.base_hook import BaseHook
     from airflow.models import BaseOperator
+    from airflow.models.baseoperator import BaseOperatorLink
     from airflow.sensors.base_sensor_operator import BaseSensorOperator
     from airflow.executors.base_executor import BaseExecutor
 
@@ -202,6 +212,19 @@ definitions in Airflow.
     def stat_name_dummy_handler(stat_name):
         return stat_name
 
+    # A global operator extra link that redirect you to
+    # task logs stored in S3
+    class S3LogLink(BaseOperatorLink):
+        name = 'S3'
+
+        def get_link(self, operator, dttm):
+            return 'https://s3.amazonaws.com/airflow-logs/{dag_id}/{task_id}/{execution_date}'.format(
+                dag_id=operator.dag_id,
+                task_id=operator.task_id,
+                execution_date=dttm,
+            )
+
+
     # Defining the plugin class
     class AirflowTestPlugin(AirflowPlugin):
         name = "test_plugin"
@@ -214,6 +237,7 @@ definitions in Airflow.
         appbuilder_views = [v_appbuilder_package]
         appbuilder_menu_items = [appbuilder_mitem]
         stat_name_handler = staticmethod(stat_name_dummy_handler)
+        global_operator_extra_links = [S3LogLink(),]
 
 
 Note on role based views

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -25,7 +25,7 @@ from flask_appbuilder import expose, BaseView as AppBuilderBaseView
 
 # Importing base classes that we need to derive
 from airflow.hooks.base_hook import BaseHook
-from airflow.models import BaseOperator
+from airflow.models.baseoperator import BaseOperatorLink, BaseOperator
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.executors.base_executor import BaseExecutor
 
@@ -88,6 +88,20 @@ def stat_name_dummy_handler(stat_name):
     return stat_name
 
 
+class AirflowLink(BaseOperatorLink):
+    name = 'airflow'
+
+    def get_link(self, operator, dttm):
+        return 'should_be_overridden'
+
+
+class GithubLink(BaseOperatorLink):
+    name = 'github'
+
+    def get_link(self, operator, dttm):
+        return 'https://github.com/apache/airflow'
+
+
 # Defining the plugin class
 class AirflowTestPlugin(AirflowPlugin):
     name = "test_plugin"
@@ -100,6 +114,10 @@ class AirflowTestPlugin(AirflowPlugin):
     appbuilder_views = [v_appbuilder_package]
     appbuilder_menu_items = [appbuilder_mitem]
     stat_name_handler = staticmethod(stat_name_dummy_handler)
+    global_operator_extra_links = [
+        AirflowLink(),
+        GithubLink(),
+    ]
 
 
 class MockPluginA(AirflowPlugin):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4306

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

A way to register global operator extra link that is available for all the operators through airflow plugin.

<img width="1680" alt="Screen Shot 2019-04-11 at 11 45 54 PM" src="https://user-images.githubusercontent.com/6065051/56088234-2d6c6e00-5e31-11e9-807c-c827d71bc6a3.png">

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
