### PR TITLE
[AIRFLOW-3628] Add smtp_mime_from

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -349,7 +349,7 @@ smtp_ssl = False
 smtp_port = 25
 smtp_mail_from = airflow@example.com
 
-smtp_mime_from = airflow
+smtp_mime_from =
 
 [celery]
 # This section only applies if you are using the CeleryExecutor in

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -348,7 +348,9 @@ smtp_ssl = False
 # smtp_password = airflow
 smtp_port = 25
 smtp_mail_from = airflow@example.com
-
+# If you want emails to be seen as sent from specific reciever and not to expose the
+# address set in smtp_mail_from use smtp_mime_from. Example: set smtp_mime_from=Airflow
+# all emails will be shown as sent from Airflow rather than from airflow@example.com
 smtp_mime_from =
 
 [celery]

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -349,6 +349,7 @@ smtp_ssl = False
 smtp_port = 25
 smtp_mail_from = airflow@example.com
 
+smtp_mime_from = airflow
 
 [celery]
 # This section only applies if you are using the CeleryExecutor in

--- a/airflow/utils/email.py
+++ b/airflow/utils/email.py
@@ -57,6 +57,7 @@ def send_email_smtp(to, subject, html_content, files=None,
 
     >>> send_email('test@example.com', 'foo', '<b>Foo</b> bar', ['/dev/null'], dryrun=True)
     """
+
     smtp_mail_from = configuration.conf.get('smtp', 'SMTP_MAIL_FROM')
     smtp_mime_from = configuration.conf.get('smtp', 'SMTP_MIME_FROM')
 

--- a/airflow/utils/email.py
+++ b/airflow/utils/email.py
@@ -58,12 +58,13 @@ def send_email_smtp(to, subject, html_content, files=None,
     >>> send_email('test@example.com', 'foo', '<b>Foo</b> bar', ['/dev/null'], dryrun=True)
     """
     smtp_mail_from = configuration.conf.get('smtp', 'SMTP_MAIL_FROM')
+    smtp_mime_from = configuration.conf.get('smtp', 'SMTP_MIME_FROM')
 
     to = get_email_address_list(to)
 
     msg = MIMEMultipart(mime_subtype)
     msg['Subject'] = subject
-    msg['From'] = smtp_mail_from
+    msg['From'] = smtp_mime_from or smtp_mail_from
     msg['To'] = ", ".join(to)
     recipients = to
     if cc:

--- a/tests/core.py
+++ b/tests/core.py
@@ -2269,7 +2269,8 @@ class EmailSmtpTest(unittest.TestCase):
         self.assertEqual(['to'], call_args[1])
         msg = call_args[2]
         self.assertEqual('subject', msg['Subject'])
-        self.assertEqual(configuration.conf.get('smtp', 'SMTP_MAIL_FROM'), msg['From'])
+        self.assertEqual(configuration.conf.get('smtp', 'SMTP_MIME_FROM') or
+                         configuration.conf.get('smtp', 'SMTP_MAIL_FROM'), msg['From'])
         self.assertEqual(2, len(msg.get_payload()))
         filename = 'attachment; filename="' + os.path.basename(attachment.name) + '"'
         self.assertEqual(filename, msg.get_payload()[-1].get('Content-Disposition'))
@@ -2297,7 +2298,8 @@ class EmailSmtpTest(unittest.TestCase):
         self.assertEqual(['to', 'cc', 'bcc'], call_args[1])
         msg = call_args[2]
         self.assertEqual('subject', msg['Subject'])
-        self.assertEqual(configuration.conf.get('smtp', 'SMTP_MAIL_FROM'), msg['From'])
+        self.assertEqual(configuration.conf.get('smtp', 'SMTP_MIME_FROM') or
+                         configuration.conf.get('smtp', 'SMTP_MAIL_FROM'), msg['From'])
         self.assertEqual(2, len(msg.get_payload()))
         self.assertEqual('attachment; filename="' + os.path.basename(attachment.name) + '"',
                          msg.get_payload()[-1].get('Content-Disposition'))


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AIRFLOW-3628
PR again the stale https://github.com/apache/airflow/pull/4435

Description
In airflow alert email, the value of the from field is the source email address, but sometimes we want to show the receiver where the alert is really from. For example, the email was sent from no-reply@example.com, but we want to show the receiver it was from "airflow", so that it is easy to distinguish it from other messages. With this PR, we just need to set "smtp_mime_from = "airflow" in airflow.cfg.