### PR TITLE
[AIRFLOW-986] HiveCliHook ignores 'proxy_user' value in a connection's extra parameter

### DIFF
--- a/tests/operators/test_hive_operator.py
+++ b/tests/operators/test_hive_operator.py
@@ -60,6 +60,32 @@ class HiveEnvironmentTest(unittest.TestCase):
         """
 
 
+class HiveCliTest(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+        self.nondefault_schema = "nondefault"
+        os.environ["AIRFLOW__CORE__SECURITY"] = "kerberos"
+
+    def tearDown(self):
+        del os.environ["AIRFLOW__CORE__SECURITY"]
+
+    def test_get_proxy_user_value(self):
+        from airflow.hooks.hive_hooks import HiveCliHook
+
+        hook = HiveCliHook()
+        returner = mock.MagicMock()
+        returner.extra_dejson = {'proxy_user': 'a_user_proxy'}
+        hook.use_beeline = True
+        hook.conn = returner
+
+        # Run
+        result = hook._prepare_cli_cmd()
+
+        # Verify
+        self.assertIn('hive.server2.proxy.user=a_user_proxy', result[2])
+
+
 class HiveOperatorConfigTest(HiveEnvironmentTest):
 
     def test_hive_airflow_default_config_queue(self):


### PR DESCRIPTION
2nd attempt to https://issues.apache.org/jira/browse/AIRFLOW-986
This PR is based on previous stale PR https://github.com/apache/airflow/pull/2153 which was not  merged nor reviewed