### PR TITLE
[AIRFLOW-4892] Fix connection creation via UIs

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3025,6 +3025,9 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
     column_default_sort = ('conn_id', False)
     column_list = ('conn_id', 'conn_type', 'host', 'port', 'is_encrypted', 'is_extra_encrypted',)
     form_overrides = dict(_password=PasswordField, _extra=TextAreaField)
+    form_args = dict(
+        conn_id=dict(validators=[validators.DataRequired()])
+    )
     form_widget_args = {
         'is_extra_encrypted': {'disabled': True},
         'is_encrypted': {'disabled': True},
@@ -3041,7 +3044,13 @@ class ConnectionModelView(wwwutils.SuperUserMixin, AirflowModelView):
         'extra__google_cloud_platform__key_path': StringField('Keyfile Path'),
         'extra__google_cloud_platform__keyfile_dict': PasswordField('Keyfile JSON'),
         'extra__google_cloud_platform__scope': StringField('Scopes (comma separated)'),
-        'extra__google_cloud_platform__num_retries': IntegerField('Number of Retries'),
+        'extra__google_cloud_platform__num_retries': IntegerField(
+            'Number of Retries',
+            validators=[
+                validators.Optional(strip_whitespace=True),
+                validators.NumberRange(min=0),
+            ],
+        ),
         'extra__grpc__auth_type': StringField('Grpc Auth Type'),
         'extra__grpc__credentials_pem_file': StringField('Credential Keyfile Path'),
         'extra__grpc__scopes': StringField('Scopes (comma separated)'),

--- a/airflow/www_rbac/forms.py
+++ b/airflow/www_rbac/forms.py
@@ -97,6 +97,7 @@ class DagRunForm(DynamicForm):
 class ConnectionForm(DynamicForm):
     conn_id = StringField(
         lazy_gettext('Conn Id'),
+        validators=[validators.DataRequired()],
         widget=BS3TextFieldWidget())
     conn_type = SelectField(
         lazy_gettext('Conn Type'),

--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -2067,7 +2067,7 @@ class ConnectionModelView(AirflowModelView):
                     'extra__google_cloud_platform__scope',
                     'extra__google_cloud_platform__num_retries',
                     'extra__grpc__auth_type',
-                    'extra__grpc__credentials_pem_file',
+                    'extra__grpc__credential_pem_file',
                     'extra__grpc__scopes']
     list_columns = ['conn_id', 'conn_type', 'host', 'port', 'is_encrypted',
                     'is_extra_encrypted']


### PR DESCRIPTION
## Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4892

### Description

- [x] The form validation for classic UI was failing with an error on the
(most often hidden) Num Retries field.

  RBAC was failing because the form wasn't rendering due to a typo in a
cherry-pick/backport to www_rbac.

  Both of these apply to the release branch only as they were the result of me back-porting PRs from master that had in-sufficient test. I have a separate PR to add more tests to the connection form on master.

### Tests

- [x] Added some tests.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
