### PR TITLE
[AIRFLOW-4837] Fix pylint errors regarding ungrouped imports

### DIFF
--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -480,7 +480,6 @@
 ./tests/contrib/hooks/test_gcs_hook.py
 ./tests/contrib/hooks/test_grpc_hook.py
 ./tests/contrib/hooks/test_imap_hook.py
-./tests/contrib/hooks/test_jdbc_hook.py
 ./tests/contrib/hooks/test_jira_hook.py
 ./tests/contrib/hooks/test_mongo_hook.py
 ./tests/contrib/hooks/test_openfaas_hook.py
@@ -563,14 +562,12 @@
 ./tests/contrib/sensors/test_aws_redshift_cluster_sensor.py
 ./tests/contrib/sensors/test_bash_sensor.py
 ./tests/contrib/sensors/test_celery_queue_sensor.py
-./tests/contrib/sensors/test_emr_job_flow_sensor.py
 ./tests/contrib/sensors/test_emr_step_sensor.py
 ./tests/contrib/sensors/test_file_sensor.py
 ./tests/contrib/sensors/test_ftp_sensor.py
 ./tests/contrib/sensors/test_gcp_transfer_sensor.py
 ./tests/contrib/sensors/test_jira_sensor_test.py
 ./tests/contrib/sensors/test_python_sensor.py
-./tests/contrib/sensors/test_qubole_sensor.py
 ./tests/contrib/sensors/test_redis_pub_sub_sensor.py
 ./tests/contrib/sensors/test_sagemaker_endpoint_sensor.py
 ./tests/contrib/sensors/test_sagemaker_training_sensor.py
@@ -625,7 +622,6 @@
 ./tests/minikube/test_kubernetes_executor.py
 ./tests/minikube/test_kubernetes_pod_operator.py
 ./tests/models/test_cleartasks.py
-./tests/models/test_connection.py
 ./tests/models/test_dag.py
 ./tests/models/test_dagbag.py
 ./tests/models/test_dagrun.py
@@ -672,13 +668,8 @@
 ./tests/test_utils/reset_warning_registry.py
 ./tests/ti_deps/deps/fake_models.py
 ./tests/ti_deps/deps/test_dagrun_exists_dep.py
-./tests/ti_deps/deps/test_not_in_retry_period_dep.py
-./tests/ti_deps/deps/test_not_running_dep.py
-./tests/ti_deps/deps/test_prev_dagrun_dep.py
 ./tests/ti_deps/deps/test_ready_to_reschedule_dep.py
 ./tests/ti_deps/deps/test_runnable_exec_date_dep.py
-./tests/ti_deps/deps/test_task_concurrency.py
-./tests/ti_deps/deps/test_valid_state_dep.py
 ./tests/utils/log/elasticmock/fake_elasticsearch.py
 ./tests/utils/log/elasticmock/__init__.py
 ./tests/utils/log/test_es_task_handler.py
@@ -695,7 +686,6 @@
 ./tests/utils/test_logging_mixin.py
 ./tests/utils/test_log_handlers.py
 ./tests/utils/test_module_loading.py
-./tests/utils/test_operator_helpers.py
 ./tests/utils/test_tests.py
 ./tests/utils/test_timezone.py
 ./tests/www/api/experimental/test_endpoints.py

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -21,9 +21,9 @@
 from six import StringIO
 import sys
 import unittest
+from unittest.mock import patch, Mock, MagicMock
 
 from datetime import datetime, timedelta, time
-from unittest.mock import patch, Mock, MagicMock
 from time import sleep
 import psutil
 import pytz

--- a/tests/contrib/hooks/test_azure_container_instance_hook.py
+++ b/tests/contrib/hooks/test_azure_container_instance_hook.py
@@ -19,8 +19,8 @@
 
 import json
 import unittest
-from collections import namedtuple
 from unittest.mock import patch
+from collections import namedtuple
 
 from airflow import configuration
 from airflow.models import Connection

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -19,10 +19,10 @@
 #
 
 import unittest
