### PR TITLE
[AIRFLOW-4347] fix WEBSERVER_CONFIG when AIRFLOW_HOME=./

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -588,7 +588,7 @@ if _old_config_file != AIRFLOW_CONFIG and os.path.isfile(_old_config_file):
     )
 
 
-WEBSERVER_CONFIG = AIRFLOW_HOME + '/webserver_config.py'
+WEBSERVER_CONFIG = os.path.abspath(AIRFLOW_HOME + '/webserver_config.py')
 
 if conf.getboolean('webserver', 'rbac'):
     DEFAULT_WEBSERVER_CONFIG = _read_default_config_file('default_webserver_config.py')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [AIRFLOW-4347](https://issues.apache.org/jira/browse/AIRFLOW-4347) issues and references them in the PR title. 

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
I set AIRFLOW_HOME=./ 
command **airflow initdb** is ok.
And command **airflow webserver** got this:
```
/Users/guoguo/Downloads/env_tmp/lib/python3.6/site-packages/flask_sqlalchemy/__init__.py:774: UserWarning: Neither SQLALCHEMY_DATABASE_URI nor SQLALCHEMY_BINDS is set. Defaulting SQLALCHEMY_DATABASE_URI to "sqlite:///:memory:".
  'Neither SQLALCHEMY_DATABASE_URI nor SQLALCHEMY_BINDS is set. '
```

Airflow v1.10.3 code load RBAC WEBSERVER_CONFIG config in https://github.com/apache/airflow/blob/v1-10-stable/airflow/www_rbac/app.py#L51. 
When **AIRFLOW_HOME=./**, then **settings.WEBSERVER_CONFIG=.//webserver_config.py**.  It will got the error path of RBAC_CODE_PATH+.//webserver_config.py


