### PR TITLE
[AIRFLOW-4849] Add gcp_conn_id to cloudsqldatabehook class to use correctly CloudSqlProxyRunner class

### DIFF
--- a/airflow/contrib/hooks/gcp_sql_hook.py
+++ b/airflow/contrib/hooks/gcp_sql_hook.py
@@ -712,6 +712,9 @@ class CloudSqlDatabaseHook(BaseHook):
 
     :param gcp_cloudsql_conn_id: URL of the connection
     :type gcp_cloudsql_conn_id: str
+    :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform for
+        cloud-sql-proxy authentication.
+    :type gcp_conn_id: str
     :param default_gcp_project_id: Default project id used if project_id not specified
            in the connection URL
     :type default_gcp_project_id: str
@@ -719,8 +722,9 @@ class CloudSqlDatabaseHook(BaseHook):
     _conn = None
 
     def __init__(self, gcp_cloudsql_conn_id='google_cloud_sql_default',
-                 default_gcp_project_id=None):
+                 gcp_conn_id='google_cloud_default', default_gcp_project_id=None):
         super().__init__(source=None)
+        self.gcp_conn_id = gcp_conn_id
         self.gcp_cloudsql_conn_id = gcp_cloudsql_conn_id
         self.cloudsql_connection = self.get_connection(self.gcp_cloudsql_conn_id)
         self.extras = self.cloudsql_connection.extra_dejson
@@ -972,7 +976,7 @@ class CloudSqlDatabaseHook(BaseHook):
             project_id=self.project_id,
             sql_proxy_version=self.sql_proxy_version,
             sql_proxy_binary_path=self.sql_proxy_binary_path,
-            gcp_conn_id=self.gcp_cloudsql_conn_id
+            gcp_conn_id=self.gcp_conn_id
         )
 
     def get_database_hook(self):

--- a/airflow/contrib/operators/gcp_sql_operator.py
+++ b/airflow/contrib/operators/gcp_sql_operator.py
@@ -772,6 +772,7 @@ class CloudSqlQueryOperator(BaseOperator):
         self.gcp_connection = BaseHook.get_connection(self.gcp_conn_id)
         self.cloudsql_db_hook = CloudSqlDatabaseHook(
             gcp_cloudsql_conn_id=gcp_cloudsql_conn_id,
+            gcp_conn_id=gcp_conn_id,
             default_gcp_project_id=self.gcp_connection.extra_dejson.get(
                 'extra__google_cloud_platform__project'))
         self.cloud_sql_proxy_runner = None

--- a/tests/hooks/test_gcp_sql_hook.py
+++ b/tests/hooks/test_gcp_sql_hook.py
@@ -17,9 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-from unittest import mock
+import json
 import unittest
+from unittest import mock
+
 from airflow.contrib.hooks.gcp_sql_hook import CloudSqlDatabaseHook
 from airflow.models.connection import Connection
 
@@ -30,27 +31,52 @@ class TestCloudSqlDatabaseHook(unittest.TestCase):
     def setUp(self, m):
         super().setUp()
 
-        self.connection = Connection(
-            conn_id='my_gcp_connection',
+        self.sql_connection = Connection(
+            conn_id='my_gcp_sql_connection',
+            conn_type='gcpcloudsql',
             login='login',
             password='password',
             host='host',
             schema='schema',
-            extra='{"database_type":"postgres", "location":"my_location", "instance":"my_instance", '
-                  '"use_proxy": true, "project_id":"my_project"}'
+            extra='{"database_type":"postgres", "location":"my_location", '
+                  '"instance":"my_instance", "use_proxy": true, '
+                  '"project_id":"my_project"}'
         )
+        self.connection = Connection(
+            conn_id='my_gcp_connection',
+            conn_type='google_cloud_platform',
+        )
+        scopes = [
+            "https://www.googleapis.com/auth/pubsub",
+            "https://www.googleapis.com/auth/datastore",
+            "https://www.googleapis.com/auth/bigquery",
+            "https://www.googleapis.com/auth/devstorage.read_write",
+            "https://www.googleapis.com/auth/logging.write",
+            "https://www.googleapis.com/auth/cloud-platform",
+        ]
+        conn_extra = {
+            "extra__google_cloud_platform__scope": ",".join(scopes),
+            "extra__google_cloud_platform__project": "your-gcp-project",
+            "extra__google_cloud_platform__key_path":
+                '/var/local/google_cloud_default.json'
+        }
+        conn_extra_json = json.dumps(conn_extra)
+        self.connection.set_extra(conn_extra_json)
 
         m.return_value = self.connection
-        self.db_hook = CloudSqlDatabaseHook('my_gcp_connection')
+        self.db_hook = CloudSqlDatabaseHook(
+            gcp_cloudsql_conn_id='my_gcp_sql_connection',
+            gcp_conn_id='my_gcp_connection'
+        )
 
     def test_get_sqlproxy_runner(self):
         self.db_hook._generate_connection_uri()
         sqlproxy_runner = self.db_hook.get_sqlproxy_runner()
         self.assertEqual(sqlproxy_runner.gcp_conn_id, self.connection.conn_id)
-        project = self.connection.extra_dejson['project_id']
-        location = self.connection.extra_dejson['location']
-        instance = self.connection.extra_dejson['instance']
-        instance_spec = "{project}:{location}:{instance}".format(project=project,
-                                                                 location=location,
-                                                                 instance=instance)
+        project = self.sql_connection.extra_dejson['project_id']
+        location = self.sql_connection.extra_dejson['location']
+        instance = self.sql_connection.extra_dejson['instance']
+        instance_spec = "{project}:{location}:{instance}".format(
+            project=project, location=location, instance=instance
+        )
         self.assertEqual(sqlproxy_runner.instance_specification, instance_spec)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4849) 

### Description

- [x] CloudSqlQueryOperator() class has gcp_conn_id,  gcp_cloudsql_conn_id attributes and a object attribute of the CloudSqlDatabaseHook class to manage cloud_sql_proxy but CloudSqlDatabaseHook doesn't passing gcp_conn_id as argument, only use gcp_cloudsql_conn_id. So when the  get_sqlproxy_runner() method in CloudSqlDatabaseHook call CloudSqlProxyRunner() class, CloudSqlProxyRunner try to get gcp credential from gcp_cloudsql_conn_id but it hasn't credential parameter and Airflow send the following message:
 
`[2019-06-25 09:31:55,381] {logging_mixin.py:95} INFO - [2019-06-25 09:31:55,381] {gcp_sql_hook.py:508} INFO - The credentials are not supplied by neither key_path nor keyfile_dict of the gcp connection google_cloud_proxy_conn_XXX. Falling back to default activated account`

This fix add gcp_coon_id attribute to CloudSqlDatabaseHook class, change parameter passed to CloudSqlProxyRunner from gcp_cloudsql_conn_id to gcp_conn_id and add gcp_conn_id parameter to CloudSqlDatabaseHook when it is called from CloudSqlQueryOperator

There was other issue about the problem (https://issues.apache.org/jira/browse/AIRFLOW-4557?jql=text%20~%20%22AIRFLOW-4557%22) but the solution was not resolve the error because CloudSqlProxyRunner() need a google cloud platform connection not a google cloud sql connection.


### Tests

- [x] My PR adds modification on the following unit tests :

- test_gcp_sql_hook.test_get_sqlproxy_runner()

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] No new functionality, fixing a bug

### Code Quality

- [x] Passes `flake8`
