### PR TITLE
[AIRFLOW-4393] Add retry logic when fetching pod status and/or logs in KubernetesPodOperator

### DIFF
--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -17,6 +17,7 @@
 
 import json
 import time
+import tenacity
 from typing import Tuple, Optional
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
@@ -27,7 +28,7 @@ from kubernetes import watch, client
 from kubernetes.client.rest import ApiException
 from kubernetes.stream import stream as kubernetes_stream
 from airflow import AirflowException
-from requests.exceptions import HTTPError
+from requests.exceptions import BaseHTTPError
 from .kube_client import get_kube_client
 
 
@@ -98,13 +99,7 @@ class PodLauncher(LoggingMixin):
         # type: (Pod, bool) -> Tuple[State, Optional[str]]
 
         if get_logs:
-            logs = self._client.read_namespaced_pod_log(
-                name=pod.name,
-                namespace=pod.namespace,
-                container='base',
-                follow=True,
-                tail_lines=10,
-                _preload_content=False)
+            logs = self.read_pod_logs(pod)
             for line in logs:
                 self.log.info(line)
         result = None
@@ -141,10 +136,36 @@ class PodLauncher(LoggingMixin):
                                   event.status.container_statuses)), None)
         return status.state.running is not None
 
+    @tenacity.retry(
+        stop=tenacity.stop_after_attempt(3),
+        wait=tenacity.wait_exponential(),
+        reraise=True
+    )
+    def read_pod_logs(self, pod):
+
+        try:
+            return self._client.read_namespaced_pod_log(
+                name=pod.name,
+                namespace=pod.namespace,
+                container='base',
+                follow=True,
+                tail_lines=10,
+                _preload_content=False
+            )
+        except BaseHTTPError as e:
+            raise AirflowException(
+                'There was an error reading the kubernetes API: {}'.format(e)
+            )
+
+    @tenacity.retry(
+        stop=tenacity.stop_after_attempt(3),
+        wait=tenacity.wait_exponential(),
+        reraise=True
+    )
     def read_pod(self, pod):
         try:
             return self._client.read_namespaced_pod(pod.name, pod.namespace)
-        except HTTPError as e:
+        except BaseHTTPError as e:
             raise AirflowException(
                 'There was an error reading the kubernetes API: {}'.format(e)
             )

--- a/tests/kubernetes/test_pod_launcher.py
+++ b/tests/kubernetes/test_pod_launcher.py
@@ -1,0 +1,103 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from requests.exceptions import BaseHTTPError
+
+from airflow import AirflowException
+from airflow.kubernetes.pod_launcher import PodLauncher
+
+import unittest
+import mock
+
+
+class TestPodLauncher(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_kube_client = mock.Mock()
+        self.pod_launcher = PodLauncher(kube_client=self.mock_kube_client)
+
+    def test_read_pod_logs_successfully_returns_logs(self):
+        self.mock_kube_client.read_namespaced_pod_log.return_value = mock.sentinel.logs
+        logs = self.pod_launcher.read_pod_logs(mock.sentinel)
+        self.assertEqual(mock.sentinel.logs, logs)
+
+    def test_read_pod_logs_retries_successfully(self):
+        self.mock_kube_client.read_namespaced_pod_log.side_effect = [
+            BaseHTTPError('Boom'),
+            mock.sentinel.logs
+        ]
+        logs = self.pod_launcher.read_pod_logs(mock.sentinel)
+        self.assertEqual(mock.sentinel.logs, logs)
+        self.mock_kube_client.read_namespaced_pod_log.assert_has_calls([
+            mock.call(
+                _preload_content=False,
+                container='base',
+                follow=True,
+                name=mock.sentinel.name,
+                namespace=mock.sentinel.namespace,
+                tail_lines=10
+            ),
+            mock.call(
+                _preload_content=False,
+                container='base',
+                follow=True,
+                name=mock.sentinel.name,
+                namespace=mock.sentinel.namespace,
+                tail_lines=10
+            )
+        ])
+
+    def test_read_pod_logs_retries_fails(self):
+        self.mock_kube_client.read_namespaced_pod_log.side_effect = [
+            BaseHTTPError('Boom'),
+            BaseHTTPError('Boom'),
+            BaseHTTPError('Boom')
+        ]
+        self.assertRaises(
+            AirflowException,
+            self.pod_launcher.read_pod_logs,
+            mock.sentinel
+        )
+
+    def test_read_pod_returns_logs(self):
+        self.mock_kube_client.read_namespaced_pod.return_value = mock.sentinel.pod_info
+        pod_info = self.pod_launcher.read_pod(mock.sentinel)
+        self.assertEqual(mock.sentinel.pod_info, pod_info)
+
+    def test_read_pod_retries_successfully(self):
+        self.mock_kube_client.read_namespaced_pod.side_effect = [
+            BaseHTTPError('Boom'),
+            mock.sentinel.pod_info
+        ]
+        pod_info = self.pod_launcher.read_pod(mock.sentinel)
+        self.assertEqual(mock.sentinel.pod_info, pod_info)
+        self.mock_kube_client.read_namespaced_pod.assert_has_calls([
+            mock.call(mock.sentinel.name, mock.sentinel.namespace),
+            mock.call(mock.sentinel.name, mock.sentinel.namespace)
+        ])
+
+    def test_read_pod_retries_fails(self):
+        self.mock_kube_client.read_namespaced_pod.side_effect = [
+            BaseHTTPError('Boom'),
+            BaseHTTPError('Boom'),
+            BaseHTTPError('Boom')
+        ]
+        self.assertRaises(
+            AirflowException,
+            self.pod_launcher.read_pod,
+            mock.sentinel
+        )


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4393

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Added an exponential backoff retry to the Kube pod launcher when reading info / fetching logs from running pods. This is to mitigate any transient network issues, which could cause Airflow to mark the task as failed and launch a new pod without removing the old one. 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
