### PR TITLE
[AIRFLOW-4738] Enforce exampleinclude for example DAGs

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -23,7 +23,7 @@ set -e
 FWDIR="$(cd "`dirname "$0"`"; pwd)"
 cd "$FWDIR"
 
-NUM_INCORRECT_USE_LITERALINCLUDE_DIRECTIVE=$(grep -in 'literalinclude::.\+example_dags' $(find . -name '*.rst') |\
+NUM_INCORRECT_USE_LITERALINCLUDE_DIRECTIVE=$(grep -inR --include \*.rst 'literalinclude::.\+example_dags' .\
     tee /dev/tty |\
     wc -l |\
     tr -d '[:space:]')

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -23,6 +23,18 @@ set -e
 FWDIR="$(cd "`dirname "$0"`"; pwd)"
 cd "$FWDIR"
 
+NUM_INCORRECT_USE_LITERALINCLUDE_DIRECTIVE=$(grep -in 'literalinclude::.\+example_dags' $(find . -name '*.rst') |\
+    tee /dev/tty |\
+    wc -l |\
+    tr -d '[:space:]')
+
+if [[ "${NUM_INCORRECT_USE_LITERALINCLUDE_DIRECTIVE}" -ne "0" ]]; then
+    echo "Unexpected problems found in the documentation. "
+    echo "You should use a exampleinclude directive to include example DAGs."
+    echo "Currently, ${NUM_INCORRECT_USE_LITERALINCLUDE_DIRECTIVE} problem found."
+    exit 1
+fi
+
 [[ -d "_build" ]] && rm -r _build
 [[ -d "_api" ]] && rm -r _api
 
@@ -37,7 +49,7 @@ NUM_CURRENT_WARNINGS=$(echo $SUCCEED_LINE |\
 if echo $SUCCEED_LINE | grep -q "warning"; then
     echo
     echo "Unexpected problems found in the documentation. "
-    echo "Currently, ${NUM_CURRENT_WARNINGS} warnings found"
+    echo "Currently, ${NUM_CURRENT_WARNINGS} warnings found. "
     echo
     exit 1
 fi

--- a/docs/howto/operator/dingding.rst
+++ b/docs/howto/operator/dingding.rst
@@ -35,7 +35,7 @@ Basic Usage
 Use the :class:`~airflow/contrib/operators/dingding_operator.DingdingOperator`
 to send Dingding message:
 
-.. literalinclude:: ../../../airflow/contrib/example_dags/example_dingding_operator.py
+.. exampleinclude:: ../../../airflow/contrib/example_dags/example_dingding_operator.py
     :language: python
     :start-after: [START howto_operator_dingding]
     :end-before: [END howto_operator_dingding]
@@ -47,7 +47,7 @@ Remind users in message
 Use parameters ``at_mobiles`` and ``at_all`` to remind specific users when you send message,
 ``at_mobiles`` will be ignored When ``at_all`` is set to ``True``:
 
-.. literalinclude:: ../../../airflow/contrib/example_dags/example_dingding_operator.py
+.. exampleinclude:: ../../../airflow/contrib/example_dags/example_dingding_operator.py
     :language: python
     :start-after: [START howto_operator_dingding_remind_users]
     :end-before: [END howto_operator_dingding_remind_users]
@@ -59,7 +59,7 @@ Send rich text message
 The Dingding operator can send rich text messages including link, markdown, actionCard and feedCard.
 A rich text message can not remind specific users except by using markdown type message:
 
-.. literalinclude:: ../../../airflow/contrib/example_dags/example_dingding_operator.py
+.. exampleinclude:: ../../../airflow/contrib/example_dags/example_dingding_operator.py
     :language: python
     :start-after: [START howto_operator_dingding_rich_text]
     :end-before: [END howto_operator_dingding_rich_text]
@@ -72,7 +72,7 @@ Dingding operator could handle task callback by writing a function wrapper dingd
 and then pass the function to ``sla_miss_callback``, ``on_success_callback``, ``on_failure_callback``,
 or ``on_retry_callback``. Here we use ``on_failure_callback`` as an example:
 
-.. literalinclude:: ../../../airflow/contrib/example_dags/example_dingding_operator.py
+.. exampleinclude:: ../../../airflow/contrib/example_dags/example_dingding_operator.py
     :language: python
     :start-after: [START howto_operator_dingding_failure_callback]
     :end-before: [END howto_operator_dingding_failure_callback]

--- a/docs/howto/operator/gcp/compute.rst
+++ b/docs/howto/operator/gcp/compute.rst
@@ -66,7 +66,7 @@ from the GCP connection id used:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_compute_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_compute_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gce_instance_start_template_fields]
@@ -121,7 +121,7 @@ from the GCP connection used:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_compute_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_compute_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gce_instance_stop_template_fields]
@@ -182,7 +182,7 @@ from the GCP connection used:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_compute_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_compute_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gce_instance_set_machine_type_template_fields]
@@ -243,7 +243,7 @@ from the GCP connection used:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_compute_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_compute_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gce_instance_template_copy_operator_template_fields]
@@ -304,7 +304,7 @@ from the GCP connection used:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_compute_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_compute_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gce_igm_update_template_operator_template_fields]

