### PR TITLE
[AIRFLOW-4949] Use OSError exception

### DIFF
--- a/airflow/api/client/json_client.py
+++ b/airflow/api/client/json_client.py
@@ -44,7 +44,7 @@ class Client(api_client.Client):
                 data = resp.json()
             except Exception:  # pylint: disable=broad-except
                 data = {}
-            raise IOError(data.get('error', 'Server error'))
+            raise OSError(data.get('error', 'Server error'))
 
         return resp.json()
 

--- a/airflow/api/common/experimental/get_code.py
+++ b/airflow/api/common/experimental/get_code.py
@@ -34,6 +34,6 @@ def get_code(dag_id: str) -> str:
         with wwwutils.open_maybe_zipped(dag.fileloc, 'r') as file:
             code = file.read()
             return code
-    except IOError as exception:
+    except OSError as exception:
         error_message = "Error {} while reading Dag id {} Code".format(str(exception), dag_id)
         raise AirflowException(error_message)

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -230,7 +230,7 @@ def trigger_dag(args):
                                          run_id=args.run_id,
                                          conf=args.conf,
                                          execution_date=args.exec_date)
-    except IOError as err:
+    except OSError as err:
         log.error(err)
         raise AirflowException(err)
     log.info(message)
@@ -249,7 +249,7 @@ def delete_dag(args):
             "Proceed? (y/n)").upper() == "Y":
         try:
             message = api_client.delete_dag(dag_id=args.dag_id)
-        except IOError as err:
+        except OSError as err:
             log.error(err)
             raise AirflowException(err)
         log.info(message)
@@ -285,7 +285,7 @@ def pool(args):
             pools = pool_export_helper(args.export)
         else:
             pools = api_client.get_pools()
-    except (AirflowException, IOError) as err:
+    except (AirflowException, OSError) as err:
         log.error(err)
     else:
         log.info(_tabulate(pools=pools))
@@ -981,7 +981,7 @@ def webserver(args):
                         with open(pid) as file:
                             gunicorn_master_proc_pid = int(file.read())
                             break
-                    except IOError:
+                    except OSError:
                         log.debug("Waiting for gunicorn's pid file to be created.")
                         time.sleep(0.1)
 

--- a/airflow/contrib/operators/sftp_operator.py
+++ b/airflow/contrib/operators/sftp_operator.py
@@ -172,7 +172,7 @@ def _make_intermediate_dirs(sftp_client, remote_directory):
         return
     try:
         sftp_client.chdir(remote_directory)
-    except IOError:
+    except OSError:
         dirname, basename = os.path.split(remote_directory.rstrip('/'))
         _make_intermediate_dirs(sftp_client, dirname)
         sftp_client.mkdir(basename)

--- a/airflow/contrib/sensors/sftp_sensor.py
+++ b/airflow/contrib/sensors/sftp_sensor.py
@@ -44,7 +44,7 @@ class SFTPSensor(BaseSensorOperator):
         self.log.info('Poking for %s', self.path)
         try:
             self.hook.get_mod_time(self.path)
-        except IOError as e:
+        except OSError as e:
             if e.errno != SFTP_NO_SUCH_FILE:
                 raise e
             return False

--- a/airflow/security/utils.py
+++ b/airflow/security/utils.py
@@ -49,7 +49,7 @@ def get_fqdn(hostname_or_ip=None):
                 fqdn = get_hostname()
         else:
             fqdn = get_hostname()
-    except IOError:
+    except OSError:
         fqdn = hostname_or_ip
 
     return fqdn

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -444,7 +444,7 @@ class Airflow(AirflowBaseView):
                 code = f.read()
             html_code = highlight(
                 code, lexers.PythonLexer(), HtmlFormatter(linenos=True))
-        except IOError as e:
+        except OSError as e:
             html_code = str(e)
 
         return self.render_template(

--- a/tests/contrib/sensors/test_sftp_sensor.py
+++ b/tests/contrib/sensors/test_sftp_sensor.py
@@ -40,7 +40,7 @@ class SFTPSensorTest(unittest.TestCase):
 
     @patch('airflow.contrib.sensors.sftp_sensor.SFTPHook')
     def test_file_absent(self, sftp_hook_mock):
-        sftp_hook_mock.return_value.get_mod_time.side_effect = IOError(
+        sftp_hook_mock.return_value.get_mod_time.side_effect = OSError(
             SFTP_NO_SUCH_FILE, 'File missing')
         sftp_sensor = SFTPSensor(
             task_id='unit_test',
@@ -55,7 +55,7 @@ class SFTPSensorTest(unittest.TestCase):
 
     @patch('airflow.contrib.sensors.sftp_sensor.SFTPHook')
     def test_sftp_failure(self, sftp_hook_mock):
-        sftp_hook_mock.return_value.get_mod_time.side_effect = IOError(
+        sftp_hook_mock.return_value.get_mod_time.side_effect = OSError(
             SFTP_FAILURE, 'SFTP failure')
         sftp_sensor = SFTPSensor(
             task_id='unit_test',
@@ -63,7 +63,7 @@ class SFTPSensorTest(unittest.TestCase):
         context = {
             'ds': '1970-01-01'
         }
-        with self.assertRaises(IOError):
+        with self.assertRaises(OSError):
             sftp_sensor.poke(context)
             sftp_hook_mock.return_value.get_mod_time.assert_called_with(
                 '/path/to/file/1970-01-01.txt')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4949
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
