### PR TITLE
[AIRFLOW-4482] Add execution_date to trigger DAG run API response

### DIFF
--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -88,7 +88,7 @@ def trigger_dag(dag_id):
     if getattr(g, 'user', None):
         _log.info("User %s created %s", g.user, dr)
 
-    response = jsonify(message="Created {}".format(dr))
+    response = jsonify(message="Created {}".format(dr), execution_date=dr.execution_date.isoformat())
     return response
 
 

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -28,7 +28,7 @@ from airflow import settings
 from airflow.api.common.experimental.trigger_dag import trigger_dag
 from airflow.models import DagBag, DagRun, Pool, TaskInstance
 from airflow.settings import Session
-from airflow.utils.timezone import datetime, utcnow
+from airflow.utils.timezone import datetime, utcnow, parse as parse_datetime
 from airflow.www import app as application
 
 
@@ -122,13 +122,20 @@ class TestApiExperimental(TestBase):
 
     def test_trigger_dag(self):
         url_template = '/api/experimental/dags/{}/dag_runs'
+        run_id = 'my_run' + utcnow().isoformat()
         response = self.client.post(
             url_template.format('example_bash_operator'),
-            data=json.dumps({'run_id': 'my_run' + utcnow().isoformat()}),
+            data=json.dumps({'run_id': run_id}),
             content_type="application/json"
         )
 
         self.assertEqual(200, response.status_code)
+        # Check execution_date is correct
+        response = json.loads(response.data.decode('utf-8'))
+        dagbag = DagBag()
+        dag = dagbag.get_dag('example_bash_operator')
+        dag_run = dag.get_dagrun(parse_datetime(response['execution_date']))
+        self.assertEqual(run_id, dag_run.run_id)
 
         response = self.client.post(
             url_template.format('does_not_exist_dag'),
@@ -154,6 +161,7 @@ class TestApiExperimental(TestBase):
             content_type="application/json"
         )
         self.assertEqual(200, response.status_code)
+        self.assertEqual(datetime_string, json.loads(response.data.decode('utf-8'))['execution_date'])
 
         dagbag = DagBag()
         dag = dagbag.get_dag(dag_id)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira AIRFLOW-4482](https://issues.apache.org/jira/browse/AIRFLOW-4482) issues and references them in the PR title. 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We are using experimental REST API for automating Airflow from Jenkins and our workflow looks like this:
 * Jenkins job triggers DAG run (using _POST /api/experimental/dags/**<dag_id>**/dag_runs_)
 * Airflow API returns response like this: 

`
{"message":"Created <DagRun dag_id @ 2019-05-08 11:42:43+00:00: run_id, externally triggered: True>"}
`
 * Jenkins job parses the response for **execution_date** (2019-05-08T11:42:43 for response above)
 * Jenkins job further uses execution_date to check DAG run state using _POST /api/experimental/dags/**<dag_id>**/dag_runs/**<execution_date>**_
 * Also Jenkins job generates DAG run UI link

Here is [the code](https://github.com/doublescoring/jenkins-pipeline-goodness/blob/master/src/main/groovy/airflow.groovy) - how it works.

Actually it is not a good idea to parse message string for execution_date. So it is proposed to add **execution_date** in DAG run trigger API response as a field. It makes it possible to get execution_date directly from the response without dirty and unpredictable parsing. After this improvement API response will be like this:

`
{'execution_date': '2019-05-08T07:03:09+00:00', 'message': 'Created <DagRun dag_id @ 2019-05-08 07:03:09+00:00: manual__2019-05-08T07:03:09+00:00, externally triggered: True>'}
` 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Asserts added for test_endpoints.test_trigger_dag

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
