### PR TITLE
[AIRFLOW-4414] AWSAthenaOperator: Push QueryExecutionID to XCom

### DIFF
--- a/airflow/contrib/operators/aws_athena_operator.py
+++ b/airflow/contrib/operators/aws_athena_operator.py
@@ -29,6 +29,9 @@ class AWSAthenaOperator(BaseOperator):
     """
     An operator that submit presto query to athena.
 
+    If BaseOperator.do_xcom_push is True, the QueryExecutionID assigned to the
+    query will be pushed to an XCom when it successfuly completes.
+
     :param query: Presto to be run on athena. (templated)
     :type query: str
     :param database: Database to select. (templated)
@@ -89,6 +92,8 @@ class AWSAthenaOperator(BaseOperator):
                 'Final state of Athena job is {}. '
                 'Max tries of poll status exceeded, query_execution_id is {}.'
                 .format(query_status, self.query_execution_id))
+
+        return self.query_execution_id
 
     def on_kill(self):
         """

--- a/airflow/contrib/operators/aws_athena_operator.py
+++ b/airflow/contrib/operators/aws_athena_operator.py
@@ -29,7 +29,7 @@ class AWSAthenaOperator(BaseOperator):
     """
     An operator that submit presto query to athena.
 
-    If BaseOperator.do_xcom_push is True, the QueryExecutionID assigned to the
+    If ``do_xcom_push`` is True, the QueryExecutionID assigned to the
     query will be pushed to an XCom when it successfuly completes.
 
     :param query: Presto to be run on athena. (templated)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4414) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-4414

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

* Currently it is not possible to make use of QueryExecutionID (the
  unique identifier of the query submitted to Athena) in the tasks that
  follow.

* This commit changes the situation by making sure QueryExecutionID gets
  pushed to XCom when BaseOperator.do_xcom_push is set to True.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

There currently does not seem to exist a simple way of testing XCom pushing of Operators.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
