### PR TITLE
[AIRFLOW-4397] Add GCSUploadSessionCompleteSensor

### DIFF
--- a/airflow/contrib/sensors/gcs_sensor.py
+++ b/airflow/contrib/sensors/gcs_sensor.py
@@ -193,8 +193,7 @@ class GoogleCloudStorageUploadSessionCompleteSensor(BaseSensorOperator):
     :param min_files: The minimum number of files needed for upload session
         to be considered valid.
     :type min_files: int
-    :param previous_num_files: The previous number of files before the next
-        iteration.
+    :param previous_num_files: The number of files found during the last poke.
     :type previous_num_files: int
     :param inactivity_seconds: The current seconds of the inactivity period.
     :type inactivity_seconds: int

--- a/airflow/contrib/sensors/gcs_sensor.py
+++ b/airflow/contrib/sensors/gcs_sensor.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 import os
 from datetime import datetime
 
@@ -125,7 +126,7 @@ class GoogleCloudStorageObjectUpdatedSensor(BaseSensorOperator):
 
 class GoogleCloudStoragePrefixSensor(BaseSensorOperator):
     """
-    Checks for the existence of a files at prefix in Google Cloud Storage bucket.
+    Checks for the existence of a objects at prefix in Google Cloud Storage bucket.
 
     :param bucket: The Google cloud storage bucket where the object is.
     :type bucket: str
@@ -175,9 +176,9 @@ def get_time():
 
 class GoogleCloudStorageUploadSessionCompleteSensor(BaseSensorOperator):
     """
-    Checks for changes in the number of files at prefix in Google Cloud Storage
+    Checks for changes in the number of objects at prefix in Google Cloud Storage
     bucket and returns True if the inactivity period has passed with no
-    increase in the number of files. Note, it is recommended to use reschedule
+    increase in the number of objects. Note, it is recommended to use reschedule
     mode if you expect this sensor to run for hours.
 
     :param bucket: The Google cloud storage bucket where the objects are.
@@ -188,15 +189,19 @@ class GoogleCloudStorageUploadSessionCompleteSensor(BaseSensorOperator):
     :param inactivity_period: The total seconds of inactivity to designate
         an upload session is over. Note, this mechanism is not real time and
         this operator may not return until a poke_interval after this period
-        has passed with no additional files sensed.
+        has passed with no additional objects sensed.
     :type inactivity_period: int
-    :param min_files: The minimum number of files needed for upload session
+    :param min_objects: The minimum number of objects needed for upload session
         to be considered valid.
-    :type min_files: int
-    :param previous_num_files: The number of files found during the last poke.
-    :type previous_num_files: int
+    :type min_objects: int
+    :param previous_num_objects: The number of objects found during the last poke.
+    :type previous_num_objects: int
     :param inactivity_seconds: The current seconds of the inactivity period.
     :type inactivity_seconds: int
+    :param allow_delete: Should this sensor consider objects being deleted
+        between pokes valid behavior. If true a warning message will be logged
+        when this happens. If false an error will be raised.
+    :type allow_delete: bool
     :param google_cloud_conn_id: The connection ID to use when connecting
         to Google cloud storage.
     :type google_cloud_conn_id: str
@@ -214,8 +219,9 @@ class GoogleCloudStorageUploadSessionCompleteSensor(BaseSensorOperator):
                  bucket,
                  prefix,
                  inactivity_period=60 * 60,
-                 min_files=1,
-                 previous_num_files=0,
+                 min_objects=1,
+                 previous_num_objects=0,
+                 allow_delete=True,
                  google_cloud_conn_id='google_cloud_default',
                  delegate_to=None,
                  *args, **kwargs):
@@ -224,30 +230,52 @@ class GoogleCloudStorageUploadSessionCompleteSensor(BaseSensorOperator):
 
         self.bucket = bucket
         self.prefix = prefix
-        self.google_cloud_conn_id = google_cloud_conn_id
         self.inactivity_period = inactivity_period
-        self.min_files = min_files
-        self.previous_num_files = previous_num_files
+        self.min_objects = min_objects
+        self.previous_num_objects = previous_num_objects
         self.inactivity_seconds = 0
+        self.allow_delete=allow_delete
         self.google_cloud_conn_id = google_cloud_conn_id
         self.delegate_to = delegate_to
         self.last_activity_time = None
 
-    def is_bucket_updated(self, current_num_files):
+    def is_bucket_updated(self, current_num_objects):
         """
-        Checks whether new files have been uploaded and the inactivity_period
+        Checks whether new objects have been uploaded and the inactivity_period
         has passed and updates the state of the sensor accordingly.
 
-        :param current_num_files: number of files in bucket during last poke.
-        :type current_num_files: int
+        :param current_num_objects: number of objects in bucket during last poke.
+        :type current_num_objects: int
         """
 
