### PR TITLE
[AIRFLOW-4995] Fix DB initialisation on MySQL

### DIFF
--- a/airflow/migrations/versions/33ae817a1ff4_add_kubernetes_resource_checkpointing.py
+++ b/airflow/migrations/versions/33ae817a1ff4_add_kubernetes_resource_checkpointing.py
@@ -43,8 +43,8 @@ def upgrade():
 
     conn = op.get_bind()
 
-    # alembic creates an invalid SQL for mssql dialect
-    if conn.dialect.name not in ('mssql'):
+    # alembic creates an invalid SQL for mssql and mysql dialects
+    if conn.dialect.name not in ('mssql', 'mysql'):
         columns_and_constraints.append(
             sa.CheckConstraint("one_row_id", name="kube_resource_version_one_row_id")
         )

--- a/airflow/migrations/versions/33ae817a1ff4_add_kubernetes_resource_checkpointing.py
+++ b/airflow/migrations/versions/33ae817a1ff4_add_kubernetes_resource_checkpointing.py
@@ -44,7 +44,11 @@ def upgrade():
     conn = op.get_bind()
 
     # alembic creates an invalid SQL for mssql and mysql dialects
-    if conn.dialect.name not in ('mssql', 'mysql'):
+    if conn.dialect.name in ("mysql"):
+        columns_and_constraints.append(
+            sa.CheckConstraint("one_row_id<>0", name="kube_resource_version_one_row_id")
+        )
+    elif conn.dialect.name not in ("mssql"):
         columns_and_constraints.append(
             sa.CheckConstraint("one_row_id", name="kube_resource_version_one_row_id")
         )

--- a/airflow/migrations/versions/86770d1215c0_add_kubernetes_scheduler_uniqueness.py
+++ b/airflow/migrations/versions/86770d1215c0_add_kubernetes_scheduler_uniqueness.py
@@ -45,8 +45,14 @@ def upgrade():
     conn = op.get_bind()
 
     # alembic creates an invalid SQL for mssql and mysql dialects
-    if conn.dialect.name not in ('mssql', 'mysql'):
-        columns_and_constraints.append(sa.CheckConstraint("one_row_id", name="kube_worker_one_row_id"))
+    if conn.dialect.name in ("mysql"):
+        columns_and_constraints.append(
+            sa.CheckConstraint("one_row_id<>0", name="kube_worker_one_row_id")
+        )
+    elif conn.dialect.name not in ("mssql"):
+        columns_and_constraints.append(
+            sa.CheckConstraint("one_row_id", name="kube_worker_one_row_id")
+        )
 
     table = op.create_table(
         RESOURCE_TABLE,

--- a/airflow/migrations/versions/86770d1215c0_add_kubernetes_scheduler_uniqueness.py
+++ b/airflow/migrations/versions/86770d1215c0_add_kubernetes_scheduler_uniqueness.py
@@ -44,8 +44,8 @@ def upgrade():
 
     conn = op.get_bind()
 
-    # alembic creates an invalid SQL for mssql dialect
-    if conn.dialect.name not in ('mssql'):
+    # alembic creates an invalid SQL for mssql and mysql dialects
+    if conn.dialect.name not in ('mssql', 'mysql'):
         columns_and_constraints.append(sa.CheckConstraint("one_row_id", name="kube_worker_one_row_id"))
 
     table = op.create_table(


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [AIRFLOW-4995](https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-4995) issues and references them in the PR title.

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:
Airflow fails to initialise MySQL as a backend due to some check constraints.
```
An expression of non-boolean type specified to a check constraint 'kube_resource_version_one_row_id'
```
This change simply includes mysql along with mssql in the conditional check for support.


### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: This line is already covered.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
