### PR TITLE
[AIRFLOW-XXX] Pin azure-mgmt-containerinstance to lower dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ azure = [
     'azure-mgmt-datalake-store==0.4.0',
     'azure-datalake-store==0.0.19',
     'azure-cosmos>=3.0.1',
-    'azure-mgmt-containerinstance',
+    'azure-mgmt-containerinstance<=1.4.1',
 ]
 cassandra = ['cassandra-driver>=3.13.0']
 celery = [


### PR DESCRIPTION

Just found that the latest release(1.5.0) of azure-mgmt-containerinstance broke the master with the following errors in CI:
```ERROR: azure-mgmt-containerinstance 1.5.0 has requirement msrest>=0.5.0, but you'll have msrest 0.4.29 which is incompatible.```

Pin the dependency to lower version for now.