### PR TITLE
[AIRFLOW-4838] Surface Athena errors in AWSAthenaOperator

### DIFF
--- a/airflow/contrib/hooks/aws_athena_hook.py
+++ b/airflow/contrib/hooks/aws_athena_hook.py
@@ -88,6 +88,22 @@ class AWSAthenaHook(AwsHook):
         finally:
             return state
 
+    def get_state_change_reason(self, query_execution_id):
+        """
+        Fetch the reason for a state change (e.g. error message). Returns None or reason string.
+        :param query_execution_id: Id of submitted athena query
+        :type query_execution_id: str
+        :return: str
+        """
+        response = self.conn.get_query_execution(QueryExecutionId=query_execution_id)
+        reason = None
+        try:
+            reason = response['QueryExecution']['Status']['StateChangeReason']
+        except Exception as ex:
+            self.log.error('Exception while getting query state change reason', ex)
+        finally:
+            return reason
+
     def get_query_results(self, query_execution_id):
         """
         Fetch submitted athena query results. returns none if query is in intermediate state or

--- a/airflow/contrib/operators/aws_athena_operator.py
+++ b/airflow/contrib/operators/aws_athena_operator.py
@@ -87,7 +87,7 @@ class AWSAthenaOperator(BaseOperator):
             error_message = self.hook.get_state_change_reason(self.query_execution_id)
             raise Exception(
                 'Final state of Athena job is {}, query_execution_id is {}. Error: {}'
-                .format(query_status, self.query_execution_id, error_message)
+                .format(query_status, self.query_execution_id, error_message))
         elif not query_status or query_status in AWSAthenaHook.INTERMEDIATE_STATES:
             raise Exception(
                 'Final state of Athena job is {}. '

--- a/airflow/contrib/operators/aws_athena_operator.py
+++ b/airflow/contrib/operators/aws_athena_operator.py
@@ -84,9 +84,10 @@ class AWSAthenaOperator(BaseOperator):
         query_status = self.hook.poll_query_status(self.query_execution_id, self.max_tries)
 
         if query_status in AWSAthenaHook.FAILURE_STATES:
+            error_message = self.hook.get_state_change_reason(self.query_execution_id)
             raise Exception(
-                'Final state of Athena job is {}, query_execution_id is {}.'
-                .format(query_status, self.query_execution_id))
+                'Final state of Athena job is {}, query_execution_id is {}. Error: {}'
+                .format(query_status, self.query_execution_id), error_message)
         elif not query_status or query_status in AWSAthenaHook.INTERMEDIATE_STATES:
             raise Exception(
                 'Final state of Athena job is {}. '

--- a/airflow/contrib/operators/aws_athena_operator.py
+++ b/airflow/contrib/operators/aws_athena_operator.py
@@ -87,7 +87,7 @@ class AWSAthenaOperator(BaseOperator):
             error_message = self.hook.get_state_change_reason(self.query_execution_id)
             raise Exception(
                 'Final state of Athena job is {}, query_execution_id is {}. Error: {}'
-                .format(query_status, self.query_execution_id), error_message)
+                .format(query_status, self.query_execution_id, error_message)
         elif not query_status or query_status in AWSAthenaHook.INTERMEDIATE_STATES:
             raise Exception(
                 'Final state of Athena job is {}. '

--- a/tests/contrib/operators/test_aws_athena_operator.py
+++ b/tests/contrib/operators/test_aws_athena_operator.py
@@ -103,15 +103,18 @@ class TestAWSAthenaOperator(unittest.TestCase):
                                                MOCK_DATA['client_request_token'])
         self.assertEqual(mock_check_query_status.call_count, 3)
 
+    @mock.patch.object(AWSAthenaHook, 'get_state_change_reason')
     @mock.patch.object(AWSAthenaHook, 'check_query_status', side_effect=("RUNNING", "FAILED",))
     @mock.patch.object(AWSAthenaHook, 'run_query', return_value=ATHENA_QUERY_ID)
     @mock.patch.object(AWSAthenaHook, 'get_conn')
-    def test_hook_run_failure_query(self, mock_conn, mock_run_query, mock_check_query_status):
+    def test_hook_run_failure_query(self, mock_conn, mock_run_query, mock_check_query_status,
+                                    mock_get_state_change_reason):
         with self.assertRaises(Exception):
             self.athena.execute(None)
         mock_run_query.assert_called_once_with(MOCK_DATA['query'], query_context, result_configuration,
                                                MOCK_DATA['client_request_token'])
         self.assertEqual(mock_check_query_status.call_count, 2)
+        self.assertEqual(mock_get_state_change_reason.call_count, 1)
 
     @mock.patch.object(AWSAthenaHook, 'check_query_status', side_effect=("RUNNING", "RUNNING", "CANCELLED",))
     @mock.patch.object(AWSAthenaHook, 'run_query', return_value=ATHENA_QUERY_ID)


### PR DESCRIPTION
When a Athena query results in a failure state
the Athena error message is available from the
boto3 response. This commit surfaces that error
message in the AWSAthenaOperator through the
get_state_change_reason in AWSAthenaHook.


### Jira
https://issues.apache.org/jira/browse/AIRFLOW-4838

### Description
This PR surfaces the Athena `StateChangeReason` which in case of a query failure includes more information about the error. The new method `get_state_change_reason` in the `AWSAthenaHook` gets the string from the returned `boto3` response

### Tests
The PR adds an additional assert to the `test_hook_run_failure_query` test which covers the new `get_state_change_reason` method.
