### PR TITLE
[AIRFLOW-4826] Fix warning in resetdb command

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -324,12 +324,13 @@ def resetdb():
 
     log.info("Dropping tables that exist")
 
-    models.base.Base.metadata.drop_all(settings.engine)
-    mc = MigrationContext.configure(settings.engine)
-    if mc._version.exists(settings.engine):
-        mc._version.drop(settings.engine)
+    connection = settings.engine.connect()
+    models.base.Base.metadata.drop_all(connection)
+    mc = MigrationContext.configure(connection)
+    if mc._version.exists(connection):
+        mc._version.drop(connection)
 
     from flask_appbuilder.models.sqla import Base
-    Base.metadata.drop_all(settings.engine)
+    Base.metadata.drop_all(connection)
 
     initdb()


### PR DESCRIPTION
Change engine to connection because error is thrown from new alembic version.
Connection is expected.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-4826

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
 - Change the resetdb command to use `settings.engine.connect()` instead of just `settings.engine` because the new version of alembic throws a warning about expecting a connection instead of an engine.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 - existing tests cover
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
