### PR TITLE
[AIRFLOW-4460] Remove __future__ import in models

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
-
 import copy
 import functools
 import os

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -17,9 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import division
-from __future__ import unicode_literals
-
 import hashlib
 import imp
 import importlib


### PR DESCRIPTION
Remove _future_ should done in
https://github.com/apache/airflow/pull/5020, but in
the same time our code base refactor models and
move some code out of _init.py. This PR to remove
__future__ in models.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4460

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Remove _future_ should done in
https://github.com/apache/airflow/pull/5020, but in
the same time our code base refactor models and
move some code out of _init.py. This PR to remove
__future__ in models.

### Code Quality

- [x] Passes `flake8`
