### PR TITLE
[AIRFLOW-4541] Deprecate mkdirs utility function for pathlib

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,12 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### airflow.utils.file.mkdirs deprecated
+
+`airflow.utils.file.mkdirs()` is deprecated in favour of Pathlib, the native Python module for dealing with the filesystem.
+
+JIRA: https://issues.apache.org/jira/browse/AIRFLOW-4541
+
 ### Removal of Mesos Executor
 The Mesos Executor is removed from the code base as it was not widely used and not maintained. [Mailing List Discussion on deleting it](https://lists.apache.org/list.html?dev@airflow.apache.org:lte=1M:mesos).
 

--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -18,10 +18,10 @@
 # under the License.
 
 import os
+import pathlib
 from typing import Dict, Any
 
 from airflow import configuration as conf
-from airflow.utils.file import mkdirs
 
 # TODO: Logging format and level should be configured
 # in this file instead of from airflow.cfg. Currently
@@ -189,7 +189,7 @@ if os.environ.get('CONFIG_PROCESSOR_MANAGER_LOGGER') == 'True':
     processor_manager_handler_config = DEFAULT_DAG_PARSING_LOGGING_CONFIG['handlers'][
         'processor_manager']
     directory = os.path.dirname(processor_manager_handler_config['filename'])
-    mkdirs(directory, 0o755)
+    pathlib.Path(directory).mkdir(mode=0o755, parents=True, exist_ok=True)
 
 if REMOTE_LOGGING and REMOTE_BASE_LOG_FOLDER.startswith('s3://'):
     DEFAULT_LOGGING_CONFIG['handlers'].update(REMOTE_HANDLERS['s3'])

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -24,6 +24,8 @@ from tempfile import mkdtemp
 
 from contextlib import contextmanager
 
+from zope import deprecation
+
 
 @contextmanager
 def TemporaryDirectory(suffix='', prefix=None, dir=None):
@@ -39,6 +41,8 @@ def TemporaryDirectory(suffix='', prefix=None, dir=None):
                 raise e
 
 
+@deprecation.deprecate(msg="airflow.utils.file.mkdirs will be removed in Airflow 2.0. "
+                           "The pathlib module (Python >=3.4) provides the same functionality.")
 def mkdirs(path, mode):
     """
     Creates the directory specified by path, creating intermediate directories

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -19,11 +19,12 @@
 
 import logging
 import os
+import pathlib
+
 import requests
 
 from airflow import configuration as conf
 from airflow.configuration import AirflowConfigException
-from airflow.utils.file import mkdirs
 from airflow.utils.helpers import parse_template_string
 
 
@@ -194,10 +195,7 @@ class FileTaskHandler(logging.Handler):
         # operator is not compatible with impersonation (e.g. if a Celery executor is used
         # for a SubDag operator and the SubDag operator has a different owner than the
         # parent DAG)
-        if not os.path.exists(directory):
-            # Create the directory as globally writable using custom mkdirs
-            # as os.makedirs doesn't set mode properly.
-            mkdirs(directory, 0o777)
+        pathlib.Path(directory).mkdir(mode=0o777, parents=True, exist_ok=True)
 
         if not os.path.exists(full_path):
             open(full_path, "a").close()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4541
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Replace all usage of `airflow.utils.file.mkdirs` by pathlib, and add a deprecation warning about future removal of mkdirs.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
