### PR TITLE
[AIRFLOW-4869] Reorganize sql to gcs operators.

### DIFF
--- a/airflow/contrib/operators/mssql_to_gcs.py
+++ b/airflow/contrib/operators/mssql_to_gcs.py
@@ -16,49 +16,23 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+MsSQL to GCS operator.
+"""
 
-import json
 import decimal
 
-from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
-from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.hooks.mssql_hook import MsSqlHook
-from tempfile import NamedTemporaryFile
+from airflow.contrib.operators.sql_to_gcs import BaseSQLToGoogleCloudStorageOperator
 
 
-class MsSqlToGoogleCloudStorageOperator(BaseOperator):
-    """
-    Copy data from Microsoft SQL Server to Google Cloud Storage
-    in JSON format.
+class MsSqlToGoogleCloudStorageOperator(BaseSQLToGoogleCloudStorageOperator):
+    """Copy data from Microsoft SQL Server to Google Cloud Storage
+    in JSON or CSV format.
 
-    :param sql: The SQL to execute on the MSSQL table.
-    :type sql: str
-    :param bucket: The bucket to upload to.
-    :type bucket: str
-    :param filename: The filename to use as the object name when uploading
-        to Google Cloud Storage. A {} should be specified in the filename
-        to allow the operator to inject file numbers in cases where the
-        file is split due to size, e.g. filename='data/customers/export_{}.json'.
-    :type filename: str
-    :param schema_filename: If set, the filename to use as the object name
-        when uploading a .json file containing the BigQuery schema fields
-        for the table that was dumped from MSSQL.
-    :type schema_filename: str
-    :param approx_max_file_size_bytes: This operator supports the ability
-        to split large table dumps into multiple files.
-    :type approx_max_file_size_bytes: long
-    :param gzip: Option to compress file for upload (does not apply to schemas).
-    :type gzip: bool
     :param mssql_conn_id: Reference to a specific MSSQL hook.
     :type mssql_conn_id: str
-    :param google_cloud_storage_conn_id: Reference to a specific Google
-        cloud storage hook.
-    :type google_cloud_storage_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to
-        work, the service account making the request must have domain-wide
-        delegation enabled.
-    :type delegate_to: str
 
     **Example**:
         The following operator will export data from the Customers table
@@ -76,55 +50,23 @@ class MsSqlToGoogleCloudStorageOperator(BaseOperator):
                 dag=dag
             )
     """
-
-    template_fields = ('sql', 'bucket', 'filename', 'schema_filename')
-    template_ext = ('.sql',)
     ui_color = '#e0a98c'
+
+    type_map = {
+        3: 'INTEGER',
+        4: 'TIMESTAMP',
+        5: 'NUMERIC'
+    }
 
     @apply_defaults
     def __init__(self,
-                 sql,
-                 bucket,
-                 filename,
-                 schema_filename=None,
-                 approx_max_file_size_bytes=1900000000,
-                 gzip=False,
                  mssql_conn_id='mssql_default',
-                 google_cloud_storage_conn_id='google_cloud_default',
-                 delegate_to=None,
                  *args,
                  **kwargs):
-
         super().__init__(*args, **kwargs)
-        self.sql = sql
-        self.bucket = bucket
-        self.filename = filename
-        self.schema_filename = schema_filename
-        self.approx_max_file_size_bytes = approx_max_file_size_bytes
-        self.gzip = gzip
         self.mssql_conn_id = mssql_conn_id
-        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
-        self.delegate_to = delegate_to
 
-    def execute(self, context):
-        cursor = self._query_mssql()
-        files_to_upload = self._write_local_data_files(cursor)
-
-        # If a schema is set, create a BQ schema JSON file.
-        if self.schema_filename:
-            files_to_upload.update(self._write_local_schema_file(cursor))
-
-        # Flush all files before uploading
-        for file_handle in files_to_upload.values():
-            file_handle.flush()
-
-        self._upload_to_gcs(files_to_upload)
-
-        # Close all temp file handles
-        for file_handle in files_to_upload.values():
-            file_handle.close()
-
-    def _query_mssql(self):
+    def query(self):
         """
         Queries MSSQL and returns a cursor of results.
 
@@ -136,100 +78,19 @@ class MsSqlToGoogleCloudStorageOperator(BaseOperator):
         cursor.execute(self.sql)
         return cursor
 
-    def _write_local_data_files(self, cursor):
-        """
-        Takes a cursor, and writes results to a local file.
-
-        :return: A dictionary where keys are filenames to be used as object
-            names in GCS, and values are file handles to local files that
-            contain the data for the GCS objects.
-        """
-        schema = list(map(lambda schema_tuple: schema_tuple[0].replace(' ', '_'), cursor.description))
-        file_no = 0
-        tmp_file_handle = NamedTemporaryFile(delete=True)
-        tmp_file_handles = {self.filename.format(file_no): tmp_file_handle}
-
-        for row in cursor:
-            # Convert if needed
-            row = map(self.convert_types, row)
-            row_dict = dict(zip(schema, row))
-
-            s = json.dumps(row_dict, sort_keys=True)
-            s = s.encode('utf-8')
-            tmp_file_handle.write(s)
-
-            # Append newline to make dumps BQ compatible
-            tmp_file_handle.write(b'\n')
-
-            # Stop if the file exceeds the file size limit
-            if tmp_file_handle.tell() >= self.approx_max_file_size_bytes:
-                file_no += 1
-                tmp_file_handle = NamedTemporaryFile(delete=True)
-                tmp_file_handles[self.filename.format(file_no)] = tmp_file_handle
-
-        return tmp_file_handles
-
-    def _write_local_schema_file(self, cursor):
-        """
-        Takes a cursor, and writes the BigQuery schema for the results to a
-        local file system.
-
-        :return: A dictionary where key is a filename to be used as an object
-            name in GCS, and values are file handles to local files that
-            contains the BigQuery schema fields in .json format.
-        """
-        schema = []
-        for field in cursor.description:
-            # See PEP 249 for details about the description tuple.
-            field_name = field[0].replace(' ', '_')  # Clean spaces
-            field_type = self.type_map(field[1])
-            field_mode = 'NULLABLE'  # pymssql doesn't support field_mode
-
-            schema.append({
-                'name': field_name,
-                'type': field_type,
-                'mode': field_mode,
-            })
-
-        self.log.info('Using schema for %s: %s', self.schema_filename, schema)
-        tmp_schema_file_handle = NamedTemporaryFile(delete=True)
-        s = json.dumps(schema, sort_keys=True)
-        s = s.encode('utf-8')
-        tmp_schema_file_handle.write(s)
-        return {self.schema_filename: tmp_schema_file_handle}
-
-    def _upload_to_gcs(self, files_to_upload):
-        """
-        Upload all of the file splits (and optionally the schema .json file) to
-        Google cloud storage.
-        """
-        hook = GoogleCloudStorageHook(
-            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
-            delegate_to=self.delegate_to)
-        for object_name, tmp_file_handle in files_to_upload.items():
-            hook.upload(self.bucket, object_name, tmp_file_handle.name, 'application/json',
-                        (self.gzip if object_name != self.schema_filename else False))
+    def field_to_bigquery(self, field):
+        return {
+            'name': field[0].replace(" ", "_"),
+            'type': self.type_map.get(field[1], "STRING"),
+            'mode': "NULLABLE",
+        }
 
     @classmethod
-    def convert_types(cls, value):
+    def convert_type(cls, value, schema_type):
         """
         Takes a value from MSSQL, and converts it to a value that's safe for
         JSON/Google Cloud Storage/BigQuery.
         """
         if isinstance(value, decimal.Decimal):
             return float(value)
-        else:
-            return value
-
-    @classmethod
-    def type_map(cls, mssql_type):
-        """
-        Helper function that maps from MSSQL fields to BigQuery fields. Used
-        when a schema_filename is set.
-        """
-        d = {
-            3: 'INTEGER',
-            4: 'TIMESTAMP',
-            5: 'NUMERIC'
-        }
-        return d[mssql_type] if mssql_type in d else 'STRING'
+        return value

--- a/airflow/contrib/operators/mysql_to_gcs.py
+++ b/airflow/contrib/operators/mysql_to_gcs.py
@@ -16,74 +16,32 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+MySQL to GCS operator.
+"""
 
 import base64
 import calendar
