### PR TITLE
[AIRFLOW-4385] Add namespace into pod's yaml

### DIFF
--- a/airflow/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -123,6 +123,10 @@ class KubernetesRequestFactory(metaclass=ABCMeta):
         req['metadata']['name'] = pod.name
 
     @staticmethod
+    def extract_namespace(pod, req):
+        req['metadata']['namespace'] = pod.namespace
+
+    @staticmethod
     def extract_volume_secrets(pod, req):
         vol_secrets = [s for s in pod.secrets if s.deploy_type == 'volume']
         if any(vol_secrets):

--- a/airflow/kubernetes/kubernetes_request_factory/pod_request_factory.py
+++ b/airflow/kubernetes/kubernetes_request_factory/pod_request_factory.py
@@ -31,6 +31,7 @@ class SimplePodRequestFactory(KubernetesRequestFactory):
     _yaml = """apiVersion: v1
 kind: Pod
 metadata:
+  namespace: default
   name: name
 spec:
   containers:
@@ -47,6 +48,7 @@ spec:
     def create(self, pod: Pod) -> Dict:
         req = yaml.safe_load(self._yaml)
         self.extract_name(pod, req)
+        self.extract_namespace(pod, req)
         self.extract_labels(pod, req)
         self.extract_image(pod, req)
         self.extract_image_pull_policy(pod, req)
@@ -82,6 +84,7 @@ class ExtractXcomPodRequestFactory(KubernetesRequestFactory):
     _yaml = """apiVersion: v1
 kind: Pod
 metadata:
+  namespace: default
   name: name
 spec:
   volumes:
@@ -118,6 +121,7 @@ spec:
     def create(self, pod: Pod) -> Dict:
         req = yaml.safe_load(self._yaml)
         self.extract_name(pod, req)
+        self.extract_namespace(pod, req)
         self.extract_labels(pod, req)
         self.extract_image(pod, req)
         self.extract_image_pull_policy(pod, req)

--- a/tests/kubernetes/kubernetes_request_factory/test_kubernetes_request_factory.py
+++ b/tests/kubernetes/kubernetes_request_factory/test_kubernetes_request_factory.py
@@ -32,6 +32,7 @@ class TestKubernetesRequestFactory(unittest.TestCase):
             'apiVersion': 'v1',
             'kind': 'Pod',
             'metadata': {
+                'namespace': 'default',
                 'name': 'name'
             },
             'spec': {
@@ -146,6 +147,13 @@ class TestKubernetesRequestFactory(unittest.TestCase):
         pod = Pod('v3.14', {}, [], name=name)
         self.expected['metadata']['name'] = name
         KubernetesRequestFactory.extract_name(pod, self.input_req)
+        self.assertEqual(self.input_req, self.expected)
+
+    def test_extract_namespace(self):
+        namespace = 'default'
+        pod = Pod('v3.14', {}, [], namespace=namespace)
+        self.expected['metadata']['namespace'] = namespace
+        KubernetesRequestFactory.extract_namespace(pod, self.input_req)
         self.assertEqual(self.input_req, self.expected)
 
     def test_extract_volume_secrets(self):

--- a/tests/kubernetes/kubernetes_request_factory/test_pod_request_factory.py
+++ b/tests/kubernetes/kubernetes_request_factory/test_pod_request_factory.py
@@ -67,6 +67,7 @@ class TestPodRequestFactory(unittest.TestCase):
             'apiVersion': 'v1',
             'kind': 'Pod',
             'metadata': {
+                'namespace': 'default',
                 'name': 'myapp-pod',
                 'labels': {'app': 'myapp'},
                 'annotations': {}},


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4385

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Pod's yaml doesn't contain any info regarding namespace

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: minor changes

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
