### PR TITLE
[AIRFLOW-2636] Fix Nonetype error for task failure instance duration

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1426,8 +1426,8 @@ class Airflow(AirflowBaseView):
 
         fails_totals = defaultdict(int)
         for tf in ti_fails:
-            dict_key = (tf.dag_id, tf.task_id, tf.execution_date)
             if tf.duration:
+                dict_key = (tf.dag_id, tf.task_id, tf.execution_date)
                 fails_totals[dict_key] += tf.duration
 
         for ti in tis:


### PR DESCRIPTION
### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-2636

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
