### PR TITLE
[AIRFLOW-4904] Retrieve test config file from $AIRFLOW_TEST_CONFIG (default to home)

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -499,6 +499,7 @@ def get_airflow_test_config(airflow_home):
         return os.path.join(airflow_home, 'unittests.cfg')
     return expand_env_var(os.environ['AIRFLOW_TEST_CONFIG'])
 
+
 TEST_CONFIG_FILE = get_airflow_test_config(AIRFLOW_HOME)
 
 # only generate a Fernet key if we need to create a new config file

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -494,7 +494,12 @@ def parameterized_config(template):
     return template.format(**all_vars)
 
 
-TEST_CONFIG_FILE = AIRFLOW_HOME + '/unittests.cfg'
+def get_airflow_test_config(airflow_home):
+    if 'AIRFLOW_TEST_CONFIG' not in os.environ:
+        return os.path.join(airflow_home, 'unittests.cfg')
+    return expand_env_var(os.environ['AIRFLOW_TEST_CONFIG'])
+
+TEST_CONFIG_FILE = get_airflow_test_config(AIRFLOW_HOME)
 
 # only generate a Fernet key if we need to create a new config file
 if not os.path.isfile(TEST_CONFIG_FILE) or not os.path.isfile(AIRFLOW_CONFIG):


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4904/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Add function to gather test config location from `$AIRFLOW_TEST_CONFIG` env var.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Trivial change

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
