### PR TITLE
AIRFLOW-4174 Fix run with backoff

### DIFF
--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -208,4 +208,4 @@ class HttpHook(BaseHook):
             **_retry_args
         )
 
-        self._retry_obj(self.run, *args, **kwargs)
+        return self._retry_obj(self.run, *args, **kwargs)

--- a/tests/hooks/test_http_hook.py
+++ b/tests/hooks/test_http_hook.py
@@ -207,7 +207,7 @@ class TestHttpHook(unittest.TestCase):
         retry_args = dict(
             wait=tenacity.wait_none(),
             stop=tenacity.stop_after_attempt(7),
-            retry=requests.exceptions.ConnectionError
+            retry=tenacity.retry_if_exception_type(requests.exceptions.ConnectionError)
         )
 
         def send_and_raise(request, **kwargs):
@@ -224,6 +224,31 @@ class TestHttpHook(unittest.TestCase):
             self.get_hook._retry_obj.stop.max_attempt_number + 1,
             mocked_session.call_count
         )
+
+    @requests_mock.mock()
+    def test_run_with_advanced_retry(self, m):
+
+        m.get(
+            u'http://test:8080/v1/test',
+            status_code=200,
+            reason=u'OK'
+        )
+
+        retry_args = dict(
+            wait=tenacity.wait_none(),
+            stop=tenacity.stop_after_attempt(3),
+            retry=tenacity.retry_if_exception_type(Exception),
+            reraise=True
+        )
+        with mock.patch(
+            'airflow.hooks.base_hook.BaseHook.get_connection',
+            side_effect=get_airflow_connection
+        ):
+            response = self.get_hook.run_with_advanced_retry(
+                    endpoint='v1/test',
+                    _retry_args=retry_args
+                )
+            self.assertIsInstance(response, requests.Response)
 
     def test_header_from_extra_and_run_method_are_merged(self):
 

--- a/tests/hooks/test_http_hook.py
+++ b/tests/hooks/test_http_hook.py
@@ -16,13 +16,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import unittest
-
 import json
+import unittest
 
 import requests
 import requests_mock
-
 import tenacity
 
 from airflow import configuration
@@ -52,6 +50,7 @@ def get_airflow_connection_with_port(conn_id=None):
 
 class TestHttpHook(unittest.TestCase):
     """Test get, post and raise_for_status"""
+
     def setUp(self):
         session = requests.Session()
         adapter = requests_mock.Adapter()
@@ -73,7 +72,6 @@ class TestHttpHook(unittest.TestCase):
             'airflow.hooks.base_hook.BaseHook.get_connection',
             side_effect=get_airflow_connection
         ):
-
             resp = self.get_hook.run('v1/test')
             self.assertEqual(resp.text, '{"status":{"status": 200}}')
 
@@ -207,7 +205,9 @@ class TestHttpHook(unittest.TestCase):
         retry_args = dict(
             wait=tenacity.wait_none(),
             stop=tenacity.stop_after_attempt(7),
-            retry=tenacity.retry_if_exception_type(requests.exceptions.ConnectionError)
+            retry=tenacity.retry_if_exception_type(
+                requests.exceptions.ConnectionError
+            )
         )
 
         def send_and_raise(request, **kwargs):
@@ -245,9 +245,9 @@ class TestHttpHook(unittest.TestCase):
             side_effect=get_airflow_connection
         ):
             response = self.get_hook.run_with_advanced_retry(
-                    endpoint='v1/test',
-                    _retry_args=retry_args
-                )
+                endpoint='v1/test',
+                _retry_args=retry_args
+            )
             self.assertIsInstance(response, requests.Response)
 
     def test_header_from_extra_and_run_method_are_merged(self):
@@ -307,7 +307,3 @@ class TestHttpHook(unittest.TestCase):
 
 
 send_email_test = mock.Mock()
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Jira

My PR addresses the following Airflow Jira issues and references them in the PR title.
https://issues.apache.org/jira/browse/AIRFLOW-4174
Description

There is a missing return in HttpHook in run_with_advanced_retry. Will add tests and return statement.
https://github.com/apache/airflow/blob/master/airflow/hooks/http_hook.py#L209

Tests

- [x] My PR adds the following unit tests OR does not need testing for this extremely good reason:
Added a unit test for the tree view for a subDAG

Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "How to write a good git commit message":
Subject is separated from body by a blank line
Subject is limited to 50 characters (not including Jira issue reference)
Subject does not end with a period
Subject uses the imperative mood ("add", not "adding")
Body wraps at 72 characters
Body explains "what" and "why", not "how"
Documentation

- [x]  In case of new functionality, my PR adds documentation that describes how to use it.
All the public functions and the classes in the PR contain docstrings that explain what it does
If you implement backwards incompatible changes, please leave a note in the Updating.md so we can assign it to a appropriate release