### PR TITLE
[AIRFLOW-4528] Cancel DataProc task on timeout

### DIFF
--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -246,6 +246,23 @@ class DataProcHook(GoogleCloudBaseHook):
                                        self.num_retries)
         submitted.wait_for_done()
 
+    def cancel(self, project_id, job_id, region='global'):
+        """
+        Cancel a Google Cloud DataProc job.
+        :param project_id: Name of the project the job belongs to
+        :type project_id: str
+        :param job_id: Identifier of the job to cancel
+        :type job_id: int
+        :param region: Region used for the job
+        :type region: str
+        :returns A Job json dictionary representing the canceled job
+        """
+        return self.get_conn().projects().regions().jobs().cancel(
+            projectId=project_id,
+            region=region,
+            jobId=job_id
+        )
+
 
 setattr(
     DataProcHook,


### PR DESCRIPTION
Make sure you have checked all steps below.

### Jira

- [x] My PR addresses the following Airflow Jira issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4528

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
  - My PR factorize code for most DataProcXXXOperator operators and primarily implements the `on_kill` callback to cancel dataproc launched jobs on timeout.

### Tests

- [x] My PR adds the following unit tests **OR** does not need testing for this extremely good reason:
  - My PR adds the `DataProcJobBaseOperatorTest` to test that the `cancel` method of the DataProc hook is called on timeout.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "How to write a good git commit message":
  i. Subject is separated from body by a blank line
  ii. Subject is limited to 50 characters (not including Jira issue reference)
  iii. Subject does not end with a period
  iv. Subject uses the imperative mood ("add", not "adding")
  v. Body wraps at 72 characters
  vi. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes flake8