+from unittest import mock
 from typing import List
 
 from google.auth.exceptions import GoogleAuthError
-from unittest import mock
 from googleapiclient.errors import HttpError
 
 from airflow.contrib.hooks import bigquery_hook as hook

--- a/tests/contrib/hooks/test_gcp_api_base_hook.py
+++ b/tests/contrib/hooks/test_gcp_api_base_hook.py
@@ -23,6 +23,8 @@ import unittest
 from io import StringIO
 
 from parameterized import parameterized
+import google.auth
+from google.auth.exceptions import GoogleAuthError
 from google.api_core.exceptions import RetryError, AlreadyExists
 from google.cloud.exceptions import MovedPermanently
 
@@ -30,9 +32,6 @@ from airflow import AirflowException, LoggingMixin
 from googleapiclient.errors import HttpError
 
 from airflow.contrib.hooks import gcp_api_base_hook as hook
-
-import google.auth
-from google.auth.exceptions import GoogleAuthError
 
 from airflow.hooks.base_hook import BaseHook
 from tests.compat import mock

--- a/tests/contrib/hooks/test_jdbc_hook.py
+++ b/tests/contrib/hooks/test_jdbc_hook.py
@@ -19,10 +19,8 @@
 #
 
 import unittest
+from unittest.mock import Mock, patch
 import json
-
-from unittest.mock import Mock
-from unittest.mock import patch
 
 from airflow import configuration
 from airflow.hooks.jdbc_hook import JdbcHook

--- a/tests/contrib/hooks/test_spark_sql_hook.py
+++ b/tests/contrib/hooks/test_spark_sql_hook.py
@@ -20,9 +20,8 @@
 
 import six
 import unittest
-from itertools import dropwhile
-
 from unittest.mock import patch, call
+from itertools import dropwhile
 
 from airflow import configuration
 from airflow.models import Connection

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -21,6 +21,8 @@
 import datetime
 import re
 import unittest
+from unittest.mock import MagicMock, Mock, patch
+
 from typing import Dict
 
 import time
@@ -44,8 +46,6 @@ from tests.compat import mock
 
 from copy import deepcopy
 
-from unittest.mock import MagicMock, Mock
-from unittest.mock import patch
 
 TASK_ID = 'test-dataproc-operator'
 CLUSTER_NAME = 'test-cluster-name'

--- a/tests/contrib/operators/test_emr_add_steps_operator.py
+++ b/tests/contrib/operators/test_emr_add_steps_operator.py
@@ -18,9 +18,8 @@
 # under the License.
 
 import unittest
-from datetime import timedelta
-
 from unittest.mock import MagicMock, patch
+from datetime import timedelta
 
 from airflow import DAG, configuration
 from airflow.contrib.operators.emr_add_steps_operator import EmrAddStepsOperator

--- a/tests/contrib/operators/test_emr_create_job_flow_operator.py
+++ b/tests/contrib/operators/test_emr_create_job_flow_operator.py
@@ -19,9 +19,8 @@
 #
 
 import unittest
-from datetime import timedelta
-
 from unittest.mock import MagicMock, patch
+from datetime import timedelta
 
 from airflow import DAG, configuration
 from airflow.contrib.operators.emr_create_job_flow_operator import EmrCreateJobFlowOperator

--- a/tests/contrib/operators/test_gcp_sql_operatorquery_system.py
+++ b/tests/contrib/operators/test_gcp_sql_operatorquery_system.py
@@ -17,10 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
+from os.path import dirname
 import random
 import string
 import unittest
-from os.path import dirname
 
 import time
 

--- a/tests/contrib/operators/test_gcp_transfer_operator_system_helper.py
+++ b/tests/contrib/operators/test_gcp_transfer_operator_system_helper.py
@@ -22,11 +22,11 @@ import os
 import subprocess
 
 from googleapiclient._auth import default_credentials, with_scopes
