### PR TITLE
[AIRFLOW-4360] Add performance metrics for Webserver UI.

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -62,7 +62,7 @@ from airflow.utils.state import State
 from airflow._vendor import nvd3
 from airflow.www import utils as wwwutils
 from airflow.www.app import app, appbuilder
-from airflow.www.decorators import action_logging, gzipped, has_dag_access
+from airflow.www.decorators import action_logging, gzipped, has_dag_access, log_webserver_stats
 from airflow.www.forms import (DateTimeForm, DateTimeWithNumRunsForm,
                                DateTimeWithNumRunsWithDagRunsForm,
                                DagRunForm, ConnectionForm)
@@ -505,6 +505,7 @@ class Airflow(AirflowBaseView):
     @has_dag_access(can_dag_read=True)
     @has_access
     @action_logging
+    @log_webserver_stats('ajax_logs_fetch', log_duration=True, log_failures=True)
     @provide_session
     def get_logs_with_metadata(self, session=None):
         dag_id = request.args.get('dag_id')
@@ -579,6 +580,7 @@ class Airflow(AirflowBaseView):
     @has_dag_access(can_dag_read=True)
     @has_access
     @action_logging
+    @log_webserver_stats('log', log_views=True, log_failures=True)
     @provide_session
     def log(self, session=None):
         dag_id = request.args.get('dag_id')
@@ -1145,6 +1147,7 @@ class Airflow(AirflowBaseView):
     @has_access
     @gzipped
     @action_logging
+    @log_webserver_stats('tree_view', log_views=True, log_duration=True, log_failures=True)
     def tree(self):
         default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_id = request.args.get('dag_id')
@@ -1280,6 +1283,7 @@ class Airflow(AirflowBaseView):
     @has_access
     @gzipped
     @action_logging
+    @log_webserver_stats('graph_view', log_views=True, log_duration=True, log_failures=True)
     @provide_session
     def graph(self, session=None):
         dag_id = request.args.get('dag_id')

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -42,18 +42,20 @@ Add the following lines to your configuration file e.g. ``airflow.cfg``
 Counters
 --------
 
-=================================== ================================================================
-Name                                Description
-=================================== ================================================================
-<job_name>_start                    Number of started <job_name> job, ex. SchedulerJob, LocalTaskJob
-<job_name>_end                      Number of ended <job_name> job, ex. SchedulerJob, LocalTaskJob
-operator_failures_<operator_name>   Operator <operator_name> failures
-operator_successes_<operator_name>  Operator <operator_name> successes
-ti_failures                         Overall task instances failures
-ti_successes                        Overall task instances successes
-zombies_killed                      Zombie tasks killed
-scheduler_heartbeat                 Scheduler heartbeats
-=================================== ================================================================
+========================================= ================================================================
+Name                                      Description
+========================================= ================================================================
+<job_name>_start                          Number of started <job_name> job, ex. SchedulerJob, LocalTaskJob
+<job_name>_end                            Number of ended <job_name> job, ex. SchedulerJob, LocalTaskJob
+operator_failures_<operator_name>         Operator <operator_name> failures
+operator_successes_<operator_name>        Operator <operator_name> successes
+ti_failures                               Overall task instances failures
+ti_successes                              Overall task instances successes
+zombies_killed                            Zombie tasks killed
+scheduler_heartbeat                       Scheduler heartbeats
+webserver.<endpoint>.load_failures        Number of failures for specified Webserver endpoint.
+webserver.<endpoint>.views                Number of views on the endpoint.
+========================================= ================================================================
 
 Gauges
 ------
@@ -75,13 +77,14 @@ pool.starving_tasks.<pool_name>                 Number of starving tasks in the 
 Timers
 ------
 