--- a/docs/howto/operator/gcp/function.rst
+++ b/docs/howto/operator/gcp/function.rst
@@ -55,7 +55,7 @@ Using the operator
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_function_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_function_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcf_function_delete_template_fields]
@@ -154,7 +154,7 @@ from the GCP connection used:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_function_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_function_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcf_function_deploy_template_fields]

--- a/docs/howto/operator/gcp/gcs.rst
+++ b/docs/howto/operator/gcp/gcs.rst
@@ -70,7 +70,7 @@ Using the operator
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcs_acl_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcs_acl_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcs_bucket_create_acl_template_fields]
@@ -114,7 +114,7 @@ Using the operator
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcs_acl_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcs_acl_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcs_object_create_acl_template_fields]

--- a/docs/howto/operator/gcp/spanner.rst
+++ b/docs/howto/operator/gcp/spanner.rst
@@ -58,7 +58,7 @@ it will be retrieved from the GCP connection used. Both variants are shown:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_spanner_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_spanner_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_spanner_delete_template_fields]
@@ -108,7 +108,7 @@ it will be retrieved from the GCP connection used. Both variants are shown:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_spanner_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_spanner_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_spanner_database_deploy_template_fields]
@@ -168,7 +168,7 @@ it will be retrieved from the GCP connection used. Both variants are shown:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_spanner_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_spanner_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_spanner_database_update_template_fields]
@@ -215,7 +215,7 @@ it will be retrieved from the GCP connection used. Both variants are shown:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_spanner_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_spanner_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_spanner_query_template_fields]
@@ -263,7 +263,7 @@ it will be retrieved from the GCP connection used. Both variants are shown:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_spanner_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_spanner_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_spanner_delete_template_fields]

--- a/docs/howto/operator/gcp/speech.rst
+++ b/docs/howto/operator/gcp/speech.rst
@@ -33,7 +33,7 @@ Arguments
 
 Some arguments in the example DAG are taken from the OS environment variables:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
       :language: python
       :start-after: [START howto_operator_text_to_speech_env_variables]
       :end-before: [END howto_operator_text_to_speech_env_variables]
@@ -43,14 +43,14 @@ google.cloud.texttospeech_v1.types module
 
 for more information, see: https://googleapis.github.io/google-cloud-python/latest/texttospeech/gapic/v1/api.html#google.cloud.texttospeech_v1.TextToSpeechClient.synthesize_speech
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
       :language: python
       :start-after: [START howto_operator_text_to_speech_api_arguments]
       :end-before: [END howto_operator_text_to_speech_api_arguments]
 
 filename is a simple string argument:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
       :language: python
       :start-after: [START howto_operator_text_to_speech_gcp_filename]
       :end-before: [END howto_operator_text_to_speech_gcp_filename]
