### PR TITLE
[AIRFLOW-4759] Don't error when marking sucessful run as failed

### DIFF
--- a/airflow/api/common/experimental/mark_tasks.py
+++ b/airflow/api/common/experimental/mark_tasks.py
@@ -86,6 +86,9 @@ def set_state(
     :param session: database session
     :return: list of tasks that have been created and updated
     """
+    if not tasks:
+        return []
+
     if not timezone.is_localized(execution_date):
         raise ValueError("Received non-localized date {}".format(execution_date))
 

--- a/tests/api/common/experimental/test_mark_tasks.py
+++ b/tests/api/common/experimental/test_mark_tasks.py
@@ -523,6 +523,17 @@ class TestMarkDAGRun(unittest.TestCase):
         self.assertRaises(ValueError, set_dag_run_state_to_success,
                           self.dag2, self.execution_dates[0])
 
+    def test_set_dag_run_state_to_failed_no_running_tasks(self):
+        """
+        set_dag_run_state_to_failed when there are no running tasks to update
+        """
+        date = self.execution_dates[0]
+        dr = self._create_test_dag_run(State.SUCCESS, date)
+        for task in self.dag1.tasks:
+            dr.get_task_instance(task.task_id).set_state(State.SUCCESS)
+
+        set_dag_run_state_to_failed(self.dag1, date)
+
     def tearDown(self):
         self.dag1.clear()
         self.dag2.clear()


### PR DESCRIPTION
### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4759 (Same jira as original PR)

### Description

- [x] The previous PR (#5403) that optimized the DB queries introduced an edge
case which would cause this to fail if no tasks were passed in. (an un-cuaght
StopIteration)

### Tests

- [x] Tests added

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
