### PR TITLE
[AIRFLOW-5010] Add typehints for core operators

### DIFF
--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -22,6 +22,7 @@ import os
 import signal
 from subprocess import Popen, STDOUT, PIPE
 from tempfile import gettempdir, NamedTemporaryFile
+from typing import Dict
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -70,10 +71,10 @@ class BashOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            bash_command,
-            env=None,
-            output_encoding='utf-8',
-            *args, **kwargs):
+            bash_command: str,
+            env: Dict[str, str] = None,
+            output_encoding: str = 'utf-8',
+            *args, **kwargs) -> None:
 
         super().__init__(*args, **kwargs)
         self.bash_command = bash_command

--- a/airflow/operators/check_operator.py
+++ b/airflow/operators/check_operator.py
@@ -72,7 +72,7 @@ class CheckOperator(BaseOperator):
         conn_id: Optional[str] = None,
         *args,
         **kwargs
-    ):
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.conn_id = conn_id
         self.sql = sql

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -18,6 +18,8 @@
 # under the License.
 
 import datetime
+from typing import Callable, Union, Optional
+
 from airflow.models import BaseOperator
 from airflow.utils import timezone
 from airflow.utils.decorators import apply_defaults
@@ -57,20 +59,21 @@ class TriggerDagRunOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            trigger_dag_id,
-            python_callable=None,
-            execution_date=None,
-            *args, **kwargs):
+            trigger_dag_id: str,
+            python_callable: Callable = None,
+            execution_date: Optional[Union[str, datetime.datetime]] = None,
+            *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.python_callable = python_callable
         self.trigger_dag_id = trigger_dag_id
 
+        self.execution_date = None  # type: Optional[Union[str, datetime.datetime]]
         if isinstance(execution_date, datetime.datetime):
             self.execution_date = execution_date.isoformat()
         elif isinstance(execution_date, str):
             self.execution_date = execution_date
         elif execution_date is None:
-            self.execution_date = execution_date
+            self.execution_date = None
         else:
             raise TypeError(
                 'Expected str or datetime.datetime type '

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -18,7 +18,7 @@
 # under the License.
 
 import datetime
-from typing import Callable, Union, Optional
+from typing import Callable, Union, Optional, Dict
 
 from airflow.models import BaseOperator
 from airflow.utils import timezone
@@ -60,7 +60,7 @@ class TriggerDagRunOperator(BaseOperator):
     def __init__(
             self,
             trigger_dag_id: str,
-            python_callable: Callable = None,
+            python_callable: Callable[[Dict, DagRunOrder], DagRunOrder] = None,
             execution_date: Optional[Union[str, datetime.datetime]] = None,
             *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -18,6 +18,7 @@
 # under the License.
 
 import json
+from typing import Union, List
 
 from airflow.hooks.docker_hook import DockerHook
 from airflow.exceptions import AirflowException
@@ -48,20 +49,12 @@ class DockerOperator(BaseOperator):
     :param api_version: Remote API version. Set to ``auto`` to automatically
         detect the server's version.
     :type api_version: str
-    :param auto_remove: Auto-removal of the container on daemon side when the
-        container's process exits.
-        The default is False.
-    :type auto_remove: bool
     :param command: Command to be run in the container. (templated)
     :type command: str or list
     :param cpus: Number of CPUs to assign to the container.
         This value gets multiplied with 1024. See
         https://docs.docker.com/engine/reference/run/#cpu-share-constraint
     :type cpus: float
-    :param dns: Docker custom DNS servers
-    :type dns: list[str]
-    :param dns_search: Docker custom DNS search domain
-    :type dns_search: list[str]
     :param docker_url: URL of the host running the docker daemon.
         Default is unix://var/run/docker.sock
     :type docker_url: str
@@ -109,6 +102,14 @@ class DockerOperator(BaseOperator):
     :type xcom_all: bool
     :param docker_conn_id: ID of the Airflow connection to use
     :type docker_conn_id: str
+    :param dns: Docker custom DNS servers
+    :type dns: list[str]
+    :param dns_search: Docker custom DNS search domain
+    :type dns_search: list[str]
+    :param auto_remove: Auto-removal of the container on daemon side when the
+        container's process exits.
+        The default is False.
+    :type auto_remove: bool
     :param shm_size: Size of ``/dev/shm`` in bytes. The size must be
         greater than 0. If omitted uses system default.
     :type shm_size: int
@@ -119,15 +120,15 @@ class DockerOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            image,
-            api_version=None,
-            command=None,
-            cpus=1.0,
-            docker_url='unix://var/run/docker.sock',
-            environment=None,
-            force_pull=False,
-            mem_limit=None,
-            host_tmp_dir=None,
+            image: str,
+            api_version: str = None,
+            command: Union[str, List[str]] = None,
+            cpus: float = 1.0,
+            docker_url: str = 'unix://var/run/docker.sock',
+            environment: dict = None,
+            force_pull: bool = False,
+            mem_limit: Union[float, str] = None,
+            host_tmp_dir: str = None,
             network_mode=None,
             tls_ca_cert=None,
             tls_client_cert=None,
@@ -145,7 +146,7 @@ class DockerOperator(BaseOperator):
             auto_remove=False,
             shm_size=None,
             *args,
-            **kwargs):
+            **kwargs) -> None:
 
         super().__init__(*args, **kwargs)
         self.api_version = api_version

