### PR TITLE
[AIRFLOW-4817] Remove deprecated methods from tests

### DIFF
--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -634,7 +634,6 @@
 ./tests/contrib/operators/test_gcs_download_operator.py
 ./tests/contrib/operators/test_gcs_list_operator.py
 ./tests/contrib/operators/test_gcs_operator.py
-./tests/contrib/operators/test_gcs_to_gcs_operator.py
 ./tests/contrib/operators/test_gcs_to_s3_operator.py
 ./tests/contrib/operators/test_grpc_operator.py
 ./tests/contrib/operators/test_hipchat_operator.py

--- a/tests/api/common/experimental/test_pool.py
+++ b/tests/api/common/experimental/test_pool.py
@@ -49,17 +49,17 @@ class TestPool(unittest.TestCase):
         self.assertEqual(pool.pool, self.pools[0].pool)
 
     def test_get_pool_non_existing(self):
-        self.assertRaisesRegexp(PoolNotFound,
-                                "^Pool 'test' doesn't exist$",
-                                pool_api.get_pool,
-                                name='test')
+        self.assertRaisesRegex(PoolNotFound,
+                               "^Pool 'test' doesn't exist$",
+                               pool_api.get_pool,
+                               name='test')
 
     def test_get_pool_bad_name(self):
         for name in ('', '    '):
-            self.assertRaisesRegexp(AirflowBadRequest,
-                                    "^Pool name shouldn't be empty$",
-                                    pool_api.get_pool,
-                                    name=name)
+            self.assertRaisesRegex(AirflowBadRequest,
+                                   "^Pool name shouldn't be empty$",
+                                   pool_api.get_pool,
+                                   name=name)
 
     def test_get_pools(self):
         pools = sorted(pool_api.get_pools(),
@@ -89,20 +89,20 @@ class TestPool(unittest.TestCase):
 
     def test_create_pool_bad_name(self):
         for name in ('', '    '):
-            self.assertRaisesRegexp(AirflowBadRequest,
-                                    "^Pool name shouldn't be empty$",
-                                    pool_api.create_pool,
-                                    name=name,
-                                    slots=5,
-                                    description='')
+            self.assertRaisesRegex(AirflowBadRequest,
+                                   "^Pool name shouldn't be empty$",
+                                   pool_api.create_pool,
+                                   name=name,
+                                   slots=5,
+                                   description='')
 
     def test_create_pool_bad_slots(self):
-        self.assertRaisesRegexp(AirflowBadRequest,
-                                "^Bad value for `slots`: foo$",
-                                pool_api.create_pool,
-                                name='foo',
-                                slots='foo',
-                                description='')
+        self.assertRaisesRegex(AirflowBadRequest,
+                               "^Bad value for `slots`: foo$",
+                               pool_api.create_pool,
+                               name='foo',
+                               slots='foo',
+                               description='')
 
     def test_delete_pool(self):
         pool = pool_api.delete_pool(name=self.pools[0].pool)
@@ -111,17 +111,17 @@ class TestPool(unittest.TestCase):
             self.assertEqual(session.query(models.Pool).count(), 1)
 
     def test_delete_pool_non_existing(self):
-        self.assertRaisesRegexp(pool_api.PoolNotFound,
-                                "^Pool 'test' doesn't exist$",
-                                pool_api.delete_pool,
-                                name='test')
+        self.assertRaisesRegex(pool_api.PoolNotFound,
+                               "^Pool 'test' doesn't exist$",
+                               pool_api.delete_pool,
+                               name='test')
 
     def test_delete_pool_bad_name(self):
         for name in ('', '    '):
-            self.assertRaisesRegexp(AirflowBadRequest,
-                                    "^Pool name shouldn't be empty$",
-                                    pool_api.delete_pool,
-                                    name=name)
+            self.assertRaisesRegex(AirflowBadRequest,
+                                   "^Pool name shouldn't be empty$",
+                                   pool_api.delete_pool,
+                                   name=name)
 
 
 if __name__ == '__main__':

--- a/tests/contrib/hooks/test_discord_webhook_hook.py
+++ b/tests/contrib/hooks/test_discord_webhook_hook.py
@@ -74,7 +74,7 @@ class TestDiscordWebhookHook(unittest.TestCase):
 
         # When/Then
         expected_message = 'Expected Discord webhook endpoint in the form of'
-        with self.assertRaisesRegexp(AirflowException, expected_message):
+        with self.assertRaisesRegex(AirflowException, expected_message):
             DiscordWebhookHook(webhook_endpoint=provided_endpoint)
 
     def test_get_webhook_endpoint_conn_id(self):
@@ -108,7 +108,7 @@ class TestDiscordWebhookHook(unittest.TestCase):
 
         # When/Then
         expected_message = 'Discord message length must be 2000 or fewer characters'
-        with self.assertRaisesRegexp(AirflowException, expected_message):
+        with self.assertRaisesRegex(AirflowException, expected_message):
             hook._build_discord_payload()
 
 

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -303,7 +303,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         response = self.gcs_hook.get_size(bucket_name=test_bucket,
                                           object_name=test_object)
 
-        self.assertEquals(response, returned_file_size)
+        self.assertEqual(response, returned_file_size)
         get_blob_method.return_value.reload.assert_called_once_with()
 
     @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
@@ -319,7 +319,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         response = self.gcs_hook.get_crc32c(bucket_name=test_bucket,
                                             object_name=test_object)
 
-        self.assertEquals(response, returned_file_crc32c)
+        self.assertEqual(response, returned_file_crc32c)
 
         # Check that reload method is called
         get_blob_method.return_value.reload.assert_called_once_with()
@@ -337,7 +337,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         response = self.gcs_hook.get_md5hash(bucket_name=test_bucket,
                                              object_name=test_object)
 
-        self.assertEquals(response, returned_file_md5hash)
+        self.assertEqual(response, returned_file_md5hash)
 
         # Check that reload method is called
         get_blob_method.return_value.reload.assert_called_once_with()
@@ -365,10 +365,10 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
             project_id=test_project
         )
 
