### PR TITLE
[AIRFLOW-3449] Write local dag parsing logs when remote logging enabled.

### DIFF
--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -139,13 +139,6 @@ REMOTE_HANDLERS = {
             's3_log_folder': REMOTE_BASE_LOG_FOLDER,
             'filename_template': FILENAME_TEMPLATE,
         },
-        'processor': {
-            'class': 'airflow.utils.log.s3_task_handler.S3TaskHandler',
-            'formatter': 'airflow',
-            'base_log_folder': os.path.expanduser(PROCESSOR_LOG_FOLDER),
-            's3_log_folder': REMOTE_BASE_LOG_FOLDER,
-            'filename_template': PROCESSOR_FILENAME_TEMPLATE,
-        },
     },
     'gcs': {
         'task': {
@@ -154,13 +147,6 @@ REMOTE_HANDLERS = {
             'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
             'gcs_log_folder': REMOTE_BASE_LOG_FOLDER,
             'filename_template': FILENAME_TEMPLATE,
-        },
-        'processor': {
-            'class': 'airflow.utils.log.gcs_task_handler.GCSTaskHandler',
-            'formatter': 'airflow',
-            'base_log_folder': os.path.expanduser(PROCESSOR_LOG_FOLDER),
-            'gcs_log_folder': REMOTE_BASE_LOG_FOLDER,
-            'filename_template': PROCESSOR_FILENAME_TEMPLATE,
         },
     },
     'wasb': {
@@ -171,15 +157,6 @@ REMOTE_HANDLERS = {
             'wasb_log_folder': REMOTE_BASE_LOG_FOLDER,
             'wasb_container': 'airflow-logs',
             'filename_template': FILENAME_TEMPLATE,
-            'delete_local_copy': False,
-        },
-        'processor': {
-            'class': 'airflow.utils.log.wasb_task_handler.WasbTaskHandler',
-            'formatter': 'airflow',
-            'base_log_folder': os.path.expanduser(PROCESSOR_LOG_FOLDER),
-            'wasb_log_folder': REMOTE_BASE_LOG_FOLDER,
-            'wasb_container': 'airflow-logs',
-            'filename_template': PROCESSOR_FILENAME_TEMPLATE,
             'delete_local_copy': False,
         },
     },
@@ -196,7 +173,7 @@ REMOTE_HANDLERS = {
     },
 }
 
-REMOTE_LOGGING = conf.get('core', 'remote_logging')
+REMOTE_LOGGING = conf.getboolean('core', 'remote_logging')
 
 # Only update the handlers and loggers when CONFIG_PROCESSOR_MANAGER_LOGGER is set.
 # This is to avoid exceptions when initializing RotatingFileHandler multiple times


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x]
  - https://issues.apache.org/jira/browse/AIRFLOW-3449

### Description

- [x] The default "processor" handler is a FileProcessorHandler (compare to
  FileTaskHandler as the default "task" handler) so setting this as a
  subclass of FileTaskHandler ended up with an invalid path for the
  processor logs, meaning they never got written to a file when remote
  logging is enabled.

  This was likely a mis-configuration introduced in #2793

### Tests

- [x] Just removing a config change, not worth testing.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`