### PR TITLE
[AIRFLOW-4775] Fix incorrect parameter order in GceHook

### DIFF
--- a/airflow/contrib/hooks/gcp_compute_hook.py
+++ b/airflow/contrib/hooks/gcp_compute_hook.py
@@ -306,8 +306,12 @@ class GceHook(GoogleCloudBaseHook):
         while True:
             if zone is None:
                 # noinspection PyTypeChecker
-                operation_response = self._check_global_operation_status(  # pylint: disable=E1120
-                    service, operation_name, project_id)
+                operation_response = self._check_global_operation_status(
+                    service=service,
+                    operation_name=operation_name,
+                    project_id=project_id,
+                    num_retries=self.num_retries
+                )
             else:
                 # noinspection PyTypeChecker
                 operation_response = self._check_zone_operation_status(
@@ -320,8 +324,7 @@ class GceHook(GoogleCloudBaseHook):
                     # Extracting the errors list as string and trimming square braces
                     error_msg = str(error.get("errors"))[1:-1]
                     raise AirflowException("{} {}: ".format(code, msg) + error_msg)
-                # No meaningful info to return from the response in case of success
-                return
+                break
             time.sleep(TIME_TO_SLEEP_IN_SECONDS)
 
     @staticmethod


### PR DESCRIPTION
Fixes incorrect parameter order in GceHook._wait_for_operation_to_complete
method and adds additional tests.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-4775


### Description

- [ ] Fixes incorrect parameter order in GceHook._wait_for_operation_to_complete
method and adds additional tests.

### Tests

- [ ] My PR adds the following unit tests

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`