-        self.assertEquals(response, sample_bucket.id)
+        self.assertEqual(response, sample_bucket.id)
 
-        self.assertEquals(sample_bucket.storage_class, test_storage_class)
-        self.assertEquals(sample_bucket.labels, test_labels)
+        self.assertEqual(sample_bucket.storage_class, test_storage_class)
+        self.assertEqual(sample_bucket.labels, test_labels)
 
         mock_service.return_value.bucket.return_value.create.assert_called_with(
             project=test_project, location=test_location
@@ -401,7 +401,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
             labels=test_labels,
             project_id=test_project
         )
-        self.assertEquals(response, sample_bucket.id)
+        self.assertEqual(response, sample_bucket.id)
 
         mock_service.return_value.bucket.return_value._patch_property.assert_called_with(
             name='versioning', value=test_versioning_enabled
@@ -502,7 +502,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
                                           object_name=test_object,
                                           filename=None)
 
-        self.assertEquals(response, test_object_bytes)
+        self.assertEqual(response, test_object_bytes)
         download_method.assert_called_once_with()
 
     @mock.patch(GCS_STRING.format('GoogleCloudStorageHook.get_conn'))
@@ -524,7 +524,7 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
                                           object_name=test_object,
                                           filename=test_file)
 
-        self.assertEquals(response, test_object_bytes)
+        self.assertEqual(response, test_object_bytes)
         download_filename_method.assert_called_once_with(test_file)
 
 

--- a/tests/contrib/hooks/test_grpc_hook.py
+++ b/tests/contrib/hooks/test_grpc_hook.py
@@ -81,7 +81,7 @@ class TestGrpcHook(unittest.TestCase):
         expected_url = "test:8080"
 
         mock_insecure_channel.assert_called_once_with(expected_url)
-        self.assertEquals(channel, mocked_channel)
+        self.assertEqual(channel, mocked_channel)
 
     @mock.patch('grpc.insecure_channel')
     @mock.patch('airflow.hooks.base_hook.BaseHook.get_connection')
@@ -96,7 +96,7 @@ class TestGrpcHook(unittest.TestCase):
         expected_url = "test.com:1234"
 
         mock_insecure_channel.assert_called_once_with(expected_url)
-        self.assertEquals(channel, mocked_channel)
+        self.assertEqual(channel, mocked_channel)
 
     @mock.patch('airflow.contrib.hooks.grpc_hook.open')
     @mock.patch('airflow.hooks.base_hook.BaseHook.get_connection')
@@ -128,7 +128,7 @@ class TestGrpcHook(unittest.TestCase):
             expected_url,
             mock_credential_object
         )
-        self.assertEquals(channel, mocked_channel)
+        self.assertEqual(channel, mocked_channel)
 
     @mock.patch('airflow.contrib.hooks.grpc_hook.open')
     @mock.patch('airflow.hooks.base_hook.BaseHook.get_connection')
@@ -160,7 +160,7 @@ class TestGrpcHook(unittest.TestCase):
             expected_url,
             mock_credential_object
         )
-        self.assertEquals(channel, mocked_channel)
+        self.assertEqual(channel, mocked_channel)
 
     @mock.patch('airflow.hooks.base_hook.BaseHook.get_connection')
     @mock.patch('google.auth.jwt.OnDemandCredentials.from_signing_credentials')
@@ -191,7 +191,7 @@ class TestGrpcHook(unittest.TestCase):
             None,
             expected_url
         )
-        self.assertEquals(channel, mocked_channel)
+        self.assertEqual(channel, mocked_channel)
 
     @mock.patch('airflow.hooks.base_hook.BaseHook.get_connection')
     @mock.patch('google.auth.transport.requests.Request')
@@ -223,7 +223,7 @@ class TestGrpcHook(unittest.TestCase):
             "request",
             expected_url
         )
