### PR TITLE
[AIRFLOW-4521] Pause dag not load dagbag

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -411,10 +411,8 @@ def unpause(args):
 
 
 def set_is_paused(is_paused, args):
-    DagModel.set_is_paused(
-        dag_id=args.dag_id,
+    DagModel.get_dagmodel(args.dag_id).set_is_paused(
         is_paused=is_paused,
-        subdir=process_subdir(args.subdir),
     )
 
     print("Dag: {}, paused: {}".format(args.dag_id, str(is_paused)))

--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -176,8 +176,7 @@ def dag_paused(dag_id, paused):
 
     is_paused = True if paused == 'true' else False
 
-    models.DagModel.set_is_paused(
-        dag_id=dag_id,
+    models.DagModel.get_dagmodel(dag_id).set_is_paused(
         is_paused=is_paused,
     )
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1663,7 +1663,7 @@ class Airflow(AirflowBaseView):
     def paused(self):
         dag_id = request.args.get('dag_id')
         is_paused = True if request.args.get('is_paused') == 'false' else False
-        models.DagModel.set_is_paused(dag_id=dag_id, is_paused=is_paused)
+        models.DagModel.get_dagmodel(dag_id).set_is_paused(is_paused=is_paused)
         return "OK"
 
     @expose('/refresh', methods=['POST'])

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -939,7 +939,7 @@ class DagTest(unittest.TestCase):
 
         self.assertEquals(2, unpaused_dags)
 
-        DagModel.set_is_paused(dag.dag_id, is_paused=True)
+        DagModel.get_dagmodel(dag.dag_id).set_is_paused(is_paused=True)
 
         paused_dags = session.query(
             DagModel


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4521

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Currently `pause_dag` loads the whole `DagBag` which is a heavy operation. This PR removes the need to load the whole `DagBag`.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
