### PR TITLE
AIRFLOW-4855 Airflow task remains in queued state

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1259,6 +1259,15 @@ class SchedulerJob(BaseJob):
                         session.merge(ti)
                         session.commit()
 
+                elif ti.try_number == try_number - 1 and ti.state == State.QUEUED \
+                        and not self.executor.has_task(ti):
+                    msg = ("Executor reports task instance {} finished ({}) although the "
+                           "task says its {} and was never tried.".format(ti, state, ti.state))
+                    self.log.error(msg)
+                    ti.state = State.NONE
+                    session.merge(ti)
+                    session.commit()
+
     def _execute(self):
         self.log.info("Starting the scheduler")
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [AIRFLOW-4855](https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-4855] issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Incase of a failure in the following method- 

https://github.com/apache/airflow/blob/65eef1ca3d848ecf02eb79c41a72d736e40a9108/airflow/models/taskinstance.py#L836

where TI increase the try_number and mark its status to RUNNING, the tasks remain stuck in QUEUED state.

I observed this in K8s executor where  Kubewatcher gets a failed event and it is processed here- https://github.com/apache/airflow/blob/65eef1ca3d848ecf02eb79c41a72d736e40a9108/airflow/jobs/scheduler_job.py#L1233

but since the try_number was not incremented by the task, this condition never meets- https://github.com/apache/airflow/blob/65eef1ca3d848ecf02eb79c41a72d736e40a9108/airflow/jobs/scheduler_job.py#L1243

and the tasks are not even marked for retry even if they have retries configured. I think the behaviour should be same for other executors.  I also think this is a rare scenario, but I still did encounter it.

I am proposing this change,where in case of this failure, I will mark the task state as NONE, (instead of exhausting task retries) so that the are picked up again for running.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
