### PR TITLE
[Airflow 4923] Fix Databricks hook leaks API secret in logs

### DIFF
--- a/airflow/contrib/hooks/databricks_hook.py
+++ b/airflow/contrib/hooks/databricks_hook.py
@@ -110,15 +110,20 @@ class DatabricksHook(BaseHook):
         :rtype: dict
         """
         method, endpoint = endpoint_info
-        url = 'https://{host}/{endpoint}'.format(
-            host=self._parse_host(self.databricks_conn.host),
-            endpoint=endpoint)
+
         if 'token' in self.databricks_conn.extra_dejson:
-            self.log.info('Using token auth.')
+            self.log.info('Using token auth. ')
             auth = _TokenAuth(self.databricks_conn.extra_dejson['token'])
+            host = self._parse_host(self.databricks_conn.extra_dejson['host'])
         else:
-            self.log.info('Using basic auth.')
+            self.log.info('Using basic auth. ')
             auth = (self.databricks_conn.login, self.databricks_conn.password)
+            host = self.databricks_conn.host
+
+        url = 'https://{host}/{endpoint}'.format(
+            host=self._parse_host(host),
+            endpoint=endpoint)
+
         if method == 'GET':
             request_func = requests.get
         elif method == 'POST':

--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -204,7 +204,7 @@ class DatabricksSubmitRunOperator(BaseOperator):
     :param databricks_conn_id: The name of the Airflow connection to use.
         By default and in the common case this will be ``databricks_default``. To use
         token based authentication, provide the key ``token`` in the extra field for the
-        connection.
+        connection and create the key ``host`` and leave the ``host`` field empty.
     :type databricks_conn_id: str
     :param polling_period_seconds: Controls the rate which we poll for the result of
         this run. By default the operator will poll every 30 seconds.
@@ -413,7 +413,7 @@ class DatabricksRunNowOperator(BaseOperator):
     :param databricks_conn_id: The name of the Airflow connection to use.
         By default and in the common case this will be ``databricks_default``. To use
         token based authentication, provide the key ``token`` in the extra field for the
-        connection.
+        connection and create the key ``host`` and leave the ``host`` field empty.
     :type databricks_conn_id: str
     :param polling_period_seconds: Controls the rate which we poll for the result of
         this run. By default the operator will poll every 30 seconds.

--- a/tests/contrib/hooks/test_databricks_hook.py
+++ b/tests/contrib/hooks/test_databricks_hook.py
@@ -400,7 +400,8 @@ class DatabricksHookTokenTest(unittest.TestCase):
         conn = session.query(Connection) \
             .filter(Connection.conn_id == DEFAULT_CONN_ID) \
             .first()
-        conn.extra = json.dumps({'token': TOKEN})
+        conn.extra = json.dumps({'token': TOKEN, 'host': HOST})
+
         session.commit()
 
         self.hook = DatabricksHook()


### PR DESCRIPTION
When users store token in the extra field for a Databricks connection the DatabricksHook leaks the token to the airflow logs. Adding ability(and updating docs) for the hook to get the host from the extra json will not cause the Basehook.get_connection to send the extra json to the airflow logs since 'host' field will be empty.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"

https://issues.apache.org/jira/browse/AIRFLOW-4923

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When users store token in the extra field for a Databricks connection the DatabricksHook leaks the token to the airflow logs. Adding ability(and updating docs) for the hook to get the host from the extra json will not cause the Basehook.get_connection to send the extra json to the airflow logs since 'host' field will be empty.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Updated testcase to look for host in extra json
tests.contrib.hooks.test_databricks_hook:DatabricksHookTokenTest.test_submit_run

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
