### PR TITLE
[AIRFLOW-4321] Replace incorrect Max Size limit of GCS Object Size

### DIFF
--- a/airflow/contrib/operators/cassandra_to_gcs.py
+++ b/airflow/contrib/operators/cassandra_to_gcs.py
@@ -57,9 +57,9 @@ class CassandraToGoogleCloudStorageOperator(BaseOperator):
     :type schema_filename: str
     :param approx_max_file_size_bytes: This operator supports the ability
         to split large table dumps into multiple files (see notes in the
-        filenamed param docs above). Google cloud storage allows for files
-        to be a maximum of 4GB. This param allows developers to specify the
-        file size of the splits.
+        filename param docs above). This param allows developers to specify the
+        file size of the splits. Check https://cloud.google.com/storage/quotas
+        to see the maximum allowed file size for a single object.
     :type approx_max_file_size_bytes: long
     :param cassandra_conn_id: Reference to a specific Cassandra hook.
     :type cassandra_conn_id: str

--- a/airflow/contrib/operators/mysql_to_gcs.py
+++ b/airflow/contrib/operators/mysql_to_gcs.py
@@ -59,9 +59,9 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
     :type schema_filename: str
     :param approx_max_file_size_bytes: This operator supports the ability
         to split large table dumps into multiple files (see notes in the
-        filenamed param docs above). Google cloud storage allows for files
-        to be a maximum of 4GB. This param allows developers to specify the
-        file size of the splits.
+        filename param docs above). This param allows developers to specify the
+        file size of the splits. Check https://cloud.google.com/storage/quotas
+        to see the maximum allowed file size for a single object.
     :type approx_max_file_size_bytes: long
     :param mysql_conn_id: Reference to a specific MySQL hook.
     :type mysql_conn_id: str

--- a/airflow/contrib/operators/postgres_to_gcs_operator.py
+++ b/airflow/contrib/operators/postgres_to_gcs_operator.py
@@ -70,9 +70,9 @@ class PostgresToGoogleCloudStorageOperator(BaseOperator):
         :type schema_filename: str
         :param approx_max_file_size_bytes: This operator supports the ability
             to split large table dumps into multiple files (see notes in the
-            filenamed param docs above). Google Cloud Storage allows for files
-            to be a maximum of 4GB. This param allows developers to specify the
-            file size of the splits.
+            filename param docs above). This param allows developers to specify the
+            file size of the splits. Check https://cloud.google.com/storage/quotas
+            to see the maximum allowed file size for a single object.
         :type approx_max_file_size_bytes: long
         :param postgres_conn_id: Reference to a specific Postgres hook.
         :type postgres_conn_id: str


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4321
 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Many places in Airflow docs for GCS it is mentioned that "Google cloud storage allows for files
to be a maximum of 4GB."

The limit is not 4GB it's 5TB:
https://cloud.google.com/storage/quotas
"There is a maximum size limit of 5 TB for individual objects stored in Cloud Storage."
I think in general It's best not to mention it at all. The limits can change at will. Airflow can't keep track of all size changes.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
n/a - doc change

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
