### PR TITLE
[AIRFLOW-3160] (Unrevert) Load latest_dagruns asynchronously

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -103,13 +103,11 @@
 
                 <!-- Column 7: Last Run -->
                 <td class="text-nowrap latest_dag_run {{ dag.dag_id }}">
-                  {% set last_run = dag.get_last_dagrun(include_externally_triggered=True) %}
-                  {% if last_run and last_run.execution_date %}
-                    <a href="{{ url_for('Airflow.graph', dag_id=dag.dag_id, execution_date=last_run.execution_date) }}">
-                      {{ last_run.execution_date.strftime("%Y-%m-%d %H:%M") }}
-                    </a>
-                    <span aria-hidden="true" id="statuses_info" title="Start Date: {{ last_run.start_date.strftime("%Y-%m-%d %H:%M") }}" class="glyphicon glyphicon-info-sign"></span>
-                  {% endif %}
+                  <div height="10" width="10" id='last-run-{{ dag.safe_dag_id }}' style="display: block;">
+                    <a></a>
+                    <img class="loading-last-run" width="15" src="{{ url_for("static", filename="loading.gif") }}">
+                    <span aria-hidden="true" id="statuses_info" title=" " class="glyphicon glyphicon-info-sign" style="display:none"></span>
+                  </div>
                 </td>
 
                 <!-- Column 8: Dag Runs -->
@@ -308,6 +306,21 @@
             .css('background-color', 'red');
           }
         });
+      });
+      d3.json("{{ url_for('Airflow.last_dagruns') }}", function(error, json) {
+        for(var safe_dag_id in json) {
+          dag_id = json[safe_dag_id].dag_id;
+          last_run = json[safe_dag_id].last_run;
+          g = d3.select('div#last-run-' + safe_dag_id)
+          g.selectAll('a')
+            .attr("href", "{{ url_for('Airflow.graph') }}?dag_id=" + encodeURIComponent(dag_id) + "&execution_date=" + last_run)
+            .text(last_run);
+          g.selectAll('span')
+            .attr("data-original-title", "Start Date: " + last_run)
+            .style('display', null);
+          g.selectAll(".loading-last-run").remove();
+        }
+        d3.selectAll(".loading-last-run").remove();
       });
       d3.json("{{ url_for('Airflow.dag_stats') }}", function(error, json) {
         for(var dag_id in json) {

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -403,6 +403,33 @@ class Airflow(AirflowBaseView):
                 })
         return wwwutils.json_response(payload)
 
+    @expose('/last_dagruns')
+    @has_access
+    @provide_session
+    def last_dagruns(self, session=None):
+        DagRun = models.DagRun
+
+        filter_dag_ids = appbuilder.sm.get_accessible_dag_ids()
+
+        if not filter_dag_ids:
+            return
+
+        dags_to_latest_runs = dict(session.query(
+            DagRun.dag_id, sqla.func.max(DagRun.execution_date).label('execution_date'))
+            .group_by(DagRun.dag_id).all())
+
+        payload = {}
+        for dag in dagbag.dags.values():
+            dag_accessible = 'all_dags' in filter_dag_ids or dag.dag_id in filter_dag_ids
+            if (dag_accessible and dag.dag_id in dags_to_latest_runs and
+                    dags_to_latest_runs[dag.dag_id]):
+                payload[dag.safe_dag_id] = {
+                    'dag_id': dag.dag_id,
+                    'last_run': dags_to_latest_runs[dag.dag_id].strftime("%Y-%m-%d %H:%M")
+                }
+
+        return wwwutils.json_response(payload)
+
     @expose('/code')
     @has_dag_access(can_dag_read=True)
     @has_access

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -490,6 +490,10 @@ class TestAirflowBaseViews(TestBase):
         resp = self.client.get(url, follow_redirects=True)
         self.check_content_in_response('runme_1', resp)
 
+    def test_last_dagruns(self):
+        resp = self.client.get('last_dagruns', follow_redirects=True)
+        self.check_content_in_response('example_bash_operator', resp)
+
     def test_tree(self):
         url = 'tree?dag_id=example_bash_operator'
         resp = self.client.get(url, follow_redirects=True)


### PR DESCRIPTION
Unreverting AIRFLOW-3160 which was reverted on suspicious of breaking CI without the clear blame of this PR, and the logs are gone now. A lot of the test code has changed significantly so it's possible that even if an issue was caused by this PR it has since been fixed. Twitter has been running for several months now with this patch with no issues.

Here is the link to the original PR: https://github.com/apache/airflow/pull/4005
Here is the link to the revert PR: https://github.com/apache/airflow/pull/4145

Tested on a local webserver after rebasing the unrevert, and no issues.

I am going to kick off 10 builds in Travis to see if the issue reproduces, and watch the master build for this issue for a couple of days once this is merged. Here are my builds: https://travis-ci.org/aoen/incubator-airflow/builds

@ashb 