### PR TITLE
[AIRFLOW-5042] Improve mocking in Dataproc operator tests

### DIFF
--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -28,6 +28,8 @@ import time
 
 from copy import deepcopy
 
+from mock import PropertyMock
+
 from airflow import DAG, AirflowException
 from airflow.contrib.operators.dataproc_operator import \
     DataprocClusterCreateOperator, \
@@ -592,13 +594,17 @@ class DataProcJobBaseOperatorTest(unittest.TestCase):
 
 class DataProcHadoopOperatorTest(unittest.TestCase):
     # Unit test for the DataProcHadoopOperator
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID
+    )
     @mock.patch('airflow.contrib.operators.dataproc_operator.DataProcJobBaseOperator.execute')
     @mock.patch('airflow.contrib.operators.dataproc_operator.uuid.uuid4', return_value='test')
-    def test_correct_job_definition(self, mock_hook, mock_uuid):
+    def test_correct_job_definition(self, mock_hook, mock_uuid, mock_project_id):
         # Expected job
         job_definition = deepcopy(DATAPROC_JOB_TO_SUBMIT)
         job_definition['job']['hadoopJob'] = {'mainClass': None}
-        job_definition['job']['reference']['projectId'] = None
         job_definition['job']['reference']['jobId'] = DATAPROC_JOB_ID + "_test"
 
         # Prepare job using operator
@@ -637,13 +643,17 @@ class DataProcHadoopOperatorTest(unittest.TestCase):
 
 class DataProcHiveOperatorTest(unittest.TestCase):
     # Unit test for the DataProcHiveOperator
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID
+    )
     @mock.patch('airflow.contrib.operators.dataproc_operator.DataProcJobBaseOperator.execute')
     @mock.patch('airflow.contrib.operators.dataproc_operator.uuid.uuid4', return_value='test')
-    def test_correct_job_definition(self, mock_hook, mock_uuid):
+    def test_correct_job_definition(self, mock_hook, mock_uuid, mock_project_id):
         # Expected job
         job_definition = deepcopy(DATAPROC_JOB_TO_SUBMIT)
         job_definition['job']['hiveJob'] = {'queryFileUri': None}
-        job_definition['job']['reference']['projectId'] = None
         job_definition['job']['reference']['jobId'] = DATAPROC_JOB_ID + "_test"
 
         # Prepare job using operator
@@ -681,13 +691,17 @@ class DataProcHiveOperatorTest(unittest.TestCase):
 
 
 class DataProcPigOperatorTest(unittest.TestCase):
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID
+    )
     @mock.patch('airflow.contrib.operators.dataproc_operator.DataProcJobBaseOperator.execute')
     @mock.patch('airflow.contrib.operators.dataproc_operator.uuid.uuid4', return_value='test')
-    def test_correct_job_definition(self, mock_hook, mock_uuid):
+    def test_correct_job_definition(self, mock_hook, mock_uuid, mock_project_id):
         # Expected job
         job_definition = deepcopy(DATAPROC_JOB_TO_SUBMIT)
         job_definition['job']['pigJob'] = {'queryFileUri': None}
-        job_definition['job']['reference']['projectId'] = None
         job_definition['job']['reference']['jobId'] = DATAPROC_JOB_ID + "_test"
 
         # Prepare job using operator
@@ -730,13 +744,17 @@ class DataProcPigOperatorTest(unittest.TestCase):
 
 class DataProcPySparkOperatorTest(unittest.TestCase):
     # Unit test for the DataProcPySparkOperator
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID
+    )
     @mock.patch('airflow.contrib.operators.dataproc_operator.DataProcJobBaseOperator.execute')
     @mock.patch('airflow.contrib.operators.dataproc_operator.uuid.uuid4', return_value='test')
-    def test_correct_job_definition(self, mock_hook, mock_uuid):
+    def test_correct_job_definition(self, mock_hook, mock_uuid, mock_project_id):
         # Expected job
         job_definition = deepcopy(DATAPROC_JOB_TO_SUBMIT)
         job_definition['job']['pysparkJob'] = {'mainPythonFileUri': 'main_class'}
-        job_definition['job']['reference']['projectId'] = None
         job_definition['job']['reference']['jobId'] = DATAPROC_JOB_ID + "_test"
 
         # Prepare job using operator
@@ -778,13 +796,17 @@ class DataProcPySparkOperatorTest(unittest.TestCase):
 
 class DataProcSparkOperatorTest(unittest.TestCase):
     # Unit test for the DataProcSparkOperator
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_dataproc_hook.DataProcHook.project_id',
+        new_callable=PropertyMock,
+        return_value=GCP_PROJECT_ID
+    )
     @mock.patch('airflow.contrib.operators.dataproc_operator.DataProcJobBaseOperator.execute')
     @mock.patch('airflow.contrib.operators.dataproc_operator.uuid.uuid4', return_value='test')
-    def test_correct_job_definition(self, mock_hook, mock_uuid):
+    def test_correct_job_definition(self, mock_hook, mock_uuid, mock_project_id):
         # Expected job
         job_definition = deepcopy(DATAPROC_JOB_TO_SUBMIT)
         job_definition['job']['sparkJob'] = {'mainClass': 'main_class'}
-        job_definition['job']['reference']['projectId'] = None
         job_definition['job']['reference']['jobId'] = DATAPROC_JOB_ID + "_test"
 
         # Prepare job using operator


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
