### PR TITLE
[AIRFLOW-4300] Task Modal Broken for DAGs that have not run

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -153,13 +153,13 @@
             View Log
           </a>
           <hr/>
-          <div>
+          <div id="dag_dl_logs">
             <label style="display:inline"> Download Log (by attempts): </label>
             <ul class="nav nav-pills" role="tablist" id="try_index" style="display:inline">
             </ul>
+            <hr/>
+            <hr/>
           </div>
-          <hr/>
-          <hr/>
           <form method="POST">
             <input name="csrf_token" type="hidden" value="{{ csrf_token() }}"/>
             <input name="dag_id" type="hidden">
@@ -416,6 +416,10 @@ function updateQueryStringParameter(uri, key, value) {
           $("#div_btn_subdag").show();
           subdag_id = "{{ dag.dag_id }}." + t;
       }
+      if (try_numbers > 0)
+          $("#dag_dl_logs").show();
+      else
+          $("#dag_dl_logs").hide();
 
       updateModalUrls();
 

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -168,10 +168,15 @@
 
     d3.selectAll("g.node").on("click", function(d){
         task = tasks[d];
-        if (task.task_type == "SubDagOperator")
-            call_modal(d, execution_date, task.extra_links, task_instances[d].try_number, true);
+        if (d in task_instances)
+            try_number = task_instances[d].try_number;
         else
-            call_modal(d, execution_date, task.extra_links, task_instances[d].try_number, undefined);
+            try_number = 0;
+
+        if (task.task_type == "SubDagOperator")
+            call_modal(d, execution_date, task.extra_links, try_number, true);
+        else
+            call_modal(d, execution_date, task.extra_links, try_number, undefined);
     });
 
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-4300

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Fixes a bug that prevents the task detail modal from appearing in the Graph view on DAGs that have not yet run

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Pure JavaScript change to fix a known bug

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
