### PR TITLE
[AIRFLOW-4954] Remove unused variables in tests

### DIFF
--- a/tests/contrib/hooks/test_ssh_hook.py
+++ b/tests/contrib/hooks/test_ssh_hook.py
@@ -161,7 +161,7 @@ class SSHHookTest(unittest.TestCase):
             response = s.recv(5)
             self.assertEqual(response, b"hello")
             s.close()
-            output, _ = server_handle.communicate()
+            server_handle.communicate()
             self.assertEqual(server_handle.returncode, 0)
 
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -310,7 +310,7 @@ class CoreTest(unittest.TestCase):
         # Create and schedule the dag runs
         dag_runs = []
         scheduler = jobs.SchedulerJob(**self.default_scheduler_args)
-        for i in range(runs):
+        for _ in range(runs):
             dag_runs.append(scheduler.create_dag_run(dag))
 
         additional_dag_run = scheduler.create_dag_run(dag)
@@ -343,7 +343,7 @@ class CoreTest(unittest.TestCase):
 
         dag_runs = []
         scheduler = jobs.SchedulerJob(**self.default_scheduler_args)
-        for i in range(runs):
+        for _ in range(runs):
             dag_run = scheduler.create_dag_run(dag)
             dag_runs.append(dag_run)
 
@@ -715,7 +715,7 @@ class CoreTest(unittest.TestCase):
     def test_doctests(self):
         modules = [utils, macros]
         for mod in modules:
-            failed, tests = doctest.testmod(mod)
+            failed, _ = doctest.testmod(mod)
             if failed:
                 raise Exception("Failed a doctest")
 

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -113,7 +113,7 @@ class DaskExecutorTest(BaseDaskTest):
                 start_date=DEFAULT_DATE,
                 end_date=DEFAULT_DATE)
 
-        for i, dag in enumerate(sorted(dags, key=lambda d: d.dag_id)):
+        for dag in sorted(dags, key=lambda d: d.dag_id):
             job = BackfillJob(
                 dag=dag,
                 start_date=DEFAULT_DATE,
@@ -136,7 +136,7 @@ class DaskExecutorTLSTest(BaseDaskTest):
     def test_tls(self):
         with dask_testing_cluster(
                 worker_kwargs={'security': tls_security()},
-                scheduler_kwargs={'security': tls_security()}) as (s, workers):
+                scheduler_kwargs={'security': tls_security()}) as (s, _):
 
             # These use test certs that ship with dask/distributed and should not be
             #  used in production

--- a/tests/executors/test_executor.py
+++ b/tests/executors/test_executor.py
@@ -53,7 +53,7 @@ class TestExecutor(BaseExecutor):
             def sort_by(item):
                 key, val = item
                 (dag_id, task_id, date, try_number) = key
-                (cmd, prio, queue, sti) = val
+                (_, prio, _, _) = val
                 # Sort by priority (DESC), then date,task, try
                 return -prio, date, dag_id, task_id, try_number
             sorted_queue = sorted(self.queued_tasks.items(), key=sort_by)

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -146,7 +146,7 @@ class LocalTaskJobTest(unittest.TestCase):
         process = multiprocessing.Process(target=job1.run)
         process.start()
         ti.refresh_from_db()
-        for i in range(0, 50):
+        for _ in range(0, 50):
             if ti.state == State.RUNNING:
                 break
             time.sleep(0.1)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -827,7 +827,7 @@ class SchedulerJobTest(unittest.TestCase):
         session = settings.Session()
 
         tis = []
-        for i in range(0, 4):
+        for _ in range(0, 4):
             dr = scheduler.create_dag_run(dag)
             ti1 = TI(task1, dr.execution_date)
             ti2 = TI(task2, dr.execution_date)
@@ -2087,7 +2087,7 @@ class SchedulerJobTest(unittest.TestCase):
                 pass
 
         ti_tuple = next(iter(executor.queued_tasks.values()))
-        (command, priority, queue, simple_ti) = ti_tuple
+        (_, _, _, simple_ti) = ti_tuple
         ti = simple_ti.construct_task_instance()
         ti.task = dag_task1
 
@@ -2460,7 +2460,7 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertEqual(detected_files, expected_files)
 
         example_dag_folder = airflow.example_dags.__path__[0]
-        for root, dirs, files in os.walk(example_dag_folder):
+        for root, _, files in os.walk(example_dag_folder):
             for file_name in files:
                 if file_name.endswith('.py') or file_name.endswith('.zip'):
                     if file_name not in ['__init__.py']:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4954
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
