### PR TITLE
[AIRFLOW-4920] Use html.escape instead of cgi.escape to fix DeprecationWarning

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -23,12 +23,6 @@ from future import standard_library
 standard_library.install_aliases()  # noqa: E402
 from builtins import str, object
 
-try:
-    # cgi.escape has been deprecated since 3.3 and removed in 3.8
-    from html import escape
-except ImportError:
-    # Use cgi.escape for Python 2
-    from cgi import escape
 from io import BytesIO as IO
 import functools
 import gzip
@@ -51,6 +45,13 @@ from airflow import configuration, models, settings
 from airflow.utils.db import create_session
 from airflow.utils import timezone
 from airflow.utils.json import AirflowJsonEncoder
+
+try:
+    # cgi.escape has been deprecated since 3.3 and removed in 3.8
+    from html import escape
+except ImportError:
+    # Use cgi.escape for Python 2
+    from cgi import escape  # type: ignore
 
 AUTHENTICATE = configuration.conf.getboolean('webserver', 'AUTHENTICATE')
 

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -23,7 +23,12 @@ from future import standard_library
 standard_library.install_aliases()  # noqa: E402
 from builtins import str, object
 
-from cgi import escape
+try:
+    # cgi.escape has been deprecated since 3.3 and removed in 3.8
+    from html import escape
+except ImportError:
+    # Use cgi.escape for Python 2
+    from cgi import escape
 from io import BytesIO as IO
 import functools
 import gzip


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This fixes a deprecation warning and has no behavior change.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from

### Code Quality

- [x] Passes `flake8`