### PR TITLE
[AIRFLOW-4885] Add virtualenv dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -268,6 +268,7 @@ snowflake = ['snowflake-connector-python>=1.5.2',
 ssh = ['paramiko>=2.1.1', 'pysftp>=0.2.9', 'sshtunnel>=0.1.4,<0.2']
 statsd = ['statsd>=3.0.1, <4.0']
 vertica = ['vertica-python>=0.5.1']
+virtualenv = ['virtualenv']
 webhdfs = ['hdfs[dataframe,avro,kerberos]>=2.0.4']
 winrm = ['pywinrm==0.2.2']
 zendesk = ['zdesk']
@@ -307,7 +308,7 @@ devel_all = (sendgrid + devel + all_dbs + doc + samba + slack + crypto + oracle 
              docker + ssh + kubernetes + celery + redis + gcp + grpc +
              datadog + zendesk + jdbc + ldap + kerberos + password + webhdfs + jenkins +
              druid + pinot + segment + snowflake + elasticsearch +
-             atlas + azure + aws + salesforce + cgroups + papermill)
+             atlas + azure + aws + salesforce + cgroups + papermill + virtualenv)
 
 # Snakebite & Google Cloud Dataflow are not Python 3 compatible :'(
 if PY3:
@@ -429,8 +430,9 @@ def do_setup():
             'ssh': ssh,
             'statsd': statsd,
             'vertica': vertica,
+            'virtualenv': virtualenv,
             'webhdfs': webhdfs,
-            'winrm': winrm
+            'winrm': winrm,
         },
         classifiers=[
             'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4885

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

We have no "virtualenv" dependency defined, but it is needed by PythonVirtualenvOperator - it nieeds virtualenv even if migrated to Python 3.x because it needs to run other python versions (even 2.7) - so venv does not help.

It was not detected before because current CI installs virtualenv. The new CI - as implemented in AIRFLOW-3718 does not install virtualenv and it was detected then.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
It's already tested but in the new CI test fails without having virtualenv in setup.py


### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] Passes `flake8`
