### PR TITLE
[AIRFLOW-4516] K8s runAsUser and fsGroup cannot be strings

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -160,8 +160,8 @@ class KubeConfig:
         self.dags_in_image = conf.getboolean(self.kubernetes_section, 'dags_in_image')
 
         # Run as user for pod security context
-        self.worker_run_as_user = conf.get(self.kubernetes_section, 'run_as_user')
-        self.worker_fs_group = conf.get(self.kubernetes_section, 'fs_group')
+        self.worker_run_as_user = self.get_security_context('run_as_user')
+        self.worker_fs_group = self.get_security_context('fs_group')
 
         # NOTE: `git_repo` and `git_branch` must be specified together as a pair
         # The http URL of the git repository to clone from
@@ -266,6 +266,15 @@ class KubeConfig:
         else:
             self.kube_client_request_args = {}
         self._validate()
+
+    # pod security context items should return integers
+    # and only return a blank string if contexts are not set.
+    def get_security_context(self, scontext):
+        temp = configuration.get(self.kubernetes_section, scontext)
+        if len(temp) == 0:
+            return temp
+        else:
+            return configuration.getint(self.kubernetes_section, scontext)
 
     def _validate(self):
         # TODO: use XOR for dags_volume_claim and git_dags_folder_mount_point

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -160,8 +160,8 @@ class KubeConfig:
         self.dags_in_image = conf.getboolean(self.kubernetes_section, 'dags_in_image')
 
         # Run as user for pod security context
-        self.worker_run_as_user = self.get_security_context('run_as_user')
-        self.worker_fs_group = self.get_security_context('fs_group')
+        self.worker_run_as_user = self._get_security_context_val('run_as_user')
+        self.worker_fs_group = self._get_security_context_val('fs_group')
 
         # NOTE: `git_repo` and `git_branch` must be specified together as a pair
         # The http URL of the git repository to clone from
@@ -269,12 +269,12 @@ class KubeConfig:
 
     # pod security context items should return integers
     # and only return a blank string if contexts are not set.
-    def get_security_context(self, scontext):
-        temp = configuration.get(self.kubernetes_section, scontext)
-        if len(temp) == 0:
-            return temp
+    def _get_security_context_val(self, scontext):
+        val = configuration.get(self.kubernetes_section, scontext)
+        if len(val) == 0:
+            return val
         else:
-            return configuration.getint(self.kubernetes_section, scontext)
+            return int(val)
 
     def _validate(self):
         # TODO: use XOR for dags_volume_claim and git_dags_folder_mount_point


### PR DESCRIPTION
 The securityContext sections  for runAsUser and fsGroup in Pod
 definitions are always integers. This PR updates makes sure
 the configuration returns an integer for both runAsUser and
 fsGroup.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4516
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
 The securityContext sections  for runAsUser and fsGroup in Pod
 definitions are always integers. This PR updates makes sure
 the configuration returns an integer for both runAsUser and
 fsGroup.


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 There is a test for the fsGroup

### Commits

- [x ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
  n/a

### Code Quality

- [x] Passes `flake8`
