### PR TITLE
[AIRFLOW-4572] Rename prepare_classpath to prepare_syspath

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -233,7 +233,7 @@ def configure_action_logging():
     pass
 
 
-def prepare_classpath():
+def prepare_syspath():
     """
     Ensures that certain subfolders of AIRFLOW_HOME are on the classpath
     """
@@ -260,7 +260,7 @@ except Exception:
 
 def initialize():
     configure_vars()
-    prepare_classpath()
+    prepare_syspath()
     global LOGGING_CLASS_PATH
     LOGGING_CLASS_PATH = configure_logging()
     configure_adapters()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

`settings.py` currently defines a `prepare_classpath()` function that ensures that certain subfolders in `AIRFLOW_HOME` are added to `sys.path`. The function's naming seems borrowed from Java, and thus could be improved by renaming it to `prepare_syspath()` which is the equivalent Python concept.

This appears to be an internal API that is only used in `settings.py` itself, so the change shouldn't have any impact.


### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR does not need extra tests as it is a trivial naming change.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
