### PR TITLE
[AIRFLOW-4945] Use super() syntax

### DIFF
--- a/airflow/contrib/hooks/gcp_cloud_build_hook.py
+++ b/airflow/contrib/hooks/gcp_cloud_build_hook.py
@@ -50,7 +50,7 @@ class CloudBuildHook(GoogleCloudBaseHook):
     _conn = None
 
     def __init__(self, api_version="v1", gcp_conn_id="google_cloud_default", delegate_to=None):
-        super(CloudBuildHook, self).__init__(gcp_conn_id, delegate_to)
+        super().__init__(gcp_conn_id, delegate_to)
         self.api_version = api_version
         self.num_retries = self._get_field("num_retries", 5)
 

--- a/airflow/contrib/hooks/gcp_video_intelligence_hook.py
+++ b/airflow/contrib/hooks/gcp_video_intelligence_hook.py
@@ -40,7 +40,7 @@ class CloudVideoIntelligenceHook(GoogleCloudBaseHook):
     """
 
     def __init__(self, gcp_conn_id="google_cloud_default", delegate_to=None):
-        super(CloudVideoIntelligenceHook, self).__init__(gcp_conn_id, delegate_to)
+        super().__init__(gcp_conn_id, delegate_to)
         self._conn = None
 
     def get_conn(self):

--- a/airflow/contrib/operators/gcp_cloud_build_operator.py
+++ b/airflow/contrib/operators/gcp_cloud_build_operator.py
@@ -179,7 +179,7 @@ class CloudBuildCreateBuildOperator(BaseOperator):
     def __init__(
         self, body, project_id=None, gcp_conn_id="google_cloud_default", api_version="v1", *args, **kwargs
     ):
-        super(CloudBuildCreateBuildOperator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.body = body
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id

--- a/airflow/contrib/operators/gcp_translate_speech_operator.py
+++ b/airflow/contrib/operators/gcp_translate_speech_operator.py
@@ -113,7 +113,7 @@ class GcpTranslateSpeechOperator(BaseOperator):
         *args,
         **kwargs
     ):
-        super(GcpTranslateSpeechOperator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.audio = audio
         self.config = config
         self.target_language = target_language

--- a/airflow/contrib/operators/gcp_video_intelligence_operator.py
+++ b/airflow/contrib/operators/gcp_video_intelligence_operator.py
@@ -75,7 +75,7 @@ class CloudVideoIntelligenceDetectVideoLabelsOperator(BaseOperator):
         *args,
         **kwargs
     ):
-        super(CloudVideoIntelligenceDetectVideoLabelsOperator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.input_uri = input_uri
         self.input_content = input_content
         self.output_uri = output_uri
@@ -148,7 +148,7 @@ class CloudVideoIntelligenceDetectVideoExplicitContentOperator(BaseOperator):
         *args,
         **kwargs
     ):
-        super(CloudVideoIntelligenceDetectVideoExplicitContentOperator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.input_uri = input_uri
         self.output_uri = output_uri
         self.input_content = input_content
@@ -221,7 +221,7 @@ class CloudVideoIntelligenceDetectVideoShotsOperator(BaseOperator):
         *args,
         **kwargs
     ):
-        super(CloudVideoIntelligenceDetectVideoShotsOperator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.input_uri = input_uri
         self.output_uri = output_uri
         self.input_content = input_content

--- a/airflow/contrib/operators/grpc_operator.py
+++ b/airflow/contrib/operators/grpc_operator.py
@@ -63,7 +63,7 @@ class GrpcOperator(BaseOperator):
                  response_callback=None,
                  log_response=False,
                  *args, **kwargs):
-        super(GrpcOperator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.stub_class = stub_class
         self.call_func = call_func
         self.grpc_conn_id = grpc_conn_id

--- a/airflow/contrib/operators/mssql_to_gcs.py
+++ b/airflow/contrib/operators/mssql_to_gcs.py
@@ -95,7 +95,7 @@ class MsSqlToGoogleCloudStorageOperator(BaseOperator):
                  *args,
                  **kwargs):
 
-        super(MsSqlToGoogleCloudStorageOperator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.sql = sql
         self.bucket = bucket
         self.filename = filename

--- a/airflow/contrib/sensors/gcs_sensor.py
+++ b/airflow/contrib/sensors/gcs_sensor.py
@@ -230,7 +230,7 @@ class GoogleCloudStorageUploadSessionCompleteSensor(BaseSensorOperator):
                  delegate_to=None,
                  *args, **kwargs):
 
-        super(GoogleCloudStorageUploadSessionCompleteSensor, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.bucket = bucket
         self.prefix = prefix

--- a/airflow/contrib/utils/log/task_handler_with_custom_formatter.py
+++ b/airflow/contrib/utils/log/task_handler_with_custom_formatter.py
@@ -26,7 +26,7 @@ from airflow.utils.helpers import parse_template_string
 
 class TaskHandlerWithCustomFormatter(StreamHandler):
     def __init__(self, stream):
-        super(TaskHandlerWithCustomFormatter, self).__init__()
+        super().__init__()
 
     def set_context(self, ti):
         if ti.raw:

--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -209,7 +209,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
             else:
                 self.handler.setFormatter(self.formatter)
         else:
-            super(ElasticsearchTaskHandler, self).set_context(ti)
+            super().set_context(ti)
 
     def emit(self, record):
         if self.write_stdout:
@@ -217,7 +217,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
             if self.handler is not None:
                 self.handler.emit(record)
         else:
-            super(ElasticsearchTaskHandler, self).emit(record)
+            super().emit(record)
 
     def flush(self):
         if self.handler is not None:

--- a/airflow/utils/log/json_formatter.py
+++ b/airflow/utils/log/json_formatter.py
@@ -40,7 +40,7 @@ class JSONFormatter(logging.Formatter):
     """
     # pylint: disable=too-many-arguments
     def __init__(self, fmt=None, datefmt=None, style='%', json_fields=None, extras=None):
