### PR TITLE
Fix permission error when creating logs

### DIFF
--- a/airflow/utils/log/file_processor_handler.py
+++ b/airflow/utils/log/file_processor_handler.py
@@ -84,7 +84,7 @@ class FileProcessorHandler(logging.Handler):
             self.handler.close()
 
     def _render_filename(self, filename):
-        filename = os.path.relpath(filename, self.dag_dir)
+        filename = os.path.relpath(filename, self.dag_dir).replace("../", "")
         ctx = dict()
         ctx['filename'] = filename
 


### PR DESCRIPTION
Just a heads up, I wasn't able to find a ticket in the airflow JIRA and I'm not sure the best method to try and test this change, so I don't expect this PR to be accepted. It's here for visibility in case someone would like to help shepherd me through the process of making this PR "good".

## Description

prevents the scheduler raising `PermissionError: [Errno 13]` when creating log files where the relative path contains references to directories higher on the filesystem, preventing execution.

traceback:

```
Process DagFileProcessor8-Process:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/process.py", line 297, in _bootstrap
    self.run()
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/multiprocessing/process.py", line 99, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/sfitzpatrick/virtualenvs/flow/lib/python3.7/site-packages/airflow/jobs.py", line 381, in helper
    set_context(log, file_path)
  File "/Users/sfitzpatrick/virtualenvs/flow/lib/python3.7/site-packages/airflow/utils/log/logging_mixin.py", line 170, in set_context
    handler.set_context(value)
  File "/Users/sfitzpatrick/virtualenvs/flow/lib/python3.7/site-packages/airflow/utils/log/file_processor_handler.py", line 65, in set_context
    local_loc = self._init_file(filename)
  File "/Users/sfitzpatrick/virtualenvs/flow/lib/python3.7/site-packages/airflow/utils/log/file_processor_handler.py", line 141, in _init_file
    os.makedirs(directory)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/os.py", line 211, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/os.py", line 211, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/os.py", line 211, in makedirs
    makedirs(head, exist_ok=exist_ok)
  [Previous line repeated 3 more times]
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/os.py", line 221, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/Users/sfitzpatrick/airflow/logs/scheduler/2019-07-07/../../../../../../virtualenvs'
```

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
