### PR TITLE
[AIRFLOW-5014] Fix sphinx doc problem and leaves API docs

### DIFF
--- a/airflow/contrib/hooks/ftp_hook.py
+++ b/airflow/contrib/hooks/ftp_hook.py
@@ -173,7 +173,7 @@ class FTPHook(BaseHook):
             [default: output_handle.write()]
         :type callback: callable
 
-        :Example::
+        .. code-block:: python
 
             hook = FTPHook(ftp_conn_id='my_conn')
 
@@ -196,6 +196,7 @@ class FTPHook(BaseHook):
 
             # without a custom callback data is written to the local_path
             hook.retrieve_file(remote_path, local_path)
+
         """
         conn = self.get_conn()
 

--- a/airflow/contrib/operators/gcs_operator.py
+++ b/airflow/contrib/operators/gcs_operator.py
@@ -72,9 +72,10 @@ class GoogleCloudStorageCreateBucketOperator(BaseOperator):
         have domain-wide delegation enabled.
     :type delegate_to: str
 
-    :Example::
     The following Operator would create a new bucket ``test-bucket``
-    with ``MULTI_REGIONAL`` storage class in ``EU`` region ::
+    with ``MULTI_REGIONAL`` storage class in ``EU`` region
+
+    .. code-block:: python
 
         CreateBucket = GoogleCloudStorageCreateBucketOperator(
             task_id='CreateNewBucket',
@@ -84,6 +85,7 @@ class GoogleCloudStorageCreateBucketOperator(BaseOperator):
             labels={'env': 'dev', 'team': 'airflow'},
             google_cloud_storage_conn_id='airflow-service-account'
         )
+
     """
     template_fields = ('bucket_name', 'storage_class',
                        'location', 'project_id')

--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -189,7 +189,7 @@ class HttpHook(BaseHook):
         :type _retry_args: dict
 
 
-        :Example::
+        .. code-block:: python
 
             hook = HttpHook(http_conn_id='my_conn',method='GET')
             retry_args = dict(
@@ -201,6 +201,7 @@ class HttpHook(BaseHook):
                      endpoint='v1/test',
                      _retry_args=retry_args
                  )
+
         """
         self._retry_obj = tenacity.Retrying(
             **_retry_args

--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -38,7 +38,7 @@ def date_range(start_date, end_date=None, num=None, delta=None):
     can be something that can be added to `datetime.datetime`
     or a cron expression as a `str`
 
-    :Example::
+    .. code-block:: python
 
         date_range(datetime(2016, 1, 1), datetime(2016, 1, 3), delta=timedelta(1))
             [datetime.datetime(2016, 1, 1, 0, 0), datetime.datetime(2016, 1, 2, 0, 0),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,8 +236,7 @@ intersphinx_mapping = {
     'mongodb': ('https://api.mongodb.com/python/current/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'python': ('https://docs.python.org/3/', None),
-    # TODO: Re-enable when python-requests.org is working again!
-    #'requests': ('http://docs.python-requests.org/en/master/', None),
+    'requests': ('http://docs.python-requests.org/en/master/', None),
     'sqlalchemy': ('https://docs.sqlalchemy.org/en/latest/', None),
     'hdfs': ('https://hdfscli.readthedocs.io/en/latest/', None),
 }
@@ -392,7 +391,7 @@ man_pages = [
 texinfo_documents = [(
     'index', 'Airflow', 'Airflow Documentation',
     'Apache Airflow', 'Airflow',
-    'Airflow is a system to programmaticaly author, schedule and monitor data pipelines.',
+    'Airflow is a system to programmatically author, schedule and monitor data pipelines.',
     'Miscellaneous'
 ), ]
 
@@ -434,7 +433,7 @@ autoapi_ignore = [
 ]
 # Keep the AutoAPI generated files on the filesystem after the run.
 # Useful for debugging.
-autoapi_keep_files = False
+autoapi_keep_files = True
 
 # Relative path to output the AutoAPI files into. This can also be used to place the generated documentation
 # anywhere in your documentation hierarchy.

--- a/scripts/ci/in_container/run_docs_build.sh
+++ b/scripts/ci/in_container/run_docs_build.sh
@@ -32,7 +32,8 @@ in_container_basic_sanity_check
 in_container_script_start
 
 sudo rm -rf "$(pwd)/docs/_build/*"
-sudo "$(pwd)/docs/build.sh"
+sudo rm -rf "$(pwd)/docs/_api/*"
+sudo -E "$(pwd)/docs/build.sh"
 
 in_container_fix_ownership
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5014


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
This change fixes autodoc generated documentation problems but also
leaves generated .rst files in _api folder so that it is easier to
debug and fix problems like that in the future.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
No tests.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
