### PR TITLE
[AIRFLOW-4422] Pool utilization stats

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -976,6 +976,10 @@ class SchedulerJob(BaseJob):
 
             Stats.gauge('pool.starving_tasks.{pool_name}'.format(pool_name=pool_name),
                         num_starving_tasks)
+            Stats.gauge('pool.open_slots.{pool_name}'.format(pool_name=pool_name),
+                        pools[pool].open_slots())
+            Stats.gauge('pool.used_slots.{pool_name}'.format(pool_name=pool_name),
+                        pools[pool].occupied_slots())
 
         task_instance_str = "\n\t".join(
             [repr(x) for x in executable_tis])

--- a/airflow/models/pool.py
+++ b/airflow/models/pool.py
@@ -57,9 +57,23 @@ class Pool(Base):
         }
 
     @provide_session
+    def occupied_slots(self, session):
+        """
+        Returns the number of slots used by running/queued tasks at the moment.
+        """
+        from airflow.models.taskinstance import TaskInstance  # Avoid circular import
+        return (
+            session
+            .query(TaskInstance)
+            .filter(TaskInstance.pool == self.pool)
+            .filter(TaskInstance.state.in_([State.QUEUED, State.RUNNING]))
+            .count()
+        )
+
+    @provide_session
     def used_slots(self, session):
         """
-        Returns the number of slots used at the moment
+        Returns the number of slots used by running tasks at the moment.
         """
         from airflow.models.taskinstance import TaskInstance  # Avoid circular import
 
@@ -75,7 +89,7 @@ class Pool(Base):
     @provide_session
     def queued_slots(self, session):
         """
-        Returns the number of slots used at the moment
+        Returns the number of slots used by queued tasks at the moment.
         """
         from airflow.models.taskinstance import TaskInstance  # Avoid circular import
 
@@ -92,11 +106,4 @@ class Pool(Base):
         """
         Returns the number of slots open at the moment
         """
-        from airflow.models.taskinstance import \
-            TaskInstance as TI  # Avoid circular import
-
-        # Issue a single query instead of using the used_slots/queued_slots to
-        # avoid load on DB
-        used_slots = session.query(func.count()).filter(TI.pool == self.pool).filter(
-            TI.state.in_([State.RUNNING, State.QUEUED])).scalar()
-        return self.slots - used_slots
+        return self.slots - self.occupied_slots(session)

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -66,9 +66,11 @@ dagbag_import_errors                            DAG import errors
 dagbag_size                                     DAG bag size
 dag_processing.last_runtime.<dag_file>          Seconds spent processing <dag_file> (in most recent iteration)
 dag_processing.last_run.seconds_ago.<dag_file>  Seconds since <dag_file> was last processed
-executor.open_slots                             Number of of open slots on executor
+executor.open_slots                             Number of open slots on executor
 executor.queued_tasks                           Number of queued tasks on executor
 executor.running_tasks                          Number of running tasks on executor
+pool.open_slots.<pool_name>                     Number of open slots in the pool
+pool.used_slots.<pool_name>                     Number of used slots in the pool
 pool.starving_tasks.<pool_name>                 Number of starving tasks in the pool
 =============================================== ========================================================================
 

--- a/tests/models/test_pool.py
+++ b/tests/models/test_pool.py
@@ -58,6 +58,9 @@ class PoolTest(unittest.TestCase):
         session.close()
 
         self.assertEqual(3, pool.open_slots())
+        self.assertEqual(1, pool.used_slots())
+        self.assertEqual(1, pool.queued_slots())
+        self.assertEqual(2, pool.occupied_slots())
 
     @mock_conf_get('core', 'non_pooled_task_slot_count', 5)
     def test_default_pool_open_slots(self):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4422

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Adding more stats around pool utilization.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

Added stats in `metrics.rst`

### Code Quality

- [X] Passes `flake8`
