### PR TITLE
[AIRFLOW-4931] Add KMS Encryption Configuration to BigQuery Hook and Operators

### DIFF
--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -125,6 +125,13 @@ class BigQueryOperator(BaseOperator):
         US and EU. See details at
         https://cloud.google.com/bigquery/docs/locations#specifying_your_location
     :type location: str
+    :param encryption_configuration: [Optional] Custom encryption configuration (e.g., Cloud KMS keys).
+        **Example**: ::
+
+            encryption_configuration = {
+                "kmsKeyName": "projects/testp/locations/us/keyRings/test-kr/cryptoKeys/test-key"
+            }
+    :type encryption_configuration: dict
     """
 
     template_fields = ('sql', 'destination_dataset_table', 'labels')
@@ -135,7 +142,7 @@ class BigQueryOperator(BaseOperator):
         BigQueryConsoleLink(),
     )
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, too-many-locals
     @apply_defaults
     def __init__(self,
                  sql: Union[str, Iterable],
@@ -158,6 +165,7 @@ class BigQueryOperator(BaseOperator):
                  api_resource_configs: Optional[dict] = None,
                  cluster_fields: Optional[List[str]] = None,
                  location: Optional[str] = None,
+                 encryption_configuration=None,
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
@@ -182,6 +190,7 @@ class BigQueryOperator(BaseOperator):
         self.api_resource_configs = api_resource_configs
         self.cluster_fields = cluster_fields
         self.location = location
+        self.encryption_configuration = encryption_configuration
 
     def execute(self, context):
         if self.bq_cursor is None:
@@ -212,6 +221,7 @@ class BigQueryOperator(BaseOperator):
                 time_partitioning=self.time_partitioning,
                 api_resource_configs=self.api_resource_configs,
                 cluster_fields=self.cluster_fields,
+                encryption_configuration=self.encryption_configuration
             )
         elif isinstance(self.sql, Iterable):
             job_id = [
@@ -232,6 +242,7 @@ class BigQueryOperator(BaseOperator):
                     time_partitioning=self.time_partitioning,
                     api_resource_configs=self.api_resource_configs,
                     cluster_fields=self.cluster_fields,
+                    encryption_configuration=self.encryption_configuration
                 )
                 for s in self.sql]
         else:
@@ -333,7 +344,13 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
                 google_cloud_storage_conn_id='airflow-service-account'
             )
     :type labels: dict
+    :param encryption_configuration: [Optional] Custom encryption configuration (e.g., Cloud KMS keys).
+        **Example**: ::
 
+            encryption_configuration = {
+                "kmsKeyName": "projects/testp/locations/us/keyRings/test-kr/cryptoKeys/test-key"
+            }
+    :type encryption_configuration: dict
     """
     template_fields = ('dataset_id', 'table_id', 'project_id',
                        'gcs_schema_object', 'labels')
@@ -352,6 +369,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
                  google_cloud_storage_conn_id='google_cloud_default',
                  delegate_to=None,
                  labels=None,
+                 encryption_configuration=None,
                  *args, **kwargs):
 
         super().__init__(*args, **kwargs)
@@ -366,6 +384,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         self.delegate_to = delegate_to
         self.time_partitioning = {} if time_partitioning is None else time_partitioning
         self.labels = labels
+        self.encryption_configuration = encryption_configuration
 
     def execute(self, context):
         bq_hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
@@ -393,7 +412,8 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
             table_id=self.table_id,
             schema_fields=schema_fields,
             time_partitioning=self.time_partitioning,
-            labels=self.labels
+            labels=self.labels,
+            encryption_configuration=self.encryption_configuration
         )
 
 
@@ -469,6 +489,13 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
     :type src_fmt_configs: dict
     :param labels: a dictionary containing labels for the table, passed to BigQuery
     :type labels: dict
