### PR TITLE
[AIRFLOW-4881] Persist the max_tries field of task instances during zombie collection

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -290,6 +290,7 @@ class DagBag(BaseDagBag, LoggingMixin):
                     ti.start_date = zombie.start_date
                     ti.end_date = zombie.end_date
                     ti.try_number = zombie.try_number
+                    ti.max_tries = zombie.max_tries
                     ti.state = zombie.state
                     ti.test_mode = configuration.getboolean('core', 'unit_test_mode')
                     ti.handle_failure("{} detected as zombie".format(ti),

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -145,6 +145,7 @@ class SimpleTaskInstance:
         self._start_date = ti.start_date
         self._end_date = ti.end_date
         self._try_number = ti.try_number
+        self._max_tries = ti.max_tries
         self._state = ti.state
         self._executor_config = ti.executor_config
         if hasattr(ti, 'run_as_user'):
@@ -185,6 +186,10 @@ class SimpleTaskInstance:
     @property
     def try_number(self):
         return self._try_number
+
+    @property
+    def max_tries(self):
+        return self._max_tries
 
     @property
     def state(self):

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -611,6 +611,8 @@ class DagBagTest(unittest.TestCase):
             task = dag.get_task(task_id='run_this_first')
 
             ti = TI(task, DEFAULT_DATE, State.RUNNING)
+            ti.try_number = 2
+            ti.max_tries = 3
 
             session.add(ti)
             session.commit()
@@ -622,6 +624,12 @@ class DagBagTest(unittest.TestCase):
                                     configuration.getboolean('core',
                                                              'unit_test_mode'),
                                     ANY)
+
+            args, _ = mock_ti_handle_failure.call_args_list[0]
+            captured_context = args[2]
+
+            self.assertEqual(ti.max_tries, captured_context["ti"].max_tries)
+            self.assertEqual(ti.try_number, captured_context["ti"].try_number)
 
     def test_deactivate_unknown_dags(self):
         """

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -197,6 +197,8 @@ class TestDagFileProcessorManager(unittest.TestCase):
             lj.state = State.SHUTDOWN
             lj.id = 1
             ti.job_id = lj.id
+            ti.try_number = 2
+            ti.max_tries = 3
 
             session.add(lj)
             session.add(ti)
@@ -210,6 +212,8 @@ class TestDagFileProcessorManager(unittest.TestCase):
             self.assertEqual(ti.dag_id, zombies[0].dag_id)
             self.assertEqual(ti.task_id, zombies[0].task_id)
             self.assertEqual(ti.execution_date, zombies[0].execution_date)
+            self.assertEqual(ti.max_tries, zombies[0].max_tries)
+            self.assertEqual(ti.try_number, zombies[0].try_number)
 
             session.query(TI).delete()
             session.query(LJ).delete()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4881) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-4881

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

In case a task instance
- has more attempts than retries (it can happen when the state of the task instance is explicitly cleared) and
- task instance is prematurely terminated (without graceful shutdown)
then zombie collection process of the scheduler can mark the task instance failed instead of up_for_retry.

This happens because the `max_retries` field is not persisted but set to its initial value (`retries`). 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
