### PR TITLE
[AIRFLOW-5002] Diagnostics of getopt fixed for zsh on MacOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -281,11 +281,25 @@ clean the docker disk space periodically.
 If you are on MacOS:
 
 * Run `brew install gnu-getopt coreutils` (if you use brew, or use equivalent command for ports)
-* Then (with brew) link the gnu-getopt to become default as suggested by brew by typing.
+* Then (with brew) link the gnu-getopt to become default as suggested by brew.
+
+If you use bash, you should run this command:
+
+
 ```bash
-echo 'export PATH=\"/usr/local/opt/gnu-getopt/bin:\$PATH\"' >> ~/.bash_profile"
-. ~/.bash_profile"
+echo 'export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"' >> ~/.bash_profile
+. ~/.bash_profile
 ```
+
+If you use zsh, you should run this command:
+
+```bash
+echo 'export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"' >> ~/.zprofile
+. ~/.zprofile
+```
+
+if you use zsh
+
 * Login and logout afterwards
 
 If you are on Linux:

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -228,21 +228,34 @@ function check_if_coreutils_installed() {
 
     set -e
 
+    CMDNAME="$(basename -- "$0")"
+
     ####################  Parsing options/arguments
     if [[ ${GETOPT_RETVAL} != 4 || "${STAT_PRESENT}" != "0" || "${MD5SUM_PRESENT}" != "0" ]]; then
         echo
         if [[ $(uname -s) == 'Darwin' ]] ; then
             echo >&2 "You are running ${CMDNAME} in OSX environment"
             echo >&2 "And you need to install gnu commands"
-            echo
+            echo >&2
             echo >&2 "Run 'brew install gnu-getopt coreutils'"
-            echo
-            echo >&2 "Then link the gnu-getopt to become default as suggested by brew by typing:"
+            echo >&2
+            echo >&2 "Then link the gnu-getopt to become default as suggested by brew."
+            echo >&2
+            echo >&2 "If you use bash, you should run this command:"
+            echo >&2
             echo >&2 "echo 'export PATH=\"/usr/local/opt/gnu-getopt/bin:\$PATH\"' >> ~/.bash_profile"
             echo >&2 ". ~/.bash_profile"
-            echo
-            echo >&2 "Login and logout afterwards"
-            echo
+            echo >&2
+            echo >&2 "If you use zsh, you should run this command:"
+            echo >&2
+            echo >&2 "echo 'export PATH=\"/usr/local/opt/gnu-getopt/bin:\$PATH\"' >> ~/.zprofile"
+            echo >&2 ". ~/.zprofile"
+            echo >&2
+            echo >&2 "Login and logout afterwards !!"
+            echo >&2
+            echo >&2 "After re-login, your PATH variable should start with \"/usr/local/opt/gnu-getopt/bin\""
+            echo >&2 "Your current path is ${PATH}"
+            echo >&2
         else
             echo >&2 "You do not have necessary tools in your path (getopt, stat, md5sum)."
             echo >&2 "Please install latest/GNU version of getopt and coreutils."


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5002

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When you use zsh on MacOS the message to diagnose getopt installation is not helpful and you do not have getopt added to your path when you follow it (plus CMDNAME unbound error is printed).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No tests needed.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
It is a built-in documentation change.

### Code Quality

- [x] Passes `flake8`
