### PR TITLE
[AIRFLOW-4883] Fix tests on Python 3.5

### DIFF
--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -192,7 +192,7 @@ class TestDagFileProcessorManager(unittest.TestCase):
         processor._start_time = timezone.make_aware(datetime.min)
         manager._processors = {'abc.txt': processor}
         manager._kill_timed_out_processors()
-        mock_kill.assert_called_once()
+        mock_kill.assert_called_once_with()
 
     @mock.patch("airflow.jobs.DagFileProcessor.pid", new_callable=PropertyMock)
     @mock.patch("airflow.jobs.scheduler_job.DagFileProcessor")


### PR DESCRIPTION
Fixes up an early merge from #5639 

### Description

- [x] `assert_called` and `assert_called_once` are new in Py 3.6
