### PR TITLE
[AIRFLOW-4509] SubDagOperator using scheduler instead of backfill

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,11 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Changes to `SubDagOperator`
+
+`SubDagOperator` is changed to use Airflow scheduler instead of backfill
+to schedule tasks in the subdag. User no longer need to specify the executor
+in `SubDagOperator`.
 
 ### `pool` config option in Celery section to support different Celery pool implementation
 

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -28,6 +28,7 @@ import time
 from collections import defaultdict
 from datetime import timedelta
 from time import sleep
+from typing import List
 
 import six
 from sqlalchemy import and_, func, not_, or_
@@ -36,7 +37,7 @@ from sqlalchemy.orm.session import make_transient
 from airflow import configuration as conf
 from airflow import executors, models, settings
 from airflow.exceptions import AirflowException
-from airflow.models import DagRun, SlaMiss, errors
+from airflow.models import DAG, DagRun, SlaMiss, errors
 from airflow.stats import Stats
 from airflow.ti_deps.dep_context import DepContext, QUEUE_DEPS
 from airflow.utils import asciiart, helpers, timezone
@@ -1202,14 +1203,17 @@ class SchedulerJob(BaseJob):
 
             self.log.info("Processing %s", dag.dag_id)
 
-            dag_run = self.create_dag_run(dag)
-            if dag_run:
-                expected_start_date = dag.following_schedule(dag_run.execution_date)
-                if expected_start_date:
-                    schedule_delay = dag_run.start_date - expected_start_date
-                    Stats.timing(
-                        'dagrun.schedule_delay.{dag_id}'.format(dag_id=dag.dag_id),
-                        schedule_delay)
+            # Only creates DagRun for DAGs that are not subdag since
+            # DagRun of subdags are created when SubDagOperator executes.
+            if not dag.is_subdag:
+                dag_run = self.create_dag_run(dag)
+                if dag_run:
+                    expected_start_date = dag.following_schedule(dag_run.execution_date)
+                    if expected_start_date:
+                        schedule_delay = dag_run.start_date - expected_start_date
+                        Stats.timing(
+                            'dagrun.schedule_delay.{dag_id}'.format(dag_id=dag.dag_id),
+                            schedule_delay)
                 self.log.info("Created %s", dag_run)
             self._process_task_instances(dag, tis_out)
             self.manage_slas(dag)
@@ -1441,6 +1445,23 @@ class SchedulerJob(BaseJob):
 
         settings.Session.remove()
 
+    def _find_dags_to_process(self, dags: List[DAG], paused_dag_ids: List[str]):
+        """
+        Find the DAGs that are not paused to process.
+
+        :param dags: specified DAGs
+        :param paused_dag_ids: paused DAG IDs
+        :return: DAGs to process
+        """
+        if len(self.dag_ids) > 0:
+            dags = [dag for dag in dags
+                    if dag.dag_id in self.dag_ids and
+                    dag.dag_id not in paused_dag_ids]
+        else:
+            dags = [dag for dag in dags
+                    if dag.dag_id not in paused_dag_ids]
+        return dags
+
     @provide_session
     def process_file(self, file_path, zombies, pickle_dags=False, session=None):
         """
@@ -1504,14 +1525,7 @@ class SchedulerJob(BaseJob):
                     pickle_id = dag.pickle(session).id
                 simple_dags.append(SimpleDag(dag, pickle_id=pickle_id))
 
-        if len(self.dag_ids) > 0:
-            dags = [dag for dag in dagbag.dags.values()
-                    if dag.dag_id in self.dag_ids and
-                    dag.dag_id not in paused_dag_ids]
-        else:
-            dags = [dag for dag in dagbag.dags.values()
-                    if not dag.parent_dag and
-                    dag.dag_id not in paused_dag_ids]
+        dags = self._find_dags_to_process(dagbag.dags.values(), paused_dag_ids)
 
         # Not using multiprocessing.Queue() since it's no longer a separate
         # process and due to some unusual behavior. (empty() incorrectly

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -27,7 +27,7 @@ import traceback
 import warnings
 from collections import OrderedDict, defaultdict
 from datetime import timedelta, datetime
-from typing import Union, Optional, Iterable, Dict, Type, Callable, List
+from typing import Union, Optional, Iterable, Dict, Type, Callable, List, TYPE_CHECKING
 
 import jinja2
 import pendulum
@@ -52,6 +52,9 @@ from airflow.utils.helpers import validate_key
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.sqlalchemy import UtcDateTime, Interval
 from airflow.utils.state import State
+
+if TYPE_CHECKING:
+    from airflow.models.baseoperator import BaseOperator  # Avoid circular dependency
 
 ScheduleInterval = Union[str, timedelta, relativedelta]
 
@@ -751,7 +754,7 @@ class DAG(BaseDag, LoggingMixin):
     def roots(self):
         return [t for t in self.tasks if not t.downstream_list]
 
-    def topological_sort(self):
+    def topological_sort(self, include_subdag_tasks: bool = False):
         """
         Sorts tasks in topographical order, such that a task comes after any of its
         upstream dependencies.