-        self.assertEquals(channel, mocked_channel)
+        self.assertEqual(channel, mocked_channel)
 
     @mock.patch('airflow.hooks.base_hook.BaseHook.get_connection')
     def test_custom_connection(self, mock_get_connection):
@@ -234,7 +234,7 @@ class TestGrpcHook(unittest.TestCase):
 
         channel = hook.get_conn()
 
-        self.assertEquals(channel, mocked_channel)
+        self.assertEqual(channel, mocked_channel)
 
     @mock.patch('airflow.hooks.base_hook.BaseHook.get_connection')
     def test_custom_connection_with_no_connection_func(self, mock_get_connection):
@@ -270,7 +270,7 @@ class TestGrpcHook(unittest.TestCase):
 
         channel = hook.get_conn()
 
-        self.assertEquals(channel, mocked_channel)
+        self.assertEqual(channel, mocked_channel)
         mock_intercept_channel.assert_called_once_with(mocked_channel, "test1")
 
     @mock.patch('airflow.hooks.base_hook.BaseHook.get_connection')
@@ -286,7 +286,7 @@ class TestGrpcHook(unittest.TestCase):
 
         response = hook.run(StubClass, "single_call", data={'data': 'hello'})
 
-        self.assertEquals(next(response), "hello")
+        self.assertEqual(next(response), "hello")
 
     @mock.patch('airflow.hooks.base_hook.BaseHook.get_connection')
     @mock.patch('airflow.contrib.hooks.grpc_hook.GrpcHook.get_conn')
@@ -301,4 +301,4 @@ class TestGrpcHook(unittest.TestCase):
 
         response = hook.run(StubClass, "stream_call", data={'data': ['hello!', "hi"]})
 
-        self.assertEquals(next(response), ["streaming", "call"])
+        self.assertEqual(next(response), ["streaming", "call"])

--- a/tests/contrib/operators/test_aws_sqs_publish_operator.py
+++ b/tests/contrib/operators/test_aws_sqs_publish_operator.py
@@ -61,9 +61,9 @@ class TestSQSPublishOperator(unittest.TestCase):
 
         message = self.sqs_hook.get_conn().receive_message(QueueUrl='test')
 
-        self.assertEquals(len(message['Messages']), 1)
-        self.assertEquals(message['Messages'][0]['MessageId'], result['MessageId'])
-        self.assertEquals(message['Messages'][0]['Body'], 'hello')
+        self.assertEqual(len(message['Messages']), 1)
+        self.assertEqual(message['Messages'][0]['MessageId'], result['MessageId'])
+        self.assertEqual(message['Messages'][0]['Body'], 'hello')
 
         context_calls = []
 

--- a/tests/contrib/operators/test_bigquery_operator.py
+++ b/tests/contrib/operators/test_bigquery_operator.py
@@ -274,12 +274,12 @@ class BigQueryOperatorTest(unittest.TestCase):
         job_id = '12345'
         ti.xcom_push(key='job_id', value=job_id)
 
