### PR TITLE
[AIRFLOW-4310] Fix incorrect link on DagModel list page

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -105,10 +105,14 @@ def dag_link(v, c, m, p):
     if m.dag_id is None:
         return Markup()
 
-    url = url_for(
-        'airflow.graph',
-        dag_id=m.dag_id,
-        execution_date=m.execution_date)
+    kwargs = {'dag_id': m.dag_id}
+
+    # This is called with various objects, TIs, (ORM) DAG - some have this,
+    # some don't
+    if hasattr(m, 'execution_date'):
+        kwargs['execution_date'] = m.execution_date
+
+    url = url_for('airflow.graph', **kwargs)
     return Markup(
         '<a href="{}">{}</a>').format(url, m.dag_id)
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4310
  
### Description

- [x] This part of the UI isn't often used, but it was in-operable. (To get to it click on the Edit icon (first column) from dags screen, then select List. It would blow up.

  That column formatter is used in a few places (Dag, DagRun, TI) so it needs to cope with differing input types.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: tested manually. 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] None

### Code Quality

- [x] Passes `flake8`
