### PR TITLE
[AIRFLOW-4532] Optimise iteration in deepcopy

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -620,7 +620,7 @@ class BaseOperator(LoggingMixin):
 
         shallow_copy = cls.shallow_copy_attrs + cls._base_operator_shallow_copy_attrs
 
-        for k, v in list(self.__dict__.items()):
+        for k, v in self.__dict__.items():
             if k not in shallow_copy:
                 setattr(result, k, copy.deepcopy(v, memo))
             else:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -977,7 +977,7 @@ class DAG(BaseDag, LoggingMixin):
         cls = self.__class__
         result = cls.__new__(cls)
         memo[id(self)] = result
-        for k, v in list(self.__dict__.items()):
+        for k, v in self.__dict__.items():
             if k not in ('user_defined_macros', 'user_defined_filters', 'params'):
                 setattr(result, k, copy.deepcopy(v, memo))
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4532
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

There is a bit of optimisation to achieve in the DAG and BaseOperator deepcopy methods. In both, we have an iteration as in `stmt_original` shown below. The fastest alternative is `stmt_no_list` which gives a +-28% speedup.

```python
import timeit

setup = """
import string

nums = list(range(25))
chars = [string.ascii_lowercase[i] for i in nums]
test = dict(zip(nums, chars))
"""

stmt_original = """
for k, v in list(test.items()):
    if k not in (3, 7, 18):
        pass
"""

stmt_no_list = """
for k, v in test.items():
    if k not in (3, 7, 18):
        pass
"""

stmt_exclude_var = """
exclude = (3,7,18)
for k, v in test.items():
    if k not in exclude:
        pass
"""

stmt_pre_filter = """
exclude = (3,7,18)
for k,v in {k:v for k,v in test.items() if k not in exclude}.items():
    pass
"""

timeit_runs = 100000
print("original: ", timeit.timeit(setup=setup, stmt=stmt_original, number=timeit_runs))
print("no list: ", timeit.timeit(setup=setup, stmt=stmt_no_list, number=timeit_runs))
print("no list & exclude var: ", timeit.timeit(setup=setup, stmt=stmt_exclude_var, number=timeit_runs))
print("exclude in dict compr: ", timeit.timeit(setup=setup, stmt=stmt_pre_filter, number=timeit_runs))
```

Results (lower is better):
```python
original:  0.25252830400131643
no list:  0.18099403311498463
no list & exclude var:  0.1814123059157282
exclude in dict compr:  0.38640512502752244
```

The "no list" is slightly faster than the "no list & exclude var" option. I wouldn't expect it and I'm not exactly sure why, but the data says so 😄 Either way, both are faster than the original implementation.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
