### PR TITLE
[AIRFLOW-4456] Add sub-classable BaseBranchOperator

### DIFF
--- a/airflow/models/skipmixin.py
+++ b/airflow/models/skipmixin.py
@@ -23,6 +23,8 @@ from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
 
+from typing import Union, Iterable, Set
+
 
 class SkipMixin(LoggingMixin):
     @provide_session
@@ -64,3 +66,35 @@ class SkipMixin(LoggingMixin):
                 session.merge(ti)
 
             session.commit()
+
+    def skip_all_except(self, ti: TaskInstance, branch_task_ids: Union[str, Iterable[str]]):
+        """
+        This method implements the logic for a branching operator; given a single
+        task ID or list of task IDs to follow, this skips all other tasks
+        immediately downstream of this operator.
+        """
+        self.log.info("Following branch %s", branch_task_ids)
+        if isinstance(branch_task_ids, str):
+            branch_task_ids = [branch_task_ids]
+
+        dag_run = ti.get_dagrun()
+        task = ti.task
+        dag = task.dag
+
+        downstream_tasks = task.downstream_list
+
+        if downstream_tasks:
+            # Also check downstream tasks of the branch task. In case the task to skip
+            # is also a downstream task of the branch task, we exclude it from skipping.
+            branch_downstream_task_ids = set()  # type: Set[str]
+            for b in branch_task_ids:
+                branch_downstream_task_ids.update(dag.
+                                                  get_task(b).
+                                                  get_flat_relative_ids(upstream=False))
+
+            skip_tasks = [t for t in downstream_tasks
+                          if t.task_id not in branch_task_ids and
+                          t.task_id not in branch_downstream_task_ids]
+
+            self.log.info("Skipping tasks %s", [t.task_id for t in skip_tasks])
+            self.skip(dag_run, ti.execution_date, skip_tasks)

--- a/airflow/operators/branch_operator.py
+++ b/airflow/operators/branch_operator.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.models import BaseOperator, SkipMixin
+
+from typing import Union, Iterable, Dict, Set
+
+
+class BranchOperator(BaseOperator, SkipMixin):
+    """
+    This is a base class for creating operators with branching functionality,
+    similarly to BranchPythonOperator.
+
+    Users should subclass this operator and implement the function
+    `choose_branch(self, context)`. This should run whatever business logic
+    is needed to determine the branch, and return either the task_id for
+    a single task (as a str) or a list of task_ids.
+
+    The operator will continue with the returned task_id(s), and all other
+    tasks directly downstream of this operator will be skipped.
+    """
+
+    def choose_branch(self, context: Dict) -> Union[str, Iterable[str]]:
+        """
+        Subclasses should implement this, running whatever logic is
+        necessary to choose a branch and returning a task_id or list of
+        task_ids.
+
+        :param context: Context dictionary as passed to execute()
+        :type context: dict
+        """
+        raise NotImplementedError
+
+    def execute(self, context: Dict):
+        branch_task_ids = self.choose_branch(context)
+        self.log.info("Following branch %s", branch_task_ids)
+
+        if isinstance(branch_task_ids, str):
+            branch_task_ids = [branch_task_ids]
+
+        downstream_tasks = context['task'].downstream_list
+
+        if downstream_tasks:
+            # Also check downstream tasks of the branch task. In case the task to skip
+            # is also a downstream task of the branch task, we exclude it from skipping.
+            branch_downstream_task_ids = set()  # type: Set[str]
+            for b in branch_task_ids:
+                branch_downstream_task_ids.update(context["dag"].
+                                                  get_task(b).
+                                                  get_flat_relative_ids(upstream=False))
+
+            skip_tasks = [t for t in downstream_tasks
+                          if t.task_id not in branch_task_ids and
+                          t.task_id not in branch_downstream_task_ids]
+
+            self.log.info("Skipping tasks %s", [t.task_id for t in skip_tasks])
+            self.skip(context['dag_run'], context['ti'].execution_date, skip_tasks)

--- a/airflow/operators/branch_operator.py
+++ b/airflow/operators/branch_operator.py
@@ -17,12 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow.models import BaseOperator, SkipMixin
-
 from typing import Union, Iterable, Dict
 
+from airflow.models import BaseOperator, SkipMixin
 
-class BranchOperator(BaseOperator, SkipMixin):
+
+class BaseBranchOperator(BaseOperator, SkipMixin):
     """
     This is a base class for creating operators with branching functionality,
     similarly to BranchPythonOperator.

--- a/airflow/operators/branch_operator.py
+++ b/airflow/operators/branch_operator.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""Branching operators"""
 
 from typing import Union, Iterable, Dict
 

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -27,7 +27,6 @@ from textwrap import dedent
 from typing import Optional, Iterable, Dict, Callable
 
 import dill
