### PR TITLE
[AIRFLOW-4857] Add templated fields to SlackWebhookOperator

### DIFF
--- a/airflow/contrib/operators/slack_webhook_operator.py
+++ b/airflow/contrib/operators/slack_webhook_operator.py
@@ -54,8 +54,8 @@ class SlackWebhookOperator(SimpleHttpOperator):
     :type proxy: str
     """
 
-    template_fields = ('webhook_token', 'message', 'attachments', 'channel',
-                       'username', 'proxy',)
+    template_fields = ['webhook_token', 'message', 'attachments', 'channel',
+                       'username', 'proxy',]
 
     @apply_defaults
     def __init__(self,

--- a/airflow/contrib/operators/slack_webhook_operator.py
+++ b/airflow/contrib/operators/slack_webhook_operator.py
@@ -55,7 +55,7 @@ class SlackWebhookOperator(SimpleHttpOperator):
     """
 
     template_fields = ['webhook_token', 'message', 'attachments', 'channel',
-                       'username', 'proxy',]
+                       'username', 'proxy', ]
 
     @apply_defaults
     def __init__(self,

--- a/airflow/contrib/operators/slack_webhook_operator.py
+++ b/airflow/contrib/operators/slack_webhook_operator.py
@@ -54,6 +54,9 @@ class SlackWebhookOperator(SimpleHttpOperator):
     :type proxy: str
     """
 
+    template_fields = ('webhook_token', 'message', 'attachments', 'channel',
+                       'username', 'proxy',)
+
     @apply_defaults
     def __init__(self,
                  http_conn_id=None,

--- a/tests/contrib/operators/test_slack_webhook_operator.py
+++ b/tests/contrib/operators/test_slack_webhook_operator.py
@@ -74,7 +74,7 @@ class TestSlackWebhookOperator(unittest.TestCase):
             **self._config
         )
 
-        template_fields = ('webhook_token', 'message', 'attachments', 'channel', 'username', 'proxy')
+        template_fields = ['webhook_token', 'message', 'attachments', 'channel', 'username', 'proxy']
 
         self.assertEqual(operator.template_fields, template_fields)
 

--- a/tests/contrib/operators/test_slack_webhook_operator.py
+++ b/tests/contrib/operators/test_slack_webhook_operator.py
@@ -67,6 +67,17 @@ class TestSlackWebhookOperator(unittest.TestCase):
         self.assertEqual(self._config['link_names'], operator.link_names)
         self.assertEqual(self._config['proxy'], operator.proxy)
 
+    def test_assert_templated_fields(self):
+        operator = SlackWebhookOperator(
+            task_id='slack_webhook_job',
+            dag=self.dag,
+            **self._config
+        )
+
+        template_fields = ('webhook_token', 'message', 'attachments', 'channel', 'username', 'proxy')
+
+        self.assertEqual(operator.template_fields, template_fields)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] Jira: https://issues.apache.org/jira/browse/AIRFLOW-4857

### Description
The `SlackWebhookOperator` has no templated fields, hence we can't pass Airflow Macros in the message field.


- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
