### PR TITLE
[AIRFLOW-XXX] Move article about defining links

### DIFF
--- a/docs/howto/define_extra_link.rst
+++ b/docs/howto/define_extra_link.rst
@@ -23,7 +23,7 @@ For each operator, you can define its own extra links that can
 redirect users to external systems. The extra link buttons
 will be available on the task page:
 
-.. image:: ../../img/operator_extra_link.png
+.. image:: ../img/operator_extra_link.png
 
 The following code shows how to add extra links to an operator:
 
@@ -32,7 +32,6 @@ The following code shows how to add extra links to an operator:
     from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
     from airflow.utils.decorators import apply_defaults
 
-    log = logging.getLogger(__name__)
 
     class GoogleLink(BaseOperatorLink):
 
@@ -50,4 +49,4 @@ The following code shows how to add extra links to an operator:
             super(MyFirstOperator, self).__init__(*args, **kwargs)
 
         def execute(self, context):
-            log.info("Hello World!")
+            self.log.info("Hello World!")

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -41,6 +41,7 @@ configuring an Airflow environment.
     run-with-upstart
     use-test-config
     check-health
+    define_extra_link
 
 .. toctree::
     :maxdepth: 2

--- a/docs/howto/operator/index.rst
+++ b/docs/howto/operator/index.rst
@@ -32,4 +32,3 @@ information.
     dingding
     gcp/index
     python
-    define_extra_link


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

This article describes how to **create** new operators. It has been placed in the section describing how to **use** operators. This can be confusing. I cleaned up the section on using operators earlier and I would not want to see a mess there. There is currently no good place to put this article, so i put him in this place temporarily. In the future this article may have been moved as part of the work of the ["Season of Docs 2019"](https://cwiki.apache.org/confluence/display/AIRFLOW/Season+of+Docs+2019) project

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
