### PR TITLE
[AIRFLOW-3143] Support Auto-Zone in DataprocClusterCreateOperator

### DIFF
--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -57,9 +57,9 @@ CUSTOM_IMAGE = 'test-custom-image'
 MASTER_MACHINE_TYPE = 'n1-standard-2'
 MASTER_DISK_SIZE = 100
 MASTER_DISK_TYPE = 'pd-standard'
-WORKER_MACHINE_TYPE = 'n1-standard-2'
-WORKER_DISK_SIZE = 100
-WORKER_DISK_TYPE = 'pd-standard'
+WORKER_MACHINE_TYPE = 'n1-standard-4'
+WORKER_DISK_SIZE = 200
+WORKER_DISK_TYPE = 'pd-ssd'
 NUM_PREEMPTIBLE_WORKERS = 2
 GET_INIT_ACTION_TIMEOUT = "600s"  # 10m
 LABEL1 = {}  # type: Dict
@@ -258,6 +258,20 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
                       "only `auto_delete_time` is used")
         self.assertEqual(cluster_data['config']['lifecycleConfig']['autoDeleteTime'],
                          "2017-06-07T00:00:00.000000Z")
+
+    def test_build_cluster_data_with_auto_zone(self):
+        dataproc_operator = DataprocClusterCreateOperator(
+            task_id=TASK_ID,
+            cluster_name=CLUSTER_NAME,
+            project_id=GCP_PROJECT_ID,
+            num_workers=NUM_WORKERS,
+            master_machine_type=MASTER_MACHINE_TYPE,
+            worker_machine_type=WORKER_MACHINE_TYPE
+        )
+        cluster_data = dataproc_operator._build_cluster_data()
+        self.assertNotIn('zoneUri', cluster_data['config']['gceClusterConfig'])
+        self.assertEqual(cluster_data['config']['masterConfig']['machineTypeUri'], MASTER_MACHINE_TYPE)
+        self.assertEqual(cluster_data['config']['workerConfig']['machineTypeUri'], WORKER_MACHINE_TYPE)
 
     def test_init_with_image_version_and_custom_image_both_set(self):
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
Allows you to let GCP decide what zone to put your cluster on by setting zone
to `None` or a blank string, making the parameter optional. Per the API spec at
https://cloud.google.com/dataproc/docs/reference/rest/v1beta2/ClusterConfig#InstanceGroupConfig,
this means that all `machineTypeUri`s have to be in short form.

Make sure you have checked _all_ steps below.

### Jira

- [ X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3143
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:
Allows you to let GCP decide what zone to put your cluster on by setting zone
to `None` or a blank string, making the parameter optional.

### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Adds `tests.contrib.operators.test_dataproc_operator.DataprocClusterCreateOperatorTest:test_build_cluster_data_with_auto_zone`

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ X ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
Added a note to the docstring explaining that zone is now optional.

### Code Quality

- [ X ] Passes `flake8`
Lol, make everything else pass `flake8` first.