### PR TITLE
[AIRFLOW-5030] fix env var expansion for config key contains __

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -389,7 +389,7 @@ class AirflowConfigParser(ConfigParser):
         if include_env:
             for ev in [ev for ev in os.environ if ev.startswith('AIRFLOW__')]:
                 try:
-                    _, section, key = ev.split('__')
+                    _, section, key = ev.split('__', 2)
                     opt = self._get_env_var_option(section, key)
                 except ValueError:
                     continue

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -51,6 +51,7 @@ class ConfTest(unittest.TestCase):
     def setUpClass(cls):
         os.environ['AIRFLOW__TESTSECTION__TESTKEY'] = 'testvalue'
         os.environ['AIRFLOW__TESTSECTION__TESTPERCENT'] = 'with%percent'
+        os.environ['AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW__TESTSECTION__TESTKEY'] = 'nested'
         conf.set('core', 'percent', 'with%%inside')
 
     @classmethod
@@ -91,6 +92,9 @@ class ConfTest(unittest.TestCase):
 
         self.assertTrue(conf.has_option('testsection', 'testkey'))
 
+        opt = conf.get('kubernetes_environment_variables', 'AIRFLOW__TESTSECTION__TESTKEY')
+        self.assertEqual(opt, 'nested')
+
     def test_conf_as_dict(self):
         cfg_dict = conf.as_dict()
 
@@ -101,6 +105,9 @@ class ConfTest(unittest.TestCase):
 
         # test env vars
         self.assertEqual(cfg_dict['testsection']['testkey'], '< hidden >')
+        self.assertEqual(
+            cfg_dict['kubernetes_environment_variables']['airflow__testsection__testkey'],
+            '< hidden >')
 
     def test_conf_as_dict_source(self):
         # test display_source


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-5030) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-5030

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

If a config name contains `__`, it will get skipped by `as_dict` method.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

See new assertions in `tests/test_configuration.py` file.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
