### PR TITLE
[AIRFLOW-4509] SubDagOperator using scheduler instead of backfill

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,12 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Changes to `SubDagOperator`
+
+`SubDagOperator` is changed to use Airflow scheduler instead of backfill
+to schedule tasks in the subdag. User no longer need to specify the executor
+in `SubDagOperator`.
+
 ### Variables removed from the task instance context
 
 The following variables were removed from the task instance context:

--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -17,27 +17,32 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow import settings, DAG
+from sqlalchemy.orm.session import Session
+from typing import Optional
+
+from airflow import settings
 from airflow.exceptions import AirflowException
-from airflow.executors import BaseExecutor
-from airflow.executors.sequential_executor import SequentialExecutor
-from airflow.models import BaseOperator, Pool
+from airflow.models.dag import DAG
+from airflow.models.dagrun import DagRun
+from airflow.models.pool import Pool
+from airflow.models.taskinstance import TaskInstance
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
+from airflow.utils.state import State
 from airflow.utils.decorators import apply_defaults
-from airflow.utils.db import provide_session
+from airflow.utils.db import create_session, provide_session
 
 
-class SubDagOperator(BaseOperator):
+class SubDagOperator(BaseSensorOperator):
     """
     This runs a sub dag. By convention, a sub dag's dag_id
     should be prefixed by its parent and a dot. As in `parent.child`.
 
+    Although SubDagOperator can occupy a pool/concurrency slot,
+    user can specify the mode=reschedule so that the slot will be
+    released periodically to avoid potential deadlock.
+
     :param subdag: the DAG object to run as a subdag of the current DAG.
-    :type subdag: airflow.models.DAG
-    :param dag: the parent DAG for the subdag.
-    :type dag: airflow.models.DAG
-    :param executor: the executor for this subdag. Default to use SequentialExecutor.
-        Please find AIRFLOW-74 for more details.
-    :type executor: airflow.executors.base_executor.BaseExecutor
+    :param session: sqlalchemy session
     """
 
     ui_color = '#555'
@@ -48,14 +53,14 @@ class SubDagOperator(BaseOperator):
     def __init__(
             self,
             subdag: DAG,
-            executor: BaseExecutor = SequentialExecutor(),
+            session: Optional[Session] = None,
             *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.subdag = subdag
         dag = kwargs.get('dag') or settings.CONTEXT_MANAGER_DAG
         if not dag:
             raise AirflowException('Please pass in the `dag` param or call '
                                    'within a DAG context manager')
-        session = kwargs.pop('session')
-        super().__init__(*args, **kwargs)
 
         # validate subdag name
         if dag.dag_id + '.' + kwargs['task_id'] != subdag.dag_id:
@@ -72,7 +77,7 @@ class SubDagOperator(BaseOperator):
             if conflicts:
                 # only query for pool conflicts if one may exist
                 pool = (
-                    session
+                    session  # type: ignore
                     .query(Pool)
                     .filter(Pool.slots == 1)
                     .filter(Pool.pool == self.pool)
@@ -90,14 +95,65 @@ class SubDagOperator(BaseOperator):
                         )
                     )
 
-        self.subdag = subdag
-        # Airflow pool is not honored by SubDagOperator.
-        # Hence resources could be consumed by SubdagOperators
-        # Use other executor with your own risk.
-        self.executor = executor
+    def _get_dagrun(self, execution_date):
+        dag_runs = DagRun.find(
+            dag_id=self.subdag.dag_id,
+            execution_date=execution_date,
+        )
+        return dag_runs[0] if dag_runs else None
 
-    def execute(self, context):
-        ed = context['execution_date']
-        self.subdag.run(
-            start_date=ed, end_date=ed, donot_pickle=True,
-            executor=self.executor)
+    def _reset_dag_run_and_task_instances(self, dag_run, execution_date):
+        """
+        Set the DagRun state to RUNNING and set the failed TaskInstances to None state
+        for scheduler to pick up.
+
+        :param dag_run: DAG run
+        :param execution_date: Execution date
+        :return: None
+        """
+        with create_session() as session:
+            dag_run.state = State.RUNNING
+            session.merge(dag_run)
+            failed_task_instances = (
+                session
+                .query(TaskInstance)
+                .filter(TaskInstance.dag_id == self.subdag.dag_id)
+                .filter(TaskInstance.execution_date == execution_date)
+                .filter(TaskInstance.state.in_([State.FAILED, State.UPSTREAM_FAILED]))
+            )
+
+            for task_instance in failed_task_instances:
+                task_instance.state = State.NONE
+                session.merge(task_instance)
+            session.commit()
+
+    def pre_execute(self, context):
+        execution_date = context['execution_date']
+        dag_run = self._get_dagrun(execution_date)
+        if dag_run is None:
+            dag_run = self.subdag.create_dagrun(
+                run_id="scheduled__{}".format(execution_date.isoformat()),
+                execution_date=execution_date,
+                state=State.RUNNING,
+                external_trigger=True,
+            )
+
+            self.log.info("Created DagRun: %s", dag_run.run_id)
+        else:
+            self.log.info("Found existing DagRun: %s", dag_run.run_id)
+            if dag_run.state == State.FAILED:
+                self._reset_dag_run_and_task_instances(dag_run, execution_date)
+
+    def poke(self, context):
+        execution_date = context['execution_date']
+        dag_run = self._get_dagrun(execution_date=execution_date)
+        return dag_run.state != State.RUNNING
+
+    def post_execute(self, context, result=None):
+        execution_date = context['execution_date']
+        dag_run = self._get_dagrun(execution_date=execution_date)
+        self.log.info("Execution finished. State is %s", dag_run.state)
+
+        if dag_run.state != State.SUCCESS:
+            raise AirflowException(
+                "Expected state: SUCCESS. Actual state: {}".format(dag_run.state))