+    :param encryption_configuration: [Optional] Custom encryption configuration (e.g., Cloud KMS keys).
+        **Example**: ::
+
+            encryption_configuration = {
+                "kmsKeyName": "projects/testp/locations/us/keyRings/test-kr/cryptoKeys/test-key"
+            }
+    :type encryption_configuration: dict
     """
     template_fields = ('bucket', 'source_objects',
                        'schema_object', 'destination_project_dataset_table', 'labels')
@@ -495,6 +522,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
                  delegate_to=None,
                  src_fmt_configs=None,
                  labels=None,
+                 encryption_configuration=None,
                  *args, **kwargs):
 
         super().__init__(*args, **kwargs)
@@ -522,6 +550,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
 
         self.src_fmt_configs = src_fmt_configs if src_fmt_configs is not None else dict()
         self.labels = labels
+        self.encryption_configuration = encryption_configuration
 
     def execute(self, context):
         bq_hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
@@ -556,7 +585,8 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
             allow_quoted_newlines=self.allow_quoted_newlines,
             allow_jagged_rows=self.allow_jagged_rows,
             src_fmt_configs=self.src_fmt_configs,
-            labels=self.labels
+            labels=self.labels,
+            encryption_configuration=self.encryption_configuration
         )
 
 

--- a/airflow/contrib/operators/bigquery_to_bigquery.py
+++ b/airflow/contrib/operators/bigquery_to_bigquery.py
@@ -55,6 +55,13 @@ class BigQueryToBigQueryOperator(BaseOperator):
     :param labels: a dictionary containing labels for the job/query,
         passed to BigQuery
     :type labels: dict
+    :param encryption_configuration: [Optional] Custom encryption configuration (e.g., Cloud KMS keys).
+        **Example**: ::
+
+            encryption_configuration = {
+                "kmsKeyName": "projects/testp/locations/us/keyRings/test-kr/cryptoKeys/test-key"
+            }
+    :type encryption_configuration: dict
     """
     template_fields = ('source_project_dataset_tables',
                        'destination_project_dataset_table', 'labels')
@@ -70,6 +77,7 @@ class BigQueryToBigQueryOperator(BaseOperator):
                  bigquery_conn_id='google_cloud_default',
                  delegate_to=None,
                  labels=None,
+                 encryption_configuration=None,
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
@@ -80,6 +88,7 @@ class BigQueryToBigQueryOperator(BaseOperator):
         self.bigquery_conn_id = bigquery_conn_id
         self.delegate_to = delegate_to
         self.labels = labels
+        self.encryption_configuration = encryption_configuration
 
     def execute(self, context):
         self.log.info(
@@ -95,4 +104,5 @@ class BigQueryToBigQueryOperator(BaseOperator):
             destination_project_dataset_table=self.destination_project_dataset_table,
             write_disposition=self.write_disposition,
             create_disposition=self.create_disposition,
-            labels=self.labels)
+            labels=self.labels,
+            encryption_configuration=self.encryption_configuration)

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -136,6 +136,13 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         Parameter must be setted to True if 'schema_fields' and 'schema_object' are undefined.
         It is suggested to set to True if table are create outside of Airflow.
     :type autodetect: bool
