### PR TITLE
[AIRFLOW-4856] Make git sync run_as_user an config option

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -675,6 +675,7 @@ git_ssh_known_hosts_configmap_name =
 git_sync_container_repository = k8s.gcr.io/git-sync
 git_sync_container_tag = v3.1.1
 git_sync_init_container_name = git-sync-clone
+git_sync_run_as_user =
 
 # The name of the Kubernetes service account to be associated with airflow workers, if any.
 # Service accounts are required for workers that require access to secrets or cluster resources.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -675,7 +675,7 @@ git_ssh_known_hosts_configmap_name =
 git_sync_container_repository = k8s.gcr.io/git-sync
 git_sync_container_tag = v3.1.1
 git_sync_init_container_name = git-sync-clone
-git_sync_run_as_user =
+git_sync_run_as_user = 65533
 
 # The name of the Kubernetes service account to be associated with airflow workers, if any.
 # Service accounts are required for workers that require access to secrets or cluster resources.

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -241,7 +241,7 @@ class KubeConfig:
             self.kubernetes_section, 'git_sync_init_container_name')
 
         self.git_sync_run_as_user = self._get_security_context_val('git_sync_run_as_user')
-        
+
         # The worker pod may optionally have a  valid Airflow config loaded via a
         # configmap
         self.airflow_configmap = conf.get(self.kubernetes_section, 'airflow_configmap')

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -237,6 +237,9 @@ class KubeConfig:
         self.git_sync_container = '{}:{}'.format(
             self.git_sync_container_repository, self.git_sync_container_tag)
 
+        self.git_sync_init_container_name = conf.get(
+            self.kubernetes_section, 'git_sync_init_container_name')
+
         self.git_sync_run_as_user = self._get_security_context_val('git_sync_run_as_user')
         
         # The worker pod may optionally have a  valid Airflow config loaded via a

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -237,9 +237,8 @@ class KubeConfig:
         self.git_sync_container = '{}:{}'.format(
             self.git_sync_container_repository, self.git_sync_container_tag)
 
-        self.git_sync_init_container_name = conf.get(
-            self.kubernetes_section, 'git_sync_init_container_name')
-
+        self.git_sync_run_as_user = self._get_security_context_val('git_sync_run_as_user')
+        
         # The worker pod may optionally have a  valid Airflow config loaded via a
         # configmap
         self.airflow_configmap = conf.get(self.kubernetes_section, 'airflow_configmap')

--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -132,7 +132,7 @@ class WorkerConfiguration(LoggingMixin):
         if self.kube_config.git_sync_run_as_user != "":
             init_containers[0]['securityContext'] = {
                 'runAsUser': self.kube_config.git_sync_run_as_user  # git-sync user
-            }  
+            }
 
         return init_containers
 

--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -121,13 +121,18 @@ class WorkerConfiguration(LoggingMixin):
                 'name': 'GIT_KNOWN_HOSTS',
                 'value': 'false'
             })
-        return [{
+
+        init_containers =  [{
             'name': self.kube_config.git_sync_init_container_name,
             'image': self.kube_config.git_sync_container,
-            'securityContext': {'runAsUser': self.kube_config.worker_run_as_user},  # git-sync user
             'env': init_environment,
             'volumeMounts': volume_mounts
         }]
+
+        if self.kube_config.git_sync_run_as_user != "":
+            init_containers[0]['securityContext'] = {'runAsUser': self.kube_config.git_sync_run_as_user} # git-sync user
+
+        return init_containers
 
     def _get_environment(self):
         """Defines any necessary environment variables for the pod executor"""

--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -121,11 +121,10 @@ class WorkerConfiguration(LoggingMixin):
                 'name': 'GIT_KNOWN_HOSTS',
                 'value': 'false'
             })
-
         return [{
             'name': self.kube_config.git_sync_init_container_name,
             'image': self.kube_config.git_sync_container,
-            'securityContext': {'runAsUser': 65533},  # git-sync user
+            'securityContext': {'runAsUser': self.kube_config.worker_run_as_user},  # git-sync user
             'env': init_environment,
             'volumeMounts': volume_mounts
         }]

--- a/airflow/kubernetes/worker_configuration.py
+++ b/airflow/kubernetes/worker_configuration.py
@@ -122,7 +122,7 @@ class WorkerConfiguration(LoggingMixin):
                 'value': 'false'
             })
 
-        init_containers =  [{
+        init_containers = [{
             'name': self.kube_config.git_sync_init_container_name,
             'image': self.kube_config.git_sync_container,
             'env': init_environment,
@@ -130,7 +130,9 @@ class WorkerConfiguration(LoggingMixin):
         }]
 
         if self.kube_config.git_sync_run_as_user != "":
-            init_containers[0]['securityContext'] = {'runAsUser': self.kube_config.git_sync_run_as_user} # git-sync user
+            init_containers[0]['securityContext'] = {
+                'runAsUser': self.kube_config.git_sync_run_as_user  # git-sync user
+            }  
 
         return init_containers
 

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -396,6 +396,18 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
                         'value': '/etc/git-secret/known_hosts'} in env)
         self.assertFalse({'name': 'GIT_SYNC_SSH', 'value': 'true'} in env)
 
