### PR TITLE
[AIRFLOW-4465] ssh_operator: pass remote_host via ssh_hook constructor

### DIFF
--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -71,11 +71,19 @@ class SSHOperator(BaseOperator):
             if self.ssh_conn_id:
                 if self.ssh_hook and isinstance(self.ssh_hook, SSHHook):
                     self.log.info("ssh_conn_id is ignored when ssh_hook is provided.")
+                    
+                if self.remote_host is not None:
+                    self.ssh_hook.remote_host = self.remote_host
+
                 else:
                     self.log.info("ssh_hook is not provided or invalid. " +
                                   "Trying ssh_conn_id to create SSHHook.")
-                    self.ssh_hook = SSHHook(ssh_conn_id=self.ssh_conn_id,
-                                            timeout=self.timeout)
+                    if self.remote_host is not None:
+                        self.ssh_hook = SSHHook(ssh_conn_id=self.ssh_conn_id, remote_host=self.remote_host
+                                                timeout=self.timeout)
+                    else: 
+                        self.ssh_hook = SSHHook(ssh_conn_id=self.ssh_conn_id,
+                                                timeout=self.timeout)
 
             if not self.ssh_hook:
                 raise AirflowException("Cannot operate without ssh_hook or ssh_conn_id.")
@@ -84,7 +92,6 @@ class SSHOperator(BaseOperator):
                 self.log.info("remote_host is provided explicitly. " +
                               "It will replace the remote_host which was defined " +
                               "in ssh_hook or predefined in connection of ssh_conn_id.")
-                self.ssh_hook.remote_host = self.remote_host
 
             if not self.command:
                 raise AirflowException("SSH command not specified. Aborting.")

--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -76,8 +76,8 @@ class SSHOperator(BaseOperator):
                 else:
                     self.log.info("ssh_hook is not provided or invalid. " +
                                   "Trying ssh_conn_id to create SSHHook.")
-                    self.ssh_hook = SSHHook(ssh_conn_id=self.ssh_conn_id, remote_host=self.remote_host
-                                                timeout=self.timeout)
+                    self.ssh_hook = SSHHook(ssh_conn_id=self.ssh_conn_id, remote_host=self.remote_host,
+                                            timeout=self.timeout)
 
             if not self.ssh_hook:
                 raise AirflowException("Cannot operate without ssh_hook or ssh_conn_id.")

--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -82,7 +82,7 @@ class SSHOperator(BaseOperator):
             if not self.ssh_hook:
                 raise AirflowException("Cannot operate without ssh_hook or ssh_conn_id.")
 
-            if self.remote_host is not None:
+            if self.remote_host:
                 self.log.info("remote_host is provided explicitly. " +
                               "It will replace the remote_host which was defined " +
                               "in ssh_hook or predefined in connection of ssh_conn_id.")

--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -71,18 +71,12 @@ class SSHOperator(BaseOperator):
             if self.ssh_conn_id:
                 if self.ssh_hook and isinstance(self.ssh_hook, SSHHook):
                     self.log.info("ssh_conn_id is ignored when ssh_hook is provided.")
-                    
-                if self.remote_host is not None:
-                    self.ssh_hook.remote_host = self.remote_host
-
+                    if self.remote_host:
+                        self.ssh_hook.remote_host = self.remote_host
                 else:
                     self.log.info("ssh_hook is not provided or invalid. " +
                                   "Trying ssh_conn_id to create SSHHook.")
-                    if self.remote_host is not None:
-                        self.ssh_hook = SSHHook(ssh_conn_id=self.ssh_conn_id, remote_host=self.remote_host
-                                                timeout=self.timeout)
-                    else: 
-                        self.ssh_hook = SSHHook(ssh_conn_id=self.ssh_conn_id,
+                    self.ssh_hook = SSHHook(ssh_conn_id=self.ssh_conn_id, remote_host=self.remote_host
                                                 timeout=self.timeout)
 
             if not self.ssh_hook:


### PR DESCRIPTION
The default method of overriding the remote_host for a SSHHook connection  that is creating in the operator should be to do so via the SSHHook constructor rather than updating an instance variable after creation.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

The code path is unchanged and already covered by existing unit tests.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