-        if current_num_files > self.previous_num_files:
-            # When new files arrived, reset the inactivity_seconds
-            # previous_num_files for the next poke.
+        if current_num_objects > self.previous_num_objects:
+            # When new objects arrived, reset the inactivity_seconds
+            # previous_num_objects for the next poke.
+            self.log.info(
+                '''
+                New objects found at {} resetting last_activity_time.
+                '''.format(os.path.join(self.bucket, self.prefix)))
             self.last_activity_time = get_time()
             self.inactivity_seconds = 0
-            self.previous_num_files = current_num_files
+            self.previous_num_objects = current_num_objects
+        elif current_num_objects < self.previous_num_objects:
+            # During the last poke interval objects were deleted.
+            if self.allow_delete:
+                self.previous_num_objects = current_num_objects
+                self.last_activity_time = get_time()
+                self.log.warning(
+                    '''
+                    Objects were deleted during the last
+                    poke interval. Updating the file counter and
+                    resetting last_activity_time.
+                    '''
+                )
+            else:
+                raise RuntimeError(
+                    '''
+                    Illegal behavior: objects were deleted in {} between pokes.
+                    '''.format(os.path.join(self.bucket, self.prefix))
+                )
         else:
             if self.last_activity_time:
                 self.inactivity_seconds = (
@@ -257,23 +285,28 @@ class GoogleCloudStorageUploadSessionCompleteSensor(BaseSensorOperator):
                 self.last_activity_time = get_time()
                 self.inactivity_seconds = 0
 
-            if self.inactivity_seconds >= self.inactivity_period and \
-               current_num_files >= self.min_files:
-                self.log.info(
-                    '''
-                    SUCCESS:
-                    Sensor found {} files at {}.
-                    Waited at least {} seconds, with no new files dropped.
-                    '''.format(
-                        current_num_files,
-                        os.path.join(self.bucket, self.prefix),
-                        self.inactivity_period))
-                return True
+            if self.inactivity_seconds >= self.inactivity_period:
+                if current_num_objects >= self.min_objects:
+                    self.log.info(
+                        '''
+                        SUCCESS:
+                        Sensor found {} objects at {}.
+                        Waited at least {} seconds, with no new objects dropped.
+                        '''.format(
+                            current_num_objects,
+                            os.path.join(self.bucket, self.prefix),
+                            self.inactivity_period))
+                    return True
 
-            warn_msg = \
-                'Inactivity Period passed, not enough files found in {}'.format(
-                    os.path.join(self.bucket, self.prefix))
-            self.log.warn(warn_msg)
+                warn_msg = \
+                    '''
+                    FAILURE:
+                    Inactivity Period passed, 
+                    not enough objects found in {}
+                    '''.format(
+                        os.path.join(self.bucket, self.prefix))
+                self.log.warning(warn_msg)
+                return False
             return False
 
     def poke(self, context):

--- a/airflow/contrib/sensors/gcs_sensor.py
+++ b/airflow/contrib/sensors/gcs_sensor.py
@@ -234,7 +234,7 @@ class GoogleCloudStorageUploadSessionCompleteSensor(BaseSensorOperator):
         self.min_objects = min_objects
         self.previous_num_objects = previous_num_objects
         self.inactivity_seconds = 0
-        self.allow_delete=allow_delete
+        self.allow_delete = allow_delete
         self.google_cloud_conn_id = google_cloud_conn_id
         self.delegate_to = delegate_to
         self.last_activity_time = None
@@ -301,7 +301,7 @@ class GoogleCloudStorageUploadSessionCompleteSensor(BaseSensorOperator):
                 warn_msg = \
                     '''
                     FAILURE:
-                    Inactivity Period passed, 
+                    Inactivity Period passed,
                     not enough objects found in {}
                     '''.format(
                         os.path.join(self.bucket, self.prefix))

--- a/airflow/contrib/sensors/gcs_sensor.py
+++ b/airflow/contrib/sensors/gcs_sensor.py
@@ -16,6 +16,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import os
+
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
@@ -160,3 +162,105 @@ class GoogleCloudStoragePrefixSensor(BaseSensorOperator):
             google_cloud_storage_conn_id=self.google_cloud_conn_id,
             delegate_to=self.delegate_to)
         return bool(hook.list(self.bucket, prefix=self.prefix))
