### PR TITLE
[AIRFLOW-4946] Use yield from syntax

### DIFF
--- a/airflow/contrib/hooks/grpc_hook.py
+++ b/airflow/contrib/hooks/grpc_hook.py
@@ -100,8 +100,7 @@ class GrpcHook(BaseHook):
                 if not streaming:
                     yield response
                 else:
-                    for single_response in response:
-                        yield single_response
+                    yield from response
             except grpc.RpcError as ex:
                 self.log.exception(
                     "Error occurred when calling the grpc service: {0}, method: {1} \

--- a/airflow/contrib/hooks/sagemaker_hook.py
+++ b/airflow/contrib/hooks/sagemaker_hook.py
@@ -283,8 +283,7 @@ class SageMakerHook(AwsHook):
             else:
                 skip = skip - event_count
                 events = []
-            for ev in events:
-                yield ev
+            yield from events
 
     def multi_stream_iter(self, log_group, streams, positions=None):
         """

--- a/airflow/hooks/hive_hooks.py
+++ b/airflow/hooks/hive_hooks.py
@@ -863,8 +863,7 @@ class HiveServer2Hook(BaseHook):
                         # DB API 2 raises when no results are returned
                         # we're silencing here as some statements in the list
                         # may be `SET` or DDL
-                        for row in cur:
-                            yield row
+                        yield from cur
                     except ProgrammingError:
                         self.log.debug("get_results returned no records")
 

--- a/airflow/lineage/datasets.py
+++ b/airflow/lineage/datasets.py
@@ -77,8 +77,7 @@ class DataSet:
         return self.__getattr__(item)
 
     def __iter__(self):
-        for key, value in six.iteritems(self._data):
-            yield (key, value)
+        yield from self._data.items()
 
     def as_dict(self):
         attributes = dict(self._data)

--- a/airflow/ti_deps/deps/base_ti_dep.py
+++ b/airflow/ti_deps/deps/base_ti_dep.py
@@ -103,8 +103,7 @@ class BaseTIDep:
                 reason="Context specified all task dependencies should be ignored.")
             return
 
-        for dep_status in self._get_dep_statuses(ti, session, dep_context):
-            yield dep_status
+        yield from self._get_dep_statuses(ti, session, dep_context)
 
     @provide_session
     def is_met(self, ti, session, dep_context=None):

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -76,16 +76,15 @@ class TriggerRuleDep(BaseTIDep):
         )
 
         successes, skipped, failed, upstream_failed, done = qry.first()
-        for dep_status in self._evaluate_trigger_rule(
-                ti=ti,
-                successes=successes,
-                skipped=skipped,
-                failed=failed,
-                upstream_failed=upstream_failed,
-                done=done,
-                flag_upstream_failed=dep_context.flag_upstream_failed,
-                session=session):
-            yield dep_status
+        yield from self._evaluate_trigger_rule(
+            ti=ti,
+            successes=successes,
+            skipped=skipped,
+            failed=failed,
+            upstream_failed=upstream_failed,
+            done=done,
+            flag_upstream_failed=dep_context.flag_upstream_failed,
+            session=session)
 
     @provide_session
     def _evaluate_trigger_rule(

--- a/tests/operators/test_check_operator.py
+++ b/tests/operators/test_check_operator.py
@@ -170,8 +170,7 @@ class IntervalCheckOperatorTest(unittest.TestCase):
                 [1, 1, 1, 1],  # current
             ]
 
-            for r in rows:
-                yield r
+            yield from rows
 
         mock_hook.get_first.side_effect = returned_row()
         mock_get_db_hook.return_value = mock_hook
@@ -201,8 +200,7 @@ class IntervalCheckOperatorTest(unittest.TestCase):
                 [1, 1, 1, 1],  # current
             ]
 
-            for r in rows:
-                yield r
+            yield from rows
 
         mock_hook.get_first.side_effect = returned_row()
         mock_get_db_hook.return_value = mock_hook


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4946
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
