### PR TITLE
[AIRFLOW-4467] Add dataproc_jars to templated fields in Dataproc oper…

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -742,7 +742,8 @@ class DataProcPigOperator(BaseOperator):
         an 8 character random string.
     :vartype dataproc_job_id: str
     """
-    template_fields = ['query', 'variables', 'job_name', 'cluster_name', 'region', 'dataproc_jars', 'dataproc_pig_jars']
+    template_fields = ['query', 'variables', 'job_name', 'cluster_name',
+                       'region', 'dataproc_jars', 'dataproc_pig_jars']
     template_ext = ('.pg', '.pig',)
     ui_color = '#0273d4'
 
@@ -839,7 +840,8 @@ class DataProcHiveOperator(BaseOperator):
         an 8 character random string.
     :vartype dataproc_job_id: str
     """
-    template_fields = ['query', 'variables', 'job_name', 'cluster_name', 'region', 'dataproc_jars', 'dataproc_hive_jars']
+    template_fields = ['query', 'variables', 'job_name', 'cluster_name',
+                       'region', 'dataproc_jars', 'dataproc_hive_jars']
     template_ext = ('.q',)
     ui_color = '#0273d4'
 
@@ -937,7 +939,8 @@ class DataProcSparkSqlOperator(BaseOperator):
         an 8 character random string.
     :vartype dataproc_job_id: str
     """
-    template_fields = ['query', 'variables', 'job_name', 'cluster_name', 'region', 'dataproc_jars', 'dataproc_spark_jars']
+    template_fields = ['query', 'variables', 'job_name', 'cluster_name',
+                       'region', 'dataproc_jars', 'dataproc_spark_jars']
     template_ext = ('.q',)
     ui_color = '#0273d4'
 
@@ -1152,7 +1155,8 @@ class DataProcHadoopOperator(BaseOperator):
     :vartype dataproc_job_id: str
     """
 
-    template_fields = ['arguments', 'job_name', 'cluster_name', 'region', 'dataproc_jars', 'dataproc_hadoop_jars']
+    template_fields = ['arguments', 'job_name', 'cluster_name',
+                       'region', 'dataproc_jars', 'dataproc_hadoop_jars']
     ui_color = '#0273d4'
 
     @apply_defaults

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -742,7 +742,7 @@ class DataProcPigOperator(BaseOperator):
         an 8 character random string.
     :vartype dataproc_job_id: str
     """
-    template_fields = ['query', 'variables', 'job_name', 'cluster_name', 'region', 'dataproc_jars']
+    template_fields = ['query', 'variables', 'job_name', 'cluster_name', 'region', 'dataproc_jars', 'dataproc_pig_jars']
     template_ext = ('.pg', '.pig',)
     ui_color = '#0273d4'
 
@@ -839,7 +839,7 @@ class DataProcHiveOperator(BaseOperator):
         an 8 character random string.
     :vartype dataproc_job_id: str
     """
-    template_fields = ['query', 'variables', 'job_name', 'cluster_name', 'region', 'dataproc_jars']
+    template_fields = ['query', 'variables', 'job_name', 'cluster_name', 'region', 'dataproc_jars', 'dataproc_hive_jars']
     template_ext = ('.q',)
     ui_color = '#0273d4'
 
@@ -937,7 +937,7 @@ class DataProcSparkSqlOperator(BaseOperator):
         an 8 character random string.
     :vartype dataproc_job_id: str
     """
-    template_fields = ['query', 'variables', 'job_name', 'cluster_name', 'region', 'dataproc_jars']
+    template_fields = ['query', 'variables', 'job_name', 'cluster_name', 'region', 'dataproc_jars', 'dataproc_spark_jars']
     template_ext = ('.q',)
     ui_color = '#0273d4'
 
@@ -1152,7 +1152,7 @@ class DataProcHadoopOperator(BaseOperator):
     :vartype dataproc_job_id: str
     """
 
-    template_fields = ['arguments', 'job_name', 'cluster_name', 'region', 'dataproc_jars']
+    template_fields = ['arguments', 'job_name', 'cluster_name', 'region', 'dataproc_jars', 'dataproc_hadoop_jars']
     ui_color = '#0273d4'
 
     @apply_defaults


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/AIRFLOW-4467

Info:
https://github.com/apache/airflow/pull/5192/ edit docs about:
dataproc_pig_jars  in DataProcPigOperator
dataproc_hive_jars in DataProcHiveOperator
dataproc_spark_jars in DataProcSparkSqlOperator
dataproc_hadoop_jars in DataProcHadoopOperator
The edit mentioned that these fields are tempated but they are not.
Raising PR to make them templated as doc suggest.