### PR TITLE
[AIRFLOW-4743] Add environment variables support to SSHOperator

### DIFF
--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -45,6 +45,9 @@ class SSHOperator(BaseOperator):
     :type command: str
     :param timeout: timeout (in seconds) for executing the command.
     :type timeout: int
+    :param environment: a dict of shell environment variables. Note that the
+        server will reject them silently if `AcceptEnv` is not set in SSH config.
+    :type environment: dict
     """
 
     template_fields = ('command', 'remote_host')
@@ -57,6 +60,7 @@ class SSHOperator(BaseOperator):
                  remote_host=None,
                  command=None,
                  timeout=10,
+                 environment=None,
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
@@ -65,6 +69,7 @@ class SSHOperator(BaseOperator):
         self.remote_host = remote_host
         self.command = command
         self.timeout = timeout
+        self.environment = environment
 
     def execute(self, context):
         try:
@@ -100,7 +105,8 @@ class SSHOperator(BaseOperator):
                 # set timeout taken as params
                 stdin, stdout, stderr = ssh_client.exec_command(command=self.command,
                                                                 get_pty=get_pty,
-                                                                timeout=self.timeout
+                                                                timeout=self.timeout,
+                                                                environment=self.environment
                                                                 )
                 # get channels
                 channel = stdout.channel

--- a/tests/contrib/operators/test_ssh_operator.py
+++ b/tests/contrib/operators/test_ssh_operator.py
@@ -121,6 +121,7 @@ class SSHOperatorTest(unittest.TestCase):
             command="echo -n airflow",
             do_xcom_push=True,
             dag=self.dag,
+            environment={'TEST': 'value'}
         )
 
         self.assertIsNotNone(task)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira]
  - https://issues.apache.org/jira/browse/AIRFLOW-4743

### Description

- [X] Add support for environment variables, which are passed to paramik:

### Tests

- [X] Only adding parameter, covered by existing tests

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.

### Code Quality

- [X] Passes `flake8`
