### PR TITLE
[AIRFLOW-4136] fix key_file of SSHHook to be overwritten by connection

### DIFF
--- a/airflow/contrib/hooks/ssh_hook.py
+++ b/airflow/contrib/hooks/ssh_hook.py
@@ -98,7 +98,7 @@ class SSHHook(BaseHook):
                 self.port = conn.port
             if conn.extra is not None:
                 extra_options = conn.extra_dejson
-                if "key_file" in extra_options:
+                if "key_file" in extra_options and self.key_file is None:
                     self.key_file = extra_options.get("key_file")
 
                 if "timeout" in extra_options:


### PR DESCRIPTION
Prevent overwrite of key_file by connection if parameter was provided to SSHHook

Make sure you have checked _all_ steps below.

### Jira

https://issues.apache.org/jira/browse/AIRFLOW-4136

### Description

Prevent overwrite of key_file by connection if parameter was provided to SSHHook
https://github.com/apache/airflow/pull/5155 did not solve this issue in the ticket.
This PR fix the issue.

### Tests