### PR TITLE
[AIRFLOW-4981][AIRFLOW-4788] Always use pendulum DateTimes in task in…

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1145,12 +1145,14 @@ class TaskInstance(Base, LoggingMixin):
         if next_execution_date:
             next_ds = next_execution_date.strftime('%Y-%m-%d')
             next_ds_nodash = next_ds.replace('-', '')
+            next_execution_date = pendulum.instance(next_execution_date)
 
         prev_ds = None
         prev_ds_nodash = None
         if prev_execution_date:
             prev_ds = prev_execution_date.strftime('%Y-%m-%d')
             prev_ds_nodash = prev_ds.replace('-', '')
+            prev_execution_date = pendulum.instance(prev_execution_date)
 
         ds_nodash = ds.replace('-', '')
         ts_nodash = self.execution_date.strftime('%Y%m%dT%H%M%S')
@@ -1204,7 +1206,7 @@ class TaskInstance(Base, LoggingMixin):
             'ds': ds,
             'ds_nodash': ds_nodash,
             'end_date': ds,
-            'execution_date': self.execution_date,
+            'execution_date': pendulum.instance(self.execution_date),
             'inlets': task.inlets,
             'latest_date': ds,
             'macros': macros,

--- a/airflow/operators/latest_only_operator.py
+++ b/airflow/operators/latest_only_operator.py
@@ -17,8 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import pendulum
+
 from airflow.models import BaseOperator, SkipMixin
-from airflow.utils import timezone
+
 
 
 class LatestOnlyOperator(BaseOperator, SkipMixin):
@@ -39,7 +41,7 @@ class LatestOnlyOperator(BaseOperator, SkipMixin):
             self.log.info("Externally triggered DAG_Run: allowing execution to proceed.")
             return
 
-        now = timezone.utcnow()
+        now = pendulum.utcnow()
         left_window = context['dag'].following_schedule(
             context['execution_date'])
         right_window = context['dag'].following_schedule(left_window)

--- a/airflow/operators/latest_only_operator.py
+++ b/airflow/operators/latest_only_operator.py
@@ -22,7 +22,6 @@ import pendulum
 from airflow.models import BaseOperator, SkipMixin
 
 
-
 class LatestOnlyOperator(BaseOperator, SkipMixin):
     """
     Allows a workflow to skip tasks that are not running during the most

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1143,3 +1143,18 @@ class TaskInstanceTest(unittest.TestCase):
             ti_list[3].previous_start_date_success,
             ti_list[2].start_date,
         )
+
+    def test_pendulum_template_dates(self):
+        dag = models.DAG(
+            dag_id='test_pendulum_template_dates', schedule_interval='0 12 * * *',
+            start_date=timezone.datetime(2016, 6, 1, 0, 0, 0))
+        task = DummyOperator(task_id='test_pendulum_template_dates_task', dag=dag)
+
+        ti = TI(task=task, execution_date=timezone.utcnow())
+
+        template_context = ti.get_template_context()
+
+        self.assertIsInstance(template_context["execution_date"], pendulum.datetime)
+        self.assertIsInstance(template_context["next_execution_date"], pendulum.datetime)
+        self.assertIsInstance(template_context["prev_execution_date"], pendulum.datetime)
+

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1157,4 +1157,3 @@ class TaskInstanceTest(unittest.TestCase):
         self.assertIsInstance(template_context["execution_date"], pendulum.datetime)
         self.assertIsInstance(template_context["next_execution_date"], pendulum.datetime)
         self.assertIsInstance(template_context["prev_execution_date"], pendulum.datetime)
-


### PR DESCRIPTION
…stance context



Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-4981
  - https://issues.apache.org/jira/browse/AIRFLOW-4788

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
In certain situations, like when using fixed cron schedules such as `0
12 * * *`, the `execution_date`, `prev_execution_date`, and
`next_execution_date` variables in macros were native python `datetime`
objects instead of, as stated in the docs, pendulum `DateTime` objects.

### Tests

- [x] My PR adds the following unit tests 
  - `tests.models.test_taskinstance:TaskInstanceTest.test_pendulum_template_dates`
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
