### PR TITLE
[AIRFLOW-4490] add dag_run_conf variable to context

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1140,6 +1140,8 @@ class TaskInstance(Base, LoggingMixin):
             prev_execution_date = task.dag.previous_schedule(self.execution_date)
             next_execution_date = task.dag.following_schedule(self.execution_date)
 
+        dag_run_conf = dag_run and dag_run.conf or {}  # type: dict
+
         next_ds = None
         next_ds_nodash = None
         if next_execution_date:
@@ -1231,6 +1233,7 @@ class TaskInstance(Base, LoggingMixin):
             'ti': self,
             'task_instance_key_str': ti_key_str,
             'conf': configuration,
+            'dag_run_conf': dag_run_conf,
             'test_mode': self.test_mode,
             'var': {
                 'value': VariableAccessor(),

--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -75,6 +75,7 @@ Variable                                Description
                                         ``airflow.cfg``
 ``{{ run_id }}``                        the ``run_id`` of the current DAG run
 ``{{ dag_run }}``                       a reference to the DagRun object
+``{{ dag_run_conf }}``                  conf associated with DagRun (dict). if no dag run or no conf, empty dict.
 ``{{ test_mode }}``                     whether the task instance was called using
                                         the CLI's test subcommand
 =====================================   ====================================


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
