### PR TITLE
[AIRFLOW-4377] Remove needless type conversion in DAG.owner()

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -542,7 +542,13 @@ class DAG(BaseDag, LoggingMixin):
 
     @property
     def owner(self):
-        return ", ".join(list(set([t.owner for t in self.tasks])))
+        """
+        Return list of all owners found in DAG tasks.
+
+        :return: Comma separated list of owners in DAG tasks
+        :rtype: str
+        """
+        return ", ".join({t.owner for t in self.tasks})
 
     @provide_session
     def _get_concurrency_reached(self, session=None):


### PR DESCRIPTION
Small optimisation to `DAG.owner()`. The conversion from list to set to list is unnecessary and removing it results in a small speedup. Also added pydoc.

Current implementation:

```bash
python -m timeit -n 1000000 '", ".join(list(set([i for i in ["test"]*100])))'
1000000 loops, best of 3: 4.47 usec per loop
```

The list & set conversion is not needed, so:
```bash
python -m timeit -n 1000000 '", ".join({i for i in ["test"]*100})'
1000000 loops, best of 3: 2.67 usec per loop
```

----------

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4377
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
