### PR TITLE
[AIRFLOW-4386] Remove urlparse and replace it with urllib.parse

### DIFF
--- a/airflow/contrib/example_dags/example_gcp_sql.py
+++ b/airflow/contrib/example_dags/example_gcp_sql.py
@@ -29,6 +29,7 @@ https://airflow.apache.org/concepts.html#variables
 """
 
 import os
+from urllib.parse import urlsplit
 
 import airflow
 from airflow import models
@@ -40,8 +41,6 @@ from airflow.contrib.operators.gcp_sql_operator import CloudSqlInstanceCreateOpe
 from airflow.contrib.operators.gcs_acl_operator import \
     GoogleCloudStorageBucketCreateAclEntryOperator, \
     GoogleCloudStorageObjectCreateAclEntryOperator
-
-from six.moves.urllib.parse import urlsplit
 
 # [START howto_operator_cloudsql_arguments]
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')

--- a/airflow/contrib/example_dags/example_gcp_sql_query.py
+++ b/airflow/contrib/example_dags/example_gcp_sql_query.py
@@ -41,8 +41,7 @@ This DAG relies on the following OS environment variables
 import os
 import subprocess
 from os.path import expanduser
-
-from six.moves.urllib.parse import quote_plus
+from urllib.parse import quote_plus
 
 import airflow
 from airflow import models

--- a/airflow/contrib/hooks/gcp_sql_hook.py
+++ b/airflow/contrib/hooks/gcp_sql_hook.py
@@ -33,7 +33,7 @@ import os.path
 
 from googleapiclient.errors import HttpError
 from subprocess import Popen, PIPE
-from six.moves.urllib.parse import quote_plus
+from urllib.parse import quote_plus
 
 import requests
 from googleapiclient.discovery import build

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -22,6 +22,7 @@ import os
 import shutil
 
 from google.cloud import storage
+from urllib.parse import urlparse
 
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 from airflow.exceptions import AirflowException
@@ -554,12 +555,6 @@ def _parse_gcs_url(gsurl):
     Given a Google Cloud Storage URL (gs://<bucket>/<blob>), returns a
     tuple containing the corresponding bucket and blob.
     """
-    # Python 3
-    try:
-        from urllib.parse import urlparse
-    # Python 2
-    except ImportError:
-        from urlparse import urlparse
 
     parsed_url = urlparse(gsurl)
     if not parsed_url.netloc:

--- a/airflow/contrib/utils/mlengine_operator_utils.py
+++ b/airflow/contrib/utils/mlengine_operator_utils.py
@@ -26,7 +26,7 @@ from airflow.contrib.operators.mlengine_operator import MLEngineBatchPredictionO
 from airflow.contrib.operators.dataflow_operator import DataFlowPythonOperator
 from airflow.exceptions import AirflowException
 from airflow.operators.python_operator import PythonOperator
-from six.moves.urllib.parse import urlsplit
+from urllib.parse import urlsplit
 
 
 def create_evaluate_ops(task_prefix,

--- a/airflow/utils/log/gcs_task_handler.py
+++ b/airflow/utils/log/gcs_task_handler.py
@@ -19,11 +19,12 @@
 import os
 
 from cached_property import cached_property
+from urllib.parse import urlparse
 
 from airflow import configuration
 from airflow.exceptions import AirflowException
-from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.file_task_handler import FileTaskHandler
+from airflow.utils.log.logging_mixin import LoggingMixin
 
 
 class GCSTaskHandler(FileTaskHandler, LoggingMixin):
@@ -167,13 +168,6 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
         Given a Google Cloud Storage URL (gs://<bucket>/<blob>), returns a
         tuple containing the corresponding bucket and blob.
         """
-        # Python 3
-        try:
-            from urllib.parse import urlparse
-        # Python 2
-        except ImportError:
-            from urlparse import urlparse
-
         parsed_url = urlparse(gsurl)
         if not parsed_url.netloc:
             raise AirflowException('Please provide a bucket name')

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -19,21 +19,21 @@
 #
 import logging
 import socket
-from typing import Any
 
 from flask import Flask
 from flask_appbuilder import AppBuilder, SQLA
 from flask_caching import Cache
 from flask_wtf.csrf import CSRFProtect
-from six.moves.urllib.parse import urlparse
-from werkzeug.wsgi import DispatcherMiddleware
+from typing import Any
+from urllib.parse import urlparse
 from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.wsgi import DispatcherMiddleware
 
-from airflow import settings
 from airflow import configuration as conf
+from airflow import settings
 from airflow.logging_config import configure_logging
-from airflow.www.static_config import configure_manifest_files
 from airflow.utils.json import AirflowJsonEncoder
+from airflow.www.static_config import configure_manifest_files
 
 app = None  # type: Any
 appbuilder = None

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -38,7 +38,7 @@ from flask import request, Response, Markup, url_for
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 import flask_appbuilder.models.sqla.filters as fab_sqlafilters
 import sqlalchemy as sqla
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 from airflow import configuration
 from airflow.models import BaseOperator

--- a/tests/contrib/hooks/test_gcp_mlengine_hook.py
+++ b/tests/contrib/hooks/test_gcp_mlengine_hook.py
@@ -16,20 +16,17 @@
 # under the License.
 
 import json
-import mock
 import unittest
 
-try:  # python 2
-    from urlparse import urlparse, parse_qsl
-except ImportError:  # python 3
-    from urllib.parse import urlparse, parse_qsl
+import mock
+import requests
+from google.auth.exceptions import GoogleAuthError
+from googleapiclient.discovery import build_from_document
+from googleapiclient.errors import HttpError
+from googleapiclient.http import HttpMockSequence
+from urllib.parse import urlparse, parse_qsl
 
 from airflow.contrib.hooks import gcp_mlengine_hook as hook
-from googleapiclient.errors import HttpError
-from googleapiclient.discovery import build_from_document
-from googleapiclient.http import HttpMockSequence
-from google.auth.exceptions import GoogleAuthError
-import requests
 
 cml_available = True
 try:

--- a/tests/contrib/operators/test_gcp_sql_operator_system_helper.py
+++ b/tests/contrib/operators/test_gcp_sql_operator_system_helper.py
@@ -27,7 +27,7 @@ from threading import Thread
 
 import time
 
-from six.moves.urllib.parse import urlsplit
+from urllib.parse import urlsplit
 
 from tests.contrib.utils.base_gcp_system_test_case import RetrieveVariables
 from tests.contrib.utils.gcp_authenticator import GcpAuthenticator, GCP_CLOUDSQL_KEY

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -17,16 +17,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import unittest
 from datetime import datetime
 from urllib.parse import parse_qs
 
 import mock
-import six
 from bs4 import BeautifulSoup
 
 from airflow.www import utils
-
-import unittest
 
 
 class UtilsTest(unittest.TestCase):

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -18,10 +18,11 @@
 # under the License.
 
 from datetime import datetime
+from urllib.parse import parse_qs
 
-from bs4 import BeautifulSoup
 import mock
-from six.moves.urllib.parse import parse_qs
+import six
+from bs4 import BeautifulSoup
 
 from airflow.www import utils
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4386

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The urlparse module is renamed to urllib.parse in Python 3.
This PR also optimize imports by reordering imports

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