@@ -58,7 +58,7 @@ filename is a simple string argument:
 Using the operator
 """"""""""""""""""
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_text_to_speech_synthesize]
@@ -94,14 +94,14 @@ google.cloud.speech_v1.types module
 
 for more information, see: https://googleapis.github.io/google-cloud-python/latest/speech/gapic/v1/api.html#google.cloud.speech_v1.SpeechClient.recognize
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
       :language: python
       :start-after: [START howto_operator_text_to_speech_api_arguments]
       :end-before: [END howto_operator_text_to_speech_api_arguments]
 
 filename is a simple string argument:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
       :language: python
       :start-after: [START howto_operator_speech_to_text_api_arguments]
       :end-before: [END howto_operator_speech_to_text_api_arguments]
@@ -109,7 +109,7 @@ filename is a simple string argument:
 Using the operator
 """"""""""""""""""
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_speech.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_speech_to_text_recognize]

--- a/docs/howto/operator/gcp/sql.rst
+++ b/docs/howto/operator/gcp/sql.rst
@@ -64,7 +64,7 @@ Example request body:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_sql_db_create_template_fields]
@@ -111,7 +111,7 @@ it will be retrieved from the GCP connection used. Both variants are shown:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_sql_db_delete_template_fields]
@@ -167,7 +167,7 @@ Example request body:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_sql_db_patch_template_fields]
@@ -225,7 +225,7 @@ Replicas are deleted the same way as primary instances:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_sql_delete_template_fields]
@@ -289,7 +289,7 @@ it will be retrieved from the GCP connection used. Both variants are shown:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_sql_export_template_fields]
@@ -386,7 +386,7 @@ it will be retrieved from the GCP connection used. Both variants are shown:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_sql_import_template_fields]
@@ -481,7 +481,7 @@ it will be retrieved from the GCP connection used. Both variants are shown:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_sql_create_template_fields]
@@ -539,7 +539,7 @@ it will be retrieved from the GCP connection used. Both variants are shown:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_sql_patch_template_fields]
@@ -631,7 +631,7 @@ standard AIRFLOW notation for defining connection via environment variables):
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_sql_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_sql_query_template_fields]

--- a/docs/howto/operator/gcp/transfer.rst
+++ b/docs/howto/operator/gcp/transfer.rst
@@ -80,7 +80,7 @@ Using the operator
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_transfer_job_create_template_fields]
@@ -121,7 +121,7 @@ Using the operator
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_transfer_job_delete_template_fields]
@@ -167,7 +167,7 @@ Using the operator
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_transfer_job_update_template_fields]
@@ -208,7 +208,7 @@ Using the operator
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_transfer_operation_cancel_template_fields]
@@ -250,7 +250,7 @@ Using the operator
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_transfer_operation_get_template_fields]
@@ -291,7 +291,7 @@ Using the operator
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_transfer_operations_list_template_fields]
@@ -332,7 +332,7 @@ Using the operator
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_transfer_operation_pause_template_fields]
@@ -373,7 +373,7 @@ Using the operator
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_transfer_operator.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_transfer_operation_resume_template_fields]
@@ -413,7 +413,7 @@ Using the operator
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/sensors/gcp_transfer_sensor.py
+.. literalinclude:: ../../../../airflow/contrib/sensors/gcp_transfer_sensor.py
     :language: python
     :dedent: 4
     :start-after: [START gcp_transfer_job_sensor_template_fields]

--- a/docs/howto/operator/gcp/translate-speech.rst
+++ b/docs/howto/operator/gcp/translate-speech.rst
@@ -65,7 +65,7 @@ Using the operator
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_translate_speech_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_translate_speech_operator.py
     :language: python
     :dedent: 4
     :start-after: [START translate_speech_template_fields]

--- a/docs/howto/operator/gcp/translate.rst
+++ b/docs/howto/operator/gcp/translate.rst
@@ -56,7 +56,7 @@ XCom mechanisms of Airflow:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_translate_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_translate_operator.py
     :language: python
     :dedent: 4
     :start-after: [START translate_template_fields]