-        self.assertEquals(
+        self.assertEqual(
             'https://console.cloud.google.com/bigquery?j={job_id}'.format(job_id=job_id),
             bigquery_task.get_extra_links(DEFAULT_DATE, BigQueryConsoleLink.name),
         )
 
-        self.assertEquals(
+        self.assertEqual(
             '',
             bigquery_task.get_extra_links(datetime(2019, 1, 1), BigQueryConsoleLink.name),
         )

--- a/tests/contrib/operators/test_databricks_operator.py
+++ b/tests/contrib/operators/test_databricks_operator.py
@@ -180,7 +180,7 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
         # Looks a bit weird since we have to escape regex reserved symbols.
         exception_message = r'Type \<(type|class) \'datetime.datetime\'\> used ' + \
                             r'for parameter json\[test\] is not a number or a string'
-        with self.assertRaisesRegexp(AirflowException, exception_message):
+        with self.assertRaisesRegex(AirflowException, exception_message):
             DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
 
     @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
@@ -347,7 +347,7 @@ class DatabricksRunNowOperatorTest(unittest.TestCase):
         # Looks a bit weird since we have to escape regex reserved symbols.
         exception_message = r'Type \<(type|class) \'datetime.datetime\'\> used ' + \
                             r'for parameter json\[test\] is not a number or a string'
-        with self.assertRaisesRegexp(AirflowException, exception_message):
+        with self.assertRaisesRegex(AirflowException, exception_message):
             DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID, json=json)
 
     @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')

--- a/tests/contrib/operators/test_gcp_natural_language_operator.py
+++ b/tests/contrib/operators/test_gcp_natural_language_operator.py
@@ -54,7 +54,7 @@ class CloudLanguageAnalyzeEntitiesOperatorTestCase(unittest.TestCase):
         hook_mock.return_value.analyze_entities.return_value = ANALYZE_ENTITIES_RESPONSE
         op = CloudLanguageAnalyzeEntitiesOperator(task_id="task-id", document=DOCUMENT)
         resp = op.execute({})
-        self.assertEquals(resp, {})
+        self.assertEqual(resp, {})
 
 
 class CloudLanguageAnalyzeEntitySentimentOperatorTestCase(unittest.TestCase):
@@ -63,7 +63,7 @@ class CloudLanguageAnalyzeEntitySentimentOperatorTestCase(unittest.TestCase):
         hook_mock.return_value.analyze_entity_sentiment.return_value = ANALYZE_ENTITY_SENTIMENT_RESPONSE
         op = CloudLanguageAnalyzeEntitySentimentOperator(task_id="task-id", document=DOCUMENT)
         resp = op.execute({})
-        self.assertEquals(resp, {})
+        self.assertEqual(resp, {})
 
 
 class CloudLanguageAnalyzeSentimentOperatorTestCase(unittest.TestCase):
@@ -72,7 +72,7 @@ class CloudLanguageAnalyzeSentimentOperatorTestCase(unittest.TestCase):
         hook_mock.return_value.analyze_sentiment.return_value = ANALYZE_SENTIMENT_RESPONSE
         op = CloudLanguageAnalyzeSentimentOperator(task_id="task-id", document=DOCUMENT)
         resp = op.execute({})
-        self.assertEquals(resp, {})
+        self.assertEqual(resp, {})
 
 
 class CloudLanguageClassifyTextOperatorTestCase(unittest.TestCase):
@@ -81,4 +81,4 @@ class CloudLanguageClassifyTextOperatorTestCase(unittest.TestCase):
         hook_mock.return_value.classify_text.return_value = CLASSIFY_TEXT_RRESPONSE
         op = CloudLanguageClassifyTextOperator(task_id="task-id", document=DOCUMENT)
         resp = op.execute({})
-        self.assertEquals(resp, {})
+        self.assertEqual(resp, {})

--- a/tests/contrib/operators/test_gcs_to_gcs_operator.py
+++ b/tests/contrib/operators/test_gcs_to_gcs_operator.py
@@ -290,7 +290,7 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
         error_msg = "Only one wildcard '[*]' is allowed in source_object parameter. " \
                     "Found {}".format(total_wildcards, SOURCE_OBJECT_MULTIPLE_WILDCARDS)
 
-        with self.assertRaisesRegexp(AirflowException, error_msg):
+        with self.assertRaisesRegex(AirflowException, error_msg):
             operator.execute(None)
 
     @mock.patch('airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageHook')
@@ -308,4 +308,4 @@ class GoogleCloudStorageToCloudStorageOperatorTest(unittest.TestCase):
                 'destination_bucket is None. Defaulting it to source_bucket (%s)',
                 TEST_BUCKET
             )
-            self.assertEquals(operator.destination_bucket, operator.source_bucket)
+            self.assertEqual(operator.destination_bucket, operator.source_bucket)

--- a/tests/contrib/operators/test_qubole_check_operator.py
+++ b/tests/contrib/operators/test_qubole_check_operator.py
@@ -89,8 +89,8 @@ class QuboleValueCheckOperatorTest(unittest.TestCase):
 
         operator = self.__construct_operator('select value from tab1 limit 1;', 5, 1)
 
-        with self.assertRaisesRegexp(AirflowException,
-                                     'Qubole Command Id: ' + str(mock_cmd.id)):
+        with self.assertRaisesRegex(AirflowException,
+                                    'Qubole Command Id: ' + str(mock_cmd.id)):
             operator.execute()
 
         mock_cmd.is_success.assert_called_with(mock_cmd.status)

--- a/tests/contrib/operators/test_redis_publish_operator.py
+++ b/tests/contrib/operators/test_redis_publish_operator.py
@@ -61,10 +61,10 @@ class TestRedisPublishOperator(unittest.TestCase):
         self.assertTrue(self.mock_context['ti'].method_calls == context_calls, "context calls should be same")
 
         message = pubsub.get_message()
-        self.assertEquals(message['type'], 'subscribe')
+        self.assertEqual(message['type'], 'subscribe')
 
         message = pubsub.get_message()
-        self.assertEquals(message['type'], 'message')
-        self.assertEquals(message['data'], b'hello')
+        self.assertEqual(message['type'], 'message')
+        self.assertEqual(message['data'], b'hello')
 
         pubsub.unsubscribe(self.channel)

--- a/tests/contrib/operators/test_winrm_operator.py
+++ b/tests/contrib/operators/test_winrm_operator.py
@@ -30,7 +30,7 @@ class WinRMOperatorTest(unittest.TestCase):
                            winrm_hook=None,
                            ssh_conn_id=None)
         exception_msg = "Cannot operate without winrm_hook or ssh_conn_id."
