### PR TITLE
[AIRFLOW-4491] Add a "Jump to end" button for logs

### DIFF
--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -29,6 +29,9 @@ limitations under the License.
     </a>
   </li>
   {% endfor %}
+  <li class="active" style="float: right">
+    <a onclick='scrollBottom()'>Jump to end</a>
+  </li>
 </ul>
 <div class="tab-content">
   {% for log in logs %}
@@ -68,6 +71,10 @@ limitations under the License.
       console.debug($(document).height())
       return $(window).scrollTop() != 0
              && ($(window).scrollTop() + $(window).height() > docHeight - AUTO_TAILING_OFFSET);
+    }
+
+    function scrollBottom() {
+      $("html, body").animate({ scrollTop: $(document).height() }, ANIMATION_SPEED);
     }
 
     // Streaming log with auto-tailing.
@@ -110,7 +117,7 @@ limitations under the License.
             document.getElementById(`try-${try_number}`).textContent += res.message + "\n";
             // Auto scroll window to the end if current window location is near the end.
             if(should_scroll) {
-              $("html, body").animate({ scrollTop: $(document).height() }, ANIMATION_SPEED);
+              scrollBottom();
             }
           }
 


### PR DESCRIPTION
Adding a convenience link to jump to the end of the page when viewing long logs.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4491) issues and references them in the PR title.

### Description
Adds a link to the same level as the task numbers, aligned to the right end of the list.
- [x] Here are some details about my PR, including screenshots of any UI changes:

![Screen Shot 2019-05-09 at 4 34 41 PM](https://user-images.githubusercontent.com/5075200/57493139-9ac8be80-7278-11e9-84eb-c6315faa63d2.png)


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: The screenshot should cover the necessary requirements. It is stable against zooming in and out as well.

### Commits

### Documentation

### Code Quality

- [x] Passes `flake8`
