### PR TITLE
[AIRFLOW-4585] Implement Kubernetes Pod Mutation Hook

### DIFF
--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -19,6 +19,8 @@ import json
 import time
 import tenacity
 from typing import Tuple, Optional
+
+from airflow.settings import pod_mutation_hook
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
 from datetime import datetime as dt
@@ -51,6 +53,8 @@ class PodLauncher(LoggingMixin):
         ) if extract_xcom else pod_factory.SimplePodRequestFactory()
 
     def run_pod_async(self, pod, **kwargs):
+        pod_mutation_hook(pod)
+
         req = self.kube_req_factory.create(pod)
         self.log.debug('Pod Creation Request: \n%s', json.dumps(req, indent=2))
         try:

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -28,6 +28,7 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.pool import NullPool
 
 from airflow.configuration import conf, AIRFLOW_HOME, WEBSERVER_CONFIG  # NOQA F401
+from airflow.kubernetes.pod import Pod
 from airflow.logging_config import configure_logging
 from airflow.utils.sqlalchemy import setup_event_handlers
 
@@ -94,6 +95,21 @@ def policy(task_instance):
         ``execution_date`` older than a week old to run in a ``backfill``
         pool.
     * ...
+    """
+    pass
+
+
+def pod_mutation_hook(pod: Pod):
+    """
+    This setting allows altering ``Pod`` objects before they are passed to
+    the Kubernetes client by the ``PodLauncher`` for scheduling.
+
+    To define a pod mutation hook, add a ``airflow_local_settings`` module
+    to your PYTHONPATH that defines this ``pod_mutation_hook`` function.
+    It receives a ``Pod`` object and can alter it where needed.
+
+    This could be used, for instance, to add sidecar or init containers
+    to every worker pod launched by KubernetesExecutor or KubernetesPodOperator.
     """
     pass
 

--- a/docs/kubernetes.rst
+++ b/docs/kubernetes.rst
@@ -145,3 +145,21 @@ Kubernetes Operator
 
 
 See :class:`airflow.contrib.operators.kubernetes_pod_operator.KubernetesPodOperator`
+
+
+Pod Mutation Hook
+^^^^^^^^^^^^^^^^^
+
+Your local Airflow settings file can define a ``pod_mutation_hook`` function that
+has the ability to mutate pod objects before sending them to the Kubernetes client
+for scheduling. It receives a single argument as a reference to pod objects, and
+is expected to alter its attributes.
+
+This could be used, for instance, to add sidecar or init containers
+to every worker pod launched by KubernetesExecutor or KubernetesPodOperator.
+
+
+.. code:: python
+
+    def pod_mutation_hook(pod: Pod):
+      pod.annotations['airflow.apache.org/launched-by'] = 'Tests'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/4585) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4585

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Adds a pod mutation hook in `airflow_local_settings` that mutates `Pod` objects before passing them to the Kubernetes client for scheduling. Compatible with `KubernetesPodOperator` as well as `KubernetesExecutor`.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- `test_pod_mutation_hook`

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
