### PR TITLE
[AIRFLOW-4944] Use new types syntax

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -90,7 +90,7 @@ def sigquit_handler(sig, frame):
     e.g. kill -s QUIT <PID> or CTRL+\
     """
     print("Dumping stack traces for all threads in PID {}".format(os.getpid()))
-    id_to_name = dict([(th.ident, th.name) for th in threading.enumerate()])
+    id_to_name = {th.ident: th.name for th in threading.enumerate()}
     code = []
     for thread_id, stack in sys._current_frames().items():
         code.append("\n# Thread: {}({})"

--- a/airflow/contrib/operators/hipchat_operator.py
+++ b/airflow/contrib/operators/hipchat_operator.py
@@ -127,5 +127,5 @@ class HipChatAPISendRoomNotificationOperator(HipChatAPIOperator):
 
         self.method = 'POST'
         self.url = '%s/room/%s/notification' % (self.base_url, self.room_id)
-        self.body = json.dumps(dict(
-            (str(k), str(v)) for k, v in params.items() if v))
+        self.body = json.dumps({
+            str(k): str(v) for k, v in params.items() if v})

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -734,7 +734,7 @@ class HiveMetastoreHook(BaseHook):
         """
         with self.metastore as client:
             table = client.get_table(dbname=schema, tbl_name=table_name)
-            key_name_set = set(key.name for key in table.partitionKeys)
+            key_name_set = {key.name for key in table.partitionKeys}
             if len(table.partitionKeys) == 1:
                 field = table.partitionKeys[0].name
             elif not field:

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -103,7 +103,7 @@ def _build_metrics(func_name, namespace):
     metrics['execution_date'] = tmp_dic.get('execution_date')
     metrics['host_name'] = socket.gethostname()
 
