### PR TITLE
[AIRFLOW-4135] Add Google Cloud Build operator and hook

### DIFF
--- a/airflow/contrib/example_dags/example_gcp_cloud_build.py
+++ b/airflow/contrib/example_dags/example_gcp_cloud_build.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Example Airflow DAG that displays interactions with Google Cloud Build.
+
+This DAG relies on the following OS environment variables:
+
+* GCP_PROJECT_ID - Google Cloud Project to use for the Cloud Function.
+* GCP_CLOUD_BUILD_ARCHIVE_URL - Path to the zipped source in Google Cloud Storage.
+    This object must be a gzipped archive file (.tar.gz) containing source to build.
+* GCP_CLOUD_BUILD_REPOSITORY_NAME - Name of the Cloud Source Repository.
+
+"""
+
+import os
+
+from future.backports.urllib.parse import urlparse
+
+from airflow import models
+from airflow.contrib.operators.gcp_cloud_build_operator import CloudBuildCreateBuildOperator
+from airflow.operators.bash_operator import BashOperator
+from airflow.utils import dates
+
+# [START howto_operator_gcp_common_variables]
+GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-project")
+# [END howto_operator_gcp_common_variables]
+
+# [START howto_operator_gcp_create_build_variables]
+GCP_SOURCE_ARCHIVE_URL = os.environ.get("GCP_CLOUD_BUILD_ARCHIVE_URL", "gs://example-bucket/file")
+GCP_SOURCE_REPOSITORY_NAME = os.environ.get("GCP_CLOUD_BUILD_REPOSITORY_NAME", "")
+# [END howto_operator_gcp_create_build_variables]
+
+GCP_SOURCE_ARCHIVE_URL_PARTS = urlparse(GCP_SOURCE_ARCHIVE_URL)
+GCP_SOURCE_BUCKET_NAME = GCP_SOURCE_ARCHIVE_URL_PARTS.netloc
+
+# [START howto_operator_gcp_create_build_from_storage_body]
+create_build_from_storage_body = {
+    "source": {"storageSource": GCP_SOURCE_ARCHIVE_URL},
+    "steps": [
+        {
+            "name": "gcr.io/cloud-builders/docker",
+            "args": ["build", "-t", "gcr.io/$PROJECT_ID/{}".format(GCP_SOURCE_BUCKET_NAME), "."],
+        }
+    ],
+    "images": ["gcr.io/$PROJECT_ID/{}".format(GCP_SOURCE_BUCKET_NAME)],
+}
+# [END howto_operator_gcp_create_build_from_storage_body]
+
+# [START howto_operator_create_build_from_repo_body]
+create_build_from_repo_body = {
+    "source": {"repoSource": {"repoName": GCP_SOURCE_REPOSITORY_NAME, "branchName": "master"}},
+    "steps": [
+        {
+            "name": "gcr.io/cloud-builders/docker",
+            "args": ["build", "-t", "gcr.io/$PROJECT_ID/$REPO_NAME", "."],
+        }
+    ],
+    "images": ["gcr.io/$PROJECT_ID/$REPO_NAME"],
+}
+# [END howto_operator_create_build_from_repo_body]
+
+with models.DAG(
+    "example_gcp_cloud_build", default_args=dict(start_date=dates.days_ago(1)), schedule_interval=None
+) as dag:
+    # [START howto_operator_create_build_from_storage]
+    create_build_from_storage = CloudBuildCreateBuildOperator(
+        task_id="create_build_from_storage", project_id=GCP_PROJECT_ID, body=create_build_from_storage_body
+    )
+    # [END howto_operator_create_build_from_storage]
+
+    # [START howto_operator_create_build_from_storage_result]
+    create_build_from_storage_result = BashOperator(
+        bash_command="echo '{{ task_instance.xcom_pull('create_build_from_storage')['images'][0] }}'",
+        task_id="create_build_from_storage_result",
+    )
+    # [END howto_operator_create_build_from_storage_result]
+
+    create_build_from_repo = CloudBuildCreateBuildOperator(
+        task_id="create_build_from_repo", project_id=GCP_PROJECT_ID, body=create_build_from_repo_body
+    )
+
+    create_build_from_repo_result = BashOperator(
+        bash_command="echo '{{ task_instance.xcom_pull('create_build_from_repo')['images'][0] }}'",
+        task_id="create_build_from_repo_result",
+    )
+
+    create_build_from_storage >> create_build_from_storage_result  # pylint: disable=pointless-statement
+
+    create_build_from_repo >> create_build_from_repo_result  # pylint: disable=pointless-statement

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -64,17 +64,16 @@ class GoogleCloudBaseHook(BaseHook):
     Legacy P12 key files are not supported.
 
     JSON data provided in the UI: Specify 'Keyfile JSON'.
+
+    :param gcp_conn_id: The connection ID to use when fetching connection info.
+    :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
     """
 
     def __init__(self, gcp_conn_id='google_cloud_default', delegate_to=None):
-        """
-        :param gcp_conn_id: The connection ID to use when fetching connection info.
-        :type gcp_conn_id: str
-        :param delegate_to: The account to impersonate, if any.
-            For this to work, the service account making the request must have
-            domain-wide delegation enabled.
-        :type delegate_to: str
-        """
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.extras = self.get_connection(self.gcp_conn_id).extra_dejson

