### PR TITLE
[AIRFLOW-4430] Fix "Zoom into Sub DAG" link

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -366,7 +366,7 @@ function updateQueryStringParameter(uri, key, value) {
 
     function updateModalUrls() {
       updateButtonUrl(buttons.subdag, {
-        dag_id: dag_id,
+        dag_id: subdag_id,
         execution_date: execution_date,
       });
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1155,6 +1155,12 @@ class Airflow(AirflowBaseView):
             return redirect(url_for('Airflow.index'))
         dag = dag_model.get_dag()
 
+        if dag is None:
+            dag = dagbag.get_dag(dag_id)
+            if dag is None:
+                flash('DAG "{0}" seems to be missing from DagBag.'.format(dag_id), "error")
+                return redirect(url_for('Airflow.index'))
+
         root = request.args.get('root')
         if root:
             dag = dag.sub_dag(

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -474,6 +474,11 @@ class TestAirflowBaseViews(TestBase):
         resp = self.client.get(url, follow_redirects=True)
         self.check_content_in_response('runme_1', resp)
 
+    def test_tree_subdag(self):
+        url = 'tree?dag_id=example_subdag_operator.section-1'
+        resp = self.client.get(url, follow_redirects=True)
+        self.check_content_in_response('section-1-task-1', resp)
+
     def test_duration(self):
         url = 'duration?days=30&dag_id=example_bash_operator'
         resp = self.client.get(url, follow_redirects=True)


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-4430

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Fixes the "Zoom into Sub DAG" button to link to the proper URL, and fixes an associated error when looking up the DAG object in the `tree` view for a SubDAG

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Added a unit test for the `tree` view for a subDAG

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
