### PR TITLE
[AIRFLOW-XXX] Reduce log spam in tests

### DIFF
--- a/tests/contrib/sensors/test_python_sensor.py
+++ b/tests/contrib/sensors/test_python_sensor.py
@@ -23,23 +23,17 @@ import unittest
 from airflow import DAG, configuration
 from airflow.contrib.sensors.python_sensor import PythonSensor
 from airflow.exceptions import AirflowSensorTimeout
-from airflow.models import DagBag
 from airflow.utils.timezone import datetime
 
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 TEST_DAG_ID = 'python_sensor_dag'
-DEV_NULL = '/dev/null'
 
 
 class PythonSensorTests(unittest.TestCase):
 
     def setUp(self):
         configuration.load_test_config()
-        self.dagbag = DagBag(
-            dag_folder=DEV_NULL,
-            include_examples=True
-        )
         self.args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE
@@ -57,8 +51,8 @@ class PythonSensorTests(unittest.TestCase):
     def test_python_sensor_false(self):
         t = PythonSensor(
             task_id='python_sensor_check_false',
-            timeout=1,
-            poke_interval=0,
+            timeout=0.01,
+            poke_interval=0.01,
             python_callable=lambda: False,
             dag=self.dag)
         with self.assertRaises(AirflowSensorTimeout):


### PR DESCRIPTION
### Jira

- [x] No Jira

### Description

- [x] The change I introduced in #5158 caused this sensor test to keep poking
in a busy loop, resulting in about **4k** lines to the logs like:

    > INFO  [airflow.task.operators] Poking callable: <function PythonSensorTests.test_python_sensor_false.<locals>.<lambda> at 0x7f354b1d0c80>

  The fix is to make sure that poke_interval is set to _something_ greater
than zero.

### Tests

- [x] n/a

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`