-import six
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, SkipMixin
@@ -133,29 +132,7 @@ class BranchPythonOperator(PythonOperator, SkipMixin):
     """
     def execute(self, context):
         branch = super().execute(context)
-        if isinstance(branch, six.string_types):
-            branch = [branch]
-        self.log.info("Following branch %s", branch)
-        self.log.info("Marking other directly downstream tasks as skipped")
-
-        downstream_tasks = context['task'].downstream_list
-        self.log.debug("Downstream task_ids %s", downstream_tasks)
-
-        if downstream_tasks:
-            # Also check downstream tasks of the branch task. In case the task to skip
-            # is a downstream task of the branch task, we exclude it from skipping.
-            branch_downstream_task_ids = set()
-            for b in branch:
-                branch_downstream_task_ids.update(context["dag"].
-                                                  get_task(b).
-                                                  get_flat_relative_ids(upstream=False))
-            skip_tasks = [t
-                          for t in downstream_tasks
-                          if t.task_id not in branch and
-                          t.task_id not in branch_downstream_task_ids]
-            self.skip(context['dag_run'], context['ti'].execution_date, skip_tasks)
-
-        self.log.info("Done.")
+        self.skip_all_except(context['ti'], branch)
 
 
 class ShortCircuitOperator(PythonOperator, SkipMixin):

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -655,16 +655,16 @@ For example:
 
   start_op >> branch_op >> [continue_op, stop_op]
 
-If you wish to implement your own operators with branching functionality,
-you can inherit from ``BranchOperator``, which behaves similarly to
-``BranchPythonOperator`` but expects you to provide an implementation of the
-method ``choose_branch``. As with the callable for ``BranchPythonOperator``,
-this method should return the ID of a downstream task, or a list of
-task IDs, which will be run, and all others will be skipped.
+If you wish to implement your own operators with branching functionality, you
+can inherit from :class:`~airflow.operators.branch_operator.BaseBranchOperator`,
+which behaves similarly to ``BranchPythonOperator`` but expects you to provide
+an implementation of the method ``choose_branch``. As with the callable for
+``BranchPythonOperator``, this method should return the ID of a downstream task,
+or a list of task IDs, which will be run, and all others will be skipped.
 
 .. code:: python
 
-  class MyBranchOperator(BranchOperator):
+  class MyBranchOperator(BaseBranchOperator):
       def choose_branch(self, context):
           """
           Run an extra branch on the first day of the month

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -655,6 +655,26 @@ For example:
 
   start_op >> branch_op >> [continue_op, stop_op]
 
+If you wish to implement your own operators with branching functionality,
+you can inherit from ``BranchOperator``, which behaves similarly to
+``BranchPythonOperator`` but expects you to provide an implementation of the
+method ``choose_branch``. As with the callable for ``BranchPythonOperator``,
+this method should return the ID of a downstream task, or a list of
+task IDs, which will be run, and all others will be skipped.
+
+.. code:: python
+
+  class MyBranchOperator(BranchOperator):
+      def choose_branch(self, context):
+          """
+          Run an extra branch on the first day of the month
+          """
+          if context['execution_date'].day == 1:
+              return ['daily_task_id', 'monthly_task_id']
+          else:
+              return 'daily_task_id'
+
+
 SubDAGs
 =======
 

