### PR TITLE
[AIRFLOW-4089] Remove pytz support from documentation

### DIFF
--- a/docs/timezone.rst
+++ b/docs/timezone.rst
@@ -109,8 +109,8 @@ it is therefore important to make sure this setting is equal on all Airflow node
 Time zone aware DAGs
 --------------------
 
-Creating a time zone aware DAG is quite simple. Just make sure to supply a time zone aware `start_date`. It is
-recommended to use `pendulum` for this, but `pytz` (to be installed manually) can also be used for this.
+Creating a time zone aware DAG is quite simple. Just make sure to supply a time zone aware `start_date`
+using `pendulum`.
 
 .. code:: python
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-4089?filter=allopenissues) issues and references them in the PR title.

### Description

- [x] This PR addresses the fact that pytz timezone objects do not have the attribute `name`. It does have a similar attribute `zone` that could be used though not with complete compatibility. For example, there are no `pendulum.tzinfo.name`s for `Africa/Casablanca, Africa/El_Aaiun` but there are for `pytz.tzinfo.zone`. I propose we just remove the mention of pytz compatibility from the docs instead of dealing with incompatibilities.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No test because just a documentation change.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] Updating documentation

### Code Quality

- [x] Passes `flake8`
