### PR TITLE
[AIRFLOW-4537] Remove the mkdir_p function in favour of native Python pathlib

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -21,9 +21,9 @@ from base64 import b64encode
 from builtins import str
 from collections import OrderedDict
 import copy
-import errno
 from future import standard_library
 import os
+import pathlib
 import shlex
 from six import iteritems
 import subprocess
@@ -441,17 +441,6 @@ class AirflowConfigParser(ConfigParser):
         )
 
 
-def mkdir_p(path):
-    try:
-        os.makedirs(path)
-    except OSError as exc:  # Python >2.5
-        if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise AirflowConfigException(
-                'Error creating {}: {}'.format(path, exc.strerror))
-
-
 def get_airflow_home():
     return expand_env_var(os.environ.get('AIRFLOW_HOME', '~/airflow'))
 
@@ -467,7 +456,7 @@ def get_airflow_config(airflow_home):
 
 AIRFLOW_HOME = get_airflow_home()
 AIRFLOW_CONFIG = get_airflow_config(AIRFLOW_HOME)
-mkdir_p(AIRFLOW_HOME)
+pathlib.Path(AIRFLOW_HOME).mkdir(parents=True, exist_ok=True)
 
 
 # Set up dags folder for unit tests

--- a/airflow/contrib/hooks/qubole_hook.py
+++ b/airflow/contrib/hooks/qubole_hook.py
@@ -19,6 +19,7 @@
 #
 
 import os
+import pathlib
 import time
 import datetime
 import six
@@ -177,7 +178,7 @@ class QuboleHook(BaseHook):
                 configuration.conf.get('core', 'BASE_LOG_FOLDER')
             )
             resultpath = logpath + '/' + self.dag_id + '/' + self.task_id + '/results'
-            configuration.mkdir_p(resultpath)
+            pathlib.Path(resultpath).mkdir(parents=True, exist_ok=True)
             fp = open(resultpath + '/' + iso, 'wb')
 
         if self.cmd is None:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -17,12 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
+import pathlib
 import six
 import sys
 import tempfile
 
 from airflow import configuration as conf
-from airflow.configuration import mkdir_p
 from airflow.exceptions import AirflowConfigException
 from tests.compat import mock, patch
 
@@ -116,7 +116,7 @@ class settings_context:
 
             # Create the directory structure
             dir_path = os.path.join(self.settings_root, dir)
-            mkdir_p(dir_path)
+            pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
 
             # Add the __init__ for the directories
             # This is required for Python 2.7

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -18,6 +18,7 @@
 # under the License.
 
 import os
+import pathlib
 import sys
 import tempfile
 import unittest
@@ -27,7 +28,6 @@ from datetime import timedelta
 from unittest.mock import MagicMock
 
 from airflow import configuration as conf
-from airflow.configuration import mkdir_p
 from airflow.jobs import DagFileProcessor
 from airflow.jobs import LocalTaskJob as LJ
 from airflow.models import DagBag, TaskInstance as TI
@@ -100,7 +100,7 @@ class settings_context:
 
             # Create the directory structure
             dir_path = os.path.join(self.settings_root, dir)
-            mkdir_p(dir_path)
+            pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
 
             # Add the __init__ for the directories
             # This is required for Python 2.7


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4537
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Was trying to cleanup configuration.py and noticed this `mkdir_p` function which seems to come straight from https://stackoverflow.com/questions/600268. This functionality is now supported by native Python with pathlib, which is also explained in the same post:

```python
pathlib.Path("/tmp/path/to/desired/directory").mkdir(parents=True, exist_ok=True)
```

This PR removes `mkdir_p` in favour of pathlib.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
