### PR TITLE
[AIRFLOW-4880] Add success, failure and fail_on_empty params to SqlSensor

### DIFF
--- a/airflow/sensors/sql_sensor.py
+++ b/airflow/sensors/sql_sensor.py
@@ -27,7 +27,7 @@ from airflow.utils.decorators import apply_defaults
 
 class SqlSensor(BaseSensorOperator):
     """
-    Runs a sql statement repeteadly until a criteria is met. It will keep trying until
+    Runs a sql statement repeatedly until a criteria is met. It will keep trying until
     sql returns no rows, or if the first cell is in (0, '0', ''). Optional success
     and failure iterables are matched to the first cell returned. If success
     iterable is defined the sensor will keep retrying until the criteria is met.

--- a/airflow/sensors/sql_sensor.py
+++ b/airflow/sensors/sql_sensor.py
@@ -27,8 +27,13 @@ from airflow.utils.decorators import apply_defaults
 
 class SqlSensor(BaseSensorOperator):
     """
-    Runs a sql statement until a criteria is met. It will keep trying while
-    sql returns no row, or if the first cell in (0, '0', '').
+    Runs a sql statement repeteadly until a criteria is met. It will keep trying until
+    sql returns no rows, or if the first cell is in (0, '0', ''). Optional success
+    and failure iterables are matched to the first cell returned. If success
+    iterable is defined the sensor will keep retrying until the criteria is met.
+    If failure iterable is defined and the criteria is met the sensor will raise AirflowException.
+    Failure criteria is evaluated before success criteria. A fail_on_empty boolean can also
+    be passed to the sensor in which case it will fail if no rows have been returned
 
     :param conn_id: The connection to run the sensor against
     :type conn_id: str
@@ -37,17 +42,27 @@ class SqlSensor(BaseSensorOperator):
     :type sql: str
     :param parameters: The parameters to render the SQL query with (optional).
     :type parameters: mapping or iterable
+    :param success: Success criteria for the sensor
+    :type: success: Optional<Iterable>
+    :param failure: Failure criteria for the sensor
+    :type: failure: Optional<Iterable>
+    :param fail_on_empty: Explicitly fail on no rows returned
+    :type: fail_on_empty: bool
     """
     template_fields = ('sql',)  # type: Iterable[str]
     template_ext = ('.hql', '.sql',)  # type: Iterable[str]
     ui_color = '#7c7287'
 
     @apply_defaults
-    def __init__(self, conn_id, sql, parameters=None, *args, **kwargs):
+    def __init__(self, conn_id, sql, parameters=None, success=None, failure=None, fail_on_empty=False, *args,
+                 **kwargs):
         self.conn_id = conn_id
         self.sql = sql
         self.parameters = parameters
-        super().__init__(*args, **kwargs)
+        self.success = success
+        self.failure = failure
+        self.fail_on_empty = fail_on_empty
+        super(SqlSensor, self).__init__(*args, **kwargs)
 
     def poke(self, context):
         conn = BaseHook.get_connection(self.conn_id)
@@ -63,5 +78,18 @@ class SqlSensor(BaseSensorOperator):
         self.log.info('Poking: %s (with parameters %s)', self.sql, self.parameters)
         records = hook.get_records(self.sql, self.parameters)
         if not records:
-            return False
-        return str(records[0][0]) not in ('0', '')
+            if self.fail_on_empty:
+                raise AirflowException("No rows returned, raising as per fail_on_empty flag")
+            else:
+                return False
+        first_cell = records[0][0]
+        if self.failure is not None:
+            if first_cell in self.failure:
+                raise AirflowException(
+                    "Failure criteria met. Value {} found in {}".format(first_cell, self.failure))
+        if self.success is not None:
+            if first_cell in self.success:
+                return True
+            else:
+                return False
+        return str(first_cell) not in ('0', '')

--- a/airflow/sensors/sql_sensor.py
+++ b/airflow/sensors/sql_sensor.py
@@ -43,14 +43,15 @@ class SqlSensor(BaseSensorOperator):
     :param parameters: The parameters to render the SQL query with (optional).
     :type parameters: mapping or iterable
     :param success: Success criteria for the sensor is a Callable that takes first_cell
-    as the only argument, and returns a boolean (optional).
+        as the only argument, and returns a boolean (optional).
     :type: success: Optional<Callable[[Any], bool]>
     :param failure: Failure criteria for the sensor is a Callable that takes first_cell
-    as the only argument and return a boolean (optional).
+        as the only argument and return a boolean (optional).
     :type: failure: Optional<Callable[[Any], bool]>
     :param fail_on_empty: Explicitly fail on no rows returned
     :type: fail_on_empty: bool
     """
+
     template_fields = ('sql',)  # type: Iterable[str]
     template_ext = ('.hql', '.sql',)  # type: Iterable[str]
     ui_color = '#7c7287'

--- a/tests/sensors/test_sql_sensor.py
+++ b/tests/sensors/test_sql_sensor.py
@@ -203,3 +203,33 @@ class SqlSensorTests(unittest.TestCase):
 
         mock_get_records.return_value = [[1]]
         self.assertRaises(AirflowException, t.poke, None)