+    def test_init_environment_using_git_sync_run_as_user_empty(self):
+        # Tests if git_syn_run_as_user is none, then no securityContext created in init container
+        
+        self.kube_config.dags_volume_claim = None
+        self.kube_config.dags_volume_host = None
+        self.kube_config.dags_in_image = None
+        self.kube_config.git_sync_run_as_user = ''
+
+        worker_config = WorkerConfiguration(self.kube_config)
+        init_containers = worker_config._get_init_containers()
+        self.assertIsNone(init_containers[0]['securityContext'])
+
     def test_make_pod_run_as_user_0(self):
         # Tests the pod created with run-as-user 0 actually gets that in it's config
         self.kube_config.worker_run_as_user = 0
@@ -413,10 +425,8 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
                                      "test_task_id", str(datetime.utcnow()), 1, "bash -c 'ls /'",
                                      kube_executor_config)
 
-        init_containers = worker_config._get_init_containers()
 
         self.assertEqual(0, pod.security_context['runAsUser'])
-        self.assertEqual(0, init_containers.security_context['runAsUser'])
 
     def test_make_pod_git_sync_ssh_without_known_hosts(self):
         # Tests the pod created with git-sync SSH authentication option is correct without known hosts
@@ -554,6 +564,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         self.kube_config.git_sync_init_container_name = 'git-sync-clone'
         self.kube_config.git_subpath = 'dags_folder'
         self.kube_config.git_sync_root = '/git'
+        self.kube_config.git_sync_run_as_user = 65533
         self.kube_config.git_dags_folder_mount_point = '/usr/local/airflow/dags/repo/dags_folder'
 
         worker_config = WorkerConfiguration(self.kube_config)
@@ -574,6 +585,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         self.assertEqual('gcr.io/google-containers/git-sync-amd64:v2.0.5', init_container['image'])
         self.assertEqual(1, len(init_container_volume_mount))
         self.assertFalse(init_container_volume_mount[0]['readOnly'])
+        self.assertEqual(65533, init_container['securityContext']['runAsUser'])
 
     def test_worker_container_dags(self):
         # Tests that the 'airflow-dags' persistence volume is NOT created when `dags_in_image` is set

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -406,7 +406,12 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
 
         worker_config = WorkerConfiguration(self.kube_config)
         init_containers = worker_config._get_init_containers()
-        self.assertIsNone(init_containers[0]['securityContext'])
+        self.assertTrue(init_containers)  # check not empty
+
+        self.assertNotIn(
+            'securityContext', init_containers[0],
+            "securityContext shouldn't be defined"
+        )
 
     def test_make_pod_run_as_user_0(self):
         # Tests the pod created with run-as-user 0 actually gets that in it's config

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -398,7 +398,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
 
     def test_init_environment_using_git_sync_run_as_user_empty(self):
         # Tests if git_syn_run_as_user is none, then no securityContext created in init container
-        
+
         self.kube_config.dags_volume_claim = None
         self.kube_config.dags_volume_host = None
         self.kube_config.dags_in_image = None
@@ -424,7 +424,6 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         pod = worker_config.make_pod("default", str(uuid.uuid4()), "test_pod_id", "test_dag_id",
                                      "test_task_id", str(datetime.utcnow()), 1, "bash -c 'ls /'",
                                      kube_executor_config)
-
 
         self.assertEqual(0, pod.security_context['runAsUser'])
 

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -413,7 +413,10 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
                                      "test_task_id", str(datetime.utcnow()), 1, "bash -c 'ls /'",
                                      kube_executor_config)
 
+        init_containers = worker_config._get_init_containers()
+
         self.assertEqual(0, pod.security_context['runAsUser'])
+        self.assertEqual(0, init_containers.security_context['runAsUser'])
 
     def test_make_pod_git_sync_ssh_without_known_hosts(self):
         # Tests the pod created with git-sync SSH authentication option is correct without known hosts


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [AIRFLOW-4856](https://issues.apache.org/jira/browse/AIRFLOW-4856) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4856


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
when using KubernetesExecutor with git_sync, an init container will be created to sync with the git repo, the init container has a security context with hard coded runAsUser=65533, this pull request aim to change the hard coded value to a config option

### Tests

- [x] My PR adds the following unit tests:
  * create test_init_environment_using_git_sync_run_as_user_empty: when the option is empty, not security context should be created
  * update test_worker_git_dags to check the value of the option has been correctly added to security context

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] Passes `flake8`
