### PR TITLE
[AIRFLOW-4311] Remove sleep in LocalExecutor

### DIFF
--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -46,7 +46,6 @@ locally, into just one `LocalExecutor` with multiple modes.
 
 import multiprocessing
 import subprocess
-import time
 
 from builtins import range
 
@@ -94,7 +93,6 @@ class LocalWorker(multiprocessing.Process, LoggingMixin):
 
     def run(self):
         self.execute_work(self.key, self.command)
-        time.sleep(1)
 
 
 class QueuedLocalWorker(LocalWorker):
@@ -116,7 +114,6 @@ class QueuedLocalWorker(LocalWorker):
                 break
             self.execute_work(key, command)
             self.task_queue.task_done()
-            time.sleep(1)
 
 
 class LocalExecutor(BaseExecutor):
@@ -164,7 +161,6 @@ class LocalExecutor(BaseExecutor):
         def end(self):
             while self.executor.workers_active > 0:
                 self.executor.sync()
-                time.sleep(0.5)
 
     class _LimitedParallelism(object):
         """Implements LocalExecutor with limited parallelism using a task queue to


### PR DESCRIPTION
The LocalExecutor currently sleeps after running a task. This is unnecessary and the time could be used more efficiently for running the next task. I wrote a performance test (not added in code, see below) which ran a set of dummy tasks much faster as the executor doesn't sleep in between tasks. (with parallelism=2, 1000 dummy tasks completed in 8 seconds vs 505 seconds)

I'm confused about the reason behind the sleeps. The [very first Airflow commit](https://github.com/apache/airflow/commit/1047940ca4363b04044c4963b9c88f7632746407#diff-16ea362a3d5cc3987eb854ccb7f129c9R88) added them, I'm guessing for debugging, and it hasn't been looked at ever since.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4311
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I did not add tests, however wrote one for testing the performance with and without changes:

```python
def test_performance(self):
    executor = LocalExecutor(parallelism=2)
    executor.start()

    for i in range(1000):
        key, command = "test_{0}".format(i), ["true", "testing..."]
        executor.execute_async(key=key, command=command)
        executor.running[key] = True

    executor.end()
```

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
