### PR TITLE
[AIRFLOW-4457] Enhance Task logs by providing the task context

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -62,6 +62,10 @@ logging_config_class =
 log_format = [%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(message)s
 simple_log_format = %%(asctime)s %%(levelname)s - %%(message)s
 
+# Specify prefix pattern like mentioned below with stream handler TaskHandlerWithCustomFormatter
+# task_log_prefix_template =  {{ti.dag_id}}-{{ti.task_id}}-{{execution_date}}-{{try_number}}
+task_log_prefix_template =
+
 # Log filename format
 log_filename_template = {{{{ ti.dag_id }}}}/{{{{ ti.task_id }}}}/{{{{ ts }}}}/{{{{ try_number }}}}.log
 log_processor_filename_template = {{{{ filename }}}}.log

--- a/airflow/contrib/utils/log/__init__.py
+++ b/airflow/contrib/utils/log/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/contrib/utils/log/task_handler_with_custom_formatter.py
+++ b/airflow/contrib/utils/log/task_handler_with_custom_formatter.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+import sys
+
+from logging import StreamHandler
+from airflow import configuration as conf
+from airflow.utils.helpers import parse_template_string
+
+class TaskHandlerWithCustomFormatter(StreamHandler):
+    def __init__(self, stream):
+        super(TaskHandlerWithCustomFormatter, self).__init__()
+
+    def set_context(self, ti):
+        if ti.raw:
+            return
+        prefix = conf.get('core','task_log_prefix_template')
+        
+        rendered_prefix=""
+        if prefix:
+            _, self.prefix_jinja_template = parse_template_string(prefix)
+            rendered_prefix = self._render_prefix(ti)
+
+        self.setFormatter(logging.Formatter(rendered_prefix + ":" + self.formatter._fmt))
+        self.setLevel(self.level)
+
+    def _render_prefix(self, ti):
+        if self.prefix_jinja_template:
+            jinja_context = ti.get_template_context()
+            return self.prefix_jinja_template.render(**jinja_context)
+        logging.warning("'task_log_prefix_template' is in invalid format, ignoring the variable value")
+        return ""

--- a/airflow/contrib/utils/log/task_handler_with_custom_formatter.py
+++ b/airflow/contrib/utils/log/task_handler_with_custom_formatter.py
@@ -18,11 +18,11 @@
 # under the License.
 
 import logging
-import sys
 
 from logging import StreamHandler
 from airflow import configuration as conf
 from airflow.utils.helpers import parse_template_string
+
 
 class TaskHandlerWithCustomFormatter(StreamHandler):
     def __init__(self, stream):
@@ -31,9 +31,9 @@ class TaskHandlerWithCustomFormatter(StreamHandler):
     def set_context(self, ti):
         if ti.raw:
             return
-        prefix = conf.get('core','task_log_prefix_template')
-        
-        rendered_prefix=""
+        prefix = conf.get('core', 'task_log_prefix_template')
+
+        rendered_prefix = ""
         if prefix:
             _, self.prefix_jinja_template = parse_template_string(prefix)
             rendered_prefix = self._render_prefix(ti)

--- a/tests/contrib/utils/test_task_handler_with_custom_formatter.py
+++ b/tests/contrib/utils/test_task_handler_with_custom_formatter.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+import unittest
+
+from airflow.models import TaskInstance, DAG, DagRun
+from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.utils.timezone import datetime
+from airflow.utils.log.logging_mixin import set_context
+from airflow import configuration as conf
+from airflow.contrib.utils.log.task_handler_with_custom_formatter import TaskHandlerWithCustomFormatter
+
+DEFAULT_DATE = datetime(2019, 1, 1)
+TASK_LOGGER = 'airflow.task'
+TASK_HANDLER = 'task'
+TASK_HANDLER_CLASS = 'airflow.contrib.utils.log.task_handler_with_custom_formatter.TaskHandlerWithCustomFormatter'
+
+class TestTaskHandlerWithCustomFormatter(unittest.TestCase):
+    def setUp(self):
+        super(TestTaskHandlerWithCustomFormatter, self).setUp()
+        DEFAULT_LOGGING_CONFIG['handlers']['task'] = {'class': TASK_HANDLER_CLASS, 'formatter': 'airflow', 'stream': 'sys.stdout'}
+        conf.set('core','task_log_prefix_template',"{{ti.dag_id}}-{{ti.task_id}}")
+
+        logging.config.dictConfig(DEFAULT_LOGGING_CONFIG)
+        logging.root.disabled = False
+
+
+    def test_formatter(self):
+        dag = DAG('test_dag', start_date=DEFAULT_DATE)
+        task = DummyOperator(task_id='test_task', dag=dag)
+        ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
+
+        logger = ti.log
+        ti.log.disabled = False
+        handler = next((handler for handler in logger.handlers
+            if handler.name == TASK_HANDLER), None)
+        self.assertIsNotNone(handler)
+
+        # setting the expected value of the formatter
+        expected_formatter_value = "test_dag-test_task:" + handler.formatter._fmt      
+        set_context(logger, ti)
+        self.assertEqual(expected_formatter_value,handler.formatter._fmt)

--- a/tests/contrib/utils/test_task_handler_with_custom_formatter.py
+++ b/tests/contrib/utils/test_task_handler_with_custom_formatter.py
@@ -39,7 +39,7 @@ class TestTaskHandlerWithCustomFormatter(unittest.TestCase):
         super(TestTaskHandlerWithCustomFormatter, self).setUp()
         DEFAULT_LOGGING_CONFIG['handlers']['task'] = {
             'class': TASK_HANDLER_CLASS,
-            'formatter': 'airflow', 
+            'formatter': 'airflow',
             'stream': 'sys.stdout'
         }
         conf.set('core', 'task_log_prefix_template', "{{ti.dag_id}}-{{ti.task_id}}")


### PR DESCRIPTION
[AIRFLOW-4457] Enhance Task logs by providing the task context

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4457
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
In Some scenarios where the airflow logs are being forwarded to external central destination like splunk, it may be cumbersome to search the logs corresponding to task execution amid all the airflow logs from different loggers.
There should be a way to append the task logs with some task context to facilitate searching those logs for the debugging or some other purpose.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
