### PR TITLE
[AIRFLOW-5140] fix all missing type annotation errors from dmypy

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -25,6 +25,7 @@ in their PYTHONPATH. airflow_login should be based off the
 `airflow.www.login`
 """
 
+from typing import Optional, Callable
 from airflow import version
 from airflow.utils.log.logging_mixin import LoggingMixin
 
@@ -39,7 +40,7 @@ from airflow.exceptions import AirflowException
 
 settings.initialize()
 
-login = None
+login = None  # type: Optional[Callable]
 
 
 class AirflowMacroPlugin:

--- a/airflow/api/auth/backend/default.py
+++ b/airflow/api/auth/backend/default.py
@@ -17,9 +17,23 @@
 # specific language governing permissions and limitations
 # under the License.
 """Default authentication backend - everything is allowed"""
+from typing import Optional
 from functools import wraps
+from typing_extensions import Protocol
 
-CLIENT_AUTH = None
+
+class ClientAuthProtocol(Protocol):
+    """
+    Protocol type for CLIENT_AUTH
+    """
+    def handle_response(self, _):
+        """
+        CLIENT_AUTH.handle_response method
+        """
+        ...
+
+
+CLIENT_AUTH = None  # type: Optional[ClientAuthProtocol]
 
 
 def init_app(_):

--- a/airflow/api/auth/backend/deny_all.py
+++ b/airflow/api/auth/backend/deny_all.py
@@ -17,10 +17,13 @@
 # specific language governing permissions and limitations
 # under the License.
 """Authentication backend that denies all requests"""
+from typing import Optional
 from functools import wraps
 from flask import Response
+from airflow.api.auth.backend.default import ClientAuthProtocol
 
-CLIENT_AUTH = None
+
+CLIENT_AUTH = None  # type: Optional[ClientAuthProtocol]
 
 
 def init_app(_):

--- a/airflow/contrib/example_dags/example_gcp_speech.py
+++ b/airflow/contrib/example_dags/example_gcp_speech.py
@@ -57,7 +57,7 @@ AUDIO = {"uri": "gs://{bucket}/{object}".format(bucket=BUCKET_NAME, object=FILEN
 TARGET_LANGUAGE = 'pl'
 FORMAT = 'text'
 MODEL = 'base'
-SOURCE_LANGUAGE = None
+SOURCE_LANGUAGE = None  # type: None
 # [END howto_operator_translate_speech_arguments]
 
 default_args = {"start_date": dates.days_ago(1)}

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -21,6 +21,7 @@
 This module contains a Google Cloud Storage hook.
 """
 
+from typing import Optional
 import gzip as gz
 import os
 import shutil
@@ -38,7 +39,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
     connection.
     """
 
-    _conn = None
+    _conn = None  # type: Optional[storage.Client]
 
     def __init__(self,
                  google_cloud_storage_conn_id='google_cloud_default',

--- a/airflow/contrib/operators/awsbatch_operator.py
+++ b/airflow/contrib/operators/awsbatch_operator.py
@@ -17,6 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+from typing import Optional
+from typing_extensions import Protocol
 import sys
 
 from math import pow
@@ -27,6 +29,20 @@ from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
 from airflow.contrib.hooks.aws_hook import AwsHook
+
+
+class BatchProtocol(Protocol):
+    def submit_job(self, jobName, jobQueue, jobDefinition, containerOverrides):
+        ...
+
+    def get_waiter(self, x: str):
+        ...
+
+    def describe_jobs(self, jobs):
+        ...
+
+    def terminate_job(self, jobId: str, reason: str):
+        ...
 
 
 class AWSBatchOperator(BaseOperator):
@@ -59,8 +75,8 @@ class AWSBatchOperator(BaseOperator):
     """
 
     ui_color = '#c3dae0'
-    client = None
-    arn = None
+    client = None  # type: Optional[BatchProtocol]
+    arn = None  # type: Optional[str]
     template_fields = ('job_name', 'overrides',)
 
     @apply_defaults

--- a/airflow/contrib/operators/ecs_operator.py
+++ b/airflow/contrib/operators/ecs_operator.py
@@ -16,6 +16,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional
+from typing_extensions import Protocol
 import sys
 import re
 
@@ -24,6 +26,20 @@ from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 
 from airflow.contrib.hooks.aws_hook import AwsHook
+
+
+class ECSProtocol(Protocol):
+    def run_task(self, **kwargs):
+        ...
+
+    def get_waiter(self, x: str):
+        ...
+
+    def describe_tasks(self, cluster, tasks):
+        ...
+
+    def stop_task(self, cluster, task, reason: str):
+        ...
 
 
 class ECSOperator(BaseOperator):
