### PR TITLE
 [AIRFLOW-4361] Fix flaky test_integration_run_dag_with_scheduler_failure

### DIFF
--- a/scripts/ci/kubernetes/kube/deploy.sh
+++ b/scripts/ci/kubernetes/kube/deploy.sh
@@ -154,6 +154,7 @@ kubectl apply -f $DIRNAME/volumes.yaml
 kubectl apply -f $BUILD_DIRNAME/airflow.yaml
 
 # wait for up to 10 minutes for everything to be deployed
+PODS_ARE_READY=0
 for i in {1..150}
 do
   echo "------- Running kubectl get pods -------"
@@ -162,10 +163,44 @@ do
   NUM_AIRFLOW_READY=$(echo $PODS | grep airflow | awk '{print $2}' | grep -E '([0-9])\/(\1)' | wc -l | xargs)
   NUM_POSTGRES_READY=$(echo $PODS | grep postgres | awk '{print $2}' | grep -E '([0-9])\/(\1)' | wc -l | xargs)
   if [ "$NUM_AIRFLOW_READY" == "1" ] && [ "$NUM_POSTGRES_READY" == "1" ]; then
+    PODS_ARE_READY=1
     break
   fi
   sleep 4
 done
+
+if [[ "$PODS_ARE_READY" == 1 ]]; then
+  echo "PODS are ready."
+else
+  echo "PODS are not ready after waiting for a long time. Exiting..."
+  exit 1
+fi
+
+# Wait until Airflow webserver is up
+MINIKUBE_IP=$(minikube ip)
+AIRFLOW_WEBSERVER_IS_READY=0
+CONSECUTIVE_SUCCESS_CALLS=0
+for i in {1..30}
+do
+  HTTP_CODE=$(curl -LI http://${MINIKUBE_IP}:30809/health -o /dev/null -w '%{http_code}\n' -sS) || true
+  if [[ "$HTTP_CODE" == 200 ]]; then
+    let "CONSECUTIVE_SUCCESS_CALLS+=1"
+  else
+    CONSECUTIVE_SUCCESS_CALLS=0
+  fi
+  if [[ "$CONSECUTIVE_SUCCESS_CALLS" == 3 ]]; then
+    AIRFLOW_WEBSERVER_IS_READY=1
+    break
+  fi
+  sleep 10
+done
+
+if [[ "$AIRFLOW_WEBSERVER_IS_READY" == 1 ]]; then
+  echo "Airflow webserver is ready."
+else
+  echo "Airflow webserver is not ready after waiting for a long time. Exiting..."
+  exit 1
+fi
 
 POD=$(kubectl get pods -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | grep airflow | head -1)
 

--- a/tests/contrib/minikube/test_kubernetes_executor.py
+++ b/tests/contrib/minikube/test_kubernetes_executor.py
@@ -65,8 +65,17 @@ class KubernetesExecutorTest(unittest.TestCase):
         session.mount('https://', HTTPAdapter(max_retries=retries))
         return session
 
+    def _ensure_airflow_webserver_is_healthy(self):
+        response = self.session.get(
+            "http://{host}/health".format(host=get_minikube_host()),
+            timeout=1,
+        )
+
+        self.assertEquals(response.status_code, 200)
+
     def setUp(self):
         self.session = self._get_session_with_retries()
+        self._ensure_airflow_webserver_is_healthy()
 
     def tearDown(self):
         self.session.close()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4361

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Block until airflow webserver is up and running.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
