### PR TITLE
[AIRFLOW-4939] Add default_task_retries config

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -196,6 +196,9 @@ worker_precheck = False
 # When discovering DAGs, ignore any files that don't contain the strings `DAG` and `airflow`.
 dag_discovery_safe_mode = True
 
+# The number of retries each task is going to have by default. Can be overridden at dag or task level.
+default_task_retries = 0
+
 
 [cli]
 # In what way should the cli access the API. The LocalClient will use the

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -51,6 +51,7 @@ killed_task_cleanup_time = 5
 secure_mode = False
 hostname_callable = socket:getfqdn
 worker_precheck = False
+default_task_retries = 0
 
 [cli]
 api_client = airflow.api.client.local_client

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -266,7 +266,7 @@ class BaseOperator(LoggingMixin):
         email: Optional[str] = None,
         email_on_retry: bool = True,
         email_on_failure: bool = True,
-        retries: int = 0,
+        retries: int = None,
         retry_delay: timedelta = timedelta(seconds=300),
         retry_exponential_backoff: bool = False,
         max_retry_delay: Optional[datetime] = None,
@@ -348,7 +348,8 @@ class BaseOperator(LoggingMixin):
                 self
             )
         self._schedule_interval = schedule_interval
-        self.retries = retries
+        self.retries = retries if retries is not None else \
+            configuration.conf.getint('core', 'default_task_retries', fallback=0)
         self.queue = queue
         self.pool = pool
         self.sla = sla
@@ -356,6 +357,7 @@ class BaseOperator(LoggingMixin):
         self.on_failure_callback = on_failure_callback
         self.on_success_callback = on_success_callback
         self.on_retry_callback = on_retry_callback
+
         if isinstance(retry_delay, timedelta):
             self.retry_delay = retry_delay
         else:

--- a/tests/operators/test_bash_operator.py
+++ b/tests/operators/test_bash_operator.py
@@ -21,8 +21,9 @@ import os
 import unittest
 from datetime import datetime, timedelta
 from tempfile import NamedTemporaryFile
+from tests.compat import mock
 
-from airflow import DAG
+from airflow import DAG, configuration
 from airflow.operators.bash_operator import BashOperator
 from airflow.utils import timezone
 from airflow.utils.state import State
@@ -98,3 +99,23 @@ class BashOperatorTest(unittest.TestCase):
         return_value = bash_operator.execute(context={})
 
         self.assertEqual(return_value, 'stdout')
+
+    def test_task_retries(self):
+        bash_operator = BashOperator(
+            bash_command='echo "stdout"',
+            task_id='test_task_retries',
+            retries=2,
+            dag=None
+        )
+
+        self.assertEqual(bash_operator.retries, 2)
+
+    @mock.patch.object(configuration.conf, 'getint', return_value=3)
+    def test_default_retries(self, mock_config):
+        bash_operator = BashOperator(
+            bash_command='echo "stdout"',
+            task_id='test_default_retries',
+            dag=None
+        )
+
+        self.assertEqual(bash_operator.retries, 3)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issue
  - https://issues.apache.org/jira/browse/AIRFLOW-4939

### Description

- [x] Adding a config level support to specify default task retries, which can be overridden at dag or task level. 

### Tests

- [x] My PR adds relevant unit test cases.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
