### PR TITLE
Dataproc autoscaling

### DIFF
--- a/airflow/contrib/example_dags/example_gcp_dataproc_create_cluster.py
+++ b/airflow/contrib/example_dags/example_gcp_dataproc_create_cluster.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import airflow
+from airflow import models
+from airflow.contrib.operators.dataproc_operator import DataprocClusterCreateOperator
+
+default_args = {"start_date": airflow.utils.dates.days_ago(1)}
+
+cluster_name = "testcluster-800"
+project_id = ""
+region = ""
+zone = ""
+
+# When using autoscaling the number of primary workers
+# must be within autoscaler min/max range
+num_workers = 2
+
+# Autoscaling policy
+# The policy must be in the same project and Cloud Dataproc region
+# but the zone doesn't have to be the same
+scaling_policy = 'test-policy'
+policy_uri = 'projects/{p}/locations/{r}/autoscalingPolicies/{id}'.format(
+    p=project_id,
+    r=region,
+    id=scaling_policy
+)
+
+with models.DAG(
+    "example_dataproc_create_cluster",
+    default_args=default_args,
+    schedule_interval=None,
+) as dag:
+    create_task = DataprocClusterCreateOperator(
+        task_id="run_example_cluster_script",
+        cluster_name=cluster_name,
+        project_id=project_id,
+        num_workers=num_workers,
+        region=region,
+        zone=zone,
+        autoscaling_policy=policy_uri
+    )

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -723,7 +723,7 @@ class DataProcPigOperator(DataProcJobBaseOperator):
             self.job_template.add_query(self.query)
         self.job_template.add_variables(self.variables)
 
-        self.execute(context)
+        super().execute(context)
 
 
 class DataProcHiveOperator(DataProcJobBaseOperator):

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -99,6 +99,10 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
     :param custom_image: custom Dataproc image for more info see
         https://cloud.google.com/dataproc/docs/guides/dataproc-images
     :type custom_image: str
+    :param autoscaling_policy: The autoscaling policy used by the cluster. Only resource names
+        including projectid and location (region) are valid. Example:
+        projects/[projectId]/locations/[dataproc_region]/autoscalingPolicies/[policy_id]
+    :type autoscaling_policy: str
     :param properties: dict of properties to set on
         config files (e.g. spark-defaults.conf), see
         https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#SoftwareConfig
@@ -184,6 +188,7 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
                  metadata=None,
                  custom_image=None,
                  image_version=None,
+                 autoscaling_policy=None,
                  properties=None,
                  master_machine_type='n1-standard-4',
                  master_disk_type='pd-standard',
@@ -217,6 +222,7 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
         self.master_machine_type = master_machine_type
         self.master_disk_type = master_disk_type
         self.master_disk_size = master_disk_size
+        self.autoscaling_policy = autoscaling_policy
         self.worker_machine_type = worker_machine_type
         self.worker_disk_type = worker_disk_type
         self.worker_disk_size = worker_disk_size
@@ -293,7 +299,8 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
                 'secondaryWorkerConfig': {},
                 'softwareConfig': {},
                 'lifecycleConfig': {},
-                'encryptionConfig': {}
+                'encryptionConfig': {},
+                'autoscalingConfig': {},
             }
         }
         if self.num_preemptible_workers > 0:
@@ -377,6 +384,9 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
         if self.customer_managed_key:
             cluster_data['config']['encryptionConfig'] =\
                 {'gcePdKmsKeyName': self.customer_managed_key}
+        if self.autoscaling_policy:
+            cluster_data['config']['autoscalingConfig'] = {'policyUri': self.autoscaling_policy}
+
         return cluster_data
 
     def start(self):

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -31,6 +31,7 @@ from airflow.contrib.operators.dataproc_operator import \
     DataprocClusterDeleteOperator, \
     DataProcHadoopOperator, \
     DataProcHiveOperator, \
+    DataProcPigOperator, \
     DataProcPySparkOperator, \
     DataProcSparkOperator, \
     DataprocWorkflowTemplateInstantiateInlineOperator, \
@@ -610,6 +611,32 @@ class DataProcHiveOperatorTest(unittest.TestCase):
         with patch(HOOK) as mock_hook:
             dataproc_task = DataProcHiveOperator(
                 task_id=TASK_ID
+            )
+
+            _assert_dataproc_job_id(mock_hook, dataproc_task)
+
+
+class DataProcPigOperatorTest(unittest.TestCase):
+    @staticmethod
+    def test_hook_correct_region():
+        with patch(HOOK) as mock_hook:
+            dataproc_task = DataProcPigOperator(
+                task_id=TASK_ID,
+                cluster_name=CLUSTER_NAME,
+                region=GCP_REGION
+            )
+
+            dataproc_task.execute(None)
+        mock_hook.return_value.submit.assert_called_once_with(mock.ANY, mock.ANY,
+                                                              GCP_REGION, mock.ANY)
+
+    @staticmethod
+    def test_dataproc_job_id_is_set():
+        with patch(HOOK) as mock_hook:
+            dataproc_task = DataProcPigOperator(
+                task_id=TASK_ID,
+                cluster_name=CLUSTER_NAME,
+                region=GCP_REGION
             )
 
             _assert_dataproc_job_id(mock_hook, dataproc_task)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
