### PR TITLE
[AIRFLOW-XXX] Name default config_file param in KubernetesPodOperator docstring

### DIFF
--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -71,7 +71,8 @@ class KubernetesPodOperator(BaseOperator):
     :type affinity: dict
     :param node_selectors: A dict containing a group of scheduling rules
     :type node_selectors: dict
-    :param config_file: The path to the Kubernetes config file
+    :param config_file: The path to the Kubernetes config file.
+        If not specified, default value is ``~/.kube/config``
     :type config_file: str
     :param do_xcom_push: If True, the content of the file
         /airflow/xcom/return.json in the container will also be pushed to an


### PR DESCRIPTION
Wasn't able to re-open #5138 after the rebase