### PR TITLE
AIRFLOW-4793 Add signature_name to mlengine operator

### DIFF
--- a/airflow/contrib/operators/mlengine_operator.py
+++ b/airflow/contrib/operators/mlengine_operator.py
@@ -178,6 +178,7 @@ class MLEngineBatchPredictionOperator(BaseOperator):
                  uri=None,
                  max_worker_count=None,
                  runtime_version=None,
+                 signature_name=None,
                  gcp_conn_id='google_cloud_default',
                  delegate_to=None,
                  *args,
@@ -195,6 +196,7 @@ class MLEngineBatchPredictionOperator(BaseOperator):
         self._uri = uri
         self._max_worker_count = max_worker_count
         self._runtime_version = runtime_version
+        self._signature_name = signature_name
         self._gcp_conn_id = gcp_conn_id
         self._delegate_to = delegate_to
 
@@ -251,6 +253,10 @@ class MLEngineBatchPredictionOperator(BaseOperator):
         if self._runtime_version:
             prediction_request['predictionInput'][
                 'runtimeVersion'] = self._runtime_version
+
+        if self._signature_name:
+            prediction_request['predictionInput'][
+                'signatureName'] = self._signature_name
 
         hook = MLEngineHook(self._gcp_conn_id, self._delegate_to)
 

--- a/airflow/contrib/operators/mlengine_operator.py
+++ b/airflow/contrib/operators/mlengine_operator.py
@@ -141,6 +141,10 @@ class MLEngineBatchPredictionOperator(BaseOperator):
         for batch prediction.
     :type runtime_version: str
 
+    :param signature_name: The name of the signature defined in the SavedModel
+        to use for this job.
+    :type signature_name: str
+
     :param gcp_conn_id: The connection ID used for connection to Google
         Cloud Platform.
     :type gcp_conn_id: str


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-4793) issues and references them in the PR title. 

### Description

- [X] Adds an allowed, optional parameter to the ml_engine operator, `signature_name`.  API documentation is here: https://cloud.google.com/ml-engine/reference/rest/v1/projects.jobs#Job
