### PR TITLE
[AIRFLOW-3407] Make BaseOperator calls super().__init__

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -274,7 +274,7 @@ class BaseOperator(LoggingMixin):
         *args,
         **kwargs
     ):
-
+        super().__init__(*args, **kwargs)
         if args or kwargs:
             # TODO remove *args and **kwargs in Airflow 2.0
             warnings.warn(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3407

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Make `BaseOperator` calls `super().__init__`

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

no change to logic

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