--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -18,7 +18,7 @@
 # under the License.
 
 import json
-from typing import Union, List
+from typing import Union, List, Dict, Iterable
 
 from airflow.hooks.docker_hook import DockerHook
 from airflow.exceptions import AirflowException
@@ -125,26 +125,26 @@ class DockerOperator(BaseOperator):
             command: Union[str, List[str]] = None,
             cpus: float = 1.0,
             docker_url: str = 'unix://var/run/docker.sock',
-            environment: dict = None,
+            environment: Dict = None,
             force_pull: bool = False,
             mem_limit: Union[float, str] = None,
             host_tmp_dir: str = None,
-            network_mode=None,
-            tls_ca_cert=None,
-            tls_client_cert=None,
-            tls_client_key=None,
-            tls_hostname=None,
-            tls_ssl_version=None,
-            tmp_dir='/tmp/airflow',
-            user=None,
-            volumes=None,
-            working_dir=None,
-            xcom_all=False,
-            docker_conn_id=None,
-            dns=None,
-            dns_search=None,
-            auto_remove=False,
-            shm_size=None,
+            network_mode: str = None,
+            tls_ca_cert: str = None,
+            tls_client_cert: str = None,
+            tls_client_key: str = None,
+            tls_hostname: Union[str, bool] = None,
+            tls_ssl_version: str = None,
+            tmp_dir: str = '/tmp/airflow',
+            user: Union[str, int] = None,
+            volumes: Iterable[str] = None,
+            working_dir: str = None,
+            xcom_all: bool = False,
+            docker_conn_id: str = None,
+            dns: List[str] = None,
+            dns_search: List[str] = None,
+            auto_remove: bool = False,
+            shm_size: int = None,
             *args,
             **kwargs) -> None:
 

--- a/airflow/operators/druid_check_operator.py
+++ b/airflow/operators/druid_check_operator.py
@@ -58,9 +58,10 @@ class DruidCheckOperator(CheckOperator):
 
     @apply_defaults
     def __init__(
-            self, sql,
-            druid_broker_conn_id='druid_broker_default',
-            *args, **kwargs):
+            self,
+            sql: str,
+            druid_broker_conn_id: str = 'druid_broker_default',
+            *args, **kwargs) -> None:
         super().__init__(sql=sql, *args, **kwargs)
         self.druid_broker_conn_id = druid_broker_conn_id
         self.sql = sql

--- a/airflow/operators/dummy_operator.py
+++ b/airflow/operators/dummy_operator.py
@@ -30,7 +30,7 @@ class DummyOperator(BaseOperator):
     ui_color = '#e8f7e4'
 
     @apply_defaults
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
     def execute(self, context):

--- a/airflow/operators/email_operator.py
+++ b/airflow/operators/email_operator.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Union, List
 
 from airflow.models import BaseOperator
 from airflow.utils.email import send_email
@@ -53,15 +54,15 @@ class EmailOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            to,
-            subject,
-            html_content,
-            files=None,
-            cc=None,
-            bcc=None,
-            mime_subtype='mixed',
-            mime_charset='utf-8',
-            *args, **kwargs):
+            to: Union[List[str], str],
+            subject: str,
+            html_content: str,
+            files: list = None,
+            cc: Union[List[str], str] = None,
+            bcc: Union[List[str], str] = None,
+            mime_subtype: str = 'mixed',
+            mime_charset: str = 'utf-8',
+            *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.to = to
         self.subject = subject

--- a/airflow/operators/email_operator.py
+++ b/airflow/operators/email_operator.py
@@ -57,7 +57,7 @@ class EmailOperator(BaseOperator):
             to: Union[List[str], str],
             subject: str,
             html_content: str,
-            files: list = None,
+            files: List = None,
             cc: Union[List[str], str] = None,
             bcc: Union[List[str], str] = None,
             mime_subtype: str = 'mixed',

--- a/airflow/operators/generic_transfer.py
+++ b/airflow/operators/generic_transfer.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Union, List
 
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
@@ -51,12 +52,12 @@ class GenericTransfer(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            sql,
-            destination_table,
-            source_conn_id,
-            destination_conn_id,
-            preoperator=None,
-            *args, **kwargs):
+            sql: str,
+            destination_table: str,
+            source_conn_id: str,
+            destination_conn_id: str,
+            preoperator: Union[str, List[str]] = None,
+            *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.sql = sql
         self.destination_table = destination_table

--- a/airflow/operators/hive_operator.py
+++ b/airflow/operators/hive_operator.py
@@ -18,6 +18,7 @@
 # under the License.
 
 import re
+from typing import Dict
 
 from airflow.hooks.hive_hooks import HiveCliHook
 from airflow import configuration
@@ -49,6 +50,8 @@ class HiveOperator(BaseOperator):
     :param script_begin_tag: If defined, the operator will get rid of the
         part of the script before the first occurrence of `script_begin_tag`
     :type script_begin_tag: str
+    :param run_as_owner: Run HQL code as a DAG's owner.
+    :type run_as_owner: bool
     :param mapred_queue: queue used by the Hadoop CapacityScheduler. (templated)
     :type  mapred_queue: str
     :param mapred_queue_priority: priority within CapacityScheduler queue.
