### PR TITLE
[AIRFLOW-4326] Airflow AWS SQS Operator

### DIFF
--- a/airflow/contrib/operators/aws_sqs_publish_operator.py
+++ b/airflow/contrib/operators/aws_sqs_publish_operator.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the ApachMee Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+from airflow.contrib.hooks.aws_sqs_hook import SQSHook
+
+
+class SQSPublishOperator(BaseOperator):
+    """
+    Publish message to a SQS queue.
+    :param sqs_queue: The SQS queue url (templated)
+    :type sqs_queue: str
+    :param message_content: The message content (templated)
+    :type message_content: str
+    :param message_attributes: additional attributes for the message (default: None)
+        For details of the attributes parameter see :py:meth:`botocore.client.SQS.send_message`
+    :type message_attributes: dict
+    :param delay_seconds: message delay (templated) (default: 1 second)
+    :type delay_seconds: int
+    :param aws_conn_id: AWS connection id (default: aws_default)
+    :type aws_conn_id: str
+    """
+    template_fields = ('sqs_queue', 'message_content', 'delay_seconds')
+    ui_color = '#6ad3fa'
+
+    @apply_defaults
+    def __init__(self,
+                 sqs_queue,
+                 message_content,
+                 message_attributes=None,
+                 delay_seconds=0,
+                 aws_conn_id='aws_default',
+                 *args,
+                 **kwargs):
+        super(SQSPublishOperator, self).__init__(*args, **kwargs)
+        self.sqs_queue = sqs_queue
+        self.aws_conn_id = aws_conn_id
+        self.message_content = message_content
+        self.delay_seconds = delay_seconds
+        self.message_attributes = message_attributes or {}
+
+    def execute(self, context):
+        """
+        Publish the message to SQS queue
+        :param context: the context object
+        :type context: dict
+        :return: dict with information about the message sent
+            For details of the returned dict see :py:meth:`botocore.client.SQS.send_message`
+        :rtype: dict
+        """
+
+        hook = SQSHook(aws_conn_id=self.aws_conn_id)
+
+        result = hook.send_message(queue_url=self.sqs_queue,
+                                   message_body=self.message_content,
+                                   delay_seconds=self.delay_seconds,
+                                   message_attributes=self.message_attributes)
+
+        self.log.info('result is send_message is %s', result)
+
+        return result

--- a/airflow/contrib/operators/aws_sqs_publish_operator.py
+++ b/airflow/contrib/operators/aws_sqs_publish_operator.py
@@ -25,6 +25,7 @@ from airflow.contrib.hooks.aws_sqs_hook import SQSHook
 class SQSPublishOperator(BaseOperator):
     """
     Publish message to a SQS queue.
+
     :param sqs_queue: The SQS queue url (templated)
     :type sqs_queue: str
     :param message_content: The message content (templated)
@@ -37,6 +38,7 @@ class SQSPublishOperator(BaseOperator):
     :param aws_conn_id: AWS connection id (default: aws_default)
     :type aws_conn_id: str
     """
+
     template_fields = ('sqs_queue', 'message_content', 'delay_seconds')
     ui_color = '#6ad3fa'
 
@@ -58,7 +60,8 @@ class SQSPublishOperator(BaseOperator):
 
     def execute(self, context):
         """
-        Publish the message to SQS queue
+        Publish the message to SQS queu
+
         :param context: the context object
         :type context: dict
         :return: dict with information about the message sent

--- a/airflow/contrib/operators/aws_sqs_publish_operator.py
+++ b/airflow/contrib/operators/aws_sqs_publish_operator.py
@@ -60,7 +60,7 @@ class SQSPublishOperator(BaseOperator):
 
     def execute(self, context):
         """
-        Publish the message to SQS queu
+        Publish the message to SQS queue
 
         :param context: the context object
         :type context: dict

--- a/tests/contrib/operators/test_aws_sqs_publish_operator.py
+++ b/tests/contrib/operators/test_aws_sqs_publish_operator.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import unittest
+from airflow import DAG, configuration
+from airflow.contrib.operators.aws_sqs_publish_operator import SQSPublishOperator
+from airflow.utils import timezone
+from mock import MagicMock
+from moto import mock_sqs
+from airflow.contrib.hooks.aws_sqs_hook import SQSHook
+
+DEFAULT_DATE = timezone.datetime(2019, 1, 1)
+
+
+class TestSQSPublishOperator(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+
+        args = {
+            'owner': 'airflow',
+            'start_date': DEFAULT_DATE
+        }
+
+        self.dag = DAG('test_dag_id', default_args=args)
+        self.operator = SQSPublishOperator(
+            task_id='test_task',
+            dag=self.dag,
+            sqs_queue='test',
+            message_content='hello',
+            aws_conn_id='aws_default'
+        )
+
+        self.mock_context = MagicMock()
+        self.sqs_hook = SQSHook()
+
+    @mock_sqs
+    def test_execute_success(self):
+        self.sqs_hook.create_queue('test')
+
+        result = self.operator.execute(self.mock_context)
+        self.assertTrue('MD5OfMessageBody' in result)
+        self.assertTrue('MessageId' in result)
+
+        message = self.sqs_hook.get_conn().receive_message(QueueUrl='test')
+
+        self.assertEquals(len(message['Messages']), 1)
+        self.assertEquals(message['Messages'][0]['MessageId'], result['MessageId'])
+        self.assertEquals(message['Messages'][0]['Body'], 'hello')
+
+        context_calls = []
+
+        self.assertTrue(self.mock_context['ti'].method_calls == context_calls, "context call  should be same")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-4326\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4326
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR: Operator to publish messages to AWS SQS Queue

### Tests

- [x] My PR adds the following unit tests: test_aws_sqs_publish_operator.py

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
