### PR TITLE
[AIRFLOW-4750] Log identified zombie task instances

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -1268,7 +1268,10 @@ class DagFileProcessorManager(LoggingMixin):
             )
             self._last_zombie_query_time = timezone.utcnow()
             for ti in tis:
-                zombies.append(SimpleTaskInstance(ti))
+                sti = SimpleTaskInstance(ti)
+                self.log.info("Detected zombie job with dag_id %s, task_id %s, and execution date %s",
+                              sti.dag_id, sti.task_id, sti.execution_date.isoformat())
+                zombies.append(sti)
 
         return zombies
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - [AIRFLOW-4750](https://issues.apache.org/jira/browse/AIRFLOW-4750)

### Description

While troubleshooting task instances that were unexpectedly killed I found it helpful to confirm whether the task was identified as a zombie by printing to log.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - No unit test appears to be productive for printing to log.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