+from googleapiclient import discovery
 
 from tests.contrib.utils.base_gcp_system_test_case import RetrieveVariables
 from tests.contrib.utils.gcp_authenticator import GcpAuthenticator, GCP_GCS_TRANSFER_KEY
 from tests.contrib.utils.logging_command_executor import LoggingCommandExecutor
-from googleapiclient import discovery
 
 
 retrieve_variables = RetrieveVariables()

--- a/tests/contrib/operators/test_hive_to_dynamodb_operator.py
+++ b/tests/contrib/operators/test_hive_to_dynamodb_operator.py
@@ -20,9 +20,9 @@
 
 import json
 import unittest
+from unittest import mock
 import datetime
 
-from unittest import mock
 import pandas as pd
 
 from airflow import configuration, DAG

--- a/tests/contrib/sensors/test_emr_job_flow_sensor.py
+++ b/tests/contrib/sensors/test_emr_job_flow_sensor.py
@@ -18,9 +18,9 @@
 # under the License.
 
 import unittest
+from unittest.mock import MagicMock, patch
 import datetime
 from dateutil.tz import tzlocal
-from unittest.mock import MagicMock, patch
 
 from airflow import configuration, AirflowException
 from airflow.contrib.sensors.emr_job_flow_sensor import EmrJobFlowSensor

--- a/tests/contrib/sensors/test_emr_step_sensor.py
+++ b/tests/contrib/sensors/test_emr_step_sensor.py
@@ -18,8 +18,8 @@
 # under the License.
 
 import unittest
-from datetime import datetime
 from unittest.mock import MagicMock, patch
+from datetime import datetime
 from dateutil.tz import tzlocal
 
 from airflow import configuration, AirflowException

--- a/tests/contrib/sensors/test_ftp_sensor.py
+++ b/tests/contrib/sensors/test_ftp_sensor.py
@@ -18,9 +18,9 @@
 # under the License.
 
 import unittest
+from unittest.mock import MagicMock
 
 from ftplib import error_perm
-from unittest.mock import MagicMock
 
 from airflow.contrib.hooks.ftp_hook import FTPHook
 from airflow.contrib.sensors.ftp_sensor import FTPSensor

--- a/tests/contrib/sensors/test_qubole_sensor.py
+++ b/tests/contrib/sensors/test_qubole_sensor.py
@@ -19,9 +19,9 @@
 #
 
 import unittest
+from unittest.mock import patch
 
 from datetime import datetime
-from unittest.mock import patch
 
 from airflow.contrib.sensors.qubole_sensor import QuboleFileSensor, QubolePartitionSensor
 from airflow.exceptions import AirflowException

--- a/tests/core.py
+++ b/tests/core.py
@@ -19,9 +19,9 @@
 
 import json
 import unittest
+from unittest import mock
 
 import doctest
-from unittest import mock
 import multiprocessing
 import os
 import pickle  # type: ignore
@@ -30,6 +30,7 @@ import signal
 import sqlalchemy
 import subprocess
 import tempfile
+from tempfile import NamedTemporaryFile
 import warnings
 from datetime import timedelta
 from dateutil.relativedelta import relativedelta
@@ -37,31 +38,26 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from numpy.testing import assert_array_almost_equal
-from tempfile import NamedTemporaryFile
 from time import sleep
 
-from airflow import configuration
+from airflow import configuration, jobs, models, DAG, utils, macros, settings, exceptions
+from airflow.bin import cli
+from airflow.configuration import AirflowConfigException, run_command
+from airflow.exceptions import AirflowException
 from airflow.executors import SequentialExecutor
-from airflow.models import Variable, TaskInstance
-
-from airflow import jobs, models, DAG, utils, macros, settings, exceptions
-from airflow.models import BaseOperator, Connection, TaskFail
+from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.sqlite_hook import SqliteHook
+from airflow.models import Variable, TaskInstance, BaseOperator, Connection, TaskFail
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.check_operator import CheckOperator, ValueCheckOperator
 from airflow.operators.dagrun_operator import TriggerDagRunOperator
-from airflow.operators.python_operator import PythonOperator
 from airflow.operators.dummy_operator import DummyOperator