-import json
-
-from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
-from airflow.hooks.mysql_hook import MySqlHook
-from airflow.models import BaseOperator
-from airflow.utils.decorators import apply_defaults
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+
 from MySQLdb.constants import FIELD_TYPE
-from tempfile import NamedTemporaryFile
-import unicodecsv as csv
+
+from airflow.hooks.mysql_hook import MySqlHook
+from airflow.utils.decorators import apply_defaults
+from airflow.contrib.operators.sql_to_gcs import BaseSQLToGoogleCloudStorageOperator
 
 
-class MySqlToGoogleCloudStorageOperator(BaseOperator):
+class MySqlToGoogleCloudStorageOperator(BaseSQLToGoogleCloudStorageOperator):
     """Copy data from MySQL to Google cloud storage in JSON or CSV format.
 
-    The JSON data files generated are newline-delimited to enable them to be
-    loaded into BigQuery.
-    Reference: https://cloud.google.com/bigquery/docs/
-    loading-data-cloud-storage-json#limitations
-
-    :param sql: The SQL to execute on the MySQL table.
-    :type sql: str
-    :param bucket: The bucket to upload to.
-    :type bucket: str
-    :param filename: The filename to use as the object name when uploading
-        to Google cloud storage. A {} should be specified in the filename
-        to allow the operator to inject file numbers in cases where the
-        file is split due to size.
-    :type filename: str
-    :param schema_filename: If set, the filename to use as the object name
-        when uploading a .json file containing the BigQuery schema fields
-        for the table that was dumped from MySQL.
-    :type schema_filename: str
-    :param approx_max_file_size_bytes: This operator supports the ability
-        to split large table dumps into multiple files (see notes in the
-        filename param docs above). This param allows developers to specify the
-        file size of the splits. Check https://cloud.google.com/storage/quotas
-        to see the maximum allowed file size for a single object.
-    :type approx_max_file_size_bytes: long
     :param mysql_conn_id: Reference to a specific MySQL hook.
     :type mysql_conn_id: str
-    :param google_cloud_storage_conn_id: Reference to a specific Google
-        cloud storage hook.
-    :type google_cloud_storage_conn_id: str
-    :param schema: The schema to use, if any. Should be a list of dict or
-        a str. Pass a string if using Jinja template, otherwise, pass a list of
-        dict. Examples could be seen: https://cloud.google.com/bigquery/docs
-        /schemas#specifying_a_json_schema_file
-    :type schema: str or list
-    :param delegate_to: The account to impersonate, if any. For this to
-        work, the service account making the request must have domain-wide
-        delegation enabled.
-    :type delegate_to: str
-    :param export_format: Desired format of files to be exported.
-    :type export_format: str
-    :param field_delimiter: The delimiter to be used for CSV files.
-    :type field_delimiter: str
     :param ensure_utc: Ensure TIMESTAMP columns exported as UTC. If set to
         `False`, TIMESTAMP columns will be exported using the MySQL server's
         default timezone.
     :type ensure_utc: bool
     """