@@ -759,13 +762,15 @@ class DAG(BaseDag, LoggingMixin):
         Heavily inspired by:
         http://blog.jupo.org/2012/04/06/topological-sorting-acyclic-directed-graphs/
 
+        :param include_subdag_tasks: whether to include tasks in subdags, default to False
         :return: list of tasks in topological order
         """
+        from airflow.operators.subdag_operator import SubDagOperator  # Avoid circular import
 
         # convert into an OrderedDict to speedup lookup while keeping order the same
         graph_unsorted = OrderedDict((task.task_id, task) for task in self.tasks)
 
-        graph_sorted = []
+        graph_sorted = []  # type: List[BaseOperator]
 
         # special case
         if len(self.tasks) == 0:
@@ -795,6 +800,8 @@ class DAG(BaseDag, LoggingMixin):
                     acyclic = True
                     del graph_unsorted[node.task_id]
                     graph_sorted.append(node)
+                    if include_subdag_tasks and isinstance(node, SubDagOperator):
+                        graph_sorted.extend(node.subdag.topological_sort(include_subdag_tasks=True))
 
             if not acyclic:
                 raise AirflowException("A cyclic dependency occurred in dag: {}"
@@ -1038,9 +1045,13 @@ class DAG(BaseDag, LoggingMixin):
     def has_task(self, task_id):
         return task_id in (t.task_id for t in self.tasks)
 
-    def get_task(self, task_id):
+    def get_task(self, task_id, include_subdags=False):
         if task_id in self.task_dict:
             return self.task_dict[task_id]
+        if include_subdags:
+            for dag in self.subdags:
+                if task_id in dag.task_dict:
+                    return dag.task_dict[task_id]
         raise AirflowException("Task {task_id} not found".format(task_id=task_id))
 
     def pickle_info(self):

--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -19,24 +19,22 @@
 
 from airflow import settings
 from airflow.exceptions import AirflowException
-from airflow.executors.sequential_executor import SequentialExecutor
-from airflow.models import BaseOperator, Pool
+from airflow.models.dag import DAG
+from airflow.models.dagrun import DagRun
+from airflow.models.pool import Pool
+from airflow.models.taskinstance import TaskInstance
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
+from airflow.utils.state import State
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.db import provide_session
 
 
-class SubDagOperator(BaseOperator):
+class SubDagOperator(BaseSensorOperator):
     """
     This runs a sub dag. By convention, a sub dag's dag_id
     should be prefixed by its parent and a dot. As in `parent.child`.
 
     :param subdag: the DAG object to run as a subdag of the current DAG.