@@ -58,8 +74,8 @@ class ECSOperator(BaseOperator):
     """
 
     ui_color = '#f0ede4'
-    client = None
-    arn = None
+    client = None  # type: Optional[ECSProtocol]
+    arn = None  # type: Optional[str]
     template_fields = ('overrides',)
 
     @apply_defaults

--- a/airflow/contrib/operators/gcp_function_operator.py
+++ b/airflow/contrib/operators/gcp_function_operator.py
@@ -20,6 +20,7 @@
 This module contains Google Cloud Functions operators.
 """
 
+from typing import Optional
 import re
 
 from googleapiclient.errors import HttpError
@@ -226,7 +227,7 @@ class ZipPathPreprocessor:
     :type body: dict
 
     """
-    upload_function = None
+    upload_function = None  # type: Optional[bool]
 
     def __init__(self, body, zip_path):
         self.body = body
@@ -260,7 +261,7 @@ class ZipPathPreprocessor:
                                    "allowed. Found both."
                                    .format(GCF_SOURCE_ARCHIVE_URL, GCF_ZIP_PATH))
 
-    def should_upload_function(self):
+    def should_upload_function(self) -> bool:
         """
         Checks if function source should be uploaded.
 

--- a/airflow/executors/__init__.py
+++ b/airflow/executors/__init__.py
@@ -17,15 +17,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import Optional
 import sys
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow import configuration
 from airflow.exceptions import AirflowException
-from airflow.executors.base_executor import BaseExecutor # noqa
+from airflow.executors.base_executor import BaseExecutor
 from airflow.executors.local_executor import LocalExecutor
 from airflow.executors.sequential_executor import SequentialExecutor
 
-DEFAULT_EXECUTOR = None
+DEFAULT_EXECUTOR = None  # type: Optional[BaseExecutor]
 
 
 def _integrate_plugins():

--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -17,14 +17,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import Optional
+from typing_extensions import Protocol
 from datetime import datetime
 from contextlib import closing
-from typing import Optional
 
 from sqlalchemy import create_engine
 
 from airflow.hooks.base_hook import BaseHook
 from airflow.exceptions import AirflowException
+
+
+class ConnectorProtocol(Protocol):
+    def connect(host, port, username, schema):
+        ...
 
 
 class DbApiHook(BaseHook):
@@ -38,7 +44,7 @@ class DbApiHook(BaseHook):
     # Override if this db supports autocommit.
     supports_autocommit = False
     # Override with the object that exposes the connect method
-    connector = None
+    connector = None  # type: Optional[ConnectorProtocol]
 
     def __init__(self, *args, **kwargs):
         if not self.conn_name_attr:

--- a/airflow/models/crypto.py
+++ b/airflow/models/crypto.py
@@ -17,9 +17,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing_extensions import Protocol
+from typing import Optional
 from airflow import configuration
 from airflow.exceptions import AirflowException
 from airflow.utils.log.logging_mixin import LoggingMixin
+
+
+class FernetProtocol(Protocol):
+    def decrypt(self, b):
+        ...
+
+    def encrypt(self, b):
+        ...
 
 
 class InvalidFernetToken(Exception):
@@ -46,7 +56,7 @@ class NullFernet:
         return b
 
 
-_fernet = None
+_fernet = None  # type: Optional[FernetProtocol]
 
 
 def get_fernet():

--- a/airflow/security/kerberos.py
+++ b/airflow/security/kerberos.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
 import socket
 import subprocess
 import sys
@@ -22,7 +23,7 @@ import time
 
 from airflow import configuration, LoggingMixin
 
-NEED_KRB181_WORKAROUND = None
+NEED_KRB181_WORKAROUND = None  # type: Optional[bool]
 
 log = LoggingMixin().log
 
@@ -97,7 +98,7 @@ def perform_krb181_workaround(principal):
         sys.exit(ret)
 
 
