### PR TITLE
[AIRFLOW-4566] Document sla & sla_miss_callback task params

### DIFF
--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -50,6 +50,7 @@ default_args = {
     # 'on_failure_callback': some_function,
     # 'on_success_callback': some_other_function,
     # 'on_retry_callback': another_function,
+    # 'sla_miss_callback': yet_another_function,
     # 'trigger_rule': 'all_success'
 }
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -694,6 +694,11 @@ detailing the list of tasks that missed their SLA. The event is also recorded
 in the database and made available in the web UI under ``Browse->SLA Misses``
 where events can be analyzed and documented.
 
+SLAs can be configured for scheduled tasks by using the `sla` parameter.
+In addition to sending alerts to the addresses specified in a task's `email` parameter,
+the `sla_miss_callback` specifies an additional `Callable`
+object to be invoked when the SLA is not met.
+
 Email Configuration
 -------------------
 


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issue and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4566

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
* Add paragraph to SLA documentation describing the `sla_miss_callback` parameter.
* Add example `sla_miss_callback` in commented-out default arguments in `airflow/example_dags/tutorial.py`
### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
My code changes update documentation and commented code in an example script. No Airflow behavior is modified.
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