--- a/airflow/contrib/hooks/gcp_cloud_build_hook.py
+++ b/airflow/contrib/hooks/gcp_cloud_build_hook.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Hook for Google Cloud Build service"""
+
+import time
+
+from googleapiclient.discovery import build
+
+from airflow import AirflowException
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+
+# Time to sleep between active checks of the operation results
+TIME_TO_SLEEP_IN_SECONDS = 5
+
+
+# noinspection PyAbstractClass
+class CloudBuildHook(GoogleCloudBaseHook):
+    """
+    Hook for the Google Cloud Build APIs.
+
+    All the methods in the hook where project_id is used must be called with
+    keyword arguments rather than positional.
+
+    :param api_version: API version used (for example v1 or v1beta1).
+    :type api_version: str
+    :param gcp_conn_id: The connection ID to use when fetching connection info.
+    :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    """
+
+    _conn = None
+
+    def __init__(self, api_version="v1", gcp_conn_id="google_cloud_default", delegate_to=None):
+        super(CloudBuildHook, self).__init__(gcp_conn_id, delegate_to)
+        self.api_version = api_version
+        self.num_retries = self._get_field("num_retries", 5)
+
+    def get_conn(self):
+        """
+        Retrieves the connection to Cloud Functions.
+
+        :return: Google Cloud Build services object.
+        """
+        if not self._conn:
+            http_authorized = self._authorize()
+            self._conn = build("cloudbuild", self.api_version, http=http_authorized, cache_discovery=False)
+        return self._conn
+
+    @GoogleCloudBaseHook.fallback_to_default_project_id
+    def create_build(self, body, project_id=None):
+        """
+        Starts a build with the specified configuration.
+
+        :param body: The request body.
+            See: https://cloud.google.com/cloud-build/docs/api/reference/rest/Shared.Types/Build
+        :type body: dict
+        :param project_id: Optional, Google Cloud Project project_id where the function belongs.
+            If set to None or missing, the default project_id from the GCP connection is used.
+        :type project_id: str
+        :return: None
+        """
+        service = self.get_conn()
+
+        # Create build
+        response = (
+            service.projects()  # pylint: disable=no-member
+            .builds()
+            .create(projectId=project_id, body=body)
+            .execute(num_retries=self.num_retries)
+        )
+
+        # Wait
+        operation_name = response["name"]
+        self._wait_for_operation_to_complete(operation_name=operation_name)
+
+        # Get result
+        build_id = response["metadata"]["build"]["id"]
+
+        result = (
+            service.projects()  # pylint: disable=no-member
+            .builds()
+            .get(projectId=project_id, id=build_id)
+            .execute(num_retries=self.num_retries)
+        )
+
+        return result
+
+    def _wait_for_operation_to_complete(self, operation_name):
+        """
+        Waits for the named operation to complete - checks status of the
+        asynchronous call.
+
+        :param operation_name: The name of the operation.
+        :type operation_name: str
+        :return: The response returned by the operation.
+        :rtype: dict
+        :exception: AirflowException in case error is returned.
+        """
+        service = self.get_conn()
+        while True:
+            operation_response = (
+                # pylint: disable=no-member
+                service.operations().get(name=operation_name).execute(num_retries=self.num_retries)
+            )
+            if operation_response.get("done"):
+                response = operation_response.get("response")
+                error = operation_response.get("error")
+                # Note, according to documentation always either response or error is
+                # set when "done" == True
+                if error:
+                    raise AirflowException(str(error))
+                return response
+            time.sleep(TIME_TO_SLEEP_IN_SECONDS)

--- a/airflow/contrib/operators/gcp_cloud_build_operator.py
+++ b/airflow/contrib/operators/gcp_cloud_build_operator.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Operators that integrat with Google Cloud Build service."""
+from copy import deepcopy
+import re
+from urllib.parse import urlparse, unquote
+
+import six
+
+from airflow import AirflowException
+from airflow.contrib.hooks.gcp_cloud_build_hook import CloudBuildHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+REGEX_REPO_PATH = re.compile(r"^/p/(?P<project_id>[^/]+)/r/(?P<repo_name>[^/]+)")
+
+
+class BuildProcessor:
+    """
+    Processes build configurations to add additional functionality to support the use of operators.
+
+    The following improvements are made:
+
+    * It is required to provide the source and only one type can be given,
+    * It is possible to provide the source as the URL address instead dict.
+
+    :param body: The request body.
+        See: https://cloud.google.com/cloud-build/docs/api/reference/rest/Shared.Types/Build
+    :type body: dict
+    """
+    def __init__(self, body):
+        self.body = deepcopy(body)
+
+    def _verify_source(self):
+        is_storage = "storageSource" in self.body["source"]
+        is_repo = "repoSource" in self.body["source"]
+
+        sources_count = sum([is_storage, is_repo])
+
+        if sources_count != 1:
+            raise AirflowException(
+                "The source could not be determined. Please choose one data source from: "
+                "storageSource and repoSource."
+            )
+
+    def _reformat_source(self):
+        self._reformat_repo_source()
+        self._reformat_storage_source()
+
+    def _reformat_repo_source(self):
+        if "repoSource" not in self.body["source"]:
+            return
+
+        source = self.body["source"]["repoSource"]
+
+        if not isinstance(source, six.string_types):
+            return
+
+        self.body["source"]["repoSource"] = self._convert_repo_url_to_dict(source)
+
+    def _reformat_storage_source(self):
+        if "storageSource" not in self.body["source"]:
+            return
+
+        source = self.body["source"]["storageSource"]
+
+        if not isinstance(source, six.string_types):
+            return
+
+        self.body["source"]["storageSource"] = self._convert_storage_url_to_dict(source)
+
+    def process_body(self):
+        """
+        Processes the body passed in the constructor
+
+        :return: the body.
+        :type: dict
+        """
+        self._verify_source()
+        self._reformat_source()
+        return self.body
+
+    @staticmethod
+    def _convert_repo_url_to_dict(source):
+        """
+        Convert url to repository in Google Cloud Source to a format supported by the API
+
+        Example valid input:
+
+        .. code-block:: none
+
+            https://source.developers.google.com/p/airflow-project/r/airflow-repo#branch-name
+
+        """
+        url_parts = urlparse(source)
+
+        match = REGEX_REPO_PATH.search(url_parts.path)
+
+        if url_parts.scheme != "https" or url_parts.hostname != "source.developers.google.com" or not match:
+            raise AirflowException(
+                "Invalid URL. You must pass the URL in the format: "
+                "https://source.developers.google.com/p/airflow-project/r/airflow-repo#branch-name"
+            )
+
+        project_id = unquote(match.group("project_id"))
+        repo_name = unquote(match.group("repo_name"))
+
+        source_dict = {"projectId": project_id, "repoName": repo_name, "branchName": "master"}
+
+        if url_parts.fragment:
+            source_dict["branchName"] = url_parts.fragment
+
+        return source_dict
+
+    @staticmethod
+    def _convert_storage_url_to_dict(storage_url):
+        """
+        Convert url to object in Google Cloud Storage to a format supported by the API
+
+        Example valid input:
+
+        .. code-block:: none
+
+            gs://bucket-name/object-name.tar.gz
+
+        """
+        url_parts = urlparse(storage_url)
+
+        if url_parts.scheme != "gs" or not url_parts.hostname or not url_parts.path or url_parts.path == "/":
+            raise AirflowException(
+                "Invalid URL. You must pass the URL in the format: "
+                "gs://bucket-name/object-name.tar.gz#24565443"
+            )
+
+        source_dict = {"bucket": url_parts.hostname, "object": url_parts.path[1:]}
+
+        if url_parts.fragment:
+            source_dict["generation"] = url_parts.fragment
+
+        return source_dict
+
+
+class CloudBuildCreateBuildOperator(BaseOperator):
+    """
+    Starts a build with the specified configuration.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudBuildCreateBuildOperator`
+
+    :param body: The request body.
+        See: https://cloud.google.com/cloud-build/docs/api/reference/rest/Shared.Types/Build
+    :type body: dict
+    :param gcp_conn_id: The connection ID to use to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param api_version: API version used (for example v1 or v1beta1).
+    :type api_version: str
+    """
+
+    template_fields = ("body", "gcp_conn_id", "api_version")
+
+    @apply_defaults
+    def __init__(
+        self, body, project_id=None, gcp_conn_id="google_cloud_default", api_version="v1", *args, **kwargs
+    ):
+        super(CloudBuildCreateBuildOperator, self).__init__(*args, **kwargs)
+        self.body = body
+        self.project_id = project_id
+        self.gcp_conn_id = gcp_conn_id
+        self.api_version = api_version
+        self._validate_inputs()
+
+    def _validate_inputs(self):
+        if not self.body:
+            raise AirflowException("The required parameter 'body' is missing")
+
+    def execute(self, context):
+        hook = CloudBuildHook(gcp_conn_id=self.gcp_conn_id, api_version=self.api_version)
+        body = BuildProcessor(body=self.body).process_body()
+        return hook.create_build(body=body, project_id=self.project_id)