-
-from airflow.hooks.base_hook import BaseHook
-from airflow.hooks.sqlite_hook import SqliteHook
-from airflow.bin import cli
+from airflow.operators.python_operator import PythonOperator
 from airflow.settings import Session
 from airflow.utils import timezone
-from airflow.utils.timezone import datetime
-from airflow.utils.state import State
 from airflow.utils.dates import days_ago, infer_time_unit, round_time, scale_time_units
-from airflow.exceptions import AirflowException
-from airflow.configuration import AirflowConfigException, run_command
+from airflow.utils.state import State
+from airflow.utils.timezone import datetime
 from pendulum import utcnow
 
 import six

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -19,10 +19,10 @@
 import os
 import sys
 import unittest
+from unittest import mock
 import contextlib
 from multiprocessing import Pool
 
-from unittest import mock
 
 from celery import Celery
 from celery import states as celery_states
@@ -37,7 +37,7 @@ from airflow import configuration
 configuration.load_test_config()
 
 # leave this it is used by the test worker
-import celery.contrib.testing.tasks  # noqa: F401
+import celery.contrib.testing.tasks  # noqa: F401 pylint: disable=ungrouped-imports
 
 
 def _prepare_test_bodies():

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -23,9 +23,9 @@ import itertools
 import os
 import random
 import unittest
+from unittest import mock
 from collections import OrderedDict
 
-from unittest import mock
 import pandas as pd
 from hmsclient import HMSClient
 

--- a/tests/hooks/test_s3_hook.py
+++ b/tests/hooks/test_s3_hook.py
@@ -17,10 +17,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
+import unittest
 from unittest import mock
 import tempfile
-import unittest
 
 from botocore.exceptions import NoCredentialsError
 

--- a/tests/models/test_connection.py
+++ b/tests/models/test_connection.py
@@ -18,10 +18,10 @@
 # under the License.
 
 import unittest
+from unittest.mock import patch
 from collections import namedtuple
 
 from cryptography.fernet import Fernet
-from unittest.mock import patch
 from parameterized import parameterized
 
 from airflow.models import Connection, crypto

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -22,13 +22,13 @@ import logging
 import os
 import re
 import unittest
+from unittest.mock import patch
 import uuid
 from tempfile import NamedTemporaryFile
 
 import jinja2
 import pendulum
 import six
-from unittest.mock import patch
 
 from airflow import models, settings, configuration
 from airflow.exceptions import AirflowException, AirflowDagCycleException

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -23,9 +23,8 @@ import os
 import shutil
 import textwrap
 import unittest
-from tempfile import mkdtemp, NamedTemporaryFile
-
 from unittest.mock import patch, ANY
+from tempfile import mkdtemp, NamedTemporaryFile
 
 from airflow import models, configuration
 from airflow.models import DagModel, DagBag, TaskInstance as TI

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -20,11 +20,11 @@
 import datetime
 import time
 import unittest
+from unittest.mock import patch, mock_open
 import urllib
 from typing import Union, List
 import pendulum
 from freezegun import freeze_time
-from unittest.mock import patch, mock_open
 from parameterized import parameterized, param
 from sqlalchemy.orm.session import Session
 from airflow import models, settings, configuration

--- a/tests/operators/test_hive_stats_operator.py
+++ b/tests/operators/test_hive_stats_operator.py
@@ -18,9 +18,9 @@
 # under the License.
 
 import unittest
+from unittest.mock import patch
 from collections import OrderedDict
 
-from unittest.mock import patch
 
 from airflow import AirflowException
 from airflow.operators.hive_stats_operator import HiveStatsCollectionOperator

--- a/tests/operators/test_mssql_to_hive.py
+++ b/tests/operators/test_mssql_to_hive.py
@@ -18,13 +18,13 @@
 # under the License.
 
 import unittest
+from unittest.mock import patch, PropertyMock, Mock
 from collections import OrderedDict
 
 try:
     import pymssql
 except ImportError:
     pymssql = None
