### PR TITLE
[AIRFLOW-4994] Bare version of integration test environment

### DIFF
--- a/scripts/ci/ci_run_airflow_testing.sh
+++ b/scripts/ci/ci_run_airflow_testing.sh
@@ -65,7 +65,7 @@ if [[ "${ENV}" == "docker" ]]; then
       -f "${MY_DIR}/docker-compose-${BACKEND}.yml" \
       "${DOCKER_COMPOSE_LOCAL[@]}" \
         run airflow-testing /opt/airflow/scripts/ci/in_container/entrypoint_ci.sh;
-else
+elif [[ "${ENV}" == "kubernetes" ]]; then
   "${MY_DIR}/kubernetes/minikube/stop_minikube.sh" && "${MY_DIR}/kubernetes/setup_kubernetes.sh" && \
     "${MY_DIR}/kubernetes/kube/deploy.sh" -d persistent_mode
   MINIKUBE_IP=$(minikube ip)
@@ -90,6 +90,17 @@ else
       "${DOCKER_COMPOSE_LOCAL[@]}" \
          run --no-deps airflow-testing /opt/airflow/scripts/ci/in_container/entrypoint_ci.sh;
   "${MY_DIR}/kubernetes/minikube/stop_minikube.sh"
+elif [[ "${ENV}" == "bare" ]]; then
+  docker-compose --log-level INFO \
+      -f "${MY_DIR}/docker-compose.yml" \
+      -f "${MY_DIR}/docker-compose-${BACKEND}.yml" \
+      "${DOCKER_COMPOSE_LOCAL[@]}" \
+        run --no-deps airflow-testing /opt/airflow/scripts/ci/in_container/entrypoint_ci.sh;
+else
+    echo >&2
+    echo >&2 "ERROR! The ENV variable should be one of [docker, kubernetes, bare] and is '${ENV}'"
+    echo >&2
+
 fi
 set -u
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4994
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

No need for tests

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