--- a/docs/howto/operator/gcp/cloud_build.rst
+++ b/docs/howto/operator/gcp/cloud_build.rst
@@ -1,0 +1,115 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Google Cloud Build Operators
+============================
+
+The `GoogleCloud Build <https://cloud.google.com/cloud-build/>`__ is a service that executes your builds on Google Cloud Platform
+infrastructure. Cloud Build can import source code from Google Cloud Storage,
+Cloud Source Repositories, execute a build to your specifications, and produce
+artifacts such as Docker containers or Java archives.
+
+.. contents::
+  :depth: 1
+  :local:
+
+
+Prerequisite Tasks
+^^^^^^^^^^^^^^^^^^
+
+.. include:: _partials/prerequisite_tasks.rst
+
+.. _howto/operator:CloudBuildBuild:
+
+Build configuration overview
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In order to trigger a build, it is necessary to pass the build configuration.
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_cloud_build.py
+    :language: python
+    :dedent: 0
+    :start-after: [START howto_operator_gcp_create_build_from_storage_body]
+    :end-before: [END howto_operator_gcp_create_build_from_storage_body]
+
+The source code for the build can come from `Google Cloud Build Storage <https://cloud.google.com/storage/>`__:
+
+.. literalinclude:: ../../../../tests/contrib/operators/test_gcp_cloud_build_operator.py
+    :language: python
+    :dedent: 12
+    :start-after: [START howto_operator_gcp_cloud_build_source_gcs_dict]
+    :end-before: [END howto_operator_gcp_cloud_build_source_gcs_dict]
+
+It is also possible to specify it using the URL:
+
+.. literalinclude:: ../../../../tests/contrib/operators/test_gcp_cloud_build_operator.py
+    :language: python
+    :dedent: 12
+    :start-after: [START howto_operator_gcp_cloud_build_source_gcs_url]
+    :end-before: [END howto_operator_gcp_cloud_build_source_gcs_url]
+
+In addition, a build can refer to source stored in `Google Cloud Source Repositories <https://cloud.google.com/source-repositories/docs/>`__.
+
+.. literalinclude:: ../../../../tests/contrib/operators/test_gcp_cloud_build_operator.py
+    :language: python
+    :dedent: 12
+    :start-after: [START howto_operator_gcp_cloud_build_source_repo_dict]
+    :end-before: [END howto_operator_gcp_cloud_build_source_repo_dict]
+
+It is also possible to specify it using the URL:
+
+.. literalinclude:: ../../../../tests/contrib/operators/test_gcp_cloud_build_operator.py
+    :language: python
+    :dedent: 12
+    :start-after: [START howto_operator_gcp_cloud_build_source_repo_url]
+    :end-before: [END howto_operator_gcp_cloud_build_source_repo_url]
+
+Read `Build Configuration Overview <https://cloud.google.com/cloud-build/docs/build-config>`__ to understand all the fields you can include in a build config file.
+
+
+.. _howto/operator:CloudBuildCreateBuildOperator:
+
+Trigger a build
+^^^^^^^^^^^^^^^
+
+Trigger a build is performed with the
+:class:`~airflow.contrib.operators.gcp_cloud_build_operator.CloudBuildCreateBuildOperator` operator.
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_cloud_build.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_create_build_from_storage]
+    :end-before: [END howto_operator_create_build_from_storage]
+
+You can use :ref:`Jinja templating <jinja-templating>` with
+:template-fields:`airflow.contrib.operators.gcp_cloud_build_operator.CloudBuildCreateBuildOperator`
+parameters which allows you to dynamically determine values. The result is saved to :ref:`XCom <concepts:xcom>`, which allows it
+to be used by other operators.
+
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_cloud_build.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_create_build_from_storage_result]
+    :end-before: [END howto_operator_create_build_from_storage_result]
+
+Reference
+^^^^^^^^^
+
+For further information, look at:
+
+* `Client Library Documentation <https://developers.google.com/resources/api-libraries/documentation/cloudbuild/v1/python/latest/index.html>`__
+* `Product Documentation <https://cloud.google.com/natural-language/docs/>`__

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -432,6 +432,15 @@ Cloud Bigtable
 
 They also use :class:`airflow.contrib.hooks.gcp_bigtable_hook.BigtableHook` to communicate with Google Cloud Platform.
 
