### PR TITLE
[AIRFLOW-4883] Kill hung file process managers

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1275,10 +1275,13 @@ class SchedulerJob(BaseJob):
         # so the scheduler job and DAG parser don't access the DB at the same time.
         async_mode = not self.using_sqlite
 
+        processor_timeout_seconds = conf.getint('core', 'dagbag_import_timeout')
+        processor_timeout = timedelta(seconds=processor_timeout_seconds)
         self.processor_agent = DagFileProcessorAgent(self.subdir,
                                                      known_file_paths,
                                                      self.num_runs,
                                                      processor_factory,
+                                                     processor_timeout,
                                                      async_mode)
 
         try:

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -467,6 +467,7 @@ class DagFileProcessorAgent(LoggingMixin):
                  file_paths,
                  max_runs,
                  processor_factory,
+                 processor_timeout,
                  async_mode):
         """
         :param dag_directory: Directory where DAG definitions are kept. All
@@ -480,6 +481,8 @@ class DagFileProcessorAgent(LoggingMixin):
         :param processor_factory: function that creates processors for DAG
             definition files. Arguments are (dag_definition_path, log_file_path)
         :type processor_factory: (unicode, unicode, list) -> (AbstractDagFileProcessor)
+        :param processor_timeout: How long to wait before timing out a DAG file processor
+        :type processor_timeout: timedelta
         :param async_mode: Whether to start agent in async mode
         :type async_mode: bool
         """
@@ -488,6 +491,7 @@ class DagFileProcessorAgent(LoggingMixin):
         self._dag_directory = dag_directory
         self._max_runs = max_runs
         self._processor_factory = processor_factory
+        self._processor_timeout = processor_timeout
         self._async_mode = async_mode
         # Map from file path to the processor
         self._processors = {}
@@ -519,6 +523,7 @@ class DagFileProcessorAgent(LoggingMixin):
                                              self._file_paths,
                                              self._max_runs,
                                              self._processor_factory,
+                                             self._processor_timeout,
                                              self._child_signal_conn,
                                              self._stat_queue,
                                              self._result_queue,
@@ -546,6 +551,7 @@ class DagFileProcessorAgent(LoggingMixin):
                         file_paths,
                         max_runs,
                         processor_factory,
+                        processor_timeout,
                         signal_conn,
                         _stat_queue,
                         result_queue,
@@ -566,6 +572,7 @@ class DagFileProcessorAgent(LoggingMixin):
                                                         file_paths,
                                                         max_runs,
                                                         processor_factory,
+                                                        processor_timeout,
                                                         signal_conn,
                                                         _stat_queue,
                                                         result_queue,
@@ -706,6 +713,7 @@ class DagFileProcessorManager(LoggingMixin):
                  file_paths,
                  max_runs,
                  processor_factory,
+                 processor_timeout,
                  signal_conn,
                  stat_queue,
                  result_queue,
@@ -722,6 +730,8 @@ class DagFileProcessorManager(LoggingMixin):
         :param processor_factory: function that creates processors for DAG
             definition files. Arguments are (dag_definition_path)
         :type processor_factory: (unicode, unicode, list) -> (AbstractDagFileProcessor)
+        :param processor_timeout: How long to wait before timing out a DAG file processor
+        :type processor_timeout: timedelta
         :param signal_conn: connection to communicate signal with processor agent.
         :type signal_conn: airflow.models.connection.Connection
         :param stat_queue: the queue to use for passing back parsing stat to agent.
@@ -771,6 +781,8 @@ class DagFileProcessorManager(LoggingMixin):
         self._run_count = defaultdict(int)
         # Manager heartbeat key.
         self._heart_beat_key = 'heart-beat'
+        # How long to wait before timing out a process to parse a DAG file
+        self._processor_timeout = processor_timeout
 
         # How often to scan the DAGs directory for new files. Default to 5 minutes.
         self.dag_dir_list_interval = conf.getint('scheduler',
@@ -1138,6 +1150,8 @@ class DagFileProcessorManager(LoggingMixin):
             have finished since the last time this was called
         :rtype: list[airflow.utils.dag_processing.SimpleDag]
         """
+        self._kill_timed_out_processors()
+
         finished_processors = {}
         """:type : dict[unicode, AbstractDagFileProcessor]"""
         running_processors = {}
@@ -1228,6 +1242,21 @@ class DagFileProcessorManager(LoggingMixin):
         self._run_count[self._heart_beat_key] += 1
 
         return simple_dags
+
+    def _kill_timed_out_processors(self):
+        """
+        Kill any file processors that timeout to defend against process hangs.
+        """
+        now = timezone.utcnow()
+        for file_path, processor in self._processors.items():
+            duration = now - processor.start_time
+            if duration > self._processor_timeout:
+                self.log.info(
+                    "Processor for %s with PID %s started at %s has timed out, "
+                    "killing it.",
+                    processor.file_path, processor.pid, processor.start_time.isoformat())
+                Stats.incr('dag_file_processor_timeouts', 1, 1)
+                processor.kill()
 
     def max_runs_reached(self):
         """

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from datetime import timedelta
 import os
 import pathlib
 import sys
@@ -134,6 +135,7 @@ class TestDagFileProcessorManager(unittest.TestCase):
             file_paths=['abc.txt'],
             max_runs=1,
             processor_factory=MagicMock().return_value,
+            processor_timeout=timedelta.max,
             signal_conn=MagicMock(),
             stat_queue=MagicMock(),
             result_queue=MagicMock,
@@ -155,6 +157,7 @@ class TestDagFileProcessorManager(unittest.TestCase):
             file_paths=['abc.txt'],
             max_runs=1,
             processor_factory=MagicMock().return_value,
+            processor_timeout=timedelta.max,
             signal_conn=MagicMock(),
             stat_queue=MagicMock(),
             result_queue=MagicMock,
@@ -210,12 +213,14 @@ class TestDagFileProcessorAgent(unittest.TestCase):
                                                     [],
                                                     0,
                                                     processor_factory,
+                                                    timedelta.max,
                                                     async_mode)
             manager_process = \
                 processor_agent._launch_process(processor_agent._dag_directory,
                                                 processor_agent._file_paths,
                                                 processor_agent._max_runs,
                                                 processor_agent._processor_factory,
+                                                processor_agent._processor_timeout,
                                                 processor_agent._child_signal_conn,
                                                 processor_agent._stat_queue,
                                                 processor_agent._result_queue,
@@ -241,6 +246,7 @@ class TestDagFileProcessorAgent(unittest.TestCase):
                                                 [test_dag_path],
                                                 1,
                                                 processor_factory,
+                                                timedelta.max,
                                                 async_mode)
         processor_agent.start()
         parsing_result = []
@@ -273,12 +279,14 @@ class TestDagFileProcessorAgent(unittest.TestCase):
                                                 [],
                                                 0,
                                                 processor_factory,
+                                                timedelta.max,
                                                 async_mode)
         manager_process = \
             processor_agent._launch_process(processor_agent._dag_directory,
                                             processor_agent._file_paths,
                                             processor_agent._max_runs,
                                             processor_agent._processor_factory,
+                                            processor_agent._processor_timeout,
                                             processor_agent._child_signal_conn,
                                             processor_agent._stat_queue,
                                             processor_agent._result_queue,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4883
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Dag processing processes are now timed out externally which is more robust using the DAG parsing timeout.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Updated existing tests. Also tested locally with a DAG that timed out and made sure the process got restarted and the logline appeared. It's a bit hard to make a good unit test for this since sleeping is a a testing smell, and I don't think there is a trivial way to mock this in the Airflow tests.

### Commits
- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
