### PR TITLE
[AIRFLOW-4319] Add tests for Bigquery related Operators

### DIFF
--- a/airflow/contrib/operators/bigquery_table_delete_operator.py
+++ b/airflow/contrib/operators/bigquery_table_delete_operator.py
@@ -63,4 +63,6 @@ class BigQueryTableDeleteOperator(BaseOperator):
                             delegate_to=self.delegate_to)
         conn = hook.get_conn()
         cursor = conn.cursor()
-        cursor.run_table_delete(self.deletion_dataset_table, self.ignore_if_missing)
+        cursor.run_table_delete(
+            deletion_dataset_table=self.deletion_dataset_table,
+            ignore_if_missing=self.ignore_if_missing)

--- a/airflow/contrib/operators/bigquery_to_bigquery.py
+++ b/airflow/contrib/operators/bigquery_to_bigquery.py
@@ -88,8 +88,8 @@ class BigQueryToBigQueryOperator(BaseOperator):
         conn = hook.get_conn()
         cursor = conn.cursor()
         cursor.run_copy(
-            self.source_project_dataset_tables,
-            self.destination_project_dataset_table,
-            self.write_disposition,
-            self.create_disposition,
-            self.labels)
+            source_project_dataset_tables=self.source_project_dataset_tables,
+            destination_project_dataset_table=self.destination_project_dataset_table,
+            write_disposition=self.write_disposition,
+            create_disposition=self.create_disposition,
+            labels=self.labels)

--- a/airflow/contrib/operators/bigquery_to_gcs.py
+++ b/airflow/contrib/operators/bigquery_to_gcs.py
@@ -96,10 +96,10 @@ class BigQueryToCloudStorageOperator(BaseOperator):
         conn = hook.get_conn()
         cursor = conn.cursor()
         cursor.run_extract(
-            self.source_project_dataset_table,
-            self.destination_cloud_storage_uris,
-            self.compression,
-            self.export_format,
-            self.field_delimiter,
-            self.print_header,
-            self.labels)
+            source_project_dataset_table=self.source_project_dataset_table,
+            destination_cloud_storage_uris=self.destination_cloud_storage_uris,
+            compression=self.compression,
+            export_format=self.export_format,
+            field_delimiter=self.field_delimiter,
+            print_header=self.print_header,
+            labels=self.labels)

--- a/tests/contrib/operators/test_bigquery_operator.py
+++ b/tests/contrib/operators/test_bigquery_operator.py
@@ -23,12 +23,17 @@ from datetime import datetime
 import six
 
 from airflow import configuration, models
-from airflow.models import DAG, TaskFail, TaskInstance
-
+from airflow.contrib.operators.bigquery_get_data import BigQueryGetDataOperator
 from airflow.contrib.operators.bigquery_operator import \
     BigQueryCreateExternalTableOperator, BigQueryCreateEmptyTableOperator, \
     BigQueryDeleteDatasetOperator, BigQueryCreateEmptyDatasetOperator, \
     BigQueryOperator
+from airflow.contrib.operators.bigquery_table_delete_operator import \
+    BigQueryTableDeleteOperator
+from airflow.contrib.operators.bigquery_to_bigquery import \
+    BigQueryToBigQueryOperator
+from airflow.contrib.operators.bigquery_to_gcs import BigQueryToCloudStorageOperator
+from airflow.models import DAG, TaskFail, TaskInstance
 from airflow.settings import Session
 from tests.compat import mock
 
@@ -250,3 +255,125 @@ class BigQueryOperatorTest(unittest.TestCase):
         ti = TaskInstance(task=operator, execution_date=DEFAULT_DATE)
         ti.render_templates()
         self.assertTrue(isinstance(ti.task.sql, six.string_types))
