### PR TITLE
[AIRFLOW-1740] Fix xcom creation and update via UI

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -27,6 +27,7 @@ import json
 import logging
 import math
 import os
+import pickle
 import traceback
 from collections import defaultdict
 from datetime import timedelta
@@ -61,7 +62,7 @@ from wtforms import (
     StringField, IntegerField, validators)
 
 import airflow
-from airflow import configuration as conf
+from airflow import configuration as conf, LoggingMixin, configuration
 from airflow import models
 from airflow import settings
 from airflow import jobs
@@ -2684,6 +2685,21 @@ class XComView(wwwutils.SuperUserMixin, AirflowModelView):
     column_searchable_list = ('key', 'timestamp', 'execution_date', 'task_id', 'dag_id')
     filter_converter = wwwutils.UtcFilterConverter()
     form_overrides = dict(execution_date=DateTimeField)
+
+    def on_model_change(self, form, model, is_created):
+        enable_pickling = configuration.getboolean('core', 'enable_xcom_pickling')
+        if enable_pickling:
+            model.value = pickle.dumps(model.value)
+        else:
+            try:
+                model.value = json.dumps(model.value).encode('UTF-8')
+            except ValueError:
+                log = LoggingMixin().log
+                log.error("Could not serialize the XCOM value into JSON. "
+                          "If you are using pickles instead of JSON "
+                          "for XCOM, then you need to enable pickle "
+                          "support for XCOM in your airflow config.")
+                raise
 
 
 class JobModelView(ModelViewOnly):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-1740
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Fixes the xcom creation and update via the classic UI.
Issue: `sqlalchemy.exc.StatementError: (builtins.TypeError) memoryview: a bytes-like object is required, not 'str' [SQL: 'INSERT INTO xcom ("key", value, timestamp, execution_date, task_id, dag_id) VALUES (?, ?, ?, ?, ?, ?)'] [parameters: [{'value': 'value1', 'dag_id': 'example_bash_operator', 'key': 'key1', 'execution_date': datetime.datetime(2019, 7, 4, 16, 42, 23), 'task_id': 'run_me_0'}]]`

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
