### PR TITLE
[AIRFLOW-4436] Don't build the same docker image twice in tests

### DIFF
--- a/scripts/ci/kubernetes/docker/build.sh
+++ b/scripts/ci/kubernetes/docker/build.sh
@@ -25,6 +25,12 @@ PYTHON_DOCKER_IMAGE=python:3.6-slim
 
 set -e
 
+# Don't rebuild the image more than once on travis
+if [[ -n "$TRAVIS" || -z "$AIRFLOW_CI_REUSE_K8S_IMAGE" ]] && docker image inspect "$IMAGE:$TAG" > /dev/null 2>/dev/null; then
+  echo "Re-using existing image"
+  exit 0
+fi
+
 if [ "${VM_DRIVER:-none}" != "none" ]; then
     ENVCONFIG=$(minikube docker-env)
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4436

### Description

- [x] Save 5 minutes of test time for the Kube job.

  **Before**: 30min 11sec

  **After**: 24 min 14 sec

### Tests

- [x] None

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
