### PR TITLE
[AIRFLOW-4343] Show warning in UI if scheduler is not running

### DIFF
--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -66,6 +66,23 @@ def ds_format(ds, input_format, output_format):
     return datetime.strptime(ds, input_format).strftime(output_format)
 
 
+def datetime_diff_for_humans(dt, since=None):
+    """
+    Return a human-readable/approximate difference between two datetimes, or
+    one and now.
+
+    :param dt: The datetime to display the diff for
+    :type dt: datetime
+    :param since: When to display the date from. If ``None`` then the diff is
+        between ``dt`` and now.
+    :type since: None or datetime
+    :rtype: str
+    """
+    import pendulum
+
+    return pendulum.instance(dt).diff_for_humans(since)
+
+
 def _integrate_plugins():
     """Integrate plugins to the context"""
     import sys

--- a/airflow/www/templates/appbuilder/baselayout.html
+++ b/airflow/www/templates/appbuilder/baselayout.html
@@ -46,6 +46,16 @@
       <div class="row">
           {% block messages %}
             {% include 'appbuilder/flash.html' %}
+            {% if scheduler_job is defined and (not scheduler_job or not scheduler_job.is_alive()) %}
+              <div class="alert alert-warning">
+                <p>The scheduler does not appear to be running.
+                {% if scheduler_job %}
+                Last heartbeat was received <time title="{{ scheduler_job.latest_heartbeat.isoformat() }}" datetime="{{ scheduler_job.latest_heartbeat.isoformat() }}">{{ macros.datetime_diff_for_humans(scheduler_job.latest_heartbeat) }}</time>.
+                {% endif %}
+                </p>
+                <p>The DAGs list may not update, and new tasks will not be scheduled.</p>
+              </div>
+            {% endif %}
           {% endblock %}
           {% block content %}
           {% endblock %}
@@ -70,6 +80,7 @@
   // below variables are used in base.js
   var hostName = '{{ hostname }}';
   var csrfToken = '{{ csrf_token() }}';
+  $("time[title]").tooltip()
 </script>
 <script src="{{ url_for_asset('base.js') }}" type="text/javascript"></script>
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -328,6 +328,7 @@ def do_setup():
             'iso8601>=0.1.12',
             'json-merge-patch==0.2',
             'jinja2>=2.10.1, <2.11.0',
+            'lazy_object_proxy~=1.3',
             'markdown>=2.5.2, <3.0',
             'pandas>=0.17.1, <1.0.0',
             'pendulum==1.4.4',

--- a/tests/jobs/test_base_job.py
+++ b/tests/jobs/test_base_job.py
@@ -18,11 +18,14 @@
 # under the License.
 #
 
+import datetime
 import unittest
 
 from airflow import configuration
 from airflow.jobs import BaseJob
+from airflow.utils import timezone
 from airflow.utils.state import State
+from airflow.utils.db import create_session
 
 configuration.load_test_config()
 
@@ -33,9 +36,9 @@ class BaseJobTest(unittest.TestCase):
             'polymorphic_identity': 'TestJob'
         }
 
-        def __init__(self, cb):
+        def __init__(self, cb, **kwargs):
             self.cb = cb
-            super().__init__()
+            super().__init__(**kwargs)
 
         def _execute(self):
             return self.cb()
@@ -65,3 +68,34 @@ class BaseJobTest(unittest.TestCase):
 
         self.assertEqual(job.state, State.FAILED)
         self.assertIsNotNone(job.end_date)
