### PR TITLE
[AIRFLOW-4417] Add AWS IAM authenication for PostgresHook

### DIFF
--- a/tests/hooks/test_postgres_hook.py
+++ b/tests/hooks/test_postgres_hook.py
@@ -24,6 +24,51 @@ import unittest
 from tempfile import NamedTemporaryFile
 
 from airflow.hooks.postgres_hook import PostgresHook
+from airflow.models import Connection
+
+
+class TestPostgresHookConn(unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.connection = Connection(
+            login='login',
+            password='password',
+            host='host',
+            schema='schema'
+        )
+
+        self.db_hook = PostgresHook()
+        self.db_hook.get_connection = mock.Mock()
+        self.db_hook.get_connection.return_value = self.connection
+
+    @mock.patch('airflow.hooks.postgres_hook.psycopg2.connect')
+    def test_get_conn(self, mock_connect):
+        self.db_hook.get_conn()
+        mock_connect.assert_called_once_with(user='login', password='password', host='host',
+                                             dbname='schema', port=None)
+
+    @mock.patch('airflow.hooks.postgres_hook.psycopg2.connect')
+    @mock.patch('airflow.contrib.hooks.aws_hook.AwsHook.get_client_type')
+    def test_get_conn_rds_iam_postgres(self, mock_client, mock_connect):
+        self.connection.extra = '{"iam":true}'
+        mock_client.return_value.generate_db_auth_token.return_value = 'aws_token'
+        self.db_hook.get_conn()
+        mock_connect.assert_called_once_with(user='login', password='aws_token', host='host',
+                                             dbname='schema', port=5432)
+
+    @mock.patch('airflow.hooks.postgres_hook.psycopg2.connect')
+    @mock.patch('airflow.contrib.hooks.aws_hook.AwsHook.get_client_type')
+    def test_get_conn_rds_iam_redshift(self, mock_client, mock_connect):
+        self.connection.extra = '{"iam":true, "redshift":true}'
+        self.connection.host = 'cluster-identifier.ccdfre4hpd39h.us-east-1.redshift.amazonaws.com'
+        login = 'IAM:{login}'.format(login=self.connection.login)
+        mock_client.return_value.get_cluster_credentials.return_value = {'DbPassword': 'aws_token',
+                                                                         'DbUser': login}
+        self.db_hook.get_conn()
+        mock_connect.assert_called_once_with(user=login, password='aws_token', host=self.connection.host,
+                                             dbname='schema', port=5439)
 
 
 class TestPostgresHook(unittest.TestCase):


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-4417

### Description

- [x] Enhance the existing PostgresHook to allow for IAM authentication for RDS Postgres and Redshift.

### Tests

- [x] My PR adds the following unit tests
  - test_get_conn()
  - test_get_conn_rds_iam_postgres()
  - test_get_conn_rds_iam_redshift

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
