### PR TITLE
[AIRFLOW-4342] Use @cached_property instead of re-implementing it each time

### DIFF
--- a/airflow/contrib/hooks/gcp_vision_hook.py
+++ b/airflow/contrib/hooks/gcp_vision_hook.py
@@ -18,12 +18,12 @@
 # under the License.
 from copy import deepcopy
 
+from cached_property import cached_property
 from google.cloud.vision_v1 import ProductSearchClient, ImageAnnotatorClient
 from google.protobuf.json_format import MessageToDict
 
 from airflow import AirflowException
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
-from airflow.utils.decorators import cached_property
 
 
 class NameDeterminer:

--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -103,19 +103,3 @@ if 'BUILDING_AIRFLOW_DOCS' in os.environ:
     # flake8: noqa: F811
     # Monkey patch hook to get good function headers while building docs
     apply_defaults = lambda x: x
-
-
-class cached_property:
-    """
-    A decorator creating a property, the value of which is calculated only once and cached for later use.
-    """
-    def __init__(self, func):
-        self.func = func
-        self.__doc__ = getattr(func, '__doc__')
-
-    def __get__(self, instance, cls=None):
-        if instance is None:
-            return self
-        result = self.func(instance)
-        instance.__dict__[self.func.__name__] = result
-        return result

--- a/airflow/utils/log/gcs_task_handler.py
+++ b/airflow/utils/log/gcs_task_handler.py
@@ -18,6 +18,8 @@
 # under the License.
 import os
 
+from cached_property import cached_property
+
 from airflow import configuration
 from airflow.exceptions import AirflowException
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -39,7 +41,8 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
         self.closed = False
         self.upload_on_close = True
 
-    def _build_hook(self):
+    @cached_property
+    def hook(self):
         remote_conn_id = configuration.conf.get('core', 'REMOTE_LOG_CONN_ID')
         try:
             from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
@@ -52,12 +55,6 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
                 '"%s". %s\n\nPlease make sure that airflow[gcp] is installed '
                 'and the GCS connection exists.', remote_conn_id, str(e)
             )
-
-    @property
-    def hook(self):
-        if self._hook is None:
-            self._hook = self._build_hook()
-        return self._hook
 
     def set_context(self, ti):
         super(GCSTaskHandler, self).set_context(ti)

--- a/airflow/utils/log/s3_task_handler.py
+++ b/airflow/utils/log/s3_task_handler.py
@@ -18,6 +18,8 @@
 # under the License.
 import os
 
+from cached_property import cached_property
+
 from airflow import configuration
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.file_task_handler import FileTaskHandler
@@ -37,7 +39,8 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         self.closed = False
         self.upload_on_close = True
 
-    def _build_hook(self):
+    @cached_property
+    def hook(self):
         remote_conn_id = configuration.conf.get('core', 'REMOTE_LOG_CONN_ID')
         try:
             from airflow.hooks.S3_hook import S3Hook
@@ -48,12 +51,6 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
                 'Please make sure that airflow[aws] is installed and '
                 'the S3 connection exists.', remote_conn_id
             )
-
-    @property
-    def hook(self):
-        if self._hook is None:
-            self._hook = self._build_hook()
-        return self._hook
 
     def set_context(self, ti):
         super(S3TaskHandler, self).set_context(ti)

--- a/airflow/utils/log/wasb_task_handler.py
+++ b/airflow/utils/log/wasb_task_handler.py
@@ -19,6 +19,8 @@
 import os
 import shutil
 
+from cached_property import cached_property
+
 from airflow import configuration
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.file_task_handler import FileTaskHandler
@@ -43,7 +45,8 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
         self.upload_on_close = True
         self.delete_local_copy = delete_local_copy
 
-    def _build_hook(self):
+    @cached_property
+    def hook(self):
         remote_conn_id = configuration.get('core', 'REMOTE_LOG_CONN_ID')
         try:
             from airflow.contrib.hooks.wasb_hook import WasbHook
@@ -54,12 +57,6 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
                 'Please make sure that airflow[azure] is installed and '
                 'the Wasb connection exists.', remote_conn_id
             )
-
-    @property
-    def hook(self):
-        if self._hook is None:
-            self._hook = self._build_hook()
-        return self._hook
 
     def set_context(self, ti):
         super(WasbTaskHandler, self).set_context(ti)

--- a/setup.py
+++ b/setup.py
@@ -309,6 +309,7 @@ def do_setup():
         scripts=['airflow/bin/airflow'],
         install_requires=[
             'alembic>=0.9, <1.0',
+            'cached_property~=1.5',
             'configparser>=3.5.0, <3.6.0',
             'croniter>=0.3.17, <0.4',
             'dill>=0.2.2, <0.3',

--- a/tests/utils/test_decorators.py
+++ b/tests/utils/test_decorators.py
@@ -19,7 +19,7 @@
 
 import unittest
 
-from airflow.utils.decorators import apply_defaults, cached_property
+from airflow.utils.decorators import apply_defaults
 from airflow.exceptions import AirflowException
 
 
@@ -73,29 +73,3 @@ class ApplyDefaultTest(unittest.TestCase):
         default_args = {'random_params': True}
         with self.assertRaisesRegexp(AirflowException, 'Argument.*test_param.*required'):
             DummyClass(default_args=default_args)
-
-
-class FixtureClass:
-    @cached_property
-    def value(self):
-        """Fixture docstring"""
-        return 1, object()
-
-
-class FixtureSubClass(FixtureClass):
-    pass
-
-
-class CachedPropertyTest(unittest.TestCase):
-
-    def setUp(self):
-        self.test_obj = FixtureClass()
-        self.test_sub_obj = FixtureSubClass()
-
-    def test_cache_works(self):
-        self.assertIs(self.test_obj.value, self.test_obj.value)
-        self.assertIs(self.test_sub_obj.value, self.test_sub_obj.value)
-
-    def test_docstring(self):
-        self.assertEqual(FixtureClass.value.__doc__, "Fixture docstring")
-        self.assertEqual(FixtureSubClass.value.__doc__, "Fixture docstring")


### PR DESCRIPTION

It's not many lines, but I just find this much clearer

Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4342
  - New module is BSD licensed.

### Description

- [x] In a few places in the code base we have something that looks like:

   ```
   @property
   def x(self):
      if not self._x:
          self._x = self._build_x()
       return self._x
   ```

   Instead we should use something like https://pypi.org/project/cached-property/ to make it more declarative for us. And I want to start using this in a few more places.


### Tests

- [x] No change in behaviour

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
