### PR TITLE
[AIRFLOW-4517] allow for airflow config to influence flask configuration

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -342,6 +342,9 @@ cookie_secure = False
 # Set samesite policy on session cookie
 cookie_samesite =
 
+[flask_web]
+# this section is for any additional flask options for the webserver. Flask keys
+# should be specified in lower-case
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -77,6 +77,8 @@ hide_paused_dags_by_default = False
 page_size = 100
 rbac = False
 
+[flask_web]
+
 [email]
 email_backend = airflow.utils.email.send_email_smtp
 

--- a/scripts/ci/airflow_travis.cfg
+++ b/scripts/ci/airflow_travis.cfg
@@ -71,3 +71,6 @@ job_heartbeat_sec = 1
 scheduler_heartbeat_sec = 5
 authenticate = true
 max_threads = 2
+
+[flask_web]
+# blank, but allows us to do getsection()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -188,6 +188,20 @@ class TestCLI(unittest.TestCase):
         p.terminate()
         p.wait()
 
+    def test_cli_webserver_flask_debug(self):
+        env = os.environ.copy()
+        env['AIRFLOW__WEBSERVER__RBAC'] = 'True'
+        env['AIRFLOW__FLASK_WEB__PREFERRED_URL_SCHEME'] = 'https'
+        p = psutil.Popen(["airflow", "webserver", "-d"], env=env)
+        sleep(3)  # wait for webserver to start
+        return_code = p.poll()
+        self.assertEqual(
+            None,
+            return_code,
+            "webserver terminated with return code {} in debug mode".format(return_code))
+        p.terminate()
+        p.wait()
+
     def test_local_run(self):
         args = create_mock_args(
             task_id='print_the_context',


### PR DESCRIPTION
Add the ability to use a [flask_web] section to set flask configuration
variables. This is particularly useful with the introduction of origin=
on some of the dags.html page links (trigger, particularly), as without
it, there's no way of specifying https in the url_for() flask function.
Right now, without a good framework for seeing the effect of flask vars,
it's difficult to write a perfect test, but I've added something that showed
me it was there.