### PR TITLE
[AIRFLOW-4741] Include Sentry into core Airflow

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -359,6 +359,10 @@ smtp_ssl = False
 smtp_port = 25
 smtp_mail_from = airflow@example.com
 
+[sentry]
+# Sentry (https://docs.sentry.io) integration
+sentry_dsn = 
+
 
 [celery]
 # This section only applies if you are using the CeleryExecutor in

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -791,7 +791,17 @@ class DAG(BaseDag, LoggingMixin):
             TaskInstance.task_id.in_([t.task_id for t in self.tasks]),
         )
         if state:
-            tis = tis.filter(TaskInstance.state == state)
+            if isinstance(state, str):
+                tis = tis.filter(TaskInstance.state == state)
+            else:
+                # this is required to deal with NULL values
+                if None in state:
+                    tis = tis.filter(
+                        or_(TaskInstance.state.in_(state),
+                            TaskInstance.state.is_(None))
+                    )
+                else:
+                    tis = tis.filter(TaskInstance.state.in_(state))
         tis = tis.order_by(TaskInstance.execution_date).all()
         return tis
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -48,6 +48,7 @@ from airflow.models.taskfail import TaskFail
 from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.variable import Variable
 from airflow.models.xcom import XCOM_RETURN_KEY, XCom
+from airflow.sentry import Sentry
 from airflow.stats import Stats
 from airflow.ti_deps.dep_context import DepContext, REQUEUEABLE_DEPS, RUNNING_DEPS
 from airflow.utils import timezone
@@ -855,6 +856,7 @@ class TaskInstance(Base, LoggingMixin):
         return True
 
     @provide_session
