### PR TITLE
[AIRFLOW-4418] Add failed only option to task modal

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -219,6 +219,11 @@
                 <input type="checkbox" value="true" name="recursive" checked autocomplete="off">
                  Recursive
               </label>
+              <label class="btn"
+                title="Only consider failed task instances when clearing this one">
+                <input type="checkbox" value="true" name="only_failed" autocomplete="off">
+                Failed
+              </label>
             </span>
             <hr/>
             <button id="btn_failed" type="button" class="btn btn-primary"

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -866,13 +866,14 @@ class Airflow(AirflowBaseView):
         return redirect(origin)
 
     def _clear_dag_tis(self, dag, start_date, end_date, origin,
-                       recursive=False, confirmed=False):
+                       recursive=False, confirmed=False, only_failed=False):
         if confirmed:
             count = dag.clear(
                 start_date=start_date,
                 end_date=end_date,
                 include_subdags=recursive,
                 include_parentdag=recursive,
+                only_failed=only_failed,
             )
 
             flash("{0} task instances have been cleared".format(count))
@@ -883,6 +884,7 @@ class Airflow(AirflowBaseView):
             end_date=end_date,
             include_subdags=recursive,
             include_parentdag=recursive,
+            only_failed=only_failed,
             dry_run=True,
         )
         if not tis:
@@ -917,6 +919,7 @@ class Airflow(AirflowBaseView):
         future = request.form.get('future') == "true"
         past = request.form.get('past') == "true"
         recursive = request.form.get('recursive') == "true"
+        only_failed = request.form.get('only_failed') == "true"
 
         dag = dag.sub_dag(
             task_regex=r"^{0}$".format(task_id),
@@ -927,7 +930,7 @@ class Airflow(AirflowBaseView):
         start_date = execution_date if not past else None
 
         return self._clear_dag_tis(dag, start_date, end_date, origin,
-                                   recursive=recursive, confirmed=confirmed)
+                                   recursive=recursive, confirmed=confirmed, only_failed=only_failed)
 
     @expose('/dagrun_clear', methods=['POST'])
     @has_dag_access(can_dag_edit=True)

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -544,6 +544,7 @@ class TestAirflowBaseViews(TestBase):
             downstream="false",
             future="false",
             past="false",
+            only_failed="false",
         )
         resp = self.client.post("clear", data=form)
         self.check_content_in_response(['example_bash_operator', 'Wait a minute'], resp)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4418
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Add an  **Failed** option to task modal:
![image](https://user-images.githubusercontent.com/47340368/56988044-f17d1c80-6b43-11e9-942a-d7fcf06844e9.png)
![image](https://user-images.githubusercontent.com/47340368/56988071-0194fc00-6b44-11e9-84e8-58835566349f.png)

The **Failed** option only considers failed tasks when clearing. This may be useful if you have downstream tasks that are both in the success and failed state, but only want to clear the failed ones.

Consider the following example DAG:

![image](https://user-images.githubusercontent.com/47340368/56988019-e0cca680-6b43-11e9-98b2-fdba7e4b11ec.png)
![image](https://user-images.githubusercontent.com/47340368/56988153-330dc780-6b44-11e9-8ffd-6b9e415c719c.png)
![image](https://user-images.githubusercontent.com/47340368/56988164-3903a880-6b44-11e9-9a62-ba8436f2a3c8.png)

By default, if we clear the top level task, we should see this, where we are clearing both successful and failed tasks:
![image](https://user-images.githubusercontent.com/47340368/56988193-4ae54b80-6b44-11e9-8741-4657a487e8a4.png)

Now if we checking the **Failed** button, we should only see and clear failed tasks:
![image](https://user-images.githubusercontent.com/47340368/56988224-605a7580-6b44-11e9-9bc3-2615ac5f4a79.png)

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Just adding a route that is similar to an existing route (/dagrun_clear) and a button to the UI that ultimately calls the clear method of the DAG class, which is already tested.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
