### PR TITLE
[AIRFLOW-4504] Remove join args option in run_command()

### DIFF
--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -112,21 +112,17 @@ class BaseTaskRunner(LoggingMixin):
                           self._task_instance.job_id, self._task_instance.task_id,
                           line.rstrip('\n'))
 
-    def run_command(self, run_with=None, join_args=False):
+    def run_command(self, run_with=None):
         """
         Run the task command.
 
         :param run_with: list of tokens to run the task command with e.g. ``['bash', '-c']``
         :type run_with: list
-        :param join_args: whether to concatenate the list of command tokens e.g. ``['airflow', 'run']`` vs
-            ``['airflow run']``
-        :param join_args: bool
         :return: the process that was run
         :rtype: subprocess.Popen
         """
         run_with = run_with or []
-        cmd = [" ".join(self._command)] if join_args else self._command
-        full_cmd = run_with + cmd
+        full_cmd = run_with + self._command
 
         self.log.info('Running: %s', full_cmd)
         proc = subprocess.Popen(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4504
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

You typically open a subprocess with a single string `"run some command"` or list of strings `["run", "some", "command"]` ([recommended by Python to use a list](https://docs.python.org/3.6/library/subprocess.html?highlight=recommended%20pass%20args%20sequence#popen-constructor)) , but not a single string in list `["run some command"]`. Technically it will work, but there's no point in doing so. There's an if-statement in `run_command` for running commands this way but it's unused, so I suggest to remove it.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
