### PR TITLE
[AIRFLOW-XXX] Fix DaskExecutor formatting in Scheduler doc

### DIFF
--- a/docs/scheduler.rst
+++ b/docs/scheduler.rst
@@ -40,7 +40,7 @@ start date, at the END of the period.
 
 The scheduler starts an instance of the executor specified in the your
 ``airflow.cfg``. If it happens to be the :class:`airflow.contrib.executors.local_executor.LocalExecutor`, tasks will be
-executed as subprocesses; in the case of :class:`airflow.executors.celery_executor.CeleryExecutor`, and :class:`airflow.executors.dask_executor.DaskExecutor`` tasks are executed remotely.
+executed as subprocesses; in the case of :class:`airflow.executors.celery_executor.CeleryExecutor`, and :class:`airflow.executors.dask_executor.DaskExecutor` tasks are executed remotely.
 
 To start a scheduler, simply run the command:
 


### PR DESCRIPTION
### Description

- Fix Sphinx documentation typo for DaskExecutor in docs/scheduler.rst