--- a/scripts/ci/ci_pylint.sh
+++ b/scripts/ci/ci_pylint.sh
@@ -28,7 +28,6 @@ basic_sanity_checks
 force_python_3_5
 
 script_start
-
 rebuild_image_if_needed_for_static_checks
 
 FILES=("$@")

--- a/tests/dags/test_impersonation_subdag.py
+++ b/tests/dags/test_impersonation_subdag.py
@@ -23,7 +23,6 @@ from airflow.models import DAG
 from airflow.operators.python_operator import PythonOperator
 from airflow.operators.subdag_operator import SubDagOperator
 from airflow.operators.bash_operator import BashOperator
-from airflow.executors import SequentialExecutor
 
 
 DEFAULT_DATE = datetime(2016, 1, 1)
@@ -60,5 +59,6 @@ BashOperator(
 
 subdag_operator = SubDagOperator(task_id='test_subdag_operation',
                                  subdag=subdag,
-                                 executor=SequentialExecutor(),
+                                 mode='reschedule',
+                                 poke_interval=1,
                                  dag=dag)

--- a/tests/dags/test_issue_1225.py
+++ b/tests/dags/test_issue_1225.py
@@ -28,7 +28,6 @@ from datetime import datetime, timedelta
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python_operator import PythonOperator
-from airflow.operators.subdag_operator import SubDagOperator
 from airflow.utils.trigger_rule import TriggerRule
 
 DEFAULT_DATE = datetime(2016, 1, 1)
@@ -105,26 +104,6 @@ dag6_task2 = DummyOperator(
     dag=dag6,)
 dag6_task2.set_upstream(dag6_task1)
 
-
-# DAG tests that a deadlocked subdag is properly caught
-dag7 = DAG(dag_id='test_subdag_deadlock', default_args=default_args)
-subdag7 = DAG(dag_id='test_subdag_deadlock.subdag', default_args=default_args)
-subdag7_task1 = PythonOperator(
-    task_id='test_subdag_fail',
-    dag=subdag7,
-    python_callable=fail)
-subdag7_task2 = DummyOperator(
-    task_id='test_subdag_dummy_1',
-    dag=subdag7,)
-subdag7_task3 = DummyOperator(
-    task_id='test_subdag_dummy_2',
-    dag=subdag7)
-dag7_subdag1 = SubDagOperator(
-    task_id='subdag',
-    dag=dag7,
-    subdag=subdag7)
-subdag7_task1.set_downstream(subdag7_task2)
-subdag7_task2.set_downstream(subdag7_task3)
 
 # DAG tests that a Dag run that doesn't complete but has a root failure is marked running
 dag8 = DAG(dag_id='test_dagrun_states_root_fail_unfinished', default_args=default_args)

--- a/tests/dags/test_subdag.py
+++ b/tests/dags/test_subdag.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+"""
+A DAG with subdag for testing purpose.
+"""
+
+from datetime import timedelta, datetime
+
+from airflow.models import DAG
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.subdag_operator import SubDagOperator
+
+DAG_NAME = 'test_subdag_operator'
+
+DEFAULT_TASK_ARGS = {
+    'owner': 'airflow',
+    'start_date': datetime(2019, 1, 1),
+    'max_active_runs': 1,
+}
+
+
+def subdag(parent_dag_name, child_dag_name, args):
+    """
+    Create a subdag.
+    """
+    dag_subdag = DAG(
+        dag_id='%s.%s' % (parent_dag_name, child_dag_name),
+        default_args=args,
+        schedule_interval="@daily",
+    )
+
+    for i in range(2):
+        DummyOperator(
+            task_id='%s-task-%s' % (child_dag_name, i + 1),
+            default_args=args,
+            dag=dag_subdag,
+        )
+
+    return dag_subdag
+
+
+with DAG(
+    dag_id=DAG_NAME,
+    start_date=datetime(2019, 1, 1),
+    max_active_runs=1,
+    default_args=DEFAULT_TASK_ARGS,
+    schedule_interval=timedelta(minutes=1),
+) as dag:
+
+    start = DummyOperator(
+        task_id='start',
+    )
+
+    section_1 = SubDagOperator(
+        task_id='section-1',
+        subdag=subdag(DAG_NAME, 'section-1', DEFAULT_TASK_ARGS),
+        default_args=DEFAULT_TASK_ARGS,
+    )
+
+    some_other_task = DummyOperator(
+        task_id='some-other-task',
+    )
+
+    start >> section_1 >> some_other_task  # pylint: disable=W0104


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4509

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Change `SubDagOperator` to use Airflow scheduler to schedule
tasks in subdags instead of backfill.

In the past, `SubDagOperator` relies on backfill scheduler
to schedule tasks in the subdags. Tasks in parent `DAG`
are scheduled via Airflow scheduler while tasks in
a subdag are scheduled via backfill, which complicates
the scheduling logic and adds difficulties to maintain
the two scheduling code path.

This PR simplifies how tasks in subdags are scheduled.
`SubDagOperator` is responsible for creating a DagRun for subdag
and wait until all the tasks in the subdag finish. Airflow
scheduler picks up the DagRun created by SubDagOperator,
create and schedule the tasks accordingly.

Although `SubDagOperator` can occupy a pool/concurrency slot,
user can specify the `mode=reschedule` so that the slot will be
released periodically to avoid potential deadlock.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
