### PR TITLE
[AIRFLOW-4842] Add Py2 deprecation notice

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -22,7 +22,13 @@ under the License.
 This file documents any backwards-incompatible changes in Airflow and
 assists users migrating to a new version.
 
-## Airflow Master
+## Airflow 1.10.4
+
+### Python 2 support is going away
+
+Airflow 1.10 will be the last release series to support Python 2. Airflow 2.0.0 will only support Python 3.5 and up.
+
+If you have a specific task that still requires Python 2 then you can use the PythonVirtualenvOperator for this.
 
 ### Changes to DatastoreHook
 * removed argument `version` from `get_conn` function and added it to the hook's `__init__` function instead and renamed it to `api_version`

--- a/setup.py
+++ b/setup.py
@@ -435,4 +435,11 @@ def do_setup():
 
 
 if __name__ == "__main__":
+    # Warn about py2 support going away. This likely won't show up if installed
+    # via pip, but we may as well have it here
+    if sys.version_info[0] == 2:
+        sys.stderr.writelines(
+            "DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Airflow 1.10 "
+            "will be the last release series to support Python 2\n"
+        )
     do_setup()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4842

### Description

- [x] Document dropping support for Py2 in Airflow 2.0.