+
+
+class GoogleCloudStorageUploadSessionCompleteSensor(BaseSensorOperator):
+    """
+    Checks for changes in the number of files at prefix in Google Cloud Storage
+    bucket and returns True if the inactivity period has passed with no
+    increase in the number of files. Note, it is recommended to use reschedule
+    mode if you expect this sensor to run for hours.
+
+    :param bucket: The Google cloud storage bucket where the objects are.
+        expected.
+    :type bucket: str
+    :param prefix: The name of the prefix to check in the Google cloud
+        storage bucket.
+    :param inactivity_period: The total seconds of inactivity to designate
+        an upload session is over. Note, this mechanism is not real time and
+        this operator may not return until a poke_interval after this period
+        has passed with no additional files sensed.
+    :type inactivity_period: int
+    :param min_files: The minimum number of files needed for upload session
+        to be considered valid.
+    :type min_files: int
+    :param previous_num_files: The previous number of files before the next
+        iteration.
+    :type previous_num_files: int
+    :param inactivity_seconds: The current seconds of the inactivity period.
+    :type inactivity_seconds: int
+    :param google_cloud_conn_id: The connection ID to use when connecting
+        to Google cloud storage.
+    :type google_cloud_conn_id: str
+    :param delegate_to: The account to impersonate, if any. For this to work,
+        the service account making the request must have domain-wide
+        delegation enabled.
+    :type delegate_to: str
+    """
+
+    template_fields = ('bucket', 'prefix')
+    ui_color = '#f0eee4'
+
+    @apply_defaults
+    def __init__(self,
+                 bucket,
+                 prefix,
+                 inactivity_period=60 * 60,
+                 min_files=1,
+                 previous_num_files=0,
+                 google_cloud_conn_id='google_cloud_default',
+                 delegate_to=None,
+                 *args, **kwargs):
+
+        super(GoogleCloudStorageUploadSessionCompleteSensor, self).__init__(*args, **kwargs)
+
+        self.bucket = bucket
+        self.prefix = prefix
+        self.google_cloud_conn_id = google_cloud_conn_id
+        self.inactivity_period = inactivity_period
+        self.min_files = min_files
+        self.previous_num_files = previous_num_files
+        self.inactivity_seconds = 0
+        self.google_cloud_conn_id = google_cloud_conn_id
+        self.delegate_to = delegate_to
+
+    def is_bucket_updated(self, current_num_files):
+        """
+        Checks whether new files have been uploaded and the inactivity_period
+        has passed and updates the state of the sensor accordingly.
+
+        :param current_num_files: number of files in bucket during last poke.
+        :type current_num_files: int
+        """
+
+        if current_num_files > self.previous_num_files:
+            # When new files arrived, reset the inactivity_seconds
+            # previous_num_files for the next poke.
+            self.inactivity_seconds = 0
+            self.previous_num_files = current_num_files
+        else:
+            self.inactivity_seconds = self.inactivity_seconds \
+                + self.poke_interval
+
+            if self.inactivity_seconds >= self.inactivity_period and \
+               current_num_files >= self.min_files:
+                self.log.info(
+                    '''
+                    SUCCESS:
+                    Sensor found {} files at {}.
+                    Waited at least {} seconds, with no new files dropped.
+                    '''.format(
+                        current_num_files,
+                        os.path.join(self.bucket, self.prefix),
+                        self.inactivity_period))
+                return True
+
+            warn_msg = \
+                'Inactivity Period passed, not enough files found in {}'.format(
+                    os.path.join(self.bucket, self.prefix))
+            self.log.warn(warn_msg)
+            return False
+
+    def poke(self, context):
+        hook = GoogleCloudStorageHook()
+        return self.is_bucket_updated(len(hook.list(self.bucket, prefix=self.prefix)))

--- a/tests/contrib/sensors/test_gcs_upload_session_sensor.py
+++ b/tests/contrib/sensors/test_gcs_upload_session_sensor.py
@@ -111,7 +111,7 @@ class GoogleCloudStorageUploadSessionCompleteSensorTest(unittest.TestCase):
         self.sensor.is_bucket_updated(2)
         self.assertEqual(self.sensor.inactivity_seconds, 10)
         self.assertTrue(self.sensor.is_bucket_updated(2))
-    
+
     @mock.patch('airflow.contrib.sensors.gcs_sensor.get_time', mock_time)
     def test_incoming_data(self):
         self.sensor.is_bucket_updated(2)


### PR DESCRIPTION
This commit add a GoogleCloudStorageUploadSessionCompleteSensor
to address the use case of accepting files from a third party vendor
who refuses to send a success indicator when providing data files
into a bucket and waiting until an inactivity period has passed to
indicate the end of an upload session.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-4937](https://issues.apache.org/jira/browse/AIRFLOW-4397) issues and references them in the PR title. 


### Description

- [x]  This PR add a GCS sensor to poke a bucket until some inactivity period has passed with no new files added to the bucket.

### Tests

- [x] My PR adds the following unit tests: `tests/contrib/sensors/test_gcs_upload_session_sensor.py`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
