### PR TITLE
[AIRFLOW-4862] Allow directly using IP address as hostname

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -72,6 +72,10 @@ log_processor_filename_template = {{{{ filename }}}}.log
 dag_processor_manager_log_location = {AIRFLOW_HOME}/logs/dag_processor_manager/dag_processor_manager.log
 
 # Hostname by providing a path to a callable, which will resolve the hostname
+# The format is "package:function". For example,
+# default value "socket:getfqdn" means that result from getfqdn() of "socket" package will be used as hostname
+# No argument should be required in the function specified.
+# If using IP address as hostname is preferred, use value "airflow.utils.net:get_host_ip_address"
 hostname_callable = socket:getfqdn
 
 # Default timezone in case supplied date times are naive

--- a/airflow/utils/net.py
+++ b/airflow/utils/net.py
@@ -22,6 +22,10 @@ import socket
 from airflow.configuration import (conf, AirflowConfigException)
 
 
+def get_host_ip_address():
+    socket.gethostbyname(socket.getfqdn())
+
+
 def get_hostname():
     """
     Fetch the hostname using the callable from the config or using


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-4862


### Description

There are some cases in which components need to talk to each other (e.g., webserver fetches log from worker), but the hostname from `airflow.utils.net.get_hostname()` may not always be resolvable.

This PR provide the choice to let use use IP address directly as hostname, so there will be no DNS resolving issue.

For mode details, like the real issue I encountered in my environments, please refer to description in the JIRA ticket https://issues.apache.org/jira/browse/AIRFLOW-4862