### PR TITLE
[AIRFLOW-4331] Correct filter for Null-state runs from Dag Detail page

### DIFF
--- a/airflow/www/templates/airflow/dag_details.html
+++ b/airflow/www/templates/airflow/dag_details.html
@@ -26,10 +26,15 @@
     <h2>{{ title }}</h2>
     <div>
       {% for state, count in states %}
+      {%- if state -%}
+        {%- set url = url_for('taskinstance.index_view', flt0_dag_id_equals=dag.dag_id, flt2_state_equals=state) -%}
+      {%- else -%}
+        {%- set url = url_for('taskinstance.index_view', flt0_dag_id_equals=dag.dag_id, flt3_state_empty=1) -%}
+      {%- endif -%}
       <a
           class="btn"
           style="border: none; background-color:{{ State.color(state)}}; color: {{ State.color_fg(state) }};"
-          href="{{ url_for('taskinstance.index_view') }}?flt0_dag_id_equals={{ dag.dag_id }}&flt2_state_equals={{ state }}">
+          href="{{ url }}">
         {{ state }} <span class="badge">{{ count }}</span>
       </a>
       {% endfor %}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4331

### Description

- [x] When a DAG Run is has state of NULL we were generating a link that wouldn't correctly filter those.

  This applies to 1.10/classic UI as FAB is lacking the ability to filter by Null/Not Null right now. I have cloned our jira issue to https://issues.apache.org/jira/browse/AIRFLOW-4331 mentioning fab so that we don't forget about it.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: UI only

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