--- a/docs/howto/operator/gcp/video.rst
+++ b/docs/howto/operator/gcp/video.rst
@@ -37,14 +37,14 @@ Arguments
 
 Some arguments in the example DAG are taken from the OS environment variables:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
       :language: python
       :start-after: [START howto_operator_video_intelligence_os_args]
       :end-before: [END howto_operator_video_intelligence_os_args]
 
 Input uri is an uri to a file in Google Cloud Storage
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
       :language: python
       :start-after: [START howto_operator_video_intelligence_other_args]
       :end-before: [END howto_operator_video_intelligence_other_args]
@@ -52,7 +52,7 @@ Input uri is an uri to a file in Google Cloud Storage
 Using the operator
 """"""""""""""""""
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_video_intelligence_detect_labels]
@@ -60,7 +60,7 @@ Using the operator
 
 You can use the annotation output via Xcom:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_video_intelligence_detect_labels_result]
@@ -96,14 +96,14 @@ Arguments
 
 Some arguments in the example DAG are taken from the OS environment variables:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
       :language: python
       :start-after: [START howto_operator_video_intelligence_os_args]
       :end-before: [END howto_operator_video_intelligence_os_args]
 
 Input uri is an uri to a file in Google Cloud Storage
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
       :language: python
       :start-after: [START howto_operator_video_intelligence_other_args]
       :end-before: [END howto_operator_video_intelligence_other_args]
@@ -111,7 +111,7 @@ Input uri is an uri to a file in Google Cloud Storage
 Using the operator
 """"""""""""""""""
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_video_intelligence_detect_explicit_content]
@@ -119,7 +119,7 @@ Using the operator
 
 You can use the annotation output via Xcom:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_video_intelligence_detect_explicit_content_result]
@@ -155,14 +155,14 @@ Arguments
 
 Some arguments in the example DAG are taken from the OS environment variables:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
       :language: python
       :start-after: [START howto_operator_video_intelligence_os_args]
       :end-before: [END howto_operator_video_intelligence_os_args]
 
 Input uri is an uri to a file in Google Cloud Storage
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
       :language: python
       :start-after: [START howto_operator_video_intelligence_other_args]
       :end-before: [END howto_operator_video_intelligence_other_args]
@@ -170,7 +170,7 @@ Input uri is an uri to a file in Google Cloud Storage
 Using the operator
 """"""""""""""""""
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_video_intelligence_detect_video_shots]
@@ -178,7 +178,7 @@ Using the operator
 
 You can use the annotation output via Xcom:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_video_intelligence.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_video_intelligence_detect_video_shots_result]

--- a/docs/howto/operator/gcp/vision.rst
+++ b/docs/howto/operator/gcp/vision.rst
@@ -95,7 +95,7 @@ Otherwise it can be specified explicitly:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
     :language: python
     :dedent: 4
     :start-after: [START vision_add_product_to_product_set_template_fields]
@@ -169,7 +169,7 @@ The result can be extracted from XCOM:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
     :language: python
     :dedent: 4
     :start-after: [START vision_annotate_image_template_fields]
@@ -252,7 +252,7 @@ Or it can be specified explicitly:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
     :language: python
     :dedent: 4
     :start-after: [START vision_product_create_template_fields]
@@ -319,7 +319,7 @@ Otherwise it can be specified explicitly:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
     :language: python
     :dedent: 4
     :start-after: [START vision_product_delete_template_fields]
@@ -382,7 +382,7 @@ Otherwise it can be specified explicitly:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
     :language: python
     :dedent: 4
     :start-after: [START vision_product_get_template_fields]
@@ -459,7 +459,7 @@ Or it can be specified explicitly:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
     :language: python
     :dedent: 4
     :start-after: [START vision_productset_create_template_fields]
@@ -520,7 +520,7 @@ Otherwise it can be specified explicitly:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
     :language: python
     :dedent: 4
     :start-after: [START vision_productset_delete_template_fields]
