### PR TITLE
[AIRFLOW-4724] Make params dict to be templated for operators

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1254,6 +1254,10 @@ class TaskInstance(Base, LoggingMixin):
                 context.update(self.task.dag.user_defined_macros)
 
         rt = self.task.render_template  # shortcut to method
+
+        if context['params']:
+            context['params'] = rt('params', context['params'], context)
+
         for attr in task.__class__.template_fields:
             content = getattr(task, attr)
             if content:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4724) issue and references them in the PR title. 
### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
The approaches discussed in https://apache-airflow.slack.com/archives/CCQ7EGB1P/p1559134166151100 to include 'params' as a templated_fields has to modified a bit to solve the issue.

The discussed approaches templates the params dict. However, to make in available for the other templated fields in the operators, it is also required to update the jinja_template_context with the rendered params dict.  

Hence, params templates are updated in the template_context similar to user_defined_macros.

### Tests

- [ ] My PR adds the python operator params are templatized case to test the functionality. 
The optional args of python operator contains params dict key which is substituted with rendered value. 

### Code Quality

- [x] Passes `flake8`
