### PR TITLE
[AIRFLOW-4919] DataProcJobBaseOperator dataproc_properties templated

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -622,7 +622,7 @@ class DataProcJobBaseOperator(BaseOperator):
     :param cluster_name: The name of the DataProc cluster.
     :type cluster_name: str
     :param dataproc_properties: Map for the Hive properties. Ideal to put in
-        default arguments
+        default arguments (templated)
     :type dataproc_properties: dict
     :param dataproc_jars: HCFS URIs of jar files to add to the CLASSPATH of the Hive server and Hadoop
         MapReduce (MR) tasks. Can contain Hive SerDes and UDFs. (templated)
@@ -747,7 +747,7 @@ class DataProcPigOperator(DataProcJobBaseOperator):
     :type variables: dict
     """
     template_fields = ['query', 'variables', 'job_name', 'cluster_name',
-                       'region', 'dataproc_jars']
+                       'region', 'dataproc_jars', 'dataproc_properties']
     template_ext = ('.pg', '.pig',)
     ui_color = '#0273d4'
     job_type = 'pigJob'
@@ -790,7 +790,7 @@ class DataProcHiveOperator(DataProcJobBaseOperator):
     :type variables: dict
     """
     template_fields = ['query', 'variables', 'job_name', 'cluster_name',
-                       'region', 'dataproc_jars']
+                       'region', 'dataproc_jars', 'dataproc_properties']
     template_ext = ('.q',)
     ui_color = '#0273d4'
     job_type = 'hiveJob'
@@ -831,7 +831,8 @@ class DataProcSparkSqlOperator(DataProcJobBaseOperator):
     :param variables: Map of named parameters for the query. (templated)
     :type variables: dict
     """
-    template_fields = ['query', 'variables', 'job_name', 'cluster_name', 'region', 'dataproc_jars']
+    template_fields = ['query', 'variables', 'job_name','cluster_name',
+                       'region', 'dataproc_jars', 'dataproc_properties']
     template_ext = ('.q',)
     ui_color = '#0273d4'
     job_type = 'sparkSqlJob'
@@ -880,7 +881,8 @@ class DataProcSparkOperator(DataProcJobBaseOperator):
     :type files: list
     """
 
-    template_fields = ['arguments', 'job_name', 'cluster_name', 'region', 'dataproc_jars']
+    template_fields = ['arguments', 'job_name', 'cluster_name',
+                       'region', 'dataproc_jars', 'dataproc_properties']
     ui_color = '#0273d4'
     job_type = 'sparkJob'
 
@@ -931,7 +933,8 @@ class DataProcHadoopOperator(DataProcJobBaseOperator):
     :type files: list
     """
 
-    template_fields = ['arguments', 'job_name', 'cluster_name', 'region', 'dataproc_jars']
+    template_fields = ['arguments', 'job_name', 'cluster_name',
+                       'region', 'dataproc_jars', 'dataproc_properties']
     ui_color = '#0273d4'
     job_type = 'hadoopJob'
 
@@ -982,7 +985,8 @@ class DataProcPySparkOperator(DataProcJobBaseOperator):
     :type pyfiles: list
     """
 
-    template_fields = ['arguments', 'job_name', 'cluster_name', 'region', 'dataproc_jars']
+    template_fields = ['arguments', 'job_name', 'cluster_name',
+                       'region', 'dataproc_jars', 'dataproc_properties']
     ui_color = '#0273d4'
     job_type = 'pysparkJob'
 

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -831,7 +831,7 @@ class DataProcSparkSqlOperator(DataProcJobBaseOperator):
     :param variables: Map of named parameters for the query. (templated)
     :type variables: dict
     """
-    template_fields = ['query', 'variables', 'job_name','cluster_name',
+    template_fields = ['query', 'variables', 'job_name', 'cluster_name',
                        'region', 'dataproc_jars', 'dataproc_properties']
     template_ext = ('.q',)
     ui_color = '#0273d4'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

https://issues.apache.org/jira/browse/AIRFLOW-4919

### Description

Modifying dataproc_properties to be templated.
Due to https://github.com/apache/airflow/pull/5250 this change is valid only for Master.

A PR against V1.10-test https://github.com/apache/airflow/pull/5555