### PR TITLE
[AIRLFOW-XXX] Fix constructor parameters docs

### DIFF
--- a/airflow/contrib/operators/postgres_to_gcs_operator.py
+++ b/airflow/contrib/operators/postgres_to_gcs_operator.py
@@ -32,6 +32,36 @@ from tempfile import NamedTemporaryFile
 class PostgresToGoogleCloudStorageOperator(BaseOperator):
     """
     Copy data from Postgres to Google Cloud Storage in JSON format.
+
+    :param sql: The SQL to execute on the Postgres table.
+    :type sql: str
+    :param bucket: The bucket to upload to.
+    :type bucket: str
+    :param filename: The filename to use as the object name when uploading
+        to Google Cloud Storage. A {} should be specified in the filename
+        to allow the operator to inject file numbers in cases where the
+        file is split due to size.
+    :type filename: str
+    :param schema_filename: If set, the filename to use as the object name
+        when uploading a .json file containing the BigQuery schema fields
+        for the table that was dumped from Postgres.
+    :type schema_filename: str
+    :param approx_max_file_size_bytes: This operator supports the ability
+        to split large table dumps into multiple files (see notes in the
+        filename param docs above). This param allows developers to specify the
+        file size of the splits. Check https://cloud.google.com/storage/quotas
+        to see the maximum allowed file size for a single object.
+    :type approx_max_file_size_bytes: long
+    :param postgres_conn_id: Reference to a specific Postgres hook.
+    :type postgres_conn_id: str
+    :param google_cloud_storage_conn_id: Reference to a specific Google
+        cloud storage hook.
+    :type google_cloud_storage_conn_id: str
+    :param delegate_to: The account to impersonate, if any. For this to
+        work, the service account making the request must have domain-wide
+        delegation enabled.
+    :param parameters: a parameters dict that is substituted at query runtime.
+    :type parameters: dict
     """
     template_fields = ('sql', 'bucket', 'filename', 'schema_filename',
                        'parameters')
@@ -51,37 +81,6 @@ class PostgresToGoogleCloudStorageOperator(BaseOperator):
                  parameters=None,
                  *args,
                  **kwargs):
-        """
-        :param sql: The SQL to execute on the Postgres table.
-        :type sql: str
-        :param bucket: The bucket to upload to.
-        :type bucket: str
-        :param filename: The filename to use as the object name when uploading
-            to Google Cloud Storage. A {} should be specified in the filename
-            to allow the operator to inject file numbers in cases where the
-            file is split due to size.
-        :type filename: str
-        :param schema_filename: If set, the filename to use as the object name
-            when uploading a .json file containing the BigQuery schema fields
-            for the table that was dumped from Postgres.
-        :type schema_filename: str
-        :param approx_max_file_size_bytes: This operator supports the ability
-            to split large table dumps into multiple files (see notes in the
-            filename param docs above). This param allows developers to specify the
-            file size of the splits. Check https://cloud.google.com/storage/quotas
-            to see the maximum allowed file size for a single object.
-        :type approx_max_file_size_bytes: long
-        :param postgres_conn_id: Reference to a specific Postgres hook.
-        :type postgres_conn_id: str
-        :param google_cloud_storage_conn_id: Reference to a specific Google
-            cloud storage hook.
-        :type google_cloud_storage_conn_id: str
-        :param delegate_to: The account to impersonate, if any. For this to
-            work, the service account making the request must have domain-wide
-            delegation enabled.
-        :param parameters: a parameters dict that is substituted at query runtime.
-        :type parameters: dict
-        """
         super().__init__(*args, **kwargs)
         self.sql = sql
         self.bucket = bucket

--- a/airflow/contrib/operators/pubsub_operator.py
+++ b/airflow/contrib/operators/pubsub_operator.py
@@ -51,6 +51,21 @@ class PubSubTopicCreateOperator(BaseOperator):
 
     Both ``project`` and ``topic`` are templated so you can use
     variables in them.
