### PR TITLE
[AIRFLOW-XXX] Add Jarek Potiuk to commiter list

### DIFF
--- a/docs/project.rst
+++ b/docs/project.rst
@@ -53,6 +53,7 @@ Committers
 - @jghoman (Jakob Homan)
 - @XD-DENG (Xiaodong Deng)
 - @dimberman (Daniel Imberman)
+- @potiuk (Jarek Potiuk)
 
 For the full list of contributors, take a look at `Airflow's Github
 Contributor page:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

No applicable

### Description

> the Airflow PMC has voted in Jarek Potiuk to be a committer

Source: 
https://lists.apache.org/thread.html/4ae749cd05d908c8c492899b1bebe3c00425205f6f16e31239d10e93@%3Cdev.airflow.apache.org%3E

CC: @potiuk 

### Tests

No applicable

### Commits

No applicable

### Documentation

No applicable

### Code Quality

No applicable