### PR TITLE
[AIRFLOW-4328] Fix link to task instances from Pool page

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -203,7 +203,7 @@ def label_link(v, c, m, p):
 def pool_link(v, c, m, p):
     title = m.pool
 
-    url = url_for('airflow.task', flt1_pool_equals=m.pool)
+    url = url_for('taskinstance.index_view', flt1_pool_equals=m.pool)
     return Markup("<a href='{url}'>{title}</a>").format(**locals())
 
 


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4328
  
### Description

- [ ] We want to link to the list of task instances that ran against this
pool, not to a specific task. (The link as it was wouldn't work, it was
missing lots of parameters, and wasn't meant to be. I messed up a
previous commit)

  Rbac is fine.
### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
