### PR TITLE
[AIRFLOW-4228] DatabricksRunNowOperator missing from documentation

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -263,9 +263,9 @@ For more instructions on using Amazon SageMaker in Airflow, please see `the Sage
 Databricks
 ----------
 
-`Databricks <https://databricks.com/>`__ has contributed an Airflow operator which enables
-submitting runs to the Databricks platform. Internally the operator talks to the
-``api/2.0/jobs/runs/submit`` `endpoint <https://docs.databricks.com/api/latest/jobs.html#runs-submit>`_.
+With contributions from `Databricks <https://databricks.com/>`__, Airflow has several operators
+which enable the submitting and running of jobs to the Databricks platform. Internally the
+operators talk to the ``api/2.0/jobs/runs/submit`` `endpoint <https://docs.databricks.com/api/latest/jobs.html#runs-submit>`_.
 
 
 :class:`airflow.contrib.operators.databricks_operator.DatabricksSubmitRunOperator`
@@ -273,6 +273,12 @@ submitting runs to the Databricks platform. Internally the operator talks to the
     `api/2.0/jobs/runs/submit
     <https://docs.databricks.com/api/latest/jobs.html#runs-submit>`_
     API endpoint.
+
+:class:`airflow.contrib.operators.databricks_operator.DatabricksRunNowOperator`
+    Runs an existing Spark job in Databricks using the
+        `api/2.0/jobs/run-now
+        <https://docs.databricks.com/api/latest/jobs.html#run-now>`_
+        API endpoint.
 
 
 .. _GCP:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4228

### Description

- [x] Updated `integration.rst` to include `DatabricksRunNowOperator`.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - Documentation update, no tests needed.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
