### PR TITLE
[AIRFLOW-4828] Remove parameter python_version

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,11 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Remove parameter python_version in PythonVirtualenvOperator 
+
+Due to [AIP-3 drop support Python 2](https://issues.apache.org/jira/browse/AIRFLOW-4196), PythonVirtualenvOperator
+not support parameter `python_version` anymore, which mean that PythonVirtualenvOperator only work with Python 3.
+
 ### Changes to Google Transfer Operator
 To obtain pylint compatibility the `filter ` argument in `GcpTransferServiceOperationsListOperator` 
 has been renamed to `request_filter`.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4828

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Part of AIP-3 Drop support for Python 2

### Code Quality

- [x] Passes `flake8`