-def detect_conf_var():
+def detect_conf_var() -> bool:
     """Return true if the ticket cache contains "conf" information as is found
     in ticket caches of Kerberos 1.8.1 or later. This is incompatible with the
     Sun Java Krb5LoginModule in Java6, so we need to take an action to work

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import Optional
 import atexit
 import logging
 import os
@@ -24,9 +25,12 @@ import pendulum
 import sys
 
 from sqlalchemy import create_engine, exc
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.pool import NullPool
+from sqlalchemy.orm.session import Session as SASession
 
+import airflow
 from airflow.configuration import conf, AIRFLOW_HOME, WEBSERVER_CONFIG  # NOQA F401
 from airflow.kubernetes.pod import Pod
 from airflow.logging_config import configure_logging
@@ -63,13 +67,13 @@ GUNICORN_WORKER_READY_PREFIX = "[ready] "
 LOG_FORMAT = conf.get('core', 'log_format')
 SIMPLE_LOG_FORMAT = conf.get('core', 'simple_log_format')
 
-SQL_ALCHEMY_CONN = None
-DAGS_FOLDER = None
-PLUGINS_FOLDER = None
-LOGGING_CLASS_PATH = None
+SQL_ALCHEMY_CONN = None  # type: Optional[str]
+DAGS_FOLDER = None  # type: Optional[str]
+PLUGINS_FOLDER = None  # type: Optional[str]
+LOGGING_CLASS_PATH = None  # type: Optional[str]
 
-engine = None
-Session = None
+engine = None  # type: Optional[Engine]
+Session = None  # type: Optional[SASession]
 
 
 def policy(task_instance):
@@ -309,4 +313,4 @@ WEB_COLORS = {'LIGHTBLUE': '#4d9de0',
               'LIGHTORANGE': '#FF9933'}
 
 # Used by DAG context_managers
-CONTEXT_MANAGER_DAG = None
+CONTEXT_MANAGER_DAG = None  # type: Optional[airflow.models.dag.DAG]

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -25,7 +25,7 @@ class State:
     """
 
     # scheduler
-    NONE = None
+    NONE = None  # type: None
     REMOVED = "removed"
     SCHEDULED = "scheduled"
 

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+from typing import Optional
 import logging
 import socket
 
@@ -36,7 +37,7 @@ from airflow.utils.json import AirflowJsonEncoder
 from airflow.www.static_config import configure_manifest_files
 
 app = None  # type: Any
-appbuilder = None
+appbuilder = None  # type: Optional[AppBuilder]
 csrf = CSRFProtect()
 
 log = logging.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -358,6 +358,7 @@ def do_setup():
             'tzlocal>=1.4,<2.0.0',
             'unicodecsv>=0.14.1',
             'zope.deprecation>=4.0, <5.0',
