### PR TITLE
[AIRFLOW-5021] move gitpython into setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -333,7 +333,6 @@ def do_setup():
             'flask-swagger==0.2.13',
             'flask-wtf>=0.14.2, <0.15',
             'funcsigs==1.0.0',
-            'gitpython>=2.0.2',
             'gunicorn>=19.5.0, <20.0',
             'iso8601>=0.1.12',
             'json-merge-patch==0.2',
@@ -360,6 +359,7 @@ def do_setup():
         ],
         setup_requires=[
             'docutils>=0.14, <1.0',
+            'gitpython>=2.0.2',
         ],
         extras_require={
             'all': devel_all,


### PR DESCRIPTION
Since this dependency is only used in setup.py

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5021) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-5021

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

gitpython is included as `install_requires` but is only used in setup.py. It's better to move it to `setup_requires` so we can reduce package size.


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

It only touches setup.py :)

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