-        super(JSONFormatter, self).__init__(fmt, datefmt, style)
+        super().__init__(fmt, datefmt, style)
         if extras is None:
             extras = {}
         if json_fields is None:
@@ -49,7 +49,7 @@ class JSONFormatter(logging.Formatter):
         self.extras = extras
 
     def format(self, record):
-        super(JSONFormatter, self).format(record)
+        super().format(record)
         record_dict = {label: getattr(record, label, None)
                        for label in self.json_fields}
         merged_record = merge_dicts(record_dict, self.extras)

--- a/scripts/perf/scheduler_ops_metrics.py
+++ b/scripts/perf/scheduler_ops_metrics.py
@@ -104,7 +104,7 @@ class SchedulerMetricsJob(SchedulerJob):
         """
         Override the scheduler heartbeat to determine when the test is complete
         """
-        super(SchedulerMetricsJob, self).heartbeat()
+        super().heartbeat()
         session = settings.Session()
         # Get all the relevant task instances
         TI = TaskInstance

--- a/tests/api/client/test_local_client.py
+++ b/tests/api/client/test_local_client.py
@@ -42,7 +42,7 @@ class TestLocalClient(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestLocalClient, cls).setUpClass()
+        super().setUpClass()
         DagBag(example_bash_operator.__file__).get_dag("example_bash_operator").sync_to_db()
 
     def setUp(self):