@@ -579,7 +579,7 @@ Otherwise it can be specified explicitly:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
     :language: python
     :dedent: 4
     :start-after: [START vision_productset_get_template_fields]
@@ -664,7 +664,7 @@ Otherwise it can be specified explicitly:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
     :language: python
     :dedent: 4
     :start-after: [START vision_productset_update_template_fields]
@@ -758,7 +758,7 @@ Otherwise it can be specified explicitly:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
     :language: python
     :dedent: 4
     :start-after: [START vision_product_update_template_fields]
@@ -835,7 +835,7 @@ Or it can be specified explicitly:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
     :language: python
     :dedent: 4
     :start-after: [START vision_reference_image_create_template_fields]
@@ -920,7 +920,7 @@ Otherwise it can be specified explicitly:
 Templating
 """"""""""
 
-.. exampleinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
+.. literalinclude:: ../../../../airflow/contrib/operators/gcp_vision_operator.py
     :language: python
     :dedent: 4
     :start-after: [START vision_remove_product_from_product_set_template_fields]
@@ -948,7 +948,7 @@ Arguments
 
 Some arguments in the example DAG are taken from the OS environment variables:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :start-after: [START howto_operator_vision_annotate_image_url]
       :end-before: [END howto_operator_vision_annotate_image_url]
@@ -960,12 +960,12 @@ Using the operator
 We are using the :class:`Retry` objects from
 Google libraries:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :start-after: [START howto_operator_vision_retry_import]
       :end-before: [END howto_operator_vision_retry_import]
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_vision_detect_text]
@@ -973,7 +973,7 @@ Google libraries:
 
 The result can be extracted from XCOM:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_vision_detect_text_result]
@@ -1010,7 +1010,7 @@ Arguments
 
 Some arguments in the example DAG are taken from the OS environment variables:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :start-after: [START howto_operator_vision_annotate_image_url]
       :end-before: [END howto_operator_vision_annotate_image_url]
@@ -1022,12 +1022,12 @@ Using the operator
 We are using the :class:`Retry` objects from
 Google libraries:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :start-after: [START howto_operator_vision_retry_import]
       :end-before: [END howto_operator_vision_retry_import]
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_vision_document_detect_text]
@@ -1035,7 +1035,7 @@ Google libraries:
 
 The result can be extracted from XCOM:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_vision_document_detect_text_result]
@@ -1072,7 +1072,7 @@ Arguments
 
 Some arguments in the example DAG are taken from the OS environment variables:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :start-after: [START howto_operator_vision_annotate_image_url]
       :end-before: [END howto_operator_vision_annotate_image_url]
@@ -1084,12 +1084,12 @@ Using the operator
 We are using the :class:`Retry` objects from
 Google libraries:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :start-after: [START howto_operator_vision_retry_import]
       :end-before: [END howto_operator_vision_retry_import]
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_vision_detect_labels]
@@ -1097,7 +1097,7 @@ Google libraries:
 
 The result can be extracted from XCOM:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_vision_detect_labels_result]
@@ -1134,7 +1134,7 @@ Arguments
 
 Some arguments in the example DAG are taken from the OS environment variables:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :start-after: [START howto_operator_vision_annotate_image_url]
       :end-before: [END howto_operator_vision_annotate_image_url]
@@ -1146,12 +1146,12 @@ Using the operator
 We are using the :class:`Retry` objects from
 Google libraries:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :start-after: [START howto_operator_vision_retry_import]
       :end-before: [END howto_operator_vision_retry_import]
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_vision_detect_safe_search]
@@ -1159,7 +1159,7 @@ Google libraries:
 
 The result can be extracted from XCOM:
 
-.. literalinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
+.. exampleinclude:: ../../../../airflow/contrib/example_dags/example_gcp_vision.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_vision_detect_safe_search_result]


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

We have a special directive in the project that allow to include a part of source code to documentation. Unfortunately, Not everyone uses it.

Exampleinclude directive adds a header with a reference to  the full source code.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation



### Code Quality

- [ ] Passes `flake8`
