### PR TITLE
[AIRFLOW-5035] Remove multiprocessing.Manager in-favour of Pipes

### DIFF
--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -294,7 +294,11 @@ def reap_process_group(pid, log, sig=signal.SIGTERM,
     if pid == os.getpid():
         raise RuntimeError("I refuse to kill myself")
 
-    parent = psutil.Process(pid)
+    try:
+        parent = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        # Race condition - the process already exited
+        return
 
     children = parent.children(recursive=True)
     children.append(parent)


### PR DESCRIPTION
Attempting to dig in to the issue reported by @Eronarn of leaking processes we've so far managed to track it down to a leaking multiprocess.Manager process. Somehow.

So in an attempt to sort that out I have just removed manager's from the scheduler entirely, and re-written the multiprocessing how I would if I was writing this in golang channels - passing objects/messages over a single channel, and shutting down when done (so we don't need a "Done" signal, and we can `.poll()` on the channel to see if there is anything to receive.

~This is a draft PR against v1-10-stable as that is what I was testing against for release purposes, but for master the diff will be similar.~ Edit: now against master.

Does this approach seem sensible? Have I forgotten something?