+
+    @mock.patch('airflow.sensors.sql_sensor.BaseHook')
+    def test_sql_sensor_postgres_poke_invalid_failure(self, mock_hook):
+        t = SqlSensor(
+            task_id='sql_sensor_check',
+            conn_id='postgres_default',
+            sql="SELECT 1",
+            failure=[1],
+        )
+
+        mock_hook.get_connection('postgres_default').conn_type = "postgres"
+        mock_get_records = mock_hook.get_connection.return_value.get_hook.return_value.get_records
+
+        mock_get_records.return_value = [[1]]
+        self.assertRaises(AirflowException, t.poke, None)
+
+    @mock.patch('airflow.sensors.sql_sensor.BaseHook')
+    def test_sql_sensor_postgres_poke_invalid_success(self, mock_hook):
+        t = SqlSensor(
+            task_id='sql_sensor_check',
+            conn_id='postgres_default',
+            sql="SELECT 1",
+            success=[1],
+        )
+
+        mock_hook.get_connection('postgres_default').conn_type = "postgres"
+        mock_get_records = mock_hook.get_connection.return_value.get_hook.return_value.get_records
+
+        mock_get_records.return_value = [[1]]
+        self.assertRaises(AirflowException, t.poke, None)

--- a/tests/sensors/test_sql_sensor.py
+++ b/tests/sensors/test_sql_sensor.py
@@ -41,16 +41,16 @@ class SqlSensorTests(unittest.TestCase):
         }
         self.dag = DAG(TEST_DAG_ID, default_args=args)
 
-    def test_unsupported_conn_type(self):
-        t = SqlSensor(
-            task_id='sql_sensor_check',
-            conn_id='redis_default',
-            sql="SELECT count(1) FROM INFORMATION_SCHEMA.TABLES",
-            dag=self.dag
-        )
-
-        with self.assertRaises(AirflowException):
-            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+    # def test_unsupported_conn_type(self):
+    #     t = SqlSensor(
+    #         task_id='sql_sensor_check',
+    #         conn_id='redis_default',
+    #         sql="SELECT count(1) FROM INFORMATION_SCHEMA.TABLES",
+    #         dag=self.dag
+    #     )
+    #
+    #     with self.assertRaises(AirflowException):
+    #         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     @unittest.skipUnless(
         'mysql' in configuration.conf.get('core', 'sql_alchemy_conn'), "this is a mysql test")
@@ -130,7 +130,7 @@ class SqlSensorTests(unittest.TestCase):
             task_id='sql_sensor_check',
             conn_id='postgres_default',
             sql="SELECT 1",
-            success=[1]
+            success=lambda x: x in [1]
         )
 
         mock_hook.get_connection('postgres_default').conn_type = "postgres"
@@ -151,7 +151,7 @@ class SqlSensorTests(unittest.TestCase):
             task_id='sql_sensor_check',
             conn_id='postgres_default',
             sql="SELECT 1",
-            failure=[1]
+            failure=lambda x: x in [1]
         )
 
         mock_hook.get_connection('postgres_default').conn_type = "postgres"
@@ -169,8 +169,8 @@ class SqlSensorTests(unittest.TestCase):
             task_id='sql_sensor_check',
             conn_id='postgres_default',
             sql="SELECT 1",
-            failure=[1],
-            success=[2]
+            failure=lambda x: x in [1],
+            success=lambda x: x in [2]
         )
 
         mock_hook.get_connection('postgres_default').conn_type = "postgres"
@@ -191,8 +191,8 @@ class SqlSensorTests(unittest.TestCase):
             task_id='sql_sensor_check',
             conn_id='postgres_default',
             sql="SELECT 1",
-            failure=[1],
-            success=[1]
+            failure=lambda x: x in [1],
+            success=lambda x: x in [1]
         )
 
         mock_hook.get_connection('postgres_default').conn_type = "postgres"

--- a/tests/sensors/test_sql_sensor.py
+++ b/tests/sensors/test_sql_sensor.py
@@ -41,16 +41,16 @@ class SqlSensorTests(unittest.TestCase):
         }
         self.dag = DAG(TEST_DAG_ID, default_args=args)
 
-    # def test_unsupported_conn_type(self):
-    #     t = SqlSensor(
-    #         task_id='sql_sensor_check',
-    #         conn_id='redis_default',
-    #         sql="SELECT count(1) FROM INFORMATION_SCHEMA.TABLES",
-    #         dag=self.dag
-    #     )
-    #
-    #     with self.assertRaises(AirflowException):
-    #         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+    def test_unsupported_conn_type(self):
+        t = SqlSensor(
+            task_id='sql_sensor_check',
+            conn_id='redis_default',
+            sql="SELECT count(1) FROM INFORMATION_SCHEMA.TABLES",
+            dag=self.dag
+        )
+
+        with self.assertRaises(AirflowException):
+            t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     @unittest.skipUnless(
         'mysql' in configuration.conf.get('core', 'sql_alchemy_conn'), "this is a mysql test")

