### PR TITLE
[AIRFLOW-4364] Allow module names to begin with 0-9 and max 60 chars

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -468,9 +468,11 @@ method-naming-style=snake_case
 # Naming style matching correct module names.
 module-naming-style=snake_case
 
-# Regular expression matching correct module names. Overrides module-naming-
-# style.
-#module-rgx=
+# Regular expression matching correct module names. Overrides module-naming-style.
+# Default regex changes:
+# - allow modules beginning with 0-9 (used in airflow/migrations)
+# - allow up to 60 chars (airflow/migrations contains quite long names)
+module-rgx=[a-z0-9_][a-z0-9_]{2,59}$
 
 # Colon-delimited sets of names that determine each other's naming style when
 # the name regexes allow several styles.


### PR DESCRIPTION
As a result of https://github.com/apache/airflow/pull/5383, it appears it's needed to loosen the restrictions on the module names. This PR allows module names to start with 0-9 and have up to 60 characters.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
