### PR TITLE
[AIRFLOW-XXX] Update docstring for SchedulerJob

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -560,7 +560,7 @@ class SchedulerJob(BaseJob):
             definitions, or a specific path to a file
         :type subdir: unicode
         :param num_runs: The number of times to try to schedule each DAG file.
-            -1 for unlimited within the run_duration.
+            -1 for unlimited times.
         :type num_runs: int
         :param processor_poll_interval: The number of seconds to wait between
             polls of running processors


### PR DESCRIPTION
`run_duration` of `ScheudlerJob` is already deprecated in https://github.com/apache/airflow/commit/327860fe4f04934750a80d39d8e1498398eebf69#diff-54a57ccc2c8e73d12c812798bf79ccb2. 

There is a minor part which was missed to be updated for `num_runs`.