### PR TITLE
[AIRFLOW-4860] Remove Redundant Information in Example Dags

### DIFF
--- a/airflow/example_dags/example_subdag_operator.py
+++ b/airflow/example_dags/example_subdag_operator.py
@@ -40,33 +40,28 @@ dag = DAG(
 
 start = DummyOperator(
     task_id='start',
-    default_args=args,
     dag=dag,
 )
 
 section_1 = SubDagOperator(
     task_id='section-1',
     subdag=subdag(DAG_NAME, 'section-1', args),
-    default_args=args,
     dag=dag,
 )
 
 some_other_task = DummyOperator(
     task_id='some-other-task',
-    default_args=args,
     dag=dag,
 )
 
 section_2 = SubDagOperator(
     task_id='section-2',
     subdag=subdag(DAG_NAME, 'section-2', args),
-    default_args=args,
     dag=dag,
 )
 
 end = DummyOperator(
     task_id='end',
-    default_args=args,
     dag=dag,
 )
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4860

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
`airflow/example_dags/example_subdag_operator.py` contains redundant `default_args=args` in all tasks.


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to an appropriate release

### Code Quality

- [x] Passes `flake8`
