### PR TITLE
[AIRFLOW-4562 ] Fix missing try_number parameter in TaskInstance.log_filepath method

### DIFF
--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -23,7 +23,7 @@ limitations under the License.
 <h4>{{ title }}</h4>
 <ul class="nav nav-pills" role="tablist">
   {% for log in logs %}
-  <li role="presentation" class="{{ 'active' if loop.last else '' }}">
+  <li role="presentation" class="{{ 'active' if loop.index == try_number | int() else '' }}">
     <a href="#{{ loop.index }}" aria-controls="{{ loop.index }}" role="tab" data-toggle="tab">
       {{ loop.index }}
     </a>
@@ -35,7 +35,7 @@ limitations under the License.
 </ul>
 <div class="tab-content">
   {% for log in logs %}
-  <div role="tabpanel" class="tab-pane {{ 'active' if loop.last else '' }}" id="{{ loop.index }}">
+  <div role="tabpanel" class="tab-pane {{ 'active' if loop.index == try_number | int() else '' }}" id="{{ loop.index }}">
     <img id="loading-{{ loop.index }}" style="margin-top:0%; margin-left:50%; height:50px; width:50px; position: absolute;"
          alt="spinner" src="{{ url_for('static', filename='loading.gif') }}">
     <pre><code id="try-{{ loop.index }}">{{ log }}</code></pre>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -604,12 +604,13 @@ class Airflow(AirflowBaseView):
                 num_logs += 1
         logs = [''] * num_logs
         root = request.args.get('root', '')
+        try_number = request.args.get('try_number', num_logs)
         return self.render_template(
             'airflow/ti_log.html',
             logs=logs, dag=dag_model, title="Log by attempts",
             dag_id=dag_id, task_id=task_id,
             execution_date=execution_date, form=form,
-            root=root)
+            root=root, try_number=try_number)
 
     @expose('/elasticsearch')
     @has_dag_access(can_dag_read=True)

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -846,7 +846,18 @@ class TaskInstanceTest(unittest.TestCase):
             'execution_date=2018-01-01T00%3A00%3A00%2B00%3A00'
             '&task_id=op'
             '&dag_id=dag'
+            '&try_number=1'
         )
+        self.assertEqual(ti.log_url, expected_url)
+
+        expected_url = (
+            'http://localhost:8080/log?'
+            'execution_date=2018-01-01T00%3A00%3A00%2B00%3A00'
+            '&task_id=op'
+            '&dag_id=dag'
+            '&try_number=42'
+        )
+        ti.try_number = 41
         self.assertEqual(ti.log_url, expected_url)
 
     def test_mark_success_url(self):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [AIRFLOW-4562](https://issues.apache.org/jira/browse/AIRFLOW-4562) issues and references them in the PR title.
### Description

    This PR fixes wrong log file name generation for TaskInstance.
    Old implementation didn't support try_number property.
    And generated wrong file name.
    (this methdod is used in task failure notiofication message generation)

    More over this commit improves log_url generation add adds try_number
    parameter into TaskInstance.log_url method

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue.


### Code Quality

- [ ] Passes `flake8`