+
+    def test_most_recent_job(self):
+
+        with create_session() as session:
+            old_job = self.TestJob(None, heartrate=10)
+            old_job.latest_heartbeat = old_job.latest_heartbeat - datetime.timedelta(seconds=20)
+            job = self.TestJob(None, heartrate=10)
+            session.add(job)
+            session.add(old_job)
+            session.flush()
+
+            self.assertEqual(
+                self.TestJob.most_recent_job(session=session),
+                job
+            )
+
+            session.rollback()
+
+    def test_is_alive(self):
+        job = self.TestJob(None, heartrate=10, state=State.RUNNING)
+        self.assertTrue(job.is_alive())
+
+        job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=20)
+        self.assertTrue(job.is_alive())
+
+        job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=21)
+        self.assertFalse(job.is_alive())
+
+        job.state = State.SUCCESS
+        job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=10)
+        self.assertFalse(job.is_alive(), "Completed jobs even with recent heartbeat should not be alive")

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -96,6 +96,20 @@ class SchedulerJobTest(unittest.TestCase):
     def tearDownClass(cls):
         cls.patcher.stop()
 
+    def test_is_alive(self):
+        job = SchedulerJob(None, heartrate=10, state=State.RUNNING)
+        self.assertTrue(job.is_alive())
+
+        job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=20)
+        self.assertTrue(job.is_alive())
+
+        job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=31)
+        self.assertFalse(job.is_alive())
+
+        job.state = State.SUCCESS
+        job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=10)
+        self.assertFalse(job.is_alive(), "Completed jobs even with recent heartbeat should not be alive")
+
     def run_single_scheduler_loop_with_no_dags(self, dags_folder):
         """
         Utility function that runs a single scheduler loop without actually

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -383,7 +383,7 @@ class TestAirflowBaseViews(TestBase):
 
         self.assertEqual('healthy', resp_json['metadatabase']['status'])
         self.assertEqual('healthy', resp_json['scheduler']['status'])
-        self.assertEqual(str(last_scheduler_heartbeat_for_testing_1),
+        self.assertEqual(last_scheduler_heartbeat_for_testing_1.isoformat(),
                          resp_json['scheduler']['latest_scheduler_heartbeat'])
 
         self.session.query(BaseJob).\
@@ -408,7 +408,7 @@ class TestAirflowBaseViews(TestBase):
 
         self.assertEqual('healthy', resp_json['metadatabase']['status'])
         self.assertEqual('unhealthy', resp_json['scheduler']['status'])
-        self.assertEqual(str(last_scheduler_heartbeat_for_testing_2),
+        self.assertEqual(last_scheduler_heartbeat_for_testing_2.isoformat(),
                          resp_json['scheduler']['latest_scheduler_heartbeat'])
 
         self.session.query(BaseJob).\
@@ -429,8 +429,7 @@ class TestAirflowBaseViews(TestBase):
 
         self.assertEqual('healthy', resp_json['metadatabase']['status'])
         self.assertEqual('unhealthy', resp_json['scheduler']['status'])
-        self.assertEqual('None',
-                         resp_json['scheduler']['latest_scheduler_heartbeat'])
+        self.assertIsNone(None, resp_json['scheduler']['latest_scheduler_heartbeat'])
 
     def test_home(self):
         resp = self.client.get('home', follow_redirects=True)


### PR DESCRIPTION
First commit is from #5125, look at the second commit only for now.
Make sure you have checked _all_ steps below.

### Jira

- [x]
  - https://issues.apache.org/jira/browse/AIRFLOW-4343
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x). - yes, Cat A

### Description

- [x]     Now that the webserver is more stateless, if the scheduler is not
    running the list of dags won't populate, making it harder for new
    starters to work out what is going on.

  **When scheduler has never run (I cleared Jobs table):**
  ![Screen Shot 2019-04-17 at 19 12 49](https://user-images.githubusercontent.com/34150/56311257-7da34300-6145-11e9-8d39-191e478e5dbe.png)

  **When scheduler not running (either crashed, or has stopped successfully)
  ![Screen Shot 2019-04-17 at 18 47 56](https://user-images.githubusercontent.com/34150/56311286-93b10380-6145-11e9-9520-2e9f1b97e968.png)

  (the time has a tooltip to display the full ISO8601 heartbeat)

  Login screen/anything not subclassed from AirflowBaseView doesn't display the message.

  On Login (not changed, doesn't show warning):

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: added tests for helper functions on BaseJob

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`


/cc @Fokko as discussed.