### PR TITLE
[AIRFLOW-4318] Create Google Cloud Translate Speech Operator

### DIFF
--- a/airflow/contrib/example_dags/example_gcp_speech.py
+++ b/airflow/contrib/example_dags/example_gcp_speech.py
@@ -21,7 +21,6 @@
 Example Airflow DAG that runs speech synthesizing and stores output in Google Cloud Storage
 
 This DAG relies on the following OS environment variables
-https://airflow.apache.org/concepts.html#variables
 * GCP_PROJECT_ID - Google Cloud Platform project for the Cloud SQL instance.
 * GCP_SPEECH_TEST_BUCKET - Name of the bucket in which the output file should be stored.
 """
@@ -32,6 +31,7 @@ from airflow.utils import dates
 from airflow import models
 from airflow.contrib.operators.gcp_text_to_speech_operator import GcpTextToSpeechSynthesizeOperator
 from airflow.contrib.operators.gcp_speech_to_text_operator import GcpSpeechToTextRecognizeSpeechOperator
+from airflow.contrib.operators.gcp_translate_speech_operator import GcpTranslateSpeechOperator
 
 # [START howto_operator_text_to_speech_env_variables]
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-project")
@@ -43,7 +43,7 @@ FILENAME = "gcp-speech-test-file"
 # [END howto_operator_text_to_speech_gcp_filename]
 
 # [START howto_operator_text_to_speech_api_arguments]
-INPUT = {"text": "This is just a test"}
+INPUT = {"text": "Sample text for demo purposes"}
 VOICE = {"language_code": "en-US", "ssml_gender": "FEMALE"}
 AUDIO_CONFIG = {"audio_encoding": "LINEAR16"}
 # [END howto_operator_text_to_speech_api_arguments]
@@ -52,6 +52,13 @@ AUDIO_CONFIG = {"audio_encoding": "LINEAR16"}
 CONFIG = {"encoding": "LINEAR16", "language_code": "en_US"}
 AUDIO = {"uri": "gs://{bucket}/{object}".format(bucket=BUCKET_NAME, object=FILENAME)}
 # [END howto_operator_speech_to_text_api_arguments]
+
+# [START howto_operator_translate_speech_arguments]
+TARGET_LANGUAGE = 'pl'
+FORMAT = 'text'
+MODEL = 'base'
+SOURCE_LANGUAGE = None
+# [END howto_operator_translate_speech_arguments]
 
 default_args = {"start_date": dates.days_ago(1)}
 
@@ -78,3 +85,18 @@ with models.DAG(
     # [END howto_operator_speech_to_text_recognize]
 
     text_to_speech_synthesize_task >> speech_to_text_recognize_task
+
+    # [START howto_operator_translate_speech]
+    translate_speech_task = GcpTranslateSpeechOperator(
+        project_id=GCP_PROJECT_ID,
+        audio=AUDIO,
+        config=CONFIG,
+        target_language=TARGET_LANGUAGE,
+        format_=FORMAT,
+        source_language=SOURCE_LANGUAGE,
+        model=MODEL,
+        task_id='translate_speech_task'
+    )
+    # [END howto_operator_translate_speech]
+
+    text_to_speech_synthesize_task >> translate_speech_task

--- a/airflow/contrib/operators/gcp_translate_speech_operator.py
+++ b/airflow/contrib/operators/gcp_translate_speech_operator.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from google.protobuf.json_format import MessageToDict
+
+from airflow import AirflowException
+from airflow.contrib.hooks.gcp_speech_to_text_hook import GCPSpeechToTextHook
+from airflow.contrib.hooks.gcp_translate_hook import CloudTranslateHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class GcpTranslateSpeechOperator(BaseOperator):
+    """
+    Recognizes speech in audio input and translates it.
+
+    Note that it uses the first result from the recognition api response - the one with the highest confidence
+    In order to see other possible results please use
+    :ref:`howto/operator:GcpSpeechToTextRecognizeSpeechOperator`
+    and
+    :ref:`howto/operator:CloudTranslateTextOperator`
+    separately
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GcpTranslateSpeechOperator`
+
+    See https://cloud.google.com/translate/docs/translating-text
+
+    Execute method returns string object with the translation
+
+    This is a list of dictionaries queried value.
+    Dictionary typically contains three keys (though not
+    all will be present in all cases).
+
+    * ``detectedSourceLanguage``: The detected language (as an
+      ISO 639-1 language code) of the text.
+    * ``translatedText``: The translation of the text into the
+      target language.
+    * ``input``: The corresponding input value.
+    * ``model``: The model used to translate the text.
+
+    Dictionary is set as XCom return value.
+
+    :param audio: audio data to be recognized. See more:
+        https://googleapis.github.io/google-cloud-python/latest/speech/gapic/v1/types.html#google.cloud.speech_v1.types.RecognitionAudio
+    :type audio: dict or google.cloud.speech_v1.types.RecognitionAudio
+
+    :param config: information to the recognizer that specifies how to process the request. See more:
+        https://googleapis.github.io/google-cloud-python/latest/speech/gapic/v1/types.html#google.cloud.speech_v1.types.RecognitionConfig
+    :type config: dict or google.cloud.speech_v1.types.RecognitionConfig
+
+    :param target_language: The language to translate results into. This is required by the API and defaults
+        to the target language of the current instance.
+        Check the list of available languages here: https://cloud.google.com/translate/docs/languages
+    :type target_language: str
+
+    :param format_: (Optional) One of ``text`` or ``html``, to specify
+        if the input text is plain text or HTML.
+    :type format_: str or None
+
+    :param source_language: (Optional) The language of the text to
+        be translated.
+    :type source_language: str or None
+
+    :param model: (Optional) The model used to translate the text, such
+        as ``'base'`` or ``'nmt'``.
+    :type model: str or None
+
+    :param project_id: Optional, Google Cloud Platform Project ID where the Compute
+        Engine Instance exists.  If set to None or missing, the default project_id from the GCP connection is
+        used.
+    :type project_id: str
+
+    :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
+        Platform. Defaults to 'google_cloud_default'.
+    :type gcp_conn_id: str
+
+    """
+
+    # [START translate_speech_template_fields]
+    template_fields = ('target_language', 'format_', 'source_language', 'model', 'project_id', 'gcp_conn_id')
+    # [END translate_speech_template_fields]
+
+    @apply_defaults
+    def __init__(
+        self,
+        audio,
+        config,
+        target_language,
+        format_,
+        source_language,
+        model,
+        project_id=None,
+        gcp_conn_id='google_cloud_default',
+        *args,
+        **kwargs
+    ):
+        super(GcpTranslateSpeechOperator, self).__init__(*args, **kwargs)
+        self.audio = audio
+        self.config = config
+        self.target_language = target_language
+        self.format_ = format_
+        self.source_language = source_language
+        self.model = model
+        self.project_id = project_id
+        self.gcp_conn_id = gcp_conn_id
+
+    def execute(self, context):
+        _speech_to_text_hook = GCPSpeechToTextHook(gcp_conn_id=self.gcp_conn_id)
+        _translate_hook = CloudTranslateHook(gcp_conn_id=self.gcp_conn_id)
+
+        recognize_result = _speech_to_text_hook.recognize_speech(
+            config=self.config, audio=self.audio
+        )
+        recognize_dict = MessageToDict(recognize_result)
+
+        self.log.info("recognition operation finished", recognize_dict)
+
+        if len(recognize_dict['results']) == 0:
+            self.log.info("No recognition results")
+            return {}
+        self.log.debug("recognition result: %s", recognize_dict)
+
+        try:
+            transcript = recognize_dict['results'][0]['alternatives'][0]['transcript']
+        except KeyError as key:
+            raise AirflowException("Wrong response '{}' returned - it should contain {} field"
+                                   .format(recognize_dict, key))
+
+        try:
+            translation = _translate_hook.translate(
+                values=transcript,
+                target_language=self.target_language,
+                format_=self.format_,
+                source_language=self.source_language,
+                model=self.model
+            )
+            self.log.info('translated output: %s', translation)
+            return translation
+        except ValueError as e:
+            self.log.error('An error has been thrown from translate speech method:')
+            self.log.error(e)
+            raise AirflowException(e)

--- a/docs/howto/operator/gcp/translate-speech.rst
+++ b/docs/howto/operator/gcp/translate-speech.rst
@@ -1,0 +1,72 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..  http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Google Cloud Speech Translate Operators
+=======================================
+
+.. contents::
+  :depth: 1
+  :local:
+
+.. _howto/operator:GcpTranslateSpeechOperator:
+
+GcpTranslateSpeechOperator
+--------------------------
+
+Recognizes speech in audio input and translates it.
+
+For parameter definition, take a look at
+:class:`airflow.contrib.operators.gcp_translate_speech_operator.GcpTranslateSpeechOperator`
+
+Arguments
+"""""""""
+
+Config and audio arguments need to be dicts or objects of corresponding classes from
+``google.cloud.speech_v1.types`` module.
+
+for more information, see: https://googleapis.github.io/google-cloud-python/latest/speech/gapic/v1/api.html#google.cloud.speech_v1.SpeechClient.recognize
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
+      :language: python
+      :start-after: [START howto_operator_speech_to_text_api_arguments]
+      :end-before: [END howto_operator_speech_to_text_api_arguments]
+
+Arguments for translation need to be specified.
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
+      :language: python
+      :start-after: [START howto_operator_translate_speech_arguments]
+      :end-before: [END howto_operator_translate_speech_arguments]
+
+
+Using the operator
+""""""""""""""""""
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
+      :language: python
+      :dedent: 4
+      :start-after: [START howto_operator_translate_speech]
+      :end-before: [END howto_operator_translate_speech]
+
+Templating
+""""""""""
+
+.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_translate_speech_operator.py
+    :language: python
+    :dedent: 4
+    :start-after: [START translate_speech_template_fields]
+    :end-before: [END translate_speech_template_fields]

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -665,6 +665,14 @@ Cloud Speech to Text
 
 They also use :class:`airflow.contrib.hooks.gcp_speech_to_text_hook.GCPSpeechToTextHook` to communicate with Google Cloud Platform.
 
+Cloud Speech Translate Operators
+--------------------------------
+
+:class:`airflow.contrib.operators.gcp_translate_speech_operator.GcpTranslateSpeechOperator`
+    Recognizes speech in audio input and translates it.
+
+They also use :class:`airflow.contrib.hooks.gcp_speech_to_text_hook.GCPSpeechToTextHook` and
+    :class:`airflow.contrib.hooks.gcp_translate_hook.CloudTranslateHook` to communicate with Google Cloud Platform.
 
 Cloud Translate
 '''''''''''''''

--- a/tests/contrib/operators/test_gcp_translate_speech_operator.py
+++ b/tests/contrib/operators/test_gcp_translate_speech_operator.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from google.cloud.speech_v1.proto.cloud_speech_pb2 import RecognizeResponse, SpeechRecognitionResult, \
+    SpeechRecognitionAlternative
+
+from airflow import AirflowException
+from airflow.contrib.operators.gcp_translate_speech_operator import GcpTranslateSpeechOperator
+from tests.compat import mock
+
+GCP_CONN_ID = 'google_cloud_default'
+
+
+class CloudTranslateSpeechTest(unittest.TestCase):
+    @mock.patch('airflow.contrib.operators.gcp_translate_speech_operator.GCPSpeechToTextHook')
+    @mock.patch('airflow.contrib.operators.gcp_translate_speech_operator.CloudTranslateHook')
+    def test_minimal_green_path(self, mock_translate_hook, mock_speech_hook):
+        mock_speech_hook.return_value.recognize_speech.return_value = RecognizeResponse(
+            results=[SpeechRecognitionResult(
+                alternatives=[SpeechRecognitionAlternative(
+                    transcript='test speech recognition result'
+                )]
+            )]
+        )
+        mock_translate_hook.return_value.translate.return_value = [
+            {
+                'translatedText': 'sprawdzić wynik rozpoznawania mowy',
+                'detectedSourceLanguage': 'en',
+                'model': 'base',
+                'input': 'test speech recognition result',
+            }
+        ]
+
+        op = GcpTranslateSpeechOperator(
+            audio={"uri": "gs://bucket/object"},
+            config={"encoding": "LINEAR16"},
+            target_language='pl',
+            format_='text',
+            source_language=None,
+            model='base',
+            gcp_conn_id=GCP_CONN_ID,
+            task_id='id',
+        )
+        return_value = op.execute(context=None)
+
+        mock_speech_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_translate_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+
+        mock_speech_hook.return_value.recognize_speech.assert_called_once_with(
+            audio={"uri": "gs://bucket/object"},
+            config={"encoding": "LINEAR16"},
+        )
+
+        mock_translate_hook.return_value.translate.assert_called_once_with(
+            values='test speech recognition result',
+            target_language='pl',
+            format_='text',
+            source_language=None,
+            model='base',
+        )
+        self.assertEqual(
+            [
+                {
+                    'translatedText': 'sprawdzić wynik rozpoznawania mowy',
+                    'detectedSourceLanguage': 'en',
+                    'model': 'base',
+                    'input': 'test speech recognition result',
+                }
+            ],
+            return_value,
+        )
+
+    @mock.patch('airflow.contrib.operators.gcp_translate_speech_operator.GCPSpeechToTextHook')
+    @mock.patch('airflow.contrib.operators.gcp_translate_speech_operator.CloudTranslateHook')
+    def test_bad_recognition_response(self, mock_translate_hook, mock_speech_hook):
+        mock_speech_hook.return_value.recognize_speech.return_value = RecognizeResponse(
+            results=[SpeechRecognitionResult()]
+        )
+        op = GcpTranslateSpeechOperator(
+            audio={"uri": "gs://bucket/object"},
+            config={"encoding": "LINEAR16"},
+            target_language='pl',
+            format_='text',
+            source_language=None,
+            model='base',
+            gcp_conn_id=GCP_CONN_ID,
+            task_id='id',
+        )
+        with self.assertRaises(AirflowException) as cm:
+            op.execute(context=None)
+        err = cm.exception
+        self.assertIn("it should contain 'alternatives' field", str(err))
+
+        mock_speech_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_translate_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+
+        mock_speech_hook.return_value.recognize_speech.assert_called_once_with(
+            audio={"uri": "gs://bucket/object"},
+            config={"encoding": "LINEAR16"},
+        )
+
+        mock_translate_hook.return_value.translate.assert_not_called()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

https://issues.apache.org/jira/browse/AIRFLOW-4318

### Description

Create dnew operator for recognising and translating speech:
GcpTranslateSpeechOperator

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
CloudTranslateSpeechTest

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