@@ -66,17 +69,18 @@ class HiveOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self, hql,
-            hive_cli_conn_id='hive_cli_default',
-            schema='default',
-            hiveconfs=None,
-            hiveconf_jinja_translate=False,
-            script_begin_tag=None,
-            run_as_owner=False,
-            mapred_queue=None,
-            mapred_queue_priority=None,
-            mapred_job_name=None,
-            *args, **kwargs):
+            self,
+            hql: str,
+            hive_cli_conn_id: str = 'hive_cli_default',
+            schema: str = 'default',
+            hiveconfs: Dict = None,
+            hiveconf_jinja_translate: bool = False,
+            script_begin_tag: str = None,
+            run_as_owner: bool = False,
+            mapred_queue: str = None,
+            mapred_queue_priority: str = None,
+            mapred_job_name: str = None,
+            *args, **kwargs) -> None:
 
         super().__init__(*args, **kwargs)
         self.hql = hql

--- a/airflow/operators/hive_stats_operator.py
+++ b/airflow/operators/hive_stats_operator.py
@@ -19,7 +19,7 @@
 
 import json
 from collections import OrderedDict
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.hive_hooks import HiveMetastoreHook
@@ -69,7 +69,7 @@ class HiveStatsCollectionOperator(BaseOperator):
                  partition: str,
                  extra_exprs: Dict = None,
                  col_blacklist: List = None,
-                 assignment_func: Callable = None,
+                 assignment_func: Callable[[str, str], Optional[Dict]] = None,
                  metastore_conn_id: str = 'metastore_default',
                  presto_conn_id: str = 'presto_default',
                  mysql_conn_id: str = 'airflow_db',
@@ -78,7 +78,7 @@ class HiveStatsCollectionOperator(BaseOperator):
         self.table = table
         self.partition = partition
         self.extra_exprs = extra_exprs or {}
-        self.col_blacklist: List = col_blacklist or []
+        self.col_blacklist = col_blacklist or []  # type: List
         self.metastore_conn_id = metastore_conn_id
         self.presto_conn_id = presto_conn_id
         self.mysql_conn_id = mysql_conn_id

--- a/airflow/operators/hive_stats_operator.py
+++ b/airflow/operators/hive_stats_operator.py
@@ -19,6 +19,7 @@
 
 import json
 from collections import OrderedDict
+from typing import Callable, Dict, List
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.hive_hooks import HiveMetastoreHook
@@ -64,20 +65,20 @@ class HiveStatsCollectionOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 table,
-                 partition,
-                 extra_exprs=None,
-                 col_blacklist=None,
-                 assignment_func=None,
-                 metastore_conn_id='metastore_default',
-                 presto_conn_id='presto_default',
-                 mysql_conn_id='airflow_db',
-                 *args, **kwargs):
+                 table: str,
+                 partition: str,
+                 extra_exprs: Dict = None,
+                 col_blacklist: List = None,
+                 assignment_func: Callable = None,
+                 metastore_conn_id: str = 'metastore_default',
+                 presto_conn_id: str = 'presto_default',
+                 mysql_conn_id: str = 'airflow_db',
+                 *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.table = table
         self.partition = partition
         self.extra_exprs = extra_exprs or {}
-        self.col_blacklist = col_blacklist or {}
+        self.col_blacklist: List = col_blacklist or []
         self.metastore_conn_id = metastore_conn_id
         self.presto_conn_id = presto_conn_id
         self.mysql_conn_id = mysql_conn_id

--- a/airflow/operators/hive_to_druid.py
+++ b/airflow/operators/hive_to_druid.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import List, Dict
 
 from airflow.hooks.hive_hooks import HiveCliHook, HiveMetastoreHook
 from airflow.hooks.druid_hook import DruidHook
@@ -52,6 +53,21 @@ class HiveToDruidTransfer(BaseOperator):
     :param intervals: list of time intervals that defines segments,
         this is passed as is to the json object. (templated)
     :type intervals: list
+    :param num_shards: Directly specify the number of shards to create.
+    :type num_shards: float
+    :param target_partition_size: Target number of rows to include in a partition,
+    :type target_partition_size: int
+    :param query_granularity: The minimum granularity to be able to query results at and the granularity of
+        the data inside the segment. E.g. a value of "minute" will mean that data is aggregated at minutely
+        granularity. That is, if there are collisions in the tuple (minute(timestamp), dimensions), then it
+        will aggregate values together using the aggregators instead of storing individual rows.
+        A granularity of 'NONE' means millisecond granularity.
+    :type query_granularity: str
+    :param segment_granularity: The granularity to create time chunks at. Multiple segments can be created per
+        time chunk. For example, with 'DAY' segmentGranularity, the events of the same day fall into the
+        same time chunk which can be optionally further partitioned into multiple segments based on other
+        configurations and input size.
+    :type segment_granularity: str
     :param hive_tblproperties: additional properties for tblproperties in
         hive for the staging table
     :type hive_tblproperties: dict
