### PR TITLE
[AIRFLOW-5027] Get logs from CloudWatch for ECSOperators

### DIFF
--- a/airflow/contrib/hooks/aws_logs_hook.py
+++ b/airflow/contrib/hooks/aws_logs_hook.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+This module contains a hook (AwsLogsHook) with some very basic
+functionality for interacting with AWS CloudWatch.
+"""
+
+from airflow.contrib.hooks.aws_hook import AwsHook
+
+
+class AwsLogsHook(AwsHook):
+    """
+    Interact with AWS CloudWatch Logs
+
+    :param region_name: AWS Region Name (example: us-west-2)
+    :type region_name: str
+    """
+
+    def __init__(self, region_name=None, *args, **kwargs):
+        self.region_name = region_name
+        super().__init__(*args, **kwargs)
+
+    def get_conn(self):
+        """
+        Establish an AWS connection for retrieving logs.
+
+        :rtype: CloudWatchLogs.Client
+        """
+        return self.get_client_type('logs', region_name=self.region_name)
+
+    def get_log_events(self, log_group, log_stream_name, start_time=0, skip=0, start_from_head=True):
+        """
+        A generator for log items in a single stream. This will yield all the
+        items that are available at the current moment.
+
+        :param log_group: The name of the log group.
+        :type log_group: str
+        :param log_stream_name: The name of the specific stream.
+        :type log_stream_name: str
+        :param start_time: The time stamp value to start reading the logs from (default: 0).
+        :type start_time: int
+        :param skip: The number of log entries to skip at the start (default: 0).
+            This is for when there are multiple entries at the same timestamp.
+        :type skip: int
+        :param start_from_head: whether to start from the beginning (True) of the log or
+            at the end of the log (False).
+        :type start_from_head: bool
+        :rtype: dict
+        :return: | A CloudWatch log event with the following key-value pairs:
+                 |   'timestamp' (int): The time in milliseconds of the event.
+                 |   'message' (str): The log event data.
+                 |   'ingestionTime' (int): The time in milliseconds the event was ingested.
+        """
+
+        next_token = None
+
+        event_count = 1
+        while event_count > 0:
+            if next_token is not None:
+                token_arg = {'nextToken': next_token}
+            else:
+                token_arg = {}
+
+            response = self.get_conn().get_log_events(logGroupName=log_group,
+                                                      logStreamName=log_stream_name,
+                                                      startTime=start_time,
+                                                      startFromHead=start_from_head,
+                                                      **token_arg)
+
+            events = response['events']
+            event_count = len(events)
+
+            if event_count > skip:
+                events = events[skip:]
+                skip = 0
+            else:
+                skip = skip - event_count
+                events = []
+
+            yield from events
+
+            if 'nextForwardToken' in response:
+                next_token = response['nextForwardToken']
+            else:
+                return

--- a/tests/contrib/hooks/test_aws_logs_hook.py
+++ b/tests/contrib/hooks/test_aws_logs_hook.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+
+from airflow.contrib.hooks.aws_logs_hook import AwsLogsHook
+
+try:
+    from moto import mock_logs
+except ImportError:
+    mock_logs = None
+
+
+class TestAwsLogsHook(unittest.TestCase):
+
+    @unittest.skipIf(mock_logs is None, 'mock_logs package not present')
+    @mock_logs
+    def test_get_conn_returns_a_boto3_connection(self):
+        hook = AwsLogsHook(aws_conn_id='aws_default',
+                           region_name="us-east-1")
+        self.assertIsNotNone(hook.get_conn())
+
+    @unittest.skipIf(mock_logs is None, 'mock_logs package not present')
+    # moto.logs does not support proper pagination so we cannot test that yet
+    # https://github.com/spulec/moto/issues/2259
+    @mock_logs
+    def test_get_log_events(self):
+        log_group_name = 'example-group'
+        log_stream_name = 'example-log-stream'
+
+        hook = AwsLogsHook(aws_conn_id='aws_default',
+                           region_name="us-east-1")
+
+        # First we create some log events
+        conn = hook.get_conn()
+        conn.create_log_group(logGroupName=log_group_name)
+        conn.create_log_stream(logGroupName=log_group_name, logStreamName=log_stream_name)
+
+        input_events = [
+            {
+                'timestamp': 1,
+                'message': 'Test Message 1'
+            }
+        ]
+
+        conn.put_log_events(logGroupName=log_group_name,
+                            logStreamName=log_stream_name,
+                            logEvents=input_events)
+
+        events = hook.get_log_events(
+            log_group=log_group_name,
+            log_stream_name=log_stream_name
+        )
+
+        # Iterate through entire generator
+        events = list(events)
+        count = len(events)
+
+        assert count == 1
+        assert events[0]['timestamp'] == input_events[0]['timestamp']
+        assert events[0]['message'] == input_events[0]['message']
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/contrib/hooks/test_sagemaker_hook.py
+++ b/tests/contrib/hooks/test_sagemaker_hook.py
@@ -25,6 +25,7 @@ from tzlocal import get_localzone
 
 from airflow.contrib.hooks.sagemaker_hook import (SageMakerHook, secondary_training_status_changed,
                                                   secondary_training_status_message, LogState)
+from airflow.contrib.hooks.aws_logs_hook import AwsLogsHook
 from airflow.hooks.S3_hook import S3Hook
 from airflow.exceptions import AirflowException
 from tests.compat import mock
@@ -244,7 +245,7 @@ test_evaluation_config = {
 
 
 class TestSageMakerHook(unittest.TestCase):
-    @mock.patch.object(SageMakerHook, 'log_stream')
+    @mock.patch.object(AwsLogsHook, 'get_log_events')
     def test_multi_stream_iter(self, mock_log_stream):
         event = {'timestamp': 1}
         mock_log_stream.side_effect = [iter([event]), iter([]), None]
@@ -548,7 +549,7 @@ class TestSageMakerHook(unittest.TestCase):
             secondary_training_status_message(SECONDARY_STATUS_DESCRIPTION_1, SECONDARY_STATUS_DESCRIPTION_2),
             expected)
 
-    @mock.patch.object(SageMakerHook, 'get_log_conn')
+    @mock.patch.object(AwsLogsHook, 'get_conn')
     @mock.patch.object(SageMakerHook, 'get_conn')
     @mock.patch.object(time, 'time')
     def test_describe_training_job_with_logs_in_progress(self, mock_time, mock_client, mock_log_client):
@@ -577,7 +578,7 @@ class TestSageMakerHook(unittest.TestCase):
                                                        last_describe_job_call=0)
         self.assertEqual(response, (LogState.JOB_COMPLETE, {}, 50))
 
-    @mock.patch.object(SageMakerHook, 'get_log_conn')
+    @mock.patch.object(AwsLogsHook, 'get_conn')
     @mock.patch.object(SageMakerHook, 'get_conn')
     def test_describe_training_job_with_logs_job_complete(self, mock_client, mock_log_client):
         mock_session = mock.Mock()
@@ -604,7 +605,7 @@ class TestSageMakerHook(unittest.TestCase):
                                                        last_describe_job_call=0)
         self.assertEqual(response, (LogState.COMPLETE, {}, 0))
 
-    @mock.patch.object(SageMakerHook, 'get_log_conn')
+    @mock.patch.object(AwsLogsHook, 'get_conn')
     @mock.patch.object(SageMakerHook, 'get_conn')
     def test_describe_training_job_with_logs_complete(self, mock_client, mock_log_client):
         mock_session = mock.Mock()
@@ -632,7 +633,7 @@ class TestSageMakerHook(unittest.TestCase):
         self.assertEqual(response, (LogState.COMPLETE, {}, 0))
 
     @mock.patch.object(SageMakerHook, 'check_training_config')
-    @mock.patch.object(SageMakerHook, 'get_log_conn')
+    @mock.patch.object(AwsLogsHook, 'get_conn')
     @mock.patch.object(SageMakerHook, 'get_conn')
     @mock.patch.object(SageMakerHook, 'describe_training_job_with_log')
     def test_training_with_logs(self, mock_describe, mock_client, mock_log_client, mock_check_training):

--- a/tests/contrib/sensors/test_sagemaker_training_sensor.py
+++ b/tests/contrib/sensors/test_sagemaker_training_sensor.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from airflow.contrib.sensors.sagemaker_training_sensor \
     import SageMakerTrainingSensor
 from airflow.contrib.hooks.sagemaker_hook import SageMakerHook, LogState
+from airflow.contrib.hooks.aws_logs_hook import AwsLogsHook
 from airflow.exceptions import AirflowException
 from tests.compat import mock
 
@@ -97,7 +98,7 @@ class TestSageMakerTrainingSensor(unittest.TestCase):
         hook_init.assert_called_with(aws_conn_id='aws_test')
 
     @mock.patch.object(SageMakerHook, 'get_conn')
-    @mock.patch.object(SageMakerHook, 'get_log_conn')
+    @mock.patch.object(AwsLogsHook, 'get_conn')
     @mock.patch.object(SageMakerHook, '__init__')
     @mock.patch.object(SageMakerHook, 'describe_training_job_with_log')
     @mock.patch.object(SageMakerHook, 'describe_training_job')


### PR DESCRIPTION
My first Airflow PR so I hope I adhered to all the contribution guidelines. All comments welcome.

---

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5027

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

It's very useful to have the CloudWatch task logs of an ECS/SageMaker job available within Airflow. Currently, this is not possible for ECS tasks.

The SageMaker operator starts a job on AWS SageMaker. It already supports grabbing the CloudWatch logs of the (finished) job to the Airflow instance.

The ECS operator is very similar in that it starts a job on AWS ECS. It doesn't, however, support grabbing CloudWatch logs at the end of a job.

I've separated the existing log grabbing of the SageMaker hook to a separate logs hook and both the SageMaker hook and ECS operator now call that logs hook at the end of a job.

### Tests

- [x] My PR adds the following unit tests:

Added: `tests.contrib.hooks.TestAwsLogsHook`
Changed: `tests.contrib.hooks.TestSageMakerHook`
Changed: `tests.contrib.sensors.TestSageMakerTrainingSensor`

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
