### PR TITLE
[AIRFLOW-3495] Prevent error due to wrong usage with DataProcSparkSql…

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -810,6 +810,8 @@ class DataProcHiveOperator(DataProcJobBaseOperator):
         self.variables = variables
 
     def execute(self, context):
+        if self.query is not None and self.query_uri is not None:
+            raise AirflowException('Only one of `query` and `query_uri` can be passed.')
         self.create_job_template()
         if self.query is None:
             self.job_template.add_query_uri(self.query_uri)
@@ -851,6 +853,8 @@ class DataProcSparkSqlOperator(DataProcJobBaseOperator):
         self.variables = variables
 
     def execute(self, context):
+        if self.query is not None and self.query_uri is not None:
+            raise AirflowException('Only one of `query` and `query_uri` can be passed.')
         self.create_job_template()
         if self.query is None:
             self.job_template.add_query_uri(self.query_uri)

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -808,10 +808,10 @@ class DataProcHiveOperator(DataProcJobBaseOperator):
         self.query = query
         self.query_uri = query_uri
         self.variables = variables
-
-    def execute(self, context):
         if self.query is not None and self.query_uri is not None:
             raise AirflowException('Only one of `query` and `query_uri` can be passed.')
+
+    def execute(self, context):
         self.create_job_template()
         if self.query is None:
             self.job_template.add_query_uri(self.query_uri)
@@ -851,10 +851,10 @@ class DataProcSparkSqlOperator(DataProcJobBaseOperator):
         self.query = query
         self.query_uri = query_uri
         self.variables = variables
-
-    def execute(self, context):
         if self.query is not None and self.query_uri is not None:
             raise AirflowException('Only one of `query` and `query_uri` can be passed.')
+
+    def execute(self, context):
         self.create_job_template()
         if self.query is None:
             self.job_template.add_query_uri(self.query_uri)


### PR DESCRIPTION
…Operator / DataProcHiveOperator

DataProcSparkSqlOperator  and  DataProcHiveOperator are working either with query or query_uri.
Trying to assign value for both will result in error which is hard to understand:
https://stackoverflow.com/questions/53424091/unable-to-query-using-file-in-data-proc-hive-operator
Adding a check before executing that makes sure only one of the arguments was assigned.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-3495
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
