### PR TITLE
[AIRFLOW-4812] Add batch images annotation

### DIFF
--- a/airflow/contrib/hooks/gcp_vision_hook.py
+++ b/airflow/contrib/hooks/gcp_vision_hook.py
@@ -449,6 +449,22 @@ class CloudVisionHook(GoogleCloudBaseHook):
         return MessageToDict(response)
 
     @GoogleCloudBaseHook.catch_http_exception
+    def batch_annotate_images(self, requests, retry=None, timeout=None):
+        """
+        For the documentation see:
+        :py:class:`~airflow.contrib.operators.gcp_vision_image_annotator_operator.CloudVisionAnnotateImage`
+        """
+        client = self.annotator_client
+
+        self.log.info('Annotating images')
+
+        response = client.batch_annotate_images(requests=requests, retry=retry, timeout=timeout)
+
+        self.log.info('Images annotated')
+
+        return MessageToDict(response)
+
+    @GoogleCloudBaseHook.catch_http_exception
     def text_detection(
         self, image, max_results=None, retry=None, timeout=None, additional_properties=None
     ):

--- a/tests/contrib/hooks/test_gcp_vision_hook.py
+++ b/tests/contrib/hooks/test_gcp_vision_hook.py
@@ -56,6 +56,16 @@ ANNOTATE_IMAGE_REQUEST = {
     'image': {'source': {'image_uri': "gs://bucket-name/object-name"}},
     'features': [{'type': enums.Feature.Type.LOGO_DETECTION}],
 }
+BATCH_ANNOTATE_IMAGE_REQUEST = [
+    {
+        'image': {'source': {'image_uri': "gs://bucket-name/object-name"}},
+        'features': [{'type': enums.Feature.Type.LOGO_DETECTION}],
+    },
+    {
+        'image': {'source': {'image_uri': "gs://bucket-name/object-name"}},
+        'features': [{'type': enums.Feature.Type.LOGO_DETECTION}],
+    }
+]
 REFERENCE_IMAGE_NAME_TEST = "projects/{}/locations/{}/products/{}/referenceImages/{}".format(
     PROJECT_ID_TEST, LOC_ID_TEST, PRODUCTSET_ID_TEST, REFERENCE_IMAGE_ID_TEST
 )
@@ -429,6 +439,19 @@ class TestGcpVisionHook(unittest.TestCase):
         # Product ID was provided explicitly in the method call above, should be returned from the method
         annotate_image_method.assert_called_once_with(
             request=ANNOTATE_IMAGE_REQUEST, retry=None, timeout=None
+        )
+
+    @mock.patch('airflow.contrib.hooks.gcp_vision_hook.CloudVisionHook.annotator_client')
+    def test_batch_annotate_images(self, annotator_client_mock):
+        # Given
+        batch_annotate_images_method = annotator_client_mock.batch_annotate_images
+
+        # When
+        self.hook.batch_annotate_images(requests=BATCH_ANNOTATE_IMAGE_REQUEST)
+        # Then
+        # Product ID was provided explicitly in the method call above, should be returned from the method
+        batch_annotate_images_method.assert_called_once_with(
+            requests=BATCH_ANNOTATE_IMAGE_REQUEST, retry=None, timeout=None
         )
 
     @mock.patch('airflow.contrib.hooks.gcp_vision_hook.CloudVisionHook.get_conn')

--- a/tests/contrib/operators/test_gcp_vision_operator.py
+++ b/tests/contrib/operators/test_gcp_vision_operator.py
@@ -50,6 +50,10 @@ PRODUCT_ID_TEST = 'my-product'
 REFERENCE_IMAGE_TEST = ReferenceImage(uri='gs://bucket_name/file.txt')
 REFERENCE_IMAGE_ID_TEST = 'my-reference-image'
 ANNOTATE_REQUEST_TEST = {'image': {'source': {'image_uri': 'https://foo.com/image.jpg'}}}
+ANNOTATE_REQUEST_BATCH_TEST = [
+    {'image': {'source': {'image_uri': 'https://foo.com/image1.jpg'}}},
+    {'image': {'source': {'image_uri': 'https://foo.com/image2.jpg'}}}
+]
 LOCATION_TEST = 'europe-west1'
 GCP_CONN_ID = 'google_cloud_default'
 DETECT_TEST_IMAGE = {"source": {"image_uri": "test_uri"}}
@@ -336,12 +340,21 @@ class CloudVisionRemoveProductFromProductSetOperatorTest(unittest.TestCase):
 
 class CloudVisionAnnotateImageOperatorTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.gcp_vision_operator.CloudVisionHook')
-    def test_minimal_green_path(self, mock_hook):
+    def test_minimal_green_path_for_one_image(self, mock_hook):
         op = CloudVisionAnnotateImageOperator(request=ANNOTATE_REQUEST_TEST, task_id='id')
         op.execute(context=None)
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
         mock_hook.return_value.annotate_image.assert_called_once_with(
             request=ANNOTATE_REQUEST_TEST, retry=None, timeout=None
+        )
+
+    @mock.patch('airflow.contrib.operators.gcp_vision_operator.CloudVisionHook')
+    def test_minimal_green_path_for_batch(self, mock_hook):
+        op = CloudVisionAnnotateImageOperator(request=ANNOTATE_REQUEST_BATCH_TEST, task_id='id')
+        op.execute(context=None)
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID)
+        mock_hook.return_value.batch_annotate_images.assert_called_once_with(
+            requests=ANNOTATE_REQUEST_BATCH_TEST, retry=None, timeout=None
         )
 
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. https://issues.apache.org/jira/browse/AIRFLOW-4812

### Description

- [x] Make use of batch images annotation option from GCP API in CloudVisionAnnotateImageOperator

### Tests

- [x] My PR adds the following unit tests:
test_batch_annotate_images,
test_minimal_green_path_for_batch

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue.

### Documentation

- [x] My PR adds documentation that describes how to use it.

### Code Quality

- [x] Passes `flake8`