-        with self.assertRaisesRegexp(AirflowException, exception_msg):
+        with self.assertRaisesRegex(AirflowException, exception_msg):
             op.execute(None)
 
     @mock.patch('airflow.contrib.operators.winrm_operator.WinRMHook')
@@ -41,7 +41,7 @@ class WinRMOperatorTest(unittest.TestCase):
             command=None
         )
         exception_msg = "No command specified so nothing to execute here."
-        with self.assertRaisesRegexp(AirflowException, exception_msg):
+        with self.assertRaisesRegex(AirflowException, exception_msg):
             op.execute(None)
 
 

--- a/tests/contrib/sensors/test_weekday_sensor.py
+++ b/tests/contrib/sensors/test_weekday_sensor.py
@@ -79,9 +79,8 @@ class DayOfWeekSensorTests(unittest.TestCase):
 
     def test_invalid_weekday_number(self):
         invalid_week_day = 'Thsday'
-        with self.assertRaisesRegexp(AttributeError,
-                                     'Invalid Week Day passed: "{}"'.format(
-                                         invalid_week_day)):
+        with self.assertRaisesRegex(AttributeError,
+                                    'Invalid Week Day passed: "{}"'.format(invalid_week_day)):
             DayOfWeekSensor(
                 task_id='weekday_sensor_invalid_weekday_num',
                 week_day=invalid_week_day,
@@ -140,11 +139,11 @@ class DayOfWeekSensorTests(unittest.TestCase):
 
     def test_weekday_sensor_with_invalid_type(self):
         invalid_week_day = ['Thsday']
-        with self.assertRaisesRegexp(TypeError,
-                                     'Unsupported Type for week_day parameter:'
-                                     ' {}. It should be one of str, set or '
-                                     'Weekday enum type'.format(type(invalid_week_day))
-                                     ):
+        with self.assertRaisesRegex(TypeError,
+                                    'Unsupported Type for week_day parameter:'
+                                    ' {}. It should be one of str, set or '
+                                    'Weekday enum type'.format(type(invalid_week_day))
+                                    ):
             DayOfWeekSensor(
                 task_id='weekday_sensor_check_true',
                 week_day=invalid_week_day,

--- a/tests/contrib/utils/test_mlengine_operator_utils.py
+++ b/tests/contrib/utils/test_mlengine_operator_utils.py
@@ -149,25 +149,23 @@ class CreateEvaluateOpsTest(unittest.TestCase):
             'dag': dag,
         }
 
-        with self.assertRaisesRegexp(AirflowException, 'Missing model origin'):
+        with self.assertRaisesRegex(AirflowException, 'Missing model origin'):
             mlengine_operator_utils.create_evaluate_ops(**other_params_but_models)
 
-        with self.assertRaisesRegexp(AirflowException, 'Ambiguous model origin'):
+        with self.assertRaisesRegex(AirflowException, 'Ambiguous model origin'):
             mlengine_operator_utils.create_evaluate_ops(model_uri='abc', model_name='cde',
                                                         **other_params_but_models)
 
-        with self.assertRaisesRegexp(AirflowException, 'Ambiguous model origin'):
+        with self.assertRaisesRegex(AirflowException, 'Ambiguous model origin'):
             mlengine_operator_utils.create_evaluate_ops(model_uri='abc', version_name='vvv',
                                                         **other_params_but_models)
 
-        with self.assertRaisesRegexp(AirflowException,
-                                     '`metric_fn` param must be callable'):
+        with self.assertRaisesRegex(AirflowException, '`metric_fn` param must be callable'):
             params = other_params_but_models.copy()
             params['metric_fn_and_keys'] = (None, ['abc'])
             mlengine_operator_utils.create_evaluate_ops(model_uri='gs://blah', **params)
 
-        with self.assertRaisesRegexp(AirflowException,
-                                     '`validate_fn` param must be callable'):
+        with self.assertRaisesRegex(AirflowException, '`validate_fn` param must be callable'):
             params = other_params_but_models.copy()
             params['validate_fn'] = None
             mlengine_operator_utils.create_evaluate_ops(model_uri='gs://blah', **params)

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -221,10 +221,10 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         mock_conf_get.side_effect = get_conf
         mock_config_as_dict.return_value = {'core': ''}
 
-        with self.assertRaisesRegexp(AirflowConfigException,
-                                     'either `git_user` and `git_password`.*'
-                                     'or `git_ssh_key_secret_name`.*'
-                                     'but not both$'):
+        with self.assertRaisesRegex(AirflowConfigException,
+                                    'either `git_user` and `git_password`.*'
+                                    'or `git_ssh_key_secret_name`.*'
+                                    'but not both$'):
             KubeConfig()
 
     def test_worker_with_subpaths(self):

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -104,7 +104,7 @@ class BackfillJobTest(unittest.TestCase):
 
         dag_run.refresh_from_db()
 
-        self.assertEquals(State.FAILED, dag_run.state)
+        self.assertEqual(State.FAILED, dag_run.state)
 
     def test_dag_run_with_finished_tasks_set_to_success(self):
         dag = self._get_dummy_dag('dummy_dag')
@@ -128,7 +128,7 @@ class BackfillJobTest(unittest.TestCase):
 
         dag_run.refresh_from_db()
 
-        self.assertEquals(State.SUCCESS, dag_run.state)
+        self.assertEqual(State.SUCCESS, dag_run.state)
 
     @unittest.skipIf('sqlite' in configuration.conf.get('core', 'sql_alchemy_conn'),
                      "concurrent access not supported in sqlite")
@@ -323,7 +323,7 @@ class BackfillJobTest(unittest.TestCase):
             if len(running_task_instances) == task_concurrency:
                 task_concurrency_limit_reached_at_least_once = True
 
-        self.assertEquals(8, num_running_task_instances)
+        self.assertEqual(8, num_running_task_instances)
         self.assertTrue(task_concurrency_limit_reached_at_least_once)
 
         times_dag_concurrency_limit_reached_in_debug = self._times_called_with(
@@ -341,8 +341,8 @@ class BackfillJobTest(unittest.TestCase):
             TaskConcurrencyLimitReached,
         )
 
-        self.assertEquals(0, times_pool_limit_reached_in_debug)
-        self.assertEquals(0, times_dag_concurrency_limit_reached_in_debug)
+        self.assertEqual(0, times_pool_limit_reached_in_debug)
+        self.assertEqual(0, times_dag_concurrency_limit_reached_in_debug)
         self.assertGreater(times_task_concurrency_limit_reached_in_debug, 0)
 
     @patch('airflow.jobs.backfill_job.BackfillJob.log')
@@ -374,7 +374,7 @@ class BackfillJobTest(unittest.TestCase):
             if len(running_task_instances) == dag.concurrency:
                 concurrency_limit_reached_at_least_once = True
 
-        self.assertEquals(8, num_running_task_instances)
+        self.assertEqual(8, num_running_task_instances)
         self.assertTrue(concurrency_limit_reached_at_least_once)
 
         times_dag_concurrency_limit_reached_in_debug = self._times_called_with(
@@ -392,8 +392,8 @@ class BackfillJobTest(unittest.TestCase):
             TaskConcurrencyLimitReached,
         )
 
-        self.assertEquals(0, times_pool_limit_reached_in_debug)
-        self.assertEquals(0, times_task_concurrency_limit_reached_in_debug)
+        self.assertEqual(0, times_pool_limit_reached_in_debug)
+        self.assertEqual(0, times_task_concurrency_limit_reached_in_debug)
         self.assertGreater(times_dag_concurrency_limit_reached_in_debug, 0)
 
     @patch('airflow.jobs.backfill_job.BackfillJob.log')
@@ -441,7 +441,7 @@ class BackfillJobTest(unittest.TestCase):
             if len(running_task_instances) == non_pooled_backfill_task_slot_count:
                 non_pooled_task_slot_count_reached_at_least_once = True
 
-        self.assertEquals(8, num_running_task_instances)
+        self.assertEqual(8, num_running_task_instances)
         self.assertTrue(non_pooled_task_slot_count_reached_at_least_once)
 
         times_dag_concurrency_limit_reached_in_debug = self._times_called_with(
@@ -459,8 +459,8 @@ class BackfillJobTest(unittest.TestCase):
             TaskConcurrencyLimitReached,
         )
 
-        self.assertEquals(0, times_dag_concurrency_limit_reached_in_debug)
-        self.assertEquals(0, times_task_concurrency_limit_reached_in_debug)
+        self.assertEqual(0, times_dag_concurrency_limit_reached_in_debug)
+        self.assertEqual(0, times_task_concurrency_limit_reached_in_debug)
         self.assertGreater(times_pool_limit_reached_in_debug, 0)
 
     def test_backfill_pool_not_found(self):
@@ -524,7 +524,7 @@ class BackfillJobTest(unittest.TestCase):
             if len(running_task_instances) == slots:
                 pool_was_full_at_least_once = True
 
-        self.assertEquals(8, num_running_task_instances)
+        self.assertEqual(8, num_running_task_instances)
         self.assertTrue(pool_was_full_at_least_once)
 
         times_dag_concurrency_limit_reached_in_debug = self._times_called_with(
@@ -542,8 +542,8 @@ class BackfillJobTest(unittest.TestCase):
             TaskConcurrencyLimitReached,
         )
 
-        self.assertEquals(0, times_task_concurrency_limit_reached_in_debug)
-        self.assertEquals(0, times_dag_concurrency_limit_reached_in_debug)
+        self.assertEqual(0, times_task_concurrency_limit_reached_in_debug)
+        self.assertEqual(0, times_dag_concurrency_limit_reached_in_debug)
         self.assertGreater(times_pool_limit_reached_in_debug, 0)
 
     def test_backfill_run_rescheduled(self):
@@ -794,7 +794,7 @@ class BackfillJobTest(unittest.TestCase):
         run_date = DEFAULT_DATE + datetime.timedelta(days=5)
 
         # backfill should deadlock
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             AirflowException,
             'BackfillJob is deadlocked',
             BackfillJob(dag=dag, start_date=run_date, end_date=run_date).run)
