### PR TITLE
[AIRFLOW-4559] JenkinsJobTriggerOperator bugfix

### DIFF
--- a/airflow/contrib/operators/jenkins_job_trigger_operator.py
+++ b/airflow/contrib/operators/jenkins_job_trigger_operator.py
@@ -142,8 +142,9 @@ class JenkinsJobTriggerOperator(BaseOperator):
             # We need a None to call the non parametrized jenkins api end point
             self.parameters = None
 
-        request = Request(jenkins_server.build_job_url(self.job_name,
-                                                       self.parameters, None))
+        request = Request(
+            method='POST',
+            url=jenkins_server.build_job_url(self.job_name, self.parameters, None))
         return jenkins_request_with_headers(jenkins_server, request)
 
     def poll_job_in_queue(self, location, jenkins_server):
@@ -167,8 +168,8 @@ class JenkinsJobTriggerOperator(BaseOperator):
         # once it will be available in python-jenkins (v > 0.4.15)
         self.log.info('Polling jenkins queue at the url %s', location)
         while try_count < self.max_try_before_job_appears:
-            location_answer = jenkins_request_with_headers(jenkins_server,
-                                                           Request(location))
+            location_answer = jenkins_request_with_headers(
+                jenkins_server, Request(method='POST', url=location))
             if location_answer is not None:
                 json_response = json.loads(location_answer['body'])
                 if 'executable' in json_response:

--- a/tests/contrib/operators/test_jenkins_operator.py
+++ b/tests/contrib/operators/test_jenkins_operator.py
@@ -136,6 +136,27 @@ class JenkinsOperatorTestCase(unittest.TestCase):
 
             self.assertRaises(AirflowException, operator.execute, None)
 
+    @unittest.skipIf(mock is None, 'mock package not present')
+    def test_build_job(self):
+        jenkins_mock = mock.Mock(spec=jenkins.Jenkins, auth='secret')
+        jenkins_mock.build_job_url.return_value = \
+            'http://www.jenkins.url/somewhere/in/the/universe'
+        
+        hook_mock = mock.Mock(spec=JenkinsHook)
+        hook_mock.get_jenkins_server.return_value = jenkins_mock
+
+        operator = JenkinsJobTriggerOperator(
+                dag=None,
+                task_id="build_job_test",
+                job_name="a_job_on_jenkins",
+                jenkins_connection_id="fake_jenkins_connection",
+                # The hook is mocked, this connection won't be used
+                sleep_time=1)
+        
+
+        self.assertEqual(operator.build_job(hook_mock)['headers']['Location'], 'http://www.jenkins.url/somewhere/in/the/universe')
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4559

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Previous version provides url to Request object implicitly. It creates weird interaction assigning it to `method` parameter instead of `url` which raises `requests.exceptions.MissingSchema: Invalid URL 'None': No schema supplied`. Fixed making both explicit.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Uses existing Operator tests.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