-================================= =================================================
-Name                              Description
-================================= =================================================
-dagrun.dependency-check.<dag_id>  Seconds taken to check DAG dependencies
-dag.<dag_id>.<task_id>.duration   Seconds taken to finish a task
-dagrun.duration.success.<dag_id>  Seconds taken for a DagRun to reach success state
-dagrun.duration.failed.<dag_id>   Seconds taken for a DagRun to reach failed state
-dagrun.schedule_delay.<dag_id>    Seconds of delay between the scheduled DagRun
-                                  start date and the actual DagRun start date
-================================= =================================================
+=========================================== =================================================
+Name                                        Description
+=========================================== =================================================
+dagrun.dependency-check.<dag_id>            Seconds taken to check DAG dependencies
+dag.<dag_id>.<task_id>.duration             Seconds taken to finish a task
+dagrun.duration.success.<dag_id>            Seconds taken for a DagRun to reach success state
+dagrun.duration.failed.<dag_id>             Seconds taken for a DagRun to reach failed state
+dagrun.schedule_delay.<dag_id>              Seconds of delay between the scheduled DagRun
+                                            start date and the actual DagRun start date
+webserver.<endpoint>.load_time              Time it takes to load server side data
+=========================================== =================================================


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [AIRFLOW-4360](https://issues.apache.org/jira/browse/AIRFLOW-4360) issues and references them in the PR title.

### Description

This PR extends Statsd usage for tracking webserver metrics as well. For starters, we track: 
1) Log page hits, and log fetching latency + failures.
2) Tree view and graph view latency + load failures.

### Tests

Once enabled, you can see the following new counters in Statsd :
```
{ counters:
   { 'statsd.bad_lines_seen': 0,
     'statsd.packets_received': 68,
     'statsd.metrics_received': 68,
     'airflow.scheduler_heartbeat': 2,
     'airflow.webserver.tree_view.views': 0,
     'airflow.webserver.tree_view.load_failures': 0,
     'airflow.webserver.graph_view.views': 0,
     'airflow.webserver.graph_view.load_failures': 0,
     'airflow.webserver.log.views': 1,
     'airflow.webserver.log.load_failures': 0,
     'airflow.webserver.ajax_logs_fetch.load_failures': 0 },
  timers:
   { 'airflow.webserver.tree_view.load_time': [],
     'airflow.webserver.graph_view.load_time': [],
     'airflow.webserver.ajax_logs_fetch.load_time': [ 17.852 ] },
  gauges:
   { 'airflow.collect_dags': 0.046903,
     'airflow.dagbag_size': 1,
     'airflow.dagbag_import_errors': 0,
     'statsd.timestamp_lag': 0,
     'airflow.pool.starving_tasks.not_pooled': 0 },
  timer_data:
   { 'airflow.webserver.tree_view.load_time': { count_ps: 0, count: 0 },
     'airflow.webserver.graph_view.load_time': { count_ps: 0, count: 0 },
     'airflow.webserver.ajax_logs_fetch.load_time':
      { count_90: 1,
        mean_90: 17.852,
        upper_90: 17.852,
        sum_90: 17.852,
        sum_squares_90: 318.69390400000003,
        std: 0,
        upper: 17.852,
        lower: 17.852,
        count: 1,
        count_ps: 0.1,
        sum: 17.852,
        sum_squares: 318.69390400000003,
        mean: 17.852,
        median: 17.852 } },
  counter_rates:
   { 'statsd.bad_lines_seen': 0,
     'statsd.packets_received': 6.8,
     'statsd.metrics_received': 6.8,
     'airflow.scheduler_heartbeat': 0.2,
     'airflow.webserver.tree_view.views': 0,
     'airflow.webserver.tree_view.load_failures': 0,
     'airflow.webserver.graph_view.views': 0,
     'airflow.webserver.graph_view.load_failures': 0,
     'airflow.webserver.log.views': 0.1,
     'airflow.webserver.log.load_failures': 0,
     'airflow.webserver.ajax_logs_fetch.load_failures': 0 },
  sets: {},
  pctThreshold: [ 90 ] }
```

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
