### PR TITLE
[AIRFLOW-4864] Remove duplicated calls to load_test_config

### DIFF
--- a/tests/api/common/experimental/test_mark_tasks.py
+++ b/tests/api/common/experimental/test_mark_tasks.py
@@ -34,8 +34,6 @@ from tests.test_utils.db import clear_db_runs
 
 DEV_NULL = "/dev/null"
 
-configuration.load_test_config()
-
 
 class TestMarkTasks(unittest.TestCase):
 

--- a/tests/cli/test_worker_initialisation.py
+++ b/tests/cli/test_worker_initialisation.py
@@ -29,10 +29,6 @@ mock_args = Namespace(queues=1, concurrency=1)
 
 
 class TestWorkerPrecheck(unittest.TestCase):
-
-    def setUp(self):
-        airflow.configuration.load_test_config()
-
     @mock.patch('airflow.settings.validate_session')
     def test_error(self, mock_validate_session):
         """

--- a/tests/contrib/hooks/test_aws_hook.py
+++ b/tests/contrib/hooks/test_aws_hook.py
@@ -22,7 +22,6 @@ import unittest
 
 import boto3
 
-from airflow import configuration
 from airflow.models import Connection
 from airflow.contrib.hooks.aws_hook import AwsHook
 from tests.compat import mock
@@ -37,10 +36,6 @@ except ImportError:
 
 
 class TestAwsHook(unittest.TestCase):
-    @mock_emr
-    def setUp(self):
-        configuration.load_test_config()
-
     @unittest.skipIf(mock_emr is None, 'mock_emr package not present')
     @mock_emr
     def test_get_client_type_returns_a_boto3_client_of_the_requested_type(self):

--- a/tests/contrib/hooks/test_azure_container_instance_hook.py
+++ b/tests/contrib/hooks/test_azure_container_instance_hook.py
@@ -22,7 +22,6 @@ import unittest
 from unittest.mock import patch
 from collections import namedtuple
 
-from airflow import configuration
 from airflow.models import Connection
 from airflow.contrib.hooks.azure_container_instance_hook import AzureContainerInstanceHook
 from airflow.utils import db
@@ -39,7 +38,6 @@ from azure.mgmt.containerinstance.models import (Container,
 class TestAzureContainerInstanceHook(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='azure_container_instance_test',

--- a/tests/contrib/hooks/test_azure_container_registry_hook.py
+++ b/tests/contrib/hooks/test_azure_container_registry_hook.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.models import Connection
 from airflow.contrib.hooks.azure_container_registry_hook import AzureContainerRegistryHook
 from airflow.utils import db
@@ -28,7 +27,6 @@ from airflow.utils import db
 class TestAzureContainerRegistryHook(unittest.TestCase):
 
     def test_get_conn(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='azure_container_registry',

--- a/tests/contrib/hooks/test_azure_container_volume_hook.py
+++ b/tests/contrib/hooks/test_azure_container_volume_hook.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.models import Connection
 from airflow.contrib.hooks.azure_container_volume_hook import AzureContainerVolumeHook
 from airflow.utils import db
@@ -28,7 +27,6 @@ from airflow.utils import db
 class TestAzureContainerVolumeHook(unittest.TestCase):
 
     def test_get_file_volume(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='wasb_test_key',

--- a/tests/contrib/hooks/test_azure_cosmos_hook.py
+++ b/tests/contrib/hooks/test_azure_cosmos_hook.py
@@ -26,7 +26,6 @@ import uuid
 from airflow.exceptions import AirflowException
 from airflow.contrib.hooks.azure_cosmos_hook import AzureCosmosDBHook
 
-from airflow import configuration
 from airflow.models import Connection
 from airflow.utils import db
 from tests.compat import mock
@@ -45,7 +44,6 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         self.test_collection_name = 'test_collection_name'
         self.test_database_default = 'test_database_default'
         self.test_collection_default = 'test_collection_default'
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='azure_cosmos_test_key_id',

--- a/tests/contrib/hooks/test_azure_data_lake_hook.py
+++ b/tests/contrib/hooks/test_azure_data_lake_hook.py
@@ -22,7 +22,6 @@
 import json
 import unittest
 
-from airflow import configuration
 from airflow.models import Connection
 from airflow.utils import db
 from tests.compat import mock
@@ -31,7 +30,6 @@ from tests.compat import mock
 class TestAzureDataLakeHook(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='adl_test_key',

--- a/tests/contrib/hooks/test_azure_fileshare_hook.py
+++ b/tests/contrib/hooks/test_azure_fileshare_hook.py
@@ -22,7 +22,6 @@
 import json
 import unittest
 
-from airflow import configuration
 from airflow.contrib.hooks.azure_fileshare_hook import AzureFileShareHook
 from airflow.models import Connection
 from airflow.utils import db
@@ -32,7 +31,6 @@ from tests.compat import mock
 class TestAzureFileshareHook(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='wasb_test_key', conn_type='wasb',

--- a/tests/contrib/hooks/test_cassandra_hook.py
+++ b/tests/contrib/hooks/test_cassandra_hook.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.contrib.hooks.cassandra_hook import CassandraHook
 from cassandra.cluster import Cluster
 from cassandra.policies import (
@@ -32,7 +31,6 @@ from tests.compat import mock, patch
 
 class CassandraHookTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='cassandra_test', conn_type='cassandra',

--- a/tests/contrib/hooks/test_dingding_hook.py
+++ b/tests/contrib/hooks/test_dingding_hook.py
@@ -22,8 +22,6 @@ import unittest
 
 from airflow.utils import db
 
-from airflow import configuration
-
 from airflow.contrib.hooks.dingding_hook import DingdingHook
 from airflow.models import Connection
 
@@ -32,7 +30,6 @@ class TestDingdingHook(unittest.TestCase):
     conn_id = 'dingding_conn_id_test'
 
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id=self.conn_id,

--- a/tests/contrib/hooks/test_discord_webhook_hook.py
+++ b/tests/contrib/hooks/test_discord_webhook_hook.py
@@ -20,7 +20,7 @@
 import json
 import unittest
 
-from airflow import configuration, AirflowException
+from airflow import AirflowException
 from airflow.models import Connection
 from airflow.utils import db
 
@@ -49,7 +49,6 @@ class TestDiscordWebhookHook(unittest.TestCase):
     expected_payload = json.dumps(expected_payload_dict)
 
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='default-discord-webhook',

--- a/tests/contrib/hooks/test_emr_hook.py
+++ b/tests/contrib/hooks/test_emr_hook.py
@@ -21,7 +21,6 @@
 import unittest
 import boto3
 
-from airflow import configuration
 from airflow.contrib.hooks.emr_hook import EmrHook
 
 try:
@@ -32,10 +31,6 @@ except ImportError:
 
 @unittest.skipIf(mock_emr is None, 'moto package not present')
 class TestEmrHook(unittest.TestCase):
-    @mock_emr
-    def setUp(self):
-        configuration.load_test_config()
-
     @mock_emr
     def test_get_conn_returns_a_boto3_connection(self):
         hook = EmrHook(aws_conn_id='aws_default', region_name='ap-southeast-2')

--- a/tests/contrib/hooks/test_ftp_hook.py
+++ b/tests/contrib/hooks/test_ftp_hook.py
@@ -129,11 +129,9 @@ class TestIntegrationFTPHook(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        from airflow import configuration
         from airflow.utils import db
         from airflow.models import Connection
 
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='ftp_passive', conn_type='ftp',

--- a/tests/contrib/hooks/test_grpc_hook.py
+++ b/tests/contrib/hooks/test_grpc_hook.py
@@ -14,7 +14,6 @@
 import unittest
 from io import StringIO
 
-from airflow import configuration
 from airflow.exceptions import AirflowConfigException
 from airflow.contrib.hooks.grpc_hook import GrpcHook
 from airflow.models import Connection
@@ -61,7 +60,6 @@ class StubClass:
 
 class TestGrpcHook(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         self.channel_mock = mock.patch('grpc.Channel').start()
 
     def custom_conn_func(self, connection):

--- a/tests/contrib/hooks/test_imap_hook.py
+++ b/tests/contrib/hooks/test_imap_hook.py
@@ -22,7 +22,7 @@ import unittest
 
 from unittest.mock import Mock, patch, mock_open
 
-from airflow import configuration, AirflowException
+from airflow import AirflowException
 from airflow.contrib.hooks.imap_hook import ImapHook
 from airflow.models import Connection
 from airflow.utils import db
@@ -54,8 +54,6 @@ def _create_fake_imap(mock_imaplib, with_mail=False, attachment_name='test1.csv'
 
 class TestImapHook(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
-
         db.merge_conn(
             Connection(
                 conn_id='imap_default',

--- a/tests/contrib/hooks/test_jdbc_hook.py
+++ b/tests/contrib/hooks/test_jdbc_hook.py
@@ -22,7 +22,6 @@ import unittest
 from unittest.mock import Mock, patch
 import json
 
-from airflow import configuration
 from airflow.hooks.jdbc_hook import JdbcHook
 from airflow.models import Connection
 from airflow.utils import db
@@ -34,7 +33,6 @@ jdbc_conn_mock = Mock(
 
 class TestJdbcHook(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='jdbc_default', conn_type='jdbc',

--- a/tests/contrib/hooks/test_jira_hook.py
+++ b/tests/contrib/hooks/test_jira_hook.py
@@ -23,7 +23,6 @@ import unittest
 from unittest.mock import Mock
 from unittest.mock import patch
 
-from airflow import configuration
 from airflow.contrib.hooks.jira_hook import JiraHook
 from airflow.models import Connection
 from airflow.utils import db
@@ -35,7 +34,6 @@ jira_client_mock = Mock(
 
 class TestJiraHook(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='jira_default', conn_type='jira',

--- a/tests/contrib/hooks/test_mongo_hook.py
+++ b/tests/contrib/hooks/test_mongo_hook.py
@@ -23,7 +23,6 @@ try:
 except ImportError:
     mongomock = None
 
-from airflow import configuration
 from airflow.contrib.hooks.mongo_hook import MongoHook
 from airflow.models import Connection
 from airflow.utils import db
@@ -43,7 +42,6 @@ class MongoHookTest(MongoHook):
 
 class TestMongoHook(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         self.hook = MongoHookTest(conn_id='mongo_default', mongo_db='default')
         self.conn = self.hook.get_conn()
         db.merge_conn(

--- a/tests/contrib/hooks/test_openfaas_hook.py
+++ b/tests/contrib/hooks/test_openfaas_hook.py
@@ -23,7 +23,7 @@ import requests_mock
 from airflow.models import Connection
 from airflow.contrib.hooks.openfaas_hook import OpenFaasHook
 from airflow.hooks.base_hook import BaseHook
-from airflow import configuration, AirflowException
+from airflow import AirflowException
 from tests.compat import mock
 
 FUNCTION_NAME = "function_name"
@@ -36,7 +36,6 @@ class TestOpenFaasHook(unittest.TestCase):
     UPDATE_FUNCTION = "/system/functions"
 
     def setUp(self):
-        configuration.load_test_config()
         self.hook = OpenFaasHook(function_name=FUNCTION_NAME)
         self.mock_response = {'ans': 'a'}
 

--- a/tests/contrib/hooks/test_opsgenie_alert_hook.py
+++ b/tests/contrib/hooks/test_opsgenie_alert_hook.py
@@ -21,7 +21,6 @@ import unittest
 import requests_mock
 import json
 
-from airflow import configuration
 from airflow.models import Connection
 from airflow.utils import db
 from airflow.contrib.hooks.opsgenie_alert_hook import OpsgenieAlertHook
@@ -67,7 +66,6 @@ class TestOpsgenieAlertHook(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id=self.conn_id,

--- a/tests/contrib/hooks/test_redis_hook.py
+++ b/tests/contrib/hooks/test_redis_hook.py
@@ -19,15 +19,10 @@
 
 
 import unittest
-from airflow import configuration
 from airflow.contrib.hooks.redis_hook import RedisHook
 
 
 class TestRedisHook(unittest.TestCase):
-
-    def setUp(self):
-        configuration.load_test_config()
-
     def test_get_conn(self):
         hook = RedisHook(redis_conn_id='redis_default')
         self.assertEqual(hook.redis, None)

--- a/tests/contrib/hooks/test_redshift_hook.py
+++ b/tests/contrib/hooks/test_redshift_hook.py
@@ -21,7 +21,6 @@
 import unittest
 import boto3
 
-from airflow import configuration
 from airflow.contrib.hooks.redshift_hook import RedshiftHook
 from airflow.contrib.hooks.aws_hook import AwsHook
 
@@ -32,9 +31,6 @@ except ImportError:
 
 
 class TestRedshiftHook(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-
     @staticmethod
     def _create_clusters():
         client = boto3.client('redshift', region_name='us-east-1')

--- a/tests/contrib/hooks/test_sagemaker_hook.py
+++ b/tests/contrib/hooks/test_sagemaker_hook.py
@@ -23,7 +23,6 @@ import time
 from datetime import datetime
 from tzlocal import get_localzone
 
-from airflow import configuration
 from airflow.contrib.hooks.sagemaker_hook import (SageMakerHook, secondary_training_status_changed,
                                                   secondary_training_status_message, LogState)
 from airflow.hooks.S3_hook import S3Hook
@@ -245,10 +244,6 @@ test_evaluation_config = {
 
 
 class TestSageMakerHook(unittest.TestCase):
-
-    def setUp(self):
-        configuration.load_test_config()
-
     @mock.patch.object(SageMakerHook, 'log_stream')
     def test_multi_stream_iter(self, mock_log_stream):
         event = {'timestamp': 1}

--- a/tests/contrib/hooks/test_segment_hook.py
+++ b/tests/contrib/hooks/test_segment_hook.py
@@ -20,7 +20,7 @@
 from unittest import mock
 import unittest
 
-from airflow import configuration, AirflowException
+from airflow import AirflowException
 
 from airflow.contrib.hooks.segment_hook import SegmentHook
 
@@ -32,7 +32,6 @@ class TestSegmentHook(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        configuration.load_test_config()
 
         self.conn = conn = mock.MagicMock()
         conn.write_key = WRITE_KEY

--- a/tests/contrib/hooks/test_sftp_hook.py
+++ b/tests/contrib/hooks/test_sftp_hook.py
@@ -23,7 +23,6 @@ import shutil
 import os
 import pysftp
 
-from airflow import configuration
 from airflow.contrib.hooks.sftp_hook import SFTPHook
 from airflow.models import Connection
 
@@ -34,7 +33,6 @@ TMP_FILE_FOR_TESTS = 'test_file.txt'
 
 class SFTPHookTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         self.hook = SFTPHook()
         os.makedirs(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS))
         with open(os.path.join(TMP_PATH, TMP_FILE_FOR_TESTS), 'a') as file:

--- a/tests/contrib/hooks/test_slack_webhook_hook.py
+++ b/tests/contrib/hooks/test_slack_webhook_hook.py
@@ -22,7 +22,6 @@ from requests.exceptions import MissingSchema
 import unittest
 from unittest import mock
 
-from airflow import configuration
 from airflow.models import Connection
 from airflow.utils import db
 from airflow.contrib.hooks.slack_webhook_hook import SlackWebhookHook
@@ -54,7 +53,6 @@ class TestSlackWebhookHook(unittest.TestCase):
     expected_method = 'POST'
 
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='slack-webhook-default',

--- a/tests/contrib/hooks/test_spark_jdbc_hook.py
+++ b/tests/contrib/hooks/test_spark_jdbc_hook.py
@@ -19,7 +19,6 @@
 #
 import unittest
 
-from airflow import configuration
 from airflow.models import Connection
 from airflow.utils import db
 
@@ -66,7 +65,6 @@ class TestSparkJDBCHook(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='spark-default', conn_type='spark',

--- a/tests/contrib/hooks/test_spark_sql_hook.py
+++ b/tests/contrib/hooks/test_spark_sql_hook.py
@@ -23,7 +23,6 @@ import unittest
 from unittest.mock import patch, call
 from itertools import dropwhile
 
-from airflow import configuration
 from airflow.models import Connection
 from airflow.utils import db
 from airflow.contrib.hooks.spark_sql_hook import SparkSqlHook
@@ -51,7 +50,6 @@ class TestSparkSqlHook(unittest.TestCase):
 
     def setUp(self):
 
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='spark_default', conn_type='spark',

--- a/tests/contrib/hooks/test_spark_submit_hook.py
+++ b/tests/contrib/hooks/test_spark_submit_hook.py
@@ -20,7 +20,7 @@
 import six
 import unittest
 
-from airflow import configuration, AirflowException
+from airflow import AirflowException
 from airflow.models import Connection
 from airflow.utils import db
 from unittest.mock import patch, call
@@ -71,8 +71,6 @@ class TestSparkSubmitHook(unittest.TestCase):
         return return_dict
 
     def setUp(self):
-
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='spark_yarn_cluster', conn_type='spark',

--- a/tests/contrib/hooks/test_sqoop_hook.py
+++ b/tests/contrib/hooks/test_sqoop_hook.py
@@ -22,7 +22,6 @@ import collections
 import json
 import unittest
 
-from airflow import configuration
 from airflow.contrib.hooks.sqoop_hook import SqoopHook
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
@@ -87,7 +86,6 @@ class TestSqoopHook(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='sqoop_test', conn_type='sqoop', schema='schema',

--- a/tests/contrib/hooks/test_ssh_hook.py
+++ b/tests/contrib/hooks/test_ssh_hook.py
@@ -18,7 +18,6 @@
 # under the License.
 
 import unittest
-from airflow import configuration
 from airflow.models import Connection
 from airflow.utils import db
 from tests.compat import mock
@@ -40,10 +39,6 @@ conn.sendall(b'hello')
 
 
 class SSHHookTest(unittest.TestCase):
-
-    def setUp(self):
-        configuration.load_test_config()
-
     @mock.patch('airflow.contrib.hooks.ssh_hook.paramiko.SSHClient')
     def test_ssh_connection_with_password(self, ssh_mock):
         hook = SSHHook(remote_host='remote_host',

--- a/tests/contrib/hooks/test_wasb_hook.py
+++ b/tests/contrib/hooks/test_wasb_hook.py
@@ -23,7 +23,7 @@ import json
 import unittest
 from collections import namedtuple
 
-from airflow import configuration, AirflowException
+from airflow import AirflowException
 from airflow.contrib.hooks.wasb_hook import WasbHook
 from airflow.models import Connection
 from airflow.utils import db
@@ -33,7 +33,6 @@ from tests.compat import mock
 class TestWasbHook(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='wasb_test_key', conn_type='wasb',

--- a/tests/contrib/operators/test_aws_athena_operator.py
+++ b/tests/contrib/operators/test_aws_athena_operator.py
@@ -25,7 +25,6 @@ from airflow.contrib.hooks.aws_athena_hook import AWSAthenaHook
 from airflow.models import DAG, TaskInstance
 from airflow.utils import timezone
 from airflow.utils.timezone import datetime
-from airflow import configuration
 from tests.compat import mock
 
 TEST_DAG_ID = 'unit_tests'
@@ -51,8 +50,6 @@ result_configuration = {
 class TestAWSAthenaOperator(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
-
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE,

--- a/tests/contrib/operators/test_aws_sqs_publish_operator.py
+++ b/tests/contrib/operators/test_aws_sqs_publish_operator.py
@@ -19,7 +19,7 @@
 
 
 import unittest
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.operators.aws_sqs_publish_operator import SQSPublishOperator
 from airflow.utils import timezone
 from unittest.mock import MagicMock
@@ -32,8 +32,6 @@ DEFAULT_DATE = timezone.datetime(2019, 1, 1)
 class TestSQSPublishOperator(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
-
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/operators/test_awsbatch_operator.py
+++ b/tests/contrib/operators/test_awsbatch_operator.py
@@ -21,7 +21,6 @@
 import sys
 import unittest
 
-from airflow import configuration
 from airflow.exceptions import AirflowException
 from airflow.contrib.operators.awsbatch_operator import AWSBatchOperator
 from tests.compat import mock
@@ -36,8 +35,6 @@ class TestAWSBatchOperator(unittest.TestCase):
 
     @mock.patch('airflow.contrib.operators.awsbatch_operator.AwsHook')
     def setUp(self, aws_hook_mock):
-        configuration.load_test_config()
-
         self.aws_hook_mock = aws_hook_mock
         self.batch = AWSBatchOperator(
             task_id='task',

--- a/tests/contrib/operators/test_azure_cosmos_insertdocument_operator.py
+++ b/tests/contrib/operators/test_azure_cosmos_insertdocument_operator.py
@@ -25,7 +25,6 @@ import uuid
 
 from airflow.contrib.operators.azure_cosmos_operator import AzureCosmosInsertDocumentOperator
 
-from airflow import configuration
 from airflow.models import Connection
 from airflow.utils import db
 from tests.compat import mock
@@ -40,7 +39,6 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         self.test_master_key = 'magic_test_key'
         self.test_database_name = 'test_database_name'
         self.test_collection_name = 'test_collection_name'
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='azure_cosmos_test_key_id',

--- a/tests/contrib/operators/test_bigquery_operator.py
+++ b/tests/contrib/operators/test_bigquery_operator.py
@@ -23,7 +23,7 @@ from datetime import datetime
 
 import six
 
-from airflow import configuration, models
+from airflow import models
 from airflow.contrib.operators.bigquery_get_data import BigQueryGetDataOperator
 from airflow.contrib.operators.bigquery_operator import \
     BigQueryCreateExternalTableOperator, BigQueryCreateEmptyTableOperator, \
@@ -156,7 +156,6 @@ class BigQueryCreateEmptyDatasetOperatorTest(unittest.TestCase):
 
 class BigQueryOperatorTest(unittest.TestCase):
     def setUp(self):
-        configuration.conf.load_test_config()
         self.dagbag = models.DagBag(
             dag_folder='/dev/null', include_examples=True)
         self.args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}

--- a/tests/contrib/operators/test_dingding_operator.py
+++ b/tests/contrib/operators/test_dingding_operator.py
@@ -21,7 +21,7 @@ import unittest
 
 from unittest import mock
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.operators.dingding_operator import DingdingOperator
 from airflow.utils import timezone
 
@@ -38,7 +38,6 @@ class TestDingdingOperator(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/operators/test_discord_webhook_operator.py
+++ b/tests/contrib/operators/test_discord_webhook_operator.py
@@ -19,7 +19,7 @@
 #
 import unittest
 
-from airflow import DAG, configuration
+from airflow import DAG
 
 from airflow.contrib.operators.discord_webhook_operator import DiscordWebhookOperator
 from airflow.utils import timezone
@@ -39,7 +39,6 @@ class TestDiscordWebhookOperator(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/operators/test_druid_operator.py
+++ b/tests/contrib/operators/test_druid_operator.py
@@ -21,7 +21,7 @@
 from unittest import mock
 import unittest
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.operators.druid_operator import DruidOperator
 from airflow.utils import timezone
 from airflow.models import TaskInstance
@@ -31,7 +31,6 @@ DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 
 class TestDruidOperator(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': timezone.datetime(2017, 1, 1)

--- a/tests/contrib/operators/test_ecs_operator.py
+++ b/tests/contrib/operators/test_ecs_operator.py
@@ -24,7 +24,6 @@ from copy import deepcopy
 
 from parameterized import parameterized
 
-from airflow import configuration
 from airflow.exceptions import AirflowException
 from airflow.contrib.operators.ecs_operator import ECSOperator
 from tests.compat import mock
@@ -55,8 +54,6 @@ class TestECSOperator(unittest.TestCase):
 
     @mock.patch('airflow.contrib.operators.ecs_operator.AwsHook')
     def setUp(self, aws_hook_mock):
-        configuration.load_test_config()
-
         self.aws_hook_mock = aws_hook_mock
         self.ecs_operator_args = {
             'task_id': 'task',

--- a/tests/contrib/operators/test_emr_add_steps_operator.py
+++ b/tests/contrib/operators/test_emr_add_steps_operator.py
@@ -21,7 +21,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 from datetime import timedelta
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.operators.emr_add_steps_operator import EmrAddStepsOperator
 from airflow.models import TaskInstance
 from airflow.utils import timezone
@@ -52,7 +52,6 @@ class TestEmrAddStepsOperator(unittest.TestCase):
     }]
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/operators/test_emr_create_job_flow_operator.py
+++ b/tests/contrib/operators/test_emr_create_job_flow_operator.py
@@ -22,7 +22,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 from datetime import timedelta
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.operators.emr_create_job_flow_operator import EmrCreateJobFlowOperator
 from airflow.models import TaskInstance
 from airflow.utils import timezone
@@ -57,7 +57,6 @@ class TestEmrCreateJobFlowOperator(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/operators/test_emr_terminate_job_flow_operator.py
+++ b/tests/contrib/operators/test_emr_terminate_job_flow_operator.py
@@ -20,7 +20,6 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from airflow import configuration
 from airflow.contrib.operators.emr_terminate_job_flow_operator import EmrTerminateJobFlowOperator
 
 TERMINATE_SUCCESS_RETURN = {
@@ -32,8 +31,6 @@ TERMINATE_SUCCESS_RETURN = {
 
 class TestEmrTerminateJobFlowOperator(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
-
         # Mock out the emr_client (moto has incorrect response)
         mock_emr_client = MagicMock()
         mock_emr_client.terminate_job_flows.return_value = TERMINATE_SUCCESS_RETURN

--- a/tests/contrib/operators/test_file_to_gcs.py
+++ b/tests/contrib/operators/test_file_to_gcs.py
@@ -21,7 +21,7 @@
 import datetime
 import unittest
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.operators.file_to_gcs import FileToGoogleCloudStorageOperator
 from tests.compat import mock
 
@@ -37,7 +37,6 @@ class TestFileToGcsOperator(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': datetime.datetime(2017, 1, 1)

--- a/tests/contrib/operators/test_file_to_wasb.py
+++ b/tests/contrib/operators/test_file_to_wasb.py
@@ -21,7 +21,7 @@
 import datetime
 import unittest
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.operators.file_to_wasb import FileToWasbOperator
 from tests.compat import mock
 
@@ -37,7 +37,6 @@ class TestFileToWasbOperator(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': datetime.datetime(2017, 1, 1)

--- a/tests/contrib/operators/test_gcp_compute_operator.py
+++ b/tests/contrib/operators/test_gcp_compute_operator.py
@@ -23,7 +23,7 @@ from copy import deepcopy
 import httplib2
 from googleapiclient.errors import HttpError
 
-from airflow import AirflowException, configuration
+from airflow import AirflowException
 from airflow.contrib.operators.gcp_compute_operator import GceInstanceStartOperator, \
     GceInstanceStopOperator, GceSetMachineTypeOperator, GceInstanceTemplateCopyOperator, \
     GceInstanceGroupManagerUpdateTemplateOperator
@@ -67,7 +67,6 @@ class GceInstanceStartTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.gcp_compute_operator.GceHook')
     def test_instance_start_with_templates(self, _):
         dag_id = 'test_dag_id'
-        configuration.load_test_config()
         args = {
             'start_date': DEFAULT_DATE
         }
@@ -162,7 +161,6 @@ class GceInstanceStopTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.gcp_compute_operator.GceHook')
     def test_instance_stop_with_templates(self, _):
         dag_id = 'test_dag_id'
-        configuration.load_test_config()
         args = {
             'start_date': DEFAULT_DATE
         }
@@ -267,7 +265,6 @@ class GceInstanceSetMachineTypeTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.gcp_compute_operator.GceHook')
     def test_set_machine_type_with_templates(self, _):
         dag_id = 'test_dag_id'
-        configuration.load_test_config()
         args = {
             'start_date': DEFAULT_DATE
         }

--- a/tests/contrib/operators/test_gcp_transfer_operator.py
+++ b/tests/contrib/operators/test_gcp_transfer_operator.py
@@ -25,7 +25,7 @@ from typing import Dict
 from parameterized import parameterized
 from botocore.credentials import Credentials
 
-from airflow import AirflowException, configuration
+from airflow import AirflowException
 from airflow.contrib.hooks.gcp_transfer_hook import (
     FILTER_JOB_NAMES,
     SCHEDULE_START_DATE,
@@ -289,7 +289,6 @@ class GcpStorageTransferJobCreateOperatorTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.gcp_transfer_operator.GCPTransferServiceHook')
     def test_templates(self, _):
         dag_id = 'test_dag_id'
-        configuration.load_test_config()
         self.dag = DAG(dag_id, default_args={'start_date': DEFAULT_DATE})
         op = GcpTransferServiceJobCreateOperator(
             body={"description": "{{ dag.dag_id }}"},
@@ -324,7 +323,6 @@ class GcpStorageTransferJobUpdateOperatorTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.gcp_transfer_operator.GCPTransferServiceHook')
     def test_templates(self, _):
         dag_id = 'test_dag_id'
-        configuration.load_test_config()
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)
         op = GcpTransferServiceJobUpdateOperator(
@@ -357,7 +355,6 @@ class GcpStorageTransferJobDeleteOperatorTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.gcp_transfer_operator.GCPTransferServiceHook')
     def test_job_delete_with_templates(self, _):
         dag_id = 'test_dag_id'
-        configuration.load_test_config()
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)
         op = GcpTransferServiceJobDeleteOperator(
@@ -399,7 +396,6 @@ class GpcStorageTransferOperationsGetOperatorTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.gcp_transfer_operator.GCPTransferServiceHook')
     def test_operation_get_with_templates(self, _):
         dag_id = 'test_dag_id'
-        configuration.load_test_config()
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)
         op = GcpTransferServiceOperationGetOperator(
@@ -435,7 +431,6 @@ class GcpStorageTransferOperationListOperatorTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.gcp_transfer_operator.GCPTransferServiceHook')
     def test_templates(self, _):
         dag_id = 'test_dag_id'
-        configuration.load_test_config()
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)
         op = GcpTransferServiceOperationsListOperator(
@@ -464,7 +459,6 @@ class GcpStorageTransferOperationsPauseOperatorTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.gcp_transfer_operator.GCPTransferServiceHook')
     def test_operation_pause_with_templates(self, _):
         dag_id = 'test_dag_id'
-        configuration.load_test_config()
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)
         op = GcpTransferServiceOperationPauseOperator(
@@ -507,7 +501,6 @@ class GcpStorageTransferOperationsResumeOperatorTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.gcp_transfer_operator.GCPTransferServiceHook')
     def test_operation_resume_with_templates(self, _):
         dag_id = 'test_dag_id'
-        configuration.load_test_config()
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)
         op = GcpTransferServiceOperationResumeOperator(
@@ -550,7 +543,6 @@ class GcpStorageTransferOperationsCancelOperatorTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.gcp_transfer_operator.GCPTransferServiceHook')
     def test_operation_cancel_with_templates(self, _):
         dag_id = 'test_dag_id'
-        configuration.load_test_config()
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)
         op = GcpTransferServiceOperationCancelOperator(
@@ -600,7 +592,6 @@ class S3ToGoogleCloudStorageTransferOperatorTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.gcp_transfer_operator.GCPTransferServiceHook')
     def test_templates(self, _):
         dag_id = 'test_dag_id'
-        configuration.load_test_config()
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)
         op = S3ToGoogleCloudStorageTransferOperator(
@@ -692,7 +683,6 @@ class GoogleCloudStorageToGoogleCloudStorageTransferOperatorTest(unittest.TestCa
     @mock.patch('airflow.contrib.operators.gcp_transfer_operator.GCPTransferServiceHook')
     def test_templates(self, _):
         dag_id = 'test_dag_id'
-        configuration.load_test_config()
         args = {'start_date': DEFAULT_DATE}
         self.dag = DAG(dag_id, default_args=args)
         op = GoogleCloudStorageToGoogleCloudStorageTransferOperator(

--- a/tests/contrib/operators/test_grpc_operator.py
+++ b/tests/contrib/operators/test_grpc_operator.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import unittest
 
-from airflow import configuration
 from airflow.contrib.operators.grpc_operator import GrpcOperator
 
 from tests.compat import mock
@@ -28,9 +27,6 @@ class StubClass(object):
 
 
 class TestGrpcOperator(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-
     def custom_conn_func(self, connection):
         pass
 

--- a/tests/contrib/operators/test_hipchat_operator.py
+++ b/tests/contrib/operators/test_hipchat_operator.py
@@ -23,14 +23,10 @@ import requests
 from airflow.contrib.operators.hipchat_operator import \
     HipChatAPISendRoomNotificationOperator
 from airflow.exceptions import AirflowException
-from airflow import configuration
 from tests.compat import mock
 
 
 class HipChatOperatorTest(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-
     @unittest.skipIf(mock is None, 'mock package not present')
     @mock.patch('requests.request')
     def test_execute(self, request_mock):

--- a/tests/contrib/operators/test_hive_to_dynamodb_operator.py
+++ b/tests/contrib/operators/test_hive_to_dynamodb_operator.py
@@ -25,12 +25,10 @@ import datetime
 
 import pandas as pd
 
-from airflow import configuration, DAG
+from airflow import DAG
 from airflow.contrib.hooks.aws_dynamodb_hook import AwsDynamoDBHook
 
 import airflow.contrib.operators.hive_to_dynamodb
-
-configuration.load_test_config()
 
 DEFAULT_DATE = datetime.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
@@ -45,7 +43,6 @@ except ImportError:
 class HiveToDynamoDBTransferOperatorTest(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         dag = DAG('test_dag_id', default_args=args)
         self.dag = dag

--- a/tests/contrib/operators/test_jira_operator_test.py
+++ b/tests/contrib/operators/test_jira_operator_test.py
@@ -23,7 +23,7 @@ import unittest
 from unittest.mock import Mock
 from unittest.mock import patch
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.operators.jira_operator import JiraOperator
 from airflow.models import Connection
 from airflow.utils import db
@@ -50,7 +50,6 @@ minimal_test_ticket = {
 
 class TestJiraOperator(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/operators/test_mlengine_operator.py
+++ b/tests/contrib/operators/test_mlengine_operator.py
@@ -23,7 +23,7 @@ import httplib2
 from googleapiclient.errors import HttpError
 from unittest.mock import ANY, patch
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.operators.mlengine_operator import (MLEngineBatchPredictionOperator,
                                                          MLEngineTrainingOperator,
                                                          MLEngineVersionOperator)
@@ -62,7 +62,6 @@ class MLEngineBatchPredictionOperatorTest(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        configuration.load_test_config()
         self.dag = DAG(
             'test_dag',
             default_args={

--- a/tests/contrib/operators/test_opsgenie_alert_operator.py
+++ b/tests/contrib/operators/test_opsgenie_alert_operator.py
@@ -20,7 +20,7 @@
 
 import unittest
 
-from airflow import DAG, configuration
+from airflow import DAG
 
 from airflow.contrib.operators.opsgenie_alert_operator import OpsgenieAlertOperator
 from airflow.utils import timezone
@@ -76,7 +76,6 @@ class TestOpsgenieAlertOperator(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/operators/test_redis_publish_operator.py
+++ b/tests/contrib/operators/test_redis_publish_operator.py
@@ -19,7 +19,7 @@
 
 
 import unittest
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.operators.redis_publish_operator import RedisPublishOperator
 from airflow.contrib.hooks.redis_hook import RedisHook
 from airflow.utils import timezone
@@ -31,8 +31,6 @@ DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 class TestRedisPublishOperator(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
-
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/operators/test_s3_to_sftp_operator.py
+++ b/tests/contrib/operators/test_s3_to_sftp_operator.py
@@ -60,7 +60,6 @@ reset()
 class S3ToSFTPOperatorTest(unittest.TestCase):
     @mock_s3
     def setUp(self):
-        configuration.load_test_config()
         from airflow.contrib.hooks.ssh_hook import SSHHook
         from airflow.hooks.S3_hook import S3Hook
 

--- a/tests/contrib/operators/test_sagemaker_base_operator.py
+++ b/tests/contrib/operators/test_sagemaker_base_operator.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.contrib.operators.sagemaker_base_operator import SageMakerBaseOperator
 
 config = {
@@ -58,7 +57,6 @@ parsed_config = {
 class TestSageMakerBaseOperator(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         self.sagemaker = SageMakerBaseOperator(
             task_id='test_sagemaker_operator',
             aws_conn_id='sagemaker_test_id',

--- a/tests/contrib/operators/test_sagemaker_endpoint_config_operator.py
+++ b/tests/contrib/operators/test_sagemaker_endpoint_config_operator.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.contrib.hooks.sagemaker_hook import SageMakerHook
 from airflow.contrib.operators.sagemaker_endpoint_config_operator \
     import SageMakerEndpointConfigOperator
@@ -45,7 +44,6 @@ create_endpoint_config_params = {
 class TestSageMakerEndpointConfigOperator(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         self.sagemaker = SageMakerEndpointConfigOperator(
             task_id='test_sagemaker_operator',
             aws_conn_id='sagemaker_test_id',

--- a/tests/contrib/operators/test_sagemaker_endpoint_operator.py
+++ b/tests/contrib/operators/test_sagemaker_endpoint_operator.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.contrib.hooks.sagemaker_hook import SageMakerHook
 from airflow.contrib.operators.sagemaker_endpoint_operator \
     import SageMakerEndpointOperator
@@ -70,7 +69,6 @@ config = {
 class TestSageMakerEndpointOperator(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         self.sagemaker = SageMakerEndpointOperator(
             task_id='test_sagemaker_operator',
             aws_conn_id='sagemaker_test_id',

--- a/tests/contrib/operators/test_sagemaker_model_operator.py
+++ b/tests/contrib/operators/test_sagemaker_model_operator.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.contrib.hooks.sagemaker_hook import SageMakerHook
 from airflow.contrib.operators.sagemaker_model_operator \
     import SageMakerModelOperator
@@ -48,7 +47,6 @@ create_model_params = {
 class TestSageMakerModelOperator(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         self.sagemaker = SageMakerModelOperator(
             task_id='test_sagemaker_operator',
             aws_conn_id='sagemaker_test_id',

--- a/tests/contrib/operators/test_sagemaker_training_operator.py
+++ b/tests/contrib/operators/test_sagemaker_training_operator.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.contrib.hooks.sagemaker_hook import SageMakerHook
 from airflow.contrib.operators.sagemaker_training_operator \
     import SageMakerTrainingOperator
@@ -83,7 +82,6 @@ create_training_params = \
 class TestSageMakerTrainingOperator(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         self.sagemaker = SageMakerTrainingOperator(
             task_id='test_sagemaker_operator',
             aws_conn_id='sagemaker_test_id',

--- a/tests/contrib/operators/test_sagemaker_transform_operator.py
+++ b/tests/contrib/operators/test_sagemaker_transform_operator.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.contrib.hooks.sagemaker_hook import SageMakerHook
 from airflow.contrib.operators.sagemaker_transform_operator \
     import SageMakerTransformOperator
@@ -82,7 +81,6 @@ config = {
 class TestSageMakerTransformOperator(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         self.sagemaker = SageMakerTransformOperator(
             task_id='test_sagemaker_operator',
             aws_conn_id='sagemaker_test_id',

--- a/tests/contrib/operators/test_sagemaker_tuning_operator.py
+++ b/tests/contrib/operators/test_sagemaker_tuning_operator.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.contrib.hooks.sagemaker_hook import SageMakerHook
 from airflow.contrib.operators.sagemaker_tuning_operator \
     import SageMakerTuningOperator
@@ -108,7 +107,6 @@ create_tuning_params = {'HyperParameterTuningJobName': job_name,
 class TestSageMakerTuningOperator(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         self.sagemaker = SageMakerTuningOperator(
             task_id='test_sagemaker_operator',
             aws_conn_id='sagemaker_test_conn',

--- a/tests/contrib/operators/test_segment_track_event_operator.py
+++ b/tests/contrib/operators/test_segment_track_event_operator.py
@@ -20,7 +20,7 @@
 from unittest import mock
 import unittest
 
-from airflow import configuration, AirflowException
+from airflow import AirflowException
 
 from airflow.contrib.hooks.segment_hook import SegmentHook
 from airflow.contrib.operators.segment_track_event_operator \
@@ -34,7 +34,6 @@ class TestSegmentHook(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        configuration.load_test_config()
 
         self.conn = conn = mock.MagicMock()
         conn.write_key = WRITE_KEY

--- a/tests/contrib/operators/test_sftp_operator.py
+++ b/tests/contrib/operators/test_sftp_operator.py
@@ -47,7 +47,6 @@ reset()
 
 class SFTPOperatorTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         from airflow.contrib.hooks.ssh_hook import SSHHook
         hook = SSHHook(ssh_conn_id='ssh_default')
         hook.no_host_key_check = True

--- a/tests/contrib/operators/test_sftp_to_s3_operator.py
+++ b/tests/contrib/operators/test_sftp_to_s3_operator.py
@@ -62,8 +62,6 @@ class SFTPToS3OperatorTest(unittest.TestCase):
 
     @mock_s3
     def setUp(self):
-        configuration.load_test_config()
-
         hook = SSHHook(ssh_conn_id='ssh_default')
         s3_hook = S3Hook('aws_default')
         hook.no_host_key_check = True

--- a/tests/contrib/operators/test_slack_webhook_operator.py
+++ b/tests/contrib/operators/test_slack_webhook_operator.py
@@ -20,8 +20,7 @@
 
 import unittest
 
-from airflow import DAG, configuration
-
+from airflow import DAG
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 from airflow.utils import timezone
 
@@ -42,7 +41,6 @@ class TestSlackWebhookOperator(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/operators/test_snowflake_operator.py
+++ b/tests/contrib/operators/test_snowflake_operator.py
@@ -19,7 +19,7 @@
 
 import unittest
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.utils import timezone
 
 from airflow.contrib.operators.snowflake_operator import SnowflakeOperator
@@ -38,7 +38,6 @@ class TestSnowflakeOperator(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        configuration.load_test_config()
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         dag = DAG(TEST_DAG_ID, default_args=args)
         self.dag = dag

--- a/tests/contrib/operators/test_spark_jdbc_operator.py
+++ b/tests/contrib/operators/test_spark_jdbc_operator.py
@@ -20,7 +20,7 @@
 
 import unittest
 
-from airflow import DAG, configuration
+from airflow import DAG
 
 from airflow.contrib.operators.spark_jdbc_operator import SparkJDBCOperator
 from airflow.utils import timezone
@@ -62,7 +62,6 @@ class TestSparkJDBCOperator(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/operators/test_spark_sql_operator.py
+++ b/tests/contrib/operators/test_spark_sql_operator.py
@@ -21,7 +21,7 @@
 import datetime
 import unittest
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.operators.spark_sql_operator import SparkSqlOperator
 
 DEFAULT_DATE = datetime.datetime(2017, 1, 1)
@@ -43,7 +43,6 @@ class TestSparkSqlOperator(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/operators/test_spark_submit_operator.py
+++ b/tests/contrib/operators/test_spark_submit_operator.py
@@ -20,7 +20,7 @@
 
 import unittest
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.models import TaskInstance
 
 from airflow.contrib.operators.spark_submit_operator import SparkSubmitOperator
@@ -67,7 +67,6 @@ class TestSparkSubmitOperator(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/operators/test_sqoop_operator.py
+++ b/tests/contrib/operators/test_sqoop_operator.py
@@ -21,7 +21,7 @@
 import datetime
 import unittest
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.operators.sqoop_operator import SqoopOperator
 from airflow.exceptions import AirflowException
 
@@ -70,7 +70,6 @@ class TestSqoopOperator(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': datetime.datetime(2017, 1, 1)

--- a/tests/contrib/operators/test_ssh_operator.py
+++ b/tests/contrib/operators/test_ssh_operator.py
@@ -45,7 +45,6 @@ reset()
 
 class SSHOperatorTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         from airflow.contrib.hooks.ssh_hook import SSHHook
         hook = SSHHook(ssh_conn_id='ssh_default')
         hook.no_host_key_check = True

--- a/tests/contrib/operators/test_vertica_to_mysql.py
+++ b/tests/contrib/operators/test_vertica_to_mysql.py
@@ -22,7 +22,7 @@ import datetime
 from unittest import mock
 import unittest
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.operators.vertica_to_mysql import VerticaToMySqlTransfer
 
 
@@ -44,7 +44,6 @@ def mock_get_conn():
 
 class TestVerticaToMySqlTransfer(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': datetime.datetime(2017, 1, 1)

--- a/tests/contrib/operators/test_wasb_delete_blob_operator.py
+++ b/tests/contrib/operators/test_wasb_delete_blob_operator.py
@@ -21,7 +21,7 @@
 import datetime
 import unittest
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.operators.wasb_delete_blob_operator import WasbDeleteBlobOperator
 from tests.compat import mock
 
@@ -34,7 +34,6 @@ class TestWasbDeleteBlobOperator(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': datetime.datetime(2017, 1, 1)

--- a/tests/contrib/sensors/test_athena_sensor.py
+++ b/tests/contrib/sensors/test_athena_sensor.py
@@ -18,7 +18,7 @@
 # under the License.
 
 import unittest
-from airflow import configuration, AirflowException
+from airflow import AirflowException
 from airflow.contrib.sensors.aws_athena_sensor import AthenaSensor
 from airflow.contrib.hooks.aws_athena_hook import AWSAthenaHook
 from tests.compat import mock
@@ -27,8 +27,6 @@ from tests.compat import mock
 class TestAthenaSensor(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
-
         self.sensor = AthenaSensor(task_id='test_athena_sensor',
                                    query_execution_id='abc',
                                    sleep_time=5,

--- a/tests/contrib/sensors/test_aws_glue_catalog_partition_sensor.py
+++ b/tests/contrib/sensors/test_aws_glue_catalog_partition_sensor.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.contrib.hooks.aws_glue_catalog_hook import AwsGlueCatalogHook
 from airflow.contrib.sensors.aws_glue_catalog_partition_sensor import AwsGlueCatalogPartitionSensor
 from tests.compat import mock
@@ -35,9 +34,6 @@ except ImportError:
 class TestAwsGlueCatalogPartitionSensor(unittest.TestCase):
 
     task_id = 'test_glue_catalog_partition_sensor'
-
-    def setUp(self):
-        configuration.load_test_config()
 
     @mock_glue
     @mock.patch.object(AwsGlueCatalogHook, 'check_for_partition')

--- a/tests/contrib/sensors/test_aws_redshift_cluster_sensor.py
+++ b/tests/contrib/sensors/test_aws_redshift_cluster_sensor.py
@@ -22,7 +22,6 @@ import unittest
 
 import boto3
 
-from airflow import configuration
 from airflow.contrib.sensors.aws_redshift_cluster_sensor import AwsRedshiftClusterSensor
 
 try:
@@ -32,9 +31,6 @@ except ImportError:
 
 
 class TestAwsRedshiftClusterSensor(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-
     @staticmethod
     def _create_cluster():
         client = boto3.client('redshift', region_name='us-east-1')

--- a/tests/contrib/sensors/test_bash_sensor.py
+++ b/tests/contrib/sensors/test_bash_sensor.py
@@ -22,14 +22,13 @@ import unittest
 
 import datetime
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.sensors.bash_sensor import BashSensor
 from airflow.exceptions import AirflowSensorTimeout
 
 
 class TestBashSensor(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': datetime.datetime(2017, 1, 1)

--- a/tests/contrib/sensors/test_cassandra_sensor.py
+++ b/tests/contrib/sensors/test_cassandra_sensor.py
@@ -23,7 +23,6 @@ import unittest
 from unittest.mock import patch
 
 from airflow import DAG
-from airflow import configuration
 from airflow.contrib.sensors.cassandra_record_sensor import CassandraRecordSensor
 from airflow.contrib.sensors.cassandra_table_sensor import CassandraTableSensor
 from airflow.utils import timezone
@@ -35,7 +34,6 @@ DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 class TestCassandraRecordSensor(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE
@@ -58,7 +56,6 @@ class TestCassandraRecordSensor(unittest.TestCase):
 class TestCassandraTableSensor(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/sensors/test_datadog_sensor.py
+++ b/tests/contrib/sensors/test_datadog_sensor.py
@@ -21,7 +21,6 @@ import json
 import unittest
 from typing import List
 
-from airflow import configuration
 from airflow.contrib.sensors.datadog_sensor import DatadogSensor
 from airflow.models import Connection
 from airflow.utils import db
@@ -62,7 +61,6 @@ zero_events = []  # type: List
 class TestDatadogSensor(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='datadog_default', conn_type='datadog',

--- a/tests/contrib/sensors/test_emr_base_sensor.py
+++ b/tests/contrib/sensors/test_emr_base_sensor.py
@@ -19,15 +19,11 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.contrib.sensors.emr_base_sensor import EmrBaseSensor
 from airflow.exceptions import AirflowException
 
 
 class TestEmrBaseSensor(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-
     def test_subclasses_that_implement_required_methods_and_constants_succeed_when_response_is_good(self):
         class EmrBaseSensorSubclass(EmrBaseSensor):
             NON_TERMINAL_STATES = ['PENDING', 'RUNNING', 'CONTINUE']

--- a/tests/contrib/sensors/test_emr_job_flow_sensor.py
+++ b/tests/contrib/sensors/test_emr_job_flow_sensor.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 import datetime
 from dateutil.tz import tzlocal
 
-from airflow import configuration, AirflowException
+from airflow import AirflowException
 from airflow.contrib.sensors.emr_job_flow_sensor import EmrJobFlowSensor
 
 DESCRIBE_CLUSTER_RUNNING_RETURN = {
@@ -131,8 +131,6 @@ DESCRIBE_CLUSTER_TERMINATED_WITH_ERRORS_RETURN = {
 
 class TestEmrJobFlowSensor(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
-
         # Mock out the emr_client (moto has incorrect response)
         self.mock_emr_client = MagicMock()
         self.mock_emr_client.describe_cluster.side_effect = [

--- a/tests/contrib/sensors/test_emr_step_sensor.py
+++ b/tests/contrib/sensors/test_emr_step_sensor.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 from datetime import datetime
 from dateutil.tz import tzlocal
 
-from airflow import configuration, AirflowException
+from airflow import AirflowException
 from airflow.contrib.sensors.emr_step_sensor import EmrStepSensor
 
 DESCRIBE_JOB_STEP_RUNNING_RETURN = {
@@ -177,8 +177,6 @@ DESCRIBE_JOB_STEP_COMPLETED_RETURN = {
 
 class TestEmrStepSensor(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
-
         self.emr_client_mock = MagicMock()
         self.sensor = EmrStepSensor(
             task_id='test_task',

--- a/tests/contrib/sensors/test_file_sensor.py
+++ b/tests/contrib/sensors/test_file_sensor.py
@@ -22,7 +22,6 @@ import unittest
 import shutil
 import tempfile
 
-from airflow import configuration
 from airflow import models, DAG
 from airflow.exceptions import AirflowSensorTimeout
 from airflow.contrib.sensors.file_sensor import FileSensor
@@ -31,7 +30,6 @@ from airflow.utils.timezone import datetime
 
 TEST_DAG_ID = 'unit_tests'
 DEFAULT_DATE = datetime(2015, 1, 1)
-configuration.load_test_config()
 
 
 def reset(dag_id=TEST_DAG_ID):
@@ -47,7 +45,6 @@ reset()
 
 class FileSensorTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         from airflow.contrib.hooks.fs_hook import FSHook
         hook = FSHook()
         args = {

--- a/tests/contrib/sensors/test_gcs_upload_session_sensor.py
+++ b/tests/contrib/sensors/test_gcs_upload_session_sensor.py
@@ -22,14 +22,13 @@ import unittest
 import unittest.mock as mock
 from datetime import datetime, timedelta
 
-from airflow import configuration, AirflowException
+from airflow import AirflowException
 from airflow import models, DAG
 from airflow.contrib.sensors import gcs_sensor
 from airflow.settings import Session
 
 TEST_DAG_ID = 'unit_tests'
 DEFAULT_DATE = datetime(2015, 1, 1)
-configuration.load_test_config()
 
 
 def reset(dag_id=TEST_DAG_ID):
@@ -60,7 +59,6 @@ mock_time = mock.Mock(side_effect=next_time_side_effect)
 class GoogleCloudStorageUploadSessionCompleteSensorTest(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE,

--- a/tests/contrib/sensors/test_imap_attachment_sensor.py
+++ b/tests/contrib/sensors/test_imap_attachment_sensor.py
@@ -21,7 +21,6 @@ import unittest
 
 from unittest.mock import patch, Mock
 
-from airflow import configuration
 from airflow.contrib.sensors.imap_attachment_sensor import ImapAttachmentSensor
 from airflow.models import Connection
 from airflow.utils import db
@@ -32,7 +31,6 @@ imap_hook_string = 'airflow.contrib.sensors.imap_attachment_sensor.ImapHook'
 class TestImapAttachmentSensor(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='imap_test',

--- a/tests/contrib/sensors/test_jira_sensor_test.py
+++ b/tests/contrib/sensors/test_jira_sensor_test.py
@@ -23,7 +23,7 @@ import unittest
 from unittest.mock import Mock
 from unittest.mock import patch
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.sensors.jira_sensor import JiraTicketSensor
 from airflow.models import Connection
 from airflow.utils import db, timezone
@@ -49,7 +49,6 @@ minimal_test_ticket = {
 
 class TestJiraSensor(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/sensors/test_mongo_sensor.py
+++ b/tests/contrib/sensors/test_mongo_sensor.py
@@ -21,7 +21,6 @@
 import unittest
 
 from airflow import DAG
-from airflow import configuration
 from airflow.contrib.hooks.mongo_hook import MongoHook
 from airflow.contrib.sensors.mongo_sensor import MongoSensor
 from airflow.models import Connection
@@ -34,7 +33,6 @@ DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 class TestMongoSensor(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='mongo_test', conn_type='mongo',

--- a/tests/contrib/sensors/test_python_sensor.py
+++ b/tests/contrib/sensors/test_python_sensor.py
@@ -20,7 +20,7 @@
 
 import unittest
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.sensors.python_sensor import PythonSensor
 from airflow.exceptions import AirflowSensorTimeout
 from airflow.utils.timezone import datetime
@@ -33,7 +33,6 @@ TEST_DAG_ID = 'python_sensor_dag'
 class PythonSensorTests(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         self.args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/sensors/test_redis_pub_sub_sensor.py
+++ b/tests/contrib/sensors/test_redis_pub_sub_sensor.py
@@ -19,7 +19,7 @@
 
 
 import unittest
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.sensors.redis_pub_sub_sensor import RedisPubSubSensor
 from airflow.utils import timezone
 from airflow.contrib.hooks.redis_hook import RedisHook
@@ -31,8 +31,6 @@ DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 class TestRedisPubSubSensor(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
-
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/sensors/test_redis_sensor.py
+++ b/tests/contrib/sensors/test_redis_sensor.py
@@ -20,7 +20,6 @@
 
 import unittest
 from airflow import DAG
-from airflow import configuration
 from airflow.contrib.hooks.redis_hook import RedisHook
 from airflow.contrib.sensors.redis_key_sensor import RedisKeySensor
 from airflow.utils import timezone
@@ -31,7 +30,6 @@ DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 class TestRedisSensor(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/sensors/test_sagemaker_base_sensor.py
+++ b/tests/contrib/sensors/test_sagemaker_base_sensor.py
@@ -19,15 +19,11 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.contrib.sensors.sagemaker_base_sensor import SageMakerBaseSensor
 from airflow.exceptions import AirflowException
 
 
 class TestSagemakerBaseSensor(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-
     def test_execute(self):
         class SageMakerBaseSensorSubclass(SageMakerBaseSensor):
             def non_terminal_states(self):

--- a/tests/contrib/sensors/test_sagemaker_endpoint_sensor.py
+++ b/tests/contrib/sensors/test_sagemaker_endpoint_sensor.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.contrib.sensors.sagemaker_endpoint_sensor \
     import SageMakerEndpointSensor
 from airflow.contrib.hooks.sagemaker_hook import SageMakerHook
@@ -56,9 +55,6 @@ DESCRIBE_ENDPOINT_UPDATING_RESPONSE = {
 
 
 class TestSageMakerEndpointSensor(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-
     @mock.patch.object(SageMakerHook, 'get_conn')
     @mock.patch.object(SageMakerHook, 'describe_endpoint')
     def test_sensor_with_failure(self, mock_describe, mock_client):

--- a/tests/contrib/sensors/test_sagemaker_training_sensor.py
+++ b/tests/contrib/sensors/test_sagemaker_training_sensor.py
@@ -20,7 +20,6 @@
 import unittest
 from datetime import datetime
 
-from airflow import configuration
 from airflow.contrib.sensors.sagemaker_training_sensor \
     import SageMakerTrainingSensor
 from airflow.contrib.hooks.sagemaker_hook import SageMakerHook, LogState
@@ -53,9 +52,6 @@ DESCRIBE_TRAINING_STOPPING_RESPONSE.update({'TrainingJobStatus': 'Stopping'})
 
 
 class TestSageMakerTrainingSensor(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-
     @mock.patch.object(SageMakerHook, 'get_conn')
     @mock.patch.object(SageMakerHook, '__init__')
     @mock.patch.object(SageMakerHook, 'describe_training_job')

--- a/tests/contrib/sensors/test_sagemaker_transform_sensor.py
+++ b/tests/contrib/sensors/test_sagemaker_transform_sensor.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.contrib.sensors.sagemaker_transform_sensor \
     import SageMakerTransformSensor
 from airflow.contrib.hooks.sagemaker_hook import SageMakerHook
@@ -54,9 +53,6 @@ DESCRIBE_TRANSFORM_STOPPING_RESPONSE = {
 
 
 class TestSageMakerTransformSensor(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-
     @mock.patch.object(SageMakerHook, 'get_conn')
     @mock.patch.object(SageMakerHook, 'describe_transform_job')
     def test_sensor_with_failure(self, mock_describe_job, mock_client):

--- a/tests/contrib/sensors/test_sagemaker_tuning_sensor.py
+++ b/tests/contrib/sensors/test_sagemaker_tuning_sensor.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.contrib.sensors.sagemaker_tuning_sensor \
     import SageMakerTuningSensor
 from airflow.contrib.hooks.sagemaker_hook import SageMakerHook
@@ -57,9 +56,6 @@ DESCRIBE_TUNING_STOPPING_RESPONSE = {
 
 
 class TestSageMakerTuningSensor(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-
     @mock.patch.object(SageMakerHook, 'get_conn')
     @mock.patch.object(SageMakerHook, 'describe_tuning_job')
     def test_sensor_with_failure(self, mock_describe_job, mock_client):

--- a/tests/contrib/sensors/test_sqs_sensor.py
+++ b/tests/contrib/sensors/test_sqs_sensor.py
@@ -19,7 +19,7 @@
 
 
 import unittest
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.sensors.aws_sqs_sensor import SQSSensor
 from airflow.utils import timezone
 from unittest.mock import patch, MagicMock
@@ -33,8 +33,6 @@ DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 class TestSQSSensor(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
-
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/contrib/sensors/test_wasb_sensor.py
+++ b/tests/contrib/sensors/test_wasb_sensor.py
@@ -22,7 +22,7 @@ import unittest
 
 import datetime
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.contrib.sensors.wasb_sensor import WasbBlobSensor
 from airflow.contrib.sensors.wasb_sensor import WasbPrefixSensor
 from tests.compat import mock
@@ -37,7 +37,6 @@ class TestWasbBlobSensor(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': datetime.datetime(2017, 1, 1)
@@ -89,7 +88,6 @@ class TestWasbPrefixSensor(unittest.TestCase):
     }
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': datetime.datetime(2017, 1, 1)

--- a/tests/contrib/sensors/test_weekday_sensor.py
+++ b/tests/contrib/sensors/test_weekday_sensor.py
@@ -19,7 +19,7 @@
 #
 
 import unittest
-from airflow import DAG, configuration, models
+from airflow import DAG, models
 from airflow.contrib.sensors.weekday_sensor import DayOfWeekSensor
 from airflow.contrib.utils.weekday import WeekDay
 from airflow.exceptions import AirflowSensorTimeout
@@ -37,7 +37,6 @@ DEV_NULL = '/dev/null'
 class DayOfWeekSensorTests(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         self.dagbag = DagBag(
             dag_folder=DEV_NULL,
             include_examples=True

--- a/tests/contrib/utils/test_mlengine_operator_utils.py
+++ b/tests/contrib/utils/test_mlengine_operator_utils.py
@@ -18,7 +18,7 @@
 import datetime
 import unittest
 
-from airflow import configuration, DAG
+from airflow import DAG
 from airflow.contrib.utils import mlengine_operator_utils
 from airflow.exceptions import AirflowException
 from airflow.version import version
@@ -51,7 +51,6 @@ class CreateEvaluateOpsTest(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        configuration.load_test_config()
         self.dag = DAG(
             'test_dag',
             default_args={

--- a/tests/core.py
+++ b/tests/core.py
@@ -91,7 +91,6 @@ class CoreTest(unittest.TestCase):
     default_scheduler_args = {"num_runs": 1}
 
     def setUp(self):
-        configuration.conf.load_test_config()
         self.dagbag = models.DagBag(
             dag_folder=DEV_NULL, include_examples=True)
         self.args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
@@ -1064,7 +1063,6 @@ class CliTests(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        configuration.load_test_config()
         from airflow.www import app as application
         self.app, self.appbuilder = application.create_app(session=Session, testing=True)
         self.app.config['TESTING'] = True
@@ -2138,7 +2136,6 @@ class FakeHDFSHook:
 
 class ConnectionTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         utils.db.initdb()
         os.environ['AIRFLOW_CONN_TEST_URI'] = (
             'postgres://username:password@ec2.compute.com:5432/the_database')
@@ -2217,9 +2214,6 @@ class ConnectionTest(unittest.TestCase):
 
 
 class WebHDFSHookTest(unittest.TestCase):
-    def setUp(self):
-        configuration.load_test_config()
-
     def test_simple_init(self):
         from airflow.hooks.webhdfs_hook import WebHDFSHook
         c = WebHDFSHook()
@@ -2238,7 +2232,6 @@ snakebite = None
                  "Skipping test because HDFSHook is not installed")
 class HDFSHookTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         os.environ['AIRFLOW_CONN_HDFS_DEFAULT'] = 'hdfs://localhost:8020'
 
     def test_get_client(self):

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -34,7 +34,6 @@ from airflow.utils.state import State
 from airflow.executors import celery_executor
 
 from airflow import configuration
-configuration.load_test_config()
 
 # leave this it is used by the test worker
 import celery.contrib.testing.tasks  # noqa: F401 pylint: disable=ungrouped-imports

--- a/tests/hooks/test_docker_hook.py
+++ b/tests/hooks/test_docker_hook.py
@@ -19,7 +19,6 @@
 
 import unittest
 
-from airflow import configuration
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.utils import db
@@ -34,7 +33,6 @@ except ImportError:
 @mock.patch('airflow.hooks.docker_hook.APIClient', autospec=True)
 class DockerHookTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         db.merge_conn(
             Connection(
                 conn_id='docker_default',

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -29,7 +29,7 @@ from collections import OrderedDict
 import pandas as pd
 from hmsclient import HMSClient
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.exceptions import AirflowException
 from airflow.hooks.hive_hooks import HiveCliHook, HiveMetastoreHook, HiveServer2Hook
 from airflow.models.connection import Connection
@@ -37,8 +37,6 @@ from airflow.operators.hive_operator import HiveOperator
 from airflow.utils import timezone
 from airflow.utils.operator_helpers import AIRFLOW_VAR_NAME_FORMAT_MAPPING
 from airflow.utils.tests import assertEqualIgnoreMultipleSpaces
-
-configuration.load_test_config()
 
 DEFAULT_DATE = timezone.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
@@ -48,7 +46,6 @@ DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
 class HiveEnvironmentTest(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         self.dag = DAG('test_dag_id', default_args=args)
         self.next_day = (DEFAULT_DATE +
@@ -367,7 +364,6 @@ class TestHiveServer2Hook(unittest.TestCase):
         df.to_csv(self.local_path, header=False, index=False)
 
     def setUp(self):
-        configuration.load_test_config()
         self._upload_dataframe()
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         self.dag = DAG('test_dag_id', default_args=args)

--- a/tests/hooks/test_http_hook.py
+++ b/tests/hooks/test_http_hook.py
@@ -23,7 +23,6 @@ import requests
 import requests_mock
 import tenacity
 
-from airflow import configuration
 from airflow.exceptions import AirflowException
 from airflow.hooks.http_hook import HttpHook
 from airflow.models import Connection
@@ -58,7 +57,6 @@ class TestHttpHook(unittest.TestCase):
         self.get_hook = HttpHook(method='GET')
         self.get_lowercase_hook = HttpHook(method='get')
         self.post_hook = HttpHook(method='POST')
-        configuration.load_test_config()
 
     @requests_mock.mock()
     def test_raise_for_status_with_200(self, m):

--- a/tests/hooks/test_s3_hook.py
+++ b/tests/hooks/test_s3_hook.py
@@ -23,8 +23,6 @@ import tempfile
 
 from botocore.exceptions import NoCredentialsError
 
-from airflow import configuration
-
 try:
     from airflow.hooks.S3_hook import S3Hook
 except ImportError:
@@ -44,7 +42,6 @@ except ImportError:
 class TestS3Hook(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         self.s3_test_url = "s3://test/this/is/not/a-real-key.txt"
 
     def test_parse_s3_url(self):

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -43,8 +43,6 @@ from tests.executors.test_executor import TestExecutor
 from tests.test_utils.db import clear_db_pools, \
     clear_db_runs, set_default_pool_slots
 
-configuration.load_test_config()
-
 logger = logging.getLogger(__name__)
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)

--- a/tests/jobs/test_base_job.py
+++ b/tests/jobs/test_base_job.py
@@ -21,13 +21,10 @@
 import datetime
 import unittest
 
-from airflow import configuration
 from airflow.jobs import BaseJob
 from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.utils.db import create_session
-
-configuration.load_test_config()
 
 
 class BaseJobTest(unittest.TestCase):

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -36,8 +36,6 @@ from tests.compat import patch
 from tests.core import TEST_DAG_FOLDER
 from tests.test_utils.db import clear_db_runs
 
-configuration.load_test_config()
-
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -49,7 +49,6 @@ from tests.executors.test_executor import TestExecutor
 from tests.test_utils.db import clear_db_dags, clear_db_errors, clear_db_pools, \
     clear_db_runs, clear_db_sla_miss, set_default_pool_slots
 
-configuration.load_test_config()
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 TRY_NUMBER = 1

--- a/tests/lineage/backend/test_atlas.py
+++ b/tests/lineage/backend/test_atlas.py
@@ -18,8 +18,7 @@
 # under the License.
 import unittest
 
-from airflow import configuration as conf
-from airflow.configuration import AirflowConfigException
+from airflow.configuration import conf, AirflowConfigException
 from airflow.lineage.backend.atlas import AtlasBackend
 from airflow.lineage.datasets import File
 from airflow.models import DAG, TaskInstance as TI
@@ -34,18 +33,17 @@ DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
 class TestAtlas(unittest.TestCase):
     def setUp(self):
-        conf.load_test_config()
         try:
-            conf.conf.add_section("atlas")
+            conf.add_section("atlas")
         except AirflowConfigException:
             pass
         except DuplicateSectionError:
             pass
 
-        conf.conf.set("atlas", "username", "none")
-        conf.conf.set("atlas", "password", "none")
-        conf.conf.set("atlas", "host", "none")
-        conf.conf.set("atlas", "port", "0")
+        conf.set("atlas", "username", "none")
+        conf.set("atlas", "password", "none")
+        conf.set("atlas", "host", "none")
+        conf.set("atlas", "port", "0")
 
         self.atlas = AtlasBackend()
 

--- a/tests/models/test_cleartasks.py
+++ b/tests/models/test_cleartasks.py
@@ -233,8 +233,6 @@ class ClearTasksTest(unittest.TestCase):
         self.assertEqual(ti2.max_tries, 1)
 
     def test_xcom_disable_pickle_type(self):
-        configuration.load_test_config()
-
         json_obj = {"key": "value"}
         execution_date = timezone.utcnow()
         key = "xcom_test1"

--- a/tests/operators/test_email_operator.py
+++ b/tests/operators/test_email_operator.py
@@ -37,7 +37,6 @@ class TestEmailOperator(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        configuration.load_test_config()
         self.dag = DAG(
             'test_dag',
             default_args={

--- a/tests/operators/test_hive_operator.py
+++ b/tests/operators/test_hive_operator.py
@@ -29,8 +29,6 @@ from airflow.models import TaskInstance
 from airflow.operators.hive_operator import HiveOperator
 from airflow.utils import timezone
 
-configuration.load_test_config()
-
 
 DEFAULT_DATE = datetime.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
@@ -40,7 +38,6 @@ DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
 class HiveEnvironmentTest(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         dag = DAG('test_dag_id', default_args=args)
         self.dag = dag
@@ -63,7 +60,6 @@ class HiveEnvironmentTest(unittest.TestCase):
 class HiveCliTest(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         self.nondefault_schema = "nondefault"
         os.environ["AIRFLOW__CORE__SECURITY"] = "kerberos"
 

--- a/tests/operators/test_hive_to_druid.py
+++ b/tests/operators/test_hive_to_druid.py
@@ -22,7 +22,7 @@ import requests
 import requests_mock
 import unittest
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.operators.hive_to_druid import HiveToDruidTransfer
 
 
@@ -63,7 +63,6 @@ class TestDruidHook(unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': '2017-01-01'

--- a/tests/operators/test_latest_only_operator.py
+++ b/tests/operators/test_latest_only_operator.py
@@ -22,7 +22,7 @@ import unittest
 
 from freezegun import freeze_time
 
-from airflow import configuration, DAG, settings
+from airflow import DAG, settings
 from airflow.models import TaskInstance
 from airflow.operators.latest_only_operator import LatestOnlyOperator
 from airflow.operators.dummy_operator import DummyOperator
@@ -48,7 +48,6 @@ class LatestOnlyOperatorTest(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        configuration.load_test_config()
         self.dag = DAG(
             'test_dag',
             default_args={

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -26,8 +26,6 @@ import os
 from unittest import mock
 import unittest
 
-configuration.load_test_config()
-
 DEFAULT_DATE = timezone.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
 DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
@@ -36,7 +34,6 @@ TEST_DAG_ID = 'unit_test_dag'
 
 class MySqlTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE
@@ -185,7 +182,6 @@ class MySqlTest(unittest.TestCase):
 
 class PostgresTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         dag = DAG(TEST_DAG_ID, default_args=args)
         self.dag = dag
@@ -295,7 +291,6 @@ class PostgresTest(unittest.TestCase):
 
 class TransferTests(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         dag = DAG(TEST_DAG_ID, default_args=args)
         self.dag = dag

--- a/tests/operators/test_python_operator.py
+++ b/tests/operators/test_python_operator.py
@@ -23,7 +23,6 @@ import os
 import unittest
 from datetime import timedelta, date
 
-from airflow import configuration
 from airflow.exceptions import AirflowException
 from airflow.models import TaskInstance as TI, DAG, DagRun
 from airflow.operators.dummy_operator import DummyOperator
@@ -73,7 +72,6 @@ class PythonOperatorTest(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        configuration.load_test_config()
         self.dag = DAG(
             'test_dag',
             default_args={

--- a/tests/operators/test_virtualenv_operator.py
+++ b/tests/operators/test_virtualenv_operator.py
@@ -25,7 +25,7 @@ import unittest
 
 from subprocess import CalledProcessError
 
-from airflow import configuration, DAG
+from airflow import DAG
 from airflow.operators.python_operator import PythonVirtualenvOperator
 from airflow.utils import timezone
 
@@ -41,7 +41,6 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        configuration.load_test_config()
         self.dag = DAG(
             'test_dag',
             default_args={

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -20,13 +20,11 @@
 import unittest
 
 
-from airflow.configuration import conf
 from airflow.www import app as application
 
 
 class PluginsTestRBAC(unittest.TestCase):
     def setUp(self):
-        conf.load_test_config()
         self.app, self.appbuilder = application.create_app(testing=True)
 
     def test_flaskappbuilder_views(self):

--- a/tests/security/test_kerberos.py
+++ b/tests/security/test_kerberos.py
@@ -29,8 +29,6 @@ from airflow import LoggingMixin
                  'Skipping Kerberos API tests due to missing KRB5_KTNAME')
 class KerberosTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
-
         if not configuration.conf.has_section("kerberos"):
             configuration.conf.add_section("kerberos")
         configuration.conf.set("kerberos", "keytab",

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -20,7 +20,7 @@
 import unittest
 from unittest.mock import Mock
 
-from airflow import DAG, configuration, settings
+from airflow import DAG, settings
 from airflow.exceptions import (AirflowSensorTimeout, AirflowException,
                                 AirflowRescheduleException)
 from airflow.models import DagRun, TaskInstance, TaskReschedule
@@ -33,8 +33,6 @@ from airflow.utils.timezone import datetime
 from datetime import timedelta
 from time import sleep
 from freezegun import freeze_time
-
-configuration.load_test_config()
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 TEST_DAG_ID = 'unit_test_dag'
@@ -53,7 +51,6 @@ class DummySensor(BaseSensorOperator):
 
 class BaseSensorTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -19,7 +19,7 @@
 import unittest
 from datetime import timedelta, time
 
-from airflow import DAG, configuration, settings
+from airflow import DAG, settings
 from airflow import exceptions
 from airflow.exceptions import AirflowException, AirflowSensorTimeout
 from airflow.models import TaskInstance, DagBag
@@ -30,8 +30,6 @@ from airflow.sensors.time_sensor import TimeSensor
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 
-configuration.load_test_config()
-
 DEFAULT_DATE = datetime(2015, 1, 1)
 TEST_DAG_ID = 'unit_test_dag'
 TEST_TASK_ID = 'time_sensor_check'
@@ -41,7 +39,6 @@ DEV_NULL = '/dev/null'
 class ExternalTaskSensorTests(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         self.dagbag = DagBag(
             dag_folder=DEV_NULL,
             include_examples=True

--- a/tests/sensors/test_hdfs_sensor.py
+++ b/tests/sensors/test_hdfs_sensor.py
@@ -20,13 +20,10 @@ import unittest
 
 from datetime import timedelta
 
-from airflow import configuration
 from airflow.exceptions import AirflowSensorTimeout
 from airflow.sensors.hdfs_sensor import HdfsSensor
 from airflow.utils.timezone import datetime
 from tests.core import FakeHDFSHook
-
-configuration.load_test_config()
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 TEST_DAG_ID = 'unit_test_dag'

--- a/tests/sensors/test_http_sensor.py
+++ b/tests/sensors/test_http_sensor.py
@@ -21,15 +21,13 @@ import unittest
 import requests
 from unittest.mock import patch
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.exceptions import AirflowException, AirflowSensorTimeout
 from airflow.models import TaskInstance
 from airflow.operators.http_operator import SimpleHttpOperator
 from airflow.sensors.http_sensor import HttpSensor
 from airflow.utils.timezone import datetime
 from tests.compat import mock
-
-configuration.load_test_config()
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
@@ -38,7 +36,6 @@ TEST_DAG_ID = 'unit_test_dag'
 
 class HttpSensorTests(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE
@@ -180,7 +177,6 @@ class FakeSession:
 
 class HttpOpSensorTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE_ISO}
         dag = DAG(TEST_DAG_ID, default_args=args)
         self.dag = dag

--- a/tests/sensors/test_named_hive_partition_sensor.py
+++ b/tests/sensors/test_named_hive_partition_sensor.py
@@ -20,12 +20,10 @@ import random
 import unittest
 from datetime import timedelta
 
-from airflow import configuration, DAG, operators
+from airflow import DAG, operators
 from airflow.sensors.named_hive_partition_sensor import NamedHivePartitionSensor
 from airflow.utils.timezone import datetime
 from airflow.hooks.hive_hooks import HiveMetastoreHook
-
-configuration.load_test_config()
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
@@ -34,7 +32,6 @@ DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
 
 class NamedHivePartitionSensorTests(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         self.dag = DAG('test_dag_id', default_args=args)
         self.next_day = (DEFAULT_DATE +

--- a/tests/sensors/test_sql_sensor.py
+++ b/tests/sensors/test_sql_sensor.py
@@ -25,8 +25,6 @@ from airflow.exceptions import AirflowException
 from airflow.sensors.sql_sensor import SqlSensor
 from airflow.utils.timezone import datetime
 
-configuration.load_test_config()
-
 DEFAULT_DATE = datetime(2015, 1, 1)
 TEST_DAG_ID = 'unit_test_sql_dag'
 
@@ -34,7 +32,6 @@ TEST_DAG_ID = 'unit_test_sql_dag'
 class SqlSensorTests(unittest.TestCase):
 
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/sensors/test_timedelta_sensor.py
+++ b/tests/sensors/test_timedelta_sensor.py
@@ -20,12 +20,9 @@ import unittest
 
 from datetime import timedelta
 
-from airflow import configuration
 from airflow import models, DAG
 from airflow.sensors.time_delta_sensor import TimeDeltaSensor
 from airflow.utils.timezone import datetime
-
-configuration.load_test_config()
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 DEV_NULL = '/dev/null'
@@ -34,7 +31,6 @@ TEST_DAG_ID = 'unit_tests'
 
 class TimedeltaSensorTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         self.dagbag = models.DagBag(
             dag_folder=DEV_NULL, include_examples=True)
         self.args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}

--- a/tests/sensors/test_timeout_sensor.py
+++ b/tests/sensors/test_timeout_sensor.py
@@ -21,14 +21,12 @@ import unittest
 import time
 from datetime import timedelta
 
-from airflow import DAG, configuration
+from airflow import DAG
 from airflow.exceptions import AirflowSensorTimeout, AirflowSkipException
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils import timezone
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.timezone import datetime
-
-configuration.load_test_config()
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 TEST_DAG_ID = 'unit_test_dag'
@@ -70,7 +68,6 @@ class TimeoutTestSensor(BaseSensorOperator):
 
 class SensorTimeoutTest(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         args = {
             'owner': 'airflow',
             'start_date': DEFAULT_DATE

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -53,7 +53,6 @@ class ConfTest(unittest.TestCase):
     def setUpClass(cls):
         os.environ['AIRFLOW__TESTSECTION__TESTKEY'] = 'testvalue'
         os.environ['AIRFLOW__TESTSECTION__TESTPERCENT'] = 'with%percent'
-        configuration.load_test_config()
         conf.set('core', 'percent', 'with%%inside')
 
     @classmethod

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -25,7 +25,6 @@ import elasticsearch
 from unittest import mock
 import pendulum
 
-from airflow import configuration
 from airflow.models import TaskInstance, DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils import timezone
@@ -71,7 +70,6 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.es.index(index=self.index_name, doc_type=self.doc_type,
                       body=self.body, id=1)
 
-        configuration.load_test_config()
         self.dag = DAG(self.DAG_ID, start_date=self.EXECUTION_DATE)
         task = DummyOperator(task_id=self.TASK_ID, dag=self.dag)
         self.ti = TaskInstance(task=task, execution_date=self.EXECUTION_DATE)

--- a/tests/utils/log/test_s3_task_handler.py
+++ b/tests/utils/log/test_s3_task_handler.py
@@ -21,7 +21,6 @@ from unittest import mock
 import unittest
 import os
 
-from airflow import configuration
 from airflow.utils.log.s3_task_handler import S3TaskHandler
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
@@ -55,7 +54,6 @@ class TestS3TaskHandler(unittest.TestCase):
             self.filename_template
         )
 
-        configuration.load_test_config()
         date = datetime(2016, 1, 1)
         self.dag = DAG('dag_for_testing_file_task_handler', start_date=date)
         task = DummyOperator(task_id='task_for_testing_file_log_handler', dag=self.dag)

--- a/tests/www/api/experimental/test_dag_runs_endpoint.py
+++ b/tests/www/api/experimental/test_dag_runs_endpoint.py
@@ -19,7 +19,6 @@
 import json
 import unittest
 
-from airflow import configuration
 from airflow.api.common.experimental.trigger_dag import trigger_dag
 from airflow.models import DagBag, DagRun
 from airflow.settings import Session
@@ -41,7 +40,6 @@ class TestDagRunsEndpoint(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        configuration.load_test_config()
         app, _ = application.create_app(testing=True)
         self.app = app.test_client()
 

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -23,7 +23,6 @@ import unittest
 from urllib.parse import quote_plus
 
 
-from airflow import configuration as conf
 from airflow import settings
 from airflow.api.common.experimental.trigger_dag import trigger_dag
 from airflow.models import DagBag, DagRun, Pool, TaskInstance
@@ -35,7 +34,6 @@ from tests.test_utils.db import clear_db_pools
 
 class TestBase(unittest.TestCase):
     def setUp(self):
-        conf.load_test_config()
         self.app, self.appbuilder = application.create_app(session=Session, testing=True)
         self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///'
         self.app.config['SECRET_KEY'] = 'secret_key'

--- a/tests/www/api/experimental/test_kerberos_endpoints.py
+++ b/tests/www/api/experimental/test_kerberos_endpoints.py
@@ -34,7 +34,6 @@ from airflow.www import app as application
                  'Skipping Kerberos API tests due to missing KRB5_KTNAME')
 class ApiKerberosTests(unittest.TestCase):
     def setUp(self):
-        configuration.load_test_config()
         try:
             configuration.conf.add_section("api")
         except Exception:

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -55,7 +55,6 @@ from airflow.www import app as application
 class TestBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        conf.load_test_config()
         cls.app, cls.appbuilder = application.create_app(session=Session, testing=True)
         cls.app.config['WTF_CSRF_ENABLED'] = False
         cls.app.jinja_env.undefined = jinja2.StrictUndefined
@@ -286,7 +285,6 @@ class TestMountPoint(unittest.TestCase):
     def setUpClass(cls):
         application.app = None
         application.appbuilder = None
-        conf.load_test_config()
         conf.set("webserver", "base_url", "http://localhost/test")
         app = application.cached_app(config={'WTF_CSRF_ENABLED': False}, session=Session, testing=True)
         cls.client = Client(app, BaseResponse)
@@ -654,8 +652,6 @@ class TestLogView(TestBase):
     def setUp(self):
         # Make sure that the configure_logging is not cached
         self.old_modules = dict(sys.modules)
-
-        conf.load_test_config()
 
         # Create a custom logging configuration
         logging_config = copy.deepcopy(DEFAULT_LOGGING_CONFIG)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4864

### Description

- [x] We already set the environment variable in the test runner so that airflow.configuration will do this -- we don't need to do it again


### Tests

- [x] Existing tests (should) still pass