### PR TITLE
[AIRFLOW-4841] Fix Sphinx doc warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -192,7 +192,7 @@ databricks = ['requests>=2.20.0, <3']
 datadog = ['datadog>=0.14.0']
 doc = [
     'sphinx-argparse>=0.1.13',
-    'sphinx-autoapi>=0.7.1',
+    'sphinx-autoapi==1.0.0',
     'sphinx-rtd-theme>=0.1.6',
     'sphinx>=1.2.3',
     'sphinxcontrib-httpdomain>=1.7.0',

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -254,10 +254,10 @@ class HelpersTest(unittest.TestCase):
         [t1, t2, t3, t4, t5, t6] = [DummyOperator(task_id='t{i}'.format(i=i), dag=dag) for i in range(1, 7)]
         helpers.chain(t1, [t2, t3], [t4, t5], t6)
 
-        self.assertItemsEqual([t2, t3], t1.get_direct_relatives(upstream=False))
+        self.assertCountEqual([t2, t3], t1.get_direct_relatives(upstream=False))
         self.assertEqual([t4], t2.get_direct_relatives(upstream=False))
         self.assertEqual([t5], t3.get_direct_relatives(upstream=False))
-        self.assertItemsEqual([t4, t5], t6.get_direct_relatives(upstream=True))
+        self.assertCountEqual([t4, t5], t6.get_direct_relatives(upstream=True))
 
     def test_chain_not_support_type(self):
         dag = DAG(dag_id='test_chain', start_date=datetime.now())

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -254,10 +254,10 @@ class HelpersTest(unittest.TestCase):
         [t1, t2, t3, t4, t5, t6] = [DummyOperator(task_id='t{i}'.format(i=i), dag=dag) for i in range(1, 7)]
         helpers.chain(t1, [t2, t3], [t4, t5], t6)
 
-        self.assertCountEqual([t2, t3], t1.get_direct_relatives(upstream=False))
+        self.assertItemsEqual([t2, t3], t1.get_direct_relatives(upstream=False))
         self.assertEqual([t4], t2.get_direct_relatives(upstream=False))
         self.assertEqual([t5], t3.get_direct_relatives(upstream=False))
-        self.assertCountEqual([t4, t5], t6.get_direct_relatives(upstream=True))
+        self.assertItemsEqual([t4, t5], t6.get_direct_relatives(upstream=True))
 
     def test_chain_not_support_type(self):
         dag = DAG(dag_id='test_chain', start_date=datetime.now())


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