-    :type subdag: airflow.models.DAG
-    :param dag: the parent DAG for the subdag.
-    :type dag: airflow.models.DAG
-    :param executor: the executor for this subdag. Default to use SequentialExecutor.
-        Please find AIRFLOW-74 for more details.
-    :type executor: airflow.executors.base_executor.BaseExecutor
     """
 
     ui_color = '#555'
@@ -46,15 +44,16 @@ class SubDagOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            subdag,
-            executor=SequentialExecutor(),
+            subdag: DAG,
             *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.subdag = subdag
+        session = kwargs.pop('session')
+
         dag = kwargs.get('dag') or settings.CONTEXT_MANAGER_DAG
         if not dag:
             raise AirflowException('Please pass in the `dag` param or call '
                                    'within a DAG context manager')
-        session = kwargs.pop('session')
-        super().__init__(*args, **kwargs)
 
         # validate subdag name
         if dag.dag_id + '.' + kwargs['task_id'] != subdag.dag_id:
@@ -89,14 +88,71 @@ class SubDagOperator(BaseOperator):
                         )
                     )
 
-        self.subdag = subdag
-        # Airflow pool is not honored by SubDagOperator.
-        # Hence resources could be consumed by SubdagOperators
-        # Use other executor with your own risk.
-        self.executor = executor
+    def _get_dagrun(self, execution_date):
+        dag_runs = DagRun.find(
+            dag_id=self.subdag.dag_id,
+            execution_date=execution_date,
+        )
+        return dag_runs[0] if dag_runs else None
 
-    def execute(self, context):
-        ed = context['execution_date']
-        self.subdag.run(
-            start_date=ed, end_date=ed, donot_pickle=True,
-            executor=self.executor)
+    @provide_session
+    def _reset_dag_run_and_task_instances(self, dag_run, execution_date, session=None):
+        """
+        Set the DagRun state to RUNNING and set the failed TaskInstances to None state
+        for scheduler to pick up.
+
+        :param dag_run: DAG run
+        :param execution_date: Execution date
+        :param session: Session
+        :return: None
+        """
+
+        try:
+            dag_run.state = State.RUNNING
+            session.merge(dag_run)
+            failed_task_instances = (
+                session
+                .query(TaskInstance)
+                .filter(TaskInstance.dag_id == self.subdag.dag_id)
+                .filter(TaskInstance.execution_date == execution_date)
+                .filter(TaskInstance.state.in_([State.FAILED, State.UPSTREAM_FAILED]))
+            )
+
+            for task_instance in failed_task_instances:
+                task_instance.state = State.NONE
+                session.merge(task_instance)
+            session.commit()
+        except Exception as e:
+            session.rollback()
+            raise e
+
+    def pre_execute(self, context):
+        execution_date = context['execution_date']
+        dag_run = self._get_dagrun(execution_date)
+        if dag_run is None:
+            dag_run = self.subdag.create_dagrun(
+                run_id="scheduled__{}".format(execution_date.isoformat()),
+                execution_date=execution_date,
+                state=State.RUNNING,
+                external_trigger=True,
+            )
+
+            self.log.info("Created DagRun: %s", dag_run.run_id)
+        else:
+            self.log.info("Found existing DagRun: %s", dag_run.run_id)
+            if dag_run.state == State.FAILED:
+                self._reset_dag_run_and_task_instances(dag_run, execution_date)
+
+    def poke(self, context):
+        execution_date = context['execution_date']
+        dag_run = self._get_dagrun(execution_date=execution_date)
+        return dag_run.state != State.RUNNING
+
+    def post_execute(self, context, result=None):
+        execution_date = context['execution_date']
+        dag_run = self._get_dagrun(execution_date=execution_date)
+        self.log.info("Execution finished. State is %s", dag_run.state)
+
+        if dag_run.state != State.SUCCESS:
+            raise AirflowException(
+                "Expected state: SUCCESS. Actual state: {}".format(dag_run.state))

--- a/scripts/ci/ci_pylint.sh
+++ b/scripts/ci/ci_pylint.sh
@@ -41,6 +41,7 @@ find . -name "*.py" \
 -not -path "./.eggs/*" \
 -not -path "./airflow/www/node_modules/*" \
 -not -path "./airflow/_vendor/*" \
+-not -path "./venv/*" \
 -not -path "./build/*" \
 -not -path "./tests/*" \
 -not -name 'webserver_config.py' | grep -vFf scripts/ci/pylint_todo.txt | xargs pylint --output-format=colorized

--- a/tests/dags/test_impersonation_subdag.py
+++ b/tests/dags/test_impersonation_subdag.py
@@ -23,7 +23,6 @@ from airflow.models import DAG
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.subdag_operator import SubDagOperator
 from airflow.operators.bash_operator import BashOperator
-from airflow.executors import SequentialExecutor
 
 
 DEFAULT_DATE = datetime(2016, 1, 1)
@@ -60,5 +59,6 @@ BashOperator(
 
 subdag_operator = SubDagOperator(task_id='test_subdag_operation',
                                  subdag=subdag,
-                                 executor=SequentialExecutor(),
+                                 mode='reschedule',
+                                 poke_interval=1,
                                  dag=dag)

--- a/tests/dags/test_issue_1225.py
+++ b/tests/dags/test_issue_1225.py
@@ -28,7 +28,6 @@ from datetime import datetime, timedelta
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator
-from airflow.operators.subdag_operator import SubDagOperator
 from airflow.utils.trigger_rule import TriggerRule
 
 DEFAULT_DATE = datetime(2016, 1, 1)
@@ -105,26 +104,6 @@ dag6_task2 = DummyOperator(
     dag=dag6,)
 dag6_task2.set_upstream(dag6_task1)
 
-
-# DAG tests that a deadlocked subdag is properly caught
-dag7 = DAG(dag_id='test_subdag_deadlock', default_args=default_args)
-subdag7 = DAG(dag_id='test_subdag_deadlock.subdag', default_args=default_args)
-subdag7_task1 = PythonOperator(
-    task_id='test_subdag_fail',
-    dag=subdag7,
-    python_callable=fail)
-subdag7_task2 = DummyOperator(
-    task_id='test_subdag_dummy_1',
-    dag=subdag7,)
-subdag7_task3 = DummyOperator(
-    task_id='test_subdag_dummy_2',
-    dag=subdag7)
-dag7_subdag1 = SubDagOperator(
-    task_id='subdag',
-    dag=dag7,
-    subdag=subdag7)
-subdag7_task1.set_downstream(subdag7_task2)
-subdag7_task2.set_downstream(subdag7_task3)
 
 # DAG tests that a Dag run that doesn't complete but has a root failure is marked running
 dag8 = DAG(dag_id='test_dagrun_states_root_fail_unfinished', default_args=default_args)

--- a/tests/dags/test_subdag.py
+++ b/tests/dags/test_subdag.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+"""
+A DAG with subdag for testing purpose.
+"""
+
+from datetime import timedelta
+
+from airflow.models import DAG
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.subdag_operator import SubDagOperator
+
+DAG_NAME = 'test_subdag_operator'
+
+DEFAULT_TASK_ARGS = {
+    'owner': 'airflow',
+    'start_date': '2019-01-01',
+    'max_active_runs': 1,
+}
+
+
+def subdag(parent_dag_name, child_dag_name, args):
+    """
+    Create a subdag.
+    """
+    dag_subdag = DAG(
+        dag_id='%s.%s' % (parent_dag_name, child_dag_name),
+        default_args=args,
+        schedule_interval="@daily",
+    )
+
+    for i in range(2):
+        DummyOperator(
+            task_id='%s-task-%s' % (child_dag_name, i + 1),
+            default_args=args,
+            dag=dag_subdag,
+        )
+
+    return dag_subdag
+
+
+with DAG(
+    dag_id=DAG_NAME,
+    max_active_runs=1,
+    default_args=DEFAULT_TASK_ARGS,
+    schedule_interval=timedelta(minutes=1),
+) as dag:
+
+    start = DummyOperator(
+        task_id='start',
+    )
+
+    section_1 = SubDagOperator(
+        task_id='section-1',
+        subdag=subdag(DAG_NAME, 'section-1', DEFAULT_TASK_ARGS),
+        default_args=DEFAULT_TASK_ARGS,
+    )
+
+    some_other_task = DummyOperator(
+        task_id='some-other-task',
+    )
+
+    start >> section_1 >> some_other_task  # pylint: disable=W0104

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -36,6 +36,7 @@ from airflow.jobs import BackfillJob, SchedulerJob
 from airflow.models import DAG, DagBag, DagRun, Pool, TaskInstance as TI
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils import timezone
+from airflow.utils.db import create_session
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 from tests.compat import Mock, patch
@@ -1199,6 +1200,10 @@ class BackfillJobTest(unittest.TestCase):
                           donot_pickle=True)
         job.run()
 
+        subdag_op_task.pre_execute(context={'execution_date': start_date})
+        subdag_op_task.execute(context={'execution_date': start_date})
+        subdag_op_task.post_execute(context={'execution_date': start_date})
+
         history = executor.history
         subdag_history = history[0]
 
@@ -1207,6 +1212,18 @@ class BackfillJobTest(unittest.TestCase):
         for sdh in subdag_history:
             ti = sdh[3]
             self.assertIn('section-1-task-', ti.task_id)
+
+        with create_session() as session:
+            successful_subdag_runs = (
+                session
+                .query(DagRun)
+                .filter(DagRun.dag_id == subdag.dag_id)
+                .filter(DagRun.execution_date == start_date)
+                .filter(DagRun.state == State.SUCCESS)
+                .count()
+            )
+
+            self.assertEqual(1, successful_subdag_runs)
 
         subdag.clear()
         dag.clear()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2687,3 +2687,52 @@ class SchedulerJobTest(unittest.TestCase):
             self.assertEqual(state, ti.state)
 
         session.close()
+
+    def test_process_dags_not_create_dagrun_for_subdags(self):
+        dag = self.dagbag.get_dag('test_subdag_operator')
+
+        scheduler = SchedulerJob()
+        scheduler._process_task_instances = mock.MagicMock()
+        scheduler.manage_slas = mock.MagicMock()
+
+        scheduler._process_dags(self.dagbag, [dag] + dag.subdags, None)
+
+        with create_session() as session:
+            sub_dagruns = (
+                session
+                .query(DagRun)
+                .filter(DagRun.dag_id == dag.subdags[0].dag_id)
+                .count()
+            )
+
+            self.assertEqual(0, sub_dagruns)
+
+            parent_dagruns = (
+                session
+                .query(DagRun)
+                .filter(DagRun.dag_id == dag.dag_id)
+                .count()
+            )
+
+            self.assertGreater(parent_dagruns, 0)
+
+    def test_find_dags_to_run_includes_subdags(self):
+        dag = self.dagbag.get_dag('test_subdag_operator')
+        print(self.dagbag.dag_ids)
+        print(self.dagbag.dag_folder)
+        self.assertGreater(len(dag.subdags), 0)
+        scheduler = SchedulerJob()
+        dags = scheduler._find_dags_to_process(self.dagbag.dags.values(), paused_dag_ids=())
+
+        self.assertIn(dag, dags)
+        for subdag in dag.subdags:
+            self.assertIn(subdag, dags)
+
+    def test_find_dags_to_run_skip_paused_dags(self):
+        dagbag = DagBag(include_examples=False)
+
+        dag = dagbag.get_dag('test_subdag_operator')
+        scheduler = SchedulerJob()
+        dags = scheduler._find_dags_to_process(dagbag.dags.values(), paused_dag_ids=[dag.dag_id])
+
+        self.assertNotIn(dag, dags)

--- a/tests/operators/test_subdag_operator.py
+++ b/tests/operators/test_subdag_operator.py
@@ -18,16 +18,18 @@
 # under the License.
 
 import unittest
-
 from unittest.mock import Mock
 
 import airflow
 from airflow.exceptions import AirflowException
-from airflow.executors.sequential_executor import SequentialExecutor
-from airflow.models import DAG, DagBag
+from airflow.models import DAG, DagRun, TaskInstance
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.subdag_operator import SubDagOperator
+from airflow.utils.state import State
 from airflow.utils.timezone import datetime
+from airflow.settings import Session
+from tests.test_utils.db import clear_db_runs
+
 
 DEFAULT_DATE = datetime(2016, 1, 1)
 
@@ -38,6 +40,15 @@ default_args = dict(
 
 
 class SubDagOperatorTests(unittest.TestCase):
+
+    def setUp(self):
+        clear_db_runs()
+        self.dag_run_running = DagRun()
+        self.dag_run_running.state = State.RUNNING
+        self.dag_run_success = DagRun()
+        self.dag_run_success.state = State.SUCCESS
+        self.dag_run_failed = DagRun()
+        self.dag_run_failed.state = State.FAILED
 
     def test_subdag_name(self):
         """
