### PR TITLE
[AIRFLOW-XXX] Add .github/SECURITY.md

### DIFF
--- a/.github/SECURITY.rst
+++ b/.github/SECURITY.rst
@@ -1,0 +1,22 @@
+Reporting Vulnerabilities
+-------------------------
+
+**⚠️ Please do not file Jira issues for security vulnerabilities as they are public! ⚠️**
+
+The Apache Software Foundation takes security issues very seriously. Apache
+Airflow specifically offers security features and is responsive to issues
+around its features. If you have any concern around Airflow Security or believe
+you have uncovered a vulnerability, we suggest that you get in touch via the
+e-mail address security@apache.org. In the message, try to provide a
+description of the issue and ideally a way of reproducing it. The security team
+will get back to you after assessing the description.
+
+Note that this security address should be used only for undisclosed
+vulnerabilities. Dealing with fixed issues or general questions on how to use
+the security features should be handled regularly via the user and the dev
+lists. Please report any security problems to the project security address
+before disclosing it publicly.
+
+The `ASF Security team's page <https://www.apache.org/security/>`_ describes
+how vulnerability reports are handled, and includes PGP keys if you wish to use
+that.

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -18,6 +18,11 @@
 Security
 ========
 
+.. include:: ../.github/SECURITY.rst
+
+Web Authentication
+------------------
+
 By default, Airflow requires users to specify a password prior to login. You can use the
 following CLI commands to create an account:
 
@@ -37,30 +42,6 @@ Be sure to checkout :doc:`api` for securing the API.
    '%'-signs.  Make sure escape any ``%`` signs in your config file (but not
    environment variables) as ``%%``, otherwise Airflow might leak these
    passwords on a config parser exception to a log.
-
-Reporting Vulnerabilities
--------------------------
-
-The Apache Software Foundation takes security issues very seriously. Apache
-Airflow specifically offers security features and is responsive to issues
-around its features. If you have any concern around Airflow Security or believe
-you have uncovered a vulnerability, we suggest that you get in touch via the
-e-mail address security@apache.org. In the message, try to provide a
-description of the issue and ideally a way of reproducing it. The security team
-will get back to you after assessing the description.
-
-Note that this security address should be used only for undisclosed
-vulnerabilities. Dealing with fixed issues or general questions on how to use
-the security features should be handled regularly via the user and the dev
-lists. Please report any security problems to the project security address
-before disclosing it publicly.
-
-The `ASF Security team's page <https://www.apache.org/security/>`_ describes
-how vulnerability reports are handled, and includes PGP keys if you wish to use
-that.
-
-Web Authentication
-------------------
 
 Password
 ''''''''


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This commit adds a .github/SECURITY.md file that defines the
contents of the "Policy" tab in the new "Security" section of
the GitHub interface.

Currently the Policy tab obtains its content from the
docs/security.rst file, which contains technical, non-policy
related information. This commit retains the
"Reporting Vulnerabilities" section of docs/security.rst, which
is relevant, and strips the extraneous content.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Documentation only.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
