### PR TITLE
[AIRFLOW-4992] Replace backports configparser by native configparser

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -26,8 +26,9 @@ import shlex
 import subprocess
 import sys
 import warnings
+# Ignored Mypy on configparser because it thinks the configparser module has no _UNSET attribute
+from configparser import ConfigParser, _UNSET, NoOptionError, NoSectionError  # type: ignore
 
-from backports.configparser import ConfigParser, _UNSET, NoOptionError, NoSectionError
 from zope.deprecation import deprecated
 
 from airflow.exceptions import AirflowConfigException

--- a/setup.py
+++ b/setup.py
@@ -324,7 +324,6 @@ def do_setup():
             'alembic>=1.0, <2.0',
             'cached_property~=1.5',
             'colorlog==4.0.2',
-            'configparser>=3.5.0, <3.6.0',
             'croniter>=0.3.17, <0.4',
             'dill>=0.2.2, <0.3',
             'dumb-init>=1.2.2',

--- a/tests/lineage/backend/test_atlas.py
+++ b/tests/lineage/backend/test_atlas.py
@@ -16,7 +16,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 import unittest
+from configparser import DuplicateSectionError
 
 from airflow.configuration import conf, AirflowConfigException
 from airflow.lineage.backend.atlas import AtlasBackend
@@ -25,8 +27,6 @@ from airflow.models import DAG, TaskInstance as TI
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.utils import timezone
 from tests.compat import mock
-
-from backports.configparser import DuplicateSectionError
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4992
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Replace backports configparser by Python native configparser module since we're dropping Python 2 support.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No changes required.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
