### PR TITLE
[AIRFLOW-4374] Make enum-like-classes inherit from enum

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,21 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### TriggerRules and WeightRules only by enum members, not by string value
+Passing a string value to `trigger_rule` and `weight_rule` in operators has been removed and only the enum member can be provided.
+
+```python
+# Not possible anymore
+task = DummyOperator(... trigger_rule="all_done" ...)
+task = DummyOperator(... weight_rule="downstream" ...)
+
+# Only valid way of setting trigger_rule/weight_rule
+task = DummyOperator(... trigger_rule=TriggerRule.ALL_DONE ...)
+task = DummyOperator(... weight_rule=WeightRule.DOWNSTREAM ...)
+```
+
+PR: https://github.com/apache/airflow/pull/5302
+
 ### Changes in writing Logs to Elasticsearch
 
 The `elasticsearch_` prefix has been removed from all config items under the `[elasticsearch]` section. For example `elasticsearch_host` is now just `host`.

--- a/airflow/contrib/example_dags/example_qubole_operator.py
+++ b/airflow/contrib/example_dags/example_qubole_operator.py
@@ -33,6 +33,7 @@ from airflow import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator, BranchPythonOperator
 from airflow.contrib.operators.qubole_operator import QuboleOperator
+from airflow.utils.trigger_rule import TriggerRule
 import filecmp
 import random
 
@@ -83,14 +84,14 @@ t2 = QuboleOperator(
     tags=['tag1', 'tag2'],
     # If the script at s3 location has any qubole specific macros to be replaced
     # macros='[{"date": "{{ ds }}"}, {"name" : "abc"}]',
-    trigger_rule="all_done",
+    trigger_rule=TriggerRule.ALL_DONE,
     dag=dag)
 
 t3 = PythonOperator(
     task_id='compare_result',
     provide_context=True,
     python_callable=compare_result,
-    trigger_rule="all_done",
+    trigger_rule=TriggerRule.ALL_DONE,
     dag=dag)
 
 t3.set_upstream(t1)
@@ -106,7 +107,7 @@ branching.set_upstream(t3)
 
 join = DummyOperator(
     task_id='join',
-    trigger_rule='one_success',
+    trigger_rule=TriggerRule.ONE_SUCCESS,
     dag=dag
 )
 
@@ -132,7 +133,7 @@ t5 = QuboleOperator(
     command_type="pigcmd",
     script_location="s3://public-qubole/qbol-library/scripts/script1-hadoop-s3-small.pig",
     parameters="key1=value1 key2=value2",
-    trigger_rule="all_done",
+    trigger_rule=TriggerRule.ALL_DONE,
     dag=dag)
 
 t4.set_upstream(branching)
@@ -150,7 +151,7 @@ t7 = QuboleOperator(
     command_type="shellcmd",
     script_location="s3://public-qubole/qbol-library/scripts/shellx.sh",
     parameters="param1 param2",
-    trigger_rule="all_done",
+    trigger_rule=TriggerRule.ALL_DONE,
     dag=dag)
 
 t6.set_upstream(branching)
@@ -172,7 +173,7 @@ t9 = QuboleOperator(
     db_table='exported_airline_origin_destination',
     partition_spec='dt=20110104-02',
     dbtap_id=2064,
-    trigger_rule="all_done",
+    trigger_rule=TriggerRule.ALL_DONE,
     dag=dag)
 
 t8.set_upstream(branching)