--- a/tests/sensors/test_sql_sensor.py
+++ b/tests/sensors/test_sql_sensor.py
@@ -108,3 +108,98 @@ class SqlSensorTests(unittest.TestCase):
 
         mock_get_records.return_value = [['1']]
         self.assertTrue(t.poke(None))
+
+    @mock.patch('airflow.sensors.sql_sensor.BaseHook')
+    def test_sql_sensor_postgres_poke_fail_on_empty(self, mock_hook):
+        t = SqlSensor(
+            task_id='sql_sensor_check',
+            conn_id='postgres_default',
+            sql="SELECT 1",
+            fail_on_empty=True
+        )
+
+        mock_hook.get_connection('postgres_default').conn_type = "postgres"
+        mock_get_records = mock_hook.get_connection.return_value.get_hook.return_value.get_records
+
+        mock_get_records.return_value = []
+        self.assertRaises(AirflowException, t.poke, None)
+
+    @mock.patch('airflow.sensors.sql_sensor.BaseHook')
+    def test_sql_sensor_postgres_poke_success(self, mock_hook):
+        t = SqlSensor(
+            task_id='sql_sensor_check',
+            conn_id='postgres_default',
+            sql="SELECT 1",
+            success=[1]
+        )
+
+        mock_hook.get_connection('postgres_default').conn_type = "postgres"
+        mock_get_records = mock_hook.get_connection.return_value.get_hook.return_value.get_records
+
+        mock_get_records.return_value = []
+        self.assertFalse(t.poke(None))
+
+        mock_get_records.return_value = [[1]]
+        self.assertTrue(t.poke(None))
+
+        mock_get_records.return_value = [['1']]
+        self.assertFalse(t.poke(None))
+
+    @mock.patch('airflow.sensors.sql_sensor.BaseHook')
+    def test_sql_sensor_postgres_poke_failure(self, mock_hook):
+        t = SqlSensor(
+            task_id='sql_sensor_check',
+            conn_id='postgres_default',
+            sql="SELECT 1",
+            failure=[1]
+        )
+
+        mock_hook.get_connection('postgres_default').conn_type = "postgres"
+        mock_get_records = mock_hook.get_connection.return_value.get_hook.return_value.get_records
+
+        mock_get_records.return_value = []
+        self.assertFalse(t.poke(None))
+
+        mock_get_records.return_value = [[1]]
+        self.assertRaises(AirflowException, t.poke, None)
+
+    @mock.patch('airflow.sensors.sql_sensor.BaseHook')
+    def test_sql_sensor_postgres_poke_failure_success(self, mock_hook):
+        t = SqlSensor(
+            task_id='sql_sensor_check',
+            conn_id='postgres_default',
+            sql="SELECT 1",
+            failure=[1],
+            success=[2]
+        )
+
+        mock_hook.get_connection('postgres_default').conn_type = "postgres"
+        mock_get_records = mock_hook.get_connection.return_value.get_hook.return_value.get_records
+
+        mock_get_records.return_value = []
+        self.assertFalse(t.poke(None))
+
+        mock_get_records.return_value = [[1]]
+        self.assertRaises(AirflowException, t.poke, None)
+
+        mock_get_records.return_value = [[2]]
+        self.assertTrue(t.poke(None))
+
+    @mock.patch('airflow.sensors.sql_sensor.BaseHook')
+    def test_sql_sensor_postgres_poke_failure_success_same(self, mock_hook):
+        t = SqlSensor(
+            task_id='sql_sensor_check',
+            conn_id='postgres_default',
+            sql="SELECT 1",
+            failure=[1],
+            success=[1]
+        )
+
+        mock_hook.get_connection('postgres_default').conn_type = "postgres"
+        mock_get_records = mock_hook.get_connection.return_value.get_hook.return_value.get_records
+
+        mock_get_records.return_value = []
+        self.assertFalse(t.poke(None))
+
+        mock_get_records.return_value = [[1]]
+        self.assertRaises(AirflowException, t.poke, None)


### PR DESCRIPTION
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR enhances `SqlSensor` with three additional parameters that allow for fine tuning of usage.
+ **success** and **failure** parameters allow for passing in an iterable of values against which the `first_cell` is checked. In case of `success` the sensor keeps poking until `first_cell` is found in the `success` iterable. In case of `failure` an `AirflowException` is raised if `first_cell` is found in the`failure` iterable. `first_cell` is matched against `failure` iterable first.
+ if **fail_on_empty** parameter is set to `True` an `AirflowException` is raised in case of no rows returned.

### Tests

- [x] My PR adds the following unit tests:
+ `test_sql_sensor_postgres_poke_fail_on_empty`
+ `test_sql_sensor_postgres_poke_success`
+ `test_sql_sensor_postgres_poke_failure`
+ `test_sql_sensor_postgres_poke_failure_success`
+ `test_sql_sensor_postgres_poke_failure_success_same`
+ `test_sql_sensor_postgres_poke_invalid_failure`
+ `test_sql_sensor_postgres_poke_invalid_success`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
