### PR TITLE
[AIRFLOW-4509] SubDagOperator using scheduler instead of backfill

### DIFF
--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -18,10 +18,11 @@
 # under the License.
 #
 
+from datetime import datetime
 import time
 from collections import OrderedDict
 
-from sqlalchemy.orm.session import make_transient
+from sqlalchemy.orm.session import make_transient, Session
 
 from airflow import configuration as conf
 from airflow import executors, models
@@ -258,31 +259,30 @@ class BackfillJob(BaseJob):
                     ti.handle_failure(msg)
 
     @provide_session
-    def _get_dag_run(self, run_date, session=None):
+    def _get_dag_run(self, run_date: datetime, dag: DAG, session: Session=None):
         """
         Returns a dag run for the given run date, which will be matched to an existing
         dag run if available or create a new dag run otherwise. If the max_active_runs
         limit is reached, this function will return None.
 
         :param run_date: the execution date for the dag run
-        :type run_date: datetime.datetime
+        :param dag: DAG
         :param session: the database session object
-        :type session: sqlalchemy.orm.session.Session
         :return: a DagRun in state RUNNING or None
         """
         run_id = BackfillJob.ID_FORMAT_PREFIX.format(run_date.isoformat())
 
         # consider max_active_runs but ignore when running subdags
         respect_dag_max_active_limit = (True
-                                        if (self.dag.schedule_interval and
-                                            not self.dag.is_subdag)
+                                        if (dag.schedule_interval and
+                                            not dag.is_subdag)
                                         else False)
 
-        current_active_dag_count = self.dag.get_num_active_runs(external_trigger=False)
+        current_active_dag_count = dag.get_num_active_runs(external_trigger=False)
 
         # check if we are scheduling on top of a already existing dag_run
         # we could find a "scheduled" run instead of a "backfill"
-        run = DagRun.find(dag_id=self.dag.dag_id,
+        run = DagRun.find(dag_id=dag.dag_id,
                           execution_date=run_date,
                           session=session)
 
@@ -296,10 +296,10 @@ class BackfillJob(BaseJob):
         # enforce max_active_runs limit for dag, special cases already
         # handled by respect_dag_max_active_limit
         if (respect_dag_max_active_limit and
-                current_active_dag_count >= self.dag.max_active_runs):
+                current_active_dag_count >= dag.max_active_runs):
             return None
 
-        run = run or self.dag.create_dagrun(
+        run = run or dag.create_dagrun(
             run_id=run_id,
             execution_date=run_date,
             start_date=timezone.utcnow(),
@@ -310,7 +310,7 @@ class BackfillJob(BaseJob):
         )
 
         # set required transient field
-        run.dag = self.dag
+        run.dag = dag
 
         # explicitly mark as backfill and running
         run.state = State.RUNNING
@@ -409,7 +409,7 @@ class BackfillJob(BaseJob):
             def _per_task_process(task, key, ti, session=None):
                 ti.refresh_from_db()
 
-                task = self.dag.get_task(ti.task_id)
+                task = self.dag.get_task(ti.task_id, include_subdags=True)
                 ti.task = task
 
                 ignore_depends_on_past = (
@@ -545,7 +545,7 @@ class BackfillJob(BaseJob):
             non_pool_slots = conf.getint('core', 'non_pooled_backfill_task_slot_count')
 
             try:
-                for task in self.dag.topological_sort():
+                for task in self.dag.topological_sort(include_subdag_tasks=True):
                     for key, ti in list(ti_status.to_run.items()):
                         if task.task_id != ti.task_id:
                             continue
@@ -692,14 +692,15 @@ class BackfillJob(BaseJob):
         :type session: sqlalchemy.orm.session.Session
         """
         for next_run_date in run_dates:
-            dag_run = self._get_dag_run(next_run_date, session=session)
-            tis_map = self._task_instances_for_dag_run(dag_run,
-                                                       session=session)
-            if dag_run is None:
-                continue
+            for dag in [self.dag] + self.dag.subdags:
+                dag_run = self._get_dag_run(next_run_date, dag, session=session)
+                tis_map = self._task_instances_for_dag_run(dag_run,
+                                                           session=session)
+                if dag_run is None:
+                    continue
 
-            ti_status.active_runs.append(dag_run)
-            ti_status.to_run.update(tis_map or {})
+                ti_status.active_runs.append(dag_run)
+                ti_status.to_run.update(tis_map or {})
 
         processed_dag_run_dates = self._process_backfill_task_instances(
             ti_status=ti_status,

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1029,9 +1029,13 @@ class DAG(BaseDag, LoggingMixin):
     def has_task(self, task_id):
         return task_id in (t.task_id for t in self.tasks)
 
-    def get_task(self, task_id):
+    def get_task(self, task_id, include_subdags=False):
         if task_id in self.task_dict:
             return self.task_dict[task_id]
+        if include_subdags:
+            for dag in self.subdags:
+                if task_id in dag.task_dict:
+                    return dag.task_dict[task_id]
         raise AirflowException("Task {task_id} not found".format(task_id=task_id))
 
     def pickle_info(self):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4059

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

tl;dr Make `SubDagOperator` use normal scheduler instead of backfill scheduler to run subtasks.

Currently `SubDagOperator` uses backfill scheduler to schedule tasks in the subdags and there are a few drawbacks:
- Relying on backfill scheduler to schedule tasks in normal `DagRun`.
- `parallelism` is not respected in backfill.
- Tasks in the subdag continues to run even when the DAG is paused.
- You need to specify an executor.

Summary of implementation:
- `SubDagOperator` creates a `DagRun` for the subdag and will wait until the `DagRun` finish. It will occupy a slot (same behavior as we run backfill in `SubDagOperator`) but we can probably introduce `reschedule` concept like `BaseSensorOperator` to release the slots.
- Scheduler will pick up the `DagRun` and schedule the tasks.
- Yet to be implemented: backfill `SubDagOperator`.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
