### PR TITLE
[AIRFLOW-4486] Support IAM Auth in MySqlHook

### DIFF
--- a/tests/hooks/test_mysql_hook.py
+++ b/tests/hooks/test_mysql_hook.py
@@ -125,6 +125,16 @@ class TestMySqlHookConn(unittest.TestCase):
         self.assertEqual(args, ())
         self.assertEqual(kwargs['ssl'], SSL_DICT)
 
+    @mock.patch('airflow.hooks.mysql_hook.MySQLdb.connect')
+    @mock.patch('airflow.contrib.hooks.aws_hook.AwsHook.get_client_type')
+    def test_get_conn_rds_iam(self, mock_client, mock_connect):
+        self.connection.extra = '{"iam":true}'
+        mock_client.return_value.generate_db_auth_token.return_value = 'aws_token'
+        self.db_hook.get_conn()
+        mock_connect.assert_called_once_with(user='login', passwd='aws_token', host='host',
+                                             db='schema', port=3306,
+                                             read_default_group='enable-cleartext-plugin')
+
 
 class TestMySqlHook(unittest.TestCase):
 


### PR DESCRIPTION
update MySQL hook and add new test

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-4486) issue.

### Description

- [x] Enhanced the MySQL Hook to allow for IAM authentication in AWS. 

### Tests

- [x] Added test test_mysql_hook.test_get_conn_rds_iam()

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
