### PR TITLE
AIRFLOW-4740 make default_args end_date permissive

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -211,7 +211,7 @@ class DAG(BaseDag, LoggingMixin):
         self.fileloc = sys._getframe().f_back.f_code.co_filename
         self.task_dict = dict()  # type: Dict[str, TaskInstance]
 
-        # set timezone
+        # set timezone for start_date
         if start_date and start_date.tzinfo:
             self.timezone = start_date.tzinfo
         elif 'start_date' in self.default_args and self.default_args['start_date']:
@@ -223,6 +223,13 @@ class DAG(BaseDag, LoggingMixin):
 
         if not hasattr(self, 'timezone') or not self.timezone:
             self.timezone = settings.TIMEZONE
+
+        # Apply the timezone we settled on to end_date if it wasn't supplied
+        if 'end_date' in self.default_args and self.default_args['end_date']:
+            if isinstance(self.default_args['end_date'], six.string_types):
+                self.default_args['end_date'] = (
+                    timezone.parse(self.default_args['end_date'], timezone=self.timezone)
+                )
 
         self.start_date = timezone.convert_to_utc(start_date)
         self.end_date = timezone.convert_to_utc(end_date)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -211,7 +211,7 @@ class DAG(BaseDag, LoggingMixin):
         self.fileloc = sys._getframe().f_back.f_code.co_filename
         self.task_dict = dict()  # type: Dict[str, TaskInstance]
 
-        # set timezone for start_date
+        # set timezone from start_date
         if start_date and start_date.tzinfo:
             self.timezone = start_date.tzinfo
         elif 'start_date' in self.default_args and self.default_args['start_date']:

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -214,13 +214,14 @@ class DagTest(unittest.TestCase):
         Tests that a start_date string with a timezone and an end_date string without a timezone
         are accepted and that the timezone from the start carries over the end
 
-        This test is a little indirect, it works by setting start and end equal except for the timezone and then
-        testing for equality after the DAG construction.  They'll be equal only if the same timezone was applied
-        to both.
+        This test is a little indirect, it works by setting start and end equal except for the
+        timezone and then testing for equality after the DAG construction.  They'll be equal
+        only if the same timezone was applied to both.
 
         An explicit check the the `tzinfo` attributes for both are the same is an extra check.
         """
-        dag = DAG('DAG', default_args={'start_date': '2019-06-05T00:00:00+05:00', 'end_date': '2019-06-05T00:00:00'})
+        dag = DAG('DAG', default_args={'start_date': '2019-06-05T00:00:00+05:00',
+                                       'end_date': '2019-06-05T00:00:00'})
         self.assertEqual(dag.default_args['start_date'], dag.default_args['end_date'])
         self.assertEqual(dag.default_args['start_date'].tzinfo, dag.default_args['end_date'].tzinfo)
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -203,6 +203,12 @@ class DagTest(unittest.TestCase):
 
         self.assertEqual(tuple(), dag.topological_sort())
 
+    def test_dag_naive_start_date_string(self):
+        DAG('DAG', default_args={'start_date': '2019-06-01'})
+
+    def test_dag_naive_start_end_dates_strings(self):
+        DAG('DAG', default_args={'start_date': '2019-06-01', 'end_date': '2019-06-05'})
+
     def test_dag_naive_default_args_start_date(self):
         dag = DAG('DAG', default_args={'start_date': datetime.datetime(2018, 1, 1)})
         self.assertEqual(dag.timezone, settings.TIMEZONE)

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -209,6 +209,21 @@ class DagTest(unittest.TestCase):
     def test_dag_naive_start_end_dates_strings(self):
         DAG('DAG', default_args={'start_date': '2019-06-01', 'end_date': '2019-06-05'})
 
+    def test_dag_start_date_propagates_to_end_date(self):
+        """
+        Tests that a start_date string with a timezone and an end_date string without a timezone
+        are accepted and that the timezone from the start carries over the end
+
+        This test is a little indirect, it works by setting start and end equal except for the timezone and then
+        testing for equality after the DAG construction.  They'll be equal only if the same timezone was applied
+        to both.
+
+        An explicit check the the `tzinfo` attributes for both are the same is an extra check.
+        """
+        dag = DAG('DAG', default_args={'start_date': '2019-06-05T00:00:00+05:00', 'end_date': '2019-06-05T00:00:00'})
+        self.assertEqual(dag.default_args['start_date'], dag.default_args['end_date'])
+        self.assertEqual(dag.default_args['start_date'].tzinfo, dag.default_args['end_date'].tzinfo)
+
     def test_dag_naive_default_args_start_date(self):
         dag = DAG('DAG', default_args={'start_date': datetime.datetime(2018, 1, 1)})
         self.assertEqual(dag.timezone, settings.TIMEZONE)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4740) 

### Description

A dag will accept, in its default_args, a `start_date` as simple as `2019-06-01`.  If it detects a string, it converts to a richer type ([code reference|https://github.com/apache/airflow/blob/master/airflow/models/dag.py#L217-L221]). However, it will not accept a similar string for `end_date` instead an exception like this is thrown:

```
Traceback (most recent call last):
 File "/airflow/tests/models/test_dag.py", line 210, in test_dag_naive_start_end_dates_strings
 DAG('DAG', default_args={'start_date': '2019-06-01', 'end_date': '2019-06-05'})
 File "/airflow/airflow/models/dag.py", line 244, in __init__
 timezone.convert_to_utc(self.default_args['end_date'])
 File "/airflow/airflow/utils/timezone.py", line 92, in convert_to_utc
 if not is_localized(value):
 File "/airflow/airflow/utils/timezone.py", line 38, in is_localized
 return value.utcoffset() is not None
AttributeError: 'str' object has no attribute 'utcoffset'
```

That's a very confusing user experience.  `end_date` should be as permissive as `start_date`


### Tests

- [X] My PR adds unit tests 

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] Passes `flake8`
