### PR TITLE
[AIRFLOW-XXX] Remove incorrect note about Scopes of GCP connection

### DIFF
--- a/docs/howto/connection/gcp.rst
+++ b/docs/howto/connection/gcp.rst
@@ -66,11 +66,6 @@ Scopes (comma separated)
     <https://developers.google.com/identity/protocols/googlescopes>`_ to
     authenticate with.
 
-    .. note::
-        Scopes are ignored when using application default credentials. See
-        issue `AIRFLOW-2522
-        <https://issues.apache.org/jira/browse/AIRFLOW-2522>`_.
-
 Number of Retries
     Integer, number of times to retry with randomized
     exponential backoff. If all retries fail, the :class:`googleapiclient.errors.HttpError`


### PR DESCRIPTION
The issue raised in https://issues.apache.org/jira/browse/AIRFLOW-2522 was resolved.
Scope is not ignored when default credentials are used. This note should be deleted.

Scope is read in:
https://github.com/apache/airflow/blob/master/airflow/contrib/hooks/gcp_api_base_hook.py#L88-L92
When default credentails is used, then this code is used:
https://github.com/apache/airflow/blob/master/airflow/contrib/hooks/gcp_api_base_hook.py#L94-L97
so scope is passed to the external library.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
