### PR TITLE
[AIRFLOW-4477] Add models methods to BQHook

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1776,6 +1776,178 @@ class BigQueryBaseCursor(LoggingMixin):
                 'BigQuery job failed. Error was: {}'.format(err.content)
             )
 
+    def list_model(self, project_id, dataset_id):
+        """
+        Method to list all models in the specified dataset.
+
+        .. seealso::
+            For more information, see:
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/models/list
+
+        :param project_id: The project ID of the models to list.
+        :type project_id: str
+        :param dataset_id: The dataset ID of the models to list.
+        :type dataset_id: str
+        """
+        project_id = project_id if project_id else self.project_id
+
+        self.log.info('Listing BigQuery models from project: %s  Dataset:%s',
+                      project_id, dataset_id)
+
+        try:
+            models = self.service.models().list(
+                projectId=project_id,
+                datasetId=dataset_id).execute(num_retries=self.num_retries)
+            self.log.info('BigQuery models listed successfully: In project %s '
+                          'Dataset %s', project_id, dataset_id)
+            return models
+        except HttpError as err:
+            raise AirflowException(
+                'BigQuery models failed to list. Error was: {}'.format(err.content)
+            )
+
+    def get_model(self, project_id, dataset_id, model_id):
+        """
+        Method to get the specified model resource by model_id.
+
+        .. seealso::
+            For more information, see:
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/models/get
+
+        :param project_id: The project ID of the requested model.
+        :type project_id: str
+        :param dataset_id: The dataset ID of the requested model.
+        :type dataset_id: str
+        :param model_id: The model ID of the requested model.
+        :type model_id: str
+        """
+        if model_id is None:
+            raise ValueError('model_id cannot be None.')
+
+        project_id = project_id if project_id else self.project_id
+
+        self.log.info('Retrieving BigQuery model %s from project: %s  Dataset:%s',
+                      model_id, project_id, dataset_id)
+
+        try:
+            model = self.service.models().get(
+                projectId=project_id,
+                datasetId=dataset_id,
+                modelId=model_id).execute(num_retries=self.num_retries)
+            self.log.info('BigQuery model retrieved successfully: In project %s '
+                          'Dataset %s Model %s', project_id, dataset_id, model_id)
+            return model
+        except HttpError as err:
+            raise AirflowException(
+                'BigQuery models failed to retrieve. Error was: {}'.format(err.content)
+            )
+
+    def patch_model(self,
+                    project_id, dataset_id, model_id,
+                    description=None,
+                    friendly_name=None,
+                    labels=None,
+                    expiration_time=None):
+        """
+        Method to patch specific fields in the specified model.
+
+        .. seealso::
+            For more information, see:
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/models/patch
+
+        :param project_id: The project ID of the model to patch.
+        :type project_id: str
+        :param dataset_id: The dataset ID of the model to patch.
+        :type dataset_id: str
+        :param model_id: The model ID of the model to patch.
+        :type model_id: str
+        :param description: The description of the model.
+        :type description: str
+        :param friendly_name: A descriptive name for this model.
+        :type friendly_name: str
+        :param labels: a dictionary containing labels for the table, passed to BigQuery.
+        :type labels: dict
+        :param expiration_time: The time when this model expires,
+            in milliseconds since the epoch. If not present,
+            the model will persist indefinitely.
+        :type expiration_time: int
+        """
+        if model_id is None:
+            raise ValueError('model_id cannot be None.')
+
+        project_id = project_id if project_id else self.project_id
+
+        body = {
+            'modelReference': {
+                'projectId': project_id,
+                'datasetId': dataset_id,
+                'modelId': model_id,
+            }
+        }
+
+        if description:
+            body['description'] = description
+
+        if friendly_name:
+            body['friendlyName'] = friendly_name
+
+        if labels:
+            body['labels'] = labels
+
+        if expiration_time:
+            body['expirationTime'] = expiration_time
+
+        self.log.info('Patching BigQuery model %s from project: %s  Dataset:%s',
+                      model_id, project_id, dataset_id)
+
+        try:
+            model = self.service.models().patch(
+                projectId=project_id,
+                datasetId=dataset_id,
+                modelId=model_id, body=body).execute(num_retries=self.num_retries)
+            self.log.info('BigQuery model %s patched successfully: In project %s '
+                          'Dataset %s', model_id, project_id, dataset_id)
+            return model
+        except HttpError as err:
+            raise AirflowException(
+                'BigQuery models failed to patch. Error was: {}'.format(err.content)
+            )
+
+    def delete_model(self, project_id, dataset_id, model_id):
+        """
+        Method to delete the model specified by model_id from the dataset.
+
+        .. seealso::
+            For more information, see:
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/models/delete
+
+        :param project_id: The project ID of the model to delete.
+        :type project_id: str
+        :param dataset_id: The dataset ID of the model to delete.
+        :type dataset_id: str
+        :param model_id: The model ID of the model to delete.
+        :type model_id: str
+        """
+        if model_id is None:
+            raise ValueError('model_id cannot be None.')
+
+        project_id = project_id if project_id else self.project_id
+
+        self.log.info('Deleting BigQuery model %s from project: %s  Dataset:%s',
+                      model_id, project_id, dataset_id)
+
+        try:
+            self.service.models().delete(
+                projectId=project_id,
+                datasetId=dataset_id,
+                modelId=model_id).execute(num_retries=self.num_retries)
+            self.log.info('BigQuery model %s deleted successfully: In project %s '
+                          'Dataset %s', model_id, project_id, dataset_id)
+        except HttpError as err:
+            raise AirflowException(
+                'BigQuery models failed to delete. Error was: {}'.format(err.content)
+            )
+
 
 class BigQueryCursor(BigQueryBaseCursor):
     """

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -963,5 +963,98 @@ class TestBigQueryHookRunWithConfiguration(unittest.TestCase):
         )
 
 
+class TestBigQueryHookModelOperations(unittest.TestCase):
+    def test_bigquery_list_model(self):
+        project_id = 'bq-project'
+        dataset_id = 'bq_dataset'
+
+        mock_service = mock.Mock()
+        method = (mock_service.models.return_value.list)
+
+        cursor = hook.BigQueryBaseCursor(mock_service, project_id)
+        cursor.list_model(project_id=project_id, dataset_id=dataset_id)
+
+        method.assert_called_once_with(
+            projectId=project_id,
+            datasetId=dataset_id
+        )
+
+    def test_bigquery_get_model(self):
+        project_id = 'bq-project'
+        dataset_id = 'bq_dataset'
+        model_id = 'test_model'
+
+        mock_service = mock.Mock()
+        method = (mock_service.models.return_value.get)
+
+        cursor = hook.BigQueryBaseCursor(mock_service, project_id)
+        cursor.get_model(project_id=project_id,
+                         dataset_id=dataset_id,
+                         model_id=model_id)
+
+        method.assert_called_once_with(
+            projectId=project_id,
+            datasetId=dataset_id,
+            modelId=model_id
+        )
+
+    def test_bigquery_patch_model(self):
+        project_id = 'bq-project'
+        dataset_id = 'bq_dataset'
+        model_id = 'test_model'
+
+        body = {
+            'modelReference': {
+                'projectId': project_id,
+                'datasetId': dataset_id,
+                'modelId': model_id
+            },
+            'description': 'This is a test model.',
+            'friendlyName': 'Test Model',
+            'labels': {
+                'name': 'test'
+            },
+            'expirationTime': 2524608000000
+        }
+
+        mock_service = mock.Mock()
+        method = (mock_service.models.return_value.patch)
+
+        cursor = hook.BigQueryBaseCursor(mock_service, project_id)
+        cursor.patch_model(project_id=project_id,
+                           dataset_id=dataset_id,
+                           model_id=model_id,
+                           description=body['description'],
+                           friendly_name=body['friendlyName'],
+                           labels=body['labels'],
+                           expiration_time=body['expirationTime'])
+
+        method.assert_called_once_with(
+            projectId=project_id,
+            datasetId=dataset_id,
+            modelId=model_id,
+            body=body
+        )
+
+    def test_bigquery_delete_model(self):
+        project_id = 'bq-project'
+        dataset_id = 'bq_dataset'
+        model_id = 'test_model'
+
+        mock_service = mock.Mock()
+        method = (mock_service.models.return_value.delete)
+
+        cursor = hook.BigQueryBaseCursor(mock_service, project_id)
+        cursor.delete_model(project_id=project_id,
+                            dataset_id=dataset_id,
+                            model_id=model_id)
+
+        method.assert_called_once_with(
+            projectId=project_id,
+            datasetId=dataset_id,
+            modelId=model_id
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-4477](https://issues.apache.org/jira/browse/AIRFLOW-4477) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Add v2.models to BigQueryHook
Reference: https://cloud.google.com/bigquery/docs/reference/rest/v2/models

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
test_bigquery_hook.py:TestBigQueryHookModelOperations.test_bigquery_list_model
test_bigquery_hook.py:TestBigQueryHookModelOperations.test_bigquery_get_model
test_bigquery_hook.py:TestBigQueryHookModelOperations.test_bigquery_patch_model
test_bigquery_hook.py:TestBigQueryHookModelOperations.test_bigquery_delete_model

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
