### PR TITLE
[AIRFLOW-XXX] Support multiple pep8 style checkers with same config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 110
-ignore = E731,W504
-exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,*/_vendor/*,node_modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,15 @@ upload-dir = docs/_build/html
 
 [easy_install]
 
+[flake8]
+# Flake8 picks up all the settings from pycodestyle _other_ than line length
+max-line-length = 110
+
+[pycodestyle]
+max-line-length = 110
+ignore = E731,W504
+exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,*/_vendor/*,node_modules
+
 [mypy]
 ignore_missing_imports = True
 


### PR DESCRIPTION
- [x] No Jira

### Description

- [x] Flake8 is based upon pycodestyle, and so is pyflakes which my editor
  uses (as it is less stringent but _much_ quicker). To support checkers
  simultaneously define the settings against pycodestlye so that both
  tools can pick them up.

  I have tested that flake8 does pick up these settings - if it didn't we
  would have a bunch of errors showing back up

### Tests

- [x] Existing tests still pass

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`