+    :param encryption_configuration: [Optional] Custom encryption configuration (e.g., Cloud KMS keys).
+        **Example**: ::
+
+            encryption_configuration = {
+                "kmsKeyName": "projects/testp/locations/us/keyRings/test-kr/cryptoKeys/test-key"
+            }
+    :type encryption_configuration: dict
     """
     template_fields = ('bucket', 'source_objects',
                        'schema_object', 'destination_project_dataset_table')
@@ -171,6 +178,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                  time_partitioning=None,
                  cluster_fields=None,
                  autodetect=False,
+                 encryption_configuration=None,
                  *args, **kwargs):
 
         super().__init__(*args, **kwargs)
@@ -210,6 +218,7 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         self.time_partitioning = time_partitioning
         self.cluster_fields = cluster_fields
         self.autodetect = autodetect
+        self.encryption_configuration = encryption_configuration
 
     def execute(self, context):
         bq_hook = BigQueryHook(bigquery_conn_id=self.bigquery_conn_id,
@@ -251,7 +260,8 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                 ignore_unknown_values=self.ignore_unknown_values,
                 allow_quoted_newlines=self.allow_quoted_newlines,
                 allow_jagged_rows=self.allow_jagged_rows,
-                src_fmt_configs=self.src_fmt_configs
+                src_fmt_configs=self.src_fmt_configs,
+                encryption_configuration=self.encryption_configuration
             )
         else:
             cursor.run_load(
@@ -272,7 +282,8 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
                 schema_update_options=self.schema_update_options,
                 src_fmt_configs=self.src_fmt_configs,
                 time_partitioning=self.time_partitioning,
-                cluster_fields=self.cluster_fields)
+                cluster_fields=self.cluster_fields,
+                encryption_configuration=self.encryption_configuration)
 
         if self.max_id_key:
             cursor.execute('SELECT MAX({}) FROM {}'.format(

--- a/tests/contrib/operators/test_bigquery_operator.py
+++ b/tests/contrib/operators/test_bigquery_operator.py
@@ -68,7 +68,8 @@ class BigQueryCreateEmptyTableOperatorTest(unittest.TestCase):
                 table_id=TEST_TABLE_ID,
                 schema_fields=None,
                 time_partitioning={},
-                labels=None
+                labels=None,
+                encryption_configuration=None
             )
 
 
@@ -108,7 +109,8 @@ class BigQueryCreateExternalTableOperatorTest(unittest.TestCase):
                 allow_quoted_newlines=False,
                 allow_jagged_rows=False,
                 src_fmt_configs={},
-                labels=None
+                labels=None,
+                encryption_configuration=None
             )
 
 
@@ -171,6 +173,8 @@ class BigQueryOperatorTest(unittest.TestCase):
 
     @mock.patch('airflow.contrib.operators.bigquery_operator.BigQueryHook')
     def test_execute(self, mock_hook):
+        encryption_configuration = {'key': 'kk'}
+
         operator = BigQueryOperator(
             task_id=TASK_ID,
             sql='Select * from test_table',
@@ -191,6 +195,7 @@ class BigQueryOperatorTest(unittest.TestCase):
             time_partitioning=None,
             api_resource_configs=None,
             cluster_fields=None,
+            encryption_configuration=encryption_configuration
         )
 
         operator.execute(MagicMock())
@@ -215,6 +220,7 @@ class BigQueryOperatorTest(unittest.TestCase):
                 time_partitioning=None,
                 api_resource_configs=None,
                 cluster_fields=None,
+                encryption_configuration=encryption_configuration
             )
 
     @mock.patch('airflow.contrib.operators.bigquery_operator.BigQueryHook')
@@ -242,6 +248,7 @@ class BigQueryOperatorTest(unittest.TestCase):
             time_partitioning=None,
             api_resource_configs=None,
             cluster_fields=None,
+            encryption_configuration=None,
         )
 
         operator.execute(MagicMock())
@@ -267,6 +274,7 @@ class BigQueryOperatorTest(unittest.TestCase):
                     time_partitioning=None,
                     api_resource_configs=None,
                     cluster_fields=None,
+                    encryption_configuration=None,
                 ),
                 mock.call(
                     sql='Select * from other_test_table',
@@ -285,6 +293,7 @@ class BigQueryOperatorTest(unittest.TestCase):
                     time_partitioning=None,
                     api_resource_configs=None,
                     cluster_fields=None,
+                    encryption_configuration=None,
                 ),
             ])
 
@@ -346,6 +355,7 @@ class BigQueryOperatorTest(unittest.TestCase):
                 time_partitioning=None,
                 api_resource_configs=None,
                 cluster_fields=None,
+                encryption_configuration=None
             )
 
         self.assertTrue(isinstance(operator.sql, str))
@@ -440,6 +450,7 @@ class BigQueryToBigQueryOperatorTest(unittest.TestCase):
         write_disposition = 'WRITE_EMPTY'
         create_disposition = 'CREATE_IF_NEEDED'
         labels = {'k1': 'v1'}
+        encryption_configuration = {'key': 'kk'}
 
         operator = BigQueryToBigQueryOperator(
             task_id=TASK_ID,
@@ -447,7 +458,8 @@ class BigQueryToBigQueryOperatorTest(unittest.TestCase):
             destination_project_dataset_table=destination_project_dataset_table,
             write_disposition=write_disposition,
             create_disposition=create_disposition,
-            labels=labels
+            labels=labels,
+            encryption_configuration=encryption_configuration
         )
 
         operator.execute(None)
@@ -460,7 +472,8 @@ class BigQueryToBigQueryOperatorTest(unittest.TestCase):
                 destination_project_dataset_table=destination_project_dataset_table,
                 write_disposition=write_disposition,
                 create_disposition=create_disposition,
-                labels=labels
+                labels=labels,
+                encryption_configuration=encryption_configuration
             )
 
 


### PR DESCRIPTION
Add Encryption Configuration, e.g. KMS, to BigQuery Hook and Operators

BigQueryHook:
- create_empty_table()
- create_external_table()
- patch_table()
- run_query()
- run_load()
- run_copy()

BigQueryOperator
BigQueryCreateEmptyTableOperator
BigQueryCreateExternalTableOperator
BigQueryToBigQueryOperator
GoogleCloudStorageToBigQueryOperator

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow-4931](https://issues.apache.org/jira/browse/AIRFLOW-4931) issues and references them in the PR title. 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
test_bigquery_hook.py:TestBigQueryWithKMS
test_bigquery_operator.py:BigQueryCreateEmptyTableOperatorTest
test_bigquery_operator.py:BigQueryOperatorTest
test_bigquery_operator.py:BigQueryToBigQueryOperatorTest

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
