### PR TITLE
[AIRFLOW-4587] Replace self.conn with self.get_conn() in AWSAthenaHook

### DIFF
--- a/airflow/contrib/hooks/aws_athena_hook.py
+++ b/airflow/contrib/hooks/aws_athena_hook.py
@@ -36,7 +36,7 @@ class AWSAthenaHook(AwsHook):
     SUCCESS_STATES = ('SUCCEEDED',)
 
     def __init__(self, aws_conn_id='aws_default', sleep_time=30, *args, **kwargs):
-        super().__init__(aws_conn_id, **kwargs)
+        super().__init__(aws_conn_id, *args, **kwargs)
         self.sleep_time = sleep_time
         self.conn = None
 
@@ -64,10 +64,10 @@ class AWSAthenaHook(AwsHook):
         :type client_request_token: str
         :return: str
         """
-        response = self.conn.start_query_execution(QueryString=query,
-                                                   ClientRequestToken=client_request_token,
-                                                   QueryExecutionContext=query_context,
-                                                   ResultConfiguration=result_configuration)
+        response = self.get_conn().start_query_execution(QueryString=query,
+                                                         ClientRequestToken=client_request_token,
+                                                         QueryExecutionContext=query_context,
+                                                         ResultConfiguration=result_configuration)
         query_execution_id = response['QueryExecutionId']
         return query_execution_id
 
@@ -79,7 +79,7 @@ class AWSAthenaHook(AwsHook):
         :type query_execution_id: str
         :return: str
         """
-        response = self.conn.get_query_execution(QueryExecutionId=query_execution_id)
+        response = self.get_conn().get_query_execution(QueryExecutionId=query_execution_id)
         state = None
         try:
             state = response['QueryExecution']['Status']['State']
@@ -104,7 +104,7 @@ class AWSAthenaHook(AwsHook):
         elif query_state in self.INTERMEDIATE_STATES or query_state in self.FAILURE_STATES:
             self.log.error('Query is in {state} state. Cannot fetch results'.format(state=query_state))
             return None
-        return self.conn.get_query_results(QueryExecutionId=query_execution_id)
+        return self.get_conn().get_query_results(QueryExecutionId=query_execution_id)
 
     def poll_query_status(self, query_execution_id, max_tries=None):
         """
@@ -147,4 +147,4 @@ class AWSAthenaHook(AwsHook):
         :type query_execution_id: str
         :return: dict
         """
-        return self.conn.stop_query_execution(QueryExecutionId=query_execution_id)
+        return self.get_conn().stop_query_execution(QueryExecutionId=query_execution_id)

--- a/airflow/contrib/operators/aws_athena_operator.py
+++ b/airflow/contrib/operators/aws_athena_operator.py
@@ -72,7 +72,6 @@ class AWSAthenaOperator(BaseOperator):
         Run Presto Query on Athena
         """
         self.hook = self.get_hook()
-        self.hook.get_conn()
 
         self.query_execution_context['Database'] = self.database
         self.result_configuration['OutputLocation'] = self.output_location


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-4587

### Description

- Prevent from functions in the hook to use the `self.conn` variable directly.