@@ -65,22 +81,22 @@ class HiveToDruidTransfer(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            sql,
-            druid_datasource,
-            ts_dim,
-            metric_spec=None,
-            hive_cli_conn_id='hive_cli_default',
-            druid_ingest_conn_id='druid_ingest_default',
-            metastore_conn_id='metastore_default',
-            hadoop_dependency_coordinates=None,
-            intervals=None,
-            num_shards=-1,
-            target_partition_size=-1,
-            query_granularity="NONE",
-            segment_granularity="DAY",
-            hive_tblproperties=None,
-            job_properties=None,
-            *args, **kwargs):
+            sql: str,
+            druid_datasource: str,
+            ts_dim: str,
+            metric_spec: List = None,
+            hive_cli_conn_id: str = 'hive_cli_default',
+            druid_ingest_conn_id: str = 'druid_ingest_default',
+            metastore_conn_id: str = 'metastore_default',
+            hadoop_dependency_coordinates: List[str] = None,
+            intervals: List = None,
+            num_shards: float = -1,
+            target_partition_size: int = -1,
+            query_granularity: str = "NONE",
+            segment_granularity: str = "DAY",
+            hive_tblproperties: Dict = None,
+            job_properties: Dict = None,
+            *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.sql = sql
         self.druid_datasource = druid_datasource

--- a/airflow/operators/hive_to_mysql.py
+++ b/airflow/operators/hive_to_mysql.py
@@ -18,6 +18,7 @@
 # under the License.
 
 from tempfile import NamedTemporaryFile
+from typing import Dict
 
 from airflow.hooks.hive_hooks import HiveServer2Hook
 from airflow.hooks.mysql_hook import MySqlHook
@@ -55,6 +56,8 @@ class HiveToMySqlTransfer(BaseOperator):
         This option requires an extra connection parameter for the
         destination MySQL connection: {'local_infile': true}.
     :type bulk_load: bool
+    :param hive_conf:
+    :type hive_conf: dict
     """
 
     template_fields = ('sql', 'mysql_table', 'mysql_preoperator', 'mysql_postoperator')
@@ -63,15 +66,15 @@ class HiveToMySqlTransfer(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 sql,
-                 mysql_table,
-                 hiveserver2_conn_id='hiveserver2_default',
-                 mysql_conn_id='mysql_default',
-                 mysql_preoperator=None,
-                 mysql_postoperator=None,
-                 bulk_load=False,
-                 hive_conf=None,
-                 *args, **kwargs):
+                 sql: str,
+                 mysql_table: str,
+                 hiveserver2_conn_id: str = 'hiveserver2_default',
+                 mysql_conn_id: str = 'mysql_default',
+                 mysql_preoperator: str = None,
+                 mysql_postoperator: str = None,
+                 bulk_load: bool = False,
+                 hive_conf: Dict = None,
+                 *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.sql = sql
         self.mysql_table = mysql_table

--- a/airflow/operators/hive_to_samba_operator.py
+++ b/airflow/operators/hive_to_samba_operator.py
@@ -46,11 +46,11 @@ class Hive2SambaOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 hql,
-                 destination_filepath,
-                 samba_conn_id='samba_default',
-                 hiveserver2_conn_id='hiveserver2_default',
-                 *args, **kwargs):
+                 hql: str,
+                 destination_filepath: str,
+                 samba_conn_id: str = 'samba_default',
+                 hiveserver2_conn_id: str = 'hiveserver2_default',
+                 *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.hiveserver2_conn_id = hiveserver2_conn_id
         self.samba_conn_id = samba_conn_id

--- a/airflow/operators/http_operator.py
+++ b/airflow/operators/http_operator.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Any, Dict, Callable
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.http_hook import HttpHook
@@ -56,15 +57,15 @@ class SimpleHttpOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 endpoint,
-                 method='POST',
-                 data=None,
-                 headers=None,
-                 response_check=None,
-                 extra_options=None,
-                 http_conn_id='http_default',
-                 log_response=False,
-                 *args, **kwargs):
+                 endpoint: str,
+                 method: str = 'POST',
+                 data: Any = None,
+                 headers: Dict[str, str] = None,
+                 response_check: Callable = None,
+                 extra_options: Dict[str, Any] = None,
+                 http_conn_id: str = 'http_default',
+                 log_response: bool = False,
+                 *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.http_conn_id = http_conn_id
         self.method = method

--- a/airflow/operators/jdbc_operator.py
+++ b/airflow/operators/jdbc_operator.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Union, Iterable, Mapping
 
 from airflow.hooks.jdbc_hook import JdbcHook
 from airflow.models import BaseOperator
@@ -47,11 +48,11 @@ class JdbcOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 sql,
-                 jdbc_conn_id='jdbc_default',
-                 autocommit=False,
-                 parameters=None,
-                 *args, **kwargs):
+                 sql: str,
+                 jdbc_conn_id: str = 'jdbc_default',
+                 autocommit: bool = False,
+                 parameters: Union[Mapping, Iterable] = None,
+                 *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.parameters = parameters
         self.sql = sql

--- a/airflow/operators/mssql_operator.py
+++ b/airflow/operators/mssql_operator.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Union, Mapping, Iterable
 
 from airflow.hooks.mssql_hook import MsSqlHook
 from airflow.models import BaseOperator
@@ -46,8 +47,13 @@ class MsSqlOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self, sql, mssql_conn_id='mssql_default', parameters=None,
-            autocommit=False, database=None, *args, **kwargs):
+            self,
+            sql: str,
+            mssql_conn_id: str = 'mssql_default',
+            parameters: Union[Mapping, Iterable] = None,
+            autocommit: bool = False,
+            database: str = None,
+            *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.mssql_conn_id = mssql_conn_id
         self.sql = sql

--- a/airflow/operators/mssql_to_hive.py
+++ b/airflow/operators/mssql_to_hive.py
@@ -19,6 +19,7 @@
 
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile
+from typing import Dict
 
 import pymssql
 import unicodecsv as csv
@@ -73,16 +74,16 @@ class MsSqlToHiveTransfer(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 sql,
-                 hive_table,
-                 create=True,
-                 recreate=False,
-                 partition=None,
-                 delimiter=chr(1),
-                 mssql_conn_id='mssql_default',
-                 hive_cli_conn_id='hive_cli_default',
-                 tblproperties=None,
-                 *args, **kwargs):
+                 sql: str,
+                 hive_table: str,
+                 create: bool = True,
+                 recreate: bool = False,
+                 partition: Dict = None,
+                 delimiter: str = chr(1),
+                 mssql_conn_id: str = 'mssql_default',
+                 hive_cli_conn_id: str = 'hive_cli_default',
+                 tblproperties: Dict = None,
+                 *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.sql = sql
         self.hive_table = hive_table

--- a/airflow/operators/mysql_operator.py
+++ b/airflow/operators/mysql_operator.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Union, Mapping, Iterable
 
 from airflow.hooks.mysql_hook import MySqlHook
 from airflow.models import BaseOperator
@@ -48,8 +49,13 @@ class MySqlOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self, sql, mysql_conn_id='mysql_default', parameters=None,
-            autocommit=False, database=None, *args, **kwargs):
+            self,
+            sql: str,
+            mysql_conn_id: str = 'mysql_default',
+            parameters: Union[Mapping, Iterable] = None,
+            autocommit: bool = False,
+            database: str = None,
+            *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.mysql_conn_id = mysql_conn_id
         self.sql = sql

--- a/airflow/operators/mysql_to_hive.py
+++ b/airflow/operators/mysql_to_hive.py
@@ -18,6 +18,8 @@
 # under the License.
 
 from collections import OrderedDict
+from typing import Dict
+
 import unicodecsv as csv
 from tempfile import NamedTemporaryFile
 import MySQLdb
@@ -81,19 +83,19 @@ class MySqlToHiveTransfer(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            sql,
-            hive_table,
-            create=True,
-            recreate=False,
-            partition=None,
-            delimiter=chr(1),
-            quoting=None,
-            quotechar='"',
-            escapechar=None,
-            mysql_conn_id='mysql_default',
-            hive_cli_conn_id='hive_cli_default',
-            tblproperties=None,
-            *args, **kwargs):
+            sql: str,
+            hive_table: str,
+            create: bool = True,
+            recreate: bool = False,
+            partition: Dict = None,
+            delimiter: str = chr(1),
+            quoting: str = None,
+            quotechar: str = '"',
+            escapechar: str = None,
+            mysql_conn_id: str = 'mysql_default',
+            hive_cli_conn_id: str = 'hive_cli_default',
+            tblproperties: Dict = None,
+            *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.sql = sql
         self.hive_table = hive_table

--- a/airflow/operators/oracle_operator.py
+++ b/airflow/operators/oracle_operator.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Union, Mapping, Iterable
 
 from airflow.hooks.oracle_hook import OracleHook
 from airflow.models import BaseOperator
@@ -46,8 +47,12 @@ class OracleOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self, sql, oracle_conn_id='oracle_default', parameters=None,
-            autocommit=False, *args, **kwargs):
+            self,
+            sql: str,
+            oracle_conn_id: str = 'oracle_default',
+            parameters: Union[Mapping, Iterable] = None,
+            autocommit: bool = False,
+            *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.oracle_conn_id = oracle_conn_id
         self.sql = sql

--- a/airflow/operators/papermill_operator.py
+++ b/airflow/operators/papermill_operator.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Dict
 
 import papermill as pm
 
@@ -41,8 +42,11 @@ class PapermillOperator(BaseOperator):
     :type parameters: dict
     """
     @apply_defaults
