### PR TITLE
[AIRFLOW-3761] Skip drop constraint `known_event_user_id_fkey` for SQLlite, not necessary

### DIFF
--- a/airflow/migrations/versions/cf5dc11e79ad_drop_user_and_chart.py
+++ b/airflow/migrations/versions/cf5dc11e79ad_drop_user_and_chart.py
@@ -45,7 +45,7 @@ def upgrade():
     conn = op.get_bind()
     inspector = Inspector.from_engine(conn)
 
-    if 'known_event' in inspector.get_table_names():
+    if 'known_event' in inspector.get_table_names() != 'sqlite':
         op.drop_constraint('known_event_user_id_fkey', 'known_event')
 
     op.drop_table("chart")


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Before this change i get error using latest `master@2bdb053d` and `v2.0.0.dev0`:

```
INFO  [alembic.runtime.migration] Running upgrade 41f5f12752f8 -> cf5dc11e79ad, drop_user_and_chart
> /Users/andrii/work/airflow/airflow/migrations/versions/cf5dc11e79ad_drop_user_and_chart.py(50)upgrade()
     49         import ipdb; ipdb.set_trace()
---> 50         op.drop_constraint('known_event_user_id_fkey', 'known_event')
     51

ipdb> op.drop_constraint('known_event_user_id_fkey', 'known_event')
*** NotImplementedError: No support for ALTER of constraints in SQLite dialect
```

After quick dig into issue, i found that no need to explicitly drop constraint for SQLite if table doesn't exists.

Steps to test:

0. Apply this change
1. `pip install -e .`
2. `airflow initdb`
3. connect to SQLlite db via cli `sqlite3 ~/airflow/airflow.db`
4. Find all constraints:
```
SELECT sql
  FROM (
        SELECT sql sql, type type, tbl_name tbl_name, name name
          FROM sqlite_master
         UNION ALL
        SELECT sql, type, tbl_name, name
          FROM sqlite_temp_master
       )
 WHERE type != 'meta'
   AND sql NOTNULL
   AND name NOT LIKE 'sqlite_%'
 ORDER BY substr(type, 2, 1), name
```

As you can see you can't find `known_event_user_id_fkey` or `known_event` table

🎉 


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/).

### Documentation

- [x] no need documentations.

### Code Quality

- [x] Passes `flake8`
