### PR TITLE
[AIRFLOW-4956] Fix LocalTaskJob heartbeat log spamming

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -22,8 +22,6 @@ import os
 import signal
 import time
 
-from sqlalchemy.exc import OperationalError
-
 from airflow import configuration as conf
 from airflow.exceptions import AirflowException
 from airflow.stats import Stats
@@ -91,7 +89,6 @@ class LocalTaskJob(BaseJob):
         try:
             self.task_runner.start()
 
-            last_heartbeat_time = time.time()
             heartbeat_time_limit = conf.getint('scheduler',
                                                'scheduler_zombie_task_threshold')
             while True:
@@ -103,16 +100,8 @@ class LocalTaskJob(BaseJob):
 
                 # Periodically heartbeat so that the scheduler doesn't think this
                 # is a zombie
-                try:
-                    self.heartbeat()
-                    last_heartbeat_time = time.time()
-                except OperationalError:
-                    Stats.incr('local_task_job_heartbeat_failure', 1, 1)
-                    self.log.exception(
-                        "Exception while trying to heartbeat! Sleeping for %s seconds",
-                        self.heartrate
-                    )
-                    time.sleep(self.heartrate)
+                last_heartbeat_time = time.time()
+                self.heartbeat()
 
                 # If it's been too long since we've heartbeat, then it's possible that
                 # the scheduler rescheduled this task, so kill launched processes.
@@ -124,6 +113,13 @@ class LocalTaskJob(BaseJob):
                                            "exceeded limit ({}s)."
                                            .format(time_since_last_heartbeat,
                                                    heartbeat_time_limit))
+
+                if time_since_last_heartbeat < self.heartrate:
+                    sleep_for = self.heartrate - time_since_last_heartbeat
+                    self.log.warning("Time since last heartbeat(%.2f s) < heartrate(%s s)"
+                                     ", sleeping for %s s", time_since_last_heartbeat,
+                                     self.heartrate, sleep_for)
+                    time.sleep(sleep_for)
         finally:
             self.on_kill()
 

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -351,3 +351,7 @@ def render_log_filename(ti, try_number, filename_template):
                                     task_id=ti.task_id,
                                     execution_date=ti.execution_date.isoformat(),
                                     try_number=try_number)
+
+
+def convert_camel_to_snake(camel_str):
+    return re.sub('(?!^)([A-Z]+)', r'_\1', camel_str).lower()

--- a/tests/dags/test_heartbeat_failed_fast.py
+++ b/tests/dags/test_heartbeat_failed_fast.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from datetime import datetime
+
+from airflow.models import DAG
+from airflow.operators.bash_operator import BashOperator
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+
+args = {
+    'owner': 'airflow',
+    'start_date': DEFAULT_DATE,
+}
+
+dag = DAG(dag_id='test_heartbeat_failed_fast', default_args=args)
+task = BashOperator(
+    task_id='test_heartbeat_failed_fast_op',
+    bash_command='sleep 5',
+    dag=dag)

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -30,10 +30,12 @@ from airflow.models import DAG, TaskInstance as TI
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
 from airflow.utils import timezone
+from airflow.utils.db import create_session
 from airflow.utils.net import get_hostname
 from airflow.utils.state import State
 from tests.compat import patch
 from tests.core import TEST_DAG_FOLDER
+from tests.executors.test_executor import TestExecutor
 from tests.test_utils.db import clear_db_runs
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
@@ -115,6 +117,50 @@ class LocalTaskJobTest(unittest.TestCase):
 
         mock_pid.return_value = 2
         self.assertRaises(AirflowException, job1.heartbeat_callback)
+
+    @patch('os.getpid')
+    def test_heartbeat_failed_fast(self, mock_getpid):
+        """
+        Test that task heartbeat will sleep when it fails fast
+        """
+        mock_getpid.return_value = 1
+
+        heartbeat_records = []
+
+        def heartbeat_recorder():
+            heartbeat_records.append(timezone.utcnow())
+
+        with create_session() as session:
+            dagbag = models.DagBag(
+                dag_folder=TEST_DAG_FOLDER,
+                include_examples=False,
+            )
+            dag_id = 'test_heartbeat_failed_fast'
+            task_id = 'test_heartbeat_failed_fast_op'
+            dag = dagbag.get_dag(dag_id)
+            task = dag.get_task(task_id)
+
+            dag.create_dagrun(run_id="test_heartbeat_failed_fast_run",
+                              state=State.RUNNING,
+                              execution_date=DEFAULT_DATE,
+                              start_date=DEFAULT_DATE,
+                              session=session)
+            ti = TI(task=task, execution_date=DEFAULT_DATE)
+            ti.refresh_from_db()
+            ti.state = State.RUNNING
+            ti.hostname = get_hostname()
+            ti.pid = 1
+            session.commit()
+
+            job = LocalTaskJob(task_instance=ti, executor=TestExecutor(do_update=False))
+            job.heartrate = 2
+            job.heartbeat = heartbeat_recorder
+            job._execute()
+            self.assertGreater(len(heartbeat_records), 1)
+            for i in range(1, len(heartbeat_records)):
+                time1 = heartbeat_records[i - 1]
+                time2 = heartbeat_records[i]
+                self.assertGreaterEqual((time2 - time1).total_seconds(), job.heartrate)
 
     @unittest.skipIf('mysql' in configuration.conf.get('core', 'sql_alchemy_conn'),
                      "flaky when run on mysql")

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -270,6 +270,11 @@ class HelpersTest(unittest.TestCase):
         with self.assertRaises(AirflowException):
             helpers.chain([t1, t2], [t3, t4, t5])
 
+    def test_convert_camel_to_snake(self):
+        self.assertEqual(helpers.convert_camel_to_snake('LocalTaskJob'), 'local_task_job')
+        self.assertEqual(helpers.convert_camel_to_snake('somethingVeryRandom'),
+                         'something_very_random')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-4956

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

If there's an exception in LocalTaskJob, e.g. DB connectivity error, the job will not wait before attempting the next heartbeat, causing the job to spam retry attempts and task logging.

This PR will unify the usage of `BaseJob.heartbeat()` so that exceptions are handled all inside the method instead of caller.

This PR also replaces `local_task_job_heartbeat_fail` metric with `lower(JobClassName)_heartbeat_failure` metrics so all jobs can have StatsD metrics on heartbeat failures.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
`tests/jobs/test_local_task_job.py. test_heartbeat_failed_fast`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
