### PR TITLE
[WIP][AIRFLOW-2910] Add HTTP URI support

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -128,7 +128,7 @@ class Connection(Base, LoggingMixin):
 
     def parse_from_uri(self, uri):
         uri_parts = urlparse(uri)
-        if uri_parts.scheme in ['http', 'https']:
+        if uri_parts.scheme in ['http', 'https'] and uri_parts.hostname and "%" not in uri_parts.hostname:
             self._parse_from_http_uri(uri)
         else:
             self._parse_from_airflow_uri(uri)
@@ -142,8 +142,8 @@ class Connection(Base, LoggingMixin):
         self.host = urlunparse((
             url_parts.scheme, netloc, url_parts.path, url_parts.params, url_parts.query, None
         ))
-        self.login = url_parts.username
-        self.password = url_parts.password
+        self.login = unquote(url_parts.username) if url_parts.username else None
+        self.password = unquote(url_parts.password) if url_parts.password else None
         if url_parts.fragment:
             self.extra = json.dumps(dict(parse_qsl(url_parts.fragment)))
 

--- a/tests/models/test_connection.py
+++ b/tests/models/test_connection.py
@@ -92,10 +92,10 @@ class ConnectionTest(unittest.TestCase):
         self.assertIsNone(connection.extra)
 
     def test_connection_from_http_uri_without_extras(self):
-        uri = 'http://user:password@host%2flocation:1234/schema'
+        uri = 'http://user:password@location:1234/schema'
         connection = Connection(uri=uri)
         self.assertEqual(connection.conn_type, 'http')
-        self.assertEqual(connection.host, 'http://host%2flocation:1234/schema')
+        self.assertEqual(connection.host, 'http://location:1234/schema')
         self.assertEqual(connection.schema, None)
         self.assertIsNone(connection.extra)
 
@@ -111,10 +111,10 @@ class ConnectionTest(unittest.TestCase):
         self.assertDictEqual(connection.extra_dejson, {'extra1': 'a value', 'extra2': '/path/'})
 
     def test_connection_from_http_uri_with_extras(self):
-        uri = 'http://user:password@host%2flocation:1234/schema#extra1=a%20value&extra2=%2fpath%2f'
+        uri = 'http://user:password@location:1234/schema#extra1=a%20value&extra2=%2fpath%2f'
         connection = Connection(uri=uri)
         self.assertEqual(connection.conn_type, 'http')
-        self.assertEqual(connection.host, 'http://host%2flocation:1234/schema')
+        self.assertEqual(connection.host, 'http://location:1234/schema')
         self.assertEqual(connection.schema, None)
         self.assertEqual(connection.login, 'user')
         self.assertEqual(connection.password, 'password')
@@ -133,16 +133,16 @@ class ConnectionTest(unittest.TestCase):
         self.assertEqual(connection.port, 1234)
         self.assertDictEqual(connection.extra_dejson, {'extra1': 'a value', 'extra2': '/path/'})
 
-    def test_connection_from_http_uri_with_colon_in_hostname(self):
-        uri = 'http://user:password@host%2flocation%3ax%3ay:1234/schema#' \
+    def test_connection_from_http_with_colon_in_hostname(self):
+        uri = 'http://user:password@host%2flocation%3ax%3ay:1234/schema?' \
               'extra1=a%20value&extra2=%2fpath%2f'
         connection = Connection(uri=uri)
         self.assertEqual(connection.conn_type, 'http')
-        self.assertEqual(connection.host, 'http://host%2flocation%3ax%3ay:1234/schema')
-        self.assertEqual(connection.schema, None)
+        self.assertEqual(connection.host, 'host/location:x:y')
+        self.assertEqual(connection.schema, 'schema')
         self.assertEqual(connection.login, 'user')
         self.assertEqual(connection.password, 'password')
-        self.assertEqual(connection.port, None)
+        self.assertEqual(connection.port, 1234)
         self.assertDictEqual(connection.extra_dejson, {'extra1': 'a value', 'extra2': '/path/'})
 
     def test_connection_from_uri_with_encoded_password(self):
@@ -156,10 +156,10 @@ class ConnectionTest(unittest.TestCase):
         self.assertEqual(connection.port, 1234)
 
     def test_connection_from_http_uri_with_encoded_password(self):
-        uri = 'http://user:password%20with%20space@host%2flocation%3ax%3ay:1234/schema'
+        uri = 'http://user:password%20with%20space@location:1234/schema'
         connection = Connection(uri=uri)
         self.assertEqual(connection.conn_type, 'http')
-        self.assertEqual(connection.host, 'http://host%2flocation%3ax%3ay:1234/schema')
+        self.assertEqual(connection.host, 'http://location:1234/schema')
         self.assertEqual(connection.schema, None)
         self.assertEqual(connection.login, 'user')
         self.assertEqual(connection.password, 'password with space')
@@ -176,10 +176,10 @@ class ConnectionTest(unittest.TestCase):
         self.assertEqual(connection.port, 1234)
 
     def test_connection_from_http_uri_with_encoded_user(self):
-        uri = 'http://domain%2fuser:password@host%2flocation%3ax%3ay:1234/schema'
+        uri = 'http://domain%2fuser:password@location:1234/schema'
         connection = Connection(uri=uri)
         self.assertEqual(connection.conn_type, 'http')
-        self.assertEqual(connection.host, 'http://host%2flocation%3ax%3ay:1234/schema')
+        self.assertEqual(connection.host, 'http://location:1234/schema')
         self.assertEqual(connection.schema, None)
         self.assertEqual(connection.login, 'domain/user')
         self.assertEqual(connection.password, 'password')
@@ -242,6 +242,16 @@ class ConnectionTest(unittest.TestCase):
         self.assertEqual(connection.password, None)
         self.assertEqual(connection.port, 1234)
 
+    def test_connection_from_http_with_https(self):
+        uri = 'https://airflow.apache.org/'
+        connection = Connection(uri=uri)
+        self.assertEqual(connection.conn_type, 'http')
+        self.assertEqual(connection.host, 'https://airflow.apache.org/')
+        self.assertEqual(connection.schema, None)
+        self.assertEqual(connection.login, None)
+        self.assertEqual(connection.password, None)
+        self.assertEqual(connection.port, None)
+
     @parameterized.expand(
         [
             (
@@ -295,9 +305,9 @@ class ConnectionTest(unittest.TestCase):
                     conn_type="http",
                     login="user",
                     password="password",
-                    host="http:///database",
+                    host="",
                     port=None,
-                    schema=None,
+                    schema='database',
                 ),
             ),
             (
@@ -326,12 +336,12 @@ class ConnectionTest(unittest.TestCase):
             (
                 "https://user:password@/",
                 ConnectionParts(
-                    conn_type="http",
+                    conn_type="https",
                     login="user",
                     password="password",
-                    host="https:///",
+                    host="",
                     port=None,
-                    schema=None,
+                    schema='',
                 ),
             ),
             (


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-2910

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Setting up an HTTP connection is not intuitive.  This PR introduces support for a different connection URI format.
Related discusion: 
https://issues.apache.org/jira/browse/AIRFLOW-2910
CC: @ashb @potiuk 

When this solution is accepted, it will update the documentation.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
