### PR TITLE
[AIRFLOW-4159] Add support for additional static labels for kubernetes

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -731,3 +731,9 @@ fs_group =
 #
 # Additionally you may override worker airflow settings with the AIRFLOW__<SECTION>__<KEY>
 # formatting as supported by airflow normally.
+
+[kubernetes_labels]
+# The Key-value pairs to be given to worker pods.
+# The worker pods will be given these static labels, as well as some additional dynamic labels
+# to identify the task.
+# Should be supplied in the format: key = value

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -142,6 +142,7 @@ class KubeConfig:
         )
         self.kube_node_selectors = configuration_dict.get('kubernetes_node_selectors', {})
         self.kube_annotations = configuration_dict.get('kubernetes_annotations', {})
+        self.kube_labels = configuration_dict.get('kubernetes_labels', {})
         self.delete_worker_pods = conf.getboolean(
             self.kubernetes_section, 'delete_worker_pods')
         self.worker_pods_creation_batch_size = conf.getint(
@@ -470,7 +471,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
 
     @staticmethod
     def _make_safe_pod_id(safe_dag_id, safe_task_id, safe_uuid):
-        r"""
+        """
         Kubernetes pod names must be <= 253 chars and must pass the following regex for
         validation
         "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -474,7 +474,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
         """
         Kubernetes pod names must be <= 253 chars and must pass the following regex for
         validation
-        "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+        "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 
         :param safe_dag_id: a dag_id with only alphanumeric characters
         :param safe_task_id: a task_id with only alphanumeric characters

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -206,7 +206,7 @@ class WorkerConfiguration(LoggingMixin):
         copy.update(self.kube_config.kube_labels)
         return copy
 
-    def init_volumes_and_mounts(self):
+    def _get_volumes_and_mounts(self):
         def _construct_volume(name, claim, host):
             volume = {
                 'name': name

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -201,7 +201,12 @@ class WorkerConfiguration(LoggingMixin):
 
         return security_context
 
-    def _get_volumes_and_mounts(self):
+    def _get_labels(self, labels):
+        copy = labels.copy()
+        copy.update(self.kube_config.kube_labels)
+        return copy
+
+    def init_volumes_and_mounts(self):
         def _construct_volume(name, claim, host):
             volume = {
                 'name': name
@@ -332,13 +337,13 @@ class WorkerConfiguration(LoggingMixin):
             image_pull_policy=(kube_executor_config.image_pull_policy or
                                self.kube_config.kube_image_pull_policy),
             cmds=airflow_command,
-            labels={
+            labels=self._get_labels({
                 'airflow-worker': worker_uuid,
                 'dag_id': dag_id,
                 'task_id': task_id,
                 'execution_date': execution_date,
                 'try_number': str(try_number),
-            },
+            }),
             envs=self._get_environment(),
             secrets=self._get_secrets(),
             service_account_name=self.kube_config.worker_service_account_name,

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -202,8 +202,8 @@ class WorkerConfiguration(LoggingMixin):
         return security_context
 
     def _get_labels(self, labels):
-        copy = labels.copy()
-        copy.update(self.kube_config.kube_labels)
+        copy = self.kube_config.kube_labels.copy()
+        copy.update(labels)
         return copy
 
     def _get_volumes_and_mounts(self):

--- a/tests/contrib/executors/test_kubernetes_executor.py
+++ b/tests/contrib/executors/test_kubernetes_executor.py
@@ -175,7 +175,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         self.kube_config.dags_in_image = False
         self.kube_config.dags_folder = None
         self.kube_config.git_dags_folder_mount_point = None
-        self.kube_config.kube_labels = {'my_label': 'label_id'}
+        self.kube_config.kube_labels = {'dag_id': 'original_dag_id', 'my_label': 'label_id'}
 
     def test_worker_configuration_no_subpaths(self):
         worker_config = WorkerConfiguration(self.kube_config)
@@ -631,9 +631,9 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
     def test_get_labels(self):
         worker_config = WorkerConfiguration(self.kube_config)
         labels = worker_config._get_labels({
-            'dag_id': 'dag_id',
+            'dag_id': 'override_dag_id',
         })
-        self.assertEqual({'my_label': 'label_id', 'dag_id': 'dag_id'}, labels)
+        self.assertEqual({'my_label': 'label_id', 'dag_id': 'override_dag_id'}, labels)
 
 
 class TestKubernetesExecutor(unittest.TestCase):

--- a/tests/contrib/executors/test_kubernetes_executor.py
+++ b/tests/contrib/executors/test_kubernetes_executor.py
@@ -175,6 +175,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         self.kube_config.dags_in_image = False
         self.kube_config.dags_folder = None
         self.kube_config.git_dags_folder_mount_point = None
+        self.kube_config.kube_labels = {'my_label': 'label_id'}
 
     def test_worker_configuration_no_subpaths(self):
         worker_config = WorkerConfiguration(self.kube_config)
@@ -626,6 +627,13 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         worker_config = WorkerConfiguration(self.kube_config)
         configmaps = worker_config._get_configmaps()
         self.assertListEqual(['configmap_a', 'configmap_b'], configmaps)
+
+    def test_get_labels(self):
+        worker_config = WorkerConfiguration(self.kube_config)
+        labels = worker_config._get_labels({
+            'dag_id': 'dag_id',
+        })
+        self.assertEqual({'my_label': 'label_id', 'dag_id': 'dag_id'}, labels)
 
 
 class TestKubernetesExecutor(unittest.TestCase):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] "[AIRFLOW-4159](https://issues.apache.org/jira/browse/AIRFLOW-4159)

### Description

- [x] Add support for additional static labels for kubernetes.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
