### PR TITLE
[AIRFLOW-5008] Fixed missing libmysql-client-dev in Oracle repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ RUN KEY="A4A9406876FCBD3C456770C88C718D3B5072E1F5" \
     && gpgconf --kill all \
     rm -rf "${GNUPGHOME}"; \
     apt-key list > /dev/null \
-    && echo "deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.6" | tee -a /etc/apt/sources.list.d/mysql.list \
+    && echo "deb http://repo.mysql.com/apt/debian/ stretch mysql-5.6" | tee -a /etc/apt/sources.list.d/mysql.list \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
         libmysqlclient-dev \


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5008

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Seems that libmysqlclient-dev disappeared from Oracle's repositories and when building images from scratch the build fails with missing dependency.

Problem is similar to described here:

https://www.answiz.com/questions/1892/package-libmysqlclient-dev-has-no-installation-candidate

Solution is to replace libmysqlclient-dev with default-libmysqlclient-dev 


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
