### PR TITLE
[AIRFLOW-5022] Fixes DockerHook for registries with port numbers

### DIFF
--- a/airflow/hooks/docker_hook.py
+++ b/airflow/hooks/docker_hook.py
@@ -54,7 +54,10 @@ class DockerHook(BaseHook, LoggingMixin):
         self.__base_url = base_url
         self.__version = version
         self.__tls = tls
-        self.__registry = conn.host
+        if conn.port:
+            self.__registry = "{}:{}".format(conn.host, conn.port)
+        else:
+            self.__registry = conn.host
         self.__username = conn.login
         self.__password = conn.password
         self.__email = extra_options.get('email')

--- a/tests/hooks/test_docker_hook.py
+++ b/tests/hooks/test_docker_hook.py
@@ -46,7 +46,8 @@ class DockerHookTest(unittest.TestCase):
             Connection(
                 conn_id='docker_with_extras',
                 conn_type='docker',
-                host='some.docker.registry.com',
+                host='another.docker.registry.com',
+                port=9876,
                 login='some_user',
                 password='some_p4$$w0rd',
                 extra='{"email": "some@example.com", "reauth": "no"}'
@@ -132,7 +133,7 @@ class DockerHookTest(unittest.TestCase):
         client.login.assert_called_with(
             username='some_user',
             password='some_p4$$w0rd',
-            registry='some.docker.registry.com',
+            registry='another.docker.registry.com:9876',
             reauth=False,
             email='some@example.com'
         )


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5022

### Description

- [x] Here are some details about my PR:
  - This fixes a bug where `DockerOperator`s failed authentication when retrieving the image when configured to use a private registry whose URL has a non-standard port number. The root problem was that `DockerHook` ignored the port number of its `conn_id` connection.


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - A small adjustment was made to test_docker_hook.py to cover the fix. 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - No new functionality in this PR

### Code Quality

- [x] Passes `flake8`
