### PR TITLE
[AIRFLOW-4895] Import Iterable from collections.abc to fix DeprecationWarning in Python 3.7

### DIFF
--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -23,7 +23,12 @@ import psutil
 
 from datetime import datetime
 from functools import reduce
-from collections import Iterable
+try:
+    # Fix Python > 3.7 deprecation
+    from collections.abc import Iterable
+except ImportError:
+    # Preserve Python < 3.3 compatibility
+    from collections import Iterable
 import os
 import re
 import signal


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.

### Description

Import Iterable from collections.abc to fix DeprecationWarning in Python 3.7. Use collections to ensure compatibility for Python 3.3 and below.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This fixes a DeprecationWarning and doesn't make code change

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] Passes `flake8`
