### PR TITLE
[AIRFLOW-4798] obviate interdependencies for dagbag and TI tests 

### DIFF
--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -194,13 +194,14 @@ class DagBagTest(unittest.TestCase):
         Test that fileloc is correctly set when we load example DAGs,
         specifically SubDAGs and packaged DAGs.
         """
-        dagbag = models.DagBag(include_examples=True)
+        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=True)
+        dagbag.process_file(os.path.join(TEST_DAGS_FOLDER, "test_zip.zip"))
 
         expected = {
             'example_bash_operator': 'airflow/example_dags/example_bash_operator.py',
             'example_subdag_operator': 'airflow/example_dags/example_subdag_operator.py',
             'example_subdag_operator.section-1': 'airflow/example_dags/subdags/subdag.py',
-            'test_zip_dag': 'tests/dags/test_zip.zip/test_zip.py'
+            'test_zip_dag': 'dags/test_zip.zip/test_zip.py'
         }
 
         for dag_id, path in expected.items():
@@ -604,7 +605,7 @@ class DagBagTest(unittest.TestCase):
         """
         Test that kill zombies call TIs failure handler with proper context
         """
-        dagbag = models.DagBag()
+        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=True)
         with create_session() as session:
             session.query(TI).delete()
             dag = dagbag.get_dag('example_branch_operator')

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -541,11 +541,20 @@ class TaskInstanceTest(unittest.TestCase):
         run_ti_and_assert(date4, date3, date4, 60, State.SUCCESS, 3, 0)
 
     def test_depends_on_past(self):
-        dagbag = models.DagBag()
-        dag = dagbag.get_dag('test_depends_on_past')
+        dag = DAG(
+            dag_id='test_depends_on_past',
+            start_date=DEFAULT_DATE
+        )
+
+        task = DummyOperator(
+            task_id='test_dop_task',
+            dag=dag,
+            depends_on_past=True,
+        )
         dag.clear()
-        task = dag.tasks[0]
+
         run_date = task.start_date + datetime.timedelta(days=5)
+
         ti = TI(task, run_date)
 
         # depends_on_past prevents the run


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses [AIRFLOW-4798]
  - https://issues.apache.org/jira/browse/AIRFLOW-4798

### Description

Some tests reference a dagbag object created in other test modules.  If you run them independently they may fail.  E.g. task instance retry test references a dagbag object created in scheduler job test.  

This PR copies into each module the few lines of code it takes to make the tests run correctly, independently of other modules.


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
