### PR TITLE
[AIRFLOW-4308] Fix TZ-loop around  DST on python 3.6+

### DIFF
--- a/airflow/utils/timezone.py
+++ b/airflow/utils/timezone.py
@@ -111,7 +111,12 @@ def make_aware(value, timezone=None):
     if is_localized(value):
         raise ValueError(
             "make_aware expects a naive datetime, got %s" % value)
-
+    if hasattr(value, 'fold'):
+        # In case of python 3.6 we want to do the same that pendulum does for python3.5
+        # i.e in case we move clock back we want to schedule the run at the time of the second
+        # instance of the same clock time rather than the first one.
+        # Fold parameter has no impact in other cases so we can safely set it to 1 here
+        value = value.replace(fold=1)
     if hasattr(timezone, 'localize'):
         # This method is available for pytz time zones.
         return timezone.localize(value)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title:
  - https://issues.apache.org/jira/browse/AIRFLOW-4308

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In case of python 3.6 we want to do the same that pendulum does for python3.5
i.e in case we move clock back we want to schedule the run at the time of the second
instance of the same clock time rather than the first one.
Fold parameter has no impact in other cases so we can safely set it to 1

### Tests

- [x] My PR adds the following unit tests:
 
test_dag.DagTest.test_following_previous_schedule_daily_dag_CEST_to_CET  was failing on python 3.6. It should now work fine.
 
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

No need for documentation
### Code Quality

- [x] Passes `flake8`
