### PR TITLE
change task_dict type to Dict[str, BaseOperator] in the comment

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -226,7 +226,7 @@ class DAG(BaseDag, LoggingMixin):
         self._description = description
         # set file location to caller source path
         self.fileloc = sys._getframe().f_back.f_code.co_filename
-        self.task_dict: Dict[str, BaseOperator] = dict()
+        self.task_dict = dict()  # type: Dict[str, BaseOperator]
 
         # set timezone from start_date
         if start_date and start_date.tzinfo:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -40,6 +40,7 @@ from airflow import configuration, settings, utils
 from airflow.dag.base_dag import BaseDag
 from airflow.exceptions import AirflowException, AirflowDagCycleException
 from airflow.executors import LocalExecutor, get_default_executor
+from airflow.models import BaseOperator
 from airflow.models.base import Base, ID_LEN
 from airflow.models.dagbag import DagBag
 from airflow.models.dagpickle import DagPickle
@@ -225,7 +226,7 @@ class DAG(BaseDag, LoggingMixin):
         self._description = description
         # set file location to caller source path
         self.fileloc = sys._getframe().f_back.f_code.co_filename
-        self.task_dict = dict()  # type: Dict[str, TaskInstance]
+        self.task_dict: Dict[str, BaseOperator] = dict()
 
         # set timezone from start_date
         if start_date and start_date.tzinfo:


### PR DESCRIPTION
### Description

Change `task_dict` type from `Dict[str, Task]` to `Dict[str, BaseOperator]` in the comment of file -`dag.py`.

By running some experiments locally. I found in `task_dict`, the value is actually `airflow.operators` instead of `TaskInstance`.

By the definition in: https://airflow.apache.org/concepts.html,
`"TaskInstance" represents a specific run of a task.` I feel Operator/Task is more accurate here. And TaskInstance confused me when reading the codes. I tried find `execute` method in `TaskInstance`.

### Tests
I ran the codes below in `test_dag.py`

```
for key in dag.task_dict:
    print type(dag.task_dict[key])
```

The results I got are 
```
<class 'airflow.operators.dummy_operator.DummyOperator'>
<class 'airflow.operators.dummy_operator.DummyOperator'>
<class 'airflow.operators.dummy_operator.DummyOperator'>
```

### Commits

- change task_dict type to Dict[str, Task] in the comment