+Cloud Build
+'''''''''''
+
+:class:`airflow.contrib.operators.gcp_cloud_build_operator.CloudBuildCreateBuildOperator`
+     Starts a build with the specified configuration.
+
+
+They also use :class:`airflow.contrib.hooks.gcp_cloud_build_hook.CloudBuildHook` to communicate with Google Cloud Platform.
+
 
 Compute Engine
 ''''''''''''''

--- a/tests/contrib/hooks/test_gcp_cloud_build_hook.py
+++ b/tests/contrib/hooks/test_gcp_cloud_build_hook.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Tests for Google Cloud Build Hook
+"""
+import unittest
+from unittest import mock
+
+import six
+
+from airflow import AirflowException
+from airflow.contrib.hooks.gcp_cloud_build_hook import CloudBuildHook
+from tests.contrib.utils.base_gcp_mock import (
+    mock_base_gcp_hook_default_project_id,
+    mock_base_gcp_hook_no_default_project_id,
+)
+
+
+TEST_CREATE_BODY = {
+    "source": {"storageSource": {"bucket": "cloud-build-examples", "object": "node-docker-example.tar.gz"}},
+    "steps": [
+        {"name": "gcr.io/cloud-builders/docker", "args": ["build", "-t", "gcr.io/$PROJECT_ID/my-image", "."]}
+    ],
+    "images": ["gcr.io/$PROJECT_ID/my-image"],
+}
+
+TEST_BUILD = {"name": "build-name", "metadata": {"build": {"id": "AAA"}}}
+TEST_WAITING_OPERATION = {"done": False, "response": "response"}
+TEST_DONE_OPERATION = {"done": True, "response": "response"}
+TEST_ERROR_OPERATION = {"done": True, "response": "response", "error": "error"}
+TEST_PROJECT_ID = "cloud-build-project-id"
+
+
+class TestCloudBuildHookWithPassedProjectId(unittest.TestCase):
+    hook = None
+
+    def setUp(self):
+        with mock.patch(
+            "airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__",
+            new=mock_base_gcp_hook_default_project_id,
+        ):
+            self.hook = CloudBuildHook(gcp_conn_id="test")
+
+    @mock.patch("airflow.contrib.hooks.gcp_cloud_build_hook.CloudBuildHook.get_conn")
+    def test_build_immediately_complete(self, get_conn_mock):
+        service_mock = get_conn_mock.return_value
+
+        service_mock.projects.return_value\
+            .builds.return_value\
+            .create.return_value\
+            .execute.return_value = TEST_BUILD
+
+        service_mock.projects.return_value.\
+            builds.return_value.\
+            get.return_value.\
+            execute.return_value = TEST_BUILD
+
+        service_mock.operations.return_value.\
+            get.return_value.\
+            execute.return_value = TEST_DONE_OPERATION
+
+        result = self.hook.create_build(body={}, project_id=TEST_PROJECT_ID)
+
+        service_mock.projects.return_value.builds.return_value.create.assert_called_once_with(
+            body={}, projectId=TEST_PROJECT_ID
+        )
+
+        self.assertEqual(result, TEST_BUILD)
+
+    @mock.patch("airflow.contrib.hooks.gcp_cloud_build_hook.CloudBuildHook.get_conn")
+    @mock.patch("airflow.contrib.hooks.gcp_cloud_build_hook.time.sleep")
+    def test_waiting_operation(self, _, get_conn_mock):
+        service_mock = get_conn_mock.return_value
+
+        service_mock.projects.return_value.builds.return_value.create.return_value.execute.return_value = (
+            TEST_BUILD
+        )
+
+        service_mock.projects.return_value.builds.return_value.get.return_value.execute.return_value = (
+            TEST_BUILD
+        )
+
+        execute_mock = mock.Mock(
+            **{"side_effect": [TEST_WAITING_OPERATION, TEST_DONE_OPERATION, TEST_DONE_OPERATION]}
+        )
+        service_mock.operations.return_value.get.return_value.execute = execute_mock
+
+        result = self.hook.create_build(body={}, project_id=TEST_PROJECT_ID)
+
+        self.assertEqual(result, TEST_BUILD)
+
+    @mock.patch("airflow.contrib.hooks.gcp_cloud_build_hook.CloudBuildHook.get_conn")
+    @mock.patch("airflow.contrib.hooks.gcp_cloud_build_hook.time.sleep")
+    def test_error_operation(self, _, get_conn_mock):
+        service_mock = get_conn_mock.return_value
+
+        service_mock.projects.return_value.builds.return_value.create.return_value.execute.return_value = (
+            TEST_BUILD
+        )
+
+        execute_mock = mock.Mock(**{"side_effect": [TEST_WAITING_OPERATION, TEST_ERROR_OPERATION]})
+        service_mock.operations.return_value.get.return_value.execute = execute_mock
+        with six.assertRaisesRegex(self, AirflowException, "error"):
+            self.hook.create_build(body={})
+
+
+class TestGcpComputeHookWithDefaultProjectIdFromConnection(unittest.TestCase):
+    hook = None
+
+    def setUp(self):
+        with mock.patch(
+            "airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__",
+            new=mock_base_gcp_hook_default_project_id,
+        ):
+            self.hook = CloudBuildHook(gcp_conn_id="test")
+
+    @mock.patch("airflow.contrib.hooks.gcp_cloud_build_hook.CloudBuildHook.get_conn")
+    def test_build_immediately_complete(self, get_conn_mock):
+        service_mock = get_conn_mock.return_value
+
+        service_mock.projects.return_value.builds.return_value.create.return_value.execute.return_value = (
+            TEST_BUILD
+        )
+
+        service_mock.projects.return_value.builds.return_value.get.return_value.execute.return_value = (
+            TEST_BUILD
+        )
+
+        service_mock.operations.return_value.get.return_value.execute.return_value = TEST_DONE_OPERATION
+
+        result = self.hook.create_build(body={})
+
+        service_mock.projects.return_value.builds.return_value.create.assert_called_once_with(
+            body={}, projectId='example-project'
+        )
+
+        self.assertEqual(result, TEST_BUILD)
+
+    @mock.patch("airflow.contrib.hooks.gcp_cloud_build_hook.CloudBuildHook.get_conn")
+    @mock.patch("airflow.contrib.hooks.gcp_cloud_build_hook.time.sleep")
+    def test_waiting_operation(self, _, get_conn_mock):
+        service_mock = get_conn_mock.return_value
+
+        service_mock.projects.return_value.builds.return_value.create.return_value.execute.return_value = (
+            TEST_BUILD
+        )
+
+        service_mock.projects.return_value.builds.return_value.get.return_value.execute.return_value = (
+            TEST_BUILD
+        )
+
+        execute_mock = mock.Mock(
+            **{"side_effect": [TEST_WAITING_OPERATION, TEST_DONE_OPERATION, TEST_DONE_OPERATION]}
+        )
+        service_mock.operations.return_value.get.return_value.execute = execute_mock
+
+        result = self.hook.create_build(body={})
+
+        self.assertEqual(result, TEST_BUILD)
+
+    @mock.patch("airflow.contrib.hooks.gcp_cloud_build_hook.CloudBuildHook.get_conn")
+    @mock.patch("airflow.contrib.hooks.gcp_cloud_build_hook.time.sleep")
+    def test_error_operation(self, _, get_conn_mock):
+        service_mock = get_conn_mock.return_value
+
+        service_mock.projects.return_value.builds.return_value.create.return_value.execute.return_value = (
+            TEST_BUILD
+        )
+
+        execute_mock = mock.Mock(**{"side_effect": [TEST_WAITING_OPERATION, TEST_ERROR_OPERATION]})
+        service_mock.operations.return_value.get.return_value.execute = execute_mock
+        with six.assertRaisesRegex(self, AirflowException, "error"):
+            self.hook.create_build(body={})
+
+
+class TestCloudBuildHookWithoutProjectId(unittest.TestCase):
+    hook = None
+
+    def setUp(self):
+        with mock.patch(
+            "airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__",
+            new=mock_base_gcp_hook_no_default_project_id,
+        ):
+            self.hook = CloudBuildHook(gcp_conn_id="test")
+
+    @mock.patch("airflow.contrib.hooks.gcp_cloud_build_hook.CloudBuildHook.get_conn")
+    def test_create_build(self, _):
+        with self.assertRaises(AirflowException) as e:
+            self.hook.create_build(body={})
+
+        self.assertEqual(
+            "The project id must be passed either as keyword project_id parameter or as project_id extra in "
+            "GCP connection definition. Both are not set!",
+            str(e.exception),
+        )

--- a/tests/contrib/operators/test_gcp_cloud_build_operator.py
+++ b/tests/contrib/operators/test_gcp_cloud_build_operator.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for Google Cloud Build operators """
+
+from copy import deepcopy
+from unittest import TestCase
+
+import six
+
+from parameterized import parameterized
+from tests.compat import mock
+
+from airflow import AirflowException
+from airflow.contrib.operators.gcp_cloud_build_operator import BuildProcessor, CloudBuildCreateBuildOperator
+
+
+TEST_CREATE_BODY = {
+    "source": {"storageSource": {"bucket": "cloud-build-examples", "object": "node-docker-example.tar.gz"}},
+    "steps": [
+        {"name": "gcr.io/cloud-builders/docker", "args": ["build", "-t", "gcr.io/$PROJECT_ID/my-image", "."]}
+    ],
+    "images": ["gcr.io/$PROJECT_ID/my-image"],
+}
+TEST_PROJECT_ID = "example-id"
+
+
+class BuildProcessorTestCase(TestCase):
+    def test_verify_source(self):
+        with six.assertRaisesRegex(self, AirflowException, "The source could not be determined."):
+            BuildProcessor(body={"source": {"storageSource": {}, "repoSource": {}}}).process_body()
+
+    @parameterized.expand(
+        [
+            (
+                "https://source.developers.google.com/p/airflow-project/r/airflow-repo",
+                {"projectId": "airflow-project", "repoName": "airflow-repo", "branchName": "master"},
+            ),
+            (
+                "https://source.developers.google.com/p/airflow-project/r/airflow-repo#branch-name",
+                {"projectId": "airflow-project", "repoName": "airflow-repo", "branchName": "branch-name"},
+            ),
+            (
+                "https://source.developers.google.com/p/airflow-project/r/airflow-repo#feature/branch",
+                {"projectId": "airflow-project", "repoName": "airflow-repo", "branchName": "feature/branch"},
+            ),
+        ]
+    )
+    def test_convert_repo_url_to_dict_valid(self, url, expected_dict):
+        body = {"source": {"repoSource": url}}
+        body = BuildProcessor(body=body).process_body()
+        self.assertEqual(body["source"]["repoSource"], expected_dict)
+
+    @parameterized.expand(
+        [
+            ("https://source.e.com/p/airflow-project/r/airflow-repo#branch-name",),
+            ("httpXs://source.developers.google.com/p/airflow-project/r/airflow-repo",),
+            ("://source.developers.google.com/p/airflow-project/r/airflow-repo",),
+            ("://source.developers.google.com/p/airflow-project/rXXXX/airflow-repo",),
+            ("://source.developers.google.com/pXXX/airflow-project/r/airflow-repo",),
+        ]
+    )
+    def test_convert_repo_url_to_storage_dict_invalid(self, url):
+        body = {"source": {"repoSource": url}}
+        with six.assertRaisesRegex(self, AirflowException, "Invalid URL."):
+            BuildProcessor(body=body).process_body()
+
+    @parameterized.expand(
+        [
+            (
+                "gs://bucket-name/airflow-object.tar.gz",
+                {"bucket": "bucket-name", "object": "airflow-object.tar.gz"},
+            ),
+            (
+                "gs://bucket-name/airflow-object.tar.gz#1231231",
+                {"bucket": "bucket-name", "object": "airflow-object.tar.gz", "generation": "1231231"},
+            ),
+        ]
+    )
+    def test_convert_storage_url_to_dict_valid(self, url, expected_dict):
+        body = {"source": {"storageSource": url}}
+        body = BuildProcessor(body=body).process_body()
+        self.assertEqual(body["source"]["storageSource"], expected_dict)
+
+    @parameterized.expand(
+        [("///object",), ("gsXXa:///object",), ("gs://bucket-name/",), ("gs://bucket-name",)]
+    )
+    def test_convert_storage_url_to_dict_invalid(self, url):
+        body = {"source": {"storageSource": url}}
+        with six.assertRaisesRegex(self, AirflowException, "Invalid URL."):
+            BuildProcessor(body=body).process_body()
+
+    @parameterized.expand([("storageSource",), ("repoSource",)])
+    def test_do_nothing(self, source_key):
+        body = {"source": {source_key: {}}}
+        expected_body = deepcopy(body)
+
+        BuildProcessor(body=body).process_body()
+        self.assertEqual(body, expected_body)
+
+
+class GcpCloudBuildCreateBuildOperatorTestCase(TestCase):
+    @mock.patch(  # type: ignore
+        "airflow.contrib.operators.gcp_cloud_build_operator.CloudBuildHook",
+        **{"return_value.create_build.return_value": TEST_CREATE_BODY}
+    )
+    def test_minimal_green_path(self, _):
+        operator = CloudBuildCreateBuildOperator(
+            body=TEST_CREATE_BODY, project_id=TEST_PROJECT_ID, task_id="task-id"
+        )
+        result = operator.execute({})
+        self.assertIs(result, TEST_CREATE_BODY)
+
+    @parameterized.expand([({},), (None,)])
+    def test_missing_input(self, body):
+        with six.assertRaisesRegex(self, AirflowException, "The required parameter 'body' is missing"):
+            CloudBuildCreateBuildOperator(body=body, project_id=TEST_PROJECT_ID, task_id="task-id")
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.operators.gcp_cloud_build_operator.CloudBuildHook",
+        **{"return_value.create_build.return_value": TEST_CREATE_BODY}
+    )
+    def test_storage_source_replace(self, hook_mock):
+        current_body = {
+            # [START howto_operator_gcp_cloud_build_source_gcs_url]
+            "source": {"storageSource": "gs://bucket-name/object-name.tar.gz"},
+            # [END howto_operator_gcp_cloud_build_source_gcs_url]
+            "steps": [
+                {
+                    "name": "gcr.io/cloud-builders/docker",
+                    "args": ["build", "-t", "gcr.io/$PROJECT_ID/docker-image", "."],
+                }
+            ],
+            "images": ["gcr.io/$PROJECT_ID/docker-image"],
+        }
+
+        operator = CloudBuildCreateBuildOperator(
+            body=current_body, project_id=TEST_PROJECT_ID, task_id="task-id"
+        )
+        operator.execute({})
+
+        expected_result = {
+            # [START howto_operator_gcp_cloud_build_source_gcs_dict]
+            "source": {"storageSource": {"bucket": "bucket-name", "object": "object-name.tar.gz"}},
+            # [END howto_operator_gcp_cloud_build_source_gcs_dict]
+            "steps": [
+                {
+                    "name": "gcr.io/cloud-builders/docker",
+                    "args": ["build", "-t", "gcr.io/$PROJECT_ID/docker-image", "."],
+                }
+            ],
+            "images": ["gcr.io/$PROJECT_ID/docker-image"],
+        }
+        hook_mock.create_build(body=expected_result, project_id=TEST_PROJECT_ID)
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.operators.gcp_cloud_build_operator.CloudBuildHook",
+        **{"return_value.create_build.return_value": TEST_CREATE_BODY}
+    )
+    def test_repo_source_replace(self, hook_mock):
+        current_body = {
+            # [START howto_operator_gcp_cloud_build_source_repo_url]
+            "source": {"repoSource": "https://source.developers.google.com/p/airflow-project/r/airflow-repo"},
+            # [END howto_operator_gcp_cloud_build_source_repo_url]
+            "steps": [
+                {
+                    "name": "gcr.io/cloud-builders/docker",
+                    "args": ["build", "-t", "gcr.io/$PROJECT_ID/docker-image", "."],
+                }
+            ],
+            "images": ["gcr.io/$PROJECT_ID/docker-image"],
+        }
+        operator = CloudBuildCreateBuildOperator(
+            body=current_body, project_id=TEST_PROJECT_ID, task_id="task-id"
+        )
+        return_value = operator.execute({})
+        expected_body = {
+            # [START howto_operator_gcp_cloud_build_source_repo_dict]
+            "source": {
+                "repoSource": {
+                    "projectId": "airflow-project",
+                    "repoName": "airflow-repo",
+                    "branchName": "master",
+                }
+            },
+            # [END howto_operator_gcp_cloud_build_source_repo_dict]
+            "steps": [
+                {
+                    "name": "gcr.io/cloud-builders/docker",
+                    "args": ["build", "-t", "gcr.io/$PROJECT_ID/docker-image", "."],
+                }
+            ],
+            "images": ["gcr.io/$PROJECT_ID/docker-image"],
+        }
+        hook_mock.return_value.create_build.assert_called_once_with(
+            body=expected_body, project_id=TEST_PROJECT_ID
+        )
+        self.assertEqual(return_value, TEST_CREATE_BODY)

--- a/tests/contrib/operators/test_gcp_cloud_build_operator_system.py
+++ b/tests/contrib/operators/test_gcp_cloud_build_operator_system.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""System tests for Google Cloud Build operators"""
+import unittest
+
+from tests.contrib.operators.test_gcp_cloud_build_system_helper import GCPCloudBuildTestHelper
+from tests.contrib.utils.base_gcp_system_test_case import SKIP_TEST_WARNING, DagGcpSystemTestCase
+from tests.contrib.utils.gcp_authenticator import GCP_CLOUD_BUILD_KEY
+
+
+@unittest.skipIf(DagGcpSystemTestCase.skip_check(GCP_CLOUD_BUILD_KEY), SKIP_TEST_WARNING)
+class CloudBuildExampleDagsSystemTest(DagGcpSystemTestCase):
+    """
+    System tests for Google Cloud Build operators
+
+    It use a real service.
+    """
+
+    def __init__(self, method_name="runTest"):
+        super(CloudBuildExampleDagsSystemTest, self).__init__(
+            method_name,
+            dag_id="example_gcp_cloud_build",
+            require_local_executor=True,
+            gcp_key=GCP_CLOUD_BUILD_KEY,
+        )
+        self.helper = GCPCloudBuildTestHelper()
+
+    def setUp(self):
+        super(CloudBuildExampleDagsSystemTest, self).setUp()
+        self.gcp_authenticator.gcp_authenticate()
+        try:
+            self.helper.create_repository_and_bucket()
+        finally:
+            self.gcp_authenticator.gcp_revoke_authentication()
+
+    def test_run_example_dag(self):
+        self._run_dag()
+
+    def tearDown(self):
+        self.gcp_authenticator.gcp_authenticate()
+        try:
+            self.helper.delete_bucket()
+            self.helper.delete_docker_images()
+            self.helper.delete_repo()
+        finally:
+            self.gcp_authenticator.gcp_revoke_authentication()
+        super(CloudBuildExampleDagsSystemTest, self).tearDown()

--- a/tests/contrib/operators/test_gcp_cloud_build_system_helper.py
+++ b/tests/contrib/operators/test_gcp_cloud_build_system_helper.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Helpers to perform system tests for the Google Cloud Build service.
+"""
+import argparse
+import os
+from urllib.parse import urlparse
+
+from airflow.utils.file import TemporaryDirectory
+from tests.contrib.utils.gcp_authenticator import GcpAuthenticator, GCP_CLOUD_BUILD_KEY
+from tests.contrib.utils.logging_command_executor import LoggingCommandExecutor
+
+GCE_INSTANCE = os.environ.get("GCE_INSTANCE", "testinstance")
+GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-project")
+GCP_ARCHIVE_URL = os.environ.get("GCP_CLOUD_BUILD_ARCHIVE_URL", "gs://example-bucket/source-code.tar.gz")
+GCP_ARCHIVE_URL_PARTS = urlparse(GCP_ARCHIVE_URL)
+GCP_BUCKET_NAME = GCP_ARCHIVE_URL_PARTS.netloc
+GCP_OBJECT_NAME = GCP_ARCHIVE_URL_PARTS.path[1:]
+
+GCP_REPOSITORY_NAME = os.environ.get("GCP_CLOUD_BUILD_REPOSITORY_NAME", "repository-name")
+
+
+class GCPCloudBuildTestHelper(LoggingCommandExecutor):
+    """
+    Helper class to perform system tests for the Google Cloud Build service.
+    """
+
+    def create_repository_and_bucket(self):
+        """Create a bucket and a repository with sample application."""
+
+        with TemporaryDirectory(prefix="airflow-gcp") as tmp_dir:
+            # 1. Create required files
+            quickstart_path = os.path.join(tmp_dir, "quickstart.sh")
+            with open(quickstart_path, "w") as file:
+                file.write("#!/bin/sh\n")
+                file.write('echo "Hello, world! The time is $(date)."\n')
+                file.flush()
+
+            os.chmod(quickstart_path, 555)
+
+            with open(os.path.join(tmp_dir, "Dockerfile"), "w") as file:
+                file.write("FROM alpine\n")
+                file.write("COPY quickstart.sh /\n")
+                file.write('CMD ["/quickstart.sh"]\n')
+                file.flush()
+
+            # 2. Prepare bucket
+            self.execute_cmd(["gsutil", "mb", "gs://{}".format(GCP_BUCKET_NAME)])
+            self.execute_cmd(
+                ["bash", "-c", "tar -zcvf - -C {} . | gsutil cp -r - {}".format(tmp_dir, GCP_ARCHIVE_URL)]
+            )
+
+            # 3. Prepare repo
+            self.execute_cmd(["gcloud", "source", "repos", "create", GCP_REPOSITORY_NAME])
+            self.execute_cmd(["git", "init"], cwd=tmp_dir)
+            self.execute_cmd(["git", "config", "user.email", "bot@example.com"], cwd=tmp_dir)
+            self.execute_cmd(["git", "config", "user.name", "system-test"])
+            self.execute_cmd(
+                ["git", "config", "credential.https://source.developers.google.com.helper", "gcloud.sh"],
+                cwd=tmp_dir,
+            )
+            self.execute_cmd(["git", "add", "."], cwd=tmp_dir)
+            self.execute_cmd(["git", "commit", "-m", "Initial commit"], cwd=tmp_dir)
+            repo_url = "https://source.developers.google.com/p/{}/r/{}".format(
+                GCP_PROJECT_ID, GCP_REPOSITORY_NAME
+            )
+            self.execute_cmd(["git", "remote", "add", "origin", repo_url], cwd=tmp_dir)
+            self.execute_cmd(["git", "push", "origin", "master"], cwd=tmp_dir)
+
+    def delete_repo(self):
+        """Delete repository in Google Cloud Source Repository service"""
+
+        self.execute_cmd(["gcloud", "source", "repos", "delete", GCP_REPOSITORY_NAME, "--quiet"])
+
+    def delete_bucket(self):
+        """Delete bucket in Google Cloud Storage service"""
+
+        self.execute_cmd(["gsutil", "rb", "gs://{}".format(GCP_BUCKET_NAME)])
+
+    def delete_docker_images(self):
+        """Delete images in Google Cloud Container Registry"""
+
+        repo_image_name = "gcr.io/{}/{}".format(GCP_PROJECT_ID, GCP_REPOSITORY_NAME)
+        self.execute_cmd(["gcloud", "container", "images", "delete", repo_image_name])
+        bucket_image_name = "gcr.io/{}/{}".format(GCP_PROJECT_ID, GCP_BUCKET_NAME)
+        self.execute_cmd(["gcloud", "container", "images", "delete", bucket_image_name])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Create and delete repo and bucket for system tests.")
+    parser.add_argument(
+        "--action",
+        dest="action",
+        required=True,
+        choices=(
+            "create-repo-and-bucket",
+            "delete-repo",
+            "delete-bucket",
+            "delete-docker-images",
+            "delete-repo-and-bucket-and-docker-images",
+            "before-tests",
+            "after-tests",
+        ),
+    )
+    action = parser.parse_args().action
+
+    helper = GCPCloudBuildTestHelper()
+    gcp_authenticator = GcpAuthenticator(GCP_CLOUD_BUILD_KEY)
+    helper.log.info("Starting action: %s", action)
+
+    gcp_authenticator.gcp_store_authentication()
+    try:
+        gcp_authenticator.gcp_authenticate()
+        if action == "before-tests":
+            pass
+        elif action == "after-tests":
+            pass
+        elif action == "create-repo-and-bucket":
+            helper.create_repository_and_bucket()
+        elif action == "delete-repo-and-bucket-and-docker-images":
+            helper.delete_repo()
+            helper.delete_bucket()
+            helper.delete_docker_images()
+        elif action == "delete-repo":
+            helper.delete_repo()
+        elif action == "delete-bucket":
+            helper.delete_bucket()
+        elif action == "delete-docker-images":
+            helper.delete_docker_images()
+        else:
+            raise Exception("Unknown action: {}".format(action))
+    finally:
+        gcp_authenticator.gcp_restore_authentication()
+
+    helper.log.info("Finishing action: %s", action)

--- a/tests/contrib/utils/gcp_authenticator.py
+++ b/tests/contrib/utils/gcp_authenticator.py
@@ -25,15 +25,18 @@ from tests.contrib.utils.logging_command_executor import LoggingCommandExecutor
 
 from airflow.models import Connection
 
-GCP_COMPUTE_KEY = 'gcp_compute.json'
-GCP_FUNCTION_KEY = 'gcp_function.json'
-GCP_CLOUDSQL_KEY = 'gcp_cloudsql.json'
-GCP_BIGTABLE_KEY = 'gcp_bigtable.json'
-GCP_SPANNER_KEY = 'gcp_spanner.json'
-GCP_GCS_KEY = 'gcp_gcs.json'
+# Please keep these variables in alphabetical order.
 GCP_AI_KEY = 'gcp_ai.json'
-GCP_GCS_TRANSFER_KEY = 'gcp_gcs_transfer.json'
+GCP_BIGTABLE_KEY = 'gcp_bigtable.json'
+GCP_CLOUD_BUILD_KEY = 'gcp_cloud_build.json'
+GCP_CLOUDSQL_KEY = 'gcp_cloudsql.json'
+GCP_COMPUTE_KEY = 'gcp_compute.json'
 GCP_DATAPROC_KEY = 'gcp_dataproc.json'
+GCP_FUNCTION_KEY = 'gcp_function.json'
+GCP_GCS_KEY = 'gcp_gcs.json'
+GCP_GCS_TRANSFER_KEY = 'gcp_gcs_transfer.json'
+GCP_SPANNER_KEY = 'gcp_spanner.json'
+
 
 KEYPATH_EXTRA = 'extra__google_cloud_platform__key_path'
 KEYFILE_DICT_EXTRA = 'extra__google_cloud_platform__keyfile_dict'

--- a/tests/contrib/utils/logging_command_executor.py
+++ b/tests/contrib/utils/logging_command_executor.py
@@ -24,15 +24,16 @@ from airflow import LoggingMixin, AirflowException
 
 class LoggingCommandExecutor(LoggingMixin):
 
-    def execute_cmd(self, cmd, silent=False):
+    def execute_cmd(self, cmd, silent=False, cwd=None):
         if silent:
             self.log.info("Executing in silent mode: '{}'".format(" ".join(cmd)))
             with open(os.devnull, 'w') as FNULL:
                 return subprocess.call(args=cmd, stdout=FNULL, stderr=subprocess.STDOUT)
         else:
             self.log.info("Executing: '{}'".format(" ".join(cmd)))
-            process = subprocess.Popen(args=cmd, stdout=subprocess.PIPE,
-                                       stderr=subprocess.PIPE, universal_newlines=True)
+            process = subprocess.Popen(
+                args=cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, cwd=cwd
+            )
             output, err = process.communicate()
             retcode = process.poll()
             self.log.info("Stdout: {}".format(output))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-4135


### Description

Hello,

I want to create a new operator and hook for Google Cloud Build.

Operator name | API URL /description
-- | --
CloudBuildCreateBuildOperator | [Python API](https://developers.google.com/resources/api-libraries/documentation/cloudbuild/v1/python/latest/cloudbuild_v1.projects.builds.html#create)

Thanks,

### Tests

Unit and system tests have been added.

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
