### PR TITLE
[AIRFLOW-5041] just force PYTHON_VERSION variable

### DIFF
--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -285,19 +285,7 @@ function assert_not_in_container() {
 # Forces Python version to 3.6 (for static checks)
 #
 function force_python_3_6() {
-    export PYTHON_BINARY=python3.6
-
-    # And fail in case it is not available
-    if [[ ! -x "$(command -v "${PYTHON_BINARY}")" ]]; then
-        echo >&2
-        echo >&2 "${PYTHON_BINARY} is missing in your \$PATH"
-        echo >&2
-        echo >&2 "Please install Python 3.6 and make it available in your path"
-        echo >&2
-        exit 1
-    fi
-
-    # Set python version variable to force it in the scripts as well
+    # Set python version variable to force it in the container scripts
     PYTHON_VERSION=3.6
     export PYTHON_VERSION
 }


### PR DESCRIPTION
There is no need for python3.6 to be installed in the host.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5041

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
