### PR TITLE
[AIRFLOW-733][AIRFLOW-883] Apply default_args when setting `op.dag = dag` or `dag >> op`

### DIFF
--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow import DAG
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+import airflow.utils.dates
+
+
+class BaseOperatorTest(unittest.TestCase):
+    def setUp(self):
+        self.dag = DAG(
+            'dag',
+            default_args={
+                'email_on_failure': False,
+                'email': 'example@localhost',
+                'x': 'x',
+            },
+            start_date=airflow.utils.dates.days_ago(2),
+        )
+
+    class Op(BaseOperator):
+        @apply_defaults
+        def __init__(self, x=None, **kwargs):
+            super().__init__(**kwargs)
+            self._x = x
+
+    def test_dag_setter_apply_defaults(self):
+        """
+        Test that apply_defaults operates correctly when using the `op.dag` setter.
+        """
+
+        op = self.Op(
+            task_id='op',
+            email_on_failure=True,  # happen to be the same as the default value in __init__ signature
+        )
+
+        op.dag = self.dag
+
+        self.assertTrue(op.email_on_failure)
+        self.assertEqual(op.email, 'example@localhost')
+        # Test that we re-call __init__ with the new default args
+        self.assertEqual(op._x, 'x')
+        self.assertEqual(op.start_date, self.dag.start_date)
+
+    def test_dag_bitshift_apply_defaults(self):
+        """
+        Test that apply_defaults operates correctly when using the `op.dag` setter.
+        """
+
+        op = self.Op(
+            task_id='op',
+            email_on_failure=True,  # happen to be the same as the default value in __init__ signature
+        )
+
+        self.dag >> op
+
+        self.assertTrue(op.email_on_failure)
+        self.assertEqual(op.email, 'example@localhost')
+        # Test that we re-call __init__ with the new default args
+        self.assertEqual(op._x, 'x')
+
+    def test_dag_setter_no_apply_decorator(self):
+        """
+        Test that default_args not applied when the operator is not annotated with `@apply_defaults`.
+        """
+        class SubclassWithoutApplyDefaults(BaseOperator):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+
+        op = SubclassWithoutApplyDefaults(
+            task_id='op',
+            email_on_failure=True,  # happen to be the same as the default value in __init__ signature
+        )
+
+        op.dag = self.dag
+
+        self.assertEqual(op.start_date, self.dag.start_date)
+        self.assertTrue(op.email_on_failure)
+        # Since we don't' use the @apply_defaults decorator on this ctor default args aren't applied.
+        self.assertIsNone(op.email)


### PR DESCRIPTION
### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-733 https://issues.apache.org/jira/browse/AIRFLOW-883
- Closes #7976
- Closes #7996 

### Description

- [x] To make this work we set an attribute on the wrapped __init__ method so that we can "re-invoke" it later with the same arguments, but with defaults applied.

  `__init__` is a "normal" method in Python, it doesn't handle the allocation so recalling it is safe. (`new X()` is roughly the same as `X.__new__().__init__()`)

### Tests

- [x] Added new tests/models/test_baseoperator.py

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`