### PR TITLE
[AIRFLOW-4146] Fix CgroupTaskRunner errors

### DIFF
--- a/airflow/contrib/task_runner/cgroup_task_runner.py
+++ b/airflow/contrib/task_runner/cgroup_task_runner.py
@@ -114,8 +114,8 @@ class CgroupTaskRunner(BaseTaskRunner):
     def start(self):
         # Use bash if it's already in a cgroup
         cgroups = self._get_cgroup_names()
-        if ((cgroups.get("cpu") and cgroups.get("cpu") != "/")
-                or (cgroups.get("memory") and cgroups.get("memory") != "/")):
+        if ((cgroups.get("cpu") and cgroups.get("cpu") != "/") or
+                (cgroups.get("memory") and cgroups.get("memory") != "/")):
             self.log.debug(
                 "Already running in a cgroup (cpu: %s memory: %s) so not "
                 "creating another one",
@@ -196,6 +196,8 @@ class CgroupTaskRunner(BaseTaskRunner):
             self._delete_cgroup(self.mem_cgroup_name)
         if self._created_cpu_cgroup:
             self._delete_cgroup(self.cpu_cgroup_name)
+        super().on_finish()
+
 
     @staticmethod
     def _get_cgroup_names():

--- a/airflow/contrib/task_runner/cgroup_task_runner.py
+++ b/airflow/contrib/task_runner/cgroup_task_runner.py
@@ -76,6 +76,8 @@ class CgroupTaskRunner(BaseTaskRunner):
         node = trees.Tree().root
         path_split = path.split(os.sep)
         for path_element in path_split:
+            # node.name is encoded to bytes:
+            # https://github.com/cloudsigma/cgroupspy/blob/e705ac4ccdfe33d8ecc700e9a35a9556084449ca/cgroupspy/nodes.py#L64
             name_to_node = {x.name.decode(): x for x in node.children}
             if path_element not in name_to_node:
                 self.log.debug("Creating cgroup %s in %s", path_element, node.path)

--- a/airflow/contrib/task_runner/cgroup_task_runner.py
+++ b/airflow/contrib/task_runner/cgroup_task_runner.py
@@ -198,7 +198,6 @@ class CgroupTaskRunner(BaseTaskRunner):
             self._delete_cgroup(self.cpu_cgroup_name)
         super().on_finish()
 
-
     @staticmethod
     def _get_cgroup_names():
         """

--- a/airflow/contrib/task_runner/cgroup_task_runner.py
+++ b/airflow/contrib/task_runner/cgroup_task_runner.py
@@ -38,7 +38,7 @@ class CgroupTaskRunner(BaseTaskRunner):
     Cgroup must be mounted first otherwise CgroupTaskRunner
     will not be able to work.
 
-    cgroup-bin package must be installed to use cgexec command.
+    cgroup-bin Ubuntu package must be installed to use cgexec command.
 
     Note that this task runner will only work if the Airflow user has root privileges,
     e.g. if the airflow user is called `airflow` then the following entries (or an even

--- a/airflow/contrib/task_runner/cgroup_task_runner.py
+++ b/airflow/contrib/task_runner/cgroup_task_runner.py
@@ -33,8 +33,12 @@ class CgroupTaskRunner(BaseTaskRunner):
     """
     Runs the raw Airflow task in a cgroup that has containment for memory and
     cpu. It uses the resource requirements defined in the task to construct
-    the settings for the cgroup. Cgroup must be mounted first otherwise CgroupTaskRunner
-    will not be able to work
+    the settings for the cgroup.
+
+    Cgroup must be mounted first otherwise CgroupTaskRunner
+    will not be able to work.
+
+    cgroup-bin package must be installed to use cgexec command.
 
     Note that this task runner will only work if the Airflow user has root privileges,
     e.g. if the airflow user is called `airflow` then the following entries (or an even
@@ -80,12 +84,12 @@ class CgroupTaskRunner(BaseTaskRunner):
             # https://github.com/cloudsigma/cgroupspy/blob/e705ac4ccdfe33d8ecc700e9a35a9556084449ca/cgroupspy/nodes.py#L64
             name_to_node = {x.name.decode(): x for x in node.children}
             if path_element not in name_to_node:
-                self.log.debug("Creating cgroup %s in %s", path_element, node.path)
+                self.log.debug("Creating cgroup %s in %s", path_element, node.path.decode())
                 node = node.create_cgroup(path_element)
             else:
                 self.log.debug(
                     "Not creating cgroup %s in %s since it already exists",
-                    path_element, node.path
+                    path_element, node.path.decode()
                 )
                 node = name_to_node[path_element]
         return node

--- a/setup.py
+++ b/setup.py
@@ -158,9 +158,7 @@ celery = [
     'flower>=0.7.3, <1.0',
     'tornado>=4.2.0, <6.0',  # Dep of flower. Pin to a version that works on Py3.5.2
 ]
-cgroups = [
-    'cgroupspy>=0.1.4',
-]
+cgroups = ['cgroupspy>=0.1.4']
 cloudant = ['cloudant>=2.0']
 crypto = ['cryptography>=0.9.3']
 dask = [

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,9 @@ celery = [
     'flower>=0.7.3, <1.0',
     'tornado>=4.2.0, <6.0',  # Dep of flower. Pin to a version that works on Py3.5.2
 ]
-cgroups = ['cgroupspy>=0.1.4']
+cgroups = [
+    'cgroupspy>=0.1.4',
+]
 cloudant = ['cloudant>=2.0']
 crypto = ['cryptography>=0.9.3']
 dask = [
@@ -282,7 +284,7 @@ devel_all = (sendgrid + devel + all_dbs + doc + samba + slack + crypto + oracle 
              docker + ssh + kubernetes + celery + redis + gcp + grpc +
              datadog + zendesk + jdbc + ldap + kerberos + password + webhdfs + jenkins +
              druid + pinot + segment + snowflake + elasticsearch +
-             atlas + azure + aws + salesforce)
+             atlas + azure + aws + salesforce + cgroups)
 
 # Snakebite & Google Cloud Dataflow are not Python 3 compatible :'(
 if PY3:

--- a/tests/contrib/task_runner/__init__.py
+++ b/tests/contrib/task_runner/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/contrib/task_runner/test_cgroup_task_runner.py
+++ b/tests/contrib/task_runner/test_cgroup_task_runner.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import mock
+import unittest
+
+from airflow.contrib.task_runner.cgroup_task_runner import CgroupTaskRunner
+
+
+class TestCgroupTaskRunner(unittest.TestCase):
+
+    @mock.patch("airflow.task.task_runner.base_task_runner.BaseTaskRunner.__init__")
+    def test_init(self, mock_super_init):
+        """
+        This test ensures that initiating CgroupTaskRunner object
+        calls init method of BaseTaskRunner
+        """
+        local_task_job = mock.Mock()
+        local_task_job.task_instance = mock.MagicMock()
+        local_task_job.task_instance.run_as_user = None
+        local_task_job.task_instance.command_as_list.return_value = ['sleep', '1000']
+
+        CgroupTaskRunner(local_task_job)
+
+        self.assertTrue(mock_super_init.called)
+
+    @mock.patch("airflow.task.task_runner.base_task_runner.BaseTaskRunner.on_finish")
+    def test_on_finish(self, mock_super_on_finish):
+        """
+        This test ensures that CgroupTaskRunner.on_finish()
+        calls on_finish method of BaseTaskRunner to remove the temp cfg file
+        """
+        local_task_job = mock.Mock()
+        local_task_job.task_instance = mock.MagicMock()
+        local_task_job.task_instance.run_as_user = None
+        local_task_job.task_instance.command_as_list.return_value = ['sleep', '1000']
+
+        runner = CgroupTaskRunner(local_task_job)
+        runner.on_finish()
+
+        self.assertTrue(mock_super_on_finish.called)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/contrib/task_runner/test_cgroup_task_runner.py
+++ b/tests/contrib/task_runner/test_cgroup_task_runner.py
@@ -24,19 +24,19 @@ from airflow.contrib.task_runner.cgroup_task_runner import CgroupTaskRunner
 
 class TestCgroupTaskRunner(unittest.TestCase):
 
+    def setUp(self):
+        self.local_task_job = mock.Mock()
+        self.local_task_job.task_instance = mock.MagicMock()
+        self.local_task_job.task_instance.run_as_user = None
+        self.local_task_job.task_instance.command_as_list.return_value = ['sleep', '1000']
+
     @mock.patch("airflow.task.task_runner.base_task_runner.BaseTaskRunner.__init__")
     def test_init(self, mock_super_init):
         """
         This test ensures that initiating CgroupTaskRunner object
         calls init method of BaseTaskRunner
         """
-        local_task_job = mock.Mock()
-        local_task_job.task_instance = mock.MagicMock()
-        local_task_job.task_instance.run_as_user = None
-        local_task_job.task_instance.command_as_list.return_value = ['sleep', '1000']
-
-        CgroupTaskRunner(local_task_job)
-
+        CgroupTaskRunner(self.local_task_job)
         self.assertTrue(mock_super_init.called)
 
     @mock.patch("airflow.task.task_runner.base_task_runner.BaseTaskRunner.on_finish")
@@ -45,14 +45,8 @@ class TestCgroupTaskRunner(unittest.TestCase):
         This test ensures that CgroupTaskRunner.on_finish()
         calls on_finish method of BaseTaskRunner to remove the temp cfg file
         """
-        local_task_job = mock.Mock()
-        local_task_job.task_instance = mock.MagicMock()
-        local_task_job.task_instance.run_as_user = None
-        local_task_job.task_instance.command_as_list.return_value = ['sleep', '1000']
-
-        runner = CgroupTaskRunner(local_task_job)
+        runner = CgroupTaskRunner(self.local_task_job)
         runner.on_finish()
-
         self.assertTrue(mock_super_on_finish.called)
 
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [AIRFLOW-4146](https://issues.apache.org/jira/browse/AIRFLOW-4146) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4146
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
1. CgroupTaskRunner import errors is fixed in this PR.
2. Node.name() is encoded but it works fine in python2. However, python3 returns False for `'abc' = b'abc'`. We have to decode it since python2 support has been dropped in this project.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
1. Add test to ensure that `CgroupTaskRunner._init_()` method calls `super()._init_` to initiate CgroupTaskRunner object.
2. Add test to ensure that when task finishes, `CgroupTaskRunner.on_finish()` will call `super().on_finish()` to delete the temp cfg file.
3. import errors will be captured as well.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
