### PR TITLE
[AIRFLOW-XXX] Fix wrong inline code highlighting

### DIFF
--- a/docs/howto/connection/index.rst
+++ b/docs/howto/connection/index.rst
@@ -73,7 +73,7 @@ named ``AIRFLOW_CONN_POSTGRES_MASTER`` (note that the environment variable
 must be all uppercase).
 
 Airflow assumes the value returned from the environment variable to be in a URI
-format (e.g.``postgres://user:password@localhost:5432/master`` or
+format (e.g. ``postgres://user:password@localhost:5432/master`` or
 ``s3://accesskey:secretkey@S3``). The underscore character is not allowed
 in the scheme part of URI, so it must be changed to a hyphen character
 (e.g. `google-compute-platform` if `conn_type` is `google_compute_platform`).


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Inline code highlighting of `postgres://user:password@localhost:5432/master` at https://airflow.apache.org/howto/connection/index.html are broken. So I fix it.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