+
+    :param project: the GCP project ID where the topic will be created
+    :type project: str
+    :param topic: the topic to create. Do not include the
+        full topic path. In other words, instead of
+        ``projects/{project}/topics/{topic}``, provide only
+        ``{topic}``. (templated)
+    :type topic: str
+    :param gcp_conn_id: The connection ID to use connecting to
+        Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request
+        must have domain-wide delegation enabled.
+    :type delegate_to: str
     """
     template_fields = ['project', 'topic']
     ui_color = '#0273d4'
@@ -65,22 +80,6 @@ class PubSubTopicCreateOperator(BaseOperator):
             delegate_to=None,
             *args,
             **kwargs):
-        """
-        :param project: the GCP project ID where the topic will be created
-        :type project: str
-        :param topic: the topic to create. Do not include the
-            full topic path. In other words, instead of
-            ``projects/{project}/topics/{topic}``, provide only
-            ``{topic}``. (templated)
-        :type topic: str
-        :param gcp_conn_id: The connection ID to use connecting to
-            Google Cloud Platform.
-        :type gcp_conn_id: str
-        :param delegate_to: The account to impersonate, if any.
-            For this to work, the service account making the request
-            must have domain-wide delegation enabled.
-        :type delegate_to: str
-        """
         super().__init__(*args, **kwargs)
 
         self.project = project

--- a/airflow/contrib/operators/sqoop_operator.py
+++ b/airflow/contrib/operators/sqoop_operator.py
@@ -35,6 +35,52 @@ class SqoopOperator(BaseOperator):
     Execute a Sqoop job.
     Documentation for Apache Sqoop can be found here:
     https://sqoop.apache.org/docs/1.4.2/SqoopUserGuide.html
+
+    :param conn_id: str
+    :param cmd_type: str specify command to execute "export" or "import"
+    :param table: Table to read
+    :param query: Import result of arbitrary SQL query. Instead of using the table,
+        columns and where arguments, you can specify a SQL statement with the query
+        argument. Must also specify a destination directory with target_dir.
+    :param target_dir: HDFS destination directory where the data
+        from the rdbms will be written
+    :param append: Append data to an existing dataset in HDFS
+    :param file_type: "avro", "sequence", "text" Imports data to
+        into the specified format. Defaults to text.
+    :param columns: <col,col,col> Columns to import from table
+    :param num_mappers: Use n mapper tasks to import/export in parallel
+    :param split_by: Column of the table used to split work units
+    :param where: WHERE clause to use during import
+    :param export_dir: HDFS Hive database directory to export to the rdbms
+    :param input_null_string: The string to be interpreted as null
+        for string columns
+    :param input_null_non_string: The string to be interpreted as null
+        for non-string columns
+    :param staging_table: The table in which data will be staged before
+        being inserted into the destination table
+    :param clear_staging_table: Indicate that any data present in the
+        staging table can be deleted
+    :param enclosed_by: Sets a required field enclosing character
+    :param escaped_by: Sets the escape character
+    :param input_fields_terminated_by: Sets the input field separator
+    :param input_lines_terminated_by: Sets the input end-of-line character
+    :param input_optionally_enclosed_by: Sets a field enclosing character
+    :param batch: Use batch mode for underlying statement execution
+    :param direct: Use direct export fast path
+    :param driver: Manually specify JDBC driver class to use
+    :param verbose: Switch to more verbose logging for debug purposes
+    :param relaxed_isolation: use read uncommitted isolation level
+    :param hcatalog_database: Specifies the database name for the HCatalog table
+    :param hcatalog_table: The argument value for this option is the HCatalog table
+    :param create_hcatalog_table: Have sqoop create the hcatalog table passed
+        in or not
+    :param properties: additional JVM properties passed to sqoop
+    :param extra_import_options: Extra import options to pass as dict.
+        If a key doesn't have a value, just pass an empty string to it.
+        Don't include prefix of -- for sqoop options.
+    :param extra_export_options: Extra export options to pass as dict.
+        If a key doesn't have a value, just pass an empty string to it.
+        Don't include prefix of -- for sqoop options.
     """
     template_fields = ('conn_id', 'cmd_type', 'table', 'query', 'target_dir',
                        'file_type', 'columns', 'split_by',
@@ -82,53 +128,6 @@ class SqoopOperator(BaseOperator):
                  extra_export_options=None,
                  *args,
                  **kwargs):
-        """
-        :param conn_id: str
-        :param cmd_type: str specify command to execute "export" or "import"
-        :param table: Table to read
-        :param query: Import result of arbitrary SQL query. Instead of using the table,
-            columns and where arguments, you can specify a SQL statement with the query
-            argument. Must also specify a destination directory with target_dir.
-        :param target_dir: HDFS destination directory where the data
-            from the rdbms will be written
-        :param append: Append data to an existing dataset in HDFS
-        :param file_type: "avro", "sequence", "text" Imports data to
-            into the specified format. Defaults to text.
-        :param columns: <col,col,col> Columns to import from table
-        :param num_mappers: Use n mapper tasks to import/export in parallel
-        :param split_by: Column of the table used to split work units
-        :param where: WHERE clause to use during import
-        :param export_dir: HDFS Hive database directory to export to the rdbms
-        :param input_null_string: The string to be interpreted as null
-            for string columns
-        :param input_null_non_string: The string to be interpreted as null
-            for non-string columns
-        :param staging_table: The table in which data will be staged before
-            being inserted into the destination table
-        :param clear_staging_table: Indicate that any data present in the
-            staging table can be deleted
-        :param enclosed_by: Sets a required field enclosing character
-        :param escaped_by: Sets the escape character
-        :param input_fields_terminated_by: Sets the input field separator
-        :param input_lines_terminated_by: Sets the input end-of-line character
-        :param input_optionally_enclosed_by: Sets a field enclosing character
-        :param batch: Use batch mode for underlying statement execution
-        :param direct: Use direct export fast path
-        :param driver: Manually specify JDBC driver class to use
-        :param verbose: Switch to more verbose logging for debug purposes
-        :param relaxed_isolation: use read uncommitted isolation level
-        :param hcatalog_database: Specifies the database name for the HCatalog table
-        :param hcatalog_table: The argument value for this option is the HCatalog table
-        :param create_hcatalog_table: Have sqoop create the hcatalog table passed
-            in or not
-        :param properties: additional JVM properties passed to sqoop
-        :param extra_import_options: Extra import options to pass as dict.
-            If a key doesn't have a value, just pass an empty string to it.
-            Don't include prefix of -- for sqoop options.
-        :param extra_export_options: Extra export options to pass as dict.
-            If a key doesn't have a value, just pass an empty string to it.
-            Don't include prefix of -- for sqoop options.
-        """
         super().__init__(*args, **kwargs)
         self.conn_id = conn_id
         self.cmd_type = cmd_type


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
