### PR TITLE
[AIRFLOW-4716] Instrument dag loading time duration

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -363,6 +363,8 @@ class DagBag(BaseDagBag, LoggingMixin):
 
         dag_folder = correct_maybe_zipped(dag_folder)
 
+        dags_by_name = {}
+
         for filepath in list_py_file_paths(dag_folder, safe_mode=safe_mode,
                                            include_examples=include_examples):
             try:
@@ -370,16 +372,19 @@ class DagBag(BaseDagBag, LoggingMixin):
                 found_dags = self.process_file(
                     filepath, only_if_updated=only_if_updated,
                     safe_mode=safe_mode)
+                dag_ids = [dag.dag_id for dag in found_dags]
+                dag_id_names = str(dag_ids)
 
                 td = timezone.utcnow() - ts
                 td = td.total_seconds() + (
                     float(td.microseconds) / 1000000)
+                dags_by_name[dag_id_names] = dag_ids
                 stats.append(FileLoadStat(
                     filepath.replace(dag_folder, ''),
                     td,
                     len(found_dags),
                     sum([len(dag.tasks) for dag in found_dags]),
-                    str([dag.dag_id for dag in found_dags]),
+                    dag_id_names,
                 ))
             except Exception as e:
                 self.log.exception(e)
@@ -391,6 +396,14 @@ class DagBag(BaseDagBag, LoggingMixin):
             'dagbag_import_errors', len(self.import_errors), 1)
         self.dagbag_stats = sorted(
             stats, key=lambda x: x.duration, reverse=True)
+        for file_stat in self.dagbag_stats:
+            dag_ids = dags_by_name[file_stat.dags]
+            if file_stat.dag_num >= 1:
+                # if we found multiple dags per file, the stat is 'dag_id1 _ dag_id2'
+                dag_names = '_'.join(dag_ids)
+                Stats.timing('dag.loading-duration.{}'.
+                             format(dag_names),
+                             file_stat.duration)
 
     def dagbag_report(self):
         """Prints a report around DagBag loading stats"""

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -80,6 +80,7 @@ Name                              Description
 ================================= =================================================
 dagrun.dependency-check.<dag_id>  Seconds taken to check DAG dependencies
 dag.<dag_id>.<task_id>.duration   Seconds taken to finish a task
+dag.loading-duration.<dag_id>     Seconds taken to load the given DAG
 dagrun.duration.success.<dag_id>  Seconds taken for a DagRun to reach success state
 dagrun.duration.failed.<dag_id>   Seconds taken for a DagRun to reach failed state
 dagrun.schedule_delay.<dag_id>    Seconds of delay between the scheduled DagRun


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4716
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
We have already captured per DAG loading time. We should expose this stat through StatsD for UI debugging purpose. And the cardinality of this stat is O(#DAG) which should be fine.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
