### PR TITLE
[AIRFLOW-5007] Remove override of python version to 3.6 in tests

### DIFF
--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -447,7 +447,6 @@ function go_to_airflow_sources {
 function basic_sanity_checks() {
     assert_not_in_container
     go_to_airflow_sources
-    force_python_3_6
     check_if_coreutils_installed
     create_cache_directory
 }

--- a/scripts/ci/ci_check_license.sh
+++ b/scripts/ci/ci_check_license.sh
@@ -25,6 +25,8 @@ MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 basic_sanity_checks
 
+force_python_3_6
+
 script_start
 
 rebuild_image_if_needed_for_tests

--- a/scripts/ci/ci_docs.sh
+++ b/scripts/ci/ci_docs.sh
@@ -25,6 +25,8 @@ MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 basic_sanity_checks
 
+force_python_3_6
+
 script_start
 
 rebuild_image_if_needed_for_static_checks

--- a/scripts/ci/ci_flake8.sh
+++ b/scripts/ci/ci_flake8.sh
@@ -25,6 +25,8 @@ MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 basic_sanity_checks
 
+force_python_3_6
+
 script_start
 
 rebuild_image_if_needed_for_static_checks

--- a/scripts/ci/ci_mypy.sh
+++ b/scripts/ci/ci_mypy.sh
@@ -25,6 +25,8 @@ MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 basic_sanity_checks
 
+force_python_3_6
+
 script_start
 
 rebuild_image_if_needed_for_static_checks

--- a/scripts/ci/ci_pylint.sh
+++ b/scripts/ci/ci_pylint.sh
@@ -25,6 +25,8 @@ MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 basic_sanity_checks
 
+force_python_3_6
+
 script_start
 
 rebuild_image_if_needed_for_static_checks


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5007

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Python version should be forced to 3.6 only in static checks but it was accidentally forced to 3.6 in running the tests as well. It should be fixed quickly

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
All tests.
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
