### PR TITLE
[AIRFLOW-4434] fix support for impala in hive hook

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -749,8 +749,12 @@ class HiveServer2Hook(BaseHook):
     """
     Wrapper around the pyhive library
 
-    Note that the default authMechanism is PLAIN, to override it you
-    can specify it in the ``extra`` of your connection in the UI as in
+    Notes:
+    * the default authMechanism is PLAIN, to override it you
+    can specify it in the ``extra`` of your connection in the UI
+    * the default for run_set_variable_statements is true, if you
+    are using impala you may need to set it to false in the
+    ``extra`` of your connection in the UI
     """
     def __init__(self, hiveserver2_conn_id='hiveserver2_default'):
         self.hiveserver2_conn_id = hiveserver2_conn_id
@@ -797,11 +801,14 @@ class HiveServer2Hook(BaseHook):
                 contextlib.closing(conn.cursor()) as cur:
             cur.arraysize = fetch_size or 1000
 
-            env_context = get_context_from_env_var()
-            if hive_conf:
-                env_context.update(hive_conf)
-            for k, v in env_context.items():
-                cur.execute("set {}={}".format(k, v))
+            # not all query services (e.g. impala AIRFLOW-4434) support the set command
+            db = self.get_connection(self.hiveserver2_conn_id)
+            if db.extra_dejson.get('run_set_variable_statements', True):
+                env_context = get_context_from_env_var()
+                if hive_conf:
+                    env_context.update(hive_conf)
+                for k, v in env_context.items():
+                    cur.execute("set {}={}".format(k, v))
 
             for statement in hql:
                 cur.execute(statement)


### PR DESCRIPTION


Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira #4434](https://issues.apache.org/jira/browse/AIRFLOW-4434) issues and references them in the PR title.

### Description

-  [X] Here are some details about my PR, including screenshots of any UI changes:

I've introduced this PR to allow users the option to avoid running set variables for the hive hook. My initial motivation was to un-break impala support (broken via https://github.com/apache/airflow/pull/3405 ) but decided to write the PR in this way so that users could disable the set statements for hive (or other systems accessed through the hive hook) as well.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Given the nature of the fix I don't think they're needed but perhaps the maintainers feel differently.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`