-    def __init__(self, input_nb: str, output_nb: str, parameters: dict,
-                 *args, **kwargs):
+    def __init__(self,
+                 input_nb: str,
+                 output_nb: str,
+                 parameters: Dict,
+                 *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self.inlets.append(NoteBook(qualified_name=input_nb,

--- a/airflow/operators/pig_operator.py
+++ b/airflow/operators/pig_operator.py
@@ -48,11 +48,12 @@ class PigOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self, pig,
-            pig_cli_conn_id='pig_cli_default',
-            pigparams_jinja_translate=False,
-            pig_opts=None,
-            *args, **kwargs):
+            self,
+            pig: str,
+            pig_cli_conn_id: str = 'pig_cli_default',
+            pigparams_jinja_translate: bool = False,
+            pig_opts: str = None,
+            *args, **kwargs) -> None:
 
         super().__init__(*args, **kwargs)
         self.pigparams_jinja_translate = pigparams_jinja_translate

--- a/airflow/operators/postgres_operator.py
+++ b/airflow/operators/postgres_operator.py
@@ -16,6 +16,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Union, Mapping, Iterable
+
 from airflow.hooks.postgres_hook import PostgresHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
@@ -46,11 +48,13 @@ class PostgresOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self, sql,
-            postgres_conn_id='postgres_default', autocommit=False,
-            parameters=None,
-            database=None,
-            *args, **kwargs):
+            self,
+            sql: str,
+            postgres_conn_id: str = 'postgres_default',
+            autocommit: bool = False,
+            parameters: Union[Mapping, Iterable] = None,
+            database: str = None,
+            *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.sql = sql
         self.postgres_conn_id = postgres_conn_id