--- a/tests/contrib/operators/test_gcp_cloud_build_operator_system.py
+++ b/tests/contrib/operators/test_gcp_cloud_build_operator_system.py
@@ -33,7 +33,7 @@ class CloudBuildExampleDagsSystemTest(DagGcpSystemTestCase):
     """
 
     def __init__(self, method_name="runTest"):
-        super(CloudBuildExampleDagsSystemTest, self).__init__(
+        super().__init__(
             method_name,
             dag_id="example_gcp_cloud_build",
             require_local_executor=True,
@@ -42,7 +42,7 @@ class CloudBuildExampleDagsSystemTest(DagGcpSystemTestCase):
         self.helper = GCPCloudBuildTestHelper()
 
     def setUp(self):
-        super(CloudBuildExampleDagsSystemTest, self).setUp()
+        super().setUp()
         self.gcp_authenticator.gcp_authenticate()
         try:
             self.helper.create_repository_and_bucket()
@@ -60,4 +60,4 @@ class CloudBuildExampleDagsSystemTest(DagGcpSystemTestCase):
             self.helper.delete_repo()
         finally:
             self.gcp_authenticator.gcp_revoke_authentication()
-        super(CloudBuildExampleDagsSystemTest, self).tearDown()
+        super().tearDown()

--- a/tests/contrib/operators/test_gcp_video_intelligence_operator_system.py
+++ b/tests/contrib/operators/test_gcp_video_intelligence_operator_system.py
@@ -28,7 +28,7 @@ from tests.contrib.utils.gcp_authenticator import GCP_AI_KEY
 @unittest.skipIf(DagGcpSystemTestCase.skip_check(GCP_AI_KEY), SKIP_TEST_WARNING)
 class CloudVideoIntelligenceExampleDagsTest(DagGcpSystemTestCase):
     def __init__(self, method_name="runTest"):
-        super(CloudVideoIntelligenceExampleDagsTest, self).__init__(
+        super().__init__(
             method_name, dag_id="example_gcp_video_intelligence", gcp_key=GCP_AI_KEY
         )
         self.helper = GCPVideoIntelligenceHelper()
@@ -40,7 +40,7 @@ class CloudVideoIntelligenceExampleDagsTest(DagGcpSystemTestCase):
             self.gcp_authenticator.gcp_revoke_authentication()
         finally:
             pass
-        super(CloudVideoIntelligenceExampleDagsTest, self).setUp()
+        super().setUp()
 
     def tearDown(self):
         self.gcp_authenticator.gcp_authenticate()
@@ -48,7 +48,7 @@ class CloudVideoIntelligenceExampleDagsTest(DagGcpSystemTestCase):
             self.helper.delete_bucket()
         finally:
             self.gcp_authenticator.gcp_revoke_authentication()
-        super(CloudVideoIntelligenceExampleDagsTest, self).tearDown()
+        super().tearDown()
 
     def test_run_example_dag_spanner(self):
         self._run_dag()

--- a/tests/contrib/utils/test_task_handler_with_custom_formatter.py
+++ b/tests/contrib/utils/test_task_handler_with_custom_formatter.py
@@ -37,7 +37,7 @@ PREV_TASK_HANDLER = DEFAULT_LOGGING_CONFIG['handlers']['task']
 
 class TestTaskHandlerWithCustomFormatter(unittest.TestCase):
     def setUp(self):
-        super(TestTaskHandlerWithCustomFormatter, self).setUp()
+        super().setUp()
         DEFAULT_LOGGING_CONFIG['handlers']['task'] = {
             'class': TASK_HANDLER_CLASS,
             'formatter': 'airflow',

--- a/tests/core.py
+++ b/tests/core.py
@@ -1092,7 +1092,7 @@ class CliTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(CliTests, cls).setUpClass()
+        super().setUpClass()
         cls._cleanup()
 
     def setUp(self):

--- a/tests/operators/test_branch_operator.py
+++ b/tests/operators/test_branch_operator.py
@@ -44,7 +44,7 @@ class ChooseBranchOneTwo(BaseBranchOperator):
 class BranchOperatorTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        super(BranchOperatorTest, cls).setUpClass()
+        super().setUpClass()
 
         with create_session() as session:
             session.query(DagRun).delete()

--- a/tests/operators/test_python_operator.py
+++ b/tests/operators/test_python_operator.py
@@ -64,7 +64,7 @@ def build_recording_function(calls_collection):
 class PythonOperatorTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        super(PythonOperatorTest, cls).setUpClass()
+        super().setUpClass()
 
         with create_session() as session:
             session.query(DagRun).delete()
@@ -246,7 +246,7 @@ class PythonOperatorTest(unittest.TestCase):
 class BranchOperatorTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        super(BranchOperatorTest, cls).setUpClass()
+        super().setUpClass()
 
         with create_session() as session:
             session.query(DagRun).delete()
@@ -420,7 +420,7 @@ class BranchOperatorTest(unittest.TestCase):
 class ShortCircuitOperatorTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        super(ShortCircuitOperatorTest, cls).setUpClass()
+        super().setUpClass()
 
         with create_session() as session:
             session.query(DagRun).delete()

--- a/tests/www/api/experimental/test_dag_runs_endpoint.py
+++ b/tests/www/api/experimental/test_dag_runs_endpoint.py
@@ -29,7 +29,7 @@ class TestDagRunsEndpoint(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestDagRunsEndpoint, cls).setUpClass()
+        super().setUpClass()
         session = Session()
         session.query(DagRun).delete()
         session.commit()

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -48,7 +48,7 @@ class TestApiExperimental(TestBase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestApiExperimental, cls).setUpClass()
+        super().setUpClass()
         session = Session()
         session.query(DagRun).delete()
         session.query(TaskInstance).delete()
@@ -292,7 +292,7 @@ class TestPoolApiExperimental(TestBase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestPoolApiExperimental, cls).setUpClass()
+        super().setUpClass()
 
     def setUp(self):
         super().setUp()

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -316,7 +316,7 @@ class TestAirflowBaseViews(TestBase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestAirflowBaseViews, cls).setUpClass()
+        super().setUpClass()
         dagbag = models.DagBag(include_examples=True)
         for dag in dagbag.dags.values():
             dag.sync_to_db()
@@ -1005,7 +1005,7 @@ class TestGraphView(TestBase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestGraphView, cls).setUpClass()
+        super().setUpClass()
 
     def setUp(self):
         super().setUp()
@@ -1019,7 +1019,7 @@ class TestGraphView(TestBase):
 
     @classmethod
     def tearDownClass(cls):
-        super(TestGraphView, cls).tearDownClass()
+        super().tearDownClass()
 
     def test_dt_nr_dr_form_default_parameters(self):
         self.tester.test_with_default_parameters()
@@ -1044,7 +1044,7 @@ class TestGanttView(TestBase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestGanttView, cls).setUpClass()
+        super().setUpClass()
 
     def setUp(self):
         super().setUp()
@@ -1058,7 +1058,7 @@ class TestGanttView(TestBase):
 
     @classmethod
     def tearDownClass(cls):
-        super(TestGanttView, cls).tearDownClass()
+        super().tearDownClass()
 
     def test_dt_nr_dr_form_default_parameters(self):
         self.tester.test_with_default_parameters()
@@ -1085,7 +1085,7 @@ class TestDagACLView(TestBase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestDagACLView, cls).setUpClass()
+        super().setUpClass()
         dagbag = models.DagBag(include_examples=True)
         for dag in dagbag.dags.values():
             dag.sync_to_db()
@@ -1857,7 +1857,7 @@ class TestExtraLinks(TestBase):
 class TestDagRunModelView(TestBase):
     @classmethod
     def setUpClass(cls):
-        super(TestDagRunModelView, cls).setUpClass()
+        super().setUpClass()
         models.DagBag().get_dag("example_bash_operator").sync_to_db(session=cls.session)
         cls.clear_table(models.DagRun)
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
