### PR TITLE
[AIRFLOW-4443] Document behavior of LatestOnlyOperator for externally triggered dagrun

### DIFF
--- a/airflow/operators/latest_only_operator.py
+++ b/airflow/operators/latest_only_operator.py
@@ -28,6 +28,9 @@ class LatestOnlyOperator(BaseOperator, SkipMixin):
 
     If the task is run outside of the latest schedule interval, all
     directly downstream tasks will be skipped.
+
+    Note that downstream tasks are never skipped if the given DAG_Run is
+    marked as externally triggered.
     """
 
     ui_color = '#e9ffdb'  # nyanza


### PR DESCRIPTION
A LatestOnlyOperator task will never skip downstream tasks if run in an
externally triggered dagrun. This is probably reasonable–the software
is not making assumptions about the trigger-er's intention when creating
an unscheduled dagrun, and in that agnostic state, the default behavior
would be to not skip any tasks.

However, that rationale may not be obvious to an enduser, who may be
confused why a latest-only task in an externally triggered dagrun with
an execution_date in the past is not skipping downstream tasks.

This PR updates the docstring for the LatestOnlyOperator to clarify
the operator's behavior in this scenario.