--- a/tests/operators/test_branch_operator.py
+++ b/tests/operators/test_branch_operator.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+import datetime
+
+from airflow.models import TaskInstance as TI, DAG, DagRun
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.branch_operator import BranchOperator
+from airflow.utils import timezone
+from airflow.utils.db import create_session
+from airflow.utils.state import State
+
+DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+INTERVAL = datetime.timedelta(hours=12)
+
+
+class ChooseBranchOne(BranchOperator):
+    def choose_branch(self, context):
+        return 'branch_1'
+
+
+class ChooseBranchOneTwo(BranchOperator):
+    def choose_branch(self, context):
+        return ['branch_1', 'branch_2']
+
+
+class BranchOperatorTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(BranchOperatorTest, cls).setUpClass()
+
+        with create_session() as session:
+            session.query(DagRun).delete()
+            session.query(TI).delete()
+
+    def setUp(self):
+        self.dag = DAG('branch_operator_test',
+                       default_args={
+                           'owner': 'airflow',
+                           'start_date': DEFAULT_DATE},
+                       schedule_interval=INTERVAL)
+
+        self.branch_1 = DummyOperator(task_id='branch_1', dag=self.dag)
+        self.branch_2 = DummyOperator(task_id='branch_2', dag=self.dag)
+
+    def tearDown(self):
+        super().tearDown()
+
+        with create_session() as session:
+            session.query(DagRun).delete()
+            session.query(TI).delete()
+
+    def test_without_dag_run(self):
+        """This checks the defensive against non existent tasks in a dag run"""
+        self.branch_op = ChooseBranchOne(task_id="make_choice", dag=self.dag)
+        self.branch_1.set_upstream(self.branch_op)
+        self.branch_2.set_upstream(self.branch_op)
+        self.dag.clear()
+
+        self.branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        with create_session() as session:
+            tis = session.query(TI).filter(
+                TI.dag_id == self.dag.dag_id,
+                TI.execution_date == DEFAULT_DATE
+            )
+
+            for ti in tis:
+                if ti.task_id == 'make_choice':
+                    self.assertEqual(ti.state, State.SUCCESS)
+                elif ti.task_id == 'branch_1':
+                    # should exist with state None
+                    self.assertEqual(ti.state, State.NONE)
+                elif ti.task_id == 'branch_2':
+                    self.assertEqual(ti.state, State.SKIPPED)
+                else:
+                    raise Exception
+
+    def test_branch_list_without_dag_run(self):
+        """This checks if the BranchOperator supports branching off to a list of tasks."""
+        self.branch_op = ChooseBranchOneTwo(task_id='make_choice', dag=self.dag)
+        self.branch_1.set_upstream(self.branch_op)
+        self.branch_2.set_upstream(self.branch_op)
+        self.branch_3 = DummyOperator(task_id='branch_3', dag=self.dag)
+        self.branch_3.set_upstream(self.branch_op)
+        self.dag.clear()
+
+        self.branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        with create_session() as session:
+            tis = session.query(TI).filter(
+                TI.dag_id == self.dag.dag_id,
+                TI.execution_date == DEFAULT_DATE
+            )
+
+            expected = {
+                "make_choice": State.SUCCESS,
+                "branch_1": State.NONE,
+                "branch_2": State.NONE,
+                "branch_3": State.SKIPPED,
+            }
+
+            for ti in tis:
+                if ti.task_id in expected:
+                    self.assertEqual(ti.state, expected[ti.task_id])
+                else:
+                    raise Exception
+
+    def test_with_dag_run(self):
+        self.branch_op = ChooseBranchOne(task_id="make_choice", dag=self.dag)
+        self.branch_1.set_upstream(self.branch_op)
+        self.branch_2.set_upstream(self.branch_op)
+        self.dag.clear()
+
+        dr = self.dag.create_dagrun(
+            run_id="manual__",
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING
+        )
+
+        self.branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        tis = dr.get_task_instances()
+        for ti in tis:
+            if ti.task_id == 'make_choice':
+                self.assertEqual(ti.state, State.SUCCESS)
+            elif ti.task_id == 'branch_1':
+                self.assertEqual(ti.state, State.NONE)
+            elif ti.task_id == 'branch_2':
+                self.assertEqual(ti.state, State.SKIPPED)
+            else:
+                raise Exception
+
+    def test_with_skip_in_branch_downstream_dependencies(self):
+        self.branch_op = ChooseBranchOne(task_id="make_choice", dag=self.dag)
+        self.branch_op >> self.branch_1 >> self.branch_2
+        self.branch_op >> self.branch_2
+        self.dag.clear()
+
+        dr = self.dag.create_dagrun(
+            run_id="manual__",
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING
+        )
+
+        self.branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        tis = dr.get_task_instances()
+        for ti in tis:
+            if ti.task_id == 'make_choice':
+                self.assertEqual(ti.state, State.SUCCESS)
+            elif ti.task_id == 'branch_1':
+                self.assertEqual(ti.state, State.NONE)
+            elif ti.task_id == 'branch_2':
+                self.assertEqual(ti.state, State.NONE)
+            else:
+                raise Exception


### PR DESCRIPTION
### Jira

- [x] My PR addresses https://issues.apache.org/jira/browse/AIRFLOW-4456

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This adds an abstract BranchOperator, which implementors can use to
create concrete operators for branching workflows fully encapsulated in
a class, rather than needing to pass an external callable (or
self-reference) to BranchPythonOperator. Also adds tests for same.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

`tests/operators/test_branch_operator.py`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
