### PR TITLE
[AIRFLOW-4871] Allow creating DagRuns via RBAC UI

### DIFF
--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -70,6 +70,7 @@ class DagRunForm(DynamicForm):
         widget=DateTimePickerWidget())
     run_id = StringField(
         lazy_gettext('Run Id'),
+        validators=[validators.DataRequired()],
         widget=BS3TextFieldWidget())
     state = SelectField(
         lazy_gettext('State'),
@@ -80,6 +81,12 @@ class DagRunForm(DynamicForm):
         widget=DateTimePickerWidget())
     external_trigger = BooleanField(
         lazy_gettext('External Trigger'))
+
+    def populate_obj(self, item):
+        # TODO: This is probably better done as a custom field type so we can
+        # set TZ at parse time
+        super().populate_obj(item)
+        item.execution_date = timezone.make_aware(item.execution_date)
 
 
 class ConnectionForm(DynamicForm):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2296,8 +2296,9 @@ class DagRunModelView(AirflowModelView):
 
     datamodel = AirflowModelView.CustomSQLAInterface(models.DagRun)
 
-    base_permissions = ['can_list']
+    base_permissions = ['can_list', 'can_add']
 
+    add_columns = ['state', 'dag_id', 'execution_date', 'run_id', 'external_trigger']
     list_columns = ['state', 'dag_id', 'execution_date', 'run_id', 'external_trigger']
     search_columns = ['state', 'dag_id', 'execution_date', 'run_id', 'external_trigger']
 
@@ -2313,10 +2314,6 @@ class DagRunModelView(AirflowModelView):
         'start_date': wwwutils.datetime_f('start_date'),
         'dag_id': wwwutils.dag_link,
         'run_id': wwwutils.dag_run_link,
-    }
-
-    validators_columns = {
-        'dag_id': [validators.DataRequired()]
     }
 
     @action('muldelete', "Delete", "Are you sure you want to delete selected records?",

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -85,10 +85,10 @@ class TestBase(unittest.TestCase):
     def logout(self):
         return self.client.get('/logout/')
 
-    def clear_table(self, model):
-        self.session.query(model).delete()
-        self.session.commit()
-        self.session.close()
+    @classmethod
+    def clear_table(cls, model):
+        with create_session() as session:
+            session.query(model).delete()
 
     def check_content_in_response(self, text, resp, resp_code=200):
         resp_html = resp.data.decode('utf-8')
@@ -1856,6 +1856,33 @@ class TestExtraLinks(TestBase):
         self.assertEqual(json.loads(response_str), {
             'url': None,
             'error': 'No URL found for no_response'})
+
+
+class TestDagRunModelView(TestBase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestDagRunModelView, cls).setUpClass()
+        models.DagBag().get_dag("example_bash_operator").sync_to_db(session=cls.session)
+        cls.clear_table(models.DagRun)
+
+    def tearDown(self):
+        self.clear_table(models.DagRun)
+
+    def test_create_dagrun(self):
+        data = {
+            "state": "running",
+            "dag_id": "example_bash_operator",
+            "execution_date": "2018-07-06 05:04:03",
+            "run_id": "manual_abc",
+        }
+        resp = self.client.post('/dagrun/add',
+                                data=data,
+                                follow_redirects=True)
+        self.check_content_in_response('Added Row', resp)
+
+        dr = self.session.query(models.DagRun).one()
+
+        self.assertEqual(dr.execution_date, timezone.convert_to_utc(datetime(2018, 7, 6, 5, 4, 3)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4871

### Description

- [x] All this needed to enable the form was to add `can_add` to the
permission list

  The run_id field is a required form (though the DB doesn't have it as
not nullable) - the scheduler requires it. so I have enabled the
required validation for it.

  The `validators_columns` attribute on the view was ignored by FAB
because we set `add_form` and `edit_form` directly, so I have removed
the property

  **Before**
  (No add button)

  ![Screenshot 2019-07-01 at 12 22 35](https://user-images.githubusercontent.com/34150/60432843-346a7780-9bfb-11e9-93e2-154bb9ccadd0.png)

  **After**
  ![Screenshot 2019-07-01 at 12 23 06](https://user-images.githubusercontent.com/34150/60432865-43512a00-9bfb-11e9-9b30-576d85c17b87.png)

  Run id required - I don't think this form was every viewable before
  ![Screenshot 2019-07-01 at 12 23 10](https://user-images.githubusercontent.com/34150/60432871-45b38400-9bfb-11e9-99ee-82d9bf8d6b7a.png)



### Tests

- [x] Added test for datetime behaviour on create form 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] None

### Code Quality

- [x] Passes `flake8`
