### PR TITLE
[AIRFLOW-4233] Remove Template Extension from Bq to GCS Operator

### DIFF
--- a/airflow/contrib/operators/bigquery_to_gcs.py
+++ b/airflow/contrib/operators/bigquery_to_gcs.py
@@ -60,7 +60,7 @@ class BigQueryToCloudStorageOperator(BaseOperator):
     """
     template_fields = ('source_project_dataset_table',
                        'destination_cloud_storage_uris', 'labels')
-    template_ext = ('.sql',)
+    template_ext = ()
     ui_color = '#e4e6f0'
 
     @apply_defaults


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-4233
  
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The issue happens when we have destination url ending with .sql. 
It is related to the defined template extension `template_ext = ('.sql',)`
The operator looks for jinja template, however, it's an output path, so the file is not found when looking for any jinja template syntax.
The BigQueryToCloudStorageOperator doesn't have sql parameter as it doesn't work with queries at all. It takes only tables.


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
n/a

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
