### PR TITLE
[AIRFLOW-4961] Set TaskFail.duration as int match DB schema column type

### DIFF
--- a/airflow/models/taskfail.py
+++ b/airflow/models/taskfail.py
@@ -50,6 +50,6 @@ class TaskFail(Base):
         self.start_date = start_date
         self.end_date = end_date
         if self.end_date and self.start_date:
-            self.duration = (self.end_date - self.start_date).total_seconds()
+            self.duration = int((self.end_date - self.start_date).total_seconds())
         else:
             self.duration = None


### PR DESCRIPTION
When writing a task failure record, convert 'duration' decimal
value -> an int before persistence, to remove reliance on the
database doing this automatically and gracefully.

-------
Make sure you have checked _all_ steps below.

### Jira
- [✅] My PR addresses the following: https://issues.apache.org/jira/browse/AIRFLOW-4961

### Description
- [✅] Here are some details about my PR, including screenshots of any UI changes:
I raised https://issues.apache.org/jira/browse/AIRFLOW-4961 earlier today, to cover a minor issue we encountered whilst running airflow using CockroachDB. That ticket covers the full explanation of this PR.

### Tests

- [ 🤔] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
There aren't currently unit tests for testfail.py (that's not to say there shouldn't be), and an integration test would pass with the present code anyway, as Postgres' error handling masks the issue.  
It's also a pretty trivial change. Happy to add a test for testfail.py if we feel it's needed though.

### Commits

- [ ✅] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ✅] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ✅ ] Passes `flake8`
