### PR TITLE
[AIRFLOW-4591] Make default_pool a real pool

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,15 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Removal of `non_pooled_task_slot_count` and `non_pooled_backfill_task_slot_count`
+
+`non_pooled_task_slot_count` and `non_pooled_backfill_task_slot_count`
+are removed in favor of a real pool, e.g. `default_pool`.
+
+By default tasks are running in `default_pool`.
+`default_pool` is initialized with 128 slots and user can change the
+number of slots through UI/CLI. `default_pool` cannot be removed.
+
 ### Changes to Google Transfer Operator
 To obtain pylint compatibility the `filter ` argument in `GcpTransferServiceOperationsListOperator` 
 has been renamed to `request_filter`.

--- a/airflow/api/common/experimental/pool.py
+++ b/airflow/api/common/experimental/pool.py
@@ -72,6 +72,9 @@ def delete_pool(name, session=None):
     if not (name and name.strip()):
         raise AirflowBadRequest("Pool name shouldn't be empty")
 
+    if name == Pool.DEFAULT_POOL_NAME:
+        raise AirflowBadRequest("default_pool cannot be deleted")
+
     pool = session.query(Pool).filter_by(pool=name).first()
     if pool is None:
         raise PoolNotFound("Pool '%s' doesn't exist" % name)

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -132,14 +132,6 @@ dag_concurrency = 16
 # Are DAGs paused by default at creation
 dags_are_paused_at_creation = True
 
-# When not using pools, tasks are run in the "default pool",
-# whose size is guided by this config element
-non_pooled_task_slot_count = 128
-
-# When not using pools, the number of backfill tasks per backfill
-# is limited by this config element
-non_pooled_backfill_task_slot_count = %(non_pooled_task_slot_count)s
-
 # The maximum number of active DAG runs per DAG
 max_active_runs_per_dag = 16
 

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -46,7 +46,6 @@ donot_pickle = False
 dag_concurrency = 16
 dags_are_paused_at_creation = False
 fernet_key = {FERNET_KEY}
-non_pooled_task_slot_count = 128
 enable_xcom_pickling = False
 killed_task_cleanup_time = 5
 secure_mode = False

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -893,21 +893,14 @@ class SchedulerJob(BaseJob):
         # any open slots in the pool.
         for pool, task_instances in pool_to_task_instances.items():
             pool_name = pool
-            if not pool:
-                # Arbitrary:
-                # If queued outside of a pool, trigger no more than
-                # non_pooled_task_slot_count
-                open_slots = models.Pool.default_pool_open_slots()
-                pool_name = models.Pool.default_pool_name
+            if pool not in pools:
+                self.log.warning(
+                    "Tasks using non-existent pool '%s' will not be scheduled",
+                    pool
+                )
+                open_slots = 0
             else:
