### PR TITLE
[AIRFLOW-4868] Fix typo in kubernetes/docker/build.sh

### DIFF
--- a/scripts/ci/kubernetes/docker/build.sh
+++ b/scripts/ci/kubernetes/docker/build.sh
@@ -43,7 +43,7 @@ echo "Airflow Docker directory $DIRNAME"
 
 cd $AIRFLOW_ROOT
 docker run -ti --rm -v ${AIRFLOW_ROOT}:/airflow \
-    -w /airflow ${PYTHON_DOCKER_IMAGE} ./scripts/ci/kubernetes/docker/compile.sh \
+    -w /airflow ${PYTHON_DOCKER_IMAGE} ./scripts/ci/kubernetes/docker/compile.sh
 
 sudo rm -rf ${AIRFLOW_ROOT}/airflow/www/node_modules
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4868

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The problem comes when trying to use airflow in k8s. The typo is preventing dist folder to be copied to www/static (see screenshots attached to issue). After removing the typo, airflow worked find

### Tests

- [x] My PR does not need testing for this extremely good reason: 

Current tests are ok for this fix.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message]

### Code Quality

- [x] Passes `flake8`
