### PR TITLE
[AIRFLOW-4323] Add 2 tests for WinRMOperator

### DIFF
--- a/tests/contrib/operators/test_winrm_operator.py
+++ b/tests/contrib/operators/test_winrm_operator.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import mock
+import unittest
+
+from airflow.contrib.operators.winrm_operator import WinRMOperator
+from airflow.exceptions import AirflowException
+
+
+class WinRMOperatorTest(unittest.TestCase):
+    def test_no_winrm_hook_no_ssh_conn_id(self):
+
+        op = WinRMOperator(task_id='test_task_id',
+                           winrm_hook=None,
+                           ssh_conn_id=None)
+        exception_msg = "Cannot operate without winrm_hook or ssh_conn_id."
+        with self.assertRaisesRegexp(AirflowException, exception_msg):
+            op.execute(None)
+
+    @mock.patch('airflow.contrib.operators.winrm_operator.WinRMHook')
+    def test_no_command(self, mock_hook):
+        op = WinRMOperator(
+            task_id='test_task_id',
+            winrm_hook=mock_hook,
+            command=None
+        )
+        exception_msg = "No command specified so nothing to execute here."
+        with self.assertRaisesRegexp(AirflowException, exception_msg):
+            op.execute(None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/contrib/operators/test_winrm_operator.py
+++ b/tests/contrib/operators/test_winrm_operator.py
@@ -26,7 +26,6 @@ from airflow.exceptions import AirflowException
 
 class WinRMOperatorTest(unittest.TestCase):
     def test_no_winrm_hook_no_ssh_conn_id(self):
-
         op = WinRMOperator(task_id='test_task_id',
                            winrm_hook=None,
                            ssh_conn_id=None)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4323

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
There were 0 tests for WinRMOperator. This PR adds 2 tests.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
added

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
