### PR TITLE
[AIRFLOW-XXX] - Add missing docs for GoogleCloudStorageDeleteOperator

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -603,6 +603,9 @@ Cloud Storage
     increase in the number of objects for situations when many objects
     are being uploaded to a bucket with no formal success signal.
 
+:class:`airflow.contrib.operators.gcs_delete_operator.GoogleCloudStorageDeleteOperator`
+    Deletes objects from a Google Cloud Storage bucket.
+
 
 They also use :class:`airflow.contrib.hooks.gcs_hook.GoogleCloudStorageHook` to communicate with Google Cloud Platform.
 


### PR DESCRIPTION
AIRFLOW-1501 introduced GoogleCloudStorageDeleteOperator (https://github.com/apache/airflow/pull/5230)
This PR adds the operator to the integration docs.