### PR TITLE
change task_dict type to Dict[str, Task] in the comment

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -225,7 +225,7 @@ class DAG(BaseDag, LoggingMixin):
         self._description = description
         # set file location to caller source path
         self.fileloc = sys._getframe().f_back.f_code.co_filename
-        self.task_dict = dict()  # type: Dict[str, TaskInstance]
+        self.task_dict = dict()  # type: Dict[str, Task]
 
         # set timezone from start_date
         if start_date and start_date.tzinfo:


### PR DESCRIPTION
### Description

Change `task_dict` type from `Dict[str, Task]` to `Dict[str, Task]` in the comment of file -`dag.py`.

By running some experiments locally. I found in `Dict[str, Task]`, the value is actually `airflow.operators` instead of `TaskInstance`.

By the definition in: https://airflow.apache.org/concepts.html,
`Task` is an accurate word than `TaskInstance` since `once an operator is instantiated, it is referred to as a “task”.  While a task instance represents a specific run of a task.`

### Tests
I ran the codes below in `test_dag.py`

```
for key in dag.task_dict:
    print type(dag.task_dict[key])
```

The results I got are 
```
<class 'airflow.operators.dummy_operator.DummyOperator'>
<class 'airflow.operators.dummy_operator.DummyOperator'>
<class 'airflow.operators.dummy_operator.DummyOperator'>
```

### Commits

- change task_dict type to Dict[str, Task] in the comment