### PR TITLE
[AIRFLOW-4847] Update config template to reflect supporting different Celery pool implementation

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -27,7 +27,7 @@ assists users migrating to a new version.
 ### `pool` config option in Celery section to support different Celery pool implementation
 
 The new `pool` config option allows users to choose different pool
-implementation. Default value is "prefork", while choices include "prefok" (default),
+implementation. Default value is "prefork", while choices include "prefork" (default),
 "eventlet", "gevent" or "solo". This may help users achieve better concurrency performance
 in different scenarios.
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,17 @@ assists users migrating to a new version.
 ## Airflow Master
 
 
+### `pool` config option in Celery section to support different Celery pool implementation
+
+The new `pool` config option allows users to choose different pool
+implementation. Default value is "prefork", while choices include "prefok" (default),
+"eventlet", "gevent" or "solo". This may help users achieve better concurrency performance
+in different scenarios.
+
+For more details about Celery pool implementation, please refer to:
+- https://docs.celeryproject.org/en/latest/userguide/workers.html#concurrency
+- https://docs.celeryproject.org/en/latest/userguide/concurrency/eventlet.html
+
 ### Removal of `non_pooled_task_slot_count` and `non_pooled_backfill_task_slot_count`
 
 `non_pooled_task_slot_count` and `non_pooled_backfill_task_slot_count`

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -415,6 +415,13 @@ ssl_key =
 ssl_cert =
 ssl_cacert =
 
+# Celery Pool implementation.
+# Choices include: prefork (default), eventlet, gevent or solo.
+# See:
+#   https://docs.celeryproject.org/en/latest/userguide/workers.html#concurrency
+#   https://docs.celeryproject.org/en/latest/userguide/concurrency/eventlet.html
+pool = prefork
+
 [celery_broker_transport_options]
 # This section is for specifying options which can be passed to the
 # underlying celery broker transport.  See:


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4847

### Description

The support to different Celery pool implementation has been added in https://github.com/apache/airflow/pull/4308 (https://github.com/apache/airflow/blob/master/airflow/bin/cli.py#L1086-L1087).

But it's not reflected in the default_airflow.cfg yet, while it's the main portal of config options to most users. Currently the only way for users to get to know the existence of this option is to check source code of `bin/cli.py` (like what I have done).

This situation can be addressed by adding it into `default_airflow.cfg` and mentioning this change in `UPDATING.md`.