### PR TITLE
[AIRFLOW-3057] add prev_*_date_success to template context

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional, cast
 
 import six
 from sqlalchemy import (
@@ -24,7 +25,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import synonym
-
+from sqlalchemy.orm.session import Session
 from airflow.exceptions import AirflowException
 from airflow.models.base import Base, ID_LEN
 from airflow.stats import Stats
@@ -218,12 +219,19 @@ class DagRun(Base, LoggingMixin):
         return self.dag
 
     @provide_session
-    def get_previous_dagrun(self, session=None):
+    def get_previous_dagrun(self, state: str = None, session: Session = None) -> Optional['DagRun']:
         """The previous DagRun, if there is one"""
 
-        return session.query(DagRun).filter(
+        session = cast(Session, session)  # mypy
+
+        filters = [
             DagRun.dag_id == self.dag_id,
-            DagRun.execution_date < self.execution_date
+            DagRun.execution_date < self.execution_date,
+        ]
+        if state is not None:
+            filters.append(DagRun.state == state)
+        return session.query(DagRun).filter(
+            *filters
         ).order_by(
             DagRun.execution_date.desc()
         ).first()

--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -28,54 +28,56 @@ Default Variables
 The Airflow engine passes a few variables by default that are accessible
 in all templates
 
-=================================   ====================================
-Variable                            Description
-=================================   ====================================
-``{{ ds }}``                        the execution date as ``YYYY-MM-DD``
-``{{ ds_nodash }}``                 the execution date as ``YYYYMMDD``
-``{{ prev_ds }}``                   the previous execution date as ``YYYY-MM-DD``
-                                    if ``{{ ds }}`` is ``2018-01-08`` and ``schedule_interval`` is ``@weekly``,
-                                    ``{{ prev_ds }}`` will be ``2018-01-01``
-``{{ prev_ds_nodash }}``            the previous execution date as ``YYYYMMDD`` if exists, else ``None``
-``{{ next_ds }}``                   the next execution date as ``YYYY-MM-DD``
-                                    if ``{{ ds }}`` is ``2018-01-01`` and ``schedule_interval`` is ``@weekly``,
-                                    ``{{ next_ds }}`` will be ``2018-01-08``
-``{{ next_ds_nodash }}``            the next execution date as ``YYYYMMDD`` if exists, else ``None``
-``{{ yesterday_ds }}``              the day before the execution date as ``YYYY-MM-DD``
-``{{ yesterday_ds_nodash }}``       the day before the execution date as ``YYYYMMDD``
-``{{ tomorrow_ds }}``               the day after the execution date as ``YYYY-MM-DD``
-``{{ tomorrow_ds_nodash }}``        the day after the execution date as ``YYYYMMDD``
-``{{ ts }}``                        same as ``execution_date.isoformat()``. Example: ``2018-01-01T00:00:00+00:00``
-``{{ ts_nodash }}``                 same as ``ts`` without ``-``, ``:`` and TimeZone info. Example: ``20180101T000000``
-``{{ ts_nodash_with_tz }}``         same as ``ts`` without ``-`` and ``:``. Example: ``20180101T000000+0000``
-``{{ execution_date }}``            the execution_date (pendulum.Pendulum)
-``{{ prev_execution_date }}``       the previous execution date (if available) (pendulum.Pendulum)
-``{{ next_execution_date }}``       the next execution date (pendulum.Pendulum)
-``{{ dag }}``                       the DAG object
-``{{ task }}``                      the Task object
-``{{ macros }}``                    a reference to the macros package, described below
-``{{ task_instance }}``             the task_instance object
-``{{ end_date }}``                  same as ``{{ ds }}``
-``{{ latest_date }}``               same as ``{{ ds }}``
-``{{ ti }}``                        same as ``{{ task_instance }}``
-``{{ params }}``                    a reference to the user-defined params dictionary which can be overridden by
-                                    the dictionary passed through ``trigger_dag -c`` if you enabled
-                                    ``dag_run_conf_overrides_params` in ``airflow.cfg``
-``{{ var.value.my_var }}``          global defined variables represented as a dictionary
-``{{ var.json.my_var.path }}``      global defined variables represented as a dictionary
-                                    with deserialized JSON object, append the path to the
-                                    key within the JSON object
-``{{ task_instance_key_str }}``     a unique, human-readable key to the task instance
-                                    formatted ``{dag_id}_{task_id}_{ds}``
-``{{ conf }}``                      the full configuration object located at
-                                    ``airflow.configuration.conf`` which
-                                    represents the content of your
-                                    ``airflow.cfg``
-``{{ run_id }}``                    the ``run_id`` of the current DAG run
-``{{ dag_run }}``                   a reference to the DagRun object
-``{{ test_mode }}``                 whether the task instance was called using
-                                    the CLI's test subcommand
-=================================   ====================================
+=====================================   ====================================
+Variable                                Description
+=====================================   ====================================
+``{{ ds }}``                            the execution date as ``YYYY-MM-DD``
+``{{ ds_nodash }}``                     the execution date as ``YYYYMMDD``
+``{{ prev_ds }}``                       the previous execution date as ``YYYY-MM-DD``
+                                        if ``{{ ds }}`` is ``2018-01-08`` and ``schedule_interval`` is ``@weekly``,
+                                        ``{{ prev_ds }}`` will be ``2018-01-01``
+``{{ prev_ds_nodash }}``                the previous execution date as ``YYYYMMDD`` if exists, else ``None``
+``{{ next_ds }}``                       the next execution date as ``YYYY-MM-DD``
+                                        if ``{{ ds }}`` is ``2018-01-01`` and ``schedule_interval`` is ``@weekly``,
+                                        ``{{ next_ds }}`` will be ``2018-01-08``
+``{{ next_ds_nodash }}``                the next execution date as ``YYYYMMDD`` if exists, else ``None``
+``{{ yesterday_ds }}``                  the day before the execution date as ``YYYY-MM-DD``
+``{{ yesterday_ds_nodash }}``           the day before the execution date as ``YYYYMMDD``
+``{{ tomorrow_ds }}``                   the day after the execution date as ``YYYY-MM-DD``
+``{{ tomorrow_ds_nodash }}``            the day after the execution date as ``YYYYMMDD``
+``{{ ts }}``                            same as ``execution_date.isoformat()``. Example: ``2018-01-01T00:00:00+00:00``
+``{{ ts_nodash }}``                     same as ``ts`` without ``-``, ``:`` and TimeZone info. Example: ``20180101T000000``
+``{{ ts_nodash_with_tz }}``             same as ``ts`` without ``-`` and ``:``. Example: ``20180101T000000+0000``
+``{{ execution_date }}``                the execution_date (pendulum.Pendulum)
+``{{ prev_execution_date }}``           the previous execution date (if available) (pendulum.Pendulum)
+``{{ prev_execution_date_success }}``   execution date from prior succesful dag run (if available) (pendulum.Pendulum)
+``{{ prev_start_date_success }}``       start date from prior successful dag run (if available) (pendulum.Pendulum)
+``{{ next_execution_date }}``           the next execution date (pendulum.Pendulum)
+``{{ dag }}``                           the DAG object
+``{{ task }}``                          the Task object
+``{{ macros }}``                        a reference to the macros package, described below
+``{{ task_instance }}``                 the task_instance object
+``{{ end_date }}``                      same as ``{{ ds }}``
+``{{ latest_date }}``                   same as ``{{ ds }}``
+``{{ ti }}``                            same as ``{{ task_instance }}``
+``{{ params }}``                        a reference to the user-defined params dictionary which can be overridden by
+                                        the dictionary passed through ``trigger_dag -c`` if you enabled
+                                        ``dag_run_conf_overrides_params` in ``airflow.cfg``
+``{{ var.value.my_var }}``              global defined variables represented as a dictionary
+``{{ var.json.my_var.path }}``          global defined variables represented as a dictionary
+                                        with deserialized JSON object, append the path to the
+                                        key within the JSON object
+``{{ task_instance_key_str }}``         a unique, human-readable key to the task instance
+                                        formatted ``{dag_id}_{task_id}_{ds}``
+``{{ conf }}``                          the full configuration object located at
+                                        ``airflow.configuration.conf`` which
+                                        represents the content of your
+                                        ``airflow.cfg``
+``{{ run_id }}``                        the ``run_id`` of the current DAG run
+``{{ dag_run }}``                       a reference to the DagRun object
+``{{ test_mode }}``                     whether the task instance was called using
+                                        the CLI's test subcommand
+=====================================   ====================================
 
 Note that you can access the object's attributes and methods with simple
 dot notation. Here are some examples of what is possible:

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -21,12 +21,12 @@ import datetime
 import time
 import unittest
 import urllib
-
+from typing import Union, List
 import pendulum
 from freezegun import freeze_time
 from unittest.mock import patch, mock_open
-from parameterized import parameterized
-
+from parameterized import parameterized, param
+from sqlalchemy.orm.session import Session
 from airflow import models, settings, configuration
 from airflow.contrib.sensors.python_sensor import PythonSensor
 from airflow.exceptions import AirflowException, AirflowSkipException
@@ -48,6 +48,7 @@ class TaskInstanceTest(unittest.TestCase):
             session.query(TaskFail).delete()
             session.query(TaskReschedule).delete()
             session.query(models.TaskInstance).delete()
+            session.query(models.DagRun).delete()
 
     def test_set_task_dates(self):
         """
@@ -976,6 +977,7 @@ class TaskInstanceTest(unittest.TestCase):
                     TI.dag_id == self.dag_id).filter(
                     TI.execution_date == self.execution_date).one()
                 self.task_state_in_callback = temp_instance.state
+
         cw = CallbackWrapper()
         dag = DAG('test_success_callbak_no_race_condition', start_date=DEFAULT_DATE,
                   end_date=DEFAULT_DATE + datetime.timedelta(days=10))
@@ -992,3 +994,119 @@ class TaskInstanceTest(unittest.TestCase):
         self.assertEqual(cw.task_state_in_callback, State.RUNNING)
         ti.refresh_from_db()
         self.assertEqual(ti.state, State.SUCCESS)
+
+    @staticmethod
+    def _test_previous_dates_setup(schedule_interval: Union[str, datetime.timedelta, None],
+                                   catchup: bool, scenario: List[str]) -> list:
+        dag_id = 'test_previous_dates'
+        dag = models.DAG(dag_id=dag_id, schedule_interval=schedule_interval, catchup=catchup)
+        task = DummyOperator(task_id='task', dag=dag, start_date=DEFAULT_DATE)
+
+        def get_test_ti(session, execution_date: pendulum.datetime, state: str) -> TI:
+            dag.create_dagrun(
+                run_id='scheduled__{}'.format(execution_date.to_iso8601_string()),
+                state=state,
+                execution_date=execution_date,
+                start_date=pendulum.utcnow(),
+                session=session
+            )
+            ti = TI(task=task, execution_date=execution_date)
+            ti.set_state(state=State.SUCCESS, session=session)
+            return ti
+
+        with create_session() as session:  # type: Session
+
+            d0 = pendulum.parse('2019-01-01T00:00:00+00:00')
+
+            ret = []
+
+            for idx, state in enumerate(scenario):
+                ed = d0.add(days=idx)
+                ti = get_test_ti(session, ed, state)
+                ret.append(ti)
+
+            return ret
+
+    _prev_dates_param_list = (
+        param('cron/catchup', '0 0 * * * ', True),
+        param('cron/no-catchup', '0 0 * * *', False),
+        param('no-sched/catchup', None, True),
+        param('no-sched/no-catchup', None, False),
+        param('timedelta/catchup', datetime.timedelta(days=1), True),
+        param('timedelta/no-catchup', datetime.timedelta(days=1), False),
+    )
+
+    @parameterized.expand(_prev_dates_param_list)
+    def test_previous_ti(self, _, schedule_interval, catchup) -> None:
+
+        scenario = [State.SUCCESS, State.FAILED, State.SUCCESS]
+
+        ti_list = self._test_previous_dates_setup(schedule_interval, catchup, scenario)
+
+        self.assertIsNone(ti_list[0].previous_ti)
+
+        self.assertEqual(
+            ti_list[2].previous_ti.execution_date,
+            ti_list[1].execution_date
+        )
+
+        self.assertNotEqual(
+            ti_list[2].previous_ti.execution_date,
+            ti_list[0].execution_date
+        )
+
+    @parameterized.expand(_prev_dates_param_list)
+    def test_previous_ti_success(self, _, schedule_interval, catchup) -> None:
+
+        scenario = [State.FAILED, State.SUCCESS, State.FAILED, State.SUCCESS]
+
+        ti_list = self._test_previous_dates_setup(schedule_interval, catchup, scenario)
+
+        self.assertIsNone(ti_list[0].previous_ti_success)
+        self.assertIsNone(ti_list[1].previous_ti_success)
+
+        self.assertEqual(
+            ti_list[3].previous_ti_success.execution_date,
+            ti_list[1].execution_date
+        )
+
+        self.assertNotEqual(
+            ti_list[3].previous_ti_success.execution_date,
+            ti_list[2].execution_date
+        )
+
+    @parameterized.expand(_prev_dates_param_list)
+    def test_previous_execution_date_success(self, _, schedule_interval, catchup) -> None:
+
+        scenario = [State.FAILED, State.SUCCESS, State.FAILED, State.SUCCESS]
+
+        ti_list = self._test_previous_dates_setup(schedule_interval, catchup, scenario)
+
+        self.assertIsNone(ti_list[0].previous_execution_date_success)
+        self.assertIsNone(ti_list[1].previous_execution_date_success)
+        self.assertEqual(
+            ti_list[3].previous_execution_date_success,
+            ti_list[1].execution_date
+        )
+        self.assertNotEqual(
+            ti_list[3].previous_execution_date_success,
+            ti_list[2].execution_date
+        )
+
+    @parameterized.expand(_prev_dates_param_list)
+    def test_previous_start_date_success(self, _, schedule_interval, catchup) -> None:
+
+        scenario = [State.FAILED, State.SUCCESS, State.FAILED, State.SUCCESS]
+
+        ti_list = self._test_previous_dates_setup(schedule_interval, catchup, scenario)
+
+        self.assertIsNone(ti_list[0].previous_start_date_success)
+        self.assertIsNone(ti_list[1].previous_start_date_success)
+        self.assertEqual(
+            ti_list[3].previous_start_date_success,
+            ti_list[1].start_date,
+        )
+        self.assertNotEqual(
+            ti_list[3].previous_start_date_success,
+            ti_list[2].start_date,
+        )


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

My PR addresses [[AIRFLOW-3057]](https://issues.apache.org/jira/browse/AIRFLOW-3057) - add macros that see only successful dags

### Description

Two new variables are added to template context: 
* `prev_execution_date_success`
* `prev_start_date_success`.

These return the exec / start date for the same task in prior _successful_ dag run.   

Lazy evaluation is employed so that the query to look up prev_ti is not executed unless a templated field references the variable in question.

To enable the above, I added `state` as a param to `DagRun.get_previous_dagrun` and `TaskInstance._get_previous_ti`, and added properties `previous_ti_success` and `previous_execution_date_success` and `previous_start_date_success` to `TaskInstance`.  

#### Notes on decisions 

##### Success of dag run vs success of TI

These new context variables e.g. `previous_execution_date_success` will return the execution date of the same TI in the prior successful dag run.  Alternatively, I could have had them return the dates for the prior successful TI.  

I decided not to do that so that (1) no new indexes were required and (2) I could reuse the `get_previous_dagrun` method with only a small change.  The only time this would give a different result would be if a trigger rule allowed the dag run to be successful despite the task failing, or perhaps if a task was run manually without a dag run (not sure if this is possible?).  But these issues did not seem to justify the slightly more elaborate changes it would require.  In any case, I have made it clear in the docs that the execution date is derived from last successful dag run.

##### Naming
On naming, I initially was going to do `previous_successful_X`, but then I saw the ticket that already existed for this issue, and they had suggested `previous_X_success`, and I thought that was maybe better anyway, so that's what I went with.  


#### Notes on less obvious changes

##### _get_previous_ti
Previously this will call `get_previous_scheduled_dagrun` if `dag.catchup` and `get_previous_dagrun` otherwise.  The `scheduled` version is more efficient -- it just looks for one row, instead of pulling many and ordering and taking one.
For my change, even if `dag.catchup` is True, I want to use `get_previous_dagrun` if either `state`  is given or `schedule_interval is None`.  
If you are asking for state (in this case success), then you are not looking for merely previous scheduled dag run -- you want the previous one with state.  
And if schedule interval is None (which could be true with dogs that are always externally triggered), then using `get_previous_scheduled_dagrun` won't find anything.
You could argue that if `dag.catchup` is True then we shouldn't be looking for previous successful or whatever.  But unless there is a very good reason, methods should do what they say they are going to do.

##### get_previous_dagrun
Here we just need to build filters dynamically because if state is not given then we don't want to add state to the filters.

### Tests

My PR adds 4 new tests:
* test_previous_ti
* test_previous_ti_success
* test_previous_execution_date_success
* test_previous_start_date_success


### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`