@@ -128,24 +139,100 @@ class SubDagOperatorTests(unittest.TestCase):
         session.delete(pool_10)
         session.commit()
 
-    def test_subdag_deadlock(self):
-        dagbag = DagBag()
-        dag = dagbag.get_dag('test_subdag_deadlock')
-        dag.clear()
-        subdag = dagbag.get_dag('test_subdag_deadlock.subdag')
-        subdag.clear()
-
-        # first make sure subdag has failed
-        self.assertRaises(AirflowException, subdag.run, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-
-        # now make sure dag picks up the subdag error
-        self.assertRaises(AirflowException, dag.run, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-
-    def test_subdag_executor(self):
+    def test_execute_create_dagrun_wait_until_success(self):
         """
-        Test default subdag executor is SequentialExecutor
+        When SubDagOperator executes, it creates a DagRun if there is no existing one
+        and wait until the DagRun succeeds.
         """
         dag = DAG('parent', default_args=default_args)
-        subdag_good = DAG('parent.test', default_args=default_args)
-        subdag = SubDagOperator(task_id='test', dag=dag, subdag=subdag_good)
-        self.assertEqual(type(subdag.executor), SequentialExecutor)
+        subdag = DAG('parent.test', default_args=default_args)
+        subdag_task = SubDagOperator(task_id='test', subdag=subdag, dag=dag, poke_interval=1)
+
+        subdag.create_dagrun = Mock()
+        subdag.create_dagrun.return_value = self.dag_run_running
+
+        subdag_task._get_dagrun = Mock()
+        subdag_task._get_dagrun.side_effect = [None, self.dag_run_success, self.dag_run_success]
+
+        subdag_task.pre_execute(context={'execution_date': DEFAULT_DATE})
+        subdag_task.execute(context={'execution_date': DEFAULT_DATE})
+        subdag_task.post_execute(context={'execution_date': DEFAULT_DATE})
+
+        subdag.create_dagrun.assert_called_once_with(
+            run_id="scheduled__{}".format(DEFAULT_DATE.isoformat()),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING,
+            external_trigger=True,
+        )
+
+        self.assertEqual(3, len(subdag_task._get_dagrun.mock_calls))
+
+    def test_execute_dagrun_failed(self):
+        """
+        When the DagRun failed during the execution, it raises an Airflow Exception.
+        """
+        dag = DAG('parent', default_args=default_args)
+        subdag = DAG('parent.test', default_args=default_args)
+        subdag_task = SubDagOperator(task_id='test', subdag=subdag, dag=dag, poke_interval=1)
+
+        subdag.create_dagrun = Mock()
+        subdag.create_dagrun.return_value = self.dag_run_running
+
+        subdag_task._get_dagrun = Mock()
+        subdag_task._get_dagrun.side_effect = [None, self.dag_run_failed, self.dag_run_failed]
+
+        with self.assertRaises(AirflowException):
+            subdag_task.pre_execute(context={'execution_date': DEFAULT_DATE})
+            subdag_task.execute(context={'execution_date': DEFAULT_DATE})
+            subdag_task.post_execute(context={'execution_date': DEFAULT_DATE})
+
+    def test_execute_skip_if_dagrun_success(self):
+        """
+        When there is an existing DagRun in SUCCESS state, skip the execution.
+        """
+        dag = DAG('parent', default_args=default_args)
+        subdag = DAG('parent.test', default_args=default_args)
+
+        subdag.create_dagrun = Mock()
+        subdag_task = SubDagOperator(task_id='test', subdag=subdag, dag=dag, poke_interval=1)
+        subdag_task._get_dagrun = Mock()
+        subdag_task._get_dagrun.return_value = self.dag_run_success
+
+        subdag_task.pre_execute(context={'execution_date': DEFAULT_DATE})
+        subdag_task.execute(context={'execution_date': DEFAULT_DATE})
+        subdag_task.post_execute(context={'execution_date': DEFAULT_DATE})
+
+        subdag.create_dagrun.assert_not_called()
+        self.assertEqual(3, len(subdag_task._get_dagrun.mock_calls))
+
+    def test_rerun_failed_subdag(self):
+        """
+        When there is an existing DagRun with failed state, reset the DagRun and the
+        corresponding TaskInstances
+        """
+        dag = DAG('parent', default_args=default_args)
+        subdag = DAG('parent.test', default_args=default_args)
+        subdag_task = SubDagOperator(task_id='test', subdag=subdag, dag=dag, poke_interval=1)
+        dummy_task = DummyOperator(task_id='dummy', dag=subdag)
+
+        session = Session()
+        dummy_task_instance = TaskInstance(task=dummy_task, execution_date=DEFAULT_DATE, state=State.FAILED)
+        session.add(dummy_task_instance)
+        session.commit()
+
+        sub_dagrun = subdag.create_dagrun(
+            run_id="scheduled__{}".format(DEFAULT_DATE.isoformat()),
+            execution_date=DEFAULT_DATE,
+            state=State.FAILED,
+            external_trigger=True,
+        )
+
+        subdag_task._reset_dag_run_and_task_instances(sub_dagrun, execution_date=DEFAULT_DATE)
+
+        dummy_task_instance.refresh_from_db()
+        self.assertEqual(dummy_task_instance.state, State.NONE)
+
+        sub_dagrun.refresh_from_db()
+        self.assertEqual(sub_dagrun.state, State.RUNNING)
+
+        session.close()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4509

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Change `SubDagOperator` to use Airflow scheduler to schedule
tasks in subdags instead of backfill.

In the past, `SubDagOperator` relies on backfill scheduler
to schedule tasks in the subdags. Tasks in parent `DAG`
are scheduled via Airflow scheduler while tasks in
a subdag are scheduled via backfill, which complicates
the scheduling logic and adds difficulties to maintain
the two scheduling code path.

This PR simplifies how tasks in subdags are scheduled.
`SubDagOperator` is responsible for creating a DagRun for subdag
and wait until all the tasks in the subdag finish. Airflow
scheduler picks up the DagRun created by SubDagOperator,
create and schedule the tasks accordingly.

Although `SubDagOperator` can occupy a pool/concurrency slot,
user can specify the `mode=reschedule` so that the slot will be
released periodically to avoid potential deadlock.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
