### PR TITLE
[AIRFLOW-XXX] Speed up tests for PythonSensor by 60s

### DIFF
--- a/tests/contrib/sensors/test_python_sensor.py
+++ b/tests/contrib/sensors/test_python_sensor.py
@@ -58,6 +58,7 @@ class PythonSensorTests(unittest.TestCase):
         t = PythonSensor(
             task_id='python_sensor_check_false',
             timeout=1,
+            poke_interval=0,
             python_callable=lambda: False,
             dag=self.dag)
         with self.assertRaises(AirflowSensorTimeout):


### PR DESCRIPTION
### Jira

- [x] No Jira

### Description

- [x] This _tried_ to set a timeout to 1 so that it only took 1 second to run
  this test, but it ended up sleeping for 60s (the default poke_interval)
  instead, often making this our slowest individual test case!

### Tests

- [x] n/a

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`