@@ -891,7 +891,7 @@ class BackfillJobTest(unittest.TestCase):
         # raises backwards
         expected_msg = 'You cannot backfill backwards because one or more tasks depend_on_past: {}'.format(
             'test_dop_task')
-        with self.assertRaisesRegexp(AirflowException, expected_msg):
+        with self.assertRaisesRegex(AirflowException, expected_msg):
             executor = TestExecutor()
             job = BackfillJob(dag=dag,
                               executor=executor,
@@ -1169,7 +1169,7 @@ class BackfillJobTest(unittest.TestCase):
                           start_date=DEFAULT_DATE,
                           end_date=DEFAULT_DATE,
                           executor=executor)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             AirflowException,
             'Some task instances failed',
             job.run)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1738,7 +1738,7 @@ class SchedulerJobTest(unittest.TestCase):
             session.merge(ti)
         session.commit()
 
-        self.assertEquals(len(scheduler.executor.queued_tasks), 0, "Check test pre-condition")
+        self.assertEqual(len(scheduler.executor.queued_tasks), 0, "Check test pre-condition")
         scheduler._execute_task_instances(dagbag,
                                           (State.SCHEDULED, State.UP_FOR_RETRY),
                                           session=session)

--- a/tests/minikube/test_kubernetes_executor.py
+++ b/tests/minikube/test_kubernetes_executor.py
@@ -71,7 +71,7 @@ class KubernetesExecutorTest(unittest.TestCase):
             timeout=1,
         )
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def setUp(self):
         self.session = self._get_session_with_retries()

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -959,7 +959,7 @@ class DagTest(unittest.TestCase):
             DagModel.is_paused.is_(False)
         ).count()
 
