### PR TITLE
[AIRFLOW-4450] has_dag_access does not handle form parameters

### DIFF
--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -102,7 +102,7 @@ def has_dag_access(**dag_kwargs):
         @functools.wraps(f)
         def wrapper(self, *args, **kwargs):
             has_access = self.appbuilder.sm.has_access
-            dag_id = request.args.get('dag_id')
+            dag_id = request.values.get('dag_id')
             # if it is false, we need to check whether user has write access on the dag
             can_dag_edit = dag_kwargs.get('can_dag_edit', False)
 


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - [AIRFLOW-4450](https://issues.apache.org/jira/browse/AIRFLOW-4450)

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
  - The initial bug discovered was that in the 1.10.3 update, we saw that non-admin users who had permission to clear task instances were no longer able to do so.
  - An unintentional side effect of [AIRFLOW-4240 #5039] broke has_dag_access so that it does not always receive the correct request arguments from form parameters passed in through the POST endpoints. The change here merges arguments from request.args and request.form before continuing.
  - This change was made on the Airflow instance I'm running and confirmed to fix the issue.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - No existing unit tests for any of the decorators; no proper test identified for this case.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
