### PR TITLE
[AIRFLOW-4419] Refine concurrency check in scheduler

### DIFF
--- a/tests/models/test_pool.py
+++ b/tests/models/test_pool.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow import settings
+from airflow.models import DAG
+from airflow.models.pool import Pool
+from airflow.models.taskinstance import TaskInstance as TI
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.utils import timezone
+from airflow.utils.state import State
+from tests.test_utils.db import clear_db_pools, clear_db_runs
+from tests.test_utils.decorators import mock_conf_get
+
+DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+
+
+class PoolTest(unittest.TestCase):
+
+    def tearDown(self):
+        clear_db_runs()
+        clear_db_pools()
+
+    def test_open_slots(self):
+        pool = Pool(pool='test_pool', slots=5)
+        dag = DAG(
+            dag_id='test_open_slots',
+            start_date=DEFAULT_DATE, )
+        t1 = DummyOperator(task_id='dummy1', dag=dag, pool='test_pool')
+        t2 = DummyOperator(task_id='dummy2', dag=dag, pool='test_pool')
+        ti1 = TI(task=t1, execution_date=DEFAULT_DATE)
+        ti2 = TI(task=t2, execution_date=DEFAULT_DATE)
+        ti1.state = State.RUNNING
+        ti2.state = State.QUEUED
+
+        session = settings.Session
+        session.add(pool)
+        session.add(ti1)
+        session.add(ti2)
+        session.commit()
+        session.close()
+
+        self.assertEqual(3, pool.open_slots())
+
+    @mock_conf_get('core', 'non_pooled_task_slot_count', 5)
+    def test_default_pool_open_slots(self):
+        dag = DAG(
+            dag_id='test_default_pool_open_slots',
+            start_date=DEFAULT_DATE, )
+        t1 = DummyOperator(task_id='dummy1', dag=dag)
+        t2 = DummyOperator(task_id='dummy2', dag=dag)
+        ti1 = TI(task=t1, execution_date=DEFAULT_DATE)
+        ti2 = TI(task=t2, execution_date=DEFAULT_DATE)
+        ti1.state = State.RUNNING
+        ti2.state = State.QUEUED
+        ti1.pool = Pool.default_pool_name
+        ti2.pool = Pool.default_pool_name
+
+        session = settings.Session
+        session.add(ti1)
+        session.add(ti2)
+        session.commit()
+        session.close()
+
+        self.assertEqual(3, Pool.default_pool_open_slots())

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -31,34 +31,35 @@ from tempfile import mkdtemp
 import psutil
 import six
 import sqlalchemy
-from tests.compat import Mock, patch, MagicMock, PropertyMock
 from parameterized import parameterized
 
-from airflow.utils.db import create_session
-from airflow import AirflowException, settings, models
+import airflow.example_dags
+from airflow import AirflowException, models, settings
 from airflow import configuration
 from airflow.bin import cli
-import airflow.example_dags
-from airflow.executors import BaseExecutor, SequentialExecutor
 from airflow.exceptions import DagConcurrencyLimitReached, NoAvailablePoolSlot
-from airflow.jobs import BaseJob, BackfillJob, SchedulerJob, LocalTaskJob
-from airflow.models import DAG, DagModel, DagBag, DagRun, Pool, TaskInstance as TI, \
-    errors, SlaMiss
+from airflow.executors import BaseExecutor, SequentialExecutor
+from airflow.jobs import BackfillJob, BaseJob, LocalTaskJob, SchedulerJob
+from airflow.models import DAG, DagBag, DagModel, DagRun, Pool, SlaMiss, \
+    TaskInstance as TI, errors
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
 from airflow.utils import timezone
 from airflow.utils.dag_processing import SimpleDag, SimpleDagBag, list_py_file_paths
 from airflow.utils.dates import days_ago
+from airflow.utils.db import create_session
 from airflow.utils.db import provide_session
 from airflow.utils.net import get_hostname
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout
-from tests.test_utils.db import clear_db_runs, clear_db_pools, clear_db_dags, \
-    clear_db_sla_miss, clear_db_errors
+from tests.compat import MagicMock, Mock, PropertyMock, patch
+from tests.compat import mock
 from tests.core import TEST_DAG_FOLDER
 from tests.executors.test_executor import TestExecutor
-from tests.compat import mock
+from tests.test_utils.db import clear_db_dags, clear_db_errors, clear_db_pools, \
+    clear_db_runs, clear_db_sla_miss
+from tests.test_utils.decorators import mock_conf_get
 
 configuration.load_test_config()
 
@@ -1887,6 +1888,50 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertIn(tis[1].key, res_keys)
         self.assertIn(tis[3].key, res_keys)
 
