### PR TITLE
[AIRFLOW-4800] fix GKEClusterHook ctor calls

### DIFF
--- a/airflow/contrib/operators/gcp_container_operator.py
+++ b/airflow/contrib/operators/gcp_container_operator.py
@@ -86,8 +86,8 @@ class GKEClusterDeleteOperator(BaseOperator):
 
     def execute(self, context):
         self._check_input()
-        hook = GKEClusterHook(self.project_id, self.location)
-        delete_result = hook.delete_cluster(name=self.name)
+        hook = GKEClusterHook(gcp_conn_id=self.gcp_conn_id, location=self.location)
+        delete_result = hook.delete_cluster(name=self.name, project_id=self.project_id)
         return delete_result
 
 
@@ -173,8 +173,8 @@ class GKEClusterCreateOperator(BaseOperator):
 
     def execute(self, context):
         self._check_input()
-        hook = GKEClusterHook(self.project_id, self.location)
-        create_op = hook.create_cluster(cluster=self.body)
+        hook = GKEClusterHook(gcp_conn_id=self.gcp_conn_id, location=self.location)
+        create_op = hook.create_cluster(cluster=self.body, project_id=self.project_id)
         return create_op
 
 

--- a/tests/contrib/operators/test_gcp_container_operator.py
+++ b/tests/contrib/operators/test_gcp_container_operator.py
@@ -55,7 +55,7 @@ class GoogleCloudPlatformContainerOperatorTest(unittest.TestCase):
 
         operator.execute(None)
         mock_hook.return_value.create_cluster.assert_called_once_with(
-            cluster=PROJECT_BODY_CREATE)
+            cluster=PROJECT_BODY_CREATE, project_id=TEST_GCP_PROJECT_ID)
 
     @mock.patch('airflow.contrib.operators.gcp_container_operator.GKEClusterHook')
     def test_create_execute_error_body(self, mock_hook):
@@ -97,7 +97,7 @@ class GoogleCloudPlatformContainerOperatorTest(unittest.TestCase):
 
         operator.execute(None)
         mock_hook.return_value.delete_cluster.assert_called_once_with(
-            name=CLUSTER_NAME)
+            name=CLUSTER_NAME, project_id=TEST_GCP_PROJECT_ID)
 
     @mock.patch('airflow.contrib.operators.gcp_container_operator.GKEClusterHook')
     def test_delete_execute_error_project_id(self, mock_hook):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4800

### Description
#4364 changed the arguments to `GKEClusterCreateOperator` but didn't update some call-sites; this fixes those call-sites.

### Tests
Existing tests are updated to expect correct arguments. Not sure if there's a better way to test this.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] Passes `flake8`
