### PR TITLE
[AIRFLOW-4850] *_cmd configuration options should interpolate environment variables

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -73,7 +73,7 @@ def run_command(command):
     Runs command and returns stdout
     """
     process = subprocess.Popen(
-        shlex.split(command),
+        shlex.split(os.path.expandvars(command)),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         close_fds=True)

--- a/tests/core.py
+++ b/tests/core.py
@@ -963,6 +963,10 @@ class CoreTest(unittest.TestCase):
         self.assertEqual(run_command('echo "foo bar"'), 'foo bar\n')
         self.assertRaises(AirflowConfigException, run_command, 'bash -c "exit 1"')
 
+        os.environ["FOO"] = "bar"
+        self.assertEqual(run_command('echo "$FOO"'), "bar\n")
+        del os.environ["FOO"]
+
     def test_trigger_dagrun_with_execution_date(self):
         utc_now = timezone.utcnow()
         run_id = 'trig__' + utc_now.isoformat()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4850
 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When specifying a configuration like sql_alchemy_conn_cmd, it should be able to interpolate environment variables from the environment that airflow is running from.  This is really useful when you mount secrets as environment variables and want to use them in this type of configuration option.  For example, this currently does not work:

`sql_alchemy_conn_cmd = echo ${POSTGRES_HOST}:${POSTGRES_PASSWORD}@postgres.com`


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
