### PR TITLE
[AIRFLOW-4518] GkeClusterCreateOperator and GkeClusterDeleteOperator …

### DIFF
--- a/airflow/contrib/operators/gcp_container_operator.py
+++ b/airflow/contrib/operators/gcp_container_operator.py
@@ -86,7 +86,7 @@ class GKEClusterDeleteOperator(BaseOperator):
 
     def execute(self, context):
         self._check_input()
-        hook = GKEClusterHook(self.project_id, self.location)
+        hook = GKEClusterHook(gcp_conn_id=self.gcp_conn_id, location=self.location)
         delete_result = hook.delete_cluster(name=self.name)
         return delete_result
 
@@ -157,23 +157,21 @@ class GKEClusterCreateOperator(BaseOperator):
 
     def _check_input(self):
         if all([self.project_id, self.location, self.body]):
-            if isinstance(self.body, dict) \
-                    and 'name' in self.body \
-                    and 'initial_node_count' in self.body:
+            if isinstance(self.body, dict) and 'name' in self.body:
                 # Don't throw error
                 return
             # If not dict, then must
-            elif self.body.name and self.body.initial_node_count:
+            elif self.body.name:
                 return
 
         self.log.error(
-            'One of (project_id, location, body, body[\'name\'], '
-            'body[\'initial_node_count\']) is missing or incorrect')
+            'One of (project_id, location, body, body[\'name\']) '
+            'is missing or incorrect')
         raise AirflowException('Operator has incorrect or missing input.')
 
     def execute(self, context):
         self._check_input()
-        hook = GKEClusterHook(self.project_id, self.location)
+        hook = GKEClusterHook(gcp_conn_id=self.gcp_conn_id, location=self.location)
         create_op = hook.create_cluster(cluster=self.body)
         return create_op
 


### PR DESCRIPTION
…do not properly instantiate GKEClusterHook. Also, initialnodecount is deprecated (https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.zones.clusters)

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4518) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4518
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

https://github.com/apache/airflow/pull/4364/files refactored GKEClusterHook's constructor but didn't update its callers, so GKEClusterCreateOperator and GkeClusterDeleteOperator no longer work. They pass the project ID in as the first arg to the hook constructor, which the hook interprets as a Connection ID.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
