### PR TITLE
[AIRFLOW-4884] Roll up import_errors in UI

### DIFF
--- a/airflow/www/static/css/flash.css
+++ b/airflow/www/static/css/flash.css
@@ -1,0 +1,36 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+.panel-heading #alerts-accordion-toggle:after {
+    /* symbol for "opening" panels */
+    font-family: FontAwesome;
+    content: "\f078"; 
+    float: right;
+    color: grey;
+}
+.panel-heading #alerts-accordion-toggle.collapsed:after {
+    /* symbol for "closing" panels */
+    font-family: FontAwesome;
+    content: "\f054"; 
+    float: right;
+    color: grey;
+}
+#errorHeading {
+    background-color: #D6D8D9; /* same color as Bootstrap's Dark Alert*/
+}

--- a/airflow/www/templates/appbuilder/flash.html
+++ b/airflow/www/templates/appbuilder/flash.html
@@ -1,0 +1,78 @@
+{#
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+#}
+<!-- Adapted from: https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/templates/appbuilder/flash.html -->
+<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/flash.css') }}">
+
+<!-- Split messages into two arrays: one for regular alerts, another for DAG import errors -->
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% set dag_import_errors = [] %}
+    {% set regular_alerts = [] %}
+
+    {% if messages %}
+        {% for category, m in messages %}
+            {% if category == 'dag_import_error' %}
+                {{ dag_import_errors.append((category, m)) if dag_import_errors.append((category, m)) != None else '' }}
+            {% else %}
+                {{ regular_alerts.append((category, m)) if regular_alerts.append((category, m)) != None else '' }}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+
+    <div>
+    {% if regular_alerts %}
+        {% for category, m in regular_alerts %}
+            {% if category %}
+                <div class="alert alert-{{ category }}">
+            {% else %}
+                <div class="alert alert-info">
+            {% endif %}
+            <button type="button" class="close" data-dismiss="alert">&times;</button>
+            {{ m }}
+            </div>
+        {% endfor %}
+    {% endif %}
+    </div>
+
+    <div>
+    {% if dag_import_errors %}
+        <div class="panel-group" id="accordion">
+            <div class="panel panel-default">
+                <div class="panel-heading" id="errorHeading">
+                  <h4 class="panel-title">
+                    <a id="alerts-accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#alerts" aria-expanded="false" >
+                      DAG Import Errors ({{ dag_import_errors|length }})
+                    </a>
+                  </h4>
+                </div>
+
+                <div id="alerts" class="panel-collapse collapse in">
+                  <div class="panel-body" >
+                    {% for category, m in dag_import_errors %}
+                        <div class="alert alert-error">
+                            {{ m }}
+                        </div>
+                    {% endfor %}
+                  </div>
+                </div>
+              </div>
+            </div>
+        </div>
+    {% endif %}
+    </div>
+
+{% endwith %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -258,7 +258,7 @@ class Airflow(AirflowBaseView):
         for ie in import_errors:
             flash(
                 "Broken DAG: [{ie.filename}] {ie.stacktrace}".format(ie=ie),
-                "error")
+                "dag_import_error")
 
         from airflow.plugins_manager import import_errors as plugin_import_errors
         for filename, stacktrace in plugin_import_errors.items():


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4884

### [Description]

- [x] Here are some details about my PR, including screenshots of any UI changes:

When a DAG suffers from an import_error it populates each error at the top of the Airflow UI in big red flash boxes. For Airflow instances that are shared across multiple teams, this can be annoying when another team's import_errors crowd the top of the screen and cannot be suppressed by users of other teams. I would like to roll up the errors into a collective dropdown so that the information is available and loud without being intrusive.

![error-ui-screenshot](https://i.imgur.com/07W3qak.png)

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No good unit test identified for jinja templating.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"