+
+
+class BigQueryGetDataOperatorTest(unittest.TestCase):
+
+    @mock.patch('airflow.contrib.operators.bigquery_get_data.BigQueryHook')
+    def test_execute(self, mock_hook):
+
+        max_results = '100'
+        selected_fields = 'DATE'
+        operator = BigQueryGetDataOperator(task_id=TASK_ID,
+                                           dataset_id=TEST_DATASET,
+                                           table_id=TEST_TABLE_ID,
+                                           max_results=max_results,
+                                           selected_fields=selected_fields,
+                                           )
+        operator.execute(None)
+        mock_hook.return_value \
+            .get_conn() \
+            .cursor() \
+            .get_tabledata \
+            .assert_called_once_with(
+                dataset_id=TEST_DATASET,
+                table_id=TEST_TABLE_ID,
+                max_results=max_results,
+                selected_fields=selected_fields,
+            )
+
+
+class BigQueryTableDeleteOperatorTest(unittest.TestCase):
+    @mock.patch('airflow.contrib.operators.bigquery_table_delete_operator.BigQueryHook')
+    def test_execute(self, mock_hook):
+        ignore_if_missing = True
+        deletion_dataset_table = '{}.{}'.format(TEST_DATASET, TEST_TABLE_ID)
+
+        operator = BigQueryTableDeleteOperator(
+            task_id=TASK_ID,
+            deletion_dataset_table=deletion_dataset_table,
+            ignore_if_missing=ignore_if_missing
+        )
+
+        operator.execute(None)
+        mock_hook.return_value \
+            .get_conn() \
+            .cursor() \
+            .run_table_delete \
+            .assert_called_once_with(
+                deletion_dataset_table=deletion_dataset_table,
+                ignore_if_missing=ignore_if_missing
+            )
+
+
+class BigQueryToBigQueryOperatorTest(unittest.TestCase):
+    @mock.patch('airflow.contrib.operators.bigquery_to_bigquery.BigQueryHook')
+    def test_execute(self, mock_hook):
+        source_project_dataset_tables = '{}.{}'.format(
+            TEST_DATASET, TEST_TABLE_ID)
+        destination_project_dataset_table = '{}.{}'.format(
+            TEST_DATASET+'_new', TEST_TABLE_ID)
+        write_disposition = 'WRITE_EMPTY'
+        create_disposition = 'CREATE_IF_NEEDED'
+        labels = {'k1': 'v1'}
+
+        operator = BigQueryToBigQueryOperator(
+            task_id=TASK_ID,
+            source_project_dataset_tables=source_project_dataset_tables,
+            destination_project_dataset_table=destination_project_dataset_table,
+            write_disposition=write_disposition,
+            create_disposition=create_disposition,
+            labels=labels
+        )
+
+        operator.execute(None)
+        mock_hook.return_value \
+            .get_conn() \
+            .cursor() \
+            .run_copy \
+            .assert_called_once_with(
+                source_project_dataset_tables=source_project_dataset_tables,
+                destination_project_dataset_table=destination_project_dataset_table,
+                write_disposition=write_disposition,
+                create_disposition=create_disposition,
+                labels=labels
+            )
+
+
+class BigQueryToCloudStorageOperatorTest(unittest.TestCase):
+    @mock.patch('airflow.contrib.operators.bigquery_to_gcs.BigQueryHook')
+    def test_execute(self, mock_hook):
+        source_project_dataset_table = '{}.{}'.format(
+            TEST_DATASET, TEST_TABLE_ID)
+        destination_cloud_storage_uris = ['gs://some-bucket/some-file.txt']
+        compression = 'NONE'
+        export_format = 'CSV'
+        field_delimiter = ','
+        print_header = True
+        labels = {'k1': 'v1'}
+
+        operator = BigQueryToCloudStorageOperator(
+            task_id=TASK_ID,
+            source_project_dataset_table=source_project_dataset_table,
+            destination_cloud_storage_uris=destination_cloud_storage_uris,
+            compression=compression,
+            export_format=export_format,
+            field_delimiter=field_delimiter,
+            print_header=print_header,
+            labels=labels
+        )
+
+        operator.execute(None)
+        mock_hook.return_value \
+            .get_conn() \
+            .cursor() \
+            .run_extract \
+            .assert_called_once_with(
+                source_project_dataset_table=source_project_dataset_table,
+                destination_cloud_storage_uris=destination_cloud_storage_uris,
+                compression=compression,
+                export_format=export_format,
+                field_delimiter=field_delimiter,
+                print_header=print_header,
+                labels=labels
+            )

--- a/tests/contrib/operators/test_bigquery_operator.py
+++ b/tests/contrib/operators/test_bigquery_operator.py
@@ -312,7 +312,7 @@ class BigQueryToBigQueryOperatorTest(unittest.TestCase):
         source_project_dataset_tables = '{}.{}'.format(
             TEST_DATASET, TEST_TABLE_ID)
         destination_project_dataset_table = '{}.{}'.format(
-            TEST_DATASET+'_new', TEST_TABLE_ID)
+            TEST_DATASET + '_new', TEST_TABLE_ID)
         write_disposition = 'WRITE_EMPTY'
         create_disposition = 'CREATE_IF_NEEDED'
         labels = {'k1': 'v1'}

