### PR TITLE
[AIRFLOW-4900] Resolve incompatible version of Werkzeug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -370,7 +370,7 @@ def do_setup():
             'thrift>=0.9.2',
             'tzlocal>=1.4',
             'unicodecsv>=0.14.1',
-            'werkzeug>=0.14.1, <0.15.0',
+            'werkzeug>=0.15.0',
             'zope.deprecation>=4.0, <5.0',
         ],
         setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -370,7 +370,6 @@ def do_setup():
             'thrift>=0.9.2',
             'tzlocal>=1.4',
             'unicodecsv>=0.14.1',
-            'werkzeug>=0.15.0',
             'zope.deprecation>=4.0, <5.0',
         ],
         setup_requires=[


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-4900

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR Pin Werkzeug version to >= 0.15 as flask requirement needs it.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No test added, because this is only changing requirements.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