@@ -188,7 +189,7 @@ t10 = QuboleOperator(
     where_clause='id < 10',
     db_parallelism=2,
     dbtap_id=2064,
-    trigger_rule="all_done",
+    trigger_rule=TriggerRule.ALL_DONE,
     dag=dag)
 
 prog = '''

--- a/airflow/example_dags/example_branch_operator.py
+++ b/airflow/example_dags/example_branch_operator.py
@@ -23,6 +23,7 @@ import airflow
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import BranchPythonOperator
+from airflow.utils.trigger_rule import TriggerRule
 
 args = {
     'owner': 'airflow',
@@ -51,7 +52,7 @@ run_this_first >> branching
 
 join = DummyOperator(
     task_id='join',
-    trigger_rule='one_success',
+    trigger_rule=TriggerRule.ONE_SUCCESS,
     dag=dag,
 )
 

--- a/airflow/example_dags/example_skip_dag.py
+++ b/airflow/example_dags/example_skip_dag.py
@@ -21,6 +21,7 @@ import airflow
 from airflow.exceptions import AirflowSkipException
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
+from airflow.utils.trigger_rule import TriggerRule
 
 args = {
     'owner': 'airflow',
@@ -39,7 +40,7 @@ class DummySkipOperator(DummyOperator):
 def create_test_pipeline(suffix, trigger_rule, dag):
     skip_operator = DummySkipOperator(task_id='skip_operator_{}'.format(suffix), dag=dag)
     always_true = DummyOperator(task_id='always_true_{}'.format(suffix), dag=dag)
-    join = DummyOperator(task_id=trigger_rule, dag=dag, trigger_rule=trigger_rule)
+    join = DummyOperator(task_id=trigger_rule.name.lower(), dag=dag, trigger_rule=trigger_rule)
     final = DummyOperator(task_id='final_{}'.format(suffix), dag=dag)
 
     skip_operator >> join
@@ -48,5 +49,5 @@ def create_test_pipeline(suffix, trigger_rule, dag):
 
 
 dag = DAG(dag_id='example_skip_dag', default_args=args)
-create_test_pipeline('1', 'all_success', dag)
-create_test_pipeline('2', 'one_success', dag)
+create_test_pipeline('1', TriggerRule.ALL_SUCCESS, dag)
+create_test_pipeline('2', TriggerRule.ONE_SUCCESS, dag)

--- a/airflow/utils/trigger_rule.py
+++ b/airflow/utils/trigger_rule.py
@@ -17,10 +17,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Set
+from enum import Enum
+from typing import List
 
 
-class TriggerRule:
+class TriggerRule(Enum):
     ALL_SUCCESS = 'all_success'
     ALL_FAILED = 'all_failed'
     ALL_DONE = 'all_done'
@@ -30,18 +31,12 @@ class TriggerRule:
     NONE_SKIPPED = 'none_skipped'
     DUMMY = 'dummy'
 
-    _ALL_TRIGGER_RULES = set()  # type: Set[str]
-
     @classmethod
-    def is_valid(cls, trigger_rule):
-        return trigger_rule in cls.all_triggers()
+    def all_triggers(cls) -> List[str]:
+        """
+        Return all TriggerRule names.
 
-    @classmethod
-    def all_triggers(cls):
-        if not cls._ALL_TRIGGER_RULES:
-            cls._ALL_TRIGGER_RULES = {
-                getattr(cls, attr)
-                for attr in dir(cls)
-                if not attr.startswith("_") and not callable(getattr(cls, attr))
-            }
-        return cls._ALL_TRIGGER_RULES
+        :return: List of all TriggerRules names
+        :rtype: List[str]
+        """
+        return [tr.name for tr in TriggerRule]

--- a/airflow/utils/weight_rule.py
+++ b/airflow/utils/weight_rule.py
@@ -17,26 +17,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Set
+from enum import Enum
+from typing import List
 
 
-class WeightRule:
+class WeightRule(Enum):
     DOWNSTREAM = 'downstream'
     UPSTREAM = 'upstream'
     ABSOLUTE = 'absolute'
 
-    _ALL_WEIGHT_RULES = set()  # type: Set[str]
-
     @classmethod
-    def is_valid(cls, weight_rule):
-        return weight_rule in cls.all_weight_rules()
+    def all_weight_rules(cls) -> List[str]:
+        """
+        Return all WeightRule names.
 
-    @classmethod
-    def all_weight_rules(cls):
-        if not cls._ALL_WEIGHT_RULES:
-            cls._ALL_WEIGHT_RULES = {
-                getattr(cls, attr)
-                for attr in dir(cls)
-                if not attr.startswith("_") and not callable(getattr(cls, attr))
-            }
-        return cls._ALL_WEIGHT_RULES
+        :return: List of all WeightRule names
+        :rtype: List[str]
+        """
+        return [wr.name for wr in WeightRule]

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -737,19 +737,19 @@ dependency settings.
 
 All operators have a ``trigger_rule`` argument which defines the rule by which
 the generated task get triggered. The default value for ``trigger_rule`` is
-``all_success`` and can be defined as "trigger this task when all directly
+``TriggerRule.ALL_SUCCESS`` and can be defined as "trigger this task when all directly
 upstream tasks have succeeded". All other rules described here are based
 on direct parent tasks and are values that can be passed to any operator
 while creating tasks:
 
-* ``all_success``: (default) all parents have succeeded
-* ``all_failed``: all parents are in a ``failed`` or ``upstream_failed`` state
-* ``all_done``: all parents are done with their execution
-* ``one_failed``: fires as soon as at least one parent has failed, it does not wait for all parents to be done
-* ``one_success``: fires as soon as at least one parent succeeds, it does not wait for all parents to be done
-* ``none_failed``: all parents have not failed (``failed`` or ``upstream_failed``) i.e. all parents have succeeded or been skipped
-* ``none_skipped``: no parent is in a ``skipped`` state, i.e. all parents are in a ``success``, ``failed``, or ``upstream_failed`` state
-* ``dummy``: dependencies are just for show, trigger at will
+* ``TriggerRule.ALL_SUCCESS``: (default) all parents have succeeded
+* ``TriggerRule.ALL_FAILED``: all parents are in a ``failed`` or ``upstream_failed`` state
+* ``TriggerRule.ALL_DONE``: all parents are done with their execution
+* ``TriggerRule.ONE_FAILED``: fires as soon as at least one parent has failed, it does not wait for all parents to be done
+* ``TriggerRule.ONE_SUCCESS``: fires as soon as at least one parent succeeds, it does not wait for all parents to be done
+* ``TriggerRule.NONE_FAILED``: all parents have not failed (``failed`` or ``upstream_failed``) i.e. all parents have succeeded or been skipped
+* ``TriggerRule.NONE_SKIPPED``: no parent is in a ``skipped`` state, i.e. all parents are in a ``success``, ``failed``, or ``upstream_failed`` state
+* ``TriggerRule.DUMMY``: dependencies are just for show, trigger at will
 
 Note that these can be used in conjunction with ``depends_on_past`` (boolean)
 that, when set to ``True``, keeps a task from getting triggered if the
@@ -757,8 +757,8 @@ previous schedule for the task hasn't succeeded.
 
 One must be aware of the interaction between trigger rules and skipped tasks
 in schedule level. Skipped tasks will cascade through trigger rules 
-``all_success`` and ``all_failed`` but not ``all_done``, ``one_failed``, ``one_success``,
-``none_failed``, ``none_skipped`` and ``dummy``.
+``ALL_SUCCESS`` and ``ALL_FAILED`` but not ``ALL_DONE``, ``ONE_FAILED``, ``ONE_SUCCESS``,
+``NONE_FAILED``, ``NONE_SKIPPED`` and ``DUMMY``.
 
 For example, consider the following DAG:
 
@@ -796,24 +796,24 @@ For example, consider the following DAG:
 
 In the case of this DAG, ``join`` is downstream of ``follow_branch_a`` 
 and ``branch_false``. The ``join`` task will show up as skipped 
-because its ``trigger_rule`` is set to ``all_success`` by default and 
+because its ``trigger_rule`` is set to ``TriggerRule.ALL_SUCCESS`` by default and
 skipped tasks will cascade through ``all_success``. 
 
 .. image:: img/branch_without_trigger.png
 
-By setting ``trigger_rule`` to ``none_failed`` in ``join`` task, 
+By setting ``trigger_rule`` to ``TriggerRule.NONE_FAILED`` in ``join`` task,
 
 .. code:: python
   
   #dags/branch_with_trigger.py
   ...
-  join = DummyOperator(task_id='join', dag=dag, trigger_rule='none_failed')
+  join = DummyOperator(task_id='join', dag=dag, trigger_rule=TriggerRule.NONE_FAILED)
   ...
 
 The ``join`` task will be triggered as soon as 
 ``branch_false`` has been skipped (a valid completion state) and 
 ``follow_branch_a`` has succeeded. Because skipped tasks **will not** 
-cascade through ``none_failed``. 
+cascade through ``NONE_FAILED``.
 
 .. image:: img/branch_with_trigger.png
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -38,6 +38,7 @@ from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.utils import timezone
 from airflow.utils.db import create_session
 from airflow.utils.state import State
+from airflow.utils.trigger_rule import TriggerRule
 from tests.models import DEFAULT_DATE
 
 
@@ -545,40 +546,40 @@ class TaskInstanceTest(unittest.TestCase):
         #
         # Tests for all_success
         #
-        ['all_success', 5, 0, 0, 0, 0, True, None, True],
-        ['all_success', 2, 0, 0, 0, 0, True, None, False],
-        ['all_success', 2, 0, 1, 0, 0, True, State.UPSTREAM_FAILED, False],
-        ['all_success', 2, 1, 0, 0, 0, True, State.SKIPPED, False],
+        [TriggerRule.ALL_SUCCESS, 5, 0, 0, 0, 0, True, None, True],
+        [TriggerRule.ALL_SUCCESS, 2, 0, 0, 0, 0, True, None, False],
+        [TriggerRule.ALL_SUCCESS, 2, 0, 1, 0, 0, True, State.UPSTREAM_FAILED, False],
+        [TriggerRule.ALL_SUCCESS, 2, 1, 0, 0, 0, True, State.SKIPPED, False],
         #
         # Tests for one_success
         #
-        ['one_success', 5, 0, 0, 0, 5, True, None, True],
-        ['one_success', 2, 0, 0, 0, 2, True, None, True],
-        ['one_success', 2, 0, 1, 0, 3, True, None, True],
-        ['one_success', 2, 1, 0, 0, 3, True, None, True],
+        [TriggerRule.ONE_SUCCESS, 5, 0, 0, 0, 5, True, None, True],
+        [TriggerRule.ONE_SUCCESS, 2, 0, 0, 0, 2, True, None, True],
+        [TriggerRule.ONE_SUCCESS, 2, 0, 1, 0, 3, True, None, True],
+        [TriggerRule.ONE_SUCCESS, 2, 1, 0, 0, 3, True, None, True],
         #
         # Tests for all_failed
         #
-        ['all_failed', 5, 0, 0, 0, 5, True, State.SKIPPED, False],
-        ['all_failed', 0, 0, 5, 0, 5, True, None, True],
-        ['all_failed', 2, 0, 0, 0, 2, True, State.SKIPPED, False],
-        ['all_failed', 2, 0, 1, 0, 3, True, State.SKIPPED, False],
-        ['all_failed', 2, 1, 0, 0, 3, True, State.SKIPPED, False],
+        [TriggerRule.ALL_FAILED, 5, 0, 0, 0, 5, True, State.SKIPPED, False],
+        [TriggerRule.ALL_FAILED, 0, 0, 5, 0, 5, True, None, True],
+        [TriggerRule.ALL_FAILED, 2, 0, 0, 0, 2, True, State.SKIPPED, False],
+        [TriggerRule.ALL_FAILED, 2, 0, 1, 0, 3, True, State.SKIPPED, False],
+        [TriggerRule.ALL_FAILED, 2, 1, 0, 0, 3, True, State.SKIPPED, False],
         #
         # Tests for one_failed
         #
-        ['one_failed', 5, 0, 0, 0, 0, True, None, False],
-        ['one_failed', 2, 0, 0, 0, 0, True, None, False],
-        ['one_failed', 2, 0, 1, 0, 0, True, None, True],
-        ['one_failed', 2, 1, 0, 0, 3, True, None, False],
-        ['one_failed', 2, 3, 0, 0, 5, True, State.SKIPPED, False],
+        [TriggerRule.ONE_FAILED, 5, 0, 0, 0, 0, True, None, False],
+        [TriggerRule.ONE_FAILED, 2, 0, 0, 0, 0, True, None, False],
+        [TriggerRule.ONE_FAILED, 2, 0, 1, 0, 0, True, None, True],
+        [TriggerRule.ONE_FAILED, 2, 1, 0, 0, 3, True, None, False],
+        [TriggerRule.ONE_FAILED, 2, 3, 0, 0, 5, True, State.SKIPPED, False],
         #
         # Tests for done
         #
-        ['all_done', 5, 0, 0, 0, 5, True, None, True],
-        ['all_done', 2, 0, 0, 0, 2, True, None, False],
-        ['all_done', 2, 0, 1, 0, 3, True, None, False],
-        ['all_done', 2, 1, 0, 0, 3, True, None, False]
+        [TriggerRule.ALL_DONE, 5, 0, 0, 0, 5, True, None, True],
+        [TriggerRule.ALL_DONE, 2, 0, 0, 0, 2, True, None, False],
+        [TriggerRule.ALL_DONE, 2, 0, 1, 0, 3, True, None, False],
+        [TriggerRule.ALL_DONE, 2, 1, 0, 0, 3, True, None, False]
     ])
     def test_check_task_dependencies(self, trigger_rule, successes, skipped,
                                      failed, upstream_failed, done,

--- a/tests/utils/test_trigger_rule.py
+++ b/tests/utils/test_trigger_rule.py
@@ -24,12 +24,12 @@ from airflow.utils.trigger_rule import TriggerRule
 class TestTriggerRule(unittest.TestCase):
 
     def test_valid_trigger_rules(self):
-        self.assertTrue(TriggerRule.is_valid(TriggerRule.ALL_SUCCESS))
-        self.assertTrue(TriggerRule.is_valid(TriggerRule.ALL_FAILED))
-        self.assertTrue(TriggerRule.is_valid(TriggerRule.ALL_DONE))
-        self.assertTrue(TriggerRule.is_valid(TriggerRule.ONE_SUCCESS))
-        self.assertTrue(TriggerRule.is_valid(TriggerRule.ONE_FAILED))
-        self.assertTrue(TriggerRule.is_valid(TriggerRule.NONE_FAILED))
-        self.assertTrue(TriggerRule.is_valid(TriggerRule.NONE_SKIPPED))
-        self.assertTrue(TriggerRule.is_valid(TriggerRule.DUMMY))
+        self.assertTrue(TriggerRule.ALL_SUCCESS in TriggerRule)
+        self.assertTrue(TriggerRule.ALL_FAILED in TriggerRule)
+        self.assertTrue(TriggerRule.ALL_DONE in TriggerRule)
+        self.assertTrue(TriggerRule.ONE_SUCCESS in TriggerRule)
+        self.assertTrue(TriggerRule.ONE_FAILED in TriggerRule)
+        self.assertTrue(TriggerRule.NONE_FAILED in TriggerRule)
+        self.assertTrue(TriggerRule.NONE_SKIPPED in TriggerRule)
+        self.assertTrue(TriggerRule.DUMMY in TriggerRule)
         self.assertEqual(len(TriggerRule.all_triggers()), 8)

--- a/tests/utils/test_weight_rule.py
+++ b/tests/utils/test_weight_rule.py
@@ -24,7 +24,7 @@ from airflow.utils.weight_rule import WeightRule
 class TestWeightRule(unittest.TestCase):
 
     def test_valid_weight_rules(self):
-        self.assertTrue(WeightRule.is_valid(WeightRule.DOWNSTREAM))
-        self.assertTrue(WeightRule.is_valid(WeightRule.UPSTREAM))
-        self.assertTrue(WeightRule.is_valid(WeightRule.ABSOLUTE))
+        self.assertTrue(WeightRule.DOWNSTREAM in WeightRule)
+        self.assertTrue(WeightRule.UPSTREAM in WeightRule)
+        self.assertTrue(WeightRule.ABSOLUTE in WeightRule)
         self.assertEqual(len(WeightRule.all_weight_rules()), 3)


### PR DESCRIPTION
_Note: breaking change!_

This PR creates enum classes for `TriggerRule` and `WeightRule`. Enums simplify the code base and improve in terms of memory usage & performance.

I had to make a breaking change choice:
In the BaseOperator we currently support passing both a string (e.g. `"all_done"`) and enum member (e.g. `TriggerRule.ALL_DONE`). When using enums, you cannot pass the string value without doing some try except, e.g (in BaseOperator.\_\_init\_\_):

```python
trigger_rule = "all_done"
if trigger_rule not in TriggerRule:
    try:
        trigger_rule = TriggerRule(trigger_rule)
    except ValueError:
        raise AirflowException(
            "The trigger_rule must be one of {all_triggers},"
            "'{d}.{t}'; received '{tr}'."
            .format(all_triggers=TriggerRule.all_triggers(), d=dag.dag_id if dag else "", t=task_id, tr=trigger_rule))
```

I suggest to remove support for passing the string value, this was only used in the qubole example operator and that way we can unify the way for providing trigger_rules and weight_rules. This helps with typing and prevents errors while developing since the IDE can hint enum members. So:

```python
# Not possible anymore
task = DummyOperator(... trigger_rule="all_done" ...)
task = DummyOperator(... weight_rule="downstream" ...)

# Only valid way of setting trigger_rule/weight_rule
task = DummyOperator(... trigger_rule=TriggerRule.ALL_DONE ...)
task = DummyOperator(... weight_rule=WeightRule.DOWNSTREAM ...)
```

-----

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4374
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Python 3.4 introduces the Enum type, which simplifies the WeightRule and TriggerRule class a lot. `is_valid` methods were removed because selecting an invalid Enum member will raise an AttributeError.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
