### PR TITLE
AIRFLOW-4791 add "schema" keyword arg to SnowflakeOperator

### DIFF
--- a/airflow/contrib/hooks/snowflake_hook.py
+++ b/airflow/contrib/hooks/snowflake_hook.py
@@ -39,6 +39,8 @@ class SnowflakeHook(DbApiHook):
         self.account = kwargs.pop("account", None)
         self.warehouse = kwargs.pop("warehouse", None)
         self.database = kwargs.pop("database", None)
+        self.role = kwargs.pop("role", None)
+        self.schema=kwargs.pop("schema", None)
 
     def _get_conn_params(self):
         """
@@ -49,14 +51,18 @@ class SnowflakeHook(DbApiHook):
         account = conn.extra_dejson.get('account', None)
         warehouse = conn.extra_dejson.get('warehouse', None)
         database = conn.extra_dejson.get('database', None)
+        role = conn.extra_dejson.get('role', None)
+        schema = conn.extra_dejson.get('schema',None)
 
         conn_config = {
             "user": conn.login,
             "password": conn.password or '',
-            "schema": conn.schema or '',
+            "schema": conn.schema or schema or '',
             "database": self.database or database or '',
             "account": self.account or account or '',
-            "warehouse": self.warehouse or warehouse or ''
+            "warehouse": self.warehouse or warehouse or '',
+            "role": self.role or role or ''
+
         }
         return conn_config
 
@@ -66,7 +72,7 @@ class SnowflakeHook(DbApiHook):
         """
         conn_config = self._get_conn_params()
         uri = 'snowflake://{user}:{password}@{account}/{database}/'
-        uri += '{schema}?warehouse={warehouse}'
+        uri += '?schema={schema}&warehouse={warehouse}&role={role}'
         return uri.format(
             **conn_config)
 

--- a/airflow/contrib/hooks/snowflake_hook.py
+++ b/airflow/contrib/hooks/snowflake_hook.py
@@ -43,7 +43,7 @@ class SnowflakeHook(DbApiHook):
         self.database = kwargs.pop("database", None)
         self.region = kwargs.pop("region", None)
         self.role = kwargs.pop("role", None)
-        self.schema=kwargs.pop("schema", None)
+        self.schema = kwargs.pop("schema", None)
 
     def _get_conn_params(self):
         """

--- a/airflow/contrib/operators/snowflake_operator.py
+++ b/airflow/contrib/operators/snowflake_operator.py
@@ -26,16 +26,16 @@ class SnowflakeOperator(BaseOperator):
     Executes sql code in a Snowflake database
 
     :param snowflake_conn_id: reference to specific snowflake connection id
-    :type snowflake_conn_id: str
+    :type snowflake_conn_id: string
     :param sql: the sql code to be executed. (templated)
     :type sql: Can receive a str representing a sql statement,
         a list of str (sql statements), or reference to a template file.
         Template reference are recognized by str ending in '.sql'
     :param warehouse: name of warehouse which overwrite defined
         one in connection
-    :type warehouse: str
+    :type warehouse: string
     :param database: name of database which overwrite defined one in connection
-    :type database: str
+    :type database: string
     """
 
     template_fields = ('sql',)
@@ -45,7 +45,7 @@ class SnowflakeOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self, sql, snowflake_conn_id='snowflake_default', parameters=None,
-            autocommit=True, warehouse=None, database=None, *args, **kwargs):
+            autocommit=True, warehouse=None, database=None, role=None, schema=None, *args, **kwargs):
         super(SnowflakeOperator, self).__init__(*args, **kwargs)
         self.snowflake_conn_id = snowflake_conn_id
         self.sql = sql
@@ -53,10 +53,12 @@ class SnowflakeOperator(BaseOperator):
         self.parameters = parameters
         self.warehouse = warehouse
         self.database = database
+        self.role = role
+        self.schema = schema
 
     def get_hook(self):
         return SnowflakeHook(snowflake_conn_id=self.snowflake_conn_id,
-                             warehouse=self.warehouse, database=self.database)
+                             warehouse=self.warehouse, database=self.database, role=self.role, schema=self.schema)
 
     def execute(self, context):
         self.log.info('Executing: %s', self.sql)

--- a/airflow/contrib/operators/snowflake_operator.py
+++ b/airflow/contrib/operators/snowflake_operator.py
@@ -31,11 +31,17 @@ class SnowflakeOperator(BaseOperator):
     :type sql: Can receive a str representing a sql statement,
         a list of str (sql statements), or reference to a template file.
         Template reference are recognized by str ending in '.sql'
-    :param warehouse: name of warehouse which overwrite defined
-        one in connection
+    :param warehouse: name of warehouse (will overwrite any warehouse
+        defined in the connection's extra JSON)
     :type warehouse: str
-    :param database: name of database which overwrite defined one in connection
+    :param database: name of database (will overwrite database defined
+        in connection)
     :type database: str
+    :param schema: name of schema (will overwrite schema defined in
+        connection)
+    :type schema: str
+    :param role: name of role (will overwrite any role defined in
+        connection's extra JSON)
     """
 
     template_fields = ('sql',)

--- a/airflow/contrib/operators/snowflake_operator.py
+++ b/airflow/contrib/operators/snowflake_operator.py
@@ -45,7 +45,8 @@ class SnowflakeOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self, sql, snowflake_conn_id='snowflake_default', parameters=None,
-            autocommit=True, warehouse=None, database=None, role=None, schema=None, *args, **kwargs):
+            autocommit=True, warehouse=None, database=None, role=None,
+            schema=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.snowflake_conn_id = snowflake_conn_id
         self.sql = sql
@@ -58,7 +59,8 @@ class SnowflakeOperator(BaseOperator):
 
     def get_hook(self):
         return SnowflakeHook(snowflake_conn_id=self.snowflake_conn_id,
-                             warehouse=self.warehouse, database=self.database, role=self.role, schema=self.schema)
+                             warehouse=self.warehouse, database=self.database,
+                             role=self.role, schema=self.schema)
 
     def execute(self, context):
         self.log.info('Executing: %s', self.sql)


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4791) issues and references them in the PR title.
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
adds `schema` as keyword argument to `airflow.contrib.operators.snowflake_operator.SnowflakeOperator`

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
existing tests cover this

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.

### Code Quality

- [x] Passes `flake8`
