### PR TITLE
[AIRFLOW-4401] SynchronizedQueue used where empty() is used.

### DIFF
--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -20,7 +20,6 @@ import hashlib
 import re
 import json
 import multiprocessing
-from queue import Queue
 from dateutil import parser
 from uuid import uuid4
 import kubernetes
@@ -38,6 +37,7 @@ from airflow.utils.db import provide_session, create_session
 from airflow import configuration, settings
 from airflow.exceptions import AirflowConfigException, AirflowException
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.synchronized_queue import SynchronizedQueue
 
 
 class KubernetesExecutorConfig:
@@ -373,7 +373,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
         self.kube_client = kube_client
         self.launcher = PodLauncher(kube_client=self.kube_client)
         self.worker_configuration = WorkerConfiguration(kube_config=self.kube_config)
-        self.watcher_queue = multiprocessing.Queue()
+        self.watcher_queue = SynchronizedQueue()
         self.worker_uuid = worker_uuid
         self.kube_watcher = self._make_kube_watcher()
 
@@ -694,8 +694,8 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
         # https://github.com/kubernetes-client/python/blob/master/kubernetes/docs
         # /CoreV1Api.md#list_namespaced_pod
         KubeResourceVersion.reset_resource_version()
-        self.task_queue = Queue()
-        self.result_queue = Queue()
+        self.task_queue = SynchronizedQueue()
+        self.result_queue = SynchronizedQueue()
         self.kube_client = get_kube_client()
         self.kube_scheduler = AirflowKubernetesScheduler(
             self.kube_config, self.task_queue, self.result_queue,

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -147,7 +147,6 @@ class BaseExecutor(LoggingMixin):
         self.sync()
 
     def change_state(self, key, state):
-        self.log.debug("Changing state: %s", key)
         self.running.pop(key, None)
         self.event_buffer[key] = state
 

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -52,6 +52,7 @@ from builtins import range
 from airflow.executors.base_executor import BaseExecutor
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
+from airflow.utils.synchronized_queue import SynchronizedQueue
 
 
 class LocalWorker(multiprocessing.Process, LoggingMixin):
@@ -62,7 +63,7 @@ class LocalWorker(multiprocessing.Process, LoggingMixin):
     def __init__(self, result_queue):
         """
         :param result_queue: the queue to store result states tuples (key, State)
-        :type result_queue: multiprocessing.Queue
+        :type result_queue: SynchronizedQueue
         """
         super().__init__()
         self.daemon = True
@@ -112,8 +113,10 @@ class QueuedLocalWorker(LocalWorker):
                 # Received poison pill, no more tasks to run
                 self.task_queue.task_done()
                 break
-            self.execute_work(key, command)
-            self.task_queue.task_done()
+            try:
+                self.execute_work(key, command)
+            finally:
+                self.task_queue.task_done()
 
 
 class LocalExecutor(BaseExecutor):
@@ -206,7 +209,7 @@ class LocalExecutor(BaseExecutor):
             self.executor.sync()
 
     def start(self):
-        self.result_queue = multiprocessing.Queue()
+        self.result_queue = SynchronizedQueue()
         self.queue = None
         self.workers = []
         self.workers_used = 0

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -60,6 +60,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin, StreamLogWriter, set_c
 from airflow.utils.net import get_hostname
 from airflow.utils.sqlalchemy import UtcDateTime
 from airflow.utils.state import State
+from airflow.utils.synchronized_queue import SynchronizedQueue
 
 Base = models.base.Base  # type: Any
 ID_LEN = models.base.ID_LEN
@@ -319,7 +320,7 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
         """
         self._file_path = file_path
         # Queue that's used to pass results from the child process.
-        self._result_queue = multiprocessing.Queue()
+        self._result_queue = SynchronizedQueue()
         # The process that was launched to process the given .
         self._process = None
         self._dag_id_white_list = dag_id_white_list
@@ -351,7 +352,7 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
         Launch a process to process the given file.
 
         :param result_queue: the queue to use for passing back the result
-        :type result_queue: multiprocessing.Queue
+        :type result_queue: SynchronizedQueue
         :param file_path: the file to process
         :type file_path: unicode
         :param pickle_dags: whether to pickle the DAGs found in the file and
@@ -487,7 +488,10 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
 
         # In case result queue is corrupted.
         if self._result_queue and not self._result_queue.empty():
-            self._result = self._result_queue.get_nowait()
+            # we use get() here because there is no guarantee the
+            # SynchronizedQueue used has something to get immediately even if
+            # empty() returns False
+            self._result = self._result_queue.get()
             self._done = True
             self.log.debug("Waiting for %s", self._process)
             self._process.join()
@@ -498,7 +502,10 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
             self._done = True
             # Get the object from the queue or else join() can hang.
             if not self._result_queue.empty():
-                self._result = self._result_queue.get_nowait()
+                # we use get() here because there is no guarantee the
+                # SynchronizedQueue used has something to get immediately  even if
+                # empty() returns False
+                self._result = self._result_queue.get()
             self.log.debug("Waiting for %s", self._process)
             self._process.join()
             return True
@@ -896,7 +903,7 @@ class SchedulerJob(BaseJob):
                 return next_run
 
     @provide_session
-    def _process_task_instances(self, dag, queue, session=None):
+    def _process_task_instances(self, dag, task_instances_list, session=None):
         """
         This method schedules the tasks for a single DAG by looking at the
         active DAG runs and adding task instances that should run to the
@@ -953,7 +960,7 @@ class SchedulerJob(BaseJob):
                         dep_context=DepContext(flag_upstream_failed=True),
                         session=session):
                     self.log.debug('Queuing task: %s', ti)
