### PR TITLE
[AIRFLOW-4394] Don't double test behaviour of BackfillJob from CLI tests

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -37,11 +37,13 @@ from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.settings import Session
 from airflow import models
+from tests.compat import mock
 
 import os
 
 dag_folder_path = '/'.join(os.path.realpath(__file__).split('/')[:-1])
 
+DEFAULT_DATE = timezone.make_aware(datetime(2015, 1, 1))
 TEST_DAG_FOLDER = os.path.join(
     os.path.dirname(dag_folder_path), 'dags')
 TEST_DAG_ID = 'unit_tests'
@@ -108,6 +110,21 @@ def create_mock_args(
 
 
 class TestCLI(unittest.TestCase):
+
+    EXAMPLE_DAGS_FOLDER = os.path.join(
+        os.path.dirname(
+            os.path.dirname(
+                os.path.dirname(os.path.realpath(__file__))
+            )
+        ),
+        "airflow/example_dags"
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        cls.dagbag = models.DagBag(include_examples=True)
+        cls.parser = cli.CLIFactory.get_parser()
+
     def setUp(self):
         self.gunicorn_master_proc = Mock(pid=None)
         self.children = MagicMock()
@@ -203,17 +220,6 @@ class TestCLI(unittest.TestCase):
             session.commit()
             session.close()
 
-        EXAMPLE_DAGS_FOLDER = os.path.join(
-            os.path.dirname(
-                os.path.dirname(
-                    os.path.dirname(os.path.realpath(__file__))
-                )
-            ),
-            "airflow/example_dags"
-        )
-
-        dagbag = models.DagBag(dag_folder=EXAMPLE_DAGS_FOLDER,
-                               include_examples=False)
         dag_ids = ['example_bash_operator',  # schedule_interval is '0 0 * * *'
                    'latest_only',  # schedule_interval is timedelta(hours=4)
                    'example_python_operator',  # schedule_interval=None
@@ -240,7 +246,7 @@ class TestCLI(unittest.TestCase):
             reset_dr_db(dag_id)
 
             p = subprocess.Popen(["airflow", "next_execution", dag_id,
-                                  "--subdir", EXAMPLE_DAGS_FOLDER],
+                                  "--subdir", self.EXAMPLE_DAGS_FOLDER],
                                  stdout=subprocess.PIPE)
             p.wait()
             stdout = []
@@ -251,7 +257,7 @@ class TestCLI(unittest.TestCase):
             # It prints `None` in such cases
             self.assertEqual(stdout[-1], "None")
 
-            dag = dagbag.dags[dag_id]
+            dag = self.dagbag.dags[dag_id]
             # Create a DagRun for each DAG, to prepare for next step
             dag.create_dagrun(
                 run_id='manual__' + now.isoformat(),
@@ -261,7 +267,7 @@ class TestCLI(unittest.TestCase):
             )
 
             p = subprocess.Popen(["airflow", "next_execution", dag_id,
-                                  "--subdir", EXAMPLE_DAGS_FOLDER],
+                                  "--subdir", self.EXAMPLE_DAGS_FOLDER],
                                  stdout=subprocess.PIPE)
             p.wait()
             stdout = []
@@ -270,3 +276,176 @@ class TestCLI(unittest.TestCase):
             self.assertEqual(stdout[-1], expected_output[i])
 
             reset_dr_db(dag_id)
+
+    @mock.patch("airflow.bin.cli.DAG.run")
+    def test_backfill(self, mock_run):
+        cli.backfill(self.parser.parse_args([
+            'backfill', 'example_bash_operator',
+            '-s', DEFAULT_DATE.isoformat()]))
+
+        mock_run.assert_called_with(
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
+            conf=None,
+            delay_on_limit_secs=1.0,
+            donot_pickle=False,
+            ignore_first_depends_on_past=False,
+            ignore_task_deps=False,
+            local=False,
+            mark_success=False,
+            pool=None,
+            rerun_failed_tasks=False,
+            run_backwards=False,
+            verbose=False,
+        )
+        mock_run.reset_mock()
+        dag = self.dagbag.get_dag('example_bash_operator')
+
+        with mock.patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+            cli.backfill(self.parser.parse_args([
+                'backfill', 'example_bash_operator', '-t', 'runme_0', '--dry_run',
+                '-s', DEFAULT_DATE.isoformat()]), dag=dag)
+
+        mock_stdout.seek(0, 0)
+        self.assertListEqual(
+            [
+                "Dry run of DAG example_bash_operator on {}\n".format(DEFAULT_DATE.isoformat()),
+                "Task runme_0\n",
+            ],
+            mock_stdout.readlines()
+        )
+
+        mock_run.assert_not_called()  # Dry run shouldn't run the backfill
+
+        cli.backfill(self.parser.parse_args([
+            'backfill', 'example_bash_operator', '--dry_run',
+            '-s', DEFAULT_DATE.isoformat()]), dag=dag)
+
+        mock_run.assert_not_called()  # Dry run shouldn't run the backfill
+
+        cli.backfill(self.parser.parse_args([
+            'backfill', 'example_bash_operator', '-l',
+            '-s', DEFAULT_DATE.isoformat()]), dag=dag)
+
+        mock_run.assert_called_with(
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
+            conf=None,
+            delay_on_limit_secs=1.0,
+            donot_pickle=False,
+            ignore_first_depends_on_past=False,
+            ignore_task_deps=False,
+            local=True,
+            mark_success=False,
+            pool=None,
+            rerun_failed_tasks=False,
+            run_backwards=False,
+            verbose=False,
+        )
+        mock_run.reset_mock()
+
+    @mock.patch("airflow.bin.cli.DAG.run")
+    def test_cli_backfill_depends_on_past(self, mock_run):
+        """
+        Test that CLI respects -I argument
+
+        We just check we call dag.run() right. The behaviour of that kwarg is
+        tested in test_jobs
+        """
+        dag_id = 'test_dagrun_states_deadlock'
+        run_date = DEFAULT_DATE + timedelta(days=1)
+        args = [
+            'backfill',
+            dag_id,
+            '-l',
+            '-s',
+            run_date.isoformat(),
+            '-I',
+        ]
+        dag = self.dagbag.get_dag(dag_id)
+
+        cli.backfill(self.parser.parse_args(args), dag=dag)
+
+        mock_run.assert_called_with(
+            start_date=run_date,
+            end_date=run_date,
+            conf=None,
+            delay_on_limit_secs=1.0,
+            donot_pickle=False,
+            ignore_first_depends_on_past=True,
+            ignore_task_deps=False,
+            local=True,
+            mark_success=False,
+            pool=None,
+            rerun_failed_tasks=False,
+            run_backwards=False,
+            verbose=False,
+        )
+
+    @mock.patch("airflow.bin.cli.DAG.run")
+    def test_cli_backfill_depends_on_past_backwards(self, mock_run):
+        """
+        Test that CLI respects -B argument and raises on interaction with depends_on_past
+        """
+        dag_id = 'test_depends_on_past'
+        start_date = DEFAULT_DATE + timedelta(days=1)
+        end_date = start_date + timedelta(days=1)
+        args = [
+            'backfill',
+            dag_id,
+            '-l',
+            '-s',
+            start_date.isoformat(),
+            '-e',
+            end_date.isoformat(),
+            '-I',
+            '-B',
+        ]
+        dag = self.dagbag.get_dag(dag_id)
+
+        cli.backfill(self.parser.parse_args(args), dag=dag)
+        mock_run.assert_called_with(
+            start_date=start_date,
+            end_date=end_date,
+            conf=None,
+            delay_on_limit_secs=1.0,
+            donot_pickle=False,
+            ignore_first_depends_on_past=True,
+            ignore_task_deps=False,
+            local=True,
+            mark_success=False,
+            pool=None,
+            rerun_failed_tasks=False,
+            run_backwards=True,
+            verbose=False,
+        )
+
+    @mock.patch("airflow.bin.cli.jobs.LocalTaskJob")
+    def test_run_naive_taskinstance(self, mock_local_job):
+        """
+        Test that we can run naive (non-localized) task instances
+        """
+        NAIVE_DATE = datetime(2016, 1, 1)
+        dag_id = 'test_run_ignores_all_dependencies'
+
+        dag = self.dagbag.get_dag('test_run_ignores_all_dependencies')
+
+        task0_id = 'test_run_dependent_task'
+        args0 = ['run',
+                 '-A',
+                 '--local',
+                 dag_id,
+                 task0_id,
+                 NAIVE_DATE.isoformat()]
+
+        cli.run(self.parser.parse_args(args0), dag=dag)
+        mock_local_job.assert_called_with(
+            task_instance=mock.ANY,
+            mark_success=False,
+            ignore_all_deps=True,
+            ignore_depends_on_past=False,
+            ignore_task_deps=False,
+            ignore_ti_state=False,
+            pickle_id=None,
+            pool=None,
+        )

--- a/tests/core.py
+++ b/tests/core.py
@@ -1717,23 +1717,6 @@ class CliTests(unittest.TestCase):
         with self.assertRaises(AirflowException):
             cli.get_dags(self.parser.parse_args(['clear', 'foobar', '-dx', '-c']))
 
-    def test_backfill(self):
-        cli.backfill(self.parser.parse_args([
-            'backfill', 'example_bash_operator',
-            '-s', DEFAULT_DATE.isoformat()]))
-
-        cli.backfill(self.parser.parse_args([
-            'backfill', 'example_bash_operator', '-t', 'runme_0', '--dry_run',
-            '-s', DEFAULT_DATE.isoformat()]))
-
-        cli.backfill(self.parser.parse_args([
-            'backfill', 'example_bash_operator', '--dry_run',
-            '-s', DEFAULT_DATE.isoformat()]))
-
-        cli.backfill(self.parser.parse_args([
-            'backfill', 'example_bash_operator', '-l',
-            '-s', DEFAULT_DATE.isoformat()]))
-
     def test_process_subdir_path_with_placeholder(self):
         self.assertEqual(os.path.join(settings.DAGS_FOLDER, 'abc'), cli.process_subdir('DAGS_FOLDER/abc'))
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4394

### Description

- [x] It is slow, and we already have tests of that behaviour. All we need to
  test is that we call `dag.run()` correctly. Mocking ftw.


### Tests

- [x] Extended (and moved) existing tests

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`