### PR TITLE
[AIRFLOW-4862] Fix bug for earlier change to allow using IP as hostname

### DIFF
--- a/airflow/utils/net.py
+++ b/airflow/utils/net.py
@@ -23,7 +23,7 @@ from airflow.configuration import (conf, AirflowConfigException)
 
 
 def get_host_ip_address():
-    socket.gethostbyname(socket.getfqdn())
+    return socket.gethostbyname(socket.getfqdn())
 
 
 def get_hostname():


### PR DESCRIPTION
### Jira

  - https://issues.apache.org/jira/browse/AIRFLOW-4862

### Description

Earlier I raised PR https://github.com/apache/airflow/pull/5501 to allow using IP address as hostname. But there was an issue in the earlier code (an explicit `return` was missing). This PR is to fix the issue