### PR TITLE
[AIRFLOW-XXX] Fix docstrings of SQSHook

### DIFF
--- a/airflow/contrib/hooks/aws_sqs_hook.py
+++ b/airflow/contrib/hooks/aws_sqs_hook.py
@@ -23,6 +23,7 @@ from airflow.contrib.hooks.aws_hook import AwsHook
 class SQSHook(AwsHook):
     """
     Get the SQS client using boto3 library
+
     :return: SQS client
     :rtype: botocore.client.SQS
     """
@@ -30,42 +31,40 @@ class SQSHook(AwsHook):
     def get_conn(self):
         return self.get_client_type('sqs')
 
-    """
-    Create queue using connection object
-    :param queue_name: name of the queue.
-    :type queue_name: str
-    :param attributes: additional attributes for the queue (default: None)
-    :type attributes: dict
-
-        For details of the attributes parameter see :py:meth:`botocore.client.SQS.create_queue`
-
-    :return: dict with the information about the queue
-    :rtype: dict
-
-        For details of the returned value see :py:meth:`botocore.client.SQS.create_queue`
-    """
     def create_queue(self, queue_name, attributes=None):
+        """
+        Create queue using connection object
+
+        :param queue_name: name of the queue.
+        :type queue_name: str
+        :param attributes: additional attributes for the queue (default: None)
+            For details of the attributes parameter see :py:meth:`botocore.client.SQS.create_queue`
+        :type attributes: dict
+
+        :return: dict with the information about the queue
+            For details of the returned value see :py:meth:`botocore.client.SQS.create_queue`
+        :rtype: dict
+        """
         return self.get_conn().create_queue(QueueName=queue_name, Attributes=attributes or {})
 
-    """
-    Send message to the queue
-    :param queue_url: queue url
-    :type queue_url: str
-    :param message_body: the contents of the message
-    :type message_body: str
-    :param delay_seconds: seconds to delay the message
-    :type delay_seconds: int
-    :param message_attributes: additional attributes for the message (default: None)
-    :type message_attributes: dict
-
-        For details of the attributes parameter see :py:meth:`botocore.client.SQS.send_message`
-
-    :return: dict with the information about the message sent
-    :rtype: dict
-
-        For details of the returned value see :py:meth:`botocore.client.SQS.send_message`
-    """
     def send_message(self, queue_url, message_body, delay_seconds=0, message_attributes=None):
+        """
+        Send message to the queue
+
+        :param queue_url: queue url
+        :type queue_url: str
+        :param message_body: the contents of the message
+        :type message_body: str
+        :param delay_seconds: seconds to delay the message
+        :type delay_seconds: int
+        :param message_attributes: additional attributes for the message (default: None)
+            For details of the attributes parameter see :py:meth:`botocore.client.SQS.send_message`
+        :type message_attributes: dict
+
+        :return: dict with the information about the message sent
+            For details of the returned value see :py:meth:`botocore.client.SQS.send_message`
+        :rtype: dict
+        """
         return self.get_conn().send_message(QueueUrl=queue_url,
                                             MessageBody=message_body,
                                             DelaySeconds=delay_seconds,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
https://github.com/apache/airflow/pull/4887 added hook but docstrings were in an incorrect position.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