--- a/airflow/operators/presto_check_operator.py
+++ b/airflow/operators/presto_check_operator.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Any, Dict
 
 from airflow.hooks.presto_hook import PrestoHook
 from airflow.operators.check_operator import CheckOperator, \
@@ -59,9 +60,10 @@ class PrestoCheckOperator(CheckOperator):
 
     @apply_defaults
     def __init__(
-            self, sql,
-            presto_conn_id='presto_default',
-            *args, **kwargs):
+            self,
+            sql: str,
+            presto_conn_id: str = 'presto_default',
+            *args, **kwargs) -> None:
         super().__init__(sql=sql, *args, **kwargs)
 
         self.presto_conn_id = presto_conn_id
@@ -83,8 +85,11 @@ class PrestoValueCheckOperator(ValueCheckOperator):
 
     @apply_defaults
     def __init__(
-            self, sql, pass_value, tolerance=None,
-            presto_conn_id='presto_default',
+            self,
+            sql: str,
+            pass_value: Any,
+            tolerance: Any = None,
+            presto_conn_id: str = 'presto_default',
             *args, **kwargs):
         super().__init__(
             sql=sql, pass_value=pass_value, tolerance=tolerance,
@@ -113,9 +118,12 @@ class PrestoIntervalCheckOperator(IntervalCheckOperator):
 
     @apply_defaults
     def __init__(
-            self, table, metrics_thresholds,
-            date_filter_column='ds', days_back=-7,
-            presto_conn_id='presto_default',
+            self,
+            table: str,
+            metrics_thresholds: Dict,
+            date_filter_column: str = 'ds',
+            days_back: int = -7,
+            presto_conn_id: str = 'presto_default',
             *args, **kwargs):
         super().__init__(
             table=table, metrics_thresholds=metrics_thresholds,

--- a/airflow/operators/presto_to_mysql.py
+++ b/airflow/operators/presto_to_mysql.py
@@ -51,12 +51,12 @@ class PrestoToMySqlTransfer(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 sql,
-                 mysql_table,
-                 presto_conn_id='presto_default',
-                 mysql_conn_id='mysql_default',
-                 mysql_preoperator=None,
-                 *args, **kwargs):
+                 sql: str,
+                 mysql_table: str,
+                 presto_conn_id: str = 'presto_default',
+                 mysql_conn_id: str = 'mysql_default',
+                 mysql_preoperator: str = None,
+                 *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.sql = sql
         self.mysql_table = mysql_table

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -84,7 +84,7 @@ class PythonOperator(BaseOperator):
         templates_exts: Optional[Iterable[str]] = None,
         *args,
         **kwargs
-    ):
+    ) -> None:
         super().__init__(*args, **kwargs)
         if not callable(python_callable):
             raise AirflowException('`python_callable` param must be callable')

--- a/airflow/operators/redshift_to_s3_operator.py
+++ b/airflow/operators/redshift_to_s3_operator.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Union, List
 
 from airflow.hooks.postgres_hook import PostgresHook
 from airflow.hooks.S3_hook import S3Hook
@@ -61,17 +62,17 @@ class RedshiftToS3Transfer(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            schema,
-            table,
-            s3_bucket,
-            s3_key,
-            redshift_conn_id='redshift_default',
-            aws_conn_id='aws_default',
-            verify=None,
-            unload_options=tuple(),
-            autocommit=False,
-            include_header=False,
-            *args, **kwargs):
+            schema: str,
+            table: str,
+            s3_bucket: str,
+            s3_key: str,
+            redshift_conn_id: str = 'redshift_default',
+            aws_conn_id: str = 'aws_default',
+            verify: Union[bool, str] = None,
+            unload_options: List = None,
+            autocommit: bool = False,
+            include_header: bool = False,
+            *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.schema = schema
         self.table = table
@@ -80,13 +81,12 @@ class RedshiftToS3Transfer(BaseOperator):
         self.redshift_conn_id = redshift_conn_id
         self.aws_conn_id = aws_conn_id
         self.verify = verify
-        self.unload_options = unload_options
+        self.unload_options: List = unload_options or []
         self.autocommit = autocommit
         self.include_header = include_header
 
-        if self.include_header and \
-           'PARALLEL OFF' not in [uo.upper().strip() for uo in unload_options]:
-            self.unload_options = list(unload_options) + ['PARALLEL OFF', ]
+        if self.include_header and 'PARALLEL OFF' not in [uo.upper().strip() for uo in self.unload_options]:
+            self.unload_options = list(self.unload_options) + ['PARALLEL OFF', ]
 
     def execute(self, context):
         self.hook = PostgresHook(postgres_conn_id=self.redshift_conn_id)

--- a/airflow/operators/redshift_to_s3_operator.py
+++ b/airflow/operators/redshift_to_s3_operator.py
@@ -81,7 +81,7 @@ class RedshiftToS3Transfer(BaseOperator):
         self.redshift_conn_id = redshift_conn_id
         self.aws_conn_id = aws_conn_id
         self.verify = verify
-        self.unload_options: List = unload_options or []
+        self.unload_options = unload_options or []  # type: List
         self.autocommit = autocommit
         self.include_header = include_header
 

--- a/airflow/operators/s3_file_transform_operator.py
+++ b/airflow/operators/s3_file_transform_operator.py
@@ -20,6 +20,7 @@
 from tempfile import NamedTemporaryFile
 import subprocess
 import sys
