### PR TITLE
[AIRFLOW-4074] Cannot put labels on Cloud Dataproc jobs

### DIFF
--- a/airflow/contrib/hooks/gcp_dataproc_hook.py
+++ b/airflow/contrib/hooks/gcp_dataproc_hook.py
@@ -215,6 +215,16 @@ class _DataProcJobBuilder:
         if properties is not None:
             self.job["job"][job_type]["properties"] = properties
 
+    def add_labels(self, labels):
+        """
+        Set labels for Dataproc job.
+
+        :param labels: Labels for the job query.
+        :type labels: dict
+        """
+        if labels:
+            self.job["job"]["labels"] = labels
+
     def add_variables(self, variables):
         """
         Set variables for Dataproc job.

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -633,6 +633,10 @@ class DataProcJobBaseOperator(BaseOperator):
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
     :type delegate_to: str
+    :param labels: The labels to associate with this job. Label keys must contain 1 to 63 characters,
+        and must conform to RFC 1035. Label values may be empty, but, if present, must contain 1 to 63
+        characters, and must conform to RFC 1035. No more than 32 labels can be associated with a job.
+    :type labels: dict
     :param region: The specified region where the dataproc cluster is created.
     :type region: str
     :param job_error_states: Job states that should be considered error states.
@@ -658,6 +662,7 @@ class DataProcJobBaseOperator(BaseOperator):
                  dataproc_jars=None,
                  gcp_conn_id='google_cloud_default',
                  delegate_to=None,
+                 labels=None,
                  region='global',
                  job_error_states=None,
                  *args,
@@ -665,6 +670,7 @@ class DataProcJobBaseOperator(BaseOperator):
         super().__init__(*args, **kwargs)
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
+        self.labels = labels
         self.job_name = job_name
         self.cluster_name = cluster_name
         self.dataproc_properties = dataproc_properties
@@ -684,8 +690,9 @@ class DataProcJobBaseOperator(BaseOperator):
         """
         self.job_template = self.hook.create_job_template(self.task_id, self.cluster_name, self.job_type,
                                                           self.dataproc_properties)
-        self.job_template.add_jar_file_uris(self.dataproc_jars)
         self.job_template.set_job_name(self.job_name)
+        self.job_template.add_jar_file_uris(self.dataproc_jars)
+        self.job_template.add_labels(self.labels)
 
     def execute(self, context):
         if self.job_template:

--- a/pylintrc
+++ b/pylintrc
@@ -324,7 +324,7 @@ dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_|
 
 # Argument names that match this expression will be ignored. Default to name
 # with leading underscore.
-ignored-argument-names=_.*|^ignored_|^unused_
+ignored-argument-names=_.*|^ignored_|^unused_|^kwargs|^args|^mock_.+
 
 # Tells whether we should check for unused import in __init__ files.
 init-import=no

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -22,7 +22,6 @@ import datetime
 import re
 import unittest
 from unittest.mock import MagicMock, Mock, patch
-
 from typing import Dict
 
 import time
@@ -82,6 +81,11 @@ GCP_REGION = 'test-region'
 MAIN_URI = 'test-uri'
 TEMPLATE_ID = 'template-id'
 
+LABELS = {
+    'label_a': 'value_a',
+    'label_b': 'value_b'
+}
+
 HOOK = 'airflow.contrib.operators.dataproc_operator.DataProcHook'
 DATAPROC_JOB_ID = 'dataproc_job_id'
 DATAPROC_JOB_TO_SUBMIT = {
@@ -92,7 +96,8 @@ DATAPROC_JOB_TO_SUBMIT = {
         },
         'placement': {
             'clusterName': CLUSTER_NAME
-        }
+        },
+        'labels': LABELS
     }
 }
 
@@ -563,7 +568,13 @@ class DataProcJobBaseOperatorTest(unittest.TestCase):
         with patch(HOOK) as mock_hook:
             mock_hook = mock_hook()
             mock_hook.submit.side_effect = submit_side_effect
