### PR TITLE
[AIRFLOW-4799] fix flaky tests due to BashOperator self.env mutation

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -90,15 +90,16 @@ class BashOperator(BaseOperator):
         self.log.info('Tmp dir root location: \n %s', gettempdir())
 
         # Prepare env for child process.
-        if self.env is None:
-            self.env = os.environ.copy()
+        env = self.env
+        if env is None:
+            env = os.environ.copy()
 
         airflow_context_vars = context_to_airflow_vars(context, in_env_var_format=True)
         self.log.info('Exporting the following env vars:\n%s',
                       '\n'.join(["{}={}".format(k, v)
                                  for k, v in
                                  airflow_context_vars.items()]))
-        self.env.update(airflow_context_vars)
+        env.update(airflow_context_vars)
 
         self.lineage_data = self.bash_command
 
@@ -122,7 +123,7 @@ class BashOperator(BaseOperator):
                     stdout=PIPE,
                     stderr=STDOUT,
                     cwd=tmp_dir,
-                    env=self.env,
+                    env=env,
                     preexec_fn=pre_exec)
 
                 self.sub_process = sub_process


### PR DESCRIPTION
* in tests using bash operator repeatedly, env is populated with contents of environment.
* on subsequent runs, render_templates will try to render contents of env.
* this produces unpredictable behavior where missing template error may be thrown, or env paths may be replaced with "template file" contents

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses [AIRFLOW-4799] 
  - https://issues.apache.org/jira/browse/AIRFLOW-4799

### Description

Bash operator mutates templated argument `self.env` in the execute.  This results in some flaky test failures if in task instance tests for example where the same TI is executed multiple times (the mutated `self.env` is re-rendered, so it looks at all `.sh` and `.bash` in your os env and tries to render them as templates. 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:  small change

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