-    template_fields = ('sql', 'bucket', 'filename', 'schema_filename', 'schema')
-    template_ext = ('.sql',)
     ui_color = '#a0e08c'
 
     type_map = {
@@ -106,55 +64,15 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 sql,
-                 bucket,
-                 filename,
-                 schema_filename=None,
-                 approx_max_file_size_bytes=1900000000,
                  mysql_conn_id='mysql_default',
-                 google_cloud_storage_conn_id='google_cloud_default',
-                 schema=None,
-                 delegate_to=None,
-                 export_format='json',
-                 field_delimiter=',',
                  ensure_utc=False,
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
-        self.sql = sql
-        self.bucket = bucket
-        self.filename = filename
-        self.schema_filename = schema_filename
-        self.approx_max_file_size_bytes = approx_max_file_size_bytes
         self.mysql_conn_id = mysql_conn_id
-        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
-        self.schema = schema
-        self.delegate_to = delegate_to
-        self.export_format = export_format.lower()
-        self.field_delimiter = field_delimiter
         self.ensure_utc = ensure_utc
 
-    def execute(self, context):
-        cursor = self._query_mysql()
-        files_to_upload = self._write_local_data_files(cursor)
-
-        # If a schema is set, create a BQ schema JSON file.
-        if self.schema_filename:
-            files_to_upload.append(self._write_local_schema_file(cursor))
-
-        # Flush all files before uploading.
-        for tmp_file in files_to_upload:
-            tmp_file_handle = tmp_file.get('file_handle')
-            tmp_file_handle.flush()
-
-        self._upload_to_gcs(files_to_upload)
-
-        # Close all temp file handles.
-        for tmp_file in files_to_upload:
-            tmp_file_handle = tmp_file.get('file_handle')
-            tmp_file_handle.close()
-
-    def _query_mysql(self):
+    def query(self):
         """
         Queries mysql and returns a cursor to the results.
         """
@@ -170,139 +88,19 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
         cursor.execute(self.sql)
         return cursor
 
-    def _write_local_data_files(self, cursor):
-        """
-        Takes a cursor, and writes results to a local file.
-
-        :return: A dictionary where keys are filenames to be used as object
-            names in GCS, and values are file handles to local files that
-            contain the data for the GCS objects.
-        """
-        schema = list(map(lambda schema_tuple: schema_tuple[0], cursor.description))
-        col_type_dict = self._get_col_type_dict()
-        file_no = 0
-        tmp_file_handle = NamedTemporaryFile(delete=True)
-        if self.export_format == 'csv':
-            file_mime_type = 'text/csv'
-        else:
-            file_mime_type = 'application/json'
-        files_to_upload = [{
-            'file_name': self.filename.format(file_no),
-            'file_handle': tmp_file_handle,
-            'file_mime_type': file_mime_type
-        }]
-
-        if self.export_format == 'csv':
-            csv_writer = self._configure_csv_file(tmp_file_handle, schema)
-
-        for row in cursor:
-            # Convert datetime objects to utc seconds, and decimals to floats.
-            # Convert binary type object to string encoded with base64.
-            row = self._convert_types(schema, col_type_dict, row)
-
-            if self.export_format == 'csv':
-                csv_writer.writerow(row)
-            else:
-                row_dict = dict(zip(schema, row))
-
-                # TODO validate that row isn't > 2MB. BQ enforces a hard row size of 2MB.
-                s = json.dumps(row_dict, sort_keys=True).encode('utf-8')
-                tmp_file_handle.write(s)
-
-                # Append newline to make dumps BigQuery compatible.
-                tmp_file_handle.write(b'\n')
-
-            # Stop if the file exceeds the file size limit.
-            if tmp_file_handle.tell() >= self.approx_max_file_size_bytes:
-                file_no += 1
-                tmp_file_handle = NamedTemporaryFile(delete=True)
-                files_to_upload.append({
-                    'file_name': self.filename.format(file_no),
-                    'file_handle': tmp_file_handle,
-                    'file_mime_type': file_mime_type
-                })
-
-                if self.export_format == 'csv':
-                    csv_writer = self._configure_csv_file(tmp_file_handle, schema)
-
-        return files_to_upload
-
-    def _configure_csv_file(self, file_handle, schema):
-        """Configure a csv writer with the file_handle and write schema
-        as headers for the new file.
-        """
-        csv_writer = csv.writer(file_handle, encoding='utf-8',
-                                delimiter=self.field_delimiter)
-        csv_writer.writerow(schema)
-        return csv_writer
-
-    def _write_local_schema_file(self, cursor):
-        """
-        Takes a cursor, and writes the BigQuery schema in .json format for the
-        results to a local file system.
-
-        :return: A dictionary where key is a filename to be used as an object
-            name in GCS, and values are file handles to local files that
-            contains the BigQuery schema fields in .json format.
-        """
-        schema_str = None
-        schema_file_mime_type = 'application/json'
-        tmp_schema_file_handle = NamedTemporaryFile(delete=True)
-        if self.schema is not None and isinstance(self.schema, str):
-            schema_str = self.schema.encode('utf-8')
-        elif self.schema is not None and isinstance(self.schema, list):
-            schema_str = json.dumps(self.schema).encode('utf-8')
-        else:
-            schema = []
-            for field in cursor.description:
-                # See PEP 249 for details about the description tuple.
-                field_name = field[0]
-                field_type = self.type_map.get(field[1], "STRING")
-                # Always allow TIMESTAMP to be nullable. MySQLdb returns None types
-                # for required fields because some MySQL timestamps can't be
-                # represented by Python's datetime (e.g. 0000-00-00 00:00:00).
-                if field[6] or field_type == 'TIMESTAMP':
-                    field_mode = 'NULLABLE'
-                else:
-                    field_mode = 'REQUIRED'
-                schema.append({
-                    'name': field_name,
-                    'type': field_type,
-                    'mode': field_mode,
-                })
-            schema_str = json.dumps(schema, sort_keys=True).encode('utf-8')
-        tmp_schema_file_handle.write(schema_str)
-
-        self.log.info('Using schema for %s: %s', self.schema_filename, schema_str)
-        schema_file_to_upload = {
-            'file_name': self.schema_filename,
-            'file_handle': tmp_schema_file_handle,
-            'file_mime_type': schema_file_mime_type
+    def field_to_bigquery(self, field):
+        field_type = self.type_map.get(field[1], "STRING")
+        # Always allow TIMESTAMP to be nullable. MySQLdb returns None types
+        # for required fields because some MySQL timestamps can't be
+        # represented by Python's datetime (e.g. 0000-00-00 00:00:00).
+        field_mode = "NULLABLE" if field[6] or field_type == "TIMESTAMP" else "REQUIRED"
+        return {
+            'name': field[0],
+            'type': field_type,
+            'mode': field_mode,
         }
-        return schema_file_to_upload
 
-    def _upload_to_gcs(self, files_to_upload):
-        """
-        Upload all of the file splits (and optionally the schema .json file) to
-        Google cloud storage.
-        """
-        hook = GoogleCloudStorageHook(
-            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
-            delegate_to=self.delegate_to)
-        for tmp_file in files_to_upload:
-            hook.upload(self.bucket, tmp_file.get('file_name'),
-                        tmp_file.get('file_handle').name,
-                        mime_type=tmp_file.get('file_mime_type'))
-
-    @classmethod
-    def _convert_types(cls, schema, col_type_dict, row):
-        return [
-            cls._convert_type(value, col_type_dict.get(name))
-            for name, value in zip(schema, row)
-        ]
-
-    @classmethod
-    def _convert_type(cls, value, schema_type):
+    def convert_type(self, value, schema_type):
         """
         Takes a value from MySQLdb, and converts it to a value that's safe for
         JSON/Google cloud storage/BigQuery. Dates are converted to UTC seconds.
@@ -324,25 +122,3 @@ class MySqlToGoogleCloudStorageOperator(BaseOperator):
         if schema_type == "BYTES":
             return base64.standard_b64encode(value).decode('ascii')
         return value
-
-    def _get_col_type_dict(self):
-        """
-        Return a dict of column name and column type based on self.schema if not None.
-        """
-        schema = []
-        if isinstance(self.schema, str):
-            schema = json.loads(self.schema)
-        elif isinstance(self.schema, list):
-            schema = self.schema
-        elif self.schema is not None:
-            self.log.warn('Using default schema due to unexpected type.'
-                          'Should be a string or list.')
-
-        col_type_dict = {}
-        try:
-            col_type_dict = {col['name']: col['type'] for col in schema}
-        except KeyError:
-            self.log.warn('Using default schema due to missing name or type. Please '
-                          'refer to: https://cloud.google.com/bigquery/docs/schemas'
-                          '#specifying_a_json_schema_file')
-        return col_type_dict

--- a/airflow/contrib/operators/postgres_to_gcs_operator.py
+++ b/airflow/contrib/operators/postgres_to_gcs_operator.py
@@ -16,233 +16,85 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+PostgreSQL to GCS operator.
+"""
 
-import json
 import time
 import datetime
-
-from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
-from airflow.hooks.postgres_hook import PostgresHook
-from airflow.models import BaseOperator
-from airflow.utils.decorators import apply_defaults
 from decimal import Decimal
-from tempfile import NamedTemporaryFile
+
+from airflow.hooks.postgres_hook import PostgresHook
+from airflow.utils.decorators import apply_defaults
+from airflow.contrib.operators.sql_to_gcs import BaseSQLToGoogleCloudStorageOperator
 
 
-class PostgresToGoogleCloudStorageOperator(BaseOperator):
+class PostgresToGoogleCloudStorageOperator(BaseSQLToGoogleCloudStorageOperator):
     """
-    Copy data from Postgres to Google Cloud Storage in JSON format.
+    Copy data from Postgres to Google Cloud Storage in JSON or CSV format.
 
-    :param sql: The SQL to execute on the Postgres table.
-    :type sql: str
-    :param bucket: The bucket to upload to.
-    :type bucket: str
-    :param filename: The filename to use as the object name when uploading
-        to Google Cloud Storage. A {} should be specified in the filename
-        to allow the operator to inject file numbers in cases where the
-        file is split due to size.
-    :type filename: str
-    :param schema_filename: If set, the filename to use as the object name
-        when uploading a .json file containing the BigQuery schema fields
-        for the table that was dumped from Postgres.
-    :type schema_filename: str
-    :param approx_max_file_size_bytes: This operator supports the ability
-        to split large table dumps into multiple files (see notes in the
-        filename param docs above). This param allows developers to specify the
-        file size of the splits. Check https://cloud.google.com/storage/quotas
-        to see the maximum allowed file size for a single object.
-    :type approx_max_file_size_bytes: long
     :param postgres_conn_id: Reference to a specific Postgres hook.
     :type postgres_conn_id: str
-    :param google_cloud_storage_conn_id: Reference to a specific Google
-        cloud storage hook.
-    :type google_cloud_storage_conn_id: str
-    :param delegate_to: The account to impersonate, if any. For this to
-        work, the service account making the request must have domain-wide
-        delegation enabled.
-    :param parameters: a parameters dict that is substituted at query runtime.
-    :type parameters: dict
     """
-    template_fields = ('sql', 'bucket', 'filename', 'schema_filename',
-                       'parameters')
-    template_ext = ('.sql', )
     ui_color = '#a0e08c'
+
+    type_map = {
+        1114: 'TIMESTAMP',
+        1184: 'TIMESTAMP',
+        1082: 'TIMESTAMP',
+        1083: 'TIMESTAMP',
+        1005: 'INTEGER',
+        1007: 'INTEGER',
+        1016: 'INTEGER',
+        20: 'INTEGER',
+        21: 'INTEGER',
+        23: 'INTEGER',
+        16: 'BOOLEAN',
+        700: 'FLOAT',
+        701: 'FLOAT',
+        1700: 'FLOAT',
+    }
 
     @apply_defaults
     def __init__(self,
-                 sql,
-                 bucket,
-                 filename,
-                 schema_filename=None,
-                 approx_max_file_size_bytes=1900000000,
                  postgres_conn_id='postgres_default',
-                 google_cloud_storage_conn_id='google_cloud_default',
-                 delegate_to=None,
-                 parameters=None,
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
-        self.sql = sql
-        self.bucket = bucket
-        self.filename = filename
-        self.schema_filename = schema_filename
-        self.approx_max_file_size_bytes = approx_max_file_size_bytes
         self.postgres_conn_id = postgres_conn_id
-        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
-        self.delegate_to = delegate_to
-        self.parameters = parameters
 
-    def execute(self, context):
-        cursor = self._query_postgres()
-        files_to_upload = self._write_local_data_files(cursor)
-
-        # If a schema is set, create a BQ schema JSON file.
-        if self.schema_filename:
-            files_to_upload.update(self._write_local_schema_file(cursor))
-
-        # Flush all files before uploading
-        for file_handle in files_to_upload.values():
-            file_handle.flush()
-
-        self._upload_to_gcs(files_to_upload)
-
-        # Close all temp file handles.
-        for file_handle in files_to_upload.values():
-            file_handle.close()
-
-    def _query_postgres(self):
+    def query(self):
         """
         Queries Postgres and returns a cursor to the results.
         """
-        postgres = PostgresHook(postgres_conn_id=self.postgres_conn_id)
-        conn = postgres.get_conn()
+        hook = PostgresHook(postgres_conn_id=self.postgres_conn_id)
+        conn = hook.get_conn()
         cursor = conn.cursor()
         cursor.execute(self.sql, self.parameters)
         return cursor
 
-    def _write_local_data_files(self, cursor):
-        """
-        Takes a cursor, and writes results to a local file.
+    def field_to_bigquery(self, field):
+        return {
+            'name': field[0],
+            'type': self.type_map.get(field[1], "STRING"),
+            'mode': 'REPEATED' if field[1] in (1009, 1005, 1007,
+                                               1016) else 'NULLABLE'
+        }
 
-        :return: A dictionary where keys are filenames to be used as object
-            names in GCS, and values are file handles to local files that
-            contain the data for the GCS objects.
-        """
-        schema = list(map(lambda schema_tuple: schema_tuple[0], cursor.description))
-        tmp_file_handles = {}
-        row_no = 0
-
-        def _create_new_file():
-            handle = NamedTemporaryFile(delete=True)
-            filename = self.filename.format(len(tmp_file_handles))
-            tmp_file_handles[filename] = handle
-            return handle
-
-        # Don't create a file if there is nothing to write
-        if cursor.rowcount > 0:
-            tmp_file_handle = _create_new_file()
-
-            for row in cursor:
-                # Convert datetime objects to utc seconds, and decimals to floats
-                row = map(self.convert_types, row)
-                row_dict = dict(zip(schema, row))
-
-                s = json.dumps(row_dict, sort_keys=True).encode('utf-8')
-                tmp_file_handle.write(s)
-
-                # Append newline to make dumps BigQuery compatible.
-                tmp_file_handle.write(b'\n')
-
-                # Stop if the file exceeds the file size limit.
-                if tmp_file_handle.tell() >= self.approx_max_file_size_bytes:
-                    tmp_file_handle = _create_new_file()
-                row_no += 1
-
-        self.log.info('Received %s rows over %s files', row_no, len(tmp_file_handles))
-
-        return tmp_file_handles
-
-    def _write_local_schema_file(self, cursor):
-        """
-        Takes a cursor, and writes the BigQuery schema for the results to a
-        local file system.
-
-        :return: A dictionary where key is a filename to be used as an object
-            name in GCS, and values are file handles to local files that
-            contains the BigQuery schema fields in .json format.
-        """
-        schema = []
-        for field in cursor.description:
-            # See PEP 249 for details about the description tuple.
-            field_name = field[0]
-            field_type = self.type_map(field[1])
-            field_mode = 'REPEATED' if field[1] in (1009, 1005, 1007,
-                                                    1016) else 'NULLABLE'
-            schema.append({
-                'name': field_name,
-                'type': field_type,
-                'mode': field_mode,
-            })
-
-        self.log.info('Using schema for %s: %s', self.schema_filename, schema)
-        tmp_schema_file_handle = NamedTemporaryFile(delete=True)
-        s = json.dumps(schema, sort_keys=True).encode('utf-8')
-        tmp_schema_file_handle.write(s)
-        return {self.schema_filename: tmp_schema_file_handle}
-
-    def _upload_to_gcs(self, files_to_upload):
-        """
-        Upload all of the file splits (and optionally the schema .json file) to
-        Google Cloud Storage.
-        """
-        hook = GoogleCloudStorageHook(
-            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
-            delegate_to=self.delegate_to)
-        for object, tmp_file_handle in files_to_upload.items():
-            hook.upload(self.bucket, object, tmp_file_handle.name,
-                        'application/json')
-
-    @classmethod
-    def convert_types(cls, value):
+    def convert_type(self, value, schema_type):
         """
         Takes a value from Postgres, and converts it to a value that's safe for
         JSON/Google Cloud Storage/BigQuery. Dates are converted to UTC seconds.
         Decimals are converted to floats. Times are converted to seconds.
         """
-        if type(value) in (datetime.datetime, datetime.date):
+        if isinstance(value, (datetime.datetime, datetime.date)):
             return time.mktime(value.timetuple())
-        elif type(value) == datetime.time:
+        if isinstance(value, datetime.time):
             formated_time = time.strptime(str(value), "%H:%M:%S")
             return datetime.timedelta(
                 hours=formated_time.tm_hour,
                 minutes=formated_time.tm_min,
                 seconds=formated_time.tm_sec).seconds
-        elif isinstance(value, Decimal):
+        if isinstance(value, Decimal):
             return float(value)
-        else:
-            return value
-
-    @classmethod
-    def type_map(cls, postgres_type):
-        """
-        Helper function that maps from Postgres fields to BigQuery fields. Used
-        when a schema_filename is set.
-        """
-        d = {
-            1114: 'TIMESTAMP',
-            1184: 'TIMESTAMP',
-            1082: 'TIMESTAMP',
-            1083: 'TIMESTAMP',
-            1005: 'INTEGER',
-            1007: 'INTEGER',
-            1016: 'INTEGER',
-            20: 'INTEGER',
-            21: 'INTEGER',
-            23: 'INTEGER',
-            16: 'BOOLEAN',
-            700: 'FLOAT',
-            701: 'FLOAT',
-            1700: 'FLOAT'
-        }
-
-        return d[postgres_type] if postgres_type in d else 'STRING'
+        return value

--- a/airflow/contrib/operators/sql_to_gcs.py
+++ b/airflow/contrib/operators/sql_to_gcs.py
@@ -1,0 +1,265 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Base operator for SQL to GCS operators.
+"""
+
+import abc
+import json
+from tempfile import NamedTemporaryFile
+
+import unicodecsv as csv
+
+from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
+from airflow.models import BaseOperator
+
+
+class BaseSQLToGoogleCloudStorageOperator(BaseOperator, metaclass=abc.ABCMeta):
+    """
+    :param sql: The SQL to execute.
+    :type sql: str
+    :param bucket: The bucket to upload to.
+    :type bucket: str
+    :param filename: The filename to use as the object name when uploading
+        to Google Cloud Storage. A {} should be specified in the filename
+        to allow the operator to inject file numbers in cases where the
+        file is split due to size.
+    :type filename: str
+    :param schema_filename: If set, the filename to use as the object name
+        when uploading a .json file containing the BigQuery schema fields
+        for the table that was dumped from the database.
+    :type schema_filename: str
+    :param approx_max_file_size_bytes: This operator supports the ability
+        to split large table dumps into multiple files (see notes in the
+        filename param docs above). This param allows developers to specify the
+        file size of the splits. Check https://cloud.google.com/storage/quotas
+        to see the maximum allowed file size for a single object.
+    :type approx_max_file_size_bytes: long
+    :param export_format: Desired format of files to be exported.
+    :type export_format: str
+    :param field_delimiter: The delimiter to be used for CSV files.
+    :type field_delimiter: str
+    :param gzip: Option to compress file for upload (does not apply to schemas).
+    :type gzip: bool
+    :param schema: The schema to use, if any. Should be a list of dict or
+        a str. Pass a string if using Jinja template, otherwise, pass a list of
+        dict. Examples could be seen: https://cloud.google.com/bigquery/docs
+        /schemas#specifying_a_json_schema_file
+    :type schema: str or list
+    :param google_cloud_storage_conn_id: Reference to a specific Google
+        cloud storage hook.
+    :type google_cloud_storage_conn_id: str
+    :param delegate_to: The account to impersonate, if any. For this to
+        work, the service account making the request must have domain-wide
+        delegation enabled.
+    :param parameters: a parameters dict that is substituted at query runtime.
+    :type parameters: dict
+    """
+    template_fields = ('sql', 'bucket', 'filename', 'schema_filename', 'schema', 'parameters')
+    template_ext = ('.sql',)
+    ui_color = '#a0e08c'
+
+    def __init__(self,  # pylint: disable=too-many-arguments
+                 sql,
+                 bucket,
+                 filename,
+                 schema_filename=None,
+                 approx_max_file_size_bytes=1900000000,
+                 export_format='json',
+                 field_delimiter=',',
+                 gzip=False,
+                 schema=None,
+                 parameters=None,
+                 google_cloud_storage_conn_id='google_cloud_default',
+                 delegate_to=None,
+                 *args,
+                 **kwargs):
+        super(BaseSQLToGoogleCloudStorageOperator, self).__init__(*args, **kwargs)
+        self.sql = sql
+        self.bucket = bucket
+        self.filename = filename
+        self.schema_filename = schema_filename
+        self.approx_max_file_size_bytes = approx_max_file_size_bytes
+        self.export_format = export_format.lower()
+        self.field_delimiter = field_delimiter
+        self.gzip = gzip
+        self.schema = schema
+        self.parameters = parameters
+        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.delegate_to = delegate_to
+        self.parameters = parameters
+
+    def execute(self, context):
+        cursor = self.query()
+        files_to_upload = self._write_local_data_files(cursor)
+
+        # If a schema is set, create a BQ schema JSON file.
+        if self.schema_filename:
+            files_to_upload.append(self._write_local_schema_file(cursor))
+
+        # Flush all files before uploading
+        for tmp_file in files_to_upload:
+            tmp_file['file_handle'].flush()
+
+        self._upload_to_gcs(files_to_upload)
+
+        # Close all temp file handles.
+        for tmp_file in files_to_upload:
+            tmp_file['file_handle'].close()
+
+    def convert_types(self, schema, col_type_dict, row):
+        """Convert values from DBAPI to output-friendly formats."""
+        return [
+            self.convert_type(value, col_type_dict.get(name))
+            for name, value in zip(schema, row)
+        ]
+
+    def _write_local_data_files(self, cursor):
+        """
+        Takes a cursor, and writes results to a local file.
+
+        :return: A dictionary where keys are filenames to be used as object
+            names in GCS, and values are file handles to local files that
+            contain the data for the GCS objects.
+        """
+        schema = list(map(lambda schema_tuple: schema_tuple[0], cursor.description))
+        col_type_dict = self._get_col_type_dict()
+        file_no = 0
+        tmp_file_handle = NamedTemporaryFile(delete=True)
+        if self.export_format == 'csv':
+            file_mime_type = 'text/csv'
+        else:
+            file_mime_type = 'application/json'
+        files_to_upload = [{
+            'file_name': self.filename.format(file_no),
+            'file_handle': tmp_file_handle,
+            'file_mime_type': file_mime_type
+        }]
+
+        if self.export_format == 'csv':
+            csv_writer = self._configure_csv_file(tmp_file_handle, schema)
+
+        for row in cursor:
+            # Convert datetime objects to utc seconds, and decimals to floats.
+            # Convert binary type object to string encoded with base64.
+            row = self.convert_types(schema, col_type_dict, row)
+
+            if self.export_format == 'csv':
+                csv_writer.writerow(row)
+            else:
+                row_dict = dict(zip(schema, row))
+
+                # TODO validate that row isn't > 2MB. BQ enforces a hard row size of 2MB.
+                tmp_file_handle.write(json.dumps(row_dict, sort_keys=True).encode('utf-8'))
+
+                # Append newline to make dumps BigQuery compatible.
+                tmp_file_handle.write(b'\n')
+
+            # Stop if the file exceeds the file size limit.
+            if tmp_file_handle.tell() >= self.approx_max_file_size_bytes:
+                file_no += 1
+                tmp_file_handle = NamedTemporaryFile(delete=True)
+                files_to_upload.append({
+                    'file_name': self.filename.format(file_no),
+                    'file_handle': tmp_file_handle,
+                    'file_mime_type': file_mime_type
+                })
+
+                if self.export_format == 'csv':
+                    csv_writer = self._configure_csv_file(tmp_file_handle, schema)
+
+        return files_to_upload
+
+    def _configure_csv_file(self, file_handle, schema):
+        """Configure a csv writer with the file_handle and write schema
+        as headers for the new file.
+        """
+        csv_writer = csv.writer(file_handle, encoding='utf-8',
+                                delimiter=self.field_delimiter)
+        csv_writer.writerow(schema)
+        return csv_writer
+
+    @abc.abstractmethod
+    def query(self):
+        """Execute DBAPI query."""
+
+    @abc.abstractmethod
+    def field_to_bigquery(self, field):
+        """Convert a DBAPI field to BigQuery schema format."""
+
+    @abc.abstractmethod
+    def convert_type(self, value, schema_type):
+        """Convert a value from DBAPI to output-friendly formats."""
+
+    def _get_col_type_dict(self):
+        """
+        Return a dict of column name and column type based on self.schema if not None.
+        """
+        schema = []
+        if isinstance(self.schema, str):
+            schema = json.loads(self.schema)
+        elif isinstance(self.schema, list):
+            schema = self.schema
+        elif self.schema is not None:
+            self.log.warning('Using default schema due to unexpected type.'
+                             'Should be a string or list.')
+
+        col_type_dict = {}
+        try:
+            col_type_dict = {col['name']: col['type'] for col in schema}
+        except KeyError:
+            self.log.warning('Using default schema due to missing name or type. Please '
+                             'refer to: https://cloud.google.com/bigquery/docs/schemas'
+                             '#specifying_a_json_schema_file')
+        return col_type_dict
+
+    def _write_local_schema_file(self, cursor):
+        """
+        Takes a cursor, and writes the BigQuery schema for the results to a
+        local file system.
+
+        :return: A dictionary where key is a filename to be used as an object
+            name in GCS, and values are file handles to local files that
+            contains the BigQuery schema fields in .json format.
+        """
+        schema = [self.field_to_bigquery(field) for field in cursor.description]
+
+        self.log.info('Using schema for %s: %s', self.schema_filename, schema)
+        tmp_schema_file_handle = NamedTemporaryFile(delete=True)
+        tmp_schema_file_handle.write(json.dumps(schema, sort_keys=True).encode('utf-8'))
+        schema_file_to_upload = {
+            'file_name': self.schema_filename,
+            'file_handle': tmp_schema_file_handle,
+            'file_mime_type': 'application/json',
+        }
+        return schema_file_to_upload
+
+    def _upload_to_gcs(self, files_to_upload):
+        """
+        Upload all of the file splits (and optionally the schema .json file) to
+        Google cloud storage.
+        """
+        hook = GoogleCloudStorageHook(
+            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+            delegate_to=self.delegate_to)
+        for tmp_file in files_to_upload:
+            hook.upload(self.bucket, tmp_file.get('file_name'),
+                        tmp_file.get('file_handle').name,
+                        mime_type=tmp_file.get('file_mime_type'),
+                        gzip=self.gzip if tmp_file.get('file_name') == self.schema_filename else False)

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -99,12 +99,9 @@
 ./airflow/contrib/operators/kubernetes_pod_operator.py
 ./airflow/contrib/operators/mlengine_operator.py
 ./airflow/contrib/operators/mongo_to_s3.py
-./airflow/contrib/operators/mssql_to_gcs.py
-./airflow/contrib/operators/mysql_to_gcs.py
 ./airflow/contrib/operators/opsgenie_alert_operator.py
 ./airflow/contrib/operators/oracle_to_azure_data_lake_transfer.py
 ./airflow/contrib/operators/oracle_to_oracle_transfer.py
-./airflow/contrib/operators/postgres_to_gcs_operator.py
 ./airflow/contrib/operators/pubsub_operator.py
 ./airflow/contrib/operators/qubole_check_operator.py
 ./airflow/contrib/operators/qubole_operator.py
@@ -464,7 +461,6 @@
 ./tests/contrib/operators/test_gcs_to_s3_operator.py
 ./tests/contrib/operators/test_grpc_operator.py
 ./tests/contrib/operators/test_mlengine_operator.py
-./tests/contrib/operators/test_mysql_to_gcs_operator.py
 ./tests/contrib/operators/test_oracle_to_azure_data_lake_transfer.py
 ./tests/contrib/operators/test_qubole_check_operator.py
 ./tests/contrib/operators/test_redis_publish_operator.py

--- a/tests/contrib/operators/test_mssql_to_gcs_operator.py
+++ b/tests/contrib/operators/test_mssql_to_gcs_operator.py
@@ -63,7 +63,7 @@ class MsSqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
         self.assertEqual(op.filename, JSON_FILENAME)
 
     @mock.patch('airflow.contrib.operators.mssql_to_gcs.MsSqlHook')
-    @mock.patch('airflow.contrib.operators.mssql_to_gcs.GoogleCloudStorageHook')
+    @mock.patch('airflow.contrib.operators.sql_to_gcs.GoogleCloudStorageHook')
     def test_exec_success_json(self, gcs_hook_mock_class, mssql_hook_mock_class):
         """Test successful run of execute function for JSON"""
         op = MsSqlToGoogleCloudStorageOperator(
@@ -95,7 +95,7 @@ class MsSqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
         mssql_hook_mock.get_conn().cursor().execute.assert_called_once_with(SQL)
 
     @mock.patch('airflow.contrib.operators.mssql_to_gcs.MsSqlHook')
-    @mock.patch('airflow.contrib.operators.mssql_to_gcs.GoogleCloudStorageHook')
+    @mock.patch('airflow.contrib.operators.sql_to_gcs.GoogleCloudStorageHook')
     def test_file_splitting(self, gcs_hook_mock_class, mssql_hook_mock_class):
         """Test that ndjson is split by approx_max_file_size_bytes param."""
         mssql_hook_mock = mssql_hook_mock_class.return_value
@@ -126,7 +126,7 @@ class MsSqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
         op.execute(None)
 
     @mock.patch('airflow.contrib.operators.mssql_to_gcs.MsSqlHook')
-    @mock.patch('airflow.contrib.operators.mssql_to_gcs.GoogleCloudStorageHook')
+    @mock.patch('airflow.contrib.operators.sql_to_gcs.GoogleCloudStorageHook')
     def test_schema_file(self, gcs_hook_mock_class, mssql_hook_mock_class):
         """Test writing schema files."""
         mssql_hook_mock = mssql_hook_mock_class.return_value
@@ -135,7 +135,7 @@ class MsSqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
 
         gcs_hook_mock = gcs_hook_mock_class.return_value
 
-        def _assert_upload(unused_bucket, obj, tmp_filename, unused_mime_type=None, unused_gzip=False):
+        def _assert_upload(bucket, obj, tmp_filename, mime_type, gzip):  # pylint: disable=unused-argument
             if obj == SCHEMA_FILENAME:
                 with open(tmp_filename, 'rb') as file:
                     self.assertEqual(b''.join(SCHEMA_JSON), file.read())

--- a/tests/contrib/operators/test_mysql_to_gcs_operator.py
+++ b/tests/contrib/operators/test_mysql_to_gcs_operator.py
@@ -21,9 +21,10 @@ import datetime
 import decimal
 import unittest
 
+from parameterized import parameterized
+
 from airflow.contrib.operators.mysql_to_gcs import \
     MySqlToGoogleCloudStorageOperator
-from parameterized import parameterized
 from tests.compat import mock
 
 TASK_ID = 'test-mysql-to-gcs'
@@ -89,12 +90,18 @@ class MySqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
         (b"bytes", "BYTES", "Ynl0ZXM="),
     ])
     def test_convert_type(self, value, schema_type, expected):
+        op = MySqlToGoogleCloudStorageOperator(
+            task_id=TASK_ID,
+            mysql_conn_id=MYSQL_CONN_ID,
+            sql=SQL,
+            bucket=BUCKET,
+            filename=JSON_FILENAME)
         self.assertEqual(
-            MySqlToGoogleCloudStorageOperator._convert_type(value, schema_type),
+            op.convert_type(value, schema_type),
             expected)
 
     @mock.patch('airflow.contrib.operators.mysql_to_gcs.MySqlHook')
-    @mock.patch('airflow.contrib.operators.mysql_to_gcs.GoogleCloudStorageHook')
+    @mock.patch('airflow.contrib.operators.sql_to_gcs.GoogleCloudStorageHook')
     def test_exec_success_json(self, gcs_hook_mock_class, mysql_hook_mock_class):
         """Test successful run of execute function for JSON"""
         op = MySqlToGoogleCloudStorageOperator(
@@ -110,10 +117,11 @@ class MySqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
 
         gcs_hook_mock = gcs_hook_mock_class.return_value
 
-        def _assert_upload(bucket, obj, tmp_filename, mime_type=None):
+        def _assert_upload(bucket, obj, tmp_filename, mime_type=None, gzip=False):
             self.assertEqual(BUCKET, bucket)
             self.assertEqual(JSON_FILENAME.format(0), obj)
             self.assertEqual('application/json', mime_type)
+            self.assertFalse(gzip)
             with open(tmp_filename, 'rb') as file:
                 self.assertEqual(b''.join(NDJSON_LINES), file.read())
 
@@ -125,7 +133,7 @@ class MySqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
         mysql_hook_mock.get_conn().cursor().execute.assert_called_once_with(SQL)
 
     @mock.patch('airflow.contrib.operators.mysql_to_gcs.MySqlHook')
-    @mock.patch('airflow.contrib.operators.mysql_to_gcs.GoogleCloudStorageHook')
+    @mock.patch('airflow.contrib.operators.sql_to_gcs.GoogleCloudStorageHook')
     def test_exec_success_csv(self, gcs_hook_mock_class, mysql_hook_mock_class):
         """Test successful run of execute function for CSV"""
         op = MySqlToGoogleCloudStorageOperator(
@@ -142,10 +150,11 @@ class MySqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
 
         gcs_hook_mock = gcs_hook_mock_class.return_value
 
-        def _assert_upload(bucket, obj, tmp_filename, mime_type=None):
+        def _assert_upload(bucket, obj, tmp_filename, mime_type=None, gzip=False):
             self.assertEqual(BUCKET, bucket)
             self.assertEqual(CSV_FILENAME.format(0), obj)
             self.assertEqual('text/csv', mime_type)
+            self.assertFalse(gzip)
             with open(tmp_filename, 'rb') as file:
                 self.assertEqual(b''.join(CSV_LINES), file.read())
 
@@ -157,7 +166,7 @@ class MySqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
         mysql_hook_mock.get_conn().cursor().execute.assert_called_once_with(SQL)
 
     @mock.patch('airflow.contrib.operators.mysql_to_gcs.MySqlHook')
-    @mock.patch('airflow.contrib.operators.mysql_to_gcs.GoogleCloudStorageHook')
+    @mock.patch('airflow.contrib.operators.sql_to_gcs.GoogleCloudStorageHook')
     def test_exec_success_csv_ensure_utc(self, gcs_hook_mock_class, mysql_hook_mock_class):
         """Test successful run of execute function for CSV"""
         op = MySqlToGoogleCloudStorageOperator(
@@ -175,10 +184,11 @@ class MySqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
 
         gcs_hook_mock = gcs_hook_mock_class.return_value
 
-        def _assert_upload(bucket, obj, tmp_filename, mime_type=None):
+        def _assert_upload(bucket, obj, tmp_filename, mime_type=None, gzip=False):
             self.assertEqual(BUCKET, bucket)
             self.assertEqual(CSV_FILENAME.format(0), obj)
             self.assertEqual('text/csv', mime_type)
+            self.assertFalse(gzip)
             with open(tmp_filename, 'rb') as file:
                 self.assertEqual(b''.join(CSV_LINES), file.read())
 
@@ -190,7 +200,7 @@ class MySqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
         mysql_hook_mock.get_conn().cursor().execute.assert_has_calls([mock.call(TZ_QUERY), mock.call(SQL)])
 
     @mock.patch('airflow.contrib.operators.mysql_to_gcs.MySqlHook')
-    @mock.patch('airflow.contrib.operators.mysql_to_gcs.GoogleCloudStorageHook')
+    @mock.patch('airflow.contrib.operators.sql_to_gcs.GoogleCloudStorageHook')
     def test_exec_success_csv_with_delimiter(self, gcs_hook_mock_class, mysql_hook_mock_class):
         """Test successful run of execute function for CSV with a field delimiter"""
         op = MySqlToGoogleCloudStorageOperator(
@@ -208,10 +218,11 @@ class MySqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
 
         gcs_hook_mock = gcs_hook_mock_class.return_value
 
-        def _assert_upload(bucket, obj, tmp_filename, mime_type=None):
+        def _assert_upload(bucket, obj, tmp_filename, mime_type=None, gzip=False):
             self.assertEqual(BUCKET, bucket)
             self.assertEqual(CSV_FILENAME.format(0), obj)
             self.assertEqual('text/csv', mime_type)
+            self.assertFalse(gzip)
             with open(tmp_filename, 'rb') as file:
                 self.assertEqual(b''.join(CSV_LINES_PIPE_DELIMITED), file.read())
 
@@ -223,7 +234,7 @@ class MySqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
         mysql_hook_mock.get_conn().cursor().execute.assert_called_once_with(SQL)
 
     @mock.patch('airflow.contrib.operators.mysql_to_gcs.MySqlHook')
-    @mock.patch('airflow.contrib.operators.mysql_to_gcs.GoogleCloudStorageHook')
+    @mock.patch('airflow.contrib.operators.sql_to_gcs.GoogleCloudStorageHook')
     def test_file_splitting(self, gcs_hook_mock_class, mysql_hook_mock_class):
         """Test that ndjson is split by approx_max_file_size_bytes param."""
         mysql_hook_mock = mysql_hook_mock_class.return_value
@@ -236,9 +247,10 @@ class MySqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
             JSON_FILENAME.format(1): NDJSON_LINES[2],
         }
 
-        def _assert_upload(bucket, obj, tmp_filename, mime_type=None):
+        def _assert_upload(bucket, obj, tmp_filename, mime_type=None, gzip=False):
             self.assertEqual(BUCKET, bucket)
             self.assertEqual('application/json', mime_type)
+            self.assertFalse(gzip)
             with open(tmp_filename, 'rb') as file:
                 self.assertEqual(expected_upload[obj], file.read())
 
@@ -253,7 +265,7 @@ class MySqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
         op.execute(None)
 
     @mock.patch('airflow.contrib.operators.mysql_to_gcs.MySqlHook')
-    @mock.patch('airflow.contrib.operators.mysql_to_gcs.GoogleCloudStorageHook')
+    @mock.patch('airflow.contrib.operators.sql_to_gcs.GoogleCloudStorageHook')
     def test_schema_file(self, gcs_hook_mock_class, mysql_hook_mock_class):
         """Test writing schema files."""
         mysql_hook_mock = mysql_hook_mock_class.return_value
@@ -262,8 +274,9 @@ class MySqlToGoogleCloudStorageOperatorTest(unittest.TestCase):
 
         gcs_hook_mock = gcs_hook_mock_class.return_value
 
-        def _assert_upload(bucket, obj, tmp_filename, mime_type):  # pylint disable=unused-argument
+        def _assert_upload(bucket, obj, tmp_filename, mime_type, gzip):  # pylint: disable=unused-argument
             if obj == SCHEMA_FILENAME:
+                self.assertFalse(gzip)
                 with open(tmp_filename, 'rb') as file:
                     self.assertEqual(b''.join(SCHEMA_JSON), file.read())
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
