### PR TITLE
[AIRFLOW-4557] Add gcp_conn_id parameter to get_sqlproxy_runner

### DIFF
--- a/airflow/contrib/hooks/gcp_sql_hook.py
+++ b/airflow/contrib/hooks/gcp_sql_hook.py
@@ -955,7 +955,8 @@ class CloudSqlDatabaseHook(BaseHook):
             instance_specification=self._get_sqlproxy_instance_specification(),
             project_id=self.project_id,
             sql_proxy_version=self.sql_proxy_version,
-            sql_proxy_binary_path=self.sql_proxy_binary_path
+            sql_proxy_binary_path=self.sql_proxy_binary_path,
+            gcp_conn_id=self.gcp_cloudsql_conn_id
         )
 
     def get_database_hook(self):

--- a/tests/hooks/test_gcp_sql_hook.py
+++ b/tests/hooks/test_gcp_sql_hook.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from unittest import mock
+import unittest
+from airflow.contrib.hooks.gcp_sql_hook import CloudSqlDatabaseHook
+from airflow.models.connection import Connection
+
+
+class TestCloudSqlDatabaseHook(unittest.TestCase):
+
+    @mock.patch('airflow.contrib.hooks.gcp_sql_hook.CloudSqlDatabaseHook.get_connection')
+    def setUp(self, m):
+        super().setUp()
+
+        self.connection = Connection(
+            conn_id='my_gcp_connection',
+            login='login',
+            password='password',
+            host='host',
+            schema='schema',
+            extra='{"database_type":"postgres", "location":"my_location", "instance":"my_instance", '
+                  '"use_proxy": true, "project_id":"my_project"}'
+        )
+
+        m.return_value = self.connection
+        self.db_hook = CloudSqlDatabaseHook('my_gcp_connection')
+
+    def test_get_sqlproxy_runner(self):
+        self.db_hook._generate_connection_uri()
+        sqlproxy_runner = self.db_hook.get_sqlproxy_runner()
+        self.assertEqual(sqlproxy_runner.gcp_conn_id, self.connection.conn_id)
+        project = self.connection.extra_dejson['project_id']
+        location = self.connection.extra_dejson['location']
+        instance = self.connection.extra_dejson['instance']
+        instance_spec = "{project}:{location}:{instance}".format(project=project,
+                                                                 location=location,
+                                                                 instance=instance)
+        self.assertEqual(sqlproxy_runner.instance_specification, instance_spec)


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [AIRFLOW-4557](https://issues.apache.org/jira/browse/AIRFLOW-4557)

### Description

- [x] The get_sqlproxy_runner method of the CloudSqlDatabaseHook did not pass in the gcp_conn_id when creating an instance of the CloudSqlProxyRunner. This meant that the  always used the `google_cloud_default`. Instead it should use whatever conn_id was passed into CloudSqlDatabaseHook gcp_cloudsql_conn_id parameter

### Tests

- [x] My PR adds the following unit tests

- test_gcp_sql_hook.test_get_sqlproxy_runner()

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] No new functionality, fixing a bug

### Code Quality

- [x] Passes `flake8`