-from unittest.mock import patch, PropertyMock, Mock
 
 from airflow.operators.mssql_to_hive import MsSqlToHiveTransfer
 

--- a/tests/operators/test_s3_file_transform_operator.py
+++ b/tests/operators/test_s3_file_transform_operator.py
@@ -24,10 +24,11 @@ import os
 import shutil
 import sys
 import unittest
+from unittest import mock
 from tempfile import mkdtemp
 
 import boto3
-from unittest import mock
+
 from moto import mock_s3
 
 from airflow.exceptions import AirflowException

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -16,11 +16,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from unittest import mock
 import os
 import psutil
 import time
 import unittest
+from unittest import mock
 
 from airflow import models, settings
 from airflow.jobs import LocalTaskJob

--- a/tests/ti_deps/deps/test_not_in_retry_period_dep.py
+++ b/tests/ti_deps/deps/test_not_in_retry_period_dep.py
@@ -18,9 +18,9 @@
 # under the License.
 
 import unittest
+from unittest.mock import Mock
 from datetime import timedelta
 from freezegun import freeze_time
-from unittest.mock import Mock
 
 from airflow.models import TaskInstance
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep

--- a/tests/ti_deps/deps/test_not_running_dep.py
+++ b/tests/ti_deps/deps/test_not_running_dep.py
@@ -18,8 +18,8 @@
 # under the License.
 
 import unittest
-from datetime import datetime
 from unittest.mock import Mock
+from datetime import datetime
 
 from airflow.ti_deps.deps.not_running_dep import NotRunningDep
 from airflow.utils.state import State

--- a/tests/ti_deps/deps/test_prev_dagrun_dep.py
+++ b/tests/ti_deps/deps/test_prev_dagrun_dep.py
@@ -18,8 +18,8 @@
 # under the License.
 
 import unittest
-from datetime import datetime
 from unittest.mock import Mock
+from datetime import datetime
 
 from airflow.models import DAG, BaseOperator
 from airflow.ti_deps.dep_context import DepContext

--- a/tests/ti_deps/deps/test_ready_to_reschedule_dep.py
+++ b/tests/ti_deps/deps/test_ready_to_reschedule_dep.py
@@ -18,8 +18,8 @@
 # under the License.
 
 import unittest
-from datetime import timedelta
 from unittest.mock import Mock, patch
+from datetime import timedelta
 
 from airflow.models import DAG, TaskInstance, TaskReschedule
 from airflow.ti_deps.dep_context import DepContext

--- a/tests/ti_deps/deps/test_task_concurrency.py
+++ b/tests/ti_deps/deps/test_task_concurrency.py
@@ -18,8 +18,8 @@
 # under the License.
 
 import unittest
-from datetime import datetime
 from unittest.mock import Mock
+from datetime import datetime
 
 from airflow.models import DAG, BaseOperator
 from airflow.ti_deps.dep_context import DepContext

--- a/tests/ti_deps/deps/test_valid_state_dep.py
+++ b/tests/ti_deps/deps/test_valid_state_dep.py
@@ -18,8 +18,8 @@
 # under the License.
 
 import unittest
-from datetime import datetime
 from unittest.mock import Mock
+from datetime import datetime
 
 from airflow import AirflowException
 from airflow.ti_deps.deps.valid_state_dep import ValidStateDep

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -23,9 +23,8 @@ import sys
 import tempfile
 import unittest
 from unittest import mock
-from datetime import timedelta
-
 from unittest.mock import MagicMock
+from datetime import timedelta
 
 from airflow import configuration as conf
 from airflow.jobs import DagFileProcessor

--- a/tests/utils/test_operator_helpers.py
+++ b/tests/utils/test_operator_helpers.py
@@ -18,9 +18,8 @@
 # under the License.
 
 import unittest
-from datetime import datetime
-
 from unittest import mock
+from datetime import datetime
 
 from airflow.utils import operator_helpers
 

--- a/tests/www/api/experimental/test_kerberos_endpoints.py
+++ b/tests/www/api/experimental/test_kerberos_endpoints.py
@@ -18,10 +18,10 @@
 # under the License.
 
 import json