+from typing import Union
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.S3_hook import S3Hook
@@ -46,6 +47,12 @@ class S3FileTransformOperator(BaseOperator):
 
     :param source_s3_key: The key to be retrieved from S3. (templated)
     :type source_s3_key: str
+    :param dest_s3_key: The key to be written from S3. (templated)
+    :type dest_s3_key: str
+    :param transform_script: location of the executable transformation script
+    :type transform_script: str
+    :param select_expression: S3 Select expression
+    :type select_expression: str
     :param source_aws_conn_id: source s3 connection
     :type source_aws_conn_id: str
     :param source_verify: Whether or not to verify SSL certificates for S3 connection.
@@ -61,16 +68,13 @@ class S3FileTransformOperator(BaseOperator):
 
         This is also applicable to ``dest_verify``.
     :type source_verify: bool or str
-    :param dest_s3_key: The key to be written from S3. (templated)
-    :type dest_s3_key: str
     :param dest_aws_conn_id: destination s3 connection
     :type dest_aws_conn_id: str
+    :param dest_verify: Whether or not to verify SSL certificates for S3 connection.
+        See: ``source_verify``
+    :type dest_verify: bool or str
     :param replace: Replace dest S3 key if it already exists
     :type replace: bool
-    :param transform_script: location of the executable transformation script
-    :type transform_script: str
-    :param select_expression: S3 Select expression
-    :type select_expression: str
     """
 
     template_fields = ('source_s3_key', 'dest_s3_key')
@@ -80,16 +84,16 @@ class S3FileTransformOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            source_s3_key,
-            dest_s3_key,
-            transform_script=None,
+            source_s3_key: str,
+            dest_s3_key: str,
+            transform_script: str = None,
             select_expression=None,
-            source_aws_conn_id='aws_default',
-            source_verify=None,
-            dest_aws_conn_id='aws_default',
-            dest_verify=None,
-            replace=False,
-            *args, **kwargs):
+            source_aws_conn_id: str = 'aws_default',
+            source_verify: Union[bool, str] = None,
+            dest_aws_conn_id: str = 'aws_default',
+            dest_verify: Union[bool, str] = None,
+            replace: bool = False,
+            *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.source_s3_key = source_s3_key
         self.source_aws_conn_id = source_aws_conn_id

--- a/airflow/operators/s3_to_hive_operator.py
+++ b/airflow/operators/s3_to_hive_operator.py
@@ -18,6 +18,8 @@
 # under the License.
 
 from tempfile import NamedTemporaryFile
+from typing import Dict, Union
+
 from airflow.utils.file import TemporaryDirectory
 import gzip
 import bz2
@@ -55,6 +57,8 @@ class S3ToHiveTransfer(BaseOperator):
     :param hive_table: target Hive table, use dot notation to target a
         specific database. (templated)
     :type hive_table: str
+    :param delimiter: field delimiter in the file
+    :type delimiter: str
     :param create: whether to create the table if it doesn't exist
     :type create: bool
     :param recreate: whether to drop and recreate the table at every
@@ -72,8 +76,6 @@ class S3ToHiveTransfer(BaseOperator):
     :param wildcard_match: whether the s3_key should be interpreted as a Unix
         wildcard pattern
     :type wildcard_match: bool
-    :param delimiter: field delimiter in the file
-    :type delimiter: str
     :param aws_conn_id: source s3 connection
     :type aws_conn_id: str
     :param verify: Whether or not to verify SSL certificates for S3 connection.
@@ -105,23 +107,23 @@ class S3ToHiveTransfer(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            s3_key,
-            field_dict,
-            hive_table,
-            delimiter=',',
-            create=True,
-            recreate=False,
-            partition=None,
-            headers=False,
-            check_headers=False,
-            wildcard_match=False,
-            aws_conn_id='aws_default',
-            verify=None,
-            hive_cli_conn_id='hive_cli_default',
-            input_compressed=False,
-            tblproperties=None,
-            select_expression=None,
-            *args, **kwargs):
+            s3_key: str,
+            field_dict: Dict,
+            hive_table: str,
+            delimiter: str = ',',
+            create: bool = True,
+            recreate: bool = False,
+            partition: Dict = None,
+            headers: bool = False,
+            check_headers: bool = False,
+            wildcard_match: bool = False,
+            aws_conn_id: str = 'aws_default',
+            verify: Union[bool, str] = None,
+            hive_cli_conn_id: str = 'hive_cli_default',
+            input_compressed: bool = False,
+            tblproperties: Dict = None,
+            select_expression: str = None,
+            *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.s3_key = s3_key
         self.field_dict = field_dict

--- a/airflow/operators/s3_to_redshift_operator.py
+++ b/airflow/operators/s3_to_redshift_operator.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Union, List
 
 from airflow.hooks.postgres_hook import PostgresHook
 from airflow.hooks.S3_hook import S3Hook
@@ -61,17 +62,16 @@ class S3ToRedshiftTransfer(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            schema,
-            table,
-            s3_bucket,
-            s3_key,
-            redshift_conn_id='redshift_default',
-            aws_conn_id='aws_default',
-            verify=None,
-            copy_options=tuple(),
-            autocommit=False,
-            parameters=None,
-            *args, **kwargs):
+            schema: str,
+            table: str,
+            s3_bucket: str,
+            s3_key: str,
+            redshift_conn_id: str = 'redshift_default',
+            aws_conn_id: str = 'aws_default',
+            verify: Union[bool, str] = None,
+            copy_options: List = None,
+            autocommit: bool = False,
+            *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.schema = schema
         self.table = table
@@ -80,9 +80,8 @@ class S3ToRedshiftTransfer(BaseOperator):
         self.redshift_conn_id = redshift_conn_id
         self.aws_conn_id = aws_conn_id
         self.verify = verify
-        self.copy_options = copy_options
+        self.copy_options = copy_options or []
         self.autocommit = autocommit
-        self.parameters = parameters
 
     def execute(self, context):
         self.hook = PostgresHook(postgres_conn_id=self.redshift_conn_id)

--- a/airflow/operators/slack_operator.py
+++ b/airflow/operators/slack_operator.py
@@ -18,6 +18,7 @@
 # under the License.
 
 import json
+from typing import Dict, Optional, List
 
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
@@ -43,11 +44,11 @@ class SlackAPIOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self,
-                 slack_conn_id=None,
-                 token=None,
-                 method=None,
-                 api_params=None,
-                 *args, **kwargs):
+                 slack_conn_id: str = None,
+                 token: str = None,
+                 method: str = None,
+                 api_params: Dict = None,
+                 *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         if token is None and slack_conn_id is None:
@@ -56,8 +57,8 @@ class SlackAPIOperator(BaseOperator):
             raise AirflowException('Cannot determine Slack credential '
                                    'when both token and slack_conn_id are supplied.')
 
-        self.token = token
-        self.slack_conn_id = slack_conn_id
+        self.token: Optional[str] = token
+        self.slack_conn_id: Optional[str] = slack_conn_id
 
         self.method = method
         self.api_params = api_params
@@ -100,7 +101,7 @@ class SlackAPIPostOperator(SlackAPIOperator):
     :type icon_url: str
     :param attachments: extra formatting details. (templated)
         - see https://api.slack.com/docs/attachments.
-    :type attachments: array of hashes
+    :type attachments: list of hashes
     """
 
     template_fields = ('username', 'text', 'attachments', 'channel')