-        self.assertEquals(2, unpaused_dags)
+        self.assertEqual(2, unpaused_dags)
 
         DagModel.get_dagmodel(dag.dag_id).set_is_paused(is_paused=True)
 
@@ -971,4 +971,4 @@ class DagTest(unittest.TestCase):
             DagModel.is_paused.is_(True)
         ).count()
 
-        self.assertEquals(2, paused_dags)
+        self.assertEqual(2, paused_dags)

--- a/tests/operators/test_check_operator.py
+++ b/tests/operators/test_check_operator.py
@@ -98,7 +98,7 @@ class TestValueCheckOperator(unittest.TestCase):
 
         operator = self._construct_operator('select value from tab1 limit 1;', 5, 1)
 
-        with self.assertRaisesRegexp(AirflowException, 'Tolerance:100.0%'):
+        with self.assertRaisesRegex(AirflowException, 'Tolerance:100.0%'):
             operator.execute()
 
 
@@ -115,7 +115,7 @@ class IntervalCheckOperatorTest(unittest.TestCase):
         )
 
     def test_invalid_ratio_formula(self):
-        with self.assertRaisesRegexp(AirflowException, 'Invalid diff_method'):
+        with self.assertRaisesRegex(AirflowException, 'Invalid diff_method'):
             self._construct_operator(
                 table='test_table',
                 metric_thresholds={
@@ -188,7 +188,7 @@ class IntervalCheckOperatorTest(unittest.TestCase):
             ignore_zero=True,
         )
 
-        with self.assertRaisesRegexp(AirflowException, "f0, f1, f2"):
+        with self.assertRaisesRegex(AirflowException, "f0, f1, f2"):
             operator.execute()
 
     @mock.patch.object(IntervalCheckOperator, 'get_db_hook')
@@ -219,5 +219,5 @@ class IntervalCheckOperatorTest(unittest.TestCase):
             ignore_zero=True,
         )
 
-        with self.assertRaisesRegexp(AirflowException, "f0, f1"):
+        with self.assertRaisesRegex(AirflowException, "f0, f1"):
             operator.execute()

--- a/tests/operators/test_s3_to_hive_operator.py
+++ b/tests/operators/test_s3_to_hive_operator.py
@@ -156,10 +156,7 @@ class S3ToHiveTransferTest(unittest.TestCase):
     def test_bad_parameters(self):
         self.kwargs['check_headers'] = True
         self.kwargs['headers'] = False
-        self.assertRaisesRegexp(AirflowException,
-                                "To check_headers.*",
-                                S3ToHiveTransfer,
-                                **self.kwargs)
+        self.assertRaisesRegex(AirflowException, "To check_headers.*", S3ToHiveTransfer, **self.kwargs)
 
     def test__get_top_row_as_list(self):
         self.kwargs['delimiter'] = '\t'