+import unittest
 from unittest import mock
 import os
 import socket
-import unittest
 
 from datetime import datetime
 

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -18,8 +18,8 @@
 # under the License.
 
 import unittest
-import logging
 from unittest import mock
+import logging
 
 from flask import Flask
 from flask_appbuilder import AppBuilder, SQLA, Model, has_access, expose

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -18,10 +18,10 @@
 # under the License.
 
 import unittest
+from unittest import mock
 from datetime import datetime
 from urllib.parse import parse_qs
 
-from unittest import mock
 from bs4 import BeautifulSoup
 
 from airflow.www import utils

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -26,11 +26,11 @@ import shutil
 import sys
 import tempfile
 import unittest
-import urllib
-from datetime import timedelta
-from urllib.parse import quote_plus
-
 from unittest import mock
+import urllib
+from urllib.parse import quote_plus
+from datetime import timedelta
+
 import jinja2
 from flask import Markup, url_for
 from parameterized import parameterized


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-4837\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4837
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-4837\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

This change fixes the following errors:
```
tests/operators/test_mssql_to_hive.py:27:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/operators/test_hive_stats_operator.py:23:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/operators/test_s3_file_transform_operator.py:30:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/core.py:24:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/core.py:40:0: C0412: Imports from package tempfile are not grouped (ungrouped-imports)
tests/utils/test_dag_processing.py:28:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/utils/test_operator_helpers.py:23:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/models/test_dag.py:31:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/models/test_connection.py:24:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/models/test_taskinstance.py:27:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/models/test_dagbag.py:28:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/cli/test_cli.py:26:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/contrib/sensors/test_qubole_sensor.py:24:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/contrib/sensors/test_ftp_sensor.py:23:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/contrib/sensors/test_emr_step_sensor.py:22:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/contrib/sensors/test_emr_job_flow_sensor.py:23:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/contrib/operators/test_emr_create_job_flow_operator.py:24:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/contrib/operators/test_emr_add_steps_operator.py:23:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/contrib/operators/test_gcp_transfer_operator_system_helper.py:29:0: C0412: Imports from package googleapiclient are not grouped (ungrouped-imports)
tests/contrib/operators/test_dataproc_operator.py:47:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/contrib/operators/test_hive_to_dynamodb_operator.py:25:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/contrib/operators/test_gcp_sql_operatorquery_system.py:23:0: C0412: Imports from package os are not grouped (ungrouped-imports)
tests/contrib/hooks/test_azure_container_instance_hook.py:23:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/contrib/hooks/test_gcp_api_base_hook.py:34:0: C0412: Imports from package google are not grouped (ungrouped-imports)
tests/contrib/hooks/test_jdbc_hook.py:24:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/contrib/hooks/test_bigquery_hook.py:25:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/contrib/hooks/test_spark_sql_hook.py:25:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/www/test_utils.py:24:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/www/test_security.py:22:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/www/test_views.py:31:0: C0412: Imports from package urllib are not grouped (ungrouped-imports)
tests/www/test_views.py:33:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/www/api/experimental/test_kerberos_endpoints.py:24:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/ti_deps/deps/test_task_concurrency.py:22:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/ti_deps/deps/test_valid_state_dep.py:22:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/ti_deps/deps/test_prev_dagrun_dep.py:22:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/ti_deps/deps/test_not_in_retry_period_dep.py:23:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/ti_deps/deps/test_ready_to_reschedule_dep.py:22:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/ti_deps/deps/test_not_running_dep.py:22:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/executors/test_celery_executor.py:25:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/executors/test_celery_executor.py:40:0: C0412: Imports from package celery are not grouped (ungrouped-imports)
tests/hooks/test_hive_hook.py:29:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/hooks/test_s3_hook.py:23:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)
tests/task/task_runner/test_standard_task_runner.py:23:0: C0412: Imports from package unittest are not grouped (ungrouped-imports)

```
### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
