### PR TITLE
[AIRFLOW-4935] Add method in the bigquery hook to list tables in a dataset

### DIFF
--- a/airflow/gcp/hooks/bigquery.py
+++ b/airflow/gcp/hooks/bigquery.py
@@ -1829,6 +1829,69 @@ class BigQueryBaseCursor(LoggingMixin):
 
         return datasets_list
 
+    @GoogleCloudBaseHook.catch_http_exception
+    def get_dataset_tables_list(self, dataset_id, project_id=None, table_prefix=None, max_results=None):
+        """
+        Method returns tables list of a BigQuery dataset. If table prefix is specified,
+        only tables beginning by it are returned.
+
+        .. seealso::
+            For more information, see:
+            https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/list
+
+        :param dataset_id: The BigQuery Dataset ID
+        :type dataset_id: str
+        :param project_id: The GCP Project ID
+        :type project_id: str
+        :param table_prefix: Tables must begin by this prefix to be returned (case sensitive)
+        :type table_prefix: str
+        :param max_results: The maximum number of results to return in a single response page.
+            Leverage the page tokens to iterate through the entire collection.
+        :type max_results: int
+        :return: dataset_tables_list
+
+            Example of returned dataset_tables_list: ::
+
+                    [
+                       {
+                          "projectId": "your-project",
+                          "datasetId": "dataset",
+                          "tableId": "table1"
+                        },
+                        {
+                          "projectId": "your-project",
+                          "datasetId": "dataset",
+                          "tableId": "table2"
+                        }
+                    ]
+        """
+
+        dataset_project_id = project_id if project_id else self.project_id
+
+        optional_params = {}
+        if max_results:
+            optional_params['maxResults'] = max_results
+
+        request = self.service.tables().list(projectId=dataset_project_id,
+                                             datasetId=dataset_id,
+                                             **optional_params)
+        dataset_tables_list = []
+        while request is not None:
+            response = request.execute(num_retries=self.num_retries)
+
+            for table in response.get('tables', []):
+                table_ref = table.get('tableReference')
+                table_id = table_ref.get('tableId')
+                if table_id and (not table_prefix or table_id.startswith(table_prefix)):
+                    dataset_tables_list.append(table_ref)
+
+            request = self.service.tables().list_next(previous_request=request,
+                                                      previous_response=response)
+
+        self.log.info("%s tables found", len(dataset_tables_list))
+
+        return dataset_tables_list
+
     def patch_dataset(self, dataset_id: str, dataset_resource: str, project_id: Optional[str] = None) -> Dict:
         """
         Patches information in an existing dataset.

--- a/tests/gcp/hooks/test_bigquery.py
+++ b/tests/gcp/hooks/test_bigquery.py
@@ -820,6 +820,73 @@ class TestDatasetsOperations(unittest.TestCase):
                 project_id=project_id)
             self.assertEqual(result, expected_result['datasets'])
 
+    def test_get_dataset_tables_list(self):
+        tables_list_result = [
+            {
+                "tableReference": {
+                    "projectId": "project_test",
+                    "datasetId": "dataset_test",
+                    "tableId": "first_table"
+                }
+            },
+            {
+                "tableReference": {
+                    "projectId": "project_test",
+                    "datasetId": "dataset_test",
+                    "tableId": "second_table"
+                }
+            }
+        ]
+
+        project_id = "project_test"
+        dataset_id = "dataset_test"
+        table_prefix = "second"
+
+        expected_result = [table['tableReference'] for table in tables_list_result
+                           if table['tableReference']['tableId'].startswith(table_prefix)]
+
+        mock_service = mock.Mock()
+        cursor = hook.BigQueryBaseCursor(mock_service, project_id)
+        mock_service.tables.return_value.list.return_value.execute.return_value = {
+            'tables': tables_list_result}
+        mock_service.tables.return_value.list_next.return_value = None
+
+        result = cursor.get_dataset_tables_list(project_id=project_id,
+                                                dataset_id=dataset_id,
+                                                table_prefix=table_prefix)
+
+        self.assertEqual(result, expected_result)
+
+    def test_get_dataset_tables_list_multiple_pages(self):
+        table = {
+            "tableReference": {
+                "projectId": "project_test",
+                "datasetId": "dataset_test",
+                "tableId": "table_test"
+            }
+        }
+        expected_result = [table['tableReference']] * 4
+        project_id = "project_test"
+        dataset_id = "dataset_test"
+
+        pages_requests = [
+            mock.Mock(**{'execute.return_value': {"tables": [table]}})
+            for _ in range(4)
+        ]
+        tables_mock = mock.Mock(
+            **{'list.return_value': pages_requests[1],
+               'list_next.side_effect': pages_requests[1:] + [None]}
+        )
+
+        mock_service = mock.Mock()
+        cursor = hook.BigQueryBaseCursor(mock_service, project_id)
+        mock_service.tables.return_value = tables_mock
+
+        result = cursor.get_dataset_tables_list(project_id=project_id,
+                                                dataset_id=dataset_id)
+
+        self.assertEqual(result, expected_result)
+
     def test_delete_dataset(self):
         project_id = 'bq-project'
         dataset_id = 'bq_dataset'


### PR DESCRIPTION
Method `get_dataset_tables_list` added in the hook, permits to use a table prefix too.