+    @Sentry.format_run_task
     def _run_raw_task(
             self,
             mark_success=False,

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -856,7 +856,7 @@ class TaskInstance(Base, LoggingMixin):
         return True
 
     @provide_session
-    @Sentry.format_run_task
+    @Sentry.enrich_errors
     def _run_raw_task(
             self,
             mark_success=False,

--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Sentry Integration"""
+
+
+from typing import Any
+from functools import wraps
+from sqlalchemy import or_
+
+from airflow import configuration as conf
+from airflow.utils.db import provide_session
+from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.state import State
+
+
+log = LoggingMixin().log
+
+
+class DummySentry:
+    """
+    Blank class for Sentry.
+    """
+
+    @classmethod
+    def add_tagging(cls, task_instance):
+        """
+        Blank function for tagging.
+        """
+
+    @classmethod
+    def add_breadcrumbs(cls, session=None):
+        """
+        Blank function for breadcrumbs.
+        """
+
+    @classmethod
+    def format_run_task(cls, run):
+        """
+        Blank function for formatting a TaskInstance._run_raw_task.
+        """
+        return run
+
+
+@provide_session
+def get_task_instances(dag_id, task_ids, execution_date, session=None):
+    """
+    Retrieves task instance based on dag_id and execution_date.
+    """
+    from airflow.models.taskinstance import TaskInstance  # Avoid circular import
+
+    if session is None or not task_ids:
+        return []
+
+    TI = TaskInstance
+    return (
+        session.query(TI)
+        .filter(
+            TI.dag_id == dag_id,
+            TI.task_id.in_(task_ids),
+            TI.execution_date == execution_date,
+            or_(TI.state == State.SUCCESS, TI.state == State.FAILED),
+        )
+        .all()
+    )
+
+
+class ConfiguredSentry:
+    """
+    Configure Sentry SDK.
+    """
+
+    SCOPE_TAGS = frozenset(("task_id", "dag_id", "execution_date", "operator"))
+    SCOPE_CRUMBS = frozenset(
+        ("dag_id", "task_id", "execution_date", "state", "operator", "duration")
+    )
+
+    def __init__(self):
+        """
+        Initialize the Sentry SDK.
+        """
+        ignore_logger("airflow.task")
+        ignore_logger("airflow.jobs.backfill_job.BackfillJob")
+        executor_name = conf.get("core", "EXECUTOR")
+
+        sentry_flask = FlaskIntegration()
+
+        # LoggingIntegration is set by default.
+        integrations = [sentry_flask]
+
+        if executor_name == "CeleryExecutor":
+            from sentry_sdk.integrations.celery import CeleryIntegration
+            from sentry_sdk.integrations.tornado import TornadoIntegration
+
+            sentry_celery = CeleryIntegration()
+            sentry_tornado = TornadoIntegration()
+            integrations += [sentry_celery, sentry_tornado]
+
+        dsn = conf.get("sentry", "sentry_dsn")
+        if dsn:
+            init(dsn=dsn, integrations=integrations)
+        else:
+            # Setting up Sentry using environment variables.
+            log.debug("Defaulting to SENTRY_DSN in environment.")
+            init(integrations=integrations)
+
+    def add_tagging(self, task_instance):
+        """
+        Function to add tagging for a task_instance.
+        """
+        task = task_instance.task
+
+        with configure_scope() as scope:
+            for tag_name in self.SCOPE_TAGS:
+                attribute = getattr(task_instance, tag_name)
+                if tag_name == "operator":
+                    attribute = task.__class__.__name__
+                scope.set_tag(tag_name, attribute)
+
+    @provide_session
+    def add_breadcrumbs(self, task_instance, session=None):
+        """
+        Function to add breadcrumbs inside of a task_instance.
+        """
+        if session is None:
+            return
+        dag_id = task_instance.dag_id
+        execution_date = task_instance.execution_date
+        task = task_instance.task
+        dag = task.dag
+        task_ids = dag.task_ids
+        task_instances = get_task_instances(
+            dag_id, task_ids, execution_date, session=session
+        )
+
+        for ti in task_instances:
+            data = {}
+            for crumb_tag in self.SCOPE_CRUMBS:
+                data[crumb_tag] = getattr(ti, crumb_tag)
+
+            add_breadcrumb(category="completed_tasks", data=data, level="info")
+
+    def format_run_task(self, func):
+        """
+        Function for formatting TaskInstance._run_raw_task.
+        """
+
+        @wraps(func)
+        def wrapper(task_instance, *args, session=None, **kwargs):
+            # Wrapping the _run_raw_task function with push_scope to contain
+            # tags and breadcrumbs to a specific Task Instance
+            with push_scope():
+                self.add_tagging(task_instance)
+                self.add_breadcrumbs(task_instance, session=session)
+                try:
+                    func(task_instance, *args, session=session, **kwargs)
+                except Exception as e:
+                    capture_exception(e)
+                    raise e
+
+        return wrapper
+
+
+Sentry = DummySentry  # type: Any
+
+try:
+    from sentry_sdk.integrations.logging import ignore_logger
+    from sentry_sdk.integrations.flask import FlaskIntegration
+    from sentry_sdk import (
+        push_scope,
+        configure_scope,
+        add_breadcrumb,
+        init,
+        capture_exception,
+    )
+
+    Sentry = ConfiguredSentry()
+
+except ImportError as e:
+    log.debug("Could not configure Sentry: %s, using DummySentry instead.", e)

--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -23,7 +23,7 @@
 from typing import Any
 from functools import wraps
 
-from airflow import configuration as conf
+from airflow.configuration import conf
 from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
@@ -55,6 +55,7 @@ class DummySentry:
         Blank function for formatting a TaskInstance._run_raw_task.
         """
         return run
+
 
 class ConfiguredSentry:
     """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,6 +195,7 @@ exclude_patterns = [
     '_api/airflow/plugins_manager',
     '_api/airflow/security',
     '_api/airflow/settings',
+    '_api/airflow/sentry',
     '_api/airflow/stats',
     '_api/airflow/task',
     '_api/airflow/kubernetes',

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -1,0 +1,62 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Error Tracking
+===============
+
+Airflow can be set up to send errors to `Sentry <https://docs.sentry.io/>`__.
+
+Setup
+------
+
+First you must install sentry requirement:
+
+.. code-block:: bash
+
+   pip install 'apache-airflow[sentry]'
+
+Add your ``SENTRY_DSN`` to your configuration file e.g. ``airflow.cfg`` under ``[sentry]``. Its template resembles the following: ``'{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PROJECT_ID}'``
+
+.. note::
+    If this value is not provided, the SDK will try to read it from the ``SENTRY_DSN`` environment variable.
+
+Tags
+-----
+
+=================================== ================================================================
+Name                                Description
+=================================== ================================================================
+dag_id                              Dag name of the dag that failed
+task_id                             Task name of the task that failed
+execution_date                      Execution date when the task failed
+operator                            Operator name of the task that failed
+=================================== ================================================================
+
+Breadcrumbs
+------------
+
+=================================== ====================================================================================================
+Name                                Description
+=================================== ====================================================================================================
+upstream_tasks[dag_id]              Dag ID of task that executed before failed task
+upstream_tasks[task_id]             Task ID of task that executed before failed task
+upstream_tasks[execution_date]      Execution date of task instance that executed before failed task
+upstream_tasks[state]               Final state of task that executed before failed task (only Success and Failed states are captured)
+upstream_tasks[operator]            Task operator of task that executed before failed task
+upstream_tasks[duration]            Duration in seconds of task that executed before failed task
+=================================== ====================================================================================================
+

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -31,7 +31,7 @@ First you must install sentry requirement:
 
 Add your ``SENTRY_DSN`` to your configuration file e.g. ``airflow.cfg`` under ``[sentry]``. Its template resembles the following: ``'{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PROJECT_ID}'``
 
-.. code-block:: python
+.. code-block:: ini
 
     [sentry]
     sentry_dsn = http://foo@sentry.io/123
@@ -54,11 +54,14 @@ operator                            Operator name of the task that failed
 Breadcrumbs
 ------------
 
+
+When a task fails with an error `breadcrumbs <https://docs.sentry.io/enriching-error-data/breadcrumbs/?platform=python>`__ will be added for the other tasks in the current dag run.
+
 =================================== ==============================================================
 Name                                Description
 =================================== ==============================================================
-upstream_tasks[task_id]             Task ID of task that executed before failed task
-upstream_tasks[state]               Final state of task that executed before failed task (only Success and Failed states are captured)
-upstream_tasks[operator]            Task operator of task that executed before failed task
-upstream_tasks[duration]            Duration in seconds of task that executed before failed task
+completed_tasks[task_id]             Task ID of task that executed before failed task
+completed_tasks[state]               Final state of task that executed before failed task (only Success and Failed states are captured)
+completed_tasks[operator]            Task operator of task that executed before failed task
+completed_tasks[duration]            Duration in seconds of task that executed before failed task
 =================================== ==============================================================

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -42,29 +42,23 @@ Add your ``SENTRY_DSN`` to your configuration file e.g. ``airflow.cfg`` under ``
 Tags
 -----
 
-=================================== ================================================================
+=================================== ==================================================
 Name                                Description
-=================================== ================================================================
+=================================== ==================================================
 dag_id                              Dag name of the dag that failed
 task_id                             Task name of the task that failed
 execution_date                      Execution date when the task failed
 operator                            Operator name of the task that failed
-=================================== ================================================================
+=================================== ==================================================
 
 Breadcrumbs
 ------------
 
-=================================== ====================================================================================================
+=================================== ==============================================================
 Name                                Description
-=================================== ====================================================================================================
-upstream_tasks[dag_id]              Dag ID of task that executed before failed task
+=================================== ==============================================================
 upstream_tasks[task_id]             Task ID of task that executed before failed task
-upstream_tasks[execution_date]      Execution date of task instance that executed before failed task
 upstream_tasks[state]               Final state of task that executed before failed task (only Success and Failed states are captured)
 upstream_tasks[operator]            Task operator of task that executed before failed task
 upstream_tasks[duration]            Duration in seconds of task that executed before failed task
-=================================== ====================================================================================================
-<<<<<<< HEAD
-=======
-
->>>>>>> ecc80b4da129d60f612acaae53fd69d55839726b
+=================================== ==============================================================

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -31,6 +31,11 @@ First you must install sentry requirement:
 
 Add your ``SENTRY_DSN`` to your configuration file e.g. ``airflow.cfg`` under ``[sentry]``. Its template resembles the following: ``'{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PROJECT_ID}'``
 
+.. code-block:: python
+
+    [sentry]
+    sentry_dsn = http://foo@sentry.io/123
+
 .. note::
     If this value is not provided, the SDK will try to read it from the ``SENTRY_DSN`` environment variable.
 

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -1,4 +1,4 @@
-..  Licensed to the Apache Software Foundation (ASF) under one
+ .. Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
     regarding copyright ownership.  The ASF licenses this file
@@ -6,9 +6,9 @@
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
 
-..    http://www.apache.org/licenses/LICENSE-2.0
+ ..   http://www.apache.org/licenses/LICENSE-2.0
 
-..  Unless required by applicable law or agreed to in writing,
+ .. Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
     KIND, either express or implied.  See the License for the
@@ -59,4 +59,7 @@ upstream_tasks[state]               Final state of task that executed before fai
 upstream_tasks[operator]            Task operator of task that executed before failed task
 upstream_tasks[duration]            Duration in seconds of task that executed before failed task
 =================================== ====================================================================================================
+<<<<<<< HEAD
+=======
 
+>>>>>>> ecc80b4da129d60f612acaae53fd69d55839726b

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,6 +90,7 @@ Content
     Using the CLI <usage-cli>
     integration
     metrics
+    errors
     kubernetes
     lineage
     changelog

--- a/setup.py
+++ b/setup.py
@@ -253,6 +253,7 @@ salesforce = ['simple-salesforce>=0.72']
 samba = ['pysmbclient>=0.1.3']
 segment = ['analytics-python>=1.2.9']
 sendgrid = ['sendgrid>=5.2.0,<6']
+sentry = ['sentry-sdk>=0.8.0', "blinker>=1.1"]
 slack = ['slackclient>=1.0.0,<2.0.0']
 mongo = ['pymongo>=3.6.0', 'dnspython>=1.13.0,<2.0.0']
 snowflake = ['snowflake-connector-python>=1.5.2',
@@ -315,7 +316,7 @@ devel_hadoop = devel_minreq + hive + hdfs + webhdfs + kerberos
 devel_all = (sendgrid + devel + all_dbs + doc + samba + slack + crypto + oracle +
              docker + ssh + kubernetes + celery + redis + gcp + grpc +
              datadog + zendesk + jdbc + ldap + kerberos + password + webhdfs + jenkins +
-             druid + pinot + segment + snowflake + elasticsearch +
+             druid + pinot + segment + snowflake + elasticsearch + sentry +
              atlas + azure + aws + salesforce + cgroups + papermill + virtualenv)
 
 # Snakebite & Google Cloud Dataflow are not Python 3 compatible :'(
@@ -445,6 +446,7 @@ def do_setup():
             'salesforce': salesforce,
             'samba': samba,
             'sendgrid': sendgrid,
+            'sentry': sentry,
             'segment': segment,
             'slack': slack,
             'snowflake': snowflake,

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import datetime
+import unittest
+from unittest.mock import Mock, MagicMock
+from freezegun import freeze_time
+
+from sentry_sdk import configure_scope
+
+from airflow.models import TaskInstance
+from airflow.settings import Session
+from airflow.sentry import ConfiguredSentry, get_task_instances
+from airflow.utils import timezone
+from airflow.utils.state import State
+
+
+EXECUTION_DATE = timezone.utcnow()
+DAG_ID = "test_dag"
+TASK_ID = "test_task"
+OPERATOR = "test_operator"
+STATE = State.SUCCESS
+DURATION = None
+TEST_SCOPE = {
+    "dag_id": DAG_ID,
+    "task_id": TASK_ID,
+    "execution_date": EXECUTION_DATE,
+    "operator": OPERATOR,
+}
+TASK_DATA = TEST_SCOPE.copy()
+TASK_DATA.update({"state": STATE, "operator": OPERATOR, "duration": DURATION})
+
+CRUMB_DATE = datetime.datetime(2019, 5, 15)
+CRUMB = {
+    "timestamp": CRUMB_DATE,
+    "type": "default",
+    "category": "completed_tasks",
+    "data": TASK_DATA,
+    "level": "info",
+}
+
+
+class MockQuery:
+    """
+    Mock Query for when session is called.
+    """
+
+    def __init__(self, task_instance):
+        task_instance.state = STATE
+        self.arr = [task_instance]
+
+    def first(self):
+        return self.arr[0]
+
+    def delete(self):
+        pass
+
+    def all(self):
+        return self.arr
+
+
+class TestSentryHook(unittest.TestCase):
+    def setUp(self):
+
+        self.sentry = ConfiguredSentry()
+        self.dag = Mock(dag_id=DAG_ID, params=[])
+        self.dag.task_ids = [TASK_ID]
+        self.task = Mock(dag=self.dag, dag_id=DAG_ID, task_id=TASK_ID, params=[])
+        self.task.__class__.__name__ = OPERATOR
+        self.task.get_flat_relatives = MagicMock(return_value=[self.task])
+
+        self.session = Session()
+        self.ti = TaskInstance(self.task, execution_date=EXECUTION_DATE)
+        self.ti.operator = OPERATOR
+
+        mock_query = MockQuery(self.ti)
+        mock_query.filter = MagicMock(return_value=mock_query)
+        mock_query.filter_by = MagicMock(return_value=mock_query)
+        self.session.query = MagicMock(return_value=mock_query)
+
+    def test_add_tagging(self):
+        """
+        Test adding tags.
+        """
+        self.sentry.add_tagging(task_instance=self.ti)
+        with configure_scope() as scope:
+            for key, value in scope._tags.items():
+                self.assertEqual(TEST_SCOPE[key], value)
+
+    def test_get_task_instance(self):
+        """
+        Test adding tags.
+        """
+        ti = get_task_instances(DAG_ID, [TASK_ID], EXECUTION_DATE, self.session)
+        self.assertEqual(ti[0], self.ti)
+
+    @freeze_time(CRUMB_DATE.isoformat())
+    def test_add_breadcrumbs(self):
+        """
+        Test adding breadcrumbs.
+        """
+        self.sentry.add_tagging(task_instance=self.ti)
+        self.sentry.add_breadcrumbs(task_instance=self.ti, session=self.session)
+
+        with configure_scope() as scope:
+            test_crumb = scope._breadcrumbs.pop()
+            self.assertEqual(CRUMB, test_crumb)

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -26,7 +26,7 @@ from sentry_sdk import configure_scope
 
 from airflow.models import TaskInstance
 from airflow.settings import Session
-from airflow.sentry import ConfiguredSentry, get_task_instances
+from airflow.sentry import ConfiguredSentry
 from airflow.utils import timezone
 from airflow.utils.state import State
 
@@ -102,13 +102,6 @@ class TestSentryHook(unittest.TestCase):
         with configure_scope() as scope:
             for key, value in scope._tags.items():
                 self.assertEqual(TEST_SCOPE[key], value)
-
-    def test_get_task_instance(self):
-        """
-        Test adding tags.
-        """
-        ti = get_task_instances(DAG_ID, [TASK_ID], EXECUTION_DATE, self.session)
-        self.assertEqual(ti[0], self.ti)
 
     @freeze_time(CRUMB_DATE.isoformat())
     def test_add_breadcrumbs(self):

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -79,15 +79,21 @@ class TestSentryHook(unittest.TestCase):
     def setUp(self):
 
         self.sentry = ConfiguredSentry()
+
+        # Mock the Dag
         self.dag = Mock(dag_id=DAG_ID, params=[])
         self.dag.task_ids = [TASK_ID]
+
+        # Mock the task
         self.task = Mock(dag=self.dag, dag_id=DAG_ID, task_id=TASK_ID, params=[])
         self.task.__class__.__name__ = OPERATOR
-        self.task.get_flat_relatives = MagicMock(return_value=[self.task])
 
-        self.session = Session()
         self.ti = TaskInstance(self.task, execution_date=EXECUTION_DATE)
         self.ti.operator = OPERATOR
+
+        self.dag.get_task_instances = MagicMock(return_value=[self.ti])
+
+        self.session = Session()
 
         mock_query = MockQuery(self.ti)
         mock_query.filter = MagicMock(return_value=mock_query)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title:

https://issues.apache.org/jira/browse/AIRFLOW-4741

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR is to add Sentry SDK functionality to Airflow. The functionality includes adding tags per task event and breadcrumbs of previous tasks that ran on the DAG. 

Differences between #5416 and #5407:
#5416:  PR focuses on adding Sentry functionality to specific DAGs. This is achieved by adding a sentry hook to the contrib folder. Users can then simply call the hook with their `SENTRY_DSN` for each DAG.
#5407: PR focuses on adding Sentry to the Airflow ecosystem. Its aim is to handle all errors within airflow (Scheduler, worker, DAGs, tasks).  (This is the continuation of #5382, which I closed by accident.)

### Tests

- [x] My PR adds unit tests for `sentry.py`.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation under `error.rst`.

### Code Quality

- [x] Passes `flake8`
