### PR TITLE
[AIRFLOW-4361] Fix flaky test_integration_run_dag_with_scheduler_failure

### DIFF
--- a/tests/contrib/minikube/test_kubernetes_executor.py
+++ b/tests/contrib/minikube/test_kubernetes_executor.py
@@ -21,6 +21,8 @@ import unittest
 from subprocess import check_call, check_output
 import requests.exceptions
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 import time
 import six
 import re
@@ -58,6 +60,19 @@ class KubernetesExecutorTest(unittest.TestCase):
         if names:
             check_call(['kubectl', 'delete', 'pod', names[0]])
 
+    def _get_session_with_retries(self):
+        session = requests.Session()
+        retries = Retry(total=3, backoff_factor=1)
+        session.mount('http://', HTTPAdapter(max_retries=retries))
+        session.mount('https://', HTTPAdapter(max_retries=retries))
+        return session
+
+    def setUp(self):
+        self.session = self._get_session_with_retries()
+
+    def tearDown(self):
+        self.session.close()
+
     def monitor_task(self, host, execution_date, dag_id, task_id, expected_final_state,
                      timeout):
         tries = 0
@@ -69,7 +84,7 @@ class KubernetesExecutorTest(unittest.TestCase):
 
             # Trigger a new dagrun
             try:
-                result = requests.get(
+                result = self.session.get(
                     'http://{host}/api/experimental/dags/{dag_id}/'
                     'dag_runs/{execution_date}/tasks/{task_id}'
                     .format(host=host,
@@ -104,7 +119,7 @@ class KubernetesExecutorTest(unittest.TestCase):
             time.sleep(5)
 
             # Trigger a new dagrun
-            result = requests.get(
+            result = self.session.get(
                 'http://{host}/api/experimental/dags/{dag_id}/'
                 'dag_runs/{execution_date}'
                 .format(host=host,
@@ -129,7 +144,7 @@ class KubernetesExecutorTest(unittest.TestCase):
         # Maybe check if we can retrieve the logs, but then we need to extend the API
 
     def start_dag(self, dag_id, host):
-        result = requests.get(
+        result = self.session.get(
             'http://{host}/api/experimental/'
             'dags/{dag_id}/paused/false'.format(host=host, dag_id=dag_id)
         )
@@ -142,7 +157,7 @@ class KubernetesExecutorTest(unittest.TestCase):
                          .format(result=result_json))
 
         # Trigger a new dagrun
-        result = requests.post(
+        result = self.session.post(
             'http://{host}/api/experimental/'
             'dags/{dag_id}/dag_runs'.format(host=host, dag_id=dag_id),
             json={}
@@ -157,7 +172,7 @@ class KubernetesExecutorTest(unittest.TestCase):
 
         time.sleep(1)
 
-        result = requests.get(
+        result = self.session.get(
             'http://{}/api/experimental/latest_runs'.format(host)
         )
         self.assertEqual(result.status_code, 200, "Could not get the latest DAG-run:"


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4361

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Add retries so that tests will not fail because of intermittent failure. 

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Fixing tests...

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
