### PR TITLE
[AIRFLOW-4560] Fix Tez queue parameter name in mapred_queue

### DIFF
--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -211,7 +211,7 @@ class HiveCliHook(BaseHook):
                          'mapred.job.queue.name={}'
                          .format(self.mapred_queue),
                          '-hiveconf',
-                         'tez.job.queue.name={}'
+                         'tez.queue.name={}'
                          .format(self.mapred_queue)
                          ])
 


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4560) issues and references them in the PR title.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes: 

The Tez configuration parameter passed is incorrect, it should be `tez.queue.name` and not `tez.job.queue.name`.
See Tez documentation https://tez.apache.org/releases/0.9.2/tez-api-javadocs/configs/TezConfiguration.html

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Only fixing a typo

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`

@krishnabhupatiraju @KevinYang21 @bolkedebruin @wolfier 