### PR TITLE
[AIRFLOW-4760] Fix package DAGs disappearing from DagBag when reloaded

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1439,6 +1439,9 @@ class DagModel(Base):
     # Foreign key to the latest pickle_id
     pickle_id = Column(Integer)
     # The location of the file containing the DAG object
+    # Note: Do not depend on fileloc pointing to a file; in the case of a
+    # packaged DAG, it will point to the subpath of the DAG within the
+    # associated zip.
     fileloc = Column(String(2000))
     # String representing the owners
     owners = Column(String(2000))

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -130,7 +130,7 @@ class DagBag(BaseDagBag, LoggingMixin):
         ):
             # Reprocess source file
             found_dags = self.process_file(
-                filepath=orm_dag.fileloc, only_if_updated=False)
+                filepath=correct_maybe_zipped(orm_dag.fileloc), only_if_updated=False)
 
             # If the source file no longer exports `dag_id`, delete it from self.dags
             if found_dags and dag_id in [found_dag.dag_id for found_dag in found_dags]:
@@ -355,7 +355,6 @@ class DagBag(BaseDagBag, LoggingMixin):
         """
         start_dttm = timezone.utcnow()
         dag_folder = dag_folder or self.dag_folder
-
         # Used to store stats around DagBag processing
         stats = []
         FileLoadStat = namedtuple(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4760

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

[AIRFLOW-2900](https://github.com/apache/airflow/pull/3749) introduced a change that broke Airflow whenever it tries to reprocess a packaged DAG. Since that change, the `fileloc` column in the database for packaged DAGs isn't an actual filepath. It looks something like: `/usr/local/airflow/dags/package.zip/my_dag.py` -- **notice that the path to the DAG inside the zip is appended to the zip file's path**. Then, when the `DagBag#process_file` method tries to load that filepath, it bails because that filepath is invalid.

This PR fixes that behavior by updating the `DagBag#get_dag` method such that when it fetches the DAG from the database and proceeds to reprocess the file, instead of using the `orm_dag.fileloc` property directly, we reuse the `correct_maybe_zipped` helper function to ensure that the passed value is an actual filepath.

#### Before

![2019-06-07-ghosting-before](https://user-images.githubusercontent.com/357481/59211651-546bc580-8b7e-11e9-9a6a-fa7ee56e65de.gif)

#### After

![2019-06-07-ghosting-after](https://user-images.githubusercontent.com/357481/59211737-9f85d880-8b7e-11e9-877a-98c1f729d186.gif)

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

  - add a sanity check test to ensure that the `fileloc` property does not change for packaged DAGs
  - add a test to verify that packaged DAGs can be refreshed
  - add a test that plain `.py` DAGs can also be refreshed (seems silly to have test coverage for only packaged DAGs 😄)

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
