### PR TITLE
[AIRFLOW-4401] Use managers for Queue synchronization

### DIFF
--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -17,10 +17,11 @@
 
 import base64
 import hashlib
+from queue import Empty
+
 import re
 import json
 import multiprocessing
-from queue import Queue
 from dateutil import parser
 from uuid import uuid4
 import kubernetes
@@ -374,7 +375,8 @@ class AirflowKubernetesScheduler(LoggingMixin):
         self.kube_client = kube_client
         self.launcher = PodLauncher(kube_client=self.kube_client)
         self.worker_configuration = WorkerConfiguration(kube_config=self.kube_config)
-        self.watcher_queue = multiprocessing.Queue()
+        self._manager = multiprocessing.Manager()
+        self.watcher_queue = self._manager.Queue()
         self.worker_uuid = worker_uuid
         self.kube_watcher = self._make_kube_watcher()
 
@@ -440,11 +442,18 @@ class AirflowKubernetesScheduler(LoggingMixin):
 
         """
         self._health_check_kube_watcher()
-        while not self.watcher_queue.empty():
-            self.process_watcher_task()
+        while True:
+            try:
+                task = self.watcher_queue.get_nowait()
+                try:
+                    self.process_watcher_task(task)
+                finally:
+                    self.watcher_queue.task_done()
+            except Empty:
+                break
 
-    def process_watcher_task(self):
-        pod_id, state, labels, resource_version = self.watcher_queue.get()
+    def process_watcher_task(self, task):
+        pod_id, state, labels, resource_version = task
         self.log.info(
             'Attempting to finish pod; pod_id: %s; state: %s; labels: %s',
             pod_id, state, labels
@@ -591,6 +600,10 @@ class AirflowKubernetesScheduler(LoggingMixin):
         )
         return None
 
+    def terminate(self):
+        self.watcher_queue.join()
+        self._manager.shutdown()
+
 
 class KubernetesExecutor(BaseExecutor, LoggingMixin):
     def __init__(self):
@@ -600,6 +613,7 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
         self.kube_scheduler = None
         self.kube_client = None
         self.worker_uuid = None
+        self._manager = multiprocessing.Manager()
         super().__init__(parallelism=self.kube_config.parallelism)
 
     @provide_session
@@ -695,8 +709,8 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
         # https://github.com/kubernetes-client/python/blob/master/kubernetes/docs
         # /CoreV1Api.md#list_namespaced_pod
         KubeResourceVersion.reset_resource_version()
-        self.task_queue = Queue()
-        self.result_queue = Queue()
+        self.task_queue = self._manager.Queue()
+        self.result_queue = self._manager.Queue()
         self.kube_client = get_kube_client()
         self.kube_scheduler = AirflowKubernetesScheduler(
             self.kube_config, self.task_queue, self.result_queue,
@@ -721,29 +735,38 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
         self.kube_scheduler.sync()
 
         last_resource_version = None
-        while not self.result_queue.empty():
-            results = self.result_queue.get()
-            key, state, pod_id, resource_version = results
-            last_resource_version = resource_version
-            self.log.info('Changing state of %s to %s', results, state)
+        while True:
             try:
-                self._change_state(key, state, pod_id)
-            except Exception as e:
-                self.log.exception('Exception: %s when attempting ' +
-                                   'to change state of %s to %s, re-queueing.', e, results, state)
-                self.result_queue.put(results)
+                results = self.result_queue.get_nowait()
+                try:
+                    key, state, pod_id, resource_version = results
+                    last_resource_version = resource_version
+                    self.log.info('Changing state of %s to %s', results, state)
+                    try:
+                        self._change_state(key, state, pod_id)
+                    except Exception as e:
+                        self.log.exception('Exception: %s when attempting ' +
+                                           'to change state of %s to %s, re-queueing.', e, results, state)
+                        self.result_queue.put(results)
+                finally:
+                    self.result_queue.task_done()
+            except Empty:
+                break
 
         KubeResourceVersion.checkpoint_resource_version(last_resource_version)
 
-        for i in range(min((self.kube_config.worker_pods_creation_batch_size, self.task_queue.qsize()))):
-            task = self.task_queue.get()
-
+        for _ in range(self.kube_config.worker_pods_creation_batch_size):
             try:
-                self.kube_scheduler.run_next(task)
-            except ApiException:
-                self.log.exception('ApiException when attempting ' +
-                                   'to run task, re-queueing.')
-                self.task_queue.put(task)
+                task = self.task_queue.get_nowait()
+                try:
+                    self.kube_scheduler.run_next(task)
+                except ApiException:
+                    self.log.exception('ApiException when attempting to run task, re-queueing.')
+                    self.task_queue.put(task)
+                finally:
+                    self.task_queue.task_done()
+            except Empty:
+                break
 
     def _change_state(self, key, state, pod_id):
         if state != State.RUNNING:
@@ -769,3 +792,7 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
     def end(self):
         self.log.info('Shutting down Kubernetes executor')
         self.task_queue.join()
+        self.result_queue.join()
+        if self.kube_scheduler:
+            self.kube_scheduler.terminate()
+        self._manager.shutdown()


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4401
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

It is a known problem https://bugs.python.org/issue23582 that
multiprocessing.Queue empty() method is not reliable - sometimes it might
return True even if another process already put something in the queue.

This resulted in some of the tasks not picked up when sync() methods
were called (in AirflowKubernetesScheduler, LocalExecutor,
DagFileProcessor). This was less of a problem if the method was called in sync()
- as the remaining jobs/files could be processed in next pass but it was a problem
in tests and when graceful shutdown was executed (some tasks could be still
unprocessed while the shutdown occured).

We switched to Managers() managed queues to handle that - the queue in this case
is run in a separate subprocess and each process using it uses a proxy to access
this shared queue.

All the cases impacted follow the same pattern now:

while not queue.empty():
   res = queue.get()
   ....

This loop runs always in single (main) process so it is safe to run it this way -
there is no risk that some other process will retrieve the data from the queue in
between empty() and get().

In all these cases overhead for inter-processing locking is negligible
comparing to the action executed (Parsing DAG, executing job)
so it appears it should be safe to merge the change.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Tests were there (but flaky)

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
