### PR TITLE
[AIRFLOW-4013] Fix Mark Success/Failed picking all execution_date bug

### DIFF
--- a/airflow/api/common/experimental/mark_tasks.py
+++ b/airflow/api/common/experimental/mark_tasks.py
@@ -251,6 +251,11 @@ def get_execution_dates(dag, execution_date, future, past):
     start_date = execution_date if not past else start_date
     if dag.schedule_interval == '@once':
         dates = [start_date]
+    elif not dag.schedule_interval:
+        # If schedule_interval is None, need to look at existing DagRun if the user wants future or
+        # past runs.
+        dag_runs = dag.get_dagruns_between(start_date=start_date, end_date=end_date)
+        dates = sorted({d.execution_date for d in dag_runs})
     else:
         dates = dag.date_range(start_date=start_date, end_date=end_date)
     return dates

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -666,6 +666,26 @@ class DAG(BaseDag, LoggingMixin):
         return dagrun
 
     @provide_session
+    def get_dagruns_between(self, start_date, end_date, session=None):
+        """
+        Returns the list of dag runs between start_date (inclusive) and end_date (inclusive).
+
+        :param start_date: The starting execution date of the DagRun to find.
+        :param end_date: The ending execution date of the DagRun to find.
+        :param session:
+        :return: The list of DagRuns found.
+        """
+        dagruns = (
+            session.query(DagRun)
+            .filter(
+                DagRun.dag_id == self.dag_id,
+                DagRun.execution_date >= start_date,
+                DagRun.execution_date <= end_date)
+            .all())
+
+        return dagruns
+
+    @provide_session
     def _get_latest_execution_date(self, session=None):
         return session.query(func.max(DagRun.execution_date)).filter(
             DagRun.dag_id == self.dag_id


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4013) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4013
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
  - The bug happens when schedule_interval is None. Marking one task for one day ends up marking all dates as Success or Failed.
  - The fix is by looking up existing DagRun if schedule_interval is None, and only mark the ones falling between start_date and end_date as Success or Failed.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - Updated test_mark_tasks.py to test the cases where schedule_interval is None.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
