### PR TITLE
[AIRFLOW-XXX] fix copy/pasta in k8s request factory extract resources

### DIFF
--- a/airflow/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -182,10 +182,10 @@ class KubernetesRequestFactory(metaclass=ABCMeta):
 
         if pod.resources.has_limits():
             req['spec']['containers'][0]['resources']['limits'] = {}
-            if pod.resources.request_memory:
+            if pod.resources.limit_memory:
                 req['spec']['containers'][0]['resources']['limits'][
                     'memory'] = pod.resources.limit_memory
-            if pod.resources.request_cpu:
+            if pod.resources.limit_cpu:
                 req['spec']['containers'][0]['resources']['limits'][
                     'cpu'] = pod.resources.limit_cpu
 

--- a/tests/kubernetes/kubernetes_request_factory/test_kubernetes_request_factory.py
+++ b/tests/kubernetes/kubernetes_request_factory/test_kubernetes_request_factory.py
@@ -233,19 +233,28 @@ class TestKubernetesRequestFactory(unittest.TestCase):
         self.input_req['spec']['containers'][0]['env'].sort(key=lambda x: x['name'])
         self.assertEqual(self.input_req, self.expected)
 
-    def test_extract_resources(self):
+    def test_extract_requested_resources(self):
         # Test when resources is not empty
-        resources = Resources('1Gi', 1, '2Gi', 2)
+        resources = Resources(request_memory='1Gi', request_cpu=1)
         pod = Pod('v3.14', {}, [], resources=resources)
         self.expected['spec']['containers'][0]['resources'] = {
             'requests': {
                 'memory': '1Gi',
                 'cpu': 1
-            },
+            }
+        }
+        KubernetesRequestFactory.extract_resources(pod, self.input_req)
+        self.assertEqual(self.input_req, self.expected)
+
+    def test_extract_limits_resources(self):
+        # Test when resources is not empty
+        resources = Resources(limit_memory='2Gi', limit_cpu=2)
+        pod = Pod('v3.14', {}, [], resources=resources)
+        self.expected['spec']['containers'][0]['resources'] = {
             'limits': {
                 'memory': '2Gi',
                 'cpu': 2
-            },
+            }
         }
         KubernetesRequestFactory.extract_resources(pod, self.input_req)
         self.assertEqual(self.input_req, self.expected)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.

### Description

- [x] Fix copy pasta in `airflow.kubernetes.kubernetes_request_factory.kubernetes_request_factory.KubernetesRequestFactory#extract_resources`

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
