### PR TITLE
[AIRFLOW-4084] Fix bug downloading incomplete logs from ElasticSearch

### DIFF
--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -97,7 +97,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
         offset = metadata['offset']
         log_id = self._render_log_id(ti, try_number)
 
-        logs = self.es_read(log_id, offset)
+        logs = self.es_read(log_id, offset, metadata)
 
         next_offset = offset if not logs else logs[-1].offset
 
@@ -113,7 +113,8 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
         # delay before Elasticsearch makes the log available.
         if 'last_log_timestamp' in metadata:
             last_log_ts = timezone.parse(metadata['last_log_timestamp'])
-            if cur_ts.diff(last_log_ts).in_minutes() >= 5:
+            if cur_ts.diff(last_log_ts).in_minutes() >= 5 or 'max_offset' in metadata \
+                    and offset >= metadata['max_offset']:
                 metadata['end_of_log'] = True
 
         if offset != next_offset or 'last_log_timestamp' not in metadata:
@@ -123,7 +124,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
 
         return message, metadata
 
-    def es_read(self, log_id, offset):
+    def es_read(self, log_id, offset, metadata):
         """
         Returns the logs matching log_id in Elasticsearch and next offset.
         Returns '' if no log is found or there was an error.
@@ -131,6 +132,8 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
         :type log_id: str
         :param offset: the offset start to read log from.
         :type offset: str
+        :param metadata: log metadata, used for steaming log download.
+        :type metadata: dict
         """
 
         # Offset is the unique key for sorting logs given log_id.
@@ -139,9 +142,15 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
             .sort('offset')
 
         s = s.filter('range', offset={'gt': offset})
+        max_log_line = s.count()
+        if 'download_logs' in metadata and metadata['download_logs'] and 'max_offset' not in metadata:
+            try:
+                metadata['max_offset'] = s[max_log_line - 1].execute()[-1].offset if max_log_line > 0 else 0
+            except Exception:
+                self.log.exception('Could not get current log size with log_id: {}'.format(log_id))
 
         logs = []
-        if s.count() != 0:
+        if max_log_line != 0:
             try:
 
                 logs = s[self.MAX_LINE_PER_PAGE * self.PAGE:self.MAX_LINE_PER_PAGE] \

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -190,6 +190,22 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.assertEqual(0, metadatas[0]['offset'])
         self.assertTrue(timezone.parse(metadatas[0]['last_log_timestamp']) == ts)
 
+    def test_read_as_download_logs(self):
+        ts = pendulum.now()
+        logs, metadatas = self.es_task_handler.read(self.ti,
+                                                    1,
+                                                    {'offset': 0,
+                                                     'last_log_timestamp': str(ts),
+                                                     'download_logs': True,
+                                                     'end_of_log': False})
+        self.assertEqual(1, len(logs))
+        self.assertEqual(len(logs), len(metadatas))
+        self.assertEqual(self.test_message, logs[0])
+        self.assertFalse(metadatas[0]['end_of_log'])
+        self.assertTrue(metadatas[0]['download_logs'])
+        self.assertEqual(1, metadatas[0]['offset'])
+        self.assertTrue(timezone.parse(metadatas[0]['last_log_timestamp']) > ts)
+
     def test_read_raises(self):
         with mock.patch.object(self.es_task_handler.log, 'exception') as mock_exception:
             with mock.patch("elasticsearch_dsl.Search.execute") as mock_execute:

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -736,6 +736,29 @@ class TestLogView(TestBase):
         self.assertEqual(200, response.status_code)
         self.assertIn('Log for testing.', response.data.decode('utf-8'))
 
+    def test_get_logs_with_metadata_as_download_large_file(self):
+        with mock.patch("airflow.utils.log.file_task_handler.FileTaskHandler.read") as read_mock:
+            first_return = (['1st line'], [{}])
+            second_return = (['2nd line'], [{'end_of_log': False}])
+            third_return = (['3rd line'], [{'end_of_log': True}])
+            fourth_return = (['should never be read'], [{'end_of_log': True}])
+            read_mock.side_effect = [first_return, second_return, third_return, fourth_return]
+            url_template = "get_logs_with_metadata?dag_id={}&" \
+                           "task_id={}&execution_date={}&" \
+                           "try_number={}&metadata={}&format=file"
+            try_number = 1
+            url = url_template.format(self.DAG_ID,
+                                      self.TASK_ID,
+                                      quote_plus(self.DEFAULT_DATE.isoformat()),
+                                      try_number,
+                                      json.dumps({}))
+            response = self.client.get(url)
+
+            self.assertIn('1st line', response.data.decode('utf-8'))
+            self.assertIn('2nd line', response.data.decode('utf-8'))
+            self.assertIn('3rd line', response.data.decode('utf-8'))
+            self.assertNotIn('should never be read', response.data.decode('utf-8'))
+
     def test_get_logs_with_metadata(self):
         url_template = "get_logs_with_metadata?dag_id={}&" \
                        "task_id={}&execution_date={}&" \


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-4084

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
  - Fix bug downloading incomplete logs from ElasticSearch
  - Use streaming logs download for memory efficiency

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - Use existing unit tests as this is not a new feature 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`

@pingzh 