+    @mock_conf_get('core', 'non_pooled_task_slot_count', 1)
+    def test_find_executable_task_instances_in_non_pool(self):
+        dag_id = 'SchedulerJobTest.test_find_executable_task_instances_in_non_pool'
+        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE)
+        t1 = DummyOperator(dag=dag, task_id='dummy1')
+        t2 = DummyOperator(dag=dag, task_id='dummy2')
+        dagbag = self._make_simple_dag_bag([dag])
+
+        executor = TestExecutor(do_update=True)
+        scheduler = SchedulerJob(executor=executor)
+        dr1 = scheduler.create_dag_run(dag)
+        dr2 = scheduler.create_dag_run(dag)
+        session = settings.Session()
+
+        ti1 = TI(task=t1, execution_date=dr1.execution_date)
+        ti2 = TI(task=t2, execution_date=dr2.execution_date)
+        ti1.state = State.SCHEDULED
+        ti2.state = State.SCHEDULED
+
+        session.merge(ti1)
+        session.merge(ti2)
+        session.commit()
+
+        # Two tasks w/o pool up for execution and our non_pool size is 1
+        res = scheduler._find_executable_task_instances(
+            dagbag,
+            states=(State.SCHEDULED,),
+            session=session)
+        self.assertEqual(1, len(res))
+
+        ti2.state = State.RUNNING
+        ti2.pool = Pool.default_pool_name
+        session.merge(ti2)
+        session.commit()
+
+        # One task w/o pool up for execution and one task task running
+        res = scheduler._find_executable_task_instances(
+            dagbag,
+            states=(State.SCHEDULED,),
+            session=session)
+        self.assertEqual(0, len(res))
+
+        session.close()
+
     def test_nonexistent_pool(self):
         dag_id = 'SchedulerJobTest.test_nonexistent_pool'
         task_id = 'dummy_wrong_pool'
@@ -2017,7 +2062,8 @@ class SchedulerJobTest(unittest.TestCase):
         task2 = DummyOperator(dag=dag, task_id=task_id_2)
         dagbag = self._make_simple_dag_bag([dag])
 
-        scheduler = SchedulerJob()
+        executor = TestExecutor(do_update=True)
+        scheduler = SchedulerJob(executor=executor)
         session = settings.Session()
 
         dr1 = scheduler.create_dag_run(dag)
@@ -2096,6 +2142,23 @@ class SchedulerJobTest(unittest.TestCase):
         res = scheduler._find_executable_task_instances(
             dagbag,
             states=[State.SCHEDULED],
+            session=session)
+
+        self.assertEqual(1, len(res))
+
+        ti1_1.state = State.QUEUED
+        ti1_2.state = State.SCHEDULED
+        ti1_3.state = State.SUCCESS
+        session.merge(ti1_1)
+        session.merge(ti1_2)
+        session.merge(ti1_3)
+        session.commit()
+
+        executor.queued_tasks[ti1_1.key] = ti1_1
+
+        res = scheduler._find_executable_task_instances(
+            dagbag,
+            states=[State.SCHEDULED, State.QUEUED],
             session=session)
 
         self.assertEqual(1, len(res))

--- a/tests/test_utils/decorators.py
+++ b/tests/test_utils/decorators.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from contextlib import ContextDecorator
+
+from mock import Mock
+
+from airflow import conf
+
+
+# So we don't depend on actual value in the test config.
+class mock_conf_get(ContextDecorator):
+    def __init__(self, mock_section, mock_key, mock_return_value):
+        self.mock_section = mock_section
+        self.mock_key = mock_key
+        self.mock_return_value = mock_return_value
+
+    def __enter__(self):
+        self.old_conf_get = conf.getint
+
+        def side_effect(section, key):
+            if section == self.mock_section and key == self.mock_key:
+                return self.mock_return_value
+            else:
+                return self.old_conf_get(section, key)
+
+        conf.getint = Mock(side_effect=side_effect)
+        return self
+
+    def __exit__(self, *exc):
+        conf.getint = self.old_conf_get
+        return False


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4419) issues and references them in the PR title.
### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

* Optimized the pool, dag and task concurrency calculation logic to make it faster. Also fix a BUG where current task concurrency should not increase if the executor already has the task.

* Added helper method in pool.py to access default pool size and optimized open slot querying method fo r performance.

* **Behavior change:** Previously scheduler will schedule at most `non_pooled_task_slot_count` non-pooled tasks per scheduler loop. After this change, scheduler will schedule at most `non_pooled_task_slot_count` non-pooled tasks in total.
  * I think this is a more intuitive interpretation of the config according to [its comment](https://github.com/KevinYang21/incubator-airflow/blob/kevin_yang_4419/airflow/config_templates/default_airflow.cfg#L121-L122).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

* Update `tests.test_jobs:SchedulerJobTest.test_find_executable_task_instances_task_concurrency` to include the use case for the BUG.
* Added `tests.models.test_pool:PoolTest`.
* Added `tests.test_jobs:SchedulerJobTest.test_find_executable_task_instances_in_non_pool`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
