### PR TITLE
[AIRFLOW-4399] Avoid duplicated os.path.isfile() check in models.dagbag

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -173,7 +173,7 @@ class DagBag(BaseDagBag, LoggingMixin):
         mods = []
         is_zipfile = zipfile.is_zipfile(filepath)
         if not is_zipfile:
-            if safe_mode and os.path.isfile(filepath):
+            if safe_mode:
                 with open(filepath, 'rb') as f:
                     content = f.read()
                     if not all([s in content for s in (b'DAG', b'airflow')]):


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-4399

### Description

The check which is removed in this commit always returns `True` for sure, because the same check has already been done earlier in this function body https://github.com/apache/airflow/blob/de1795c8f1e65a5f4a848e88ef3848ba51aab449/airflow/models/dagbag.py#L157-L158

