### PR TITLE
[AIRFLOW-1501] Add GoogleCloudStorageDeleteOperator

### DIFF
--- a/airflow/contrib/operators/gcs_delete_operator.py
+++ b/airflow/contrib/operators/gcs_delete_operator.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+from typing import Optional, Iterable
+
+
+class GoogleCloudStorageDeleteOperator(BaseOperator):
+    """
+    Deletes objects from a Google Cloud Storage bucket, either
+    from an explicit list of object names or all objects
+    matching a prefix.
+
+    :param bucket_name: The GCS bucket to delete from
+    :type bucket_name: str
+    :param objects: List of objects to delete. These should be the names
+        of objects in the bucket, not including gs://bucket/
+    :type objects: Iterable[str]
+    :param prefix: Prefix of objects to delete. All objects matching this
+        prefix in the bucket will be deleted.
+    :param google_cloud_storage_conn_id: The connection ID to use for
+        Google Cloud Storage
+    :type google_cloud_storage_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    """
+
+    template_fields = ('bucket_name', 'prefix', 'objects')
+
+    @apply_defaults
+    def __init__(self,
+                 bucket_name: str,
+                 objects: Optional[Iterable[str]] = None,
+                 prefix: Optional[str] = None,
+                 google_cloud_storage_conn_id: str = 'google_cloud_default',
+                 delegate_to: Optional[str] = None,
+                 *args, **kwargs):
+        self.bucket_name = bucket_name
+        self.objects = objects
+        self.prefix = prefix
+        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.delegate_to = delegate_to
+
+        assert objects is not None or prefix is not None
+
+        super().__init__(*args, **kwargs)
+
+    def execute(self, context):
+        hook = GoogleCloudStorageHook(
+            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+            delegate_to=self.delegate_to
+        )
+
+        if self.objects:
+            objects = self.objects
+        else:
+            objects = hook.list(bucket_name=self.bucket_name,
+                                prefix=self.prefix)
+
+        self.log.info("Deleting %s objects from %s",
+                      len(objects), self.bucket_name)
+        for object_name in objects:
+            hook.delete(bucket_name=self.bucket_name,
+                        object_name=object_name)

--- a/tests/contrib/operators/test_gcs_delete_operator.py
+++ b/tests/contrib/operators/test_gcs_delete_operator.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow.contrib.operators.gcs_delete_operator import GoogleCloudStorageDeleteOperator
+from tests.compat import mock
+
+TASK_ID = 'test-gcs-delete-operator'
+TEST_BUCKET = 'test-bucket'
+PREFIX = 'ab'
+MOCK_FILES = ["a", "ab", "abc"]
+
+
+class GoogleCloudStorageDeleteOperatorTest(unittest.TestCase):
+    @mock.patch('airflow.contrib.operators.gcs_delete_operator.GoogleCloudStorageHook')
+    def test_delete_objects(self, mock_hook):
+        operator = GoogleCloudStorageDeleteOperator(task_id=TASK_ID,
+                                                    bucket_name=TEST_BUCKET,
+                                                    objects=MOCK_FILES[0:2])
+
+        operator.execute(None)
+        mock_hook.return_value.list.assert_not_called()
+        mock_hook.return_value.delete.assert_has_calls(
+            calls=[
+                mock.call(bucket_name=TEST_BUCKET, object_name=MOCK_FILES[0]),
+                mock.call(bucket_name=TEST_BUCKET, object_name=MOCK_FILES[1])
+            ],
+            any_order=True
+        )
+
+    @mock.patch('airflow.contrib.operators.gcs_delete_operator.GoogleCloudStorageHook')
+    def test_delete_prefix(self, mock_hook):
+        mock_hook.return_value.list.return_value = MOCK_FILES[1:3]
+        operator = GoogleCloudStorageDeleteOperator(task_id=TASK_ID,
+                                                    bucket_name=TEST_BUCKET,
+                                                    prefix=PREFIX)
+
+        operator.execute(None)
+        mock_hook.return_value.list.assert_called_once_with(
+            bucket_name=TEST_BUCKET, prefix=PREFIX
+        )
+        mock_hook.return_value.delete.assert_has_calls(
+            calls=[
+                mock.call(bucket_name=TEST_BUCKET, object_name=MOCK_FILES[1]),
+                mock.call(bucket_name=TEST_BUCKET, object_name=MOCK_FILES[2])
+            ],
+            any_order=True
+        )


### PR DESCRIPTION
### Jira

- [x] My PR addresses https://issues.apache.org/jira/browse/AIRFLOW-1501

This has been previously marked as `Fixed` (a year ago), but no operator appears to either exist in `master` or in any current PR (although delete is supported by the GCS hook).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Creates `GoogleCloudStorageDeleteOperator`, which (analogously to the existing S3 object delete operator), exposes the `delete` function of the GCS hook as an operator supporting templating and deletion either by a list of objects or all objects matching a prefix.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

`tests/contrib/operators/test_gcs_delete_operator.py`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
