### PR TITLE
[AIRFLOW-4420] Backfill respects task_concurrency

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -119,5 +119,10 @@ class NoAvailablePoolSlot(AirflowException):
 
 
 class DagConcurrencyLimitReached(AirflowException):
-    """Raise when concurrency limit is reached"""
+    """Raise when DAG concurrency limit is reached"""
+    pass
+
+
+class TaskConcurrencyLimitReached(AirflowException):
+    """Raise when task concurrency limit is reached"""
     pass

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -37,8 +37,13 @@ from typing import Any
 
 from airflow import configuration as conf
 from airflow import executors, models, settings
-from airflow.exceptions import (AirflowException, DagConcurrencyLimitReached,
-                                NoAvailablePoolSlot, PoolNotFound)
+from airflow.exceptions import (
+    AirflowException,
+    DagConcurrencyLimitReached,
+    NoAvailablePoolSlot,
+    PoolNotFound,
+    TaskConcurrencyLimitReached,
+)
 from airflow.models import DAG, DagPickle, DagRun, SlaMiss, errors
 from airflow.stats import Stats
 from airflow.task.task_runner import get_task_runner
@@ -1800,6 +1805,7 @@ class BackfillJob(BaseJob):
     """
     ID_PREFIX = 'backfill_'
     ID_FORMAT_PREFIX = ID_PREFIX + '{0}'
+    STATES_COUNT_AS_RUNNING = (State.RUNNING, State.QUEUED)
 
     __mapper_args__ = {
         'polymorphic_identity': 'BackfillJob'
@@ -2315,18 +2321,32 @@ class BackfillJob(BaseJob):
                                     "non_pooled_backfill_task_slot_count.")
                             non_pool_slots -= 1
 
-                        num_running_tasks = DAG.get_num_task_instances(
+                        num_running_task_instances_in_dag = DAG.get_num_task_instances(
                             self.dag_id,
-                            states=(State.QUEUED, State.RUNNING))
+                            states=self.STATES_COUNT_AS_RUNNING,
+                        )
 
-                        if num_running_tasks >= self.dag.concurrency:
+                        if num_running_task_instances_in_dag >= self.dag.concurrency:
                             raise DagConcurrencyLimitReached(
-                                "Not scheduling since concurrency limit "
+                                "Not scheduling since DAG concurrency limit "
                                 "is reached."
                             )
 
+                        if task.task_concurrency:
+                            num_running_task_instances_in_task = DAG.get_num_task_instances(
+                                dag_id=self.dag_id,
+                                task_ids=[task.task_id],
+                                states=self.STATES_COUNT_AS_RUNNING,
+                            )
+
+                            if num_running_task_instances_in_task >= task.task_concurrency:
+                                raise TaskConcurrencyLimitReached(
+                                    "Not scheduling since Task concurrency limit "
+                                    "is reached."
+                                )
+
                         _per_task_process(task, key, ti)
-            except (NoAvailablePoolSlot, DagConcurrencyLimitReached) as e:
+            except (NoAvailablePoolSlot, DagConcurrencyLimitReached, TaskConcurrencyLimitReached) as e:
                 self.log.debug(e)
 
             # execute the tasks in the queue


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4420

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Ensure that Airflow backfill respects `task_concurrency`.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
