### PR TITLE
[AIRFLOW-XXX] Attempt to remove flakeyness of LocalExecutor

### DIFF
--- a/tests/executors/test_local_executor.py
+++ b/tests/executors/test_local_executor.py
@@ -21,7 +21,6 @@ import unittest
 
 from airflow.executors.local_executor import LocalExecutor
 from airflow.utils.state import State
-from airflow.utils.timeout import timeout
 
 
 class LocalExecutorTest(unittest.TestCase):
@@ -38,8 +37,8 @@ class LocalExecutorTest(unittest.TestCase):
 
         for i in range(self.TEST_SUCCESS_COMMANDS):
             key, command = success_key.format(i), success_command
-            executor.execute_async(key=key, command=command)
             executor.running[key] = True
+            executor.execute_async(key=key, command=command)
 
         # errors are propagated for some reason
         try:
@@ -49,11 +48,7 @@ class LocalExecutorTest(unittest.TestCase):
 
         executor.running['fail'] = True
 
-        if parallelism == 0:
-            with timeout(seconds=10):
-                executor.end()
-        else:
-            executor.end()
+        executor.end()
 
         if isinstance(executor.impl, LocalExecutor._LimitedParallelism):
             self.assertTrue(executor.queue.empty())


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] No Jira

### Description

- [x] Removing the timeout might seem like an odd way of fixing tests, but
  given this specific test case is running `true` or `false` the
  individual commands shouldn't take _long_, and when the
  LimitedParallelism mode we've seen tests fail with:

      > 48) FAIL: test_execution_limited_parallelism (tests.executors.test_local_executor.LocalExecutorTest)
      > ----------------------------------------------------------------------
      >    Traceback (most recent call last):
      >     tests/executors/test_local_executor.py line 77 in test_execution_limited_parallelism
      >       self.execution_parallelism(parallelism=test_parallelism)
      >     tests/executors/test_local_executor.py line 61 in execution_parallelism
      >       self.assertEqual(len(executor.running), 0)
      >    AssertionError: 1 != 0

  By removing this timeout we will let the commands finish, which is
  better than failing the whole test run!

### Tests

- [x] N/a

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`