### PR TITLE
[AIRFLOW-XXX] Remove smart quotes from default config

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -102,7 +102,7 @@ sql_alchemy_pool_size = 5
 # additional connections will be returned up to this limit.
 # When those additional connections are returned to the pool, they are disconnected and discarded.
 # It follows then that the total number of simultaneous connections the pool will allow is pool_size + max_overflow,
-# and the total number of “sleeping” connections the pool will allow is pool_size.
+# and the total number of "sleeping" connections the pool will allow is pool_size.
 # max_overflow can be set to -1 to indicate no overflow limit;
 # no limit will be placed on the total number of concurrent connections. Defaults to 10.
 sql_alchemy_max_overflow = 10


### PR DESCRIPTION
### Jira
- [x] No jira

### Description
- [x] It _might_ cause problems on Python2 trying to read the file as ASCII, and we don't need it, so better safe than sorry.