### PR TITLE
Add connection protocol mapping for https:// connections

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -72,6 +72,7 @@ class Connection(Base, LoggingMixin):
         ('google_cloud_platform', 'Google Cloud Platform'),
         ('hdfs', 'HDFS',),
         ('http', 'HTTP',),
+        ('https', 'HTTP',),
         ('pig_cli', 'Pig Client Wrapper',),
         ('hive_cli', 'Hive Client Wrapper',),
         ('hive_metastore', 'Hive Metastore Thrift',),


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] There is no Jira story addressing issue I've encountered.

### Description

- [ ] When 'creating' connections by environmental variables, right now it is impossible to add connection starting with https:// , which is common case for connections to chat services (google, slack). My fix address this issue.

### Tests

- [ ] There are no tests, it's only expanding functionality by adding additional mapping.

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] I guess no documentation is needed for this change.

### Code Quality

- [ ] Passes `flake8`
