### PR TITLE
[AIRFLOW-XXX] Update docs to accurately describe the precedence of remote and local logs

### DIFF
--- a/docs/howto/write-logs.rst
+++ b/docs/howto/write-logs.rst
@@ -29,10 +29,10 @@ The following convention is followed while naming logs: ``{dag_id}/{task_id}/{ex
 
 In addition, users can supply a remote location to store current logs and backups.
 
-In the Airflow Web UI, local logs take precedence over remote logs. If local logs
-can not be found or accessed, the remote logs will be displayed. Note that logs
+In the Airflow Web UI, remote logs take precedence over local logs when remote logging is enabled. If remote logs
+can not be found or accessed, local logs will be displayed. Note that logs
 are only sent to remote storage once a task is complete (including failure); In other words, remote logs for
-running tasks are unavailable.
+running tasks are unavailable (but local logs are available).
 
 Before you begin
 ''''''''''''''''


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

Currently, the docs state that local logs are preferred over remote logs. However, looking at the remote logging handlers for AWS S3, Azure Blog Storage, and Google Cloud Storage, each of them actually gives precedence to the remote logs. This corrects the documentation.

As an aside, it looks like the ElasticSearch remote storage handler has no fallback to local logs.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
