### PR TITLE
[AIRFLOW-4943] Replace six assertion method with native

### DIFF
--- a/tests/contrib/hooks/test_gcp_cloud_build_hook.py
+++ b/tests/contrib/hooks/test_gcp_cloud_build_hook.py
@@ -22,8 +22,6 @@ Tests for Google Cloud Build Hook
 import unittest
 from unittest import mock
 
-import six
-
 from airflow import AirflowException
 from airflow.contrib.hooks.gcp_cloud_build_hook import CloudBuildHook
 from tests.contrib.utils.base_gcp_mock import (
@@ -116,7 +114,7 @@ class TestCloudBuildHookWithPassedProjectId(unittest.TestCase):
 
         execute_mock = mock.Mock(**{"side_effect": [TEST_WAITING_OPERATION, TEST_ERROR_OPERATION]})
         service_mock.operations.return_value.get.return_value.execute = execute_mock
-        with six.assertRaisesRegex(self, AirflowException, "error"):
+        with self.assertRaisesRegex(AirflowException, "error"):
             self.hook.create_build(body={})
 
 
@@ -185,7 +183,7 @@ class TestGcpComputeHookWithDefaultProjectIdFromConnection(unittest.TestCase):
 
         execute_mock = mock.Mock(**{"side_effect": [TEST_WAITING_OPERATION, TEST_ERROR_OPERATION]})
         service_mock.operations.return_value.get.return_value.execute = execute_mock
-        with six.assertRaisesRegex(self, AirflowException, "error"):
+        with self.assertRaisesRegex(AirflowException, "error"):
             self.hook.create_build(body={})
 
 

--- a/tests/contrib/hooks/test_gcp_transfer_hook.py
+++ b/tests/contrib/hooks/test_gcp_transfer_hook.py
@@ -21,7 +21,6 @@ import json
 import unittest
 from copy import deepcopy
 
-import six
 from parameterized import parameterized
 
 from airflow import AirflowException
@@ -267,8 +266,8 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         }
 
         get_conn.return_value.transferOperations.return_value.list_next.return_value = None
-        with six.assertRaisesRegex(
-            self, AirflowException, "An unexpected operation status was encountered. Expected: SUCCESS"
+        with self.assertRaisesRegex(
+            AirflowException, "An unexpected operation status was encountered. Expected: SUCCESS"
         ):
             self.gct_hook.wait_for_transfer_job(
                 job={PROJECT_ID: 'test-project', NAME: 'transferJobs/test-job'},
@@ -300,8 +299,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
     def test_operations_contain_expected_statuses_red_path(self, statuses, expected_statuses):
         operations = [{NAME: TEST_TRANSFER_OPERATION_NAME, METADATA: {STATUS: status}} for status in statuses]
 
-        with six.assertRaisesRegex(
-            self,
+        with self.assertRaisesRegex(
             AirflowException,
             "An unexpected operation status was encountered. Expected: {}".format(
                 ", ".join(expected_statuses)

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -17,9 +17,9 @@
 # specific language governing permissions and limitations
 # under the License.
 import io
-import tempfile
 import os
-import six
+import tempfile
+import unittest
 
 from google.cloud import storage
 from google.cloud import exceptions
@@ -28,12 +28,6 @@ from airflow.contrib.hooks import gcs_hook
 from airflow.exceptions import AirflowException
 from tests.compat import mock
 from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
-
-if six.PY2:
-    # Need `assertWarns` back-ported from unittest2
-    import unittest2 as unittest
-else:
-    import unittest
 
 BASE_STRING = 'airflow.contrib.hooks.gcp_api_base_hook.{}'
 GCS_STRING = 'airflow.contrib.hooks.gcs_hook.{}'

--- a/tests/contrib/operators/test_gcp_cloud_build_operator.py
+++ b/tests/contrib/operators/test_gcp_cloud_build_operator.py
@@ -21,8 +21,6 @@
 from copy import deepcopy
 from unittest import TestCase
 
-import six
-
 from parameterized import parameterized
 from tests.compat import mock
 
@@ -42,7 +40,7 @@ TEST_PROJECT_ID = "example-id"
 
 class BuildProcessorTestCase(TestCase):
     def test_verify_source(self):
-        with six.assertRaisesRegex(self, AirflowException, "The source could not be determined."):
+        with self.assertRaisesRegex(AirflowException, "The source could not be determined."):
             BuildProcessor(body={"source": {"storageSource": {}, "repoSource": {}}}).process_body()
 
     @parameterized.expand(
@@ -77,7 +75,7 @@ class BuildProcessorTestCase(TestCase):
     )
     def test_convert_repo_url_to_storage_dict_invalid(self, url):
         body = {"source": {"repoSource": url}}
-        with six.assertRaisesRegex(self, AirflowException, "Invalid URL."):
+        with self.assertRaisesRegex(AirflowException, "Invalid URL."):
             BuildProcessor(body=body).process_body()
 
     @parameterized.expand(
@@ -102,7 +100,7 @@ class BuildProcessorTestCase(TestCase):
     )
     def test_convert_storage_url_to_dict_invalid(self, url):
         body = {"source": {"storageSource": url}}
-        with six.assertRaisesRegex(self, AirflowException, "Invalid URL."):
+        with self.assertRaisesRegex(AirflowException, "Invalid URL."):
             BuildProcessor(body=body).process_body()
 
     @parameterized.expand([("storageSource",), ("repoSource",)])
@@ -128,7 +126,7 @@ class GcpCloudBuildCreateBuildOperatorTestCase(TestCase):
 
     @parameterized.expand([({},), (None,)])
     def test_missing_input(self, body):
-        with six.assertRaisesRegex(self, AirflowException, "The required parameter 'body' is missing"):
+        with self.assertRaisesRegex(AirflowException, "The required parameter 'body' is missing"):
             CloudBuildCreateBuildOperator(body=body, project_id=TEST_PROJECT_ID, task_id="task-id")
 
     @mock.patch(  # type: ignore

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -807,7 +807,7 @@ class SchedulerJobTest(unittest.TestCase):
         )
         self.assertEqual(State.RUNNING, ti1.state)
         self.assertEqual(State.RUNNING, ti2.state)
-        six.assertCountEqual(self, [State.QUEUED, State.SCHEDULED], [ti3.state, ti4.state])
+        self.assertCountEqual([State.QUEUED, State.SCHEDULED], [ti3.state, ti4.state])
         self.assertEqual(1, res)
 
     def test_execute_task_instances_limit(self):

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -26,7 +26,6 @@ import unittest
 from datetime import datetime
 
 import psutil
-import six
 
 from airflow import DAG
 from airflow.utils import helpers
@@ -247,7 +246,7 @@ class HelpersTest(unittest.TestCase):
         helpers.cross_downstream(from_tasks=start_tasks, to_tasks=end_tasks)
 
         for start_task in start_tasks:
-            six.assertCountEqual(self, start_task.get_direct_relatives(upstream=False), end_tasks)
+            self.assertCountEqual(start_task.get_direct_relatives(upstream=False), end_tasks)
 
     def test_chain(self):
         dag = DAG(dag_id='test_chain', start_date=datetime.now())

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -21,7 +21,6 @@ import logging
 import logging.config
 import os
 import unittest
-import six
 
 from airflow.models import TaskInstance, DAG, DagRun
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
@@ -107,8 +106,7 @@ class TestFileTaskLogHandler(unittest.TestCase):
 
         # We should expect our log line from the callable above to appear in
         # the logs we read back
-        six.assertRegex(
-            self,
+        self.assertRegex(
             logs[0],
             target_re,
             "Logs were " + str(logs)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
