### PR TITLE
[AIRFLOW-4926] Fix example dags where its start_date is datetime.utcnow()

### DIFF
--- a/airflow/example_dags/docker_copy_data.py
+++ b/airflow/example_dags/docker_copy_data.py
@@ -29,7 +29,7 @@ TODO: Review the workflow, change it accordingly to
 #
 # from airflow import DAG
 # import airflow
-# from datetime import datetime, timedelta
+# from datetime import timedelta
 # from airflow.operators import BashOperator
 # from airflow.operators import ShortCircuitOperator
 # from airflow.operators.docker_operator import DockerOperator
@@ -37,7 +37,7 @@ TODO: Review the workflow, change it accordingly to
 # default_args = {
 #     'owner': 'airflow',
 #     'depends_on_past': False,
-#     'start_date': datetime.utcnow(),
+#     'start_date': airflow.utils.dates.days_ago(2),
 #     'email': ['airflow@example.com'],
 #     'email_on_failure': False,
 #     'email_on_retry': False,

--- a/airflow/example_dags/example_docker_operator.py
+++ b/airflow/example_dags/example_docker_operator.py
@@ -17,15 +17,16 @@
 # specific language governing permissions and limitations
 # under the License.
 """
+import airflow
 from airflow import DAG
 from airflow.operators import BashOperator
-from datetime import datetime, timedelta
+from datetime import timedelta
 from airflow.operators.docker_operator import DockerOperator
 
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': datetime.utcnow(),
+    'start_date': airflow.utils.dates.days_ago(2),
     'email': ['airflow@example.com'],
     'email_on_failure': False,
     'email_on_retry': False,

--- a/airflow/example_dags/example_trigger_controller_dag.py
+++ b/airflow/example_dags/example_trigger_controller_dag.py
@@ -34,8 +34,8 @@ This example illustrates the following features :
 """
 
 import pprint
-from datetime import datetime
 
+import airflow
 from airflow import DAG
 from airflow.operators.dagrun_operator import TriggerDagRunOperator
 
@@ -58,7 +58,7 @@ dag = DAG(
     dag_id='example_trigger_controller_dag',
     default_args={
         "owner": "airflow",
-        "start_date": datetime.utcnow(),
+        "start_date": airflow.utils.dates.days_ago(2),
     },
     schedule_interval='@once',
 )

--- a/airflow/example_dags/example_trigger_target_dag.py
+++ b/airflow/example_dags/example_trigger_target_dag.py
@@ -37,8 +37,8 @@ This example illustrates the following features :
 """
 
 import pprint
-from datetime import datetime
 
+import airflow
 from airflow.models import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
@@ -46,7 +46,7 @@ from airflow.operators.python_operator import PythonOperator
 pp = pprint.PrettyPrinter(indent=4)
 
 args = {
-    'start_date': datetime.utcnow(),
+    'start_date': airflow.utils.dates.days_ago(2),
     'owner': 'airflow',
 }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4926
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Example dags with datetime.utcnow() start_date do not run tasks.

The solution is to change the start_date to a date where a period (execution_date + schedule_interval) can end.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
