### PR TITLE
[AIRFLOW-4490] dag_run.conf should be an empty dictionary by default instead of None

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -54,7 +54,7 @@ class DagRun(Base, LoggingMixin):
     _state = Column('state', String(50), default=State.RUNNING)
     run_id = Column(String(ID_LEN))
     external_trigger = Column(Boolean, default=True)
-    conf = Column(PickleType)
+    conf = Column(PickleType, default={})
 
     dag = None
 

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -575,17 +575,15 @@ class DagRunTest(unittest.TestCase):
             state=State.RUNNING,
             external_trigger=True,
         )
-        
+
         self.assertEqual(dag_run.conf, {})
-        
+
         session.add(dag_run)
 
         session.commit()
-        
+
         dr_database = session.query(DagRun).filter(
             DagRun.run_id == dag_run_id
         ).one()
-        
+
         self.assertEqual(dr_database.conf, {})
-        
-            

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -560,7 +560,7 @@ class DagRunTest(unittest.TestCase):
         dagrun.verify_integrity()
         flaky_ti.refresh_from_db()
         self.assertEqual(State.NONE, flaky_ti.state)
-        
+
     def test_dagrun_conf_is_empty_dict_by_default(self):
         session = settings.Session()
         now = timezone.utcnow()

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -560,3 +560,32 @@ class DagRunTest(unittest.TestCase):
         dagrun.verify_integrity()
         flaky_ti.refresh_from_db()
         self.assertEqual(State.NONE, flaky_ti.state)
+        
+    def test_dagrun_conf_is_empty_dict_by_default(self):
+        session = settings.Session()
+        now = timezone.utcnow()
+
+        dag_id1 = "test_dagrun_conf_is_dict_on_create"
+        dag_run_id = "manual__" + now.isoformat()
+        dag_run = models.DagRun(
+            dag_id=dag_id1,
+            run_id=dag_run_id,
+            execution_date=now,
+            start_date=now,
+            state=State.RUNNING,
+            external_trigger=True,
+        )
+        
+        self.assertEqual(dag_run.conf, {})
+        
+        session.add(dag_run)
+
+        session.commit()
+        
+        dr_database = session.query(DagRun).filter(
+            DagRun.run_id == dag_run_id
+        ).one()
+        
+        self.assertEqual(dr_database.conf, {})
+        
+            

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -576,8 +576,6 @@ class DagRunTest(unittest.TestCase):
             external_trigger=True,
         )
 
-        self.assertEqual(dag_run.conf, {})
-
         session.add(dag_run)
 
         session.commit()


### PR DESCRIPTION
Changes DagRun.conf to be an empty dictionary by default, rather than None.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-4490\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4490
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-4490\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
