### PR TITLE
[AIRFLOW-4722] Add third PV mount to worker node to share data

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -39,6 +39,10 @@ dags_folder = {AIRFLOW_HOME}/dags
 # This path must be absolute
 base_log_folder = {AIRFLOW_HOME}/logs
 
+# The folder where the data PVC is mounted
+# This path must be absolute
+base_data_folder = {AIRFLOW_HOME}/data
+
 # Airflow can store logs remotely in AWS S3, Google Cloud Storage or Elastic Search.
 # Users must supply an Airflow connection id that provides access to the storage
 # location. If remote_logging is set to true, see UPDATING.md for additional
@@ -603,6 +607,12 @@ logs_volume_subpath =
 # A shared volume claim for the logs
 logs_volume_claim =
 
+# For volume mounted data, the worker will look in this subpath for data
+data_volume_subpath =
+
+# A shared volume claim for the data (which can be used to share data between workers)
+data_volume_claim =
+
 # For DAGs mounted via a hostPath volume (mutually exclusive with volume claim and git-sync)
 # Useful in local environment, discouraged in production
 dags_volume_host =
@@ -610,6 +620,10 @@ dags_volume_host =
 # A hostPath volume for the logs
 # Useful in local environment, discouraged in production
 logs_volume_host =
+
+# A hostPath volume for the data
+# Useful in local environment, discouraged in production
+data_volume_host =
 
 # A list of configMapsRefs to envFrom. If more than one configMap is
 # specified, provide a comma separated list: configmap_a,configmap_b

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -191,7 +191,8 @@ class KubeConfig:
         # This prop may optionally be set for PV Claims and is used to write logs
         self.logs_volume_claim = conf.get(self.kubernetes_section, 'logs_volume_claim')
 
-        # This prop may optionally be set for PV Claims and is used to write data which can be shared with other workers
+        # This prop may optionally be set for PV Claims and is used to write data which 
+        # can be shared with other workers
         self.data_volume_claim = conf.get(self.kubernetes_section, 'data_volume_claim')
 
         # This prop may optionally be set for PV Claims and is used to locate DAGs
@@ -221,7 +222,8 @@ class KubeConfig:
         # This prop may optionally be set for PV Claims and is used to write logs
         self.base_log_folder = configuration.get(self.core_section, 'base_log_folder')
 
-        # This prop may optionally be set for PV Claims and is used to write data which can be shared with other workers
+        # This prop may optionally be set for PV Claims and is used to write data which 
+        # can be shared with other workers
         self.base_data_folder = configuration.get(self.core_section, 'base_data_folder')
 
         # The Kubernetes Namespace in which the Scheduler and Webserver reside. Note

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -191,6 +191,9 @@ class KubeConfig:
         # This prop may optionally be set for PV Claims and is used to write logs
         self.logs_volume_claim = conf.get(self.kubernetes_section, 'logs_volume_claim')
 
+        # This prop may optionally be set for PV Claims and is used to write data which can be shared with other workers
+        self.data_volume_claim = conf.get(self.kubernetes_section, 'data_volume_claim')
+
         # This prop may optionally be set for PV Claims and is used to locate DAGs
         # on a SubPath
         self.dags_volume_subpath = conf.get(
@@ -201,14 +204,25 @@ class KubeConfig:
         self.logs_volume_subpath = conf.get(
             self.kubernetes_section, 'logs_volume_subpath')
 
+        # This prop may optionally be set for PV Claims and is used to locate data
+        # on a SubPath
+        self.data_volume_subpath = conf.get(
+            self.kubernetes_section, 'data_volume_subpath')
+
         # Optionally, hostPath volume containing DAGs
         self.dags_volume_host = conf.get(self.kubernetes_section, 'dags_volume_host')
 
         # Optionally, write logs to a hostPath Volume
         self.logs_volume_host = conf.get(self.kubernetes_section, 'logs_volume_host')
 
+        # Optionally, write data to a hostPath Volume
+        self.data_volume_host = conf.get(self.kubernetes_section, 'data_volume_host')
+
         # This prop may optionally be set for PV Claims and is used to write logs
         self.base_log_folder = configuration.get(self.core_section, 'base_log_folder')
+
+        # This prop may optionally be set for PV Claims and is used to write data which can be shared with other workers
+        self.base_data_folder = configuration.get(self.core_section, 'base_data_folder')
 
         # The Kubernetes Namespace in which the Scheduler and Webserver reside. Note
         # that if your

--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -29,6 +29,7 @@ class WorkerConfiguration(LoggingMixin):
 
     dags_volume_name = 'airflow-dags'
     logs_volume_name = 'airflow-logs'
+    data_volume_name = 'airflow-data'
     git_sync_ssh_secret_volume_name = 'git-sync-ssh-key'
     git_ssh_key_secret_key = 'gitSshKey'
     git_sync_ssh_known_hosts_volume_name = 'git-sync-known-hosts'
@@ -39,6 +40,7 @@ class WorkerConfiguration(LoggingMixin):
         self.worker_airflow_home = self.kube_config.airflow_home
         self.worker_airflow_dags = self.kube_config.dags_folder
         self.worker_airflow_logs = self.kube_config.base_log_folder
+        self.worker_airflow_data = self.kube_config.base_data_folder
 
         super().__init__()
 
@@ -234,6 +236,11 @@ class WorkerConfiguration(LoggingMixin):
                 self.logs_volume_name,
                 self.kube_config.logs_volume_claim,
                 self.kube_config.logs_volume_host
+            ),
+            self.data_volume_name: _construct_volume(
+                self.data_volume_name,
+                self.kube_config.data_volume_claim,
+                self.kube_config.data_volume_host
             )
         }
 
@@ -246,6 +253,10 @@ class WorkerConfiguration(LoggingMixin):
             self.logs_volume_name: {
                 'name': self.logs_volume_name,
                 'mountPath': self.worker_airflow_logs,
+            },
+            self.data_volume_name: {
+                'name': self.data_volume_name,
+                'mountPath': self.worker_airflow_data,
             }
         }
 
@@ -254,6 +265,9 @@ class WorkerConfiguration(LoggingMixin):
 
         if self.kube_config.logs_volume_subpath:
             volume_mounts[self.logs_volume_name]['subPath'] = self.kube_config.logs_volume_subpath
+
+        if self.kube_config.data_volume_subpath:
+            volume_mounts[self.data_volume_name]['subPath'] = self.kube_config.data_volume_subpath
 
         if self.kube_config.dags_in_image:
             del volumes[self.dags_volume_name]


### PR DESCRIPTION
For many use cases it is neccessary to write data from a worker back to a PV to share it between other workers (e.g. for TFX). Therefore a new (third) PVC should be optionaly mounted into the worker nodes (as well as the webserver). The PVC has to be provided by the user (similiar to DAG and log PV). It has to be mounted with the ReadOnly flag off. 

As this is very new to me, I am not sure if I did everything correct. I was not able to run all tests but it should not break anything as this is mainly a copy of the log PV. Also I am not sure if the mount also works for the webserver pod.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4722)

### Description

- Add a new parameter to add a new PV called airflow-data, which is mounted as writeable into a worker to allow sharing of data between workers.

### Tests

- Sorry but I have no idea what to here :-/

### Documentation

Updaded the default config with the new param. 

### Code Quality

- How can I run this?