--- a/tests/contrib/operators/test_bigquery_operator.py
+++ b/tests/contrib/operators/test_bigquery_operator.py
@@ -59,8 +59,8 @@ class BigQueryCreateEmptyTableOperatorTest(unittest.TestCase):
 
         operator.execute(None)
         mock_hook.return_value \
-            .get_conn() \
-            .cursor() \
+            .get_conn.return_value \
+            .cursor.return_value \
             .create_empty_table \
             .assert_called_once_with(
                 dataset_id=TEST_DATASET,
@@ -89,8 +89,8 @@ class BigQueryCreateExternalTableOperatorTest(unittest.TestCase):
 
         operator.execute(None)
         mock_hook.return_value \
-            .get_conn() \
-            .cursor() \
+            .get_conn.return_value \
+            .cursor.return_value \
             .create_external_table \
             .assert_called_once_with(
                 external_project_dataset_table='{}.{}'.format(
@@ -123,8 +123,8 @@ class BigQueryDeleteDatasetOperatorTest(unittest.TestCase):
 
         operator.execute(None)
         mock_hook.return_value \
-            .get_conn() \
-            .cursor() \
+            .get_conn.return_value \
+            .cursor.return_value \
             .delete_dataset \
             .assert_called_once_with(
                 dataset_id=TEST_DATASET,
@@ -143,8 +143,8 @@ class BigQueryCreateEmptyDatasetOperatorTest(unittest.TestCase):
 
         operator.execute(None)
         mock_hook.return_value \
-            .get_conn() \
-            .cursor() \
+            .get_conn.return_value \
+            .cursor.return_value \
             .create_empty_dataset \
             .assert_called_once_with(
                 dataset_id=TEST_DATASET,
@@ -196,8 +196,8 @@ class BigQueryOperatorTest(unittest.TestCase):
 
         operator.execute(None)
         mock_hook.return_value \
-            .get_conn() \
-            .cursor() \
+            .get_conn.return_value \
+            .cursor.return_value \
             .run_query \
             .assert_called_once_with(
                 sql='Select * from test_table',
@@ -229,8 +229,8 @@ class BigQueryOperatorTest(unittest.TestCase):
 
         operator.execute(None)
         mock_hook.return_value \
-            .get_conn() \
-            .cursor() \
+            .get_conn.return_value \
+            .cursor.return_value \
             .run_query \
             .assert_called_once_with(
                 sql='Select * from test_table',
@@ -272,8 +272,8 @@ class BigQueryGetDataOperatorTest(unittest.TestCase):
                                            )
         operator.execute(None)
         mock_hook.return_value \
-            .get_conn() \
-            .cursor() \
+            .get_conn.return_value \
+            .cursor.return_value \
             .get_tabledata \
             .assert_called_once_with(
                 dataset_id=TEST_DATASET,
@@ -297,8 +297,8 @@ class BigQueryTableDeleteOperatorTest(unittest.TestCase):
 
         operator.execute(None)
         mock_hook.return_value \
-            .get_conn() \
-            .cursor() \
+            .get_conn.return_value \
+            .cursor.return_value \
             .run_table_delete \
             .assert_called_once_with(
                 deletion_dataset_table=deletion_dataset_table,
@@ -328,8 +328,8 @@ class BigQueryToBigQueryOperatorTest(unittest.TestCase):
 
         operator.execute(None)
         mock_hook.return_value \
-            .get_conn() \
-            .cursor() \
+            .get_conn.return_value \
+            .cursor.return_value \
             .run_copy \
             .assert_called_once_with(
                 source_project_dataset_tables=source_project_dataset_tables,
@@ -365,8 +365,8 @@ class BigQueryToCloudStorageOperatorTest(unittest.TestCase):
 
         operator.execute(None)
         mock_hook.return_value \
-            .get_conn() \
-            .cursor() \
+            .get_conn.return_value \
+            .cursor.return_value \
             .run_extract \
             .assert_called_once_with(
                 source_project_dataset_table=source_project_dataset_table,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4319

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Some of the BigQuery Operators are missing tests:
- BigQueryToBigQueryOperator
- BigQueryToCloudStorageOperator
- BigQueryTableDeleteOperator
- BigQueryGetDataOperator

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
