### PR TITLE
[AIRFLOW-4756] fix gantt view error after clearing failed task

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1725,7 +1725,7 @@ class Airflow(AirflowBaseView):
 
         tis = [
             ti for ti in dag.get_task_instances(dttm, dttm)
-            if ti.start_date]
+            if ti.start_date and ti.state]
         tis = sorted(tis, key=lambda ti: ti.start_date)
         TF = TaskFail
         ti_fails = list(itertools.chain(*[(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

Resolves [AIRFLOW-4756](https://issues.apache.org/jira/browse/AIRFLOW-4756).

Previously, if you have a long-running dag run, and a task fails, and you clear it, then until the cleared task starts running again, viewing gantt chart will throw a json encode error.

It appears this is because current gantt view logic uses ti.start_date to select tis for inclusion in gantt chart.  And when you clear a TI, it only nulls out the state -- not the start_date -- so these cleared TIs would still be added to `tis` even though they have been cleared and thus have no state. And for whatever reason, json conversion does not like None type for state. 

This solution just adds a check to ensure state is not None for TI inclusion in gantt.

Relevant error bit is here:
```  File "/Users/dstandish/.virtualenvs/scratch/lib/python3.7/site-packages/airflow/www/templates/airflow/gantt.html", line 58, in block "tail"
    data = {{ data |tojson|safe }};
  File "/Users/dstandish/.virtualenvs/scratch/lib/python3.7/site-packages/flask/json/__init__.py", line 327, in tojson_filter
    return Markup(htmlsafe_dumps(obj, **kwargs))
  File "/Users/dstandish/.virtualenvs/scratch/lib/python3.7/site-packages/flask/json/__init__.py", line 242, in htmlsafe_dumps
    rv = dumps(obj, **kwargs) \
  File "/Users/dstandish/.virtualenvs/scratch/lib/python3.7/site-packages/flask/json/__init__.py", line 179, in dumps
    rv = _json.dumps(obj, **kwargs)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: 

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
