### PR TITLE
[AIRFLOW-4725] Fix setup.py PEP440 & Sphinx-PyPI-upload dependency

### DIFF
--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '2.0.0.dev0+'
+version = '2.0.0.dev0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,14 +33,6 @@ universal=1
 [files]
 packages = airflow
 
-[build_sphinx]
-source-dir = docs/
-build-dir = docs/_build
-all_files = 1
-
-[upload_sphinx]
-upload-dir = docs/_build/html
-
 [easy_install]
 
 [mypy]

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,12 @@ class Tox(TestCommand):
 
 
 class CleanCommand(Command):
-    """Command to tidy up the project root."""
+    """
+    Command to tidy up the project root.
+    Registered as cmdclass in setup() so it can be called with ``python setup.py extra_clean``.
+    """
+
+    description = "Tidy up the project root"
     user_options = []
 
     def initialize_options(self):
@@ -86,7 +91,10 @@ class CleanCommand(Command):
 class CompileAssets(Command):
     """
     Compile and build the frontend assets using npm and webpack.
+    Registered as cmdclass in setup() so it can be called with ``python setup.py compile_assets``.
     """
+
+    description = "Compile and build the frontend assets"
     user_options = []
 
     def initialize_options(self):
@@ -171,7 +179,6 @@ datadog = ['datadog>=0.14.0']
 doc = [
     'sphinx-argparse>=0.1.13',
     'sphinx-autoapi>=0.7.1',
-    'Sphinx-PyPI-upload>=0.2.1',
     'sphinx-rtd-theme>=0.1.6',
     'sphinx>=1.2.3',
     'sphinxcontrib-httpdomain>=1.7.0',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

In this PR I make 3 improvements to setup.py:

1. It doesn't throw a warning "UserWarning: The version specified ('2.0.0.dev0+') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details."

Newer versions of setuptools expect PEP440 versioning and our version `2.0.0.dev0+` does not comply to that. Removed the + and now it is.

2. It fixes the Sphinx-PyPI-upload dependency which was making setup.py crash when running "python setup.py --help-commands".

Running `python setup.py --help-commands` crashes setup.py (testing with Python 3.5 and 3.6):

```
...
airflow/lib/python3.6/site-packages/sphinx_pypi_upload.py", line 61
    raise DistutilsOptionError, \
```

Found [this thread](https://bitbucket.org/jezdez/sphinx-pypi-upload/issues/4/syntax-error-in-python-33) and appears to be related to the super old Sphinx-PyPI-upload version we're using. Updated to Sphinx-PyPI-upload3 with newer version and no more crash.

3. And it adds descriptions for the custom commands.

The custom commands now display descriptions:

```
python setup.py --help-commands
...
Extra commands:
  extra_clean       Tidy up the project root
  compile_assets    Compile and build the frontend assets
```

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
