### PR TITLE
[AIRFLOW-XXX] Disable intersphinx loading of `requests` modules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,7 +236,8 @@ intersphinx_mapping = {
     'mongodb': ('https://api.mongodb.com/python/current/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'python': ('https://docs.python.org/3/', None),
-    'requests': ('http://docs.python-requests.org/en/master/', None),
+    # Re-enable when python-requests.org is working again!
+    #'requests': ('http://docs.python-requests.org/en/master/', None),
     'sqlalchemy': ('https://docs.sqlalchemy.org/en/latest/', None),
     'hdfs': ('https://hdfscli.readthedocs.io/en/latest/', None),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,7 +236,7 @@ intersphinx_mapping = {
     'mongodb': ('https://api.mongodb.com/python/current/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'python': ('https://docs.python.org/3/', None),
-    # Re-enable when python-requests.org is working again!
+    # TODO: Re-enable when python-requests.org is working again!
     #'requests': ('http://docs.python-requests.org/en/master/', None),
     'sqlalchemy': ('https://docs.sqlalchemy.org/en/latest/', None),
     'hdfs': ('https://hdfscli.readthedocs.io/en/latest/', None),


### PR DESCRIPTION
Their website is currently not responding making this inventory
unreachable which is causing all our builds to fail.


Make sure you have checked _all_ steps below.

### Jira

- [x] No Jira

### Description

- [x] python-requests.org is currently having troubles so we can't fetch the sphinx objects.inv for intersphinx linking. This appears as a "warning" in our docs build which causes the build to fail. Until their site is fixed I have disabled the intersphinx link so that builds can pass again