-                if pool not in pools:
-                    self.log.warning(
-                        "Tasks using non-existent pool '%s' will not be scheduled",
-                        pool
-                    )
-                    open_slots = 0
-                else:
-                    open_slots = pools[pool].open_slots(session=session)
+                open_slots = pools[pool].open_slots(session=session)
 
             num_ready = len(task_instances)
             self.log.info(

--- a/airflow/migrations/versions/6e96a59344a4_make_taskinstance_pool_not_nullable.py
+++ b/airflow/migrations/versions/6e96a59344a4_make_taskinstance_pool_not_nullable.py
@@ -1,0 +1,122 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Make TaskInstance.pool not nullable
+
+Revision ID: 6e96a59344a4
+Revises: 939bb1e647c8
+Create Date: 2019-06-13 21:51:32.878437
+
+"""
+
+from alembic import op
+import dill
+import sqlalchemy as sa
+from sqlalchemy import Column, Float, Integer, PickleType, String
+from sqlalchemy.ext.declarative import declarative_base
+
+from airflow.utils.db import create_session
+from airflow.utils.sqlalchemy import UtcDateTime
+
+
+# revision identifiers, used by Alembic.
+revision = '6e96a59344a4'
+down_revision = '939bb1e647c8'
+branch_labels = None
+depends_on = None
+
+
+Base = declarative_base()
+ID_LEN = 250
+
+
+class TaskInstance(Base):
+    """
+    Task instances store the state of a task instance. This table is the
+    authority and single source of truth around what tasks have run and the
+    state they are in.
+
+    The SqlAlchemy model doesn't have a SqlAlchemy foreign key to the task or
+    dag model deliberately to have more control over transactions.
+
+    Database transactions on this table should insure double triggers and
+    any confusion around what task instances are or aren't ready to run
+    even while multiple schedulers may be firing task instances.
+    """
+
+    __tablename__ = "task_instance"
+
+    task_id = Column(String(ID_LEN), primary_key=True)
+    dag_id = Column(String(ID_LEN), primary_key=True)
+    execution_date = Column(UtcDateTime, primary_key=True)
+    start_date = Column(UtcDateTime)
+    end_date = Column(UtcDateTime)
+    duration = Column(Float)
+    state = Column(String(20))
+    _try_number = Column('try_number', Integer, default=0)
+    max_tries = Column(Integer)
+    hostname = Column(String(1000))
+    unixname = Column(String(1000))
+    job_id = Column(Integer)
+    pool = Column(String(50), nullable=False)
+    queue = Column(String(256))
+    priority_weight = Column(Integer)
+    operator = Column(String(1000))
+    queued_dttm = Column(UtcDateTime)
+    pid = Column(Integer)
+    executor_config = Column(PickleType(pickler=dill))
+
+
+def upgrade():
+    """
+    Make TaskInstance.pool field not nullable.
+    """
+    with create_session() as session:
+        session.query(TaskInstance)\
+            .filter(TaskInstance.pool.is_(None))\
+            .update({TaskInstance.pool: 'default_pool'},
+                    synchronize_session=False)  # Avoid select updated rows
+        session.commit()
+
+    # use batch_alter_table to support SQLite workaround
+    with op.batch_alter_table('task_instance') as batch_op:
+        batch_op.alter_column(
+            column_name='pool',
+            type_=sa.String(50),
+            nullable=False,
+        )
+
+
+def downgrade():
+    """
+    Make TaskInstance.pool field nullable.
+    """
+    # use batch_alter_table to support SQLite workaround
+    with op.batch_alter_table('task_instance') as batch_op:
+        batch_op.alter_column(
+            column_name='pool',
+            type_=sa.String(50),
+            nullable=True,
+        )
+
+    with create_session() as session:
+        session.query(TaskInstance)\
+            .filter(TaskInstance.pool == 'default_pool')\
+            .update({TaskInstance.pool: None},
+                    synchronize_session=False)  # Avoid select updated rows
+        session.commit()

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -34,6 +34,7 @@ from airflow import configuration, settings
 from airflow.exceptions import AirflowException
 from airflow.lineage import prepare_lineage, apply_lineage, DataSet
 from airflow.models.dag import DAG
+from airflow.models.pool import Pool
 from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
@@ -258,7 +259,7 @@ class BaseOperator(LoggingMixin):
         priority_weight: int = 1,
         weight_rule: str = WeightRule.DOWNSTREAM,
         queue: str = configuration.conf.get('celery', 'default_queue'),
-        pool: Optional[str] = None,
+        pool: str = Pool.DEFAULT_POOL_NAME,
         sla: Optional[timedelta] = None,
         execution_timeout: Optional[timedelta] = None,
         on_failure_callback: Optional[Callable] = None,

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -140,7 +140,7 @@ class TaskInstance(Base, LoggingMixin):
     hostname = Column(String(1000))
     unixname = Column(String(1000))
     job_id = Column(Integer)
-    pool = Column(String(50))
+    pool = Column(String(50), nullable=False)
     queue = Column(String(256))
     priority_weight = Column(Integer)
     operator = Column(String(1000))

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -23,6 +23,7 @@ import os
 import contextlib
 
 from airflow import settings
+from airflow.configuration import conf
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 log = LoggingMixin().log
@@ -75,6 +76,20 @@ def merge_conn(conn, session=None):
     from airflow.models import Connection
     if not session.query(Connection).filter(Connection.conn_id == conn.conn_id).first():
         session.add(conn)
+        session.commit()
+
+
+@provide_session
+def add_default_pool_if_not_exists(session=None):
+    from airflow.models.pool import Pool
+    if not Pool.get_pool(Pool.DEFAULT_POOL_NAME, session=session):
+        default_pool = Pool(
+            pool=Pool.DEFAULT_POOL_NAME,
+            slots=conf.getint(section='core', key='non_pooled_task_slot_count',
+                              fallback=128),
+            description="Default pool",
+        )
+        session.add(default_pool)
         session.commit()
 
 
@@ -311,6 +326,7 @@ def upgradedb():
     config.set_main_option('script_location', directory.replace('%', '%%'))
     config.set_main_option('sqlalchemy.url', settings.SQL_ALCHEMY_CONN.replace('%', '%%'))
     command.upgrade(config, 'heads')
+    add_default_pool_if_not_exists()
 
 
 def resetdb():

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2109,6 +2109,10 @@ class PoolModelView(AirflowModelView):
     @action('muldelete', 'Delete', 'Are you sure you want to delete selected records?',
             single=False)
     def action_muldelete(self, items):
+        if any(item.pool == models.Pool.DEFAULT_POOL_NAME for item in items):
+            flash("default_pool cannot be deleted", 'error')
+            self.update_redirect()
+            return redirect(self.get_redirect())
         self.datamodel.delete_all(items)
         self.update_redirect()
         return redirect(self.get_redirect())

--- a/tests/api/client/test_local_client.py
+++ b/tests/api/client/test_local_client.py
@@ -124,18 +124,19 @@ class TestLocalClient(unittest.TestCase):
         self.client.create_pool(name='foo1', slots=1, description='')
         self.client.create_pool(name='foo2', slots=2, description='')
         pools = sorted(self.client.get_pools(), key=lambda p: p[0])
-        self.assertEqual(pools, [('foo1', 1, ''), ('foo2', 2, '')])
+        self.assertEqual(pools, [('default_pool', 128, 'Default pool'),
+                                 ('foo1', 1, ''), ('foo2', 2, '')])
 
     def test_create_pool(self):
         pool = self.client.create_pool(name='foo', slots=1, description='')
         self.assertEqual(pool, ('foo', 1, ''))
         with create_session() as session:
-            self.assertEqual(session.query(models.Pool).count(), 1)
+            self.assertEqual(session.query(models.Pool).count(), 2)
 
     def test_delete_pool(self):
         self.client.create_pool(name='foo', slots=1, description='')
         with create_session() as session:
-            self.assertEqual(session.query(models.Pool).count(), 1)
+            self.assertEqual(session.query(models.Pool).count(), 2)
         self.client.delete_pool(name='foo')
         with create_session() as session:
-            self.assertEqual(session.query(models.Pool).count(), 0)
+            self.assertEqual(session.query(models.Pool).count(), 1)

--- a/tests/models/test_pool.py
+++ b/tests/models/test_pool.py
@@ -26,13 +26,16 @@ from airflow.models.taskinstance import TaskInstance as TI
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils import timezone
 from airflow.utils.state import State
-from tests.test_utils.db import clear_db_pools, clear_db_runs
-from tests.test_utils.decorators import mock_conf_get
+from tests.test_utils.db import clear_db_pools, clear_db_runs, set_default_pool_slots
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
 
 class PoolTest(unittest.TestCase):
+
+    def setUp(self):
+        clear_db_runs()
+        clear_db_pools()
 
     def tearDown(self):
         clear_db_runs()
@@ -59,8 +62,10 @@ class PoolTest(unittest.TestCase):
 
         self.assertEqual(3, pool.open_slots())
 
-    @mock_conf_get('core', 'non_pooled_task_slot_count', 5)
     def test_default_pool_open_slots(self):
+        set_default_pool_slots(5)
+        self.assertEqual(5, Pool.get_default_pool().open_slots())
+
         dag = DAG(
             dag_id='test_default_pool_open_slots',
             start_date=DEFAULT_DATE, )
@@ -70,8 +75,6 @@ class PoolTest(unittest.TestCase):
         ti2 = TI(task=t2, execution_date=DEFAULT_DATE)
         ti1.state = State.RUNNING
         ti2.state = State.QUEUED
-        ti1.pool = Pool.default_pool_name
-        ti2.pool = Pool.default_pool_name
 
         session = settings.Session
         session.add(ti1)
@@ -79,4 +82,4 @@ class PoolTest(unittest.TestCase):
         session.commit()
         session.close()
 
-        self.assertEqual(3, Pool.default_pool_open_slots())
+        self.assertEqual(3, Pool.get_default_pool().open_slots())

--- a/tests/test_impersonation.py
+++ b/tests/test_impersonation.py
@@ -24,6 +24,7 @@ import unittest
 import logging
 
 from airflow import jobs, models
+from airflow.utils.db import add_default_pool_if_not_exists
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 
@@ -45,6 +46,7 @@ logger = logging.getLogger(__name__)
 
 class ImpersonationTest(unittest.TestCase):
     def setUp(self):
+        add_default_pool_if_not_exists()
         self.dagbag = models.DagBag(
             dag_folder=TEST_DAG_FOLDER,
             include_examples=False,

--- a/tests/test_utils/db.py
+++ b/tests/test_utils/db.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from airflow.models import DagModel, DagRun, errors, Pool, SlaMiss, TaskInstance
+from airflow.utils.db import add_default_pool_if_not_exists
 from airflow.utils.db import create_session
 
 
@@ -44,3 +45,10 @@ def clear_db_errors():
 def clear_db_pools():
     with create_session() as session:
         session.query(Pool).delete()
+        add_default_pool_if_not_exists(session)
+
+
+def set_default_pool_slots(slots):
+    with create_session() as session:
+        default_pool = Pool.get_default_pool(session)
+        default_pool.slots = slots

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -30,6 +30,7 @@ from airflow.models import DagBag, DagRun, Pool, TaskInstance
 from airflow.settings import Session
 from airflow.utils.timezone import datetime, utcnow, parse as parse_datetime
 from airflow.www import app as application
+from tests.test_utils.db import clear_db_pools
 
 
 class TestBase(unittest.TestCase):
@@ -288,19 +289,18 @@ class TestApiExperimental(TestBase):
 
 class TestPoolApiExperimental(TestBase):
 
+    USER_POOL_COUNT = 2
+    TOTAL_POOL_COUNT = USER_POOL_COUNT + 1  # including default_pool
+
     @classmethod
     def setUpClass(cls):
         super(TestPoolApiExperimental, cls).setUpClass()
-        session = Session()
-        session.query(Pool).delete()
-        session.commit()
-        session.close()
 
     def setUp(self):
         super().setUp()
-
-        self.pools = []
-        for i in range(2):
+        clear_db_pools()
+        self.pools = [Pool.get_default_pool()]
+        for i in range(self.USER_POOL_COUNT):
             name = 'experimental_%s' % (i + 1)
             pool = Pool(
                 pool=name,
@@ -310,12 +310,9 @@ class TestPoolApiExperimental(TestBase):
             self.session.add(pool)
             self.pools.append(pool)
         self.session.commit()
-        self.pool = self.pools[0]
+        self.pool = self.pools[-1]
 
     def tearDown(self):
-        self.session.query(Pool).delete()
-        self.session.commit()
-        self.session.close()
         super().tearDown()
 
     def _get_pool_count(self):
@@ -341,7 +338,7 @@ class TestPoolApiExperimental(TestBase):
         response = self.client.get('/api/experimental/pools')
         self.assertEqual(response.status_code, 200)
         pools = json.loads(response.data.decode('utf-8'))
-        self.assertEqual(len(pools), 2)
+        self.assertEqual(len(pools), self.TOTAL_POOL_COUNT)
         for i, pool in enumerate(sorted(pools, key=lambda p: p['pool'])):
             self.assertDictEqual(pool, self.pools[i].to_json())
 
@@ -360,7 +357,7 @@ class TestPoolApiExperimental(TestBase):
         self.assertEqual(pool['pool'], 'foo')
         self.assertEqual(pool['slots'], 1)
         self.assertEqual(pool['description'], '')
-        self.assertEqual(self._get_pool_count(), 3)
+        self.assertEqual(self._get_pool_count(), self.TOTAL_POOL_COUNT + 1)
 
     def test_create_pool_with_bad_name(self):
         for name in ('', '    '):
@@ -378,7 +375,7 @@ class TestPoolApiExperimental(TestBase):
                 json.loads(response.data.decode('utf-8'))['error'],
                 "Pool name shouldn't be empty",
             )
-        self.assertEqual(self._get_pool_count(), 2)
+        self.assertEqual(self._get_pool_count(), self.TOTAL_POOL_COUNT)
 
     def test_delete_pool(self):
         response = self.client.delete(
@@ -387,7 +384,7 @@ class TestPoolApiExperimental(TestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.data.decode('utf-8')),
                          self.pool.to_json())
-        self.assertEqual(self._get_pool_count(), 1)
+        self.assertEqual(self._get_pool_count(), self.TOTAL_POOL_COUNT - 1)
 
     def test_delete_pool_non_existing(self):
         response = self.client.delete(
@@ -396,6 +393,15 @@ class TestPoolApiExperimental(TestBase):
         self.assertEqual(response.status_code, 404)
         self.assertEqual(json.loads(response.data.decode('utf-8'))['error'],
                          "Pool 'foo' doesn't exist")
+
+    def test_delete_default_pool(self):
+        clear_db_pools()
+        response = self.client.delete(
+            '/api/experimental/pools/default_pool',
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.data.decode('utf-8'))['error'],
+                         "default_pool cannot be deleted")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4591

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

tl;dl `non_pooled_task_slot_count` and `non_pooled_backfill_task_slot_count`
are removed in favor of a real pool, e.g. `default_pool`.

Currently the number of running tasks that do not have a pool specified will be limited by `non_pooled_task_slot_count` or `non_pooled_backfill_task_slot_count` depends on the whether the task is triggered by scheduler or backfill. Conceptually it is a pool with slots specified through configuration but with a bit different implementation. This PR propose to make this pool a real pool, e.g. using the common implementation of pool so that the implementation can be simplified.

By default tasks are running in `default_pool`.
`default_pool` is initialized with 128 slots and user can change the
number of slots through UI/CLI. `default_pool` cannot be removed.

<img width="1680" alt="Screen Shot 2019-05-30 at 6 23 23 PM" src="https://user-images.githubusercontent.com/6065051/58679870-30a4b600-831a-11e9-84fc-dcf03da3c41b.png">
<img width="1680" alt="Screen Shot 2019-05-30 at 6 26 15 PM" src="https://user-images.githubusercontent.com/6065051/58679871-30a4b600-831a-11e9-8afa-40922850ec7b.png">


### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
