### PR TITLE
Worker config, read only of dag volume mount now a option in config

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -146,6 +146,8 @@ class KubeConfig:
         self.kube_labels = configuration_dict.get('kubernetes_labels', {})
         self.delete_worker_pods = conf.getboolean(
             self.kubernetes_section, 'delete_worker_pods')
+        self.worker_mount_dag_volume_read_only = conf.getboolean(
+            self.kubernetes_section, 'worker_mount_dag_volume_read_only')
         self.worker_pods_creation_batch_size = conf.getint(
             self.kubernetes_section, 'worker_pods_creation_batch_size')
         self.worker_service_account_name = conf.get(

--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -241,7 +241,7 @@ class WorkerConfiguration(LoggingMixin):
             self.dags_volume_name: {
                 'name': self.dags_volume_name,
                 'mountPath': self.generate_dag_volume_mount_path(),
-                'readOnly': True,
+                'readOnly': self.kube_config.worker_mount_dag_volume_read_only,
             },
             self.logs_volume_name: {
                 'name': self.logs_volume_name,


### PR DESCRIPTION
I have added a new option, which allows to enable/disable the readonly option when mounting the dag volume into a new worker. Sometimes it is neccessary that the worker has write priveleges to write data back to the PV. This way other workers can access the data. The user should have the option to decide this on his own.

I am not familiar with the PR etc., so please tell me what I have to do in addition. Here is what I did not understand:

- Where to set default value of option (if not specifed in config, it should be True)
- Where to document the change
- How to add test / Jira issue

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
