### PR TITLE
[AIRFLOW-4298] Stop Scheduler repeatedly warning "connection invalidated"

### DIFF
--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -73,7 +73,13 @@ def setup_event_handlers(engine,
                         err)
                     raise
                 if err.connection_invalidated:
-                    log.warning("DB connection invalidated. Reconnecting...")
+                    # Don't log the first time -- this happens a lot and unless
+                    # there is a problem reconnecting is not a sign of a
+                    # problem
+                    if backoff > initial_backoff_seconds:
+                        log.warning("DB connection invalidated. Reconnecting...")
+                    else:
+                        log.debug("DB connection invalidated. Initial reconnect")
 
                     # Use a truncated binary exponential backoff. Also includes
                     # a jitter to prevent the thundering herd problem of


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4298

### Description

- [x] This appeared a lot more often with recent versions of SQLAlchemy and is
not a sign of any problem in the _initial_ case, so don't log the
message as a warning the first time we retry.


### Tests

- [x] No automated tests. Change tested manually

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`