### PR TITLE
[AIRFLOW-4444][WIP] Introducing ghosts and parallel executor event handling

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -512,6 +512,9 @@ authenticate = False
 # DAGs submitted manually in the web UI or with trigger_dag will still run.
 use_job_schedule = True
 
+# Ghosts are handled by DagFileProcessor like zombies if set to true.
+deferred_ghosts = False
+
 [ldap]
 # set this to ldaps://<your.ldap.server>:<port>
 uri =

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -143,6 +143,7 @@ class TestDagFileProcessorManager(unittest.TestCase):
             signal_conn=MagicMock(),
             stat_queue=MagicMock(),
             result_queue=MagicMock,
+            ghost_queue=MagicMock,
             async_mode=True)
 
         mock_processor = MagicMock()
@@ -164,6 +165,7 @@ class TestDagFileProcessorManager(unittest.TestCase):
             signal_conn=MagicMock(),
             stat_queue=MagicMock(),
             result_queue=MagicMock,
+            ghost_queue=MagicMock,
             async_mode=True)
 
         mock_processor = MagicMock()
@@ -185,6 +187,7 @@ class TestDagFileProcessorManager(unittest.TestCase):
             signal_conn=MagicMock(),
             stat_queue=MagicMock(),
             result_queue=MagicMock,
+            ghost_queue=MagicMock,
             async_mode=True)
 
         dagbag = DagBag(TEST_DAG_FOLDER)
@@ -246,6 +249,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
                                                     [],
                                                     0,
                                                     processor_factory,
+                                                    None,
                                                     async_mode)
             manager_process = \
                 processor_agent._launch_process(processor_agent._dag_directory,
@@ -255,6 +259,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
                                                 processor_agent._child_signal_conn,
                                                 processor_agent._stat_queue,
                                                 processor_agent._result_queue,
+                                                processor_agent._ghost_queue,
                                                 processor_agent._async_mode)
             if not async_mode:
                 processor_agent.heartbeat()
@@ -278,6 +283,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
                                                 [test_dag_path],
                                                 1,
                                                 processor_factory,
+                                                None,
                                                 async_mode)
         processor_agent.start()
         parsing_result = []
@@ -311,6 +317,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
                                                 [],
                                                 0,
                                                 processor_factory,
+                                                None,
                                                 async_mode)
         manager_process = \
             processor_agent._launch_process(processor_agent._dag_directory,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4444)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR is currently a WIP, but establishes the core changes that are being proposed.
 - Executor events are being re-termed as ghosts (to keep in line with the zombies nomenclature). Ghosts are events that are recorded as QUEUED in the DB, but executor has marked them as finished.
 - Ghosts are stateful if discovered using the event buffer, and hence need to be handled sequentially and aggressively. Ghosts can be stateless if discovered using the DB first, and then mapped against executor directly.
 - If the discovery is stateless, then we can defer the handling of ghosts, and push them just like zombies to the `DagFileProcessor` instances for handling.

Main changes :
 - Ghosts will be discovered in a single query in a scheduler heartbeat. (previously it was a single query per ghost)
 - Ghosts will be lazily handled when the DAG is eventually parsed again by the processors.
 - Ghosts won't appear individually inside the logs as executor events, they will appear as zombies instead.
 - Each DAG is guaranteed to be parsed only once per loop.

This PR addresses an important concern for us as we see Scheduler loops sometimes exceed 100s if there is a big accumulation of executor events.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

TODO, will add next.

### Commits

### Documentation

### Code Quality

- [ ] Passes `flake8`
