### PR TITLE
[AIRFLOW-4148] Fix editing DagRuns by clicking state column

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2684,7 +2684,7 @@ class DagRunModelView(ModelViewOnly):
     verbose_name = "dag run"
     column_default_sort = ('execution_date', True)
     form_choices = {
-        'state': [
+        '_state': [
             ('success', 'success'),
             ('running', 'running'),
             ('failed', 'failed'),


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4148

### Description

- [x]  The update from Flask-Admin to 1.5.2 broke editing the state by clicking
 on the column. This makes it work again (although the edited column is
 no-longer styled once edited). This is good enough a fix for the
 deprecated UI

   (Authorship taken from #4969)

   **Before**

  ![image](https://user-images.githubusercontent.com/1303581/55135154-cfb80080-5165-11e9-9fc7-03c12b510f18.png)

  **After**

   ![Screenshot 2019-06-19 at 11 23 00](https://user-images.githubusercontent.com/34150/59757888-a1d5ea00-9284-11e9-9c96-7e4b46bd024c.png)

### Tests

- [x] UI Only


### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`