### PR TITLE
[AIRFLOW-4320] Add tests for SegmentTrackEventOperator

### DIFF
--- a/airflow/contrib/operators/segment_track_event_operator.py
+++ b/airflow/contrib/operators/segment_track_event_operator.py
@@ -63,7 +63,10 @@ class SegmentTrackEventOperator(BaseOperator):
                            segment_debug_mode=self.segment_debug_mode)
 
         self.log.info(
-            'Sending track event ({0}) for user id: {1} with properties: {2}'.
-            format(self.event, self.user_id, self.properties))
+            'Sending track event (%s) for user id: %s with properties: %s',
+            self.event, self.user_id, self.properties)
 
-        hook.track(self.user_id, self.event, self.properties)
+        hook.track(
+            user_id=self.user_id,
+            event=self.event,
+            properties=self.properties)

--- a/tests/contrib/operators/test_segment_track_event_operator.py
+++ b/tests/contrib/operators/test_segment_track_event_operator.py
@@ -66,6 +66,7 @@ class SegmentTrackEventOperatorTest(unittest.TestCase):
 
     @mock.patch('airflow.contrib.operators.segment_track_event_operator.SegmentHook')
     def test_execute(self, mock_hook):
+        # Given
         user_id = 'user_id'
         event = 'event'
         properties = {}
@@ -77,7 +78,10 @@ class SegmentTrackEventOperatorTest(unittest.TestCase):
             properties=properties,
         )
 
+        # When
         operator.execute(None)
+
+        # Then
         mock_hook.return_value.track.assert_called_once_with(
             user_id=user_id,
             event=event,

--- a/tests/contrib/operators/test_segment_track_event_operator.py
+++ b/tests/contrib/operators/test_segment_track_event_operator.py
@@ -23,6 +23,8 @@ import unittest
 from airflow import configuration, AirflowException
 
 from airflow.contrib.hooks.segment_hook import SegmentHook
+from airflow.contrib.operators.segment_track_event_operator \
+    import SegmentTrackEventOperator
 
 TEST_CONN_ID = 'test_segment'
 WRITE_KEY = 'foo'
@@ -58,6 +60,29 @@ class TestSegmentHook(unittest.TestCase):
     def test_on_error(self):
         with self.assertRaises(AirflowException):
             self.test_hook.on_error('error', ['items'])
+
+
+class SegmentTrackEventOperatorTest(unittest.TestCase):
+
+    @mock.patch('airflow.contrib.operators.segment_track_event_operator.SegmentHook')
+    def test_execute(self, mock_hook):
+        user_id = 'user_id'
+        event = 'event'
+        properties = {}
+
+        operator = SegmentTrackEventOperator(
+            task_id='segment-track',
+            user_id=user_id,
+            event=event,
+            properties=properties,
+        )
+
+        operator.execute(None)
+        mock_hook.return_value.track.assert_called_once_with(
+            user_id=user_id,
+            event=event,
+            properties=properties,
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4320

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
SegmentTrackEventOperator didn't have any test


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
