### PR TITLE
[AIRFLOW-XXX] Fix Typos

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -56,7 +56,7 @@ from airflow.utils.state import State
 class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
     """Helps call SchedulerJob.process_file() in a separate process."""
 
-    # Counter that increments everytime an instance of this class is created
+    # Counter that increments every time an instance of this class is created
     class_creation_counter = 0
 
     def __init__(self, file_path, pickle_dags, dag_id_white_list):

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -395,7 +395,7 @@ class SchedulerJob(BaseJob):
         Finding all tasks that have SLAs defined, and sending alert emails
         where needed. New SLA misses are also recorded in the database.
 
-        Where assuming that the scheduler runs often, so we only check for
+        We are assuming that the scheduler runs often, so we only check for
         tasks that should have succeeded in the past hour.
         """
         if not any([isinstance(ti.sla, timedelta) for ti in dag.tasks]):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -137,7 +137,7 @@ class BaseOperator(LoggingMixin):
         complete for all runs before each dag can continue processing
         downstream tasks. When set to ``upstream`` the effective weight is the
         aggregate sum of all upstream ancestors. This is the opposite where
-        downtream tasks have higher weight and will be scheduled more
+        downstream tasks have higher weight and will be scheduled more
         aggressively when using positive weight values. This is useful when you
         have multiple dag run instances and prefer to have each dag complete
         before starting upstream tasks of other dags.  When set to

--- a/tests/core.py
+++ b/tests/core.py
@@ -1587,7 +1587,7 @@ class CliTests(unittest.TestCase):
 
             self.assertTrue(result is None)
 
-        # Attempt to delete a non-existing connnection
+        # Attempt to delete a non-existing connection
         with mock.patch('sys.stdout',
                         new_callable=six.StringIO) as mock_stdout:
             cli.connections_delete(self.parser.parse_args(

--- a/tests/core.py
+++ b/tests/core.py
@@ -749,13 +749,13 @@ class CoreTest(unittest.TestCase):
 
     def test_variable_setdefault_round_trip_json(self):
         key = "tested_var_setdefault_2_id"
-        value = {"city": 'Paris', "Hapiness": True}
+        value = {"city": 'Paris', "Happiness": True}
         Variable.setdefault(key, value, deserialize_json=True)
         self.assertEqual(value, Variable.get(key, deserialize_json=True))
 
     def test_variable_setdefault_existing_json(self):
         key = "tested_var_setdefault_2_id"
-        value = {"city": 'Paris', "Hapiness": True}
+        value = {"city": 'Paris', "Happiness": True}
         Variable.set(key, value, serialize_json=True)
         val = Variable.setdefault(key, value, deserialize_json=True)
         # Check the returned value, and the stored value are handled correctly.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
None
### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Documentation
### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