+            'typing-extensions>=3.7.4;python_version<"3.7"',
         ],
         setup_requires=[
             'docutils>=0.14, <1.0',

--- a/tests/contrib/hooks/test_databricks_hook.py
+++ b/tests/contrib/hooks/test_databricks_hook.py
@@ -69,7 +69,7 @@ NOTEBOOK_PARAMS = {
     "oldest-time-to-consider": "1457570074236"
 }
 JAR_PARAMS = ["param1", "param2"]
-RESULT_STATE = None
+RESULT_STATE = None  # type: None
 
 
 def run_now_endpoint(host):

--- a/tests/contrib/hooks/test_gcp_cloud_build_hook.py
+++ b/tests/contrib/hooks/test_gcp_cloud_build_hook.py
@@ -19,6 +19,7 @@
 """
 Tests for Google Cloud Build Hook
 """
+from typing import Optional
 import unittest
 from unittest import mock
 
@@ -46,7 +47,7 @@ TEST_PROJECT_ID = "cloud-build-project-id"
 
 
 class TestCloudBuildHookWithPassedProjectId(unittest.TestCase):
-    hook = None
+    hook = None  # type: Optional[CloudBuildHook]
 
     def setUp(self):
         with mock.patch(
@@ -119,7 +120,7 @@ class TestCloudBuildHookWithPassedProjectId(unittest.TestCase):
 
 
 class TestGcpComputeHookWithDefaultProjectIdFromConnection(unittest.TestCase):
-    hook = None
+    hook = None  # type: Optional[CloudBuildHook]
 
     def setUp(self):
         with mock.patch(
@@ -188,7 +189,7 @@ class TestGcpComputeHookWithDefaultProjectIdFromConnection(unittest.TestCase):
 
 
 class TestCloudBuildHookWithoutProjectId(unittest.TestCase):
-    hook = None
+    hook = None  # type: Optional[CloudBuildHook]
 
     def setUp(self):
         with mock.patch(

--- a/tests/contrib/utils/gcp_authenticator.py
+++ b/tests/contrib/utils/gcp_authenticator.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Optional  # noqa: W0611
 import json
 import os
 import subprocess
@@ -55,7 +56,7 @@ class GcpAuthenticator(LoggingCommandExecutor):
     connection - it can authenticate with the gcp key name specified
     """
 
-    original_account = None
+    original_account = None  # type: Optional[str]
 
     def __init__(self, gcp_key, project_extra=None):
         """

--- a/tests/core.py
+++ b/tests/core.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import Optional
 import io
 import json
 import multiprocessing
@@ -73,6 +74,7 @@ from airflow.utils.dates import (
 )
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
+from airflow.hooks import hdfs_hook
 from tests.test_utils.config import conf_vars
 
 NUM_EXAMPLE_DAGS = 19
@@ -2178,8 +2180,8 @@ class WebHDFSHookTest(unittest.TestCase):
         self.assertEqual('someone', c.proxy_user)
 
 
-HDFSHook = None
-snakebite = None
+HDFSHook = None  # type: Optional[hdfs_hook.HDFSHook]
+snakebite = None  # type: None
 
 @unittest.skipIf(HDFSHook is None,
                  "Skipping test because HDFSHook is not installed")

--- a/tests/test_utils/reset_warning_registry.py
+++ b/tests/test_utils/reset_warning_registry.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import Optional, Dict, Match
 import re
 import sys
 
@@ -42,10 +43,10 @@ class reset_warning_registry:
     """
 
     #: regexp for filtering which modules are reset
-    _pattern = None
+    _pattern = None  # type: Optional[Match[str]]
 
     #: dict mapping module name -> old registry contents
-    _backup = None
+    _backup = None  # type: Optional[Dict]
 
     def __init__(self, pattern=None):
         self._pattern = re.compile(pattern or ".*")


### PR DESCRIPTION
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This PR fixes all missing type annotation errors from dmypy:

```bash
$ dmypy run -- --follow-imports=error airflow tests
tests/core.py:2188: error: Need type annotation for 'HDFSHook'
tests/core.py:2189: error: Need type annotation for 'snakebite'
airflow/__init__.py:42: error: Need type annotation for 'login'
airflow/api/auth/backend/default.py:22: error: Need type annotation for 'CLIENT_AUTH'
airflow/api/auth/backend/deny_all.py:23: error: Need type annotation for 'CLIENT_AUTH'
airflow/contrib/example_dags/example_gcp_speech.py:60: error: Need type annotation for 'SOURCE_LANGUAGE'
airflow/contrib/hooks/gcp_cloud_build_hook.py:50: error: Need type annotation for '_conn'
airflow/contrib/hooks/gcp_compute_hook.py:50: error: Need type annotation for '_conn'
airflow/contrib/hooks/gcp_function_hook.py:41: error: Need type annotation for '_conn'
airflow/contrib/hooks/gcp_sql_hook.py:722: error: Need type annotation for '_conn'
airflow/contrib/hooks/gcp_translate_hook.py:35: error: Need type annotation for '_client'
airflow/contrib/hooks/gcs_hook.py:41: error: Need type annotation for '_conn'
airflow/contrib/operators/awsbatch_operator.py:62: error: Need type annotation for 'client'
airflow/contrib/operators/awsbatch_operator.py:63: error: Need type annotation for 'arn'
airflow/contrib/operators/ecs_operator.py:61: error: Need type annotation for 'client'
airflow/contrib/operators/ecs_operator.py:62: error: Need type annotation for 'arn'
airflow/contrib/operators/gcp_function_operator.py:229: error: Need type annotation for 'upload_function'
airflow/executors/__init__.py:28: error: Need type annotation for 'DEFAULT_EXECUTOR'
airflow/hooks/dbapi_hook.py:41: error: Need type annotation for 'connector'
airflow/models/crypto.py:49: error: Need type annotation for '_fernet'
airflow/security/kerberos.py:25: error: Need type annotation for 'NEED_KRB181_WORKAROUND'
airflow/settings.py:66: error: Need type annotation for 'SQL_ALCHEMY_CONN'
airflow/settings.py:67: error: Need type annotation for 'DAGS_FOLDER'
airflow/settings.py:68: error: Need type annotation for 'PLUGINS_FOLDER'
airflow/settings.py:69: error: Need type annotation for 'LOGGING_CLASS_PATH'
airflow/settings.py:71: error: Need type annotation for 'engine'
airflow/settings.py:72: error: Need type annotation for 'Session'
airflow/settings.py:312: error: Need type annotation for 'CONTEXT_MANAGER_DAG'
airflow/utils/state.py:28: error: Need type annotation for 'NONE'
airflow/www/app.py:39: error: Need type annotation for 'appbuilder'
tests/contrib/hooks/test_databricks_hook.py:72: error: Need type annotation for 'RESULT_STATE'
tests/contrib/hooks/test_gcp_cloud_build_hook.py:49: error: Need type annotation for 'hook'
tests/contrib/hooks/test_gcp_cloud_build_hook.py:122: error: Need type annotation for 'hook'
tests/contrib/hooks/test_gcp_cloud_build_hook.py:191: error: Need type annotation for 'hook'
tests/contrib/utils/gcp_authenticator.py:57: error: Need type annotation for 'original_account'
tests/test_utils/reset_warning_registry.py:45: error: Need type annotation for '_pattern'
tests/test_utils/reset_warning_registry.py:48: error: Need type annotation for '_backup'
```

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

There is no logic change, only type annotations. If `dmypy` passes without error, then it should be good to go.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
