### PR TITLE
[ AIRFLOW-4554] Test for sudo command, add some other test docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,13 +127,12 @@ There are three ways to setup an Apache Airflow development environment.
   # Start docker in your Airflow directory
   docker run -t -i -v `pwd`:/airflow/ -w /airflow/ python:3 bash
 
-  # Install Airflow with all the required dependencies,
-  # including the devel which will provide the development tools
-  pip install -e '.[hdfs,hive,druid,devel]'
-
-  # Install any other dependencies for specific test groups you might need
-  # e.g.:
-  #       pip install -e '.[gcp]'
+  # To install all of airflows dependencies to run all tests (this is a lot)
+  pip install -e .
+  
+  # To run only certain tests install the devel requirements and whatever is required
+  # for your test.  See setup.py for the possible requirements. For example:
+  pip install -e '.[gcp,devel]'
 
   # Init the database
   airflow initdb

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,10 @@ There are three ways to setup an Apache Airflow development environment.
   # including the devel which will provide the development tools
   pip install -e '.[hdfs,hive,druid,devel]'
 
+  # Install any other dependencies for specific test groups you might need
+  # e.g.:
+  #       pip install -e '.[gcp]'
+
   # Init the database
   airflow initdb
 
@@ -189,6 +193,10 @@ or a single test method:
 
 ```
 ./run_unit_tests.sh tests.core:CoreTest.test_check_operators -s --logging-level=DEBUG
+```
+or another example:
+```
+./run_unit_tests.sh tests.contrib.operators.test_dataproc_operator:DataprocClusterCreateOperatorTest.test_create_cluster_deletes_error_cluster  -s --logging-level=DEBUG
 ```
 
 To run the whole test suite with Docker Compose, do:

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -63,7 +63,7 @@ fi
 # For impersonation tests on Travis, make airflow accessible to other users via the global PATH
 # (which contains /usr/local/bin).  Some test environments, like the docker instructions, won't have sudo and
 # are probably running as root anyway
-if which sudo > /dev/null; then
+if command -v sudo > /dev/null; then
   sudo ln -sf "${VIRTUAL_ENV}/bin/airflow" /usr/local/bin/
 else
   ln -sf "${VIRTUAL_ENV}/bin/airflow" /usr/local/bin/

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -61,8 +61,13 @@ if [ -f "${AIRFLOW_DB}" ]; then
 fi
 
 # For impersonation tests on Travis, make airflow accessible to other users via the global PATH
-# (which contains /usr/local/bin)
-sudo ln -sf "${VIRTUAL_ENV}/bin/airflow" /usr/local/bin/
+# (which contains /usr/local/bin).  Some test environments, like the docker instructions, won't have sudo and
+# are probably running as root anyway
+if which sudo > /dev/null; then
+  sudo ln -sf "${VIRTUAL_ENV}/bin/airflow" /usr/local/bin/
+else
+  ln -sf "${VIRTUAL_ENV}/bin/airflow" /usr/local/bin/
+fi
 
 echo "Starting the unit tests with the following nose arguments: "$nose_args
 nosetests $nose_args


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses [Airflow Jira 4554](https://issues.apache.org/jira/browse/AIRFLOW-4554) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

Shell script tests for the `sudo` command and only uses it if present.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:  The bash script is untested.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`   (N/A - no python change)