-                    queue.append(ti.key)
+                    task_instances_list.append(ti.key)
 
     @provide_session
     def _change_state_for_tis_without_dagrun(self,
@@ -1418,8 +1425,8 @@ class SchedulerJob(BaseJob):
         :type dagbag: airflow.models.DagBag
         :param dags: the DAGs from the DagBag to process
         :type dags: airflow.models.DAG
-        :param tis_out: A queue to add generated TaskInstance objects
-        :type tis_out: multiprocessing.Queue[TaskInstance]
+        :param tis_out: A list to add generated TaskInstance objects
+        :type tis_out: list[TaskInstance]
         :rtype: None
         """
         for dag in dags:
@@ -1747,7 +1754,7 @@ class SchedulerJob(BaseJob):
 
         # Not using multiprocessing.Queue() since it's no longer a separate
         # process and due to some unusual behavior. (empty() incorrectly
-        # returns true?)
+        # returns true as described in https://bugs.python.org/issue23582 )
         ti_keys_to_schedule = []
 
         self._process_dags(dagbag, dags, ti_keys_to_schedule)

--- a/airflow/utils/synchronized_queue.py
+++ b/airflow/utils/synchronized_queue.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This code originates from
+# https://github.com/vterron/lemon/commit/9ca6b4b1212228dbd4f69b88aaf88b12952d7d6f
+# and it has been updated to work with python 3.4+
+import multiprocessing
+from queue import Full, Empty
+
+from multiprocessing.queues import Queue
+
+
+class SharedCounter(object):
+    """ A synchronized shared counter.
+
+    The locking done by multiprocessing.Value ensures that only a single
+    process or thread may read or write the in-memory ctypes object. However,
+    in order to do n += 1, Python performs a read followed by a write, so a
+    second process may read the old value before the new one is written by the
+    first process. The solution is to use a multiprocessing.Lock to guarantee
+    the atomicity of the modifications to Value.
+
+    This class comes almost entirely from Eli Bendersky's blog:
+    http://eli.thegreenplace.net/2012/01/04/shared-counter-with-pythons-multiprocessing/
+
+    """
+
+    def __init__(self, n=0):
+        self.count = multiprocessing.Value('i', n)
+
+    def increment(self, n=1):
+        """ Increment the counter by n (default = 1) """
+        with self.count.get_lock():
+            self.count.value += n
+
+    @property
+    def value(self):
+        """ Return the value of the counter """
+        return self.count.value
+
+
+class SynchronizedQueue(Queue):
+    """ A portable implementation of multiprocessing.Queue with reliable empty() and qsize()
+
+    Because of multithreading / multiprocessing semantics, Queue.qsize() may
+    raise the NotImplementedError exception on Unix platforms like Mac OS X
+    where sem_getvalue() is not implemented. This subclass addresses this
+    problem by using a synchronized shared counter (initialized to zero) and
+    increasing / decreasing its value every time the put() and get() methods
+    are called, respectively. This not only prevents NotImplementedError from
+    being raised, but also allows us to implement a reliable version of both
+    qsize() and empty().
+
+    """
+
+    def __init__(self, maxsize=-1, block=True, timeout=None):
+        self.block = block
+        self.timeout = timeout
+        self.size = SharedCounter(0)
+        super().__init__(maxsize, ctx=multiprocessing.get_context())
+
+    def put(self, obj, block=True, timeout=None):
+        try:
+            super(SynchronizedQueue, self).put(obj, block=block, timeout=timeout)
+            # Only increment size if succeeded to put the object
+            self.size.increment(1)
+        except Full:
+            raise
+
+    def get(self, block=True, timeout=None):
+        try:
+            result = super(SynchronizedQueue, self).get(block=block, timeout=timeout)
+            # Only decrement size if succeeded to get the object
+            self.size.increment(-1)
+            return result
+        except Empty:
+            raise
+
+    def qsize(self):
+        """ Reliable qsize implementation of multiprocessing.Queue.qsize().
+
+        Unlike in the original queue, size() is guaranteed to return the actual size of the queue - matching
+        put/get requests executed. It does however that qsize() > 0 will make new data available
+        instantly. It is possible that in this case, get_nowait() or get(block=False) will throw an
+        an Empty exception.
+
+        If you expect data to be returned, you should use get() or check for an Empty exception.
+
+
+        """
+        # Synchronize on the lock
+        self.size.increment(0)
+        return self.size.value
+
+    def empty(self):
+        """ Reliable implementation of multiprocessing.Queue.empty().
+
+        Unlike in the original queue, empty() is guaranteed to return True
+        only when successful put requests matched get requests.
+
+        It does not mean however that empty() == False will make new data available
+        instantly. It is possible that in this case that, get_nowait() or get(block=False) will throw
+        an Empty exception.
+
+        If you expect data to be returned, you should use get() or check for an Empty exception.
+
+        """
+        return not self.qsize()

--- a/tests/executors/test_local_executor.py
+++ b/tests/executors/test_local_executor.py
@@ -21,7 +21,6 @@ import unittest
 
 from airflow.executors.local_executor import LocalExecutor
 from airflow.utils.state import State
-from airflow.utils.timeout import timeout
 
 
 class LocalExecutorTest(unittest.TestCase):
@@ -35,29 +34,20 @@ class LocalExecutorTest(unittest.TestCase):
         success_key = 'success {}'
         success_command = ['true', 'some_parameter']
         fail_command = ['false', 'some_parameter']
+        self.assertTrue(executor.result_queue.empty())
 
         for i in range(self.TEST_SUCCESS_COMMANDS):
             key, command = success_key.format(i), success_command
-            executor.execute_async(key=key, command=command)
             executor.running[key] = True
-
-        # errors are propagated for some reason
-        try:
-            executor.execute_async(key='fail', command=fail_command)
-        except Exception:
-            pass
+            executor.execute_async(key=key, command=command)
 
         executor.running['fail'] = True
+        executor.execute_async(key='fail', command=fail_command)
 
-        if parallelism == 0:
-            with timeout(seconds=10):
-                executor.end()
-        else:
-            executor.end()
+        executor.end()
 
         if isinstance(executor.impl, LocalExecutor._LimitedParallelism):
             self.assertTrue(executor.queue.empty())
-
         self.assertEqual(len(executor.running), 0)
         self.assertTrue(executor.result_queue.empty())
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -206,7 +206,7 @@ class BackfillJobTest(unittest.TestCase):
 
         scheduler = SchedulerJob()
         queue = Mock()
-        scheduler._process_task_instances(target_dag, queue=queue)
+        scheduler._process_task_instances(target_dag, task_instances_list=queue)
         self.assertFalse(queue.append.called)
 
         job = BackfillJob(
@@ -219,7 +219,7 @@ class BackfillJobTest(unittest.TestCase):
 
         scheduler = SchedulerJob()
         queue = Mock()
-        scheduler._process_task_instances(target_dag, queue=queue)
+        scheduler._process_task_instances(target_dag, task_instances_list=queue)
 
         self.assertTrue(queue.append.called)
         target_dag.clear()
@@ -2848,7 +2848,7 @@ class SchedulerJobTest(unittest.TestCase):
                 ti.end_date = end_date
 
         queue = Mock()
-        scheduler._process_task_instances(dag, queue=queue)
+        scheduler._process_task_instances(dag, task_instances_list=queue)
 
         queue.append.assert_called_with(
             (dag.dag_id, dag_task1.task_id, DEFAULT_DATE, TRY_NUMBER)
@@ -2880,7 +2880,7 @@ class SchedulerJobTest(unittest.TestCase):
             start_date=DEFAULT_DATE)
 
         queue = Mock()
-        scheduler._process_task_instances(dag, queue=queue)
+        scheduler._process_task_instances(dag, task_instances_list=queue)
 
         queue.put.assert_not_called()
 
@@ -2906,7 +2906,7 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertIsNone(dr)
 
         queue = Mock()
-        scheduler._process_task_instances(dag, queue=queue)
+        scheduler._process_task_instances(dag, task_instances_list=queue)
 
         queue.put.assert_not_called()
 
@@ -2952,7 +2952,7 @@ class SchedulerJobTest(unittest.TestCase):
         session.close()
 
         queue = Mock()
-        scheduler._process_task_instances(dag, queue=queue)
+        scheduler._process_task_instances(dag, task_instances_list=queue)
 
         queue.put.assert_not_called()
 
@@ -2990,7 +2990,7 @@ class SchedulerJobTest(unittest.TestCase):
             owner='airflow')
 
         queue = Mock()
-        scheduler._process_task_instances(dag, queue=queue)
+        scheduler._process_task_instances(dag, task_instances_list=queue)
 
         tis = dr.get_task_instances()
         self.assertEqual(len(tis), 2)
@@ -3133,7 +3133,7 @@ class SchedulerJobTest(unittest.TestCase):
         queue = Mock()
         # and schedule them in, so we can check how many
         # tasks are put on the queue (should be one, not 3)
-        scheduler._process_task_instances(dag, queue=queue)
+        scheduler._process_task_instances(dag, task_instances_list=queue)
 
         queue.append.assert_called_with(
             (dag.dag_id, dag_task1.task_id, DEFAULT_DATE, TRY_NUMBER)
@@ -3174,7 +3174,7 @@ class SchedulerJobTest(unittest.TestCase):
         dr = scheduler.create_dag_run(dag)
         self.assertIsNotNone(dr)
         queue = []
-        scheduler._process_task_instances(dag, queue=queue)
+        scheduler._process_task_instances(dag, task_instances_list=queue)
         self.assertEqual(len(queue), 2)
         dagbag = self._make_simple_dag_bag([dag])
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4401
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

It is a known problem https://bugs.python.org/issue23582 that
multiprocessing.Queue empty() method is not reliable - sometimes it might
return True even if another process already put something in the queue.

This resulted in some of the tasks not picked up when sync() methods
were called (in AirflowKubernetesScheduler, LocalExecutor,
DagFileProcessor). This was less of a problem if the method was called in sync()
- as the remaining jobs/files could be processed in next pass but it was a problem
in tests and when graceful shutdown was executed (some tasks could be still
unprocessed while the shutdown occured).

All the cases impacted follow the same pattern now:

while not queue.empty():
   res = queue.get()
   ....

This loop runs always in single (main) process so it is safe to run it this way -
there is no risk that some other process will retrieve the data from the queue in
between empty() and get().

Note that unlike in the standard multiprocessing.Queue, you cannot rely
on data being immediately available after empty() is False. You should be
prepared that subsequent get_nowait() raises Empty, or (better) use get()
to retrieve the data.

In all these cases overhead for inter-processing locking is negligible
comparing to the action executed (Parsing DAG, executing job)
so it appears it should be safe to merge the change.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No need. Lots of tests for that already (flaky ones).


### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
