### PR TITLE
[AIRFLOW-4363] Fix Json encoding error when retrieving `status` from cli in docker operator

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -197,7 +197,7 @@ class DockerOperator(BaseOperator):
             )
 
         if self.force_pull or len(self.cli.images(name=self.image)) == 0:
-            self.log.info('Pulling docker image %s', self.image)
+            self.log.info('Pulling docker image %s', self.image, decode=True)
             for l in self.cli.pull(self.image, stream=True):
                 output = json.loads(l.decode('utf-8').strip())
                 if 'status' in output:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

[Update]: AIRFLOW-4363

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Issue: When using the `docker_operator`, I experienced some issue while using Mac OS 10.14.4. The error was `json.JSONDecodeError`. After my investigation about this error, I found that there are several messages for logging aren't well separated, for example it contains `\n` inside one single message which should be split into 2 to more different messages.

What my PR do: add try-catch for reading to json, if it encounter `json.JSONDecodeError` again, we should either split by `\n` and then find `status` to be logged or just print all the payload instead of throw an error just due to an non-critical issue like this.

### Tests

- [] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