@@ -108,14 +109,14 @@ class SlackAPIPostOperator(SlackAPIOperator):
 
     @apply_defaults
     def __init__(self,
-                 channel='#general',
-                 username='Airflow',
-                 text='No message has been set.\n'
-                      'Here is a cat video instead\n'
-                      'https://www.youtube.com/watch?v=J---aiyznGQ',
-                 icon_url='https://raw.githubusercontent.com/apache/'
-                          'airflow/master/airflow/www/static/pin_100.jpg',
-                 attachments=None,
+                 channel: str = '#general',
+                 username: str = 'Airflow',
+                 text: str = 'No message has been set.\n'
+                             'Here is a cat video instead\n'
+                             'https://www.youtube.com/watch?v=J---aiyznGQ',
+                 icon_url: str = 'https://raw.githubusercontent.com/apache/'
+                                 'airflow/master/airflow/www/static/pin_100.jpg',
+                 attachments: List = None,
                  *args, **kwargs):
         self.method = 'chat.postMessage'
         self.channel = channel

--- a/airflow/operators/slack_operator.py
+++ b/airflow/operators/slack_operator.py
@@ -57,8 +57,8 @@ class SlackAPIOperator(BaseOperator):
             raise AirflowException('Cannot determine Slack credential '
                                    'when both token and slack_conn_id are supplied.')
 
-        self.token: Optional[str] = token
-        self.slack_conn_id: Optional[str] = slack_conn_id
+        self.token = token  # type: Optional[str]
+        self.slack_conn_id = slack_conn_id  # type: Optional[str]
 
         self.method = method
         self.api_params = api_params

--- a/airflow/operators/sqlite_operator.py
+++ b/airflow/operators/sqlite_operator.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Union, Mapping, Iterable
 
 from airflow.hooks.sqlite_hook import SqliteHook
 from airflow.models import BaseOperator
@@ -41,8 +42,11 @@ class SqliteOperator(BaseOperator):
 
     @apply_defaults
     def __init__(
-            self, sql, sqlite_conn_id='sqlite_default', parameters=None,
-            *args, **kwargs):
+            self,
+            sql: str,
+            sqlite_conn_id: str = 'sqlite_default',
+            parameters: Union[Mapping, Iterable] = None,
+            *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.sqlite_conn_id = sqlite_conn_id
         self.sql = sql

--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -17,8 +17,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow import settings
+from airflow import settings, DAG
 from airflow.exceptions import AirflowException
+from airflow.executors import BaseExecutor
 from airflow.executors.sequential_executor import SequentialExecutor
 from airflow.models import BaseOperator, Pool
 from airflow.utils.decorators import apply_defaults
@@ -46,9 +47,9 @@ class SubDagOperator(BaseOperator):
     @apply_defaults
     def __init__(
             self,
-            subdag,
-            executor=SequentialExecutor(),
-            *args, **kwargs):
+            subdag: DAG,
+            executor: BaseExecutor = SequentialExecutor(),
+            *args, **kwargs) -> None:
         dag = kwargs.get('dag') or settings.CONTEXT_MANAGER_DAG
         if not dag:
             raise AirflowException('Please pass in the `dag` param or call '


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
