### PR TITLE
[AIRFLOW-4490] DagRun.conf should return empty dictionary by default

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -54,7 +54,7 @@ class DagRun(Base, LoggingMixin):
     _state = Column('state', String(50), default=State.RUNNING)
     run_id = Column(String(ID_LEN))
     external_trigger = Column(Boolean, default=True)
-    conf = Column(PickleType)
+    _conf = Column('conf', PickleType)
 
     dag = None
 
@@ -97,6 +97,16 @@ class DagRun(Base, LoggingMixin):
     def state(self):
         return synonym('_state',
                        descriptor=property(self.get_state, self.set_state))
+
+    def _get_conf(self):
+        return self._conf or {}
+
+    def _set_conf(self, conf: dict):
+        self._conf = conf
+
+    @declared_attr
+    def conf(self):
+        return synonym('_conf', descriptor=property(self._get_conf, self._set_conf))
 
     @classmethod
     def id_for_date(cls, date, prefix=ID_FORMAT_PREFIX):


### PR DESCRIPTION
Currently, we can access dag_run.conf in templates like so:
```
 "{{ dag_run.conf.get('abc', 'def_val') }}"
```

But if no conf is passed to the dag run, the above jinja template will fail upon rendering, because `conf` will be `None`.

So currently, to be safe, you have to do this:
```
 "{{ dag_run.conf and dag_run.conf.get('abc', 'def_val') }}"
```

This PR changes DagRun model so that it returns an empty dictionary when there is no conf.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
