### PR TITLE
[AIRFLOW-4289] fix spark_binary argument being ignored in SparkSubmit…

### DIFF
--- a/airflow/contrib/hooks/spark_submit_hook.py
+++ b/airflow/contrib/hooks/spark_submit_hook.py
@@ -114,7 +114,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                  application_args=None,
                  env_vars=None,
                  verbose=False,
-                 spark_binary="spark-submit"):
+                 spark_binary=None):
         self._conf = conf
         self._conn_id = conn_id
         self._files = files
@@ -170,7 +170,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                      'queue': None,
                      'deploy_mode': None,
                      'spark_home': None,
-                     'spark_binary': self._spark_binary,
+                     'spark_binary': self._spark_binary or "spark-submit",
                      'namespace': 'default'}
 
         try:
@@ -187,7 +187,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             conn_data['queue'] = extra.get('queue', None)
             conn_data['deploy_mode'] = extra.get('deploy-mode', None)
             conn_data['spark_home'] = extra.get('spark-home', None)
-            conn_data['spark_binary'] = extra.get('spark-binary', "spark-submit")
+            conn_data['spark_binary'] = self._spark_binary or  \
+                extra.get('spark-binary', "spark-submit")
             conn_data['namespace'] = extra.get('namespace', 'default')
         except AirflowException:
             self.log.info(

--- a/tests/contrib/hooks/test_spark_submit_hook.py
+++ b/tests/contrib/hooks/test_spark_submit_hook.py
@@ -380,6 +380,43 @@ class TestSparkSubmitHook(unittest.TestCase):
         self.assertEqual(connection, expected_spark_connection)
         self.assertEqual(cmd[0], 'custom-spark-submit')
 
+    def test_resolve_connection_spark_binary_default_value_override(self):
+        # Given
+        hook = SparkSubmitHook(conn_id='spark_binary_set',
+                               spark_binary='another-custom-spark-submit')
+
+        # When
+        connection = hook._resolve_connection()
+        cmd = hook._build_spark_submit_command(self._spark_job_file)
+
+        # Then
+        expected_spark_connection = {"master": "yarn",
+                                     "spark_binary": "another-custom-spark-submit",
+                                     "deploy_mode": None,
+                                     "queue": None,
+                                     "spark_home": None,
+                                     "namespace": 'default'}
+        self.assertEqual(connection, expected_spark_connection)
+        self.assertEqual(cmd[0], 'another-custom-spark-submit')
+
+    def test_resolve_connection_spark_binary_default_value(self):
+        # Given
+        hook = SparkSubmitHook(conn_id='spark_default')
+
+        # When
+        connection = hook._resolve_connection()
+        cmd = hook._build_spark_submit_command(self._spark_job_file)
+
+        # Then
+        expected_spark_connection = {"master": "yarn",
+                                     "spark_binary": "spark-submit",
+                                     "deploy_mode": None,
+                                     "queue": 'root.default',
+                                     "spark_home": None,
+                                     "namespace": 'default'}
+        self.assertEqual(connection, expected_spark_connection)
+        self.assertEqual(cmd[0], 'spark-submit')
+
     def test_resolve_connection_spark_binary_and_home_set_connection(self):
         # Given
         hook = SparkSubmitHook(conn_id='spark_binary_and_home_set')


### PR DESCRIPTION
…Hook

### Jira

https://issues.apache.org/jira/browse/AIRFLOW-4289

### Description

Fix bug where the spark_binary argument in the constructor of SparkSubmitHook was overwritten by spark Connection.