-            mock_hook.create_job_template().build.return_value = {'job': {'reference': {'jobId': job_id}}}
+            mock_hook.create_job_template().build.return_value = {
+                'job': {
+                    'reference': {
+                        'jobId': job_id
+                    }
+                }
+            }
 
             task = DataProcJobBaseOperator(
                 task_id=TASK_ID,
@@ -580,6 +591,27 @@ class DataProcJobBaseOperatorTest(unittest.TestCase):
 
 class DataProcHadoopOperatorTest(unittest.TestCase):
     # Unit test for the DataProcHadoopOperator
+    @mock.patch('airflow.contrib.operators.dataproc_operator.DataProcJobBaseOperator.execute')
+    @mock.patch('airflow.contrib.operators.dataproc_operator.uuid.uuid4', return_value='test')
+    def test_correct_job_definition(self, mock_hook, mock_uuid):
+        # Expected job
+        job_definition = deepcopy(DATAPROC_JOB_TO_SUBMIT)
+        job_definition['job']['hadoopJob'] = {'mainClass': None}
+        job_definition['job']['reference']['projectId'] = None
+        job_definition['job']['reference']['jobId'] = DATAPROC_JOB_ID + "_test"
+
+        # Prepare job using operator
+        task = DataProcHadoopOperator(
+            task_id=TASK_ID,
+            region=GCP_REGION,
+            cluster_name=CLUSTER_NAME,
+            job_name=DATAPROC_JOB_ID,
+            labels=LABELS
+        )
+
+        task.execute(context=None)
+        self.assertDictEqual(job_definition, task.job_template.job)
+
     @staticmethod
     def test_hook_correct_region():
         with patch(HOOK) as mock_hook:
@@ -604,6 +636,27 @@ class DataProcHadoopOperatorTest(unittest.TestCase):
 
 class DataProcHiveOperatorTest(unittest.TestCase):
     # Unit test for the DataProcHiveOperator
+    @mock.patch('airflow.contrib.operators.dataproc_operator.DataProcJobBaseOperator.execute')
+    @mock.patch('airflow.contrib.operators.dataproc_operator.uuid.uuid4', return_value='test')
+    def test_correct_job_definition(self, mock_hook, mock_uuid):
+        # Expected job
+        job_definition = deepcopy(DATAPROC_JOB_TO_SUBMIT)
+        job_definition['job']['hiveJob'] = {'queryFileUri': None}
+        job_definition['job']['reference']['projectId'] = None
+        job_definition['job']['reference']['jobId'] = DATAPROC_JOB_ID + "_test"
+
+        # Prepare job using operator
+        task = DataProcHiveOperator(
+            task_id=TASK_ID,
+            region=GCP_REGION,
+            cluster_name=CLUSTER_NAME,
+            job_name=DATAPROC_JOB_ID,
+            labels=LABELS
+        )
+
+        task.execute(context=None)
+        self.assertDictEqual(job_definition, task.job_template.job)
+
     @staticmethod
     def test_hook_correct_region():
         with patch(HOOK) as mock_hook:
@@ -627,6 +680,27 @@ class DataProcHiveOperatorTest(unittest.TestCase):
 
 
 class DataProcPigOperatorTest(unittest.TestCase):
+    @mock.patch('airflow.contrib.operators.dataproc_operator.DataProcJobBaseOperator.execute')
+    @mock.patch('airflow.contrib.operators.dataproc_operator.uuid.uuid4', return_value='test')
+    def test_correct_job_definition(self, mock_hook, mock_uuid):
+        # Expected job
+        job_definition = deepcopy(DATAPROC_JOB_TO_SUBMIT)
+        job_definition['job']['pigJob'] = {'queryFileUri': None}
+        job_definition['job']['reference']['projectId'] = None
+        job_definition['job']['reference']['jobId'] = DATAPROC_JOB_ID + "_test"
+
+        # Prepare job using operator
+        task = DataProcPigOperator(
+            task_id=TASK_ID,
+            region=GCP_REGION,
+            cluster_name=CLUSTER_NAME,
+            job_name=DATAPROC_JOB_ID,
+            labels=LABELS
+        )
+
+        task.execute(context=None)
+        self.assertDictEqual(job_definition, task.job_template.job)
+
     @staticmethod
     def test_hook_correct_region():
         with patch(HOOK) as mock_hook:
@@ -655,6 +729,28 @@ class DataProcPigOperatorTest(unittest.TestCase):
 
 class DataProcPySparkOperatorTest(unittest.TestCase):
     # Unit test for the DataProcPySparkOperator
+    @mock.patch('airflow.contrib.operators.dataproc_operator.DataProcJobBaseOperator.execute')
+    @mock.patch('airflow.contrib.operators.dataproc_operator.uuid.uuid4', return_value='test')
+    def test_correct_job_definition(self, mock_hook, mock_uuid):
+        # Expected job
+        job_definition = deepcopy(DATAPROC_JOB_TO_SUBMIT)
+        job_definition['job']['pysparkJob'] = {'mainPythonFileUri': 'main_class'}
+        job_definition['job']['reference']['projectId'] = None
+        job_definition['job']['reference']['jobId'] = DATAPROC_JOB_ID + "_test"
+
+        # Prepare job using operator
+        task = DataProcPySparkOperator(
+            task_id=TASK_ID,
+            region=GCP_REGION,
+            cluster_name=CLUSTER_NAME,
+            job_name=DATAPROC_JOB_ID,
+            labels=LABELS,
+            main="main_class"
+        )
+
+        task.execute(context=None)
+        self.assertDictEqual(job_definition, task.job_template.job)
+
     @staticmethod
     def test_hook_correct_region():
         with patch(HOOK) as mock_hook:
@@ -681,6 +777,29 @@ class DataProcPySparkOperatorTest(unittest.TestCase):
 
 class DataProcSparkOperatorTest(unittest.TestCase):
     # Unit test for the DataProcSparkOperator
+    # Unit test for the DataProcPySparkOperator
+    @mock.patch('airflow.contrib.operators.dataproc_operator.DataProcJobBaseOperator.execute')
+    @mock.patch('airflow.contrib.operators.dataproc_operator.uuid.uuid4', return_value='test')
+    def test_correct_job_definition(self, mock_hook, mock_uuid):
+        # Expected job
+        job_definition = deepcopy(DATAPROC_JOB_TO_SUBMIT)
+        job_definition['job']['sparkJob'] = {'mainClass': 'main_class'}
+        job_definition['job']['reference']['projectId'] = None
+        job_definition['job']['reference']['jobId'] = DATAPROC_JOB_ID + "_test"
+
+        # Prepare job using operator
+        task = DataProcSparkOperator(
+            task_id=TASK_ID,
+            region=GCP_REGION,
+            cluster_name=CLUSTER_NAME,
+            job_name=DATAPROC_JOB_ID,
+            labels=LABELS,
+            main_class="main_class"
+        )
+
+        task.execute(context=None)
+        self.assertDictEqual(job_definition, task.job_template.job)
+
     @staticmethod
     def test_hook_correct_region():
         with patch(HOOK) as mock_hook:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4074
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
