### PR TITLE
[AIRFLOW-4790] Change dag processing stats to timers

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -984,7 +984,7 @@ class DagFileProcessorManager(LoggingMixin):
             file_name = os.path.basename(file_path)
             file_name = os.path.splitext(file_name)[0].replace(os.sep, '.')
             if last_runtime:
-                Stats.gauge(
+                Stats.timing(
                     'dag_processing.last_runtime.{}'.format(file_name),
                     last_runtime
                 )
@@ -996,7 +996,7 @@ class DagFileProcessorManager(LoggingMixin):
             last_run = self.get_last_finish_time(file_path)
             if last_run:
                 seconds_ago = (timezone.utcnow() - last_run).total_seconds()
-                Stats.gauge(
+                Stats.timing(
                     'dag_processing.last_run.seconds_ago.{}'.format(file_name),
                     seconds_ago
                 )

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -64,8 +64,6 @@ Name                                            Description
 collect_dags                                    Seconds taken to scan and import DAGs
 dagbag_import_errors                            DAG import errors
 dagbag_size                                     DAG bag size
-dag_processing.last_runtime.<dag_file>          Seconds spent processing <dag_file> (in most recent iteration)
-dag_processing.last_run.seconds_ago.<dag_file>  Seconds since <dag_file> was last processed
 executor.open_slots                             Number of of open slots on executor
 executor.queued_tasks                           Number of queued tasks on executor
 executor.running_tasks                          Number of running tasks on executor
@@ -75,13 +73,15 @@ pool.starving_tasks.<pool_name>                 Number of starving tasks in the 
 Timers
 ------
 
-================================= =================================================
-Name                              Description
-================================= =================================================
-dagrun.dependency-check.<dag_id>  Seconds taken to check DAG dependencies
-dag.<dag_id>.<task_id>.duration   Seconds taken to finish a task
-dagrun.duration.success.<dag_id>  Seconds taken for a DagRun to reach success state
-dagrun.duration.failed.<dag_id>   Seconds taken for a DagRun to reach failed state
-dagrun.schedule_delay.<dag_id>    Seconds of delay between the scheduled DagRun
-                                  start date and the actual DagRun start date
-================================= =================================================
+=============================================== =================================================
+Name                                            Description
+=============================================== =================================================
+dagrun.dependency-check.<dag_id>                Seconds taken to check DAG dependencies
+dag.<dag_id>.<task_id>.duration                 Seconds taken to finish a task
+dagrun.duration.success.<dag_id>                Seconds taken for a DagRun to reach success state
+dagrun.duration.failed.<dag_id>                 Seconds taken for a DagRun to reach failed state
+dagrun.schedule_delay.<dag_id>                  Seconds of delay between the scheduled DagRun
+                                                start date and the actual DagRun start date
+dag_processing.last_runtime.<dag_file>          Seconds spent processing <dag_file> (in most recent iteration)
+dag_processing.last_run.seconds_ago.<dag_file>  Seconds since <dag_file> was last processed
+=============================================== =================================================


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-4790

### Description

- [x] the stasd metrics for dag processing should be changed from gauges to timers

### Tests

- [x] scheduler job already has unit test

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - updated metrics docs

### Code Quality

- [x] Passes `flake8`
