### PR TITLE
[AIRFLOW-XXX] Fix example "extras" field in mysql connect doc

### DIFF
--- a/docs/howto/connection/mysql.rst
+++ b/docs/howto/connection/mysql.rst
@@ -57,7 +57,7 @@ Extra (optional)
 
        {
           "charset": "utf8",
-          "cursorclass": "sscursor",
+          "cursor": "sscursor",
           "local_infile": true,
           "unix_socket": "/var/socket",
           "ssl": {
@@ -73,7 +73,7 @@ Extra (optional)
 
        {
           "charset": "utf8",
-          "cursorclass": "sscursor",
+          "cursor": "sscursor",
           "local_infile": true,
           "unix_socket": "/var/socket",
           "ssl": "{\"cert\": \"/tmp/client-cert.pem\", \"ca\": \"/tmp/server-ca.pem\", \"key\": \"/tmp/client-key.pem\"}"


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Change "cursorclass" to "cursor" in mysql connection example "extras" field, for code in mysql_hook.py on line 84, 86 and 88 are using `conn.extra_dejson["cursor"] `.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"