-    extra = json.dumps(dict((k, metrics[k]) for k in ('host_name', 'full_command')))
+    extra = json.dumps({k: metrics[k] for k in ('host_name', 'full_command')})
     log = Log(
         event='cli_{}'.format(func_name),
         task_instance=None,

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -271,7 +271,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
 
         user_perms_views = self.get_all_permissions_views()
         # return a set of all dags that the user could access
-        return set([view for perm, view in user_perms_views if perm in self.DAG_PERMS])
+        return {view for perm, view in user_perms_views if perm in self.DAG_PERMS}
 
     def has_access(self, permission, view_name, user=None):
         """
@@ -426,15 +426,14 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
             .filter(ab_perm_view_role.columns.role_id == user_role.id)\
             .join(view_menu)\
             .filter(perm_view.view_menu_id != dag_vm.id)
-        all_perm_views = set([role.permission_view_id for role in all_perm_view_by_user])
+        all_perm_views = {role.permission_view_id for role in all_perm_view_by_user}
 
         for role in dag_role:
             # Get all the perm-view of the role
             existing_perm_view_by_user = self.get_session.query(ab_perm_view_role)\
                 .filter(ab_perm_view_role.columns.role_id == role.id)
 
-            existing_perms_views = set([pv.permission_view_id
-                                        for pv in existing_perm_view_by_user])
+            existing_perms_views = {pv.permission_view_id for pv in existing_perm_view_by_user}
             missing_perm_views = all_perm_views - existing_perms_views
 
             for perm_view_id in missing_perm_views:

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -420,11 +420,11 @@ class CustomSQLAInterface(SQLAInterface):
 
         def clean_column_names():
             if self.list_properties:
-                self.list_properties = dict(
-                    (k.lstrip('_'), v) for k, v in self.list_properties.items())
+                self.list_properties = {
+                    k.lstrip('_'): v for k, v in self.list_properties.items()}
             if self.list_columns:
-                self.list_columns = dict(
-                    (k.lstrip('_'), v) for k, v in self.list_columns.items())
+                self.list_columns = {
+                    k.lstrip('_'): v for k, v in self.list_columns.items()}
 
         clean_column_names()
 

--- a/tests/contrib/hooks/test_aws_glue_catalog_hook.py
+++ b/tests/contrib/hooks/test_aws_glue_catalog_hook.py
@@ -96,7 +96,7 @@ class TestAwsGlueCatalogHook(unittest.TestCase):
                                      page_size=2,
                                      max_items=3)
 
-        self.assertEqual(result, set([('2015-01-01',)]))
+        self.assertEqual(result, {('2015-01-01',)})
         mock_conn.get_paginator.assert_called_once_with('get_partitions')
         mock_paginator.paginate.assert_called_once_with(DatabaseName='db',
                                                         TableName='tbl',
@@ -108,7 +108,7 @@ class TestAwsGlueCatalogHook(unittest.TestCase):
     @mock_glue
     @mock.patch.object(AwsGlueCatalogHook, 'get_partitions')
     def test_check_for_partition(self, mock_get_partitions):
-        mock_get_partitions.return_value = set([('2018-01-01',)])
+        mock_get_partitions.return_value = {('2018-01-01',)}
         hook = AwsGlueCatalogHook(region_name="us-east-1")
 
         self.assertTrue(hook.check_for_partition('db', 'tbl', 'expr'))

--- a/tests/contrib/hooks/test_gcp_pubsub_hook.py
+++ b/tests/contrib/hooks/test_gcp_pubsub_hook.py
@@ -28,7 +28,7 @@ from tests.compat import mock
 BASE_STRING = 'airflow.contrib.hooks.gcp_api_base_hook.{}'
 PUBSUB_STRING = 'airflow.contrib.hooks.gcp_pubsub_hook.{}'
 
-EMPTY_CONTENT = ''.encode('utf8')
+EMPTY_CONTENT = b''
 TEST_PROJECT = 'test-project'
 TEST_TOPIC = 'test-topic'
 TEST_SUBSCRIPTION = 'test-subscription'

--- a/tests/contrib/hooks/test_gcp_sql_hook.py
+++ b/tests/contrib/hooks/test_gcp_sql_hook.py
@@ -44,7 +44,7 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
     def test_instance_import_exception(self):
         self.cloudsql_hook.get_conn = mock.Mock(
             side_effect=HttpError(resp={'status': '400'},
-                                  content='Error content'.encode('utf-8'))
+                                  content=b'Error content')
         )
         with self.assertRaises(AirflowException) as cm:
             self.cloudsql_hook.import_instance(
@@ -56,7 +56,7 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
     def test_instance_export_exception(self):
         self.cloudsql_hook.get_conn = mock.Mock(
             side_effect=HttpError(resp={'status': '400'},
-                                  content='Error content'.encode('utf-8'))
+                                  content=b'Error content')
         )
         with self.assertRaises(AirflowException) as cm:
             self.cloudsql_hook.export_instance(

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -38,7 +38,7 @@ else:
 BASE_STRING = 'airflow.contrib.hooks.gcp_api_base_hook.{}'
 GCS_STRING = 'airflow.contrib.hooks.gcs_hook.{}'
 
-EMPTY_CONTENT = ''.encode('utf8')
+EMPTY_CONTENT = b''
 PROJECT_ID_TEST = 'project-id'
 
 

--- a/tests/contrib/hooks/test_grpc_hook.py
+++ b/tests/contrib/hooks/test_grpc_hook.py
@@ -215,7 +215,7 @@ class TestGrpcHook(unittest.TestCase):
         channel = hook.get_conn()
         expected_url = "test:8080"
 
-        mock_google_default_auth.assert_called_once_with(scopes=[u"grpc", u"gcs"])
+        mock_google_default_auth.assert_called_once_with(scopes=["grpc", "gcs"])
         mock_secure_channel.assert_called_once_with(
             mock_credential_object,
             "request",

--- a/tests/contrib/operators/test_gcp_compute_operator.py
+++ b/tests/contrib/operators/test_gcp_compute_operator.py
@@ -34,7 +34,7 @@ from airflow.models import TaskInstance, DAG
 from airflow.utils import timezone
 from tests.compat import mock
 
-EMPTY_CONTENT = ''.encode('utf8')
+EMPTY_CONTENT = b''
 
 GCP_PROJECT_ID = 'project-id'
 GCE_ZONE = 'zone'

--- a/tests/contrib/operators/test_gcp_function_operator.py
+++ b/tests/contrib/operators/test_gcp_function_operator.py
@@ -31,7 +31,7 @@ from airflow.version import version
 from tests.compat import mock
 
 
-EMPTY_CONTENT = ''.encode('utf8')
+EMPTY_CONTENT = b''
 MOCK_RESP_404 = type('', (object,), {"status": 404})()
 
 GCP_PROJECT_ID = 'test_project_id'

--- a/tests/contrib/operators/test_s3_to_sftp_operator.py
+++ b/tests/contrib/operators/test_s3_to_sftp_operator.py
@@ -96,7 +96,7 @@ class S3ToSFTPOperatorTest(unittest.TestCase):
         # Test for creation of s3 bucket
         conn = boto3.client('s3')
         conn.create_bucket(Bucket=self.s3_bucket)
-        self.assertTrue((self.s3_hook.check_for_bucket(self.s3_bucket)))
+        self.assertTrue(self.s3_hook.check_for_bucket(self.s3_bucket))
 
         with open(LOCAL_FILE_PATH, 'w') as file:
             file.write(test_remote_file_content)

--- a/tests/contrib/operators/test_sftp_to_s3_operator.py
+++ b/tests/contrib/operators/test_sftp_to_s3_operator.py
@@ -108,7 +108,7 @@ class SFTPToS3OperatorTest(unittest.TestCase):
         # Test for creation of s3 bucket
         conn = boto3.client('s3')
         conn.create_bucket(Bucket=self.s3_bucket)
-        self.assertTrue((self.s3_hook.check_for_bucket(self.s3_bucket)))
+        self.assertTrue(self.s3_hook.check_for_bucket(self.s3_bucket))
 
         # get remote file to local
         run_task = SFTPToS3Operator(
@@ -136,7 +136,7 @@ class SFTPToS3OperatorTest(unittest.TestCase):
         # Clean up after finishing with test
         conn.delete_object(Bucket=self.s3_bucket, Key=self.s3_key)
         conn.delete_bucket(Bucket=self.s3_bucket)
-        self.assertFalse((self.s3_hook.check_for_bucket(self.s3_bucket)))
+        self.assertFalse(self.s3_hook.check_for_bucket(self.s3_bucket))
 
 
 if __name__ == '__main__':

--- a/tests/hooks/test_hive_hook.py
+++ b/tests/hooks/test_hive_hook.py
@@ -194,7 +194,7 @@ class TestHiveCliHook(unittest.TestCase):
         d['c'] = ['c']
         d['M'] = [datetime.datetime(2018, 1, 1)]
         d['O'] = [object()]
-        d['S'] = ['STRING'.encode('utf-8')]
+        d['S'] = [b'STRING']
         d['U'] = ['STRING']
         d['V'] = [None]
         df = pd.DataFrame(d)

--- a/tests/hooks/test_http_hook.py
+++ b/tests/hooks/test_http_hook.py
@@ -249,9 +249,9 @@ class TestHttpHook(unittest.TestCase):
     def test_run_with_advanced_retry(self, m):
 
         m.get(
-            u'http://test:8080/v1/test',
+            'http://test:8080/v1/test',
             status_code=200,
-            reason=u'OK'
+            reason='OK'
         )
 
         retry_args = dict(

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -600,7 +600,7 @@ class DagTest(unittest.TestCase):
     def test_resolve_template_files_value(self):
 
         with NamedTemporaryFile(suffix='.template') as f:
-            f.write('{{ ds }}'.encode('utf8'))
+            f.write(b'{{ ds }}')
             f.flush()
             template_dir = os.path.dirname(f.name)
             template_file = os.path.basename(f.name)
@@ -623,7 +623,7 @@ class DagTest(unittest.TestCase):
 
         with NamedTemporaryFile(suffix='.template') as f:
             f = NamedTemporaryFile(suffix='.template')
-            f.write('{{ ds }}'.encode('utf8'))
+            f.write(b'{{ ds }}')
             f.flush()
             template_dir = os.path.dirname(f.name)
             template_file = os.path.basename(f.name)

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -84,8 +84,8 @@ class DagBagTest(unittest.TestCase):
         should be discovered.
         """
         with NamedTemporaryFile(dir=self.empty_dir, suffix=".py") as fp:
-            fp.write("# airflow".encode())
-            fp.write("# DAG".encode())
+            fp.write(b"# airflow")
+            fp.write(b"# DAG")
             fp.flush()
             dagbag = models.DagBag(
                 dag_folder=self.empty_dir, include_examples=False, safe_mode=True)
@@ -119,7 +119,7 @@ class DagBagTest(unittest.TestCase):
         test that we're able to parse file that contains multi-byte char
         """
         f = NamedTemporaryFile()
-        f.write('\u3042'.encode('utf8'))  # write multi-byte char (hiragana)
+        f.write('\u3042'.encode())  # write multi-byte char (hiragana)
         f.flush()
 
         dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)

--- a/tests/operators/test_s3_to_hive_operator.py
+++ b/tests/operators/test_s3_to_hive_operator.py
@@ -69,9 +69,9 @@ class S3ToHiveTransferTest(unittest.TestCase):
                        'input_compressed': self.input_compressed
                        }
         try:
-            header = "Sno\tSome,Text \n".encode()
-            line1 = "1\tAirflow Test\n".encode()
-            line2 = "2\tS32HiveTransfer\n".encode()
+            header = b"Sno\tSome,Text \n"
+            line1 = b"1\tAirflow Test\n"
+            line2 = b"2\tS32HiveTransfer\n"
             self.tmp_dir = mkdtemp(prefix='test_tmps32hive_')
             # create sample txt, gz and bz2 with and without headers
             with NamedTemporaryFile(mode='wb+',

--- a/tests/utils/test_compression.py
+++ b/tests/utils/test_compression.py
@@ -34,9 +34,9 @@ class Compression(unittest.TestCase):
     def setUp(self):
         self.fn = {}
         try:
-            header = "Sno\tSome,Text \n".encode()
-            line1 = "1\tAirflow Test\n".encode()
-            line2 = "2\tCompressionUtil\n".encode()
+            header = b"Sno\tSome,Text \n"
+            line1 = b"1\tAirflow Test\n"
+            line2 = b"2\tCompressionUtil\n"
             self.tmp_dir = tempfile.mkdtemp(prefix='test_utils_compression_')
             # create sample txt, gz and bz2 files
             with tempfile.NamedTemporaryFile(mode='wb+',

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -197,7 +197,7 @@ class TestSecurity(unittest.TestCase):
 
         mock_get_user_roles.return_value = [role]
         self.assertEqual(self.security_manager
-                         .get_accessible_dag_ids(user), set(['dag_id']))
+                         .get_accessible_dag_ids(user), {'dag_id'})
 
     @mock.patch('airflow.www.security.AirflowSecurityManager._has_view_access')
     def test_has_access(self, mock_has_view_access):

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -1256,7 +1256,7 @@ class TestDagACLView(TestBase):
         self.login(username='test',
                    password='test')
         test_role = self.appbuilder.sm.find_role('dag_acl_tester')
-        perms = set([str(perm) for perm in test_role.permissions])
+        perms = {str(perm) for perm in test_role.permissions}
         self.assertIn('can dag edit on example_bash_operator', perms)
         self.assertNotIn('can dag read on example_bash_operator', perms)
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4944
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