--- a/tests/sensors/test_http_sensor.py
+++ b/tests/sensors/test_http_sensor.py
@@ -64,7 +64,7 @@ class HttpSensorTests(unittest.TestCase):
             response_check=resp_check,
             timeout=5,
             poke_interval=1)
-        with self.assertRaisesRegexp(AirflowException, 'AirflowException raised here!'):
+        with self.assertRaisesRegex(AirflowException, 'AirflowException raised here!'):
             task.execute(None)
 
     @patch("airflow.hooks.http_hook.requests.Session.send")

--- a/tests/utils/test_compression.py
+++ b/tests/utils/test_compression.py
@@ -81,13 +81,13 @@ class Compression(unittest.TestCase):
 
     def test_uncompress_file(self):
         # Testing txt file type
-        self.assertRaisesRegexp(NotImplementedError,
-                                "^Received .txt format. Only gz and bz2.*",
-                                compression.uncompress_file,
-                                **{'input_file_name': None,
-                                   'file_extension': '.txt',
-                                   'dest_dir': None
-                                   })
+        self.assertRaisesRegex(NotImplementedError,
+                               "^Received .txt format. Only gz and bz2.*",
+                               compression.uncompress_file,
+                               **{'input_file_name': None,
+                                  'file_extension': '.txt',
+                                  'dest_dir': None
+                                  })
         # Testing gz file type
         fn_txt = self._get_fn('.txt')
         fn_gz = self._get_fn('.gz')

--- a/tests/utils/test_decorators.py
+++ b/tests/utils/test_decorators.py
@@ -43,7 +43,7 @@ class ApplyDefaultTest(unittest.TestCase):
         dc = DummyClass(test_param=True)
         self.assertTrue(dc.test_param)
 
-        with self.assertRaisesRegexp(AirflowException, 'Argument.*test_param.*required'):
+        with self.assertRaisesRegex(AirflowException, 'Argument.*test_param.*required'):
             DummySubClass(test_sub_param=True)
 
     def test_default_args(self):
@@ -61,8 +61,8 @@ class ApplyDefaultTest(unittest.TestCase):
         self.assertTrue(dc.test_param)
         self.assertTrue(dsc.test_sub_param)
 
-        with self.assertRaisesRegexp(AirflowException,
-                                     'Argument.*test_sub_param.*required'):
+        with self.assertRaisesRegex(AirflowException,
+                                    'Argument.*test_sub_param.*required'):
             DummySubClass(default_args=default_args)
 
     def test_incorrect_default_args(self):
@@ -71,5 +71,5 @@ class ApplyDefaultTest(unittest.TestCase):
         self.assertTrue(dc.test_param)
 
         default_args = {'random_params': True}
-        with self.assertRaisesRegexp(AirflowException, 'Argument.*test_param.*required'):
+        with self.assertRaisesRegex(AirflowException, 'Argument.*test_param.*required'):
             DummyClass(default_args=default_args)

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -60,11 +60,11 @@ class TestAirflowJsonEncoder(unittest.TestCase):
         )
 
     def test_encode_raises(self):
-        self.assertRaisesRegexp(TypeError,
-                                "^%s is not JSON serializable$" % Exception,
-                                json.dumps,
-                                Exception,
-                                cls=utils_json.AirflowJsonEncoder)
+        self.assertRaisesRegex(TypeError,
+                               "^%s is not JSON serializable$" % Exception,
+                               json.dumps,
+                               Exception,
+                               cls=utils_json.AirflowJsonEncoder)
 
 
 if __name__ == '__main__':

--- a/tests/utils/test_module_loading.py
+++ b/tests/utils/test_module_loading.py
@@ -31,5 +31,5 @@ class ModuleImportTestCase(unittest.TestCase):
         with self.assertRaises(ImportError):
             import_string('no_dots_in_path')
         msg = 'Module "airflow.utils" does not define a "nonexistent" attribute'
-        with self.assertRaisesRegexp(ImportError, msg):
+        with self.assertRaisesRegex(ImportError, msg):
             import_string('airflow.utils.nonexistent')

--- a/tests/www/test_validators.py
+++ b/tests/www/test_validators.py
@@ -46,7 +46,7 @@ class TestGreaterEqualThan(unittest.TestCase):
         return validator(self.form_mock, self.form_field_mock)
 
     def test_field_not_found(self):
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             validators.ValidationError,
             "^Invalid field name 'some'.$",
             self._validate,
@@ -75,7 +75,7 @@ class TestGreaterEqualThan(unittest.TestCase):
     def test_validation_raises(self):
         self.form_field_mock.data = '2017-05-04'
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             validators.ValidationError,
             "^Field must be greater than or equal to other field.$",
             self._validate,
@@ -84,7 +84,7 @@ class TestGreaterEqualThan(unittest.TestCase):
     def test_validation_raises_custom_message(self):
         self.form_field_mock.data = '2017-05-04'
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             validators.ValidationError,
             "^This field must be greater than or equal to MyField.$",
             self._validate,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-4817\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4817
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-4817\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
