### PR TITLE
[AIRFLOW-4459] Fix wrong DAG count in /home page when DAG count is zero

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -277,7 +277,7 @@ class Airflow(AirflowBaseView):
             search_query=arg_search_query if arg_search_query else '',
             page_size=dags_per_page,
             num_of_pages=num_of_pages,
-            num_dag_from=start + 1,
+            num_dag_from=min(start + 1, num_of_all_dags),
             num_dag_to=min(end, num_of_all_dags),
             num_of_all_dags=num_of_all_dags,
             paging=wwwutils.generate_pages(current_page, num_of_pages,


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-4459

### Description

When there is no DAG (maybe no DAG file deployed yet, or no matching result when we search), the the DAG count at the right bottom corner may be wrong. It will be "Showing 1 to 0  of 0 entries", while it should be "Showing 0 to 0  of 0 entries".
<img width="1278" alt="before-1" src="https://user-images.githubusercontent.com/11539188/57175642-eea26480-6e80-11e9-85c4-cda873691ad7.png">

On the other hand, if we provide URL argument "page" a too big value, let's say we only have 10 DAGs, and we visit "http://localhost:8080/home?page=3", we may see results like "Showing 21 to 10 of 10 entries", which is wrong for sure as well.
<img width="1279" alt="before-2" src="https://user-images.githubusercontent.com/11539188/57175648-f95cf980-6e80-11e9-9b3a-047f1e05eacb.png">

### After fix

<img width="1280" alt="Screen Shot 2019-05-04 at 3 12 59 PM" src="https://user-images.githubusercontent.com/11539188/57175661-15609b00-6e81-11e9-94b3-32003a28136d.png">

<img width="1280" alt="Screen Shot 2019-05-04 at 3 13 26 PM" src="https://user-images.githubusercontent.com/11539188/57175664-1abde580-6e81-11e9-9b9e-0b5c33434450.png">

