### PR TITLE
[AIRFLOW-4316] support setting kubernetes_environment_variables config section from env var

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -148,6 +148,9 @@ class AirflowConfigParser(ConfigParser):
         },
     }
 
+    # This method transforms option names on every read, get, or set operation.
+    # This changes from the default behaviour of ConfigParser from lowercasing
+    # to instead be case-preserving
     def optionxform(self, optionstr: str) -> str:
         return optionstr
 

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -89,7 +89,7 @@ def run_command(command):
     return output
 
 
-def _read_default_config_file(file_name):
+def _read_default_config_file(file_name: str) -> str:
     templates_dir = os.path.join(os.path.dirname(__file__), 'config_templates')
     file_path = os.path.join(templates_dir, file_name)
     with open(file_path, encoding='utf-8') as file:
@@ -147,6 +147,9 @@ class AirflowConfigParser(ConfigParser):
             'task_runner': ('BashTaskRunner', 'StandardTaskRunner', '2.0'),
         },
     }
+
+    def optionxform(self, optionstr: str) -> str:
+        return optionstr
 
     def __init__(self, default_config=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -399,8 +402,15 @@ class AirflowConfigParser(ConfigParser):
                     opt = opt.replace('%', '%%')
                 if display_source:
                     opt = (opt, 'env var')
-                cfg.setdefault(section.lower(), OrderedDict()).update(
-                    {key.lower(): opt})
+
+                section = section.lower()
+                # if we lower key for kubernetes_environment_variables section,
+                # then we won't be able to set any Airflow environment
+                # variables. Airflow only parse environment variables starts
+                # with AIRFLOW_. Therefore, we need to make it a special case.
+                if section != 'kubernetes_environment_variables':
+                    key = key.lower()
+                cfg.setdefault(section, OrderedDict()).update({key: opt})
 
         # add bash commands
         if include_cmds:

--- a/tests/core.py
+++ b/tests/core.py
@@ -814,7 +814,7 @@ class CoreTest(unittest.TestCase):
         self.assertTrue(configuration.conf.has_option("core", "FERNET_KEY"))
         self.assertFalse(configuration.conf.has_option("core", "FERNET_KEY_CMD"))
 
-        with conf_vars({('core', 'FERNET_KEY'): None}):
+        with conf_vars({('core', 'fernet_key'): None}):
             with self.assertRaises(AirflowConfigException) as cm:
                 configuration.conf.get("core", "FERNET_KEY")
 
@@ -2240,7 +2240,7 @@ class EmailTest(unittest.TestCase):
 
     @mock.patch('airflow.utils.email.send_email_smtp')
     def test_custom_backend(self, mock_send_email):
-        with conf_vars({('email', 'EMAIL_BACKEND'): 'tests.core.send_email_test'}):
+        with conf_vars({('email', 'email_backend'): 'tests.core.send_email_test'}):
             utils.email.send_email('to', 'subject', 'content')
         send_email_test.assert_called_with(
             'to', 'subject', 'content', files=None, dryrun=False,
@@ -2323,7 +2323,7 @@ class EmailSmtpTest(unittest.TestCase):
     def test_send_mime_ssl(self, mock_smtp, mock_smtp_ssl):
         mock_smtp.return_value = mock.Mock()
         mock_smtp_ssl.return_value = mock.Mock()
-        with conf_vars({('smtp', 'SMTP_SSL'): 'True'}):
+        with conf_vars({('smtp', 'smtp_ssl'): 'True'}):
             utils.email.send_MIME_email('from', 'to', MIMEMultipart(), dryrun=False)
         self.assertFalse(mock_smtp.called)
         mock_smtp_ssl.assert_called_with(
@@ -2337,8 +2337,8 @@ class EmailSmtpTest(unittest.TestCase):
         mock_smtp.return_value = mock.Mock()
         mock_smtp_ssl.return_value = mock.Mock()
         with conf_vars({
-                ('smtp', 'SMTP_USER'): None,
-                ('smtp', 'SMTP_PASSWORD'): None,
+                ('smtp', 'smtp_user'): None,
+                ('smtp', 'smtp_password'): None,
         }):
             utils.email.send_MIME_email('from', 'to', MIMEMultipart(), dryrun=False)
         self.assertFalse(mock_smtp_ssl.called)

--- a/tests/models/test_connection.py
+++ b/tests/models/test_connection.py
@@ -36,7 +36,7 @@ class ConnectionTest(unittest.TestCase):
     def tearDown(self):
         crypto._fernet = None
 
-    @conf_vars({('core', 'FERNET_KEY'): ''})
+    @conf_vars({('core', 'fernet_key'): ''})
     def test_connection_extra_no_encryption(self):
         """
         Tests extras on a new connection without encryption. The fernet key
@@ -47,7 +47,7 @@ class ConnectionTest(unittest.TestCase):
         self.assertFalse(test_connection.is_extra_encrypted)
         self.assertEqual(test_connection.extra, 'testextra')
 
-    @conf_vars({('core', 'FERNET_KEY'): Fernet.generate_key().decode()})
+    @conf_vars({('core', 'fernet_key'): Fernet.generate_key().decode()})
     def test_connection_extra_with_encryption(self):
         """
         Tests extras on a new connection with encryption.
@@ -63,14 +63,14 @@ class ConnectionTest(unittest.TestCase):
         key1 = Fernet.generate_key()
         key2 = Fernet.generate_key()
 
-        with conf_vars({('core', 'FERNET_KEY'): key1.decode()}):
+        with conf_vars({('core', 'fernet_key'): key1.decode()}):
             test_connection = Connection(extra='testextra')
             self.assertTrue(test_connection.is_extra_encrypted)
             self.assertEqual(test_connection.extra, 'testextra')
             self.assertEqual(Fernet(key1).decrypt(test_connection._extra.encode()), b'testextra')
 
         # Test decrypt of old value with new key
-        with conf_vars({('core', 'FERNET_KEY'): ','.join([key2.decode(), key1.decode()])}):
+        with conf_vars({('core', 'fernet_key'): ','.join([key2.decode(), key1.decode()])}):
             crypto._fernet = None
             self.assertEqual(test_connection.extra, 'testextra')
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1058,8 +1058,8 @@ class TaskInstanceTest(unittest.TestCase):
         ti = TI(
             task=task, execution_date=datetime.datetime.now())
 
-        configuration.set('email', 'SUBJECT_TEMPLATE', '/subject/path')
-        configuration.set('email', 'HTML_CONTENT_TEMPLATE', '/html_content/path')
+        configuration.set('email', 'subject_template', '/subject/path')
+        configuration.set('email', 'html_content_template', '/html_content/path')
 
         opener = mock_open(read_data='template: {{ti.task_id}}')
         with patch('airflow.models.taskinstance.open', opener, create=True):

--- a/tests/models/test_variable.py
+++ b/tests/models/test_variable.py
@@ -33,7 +33,7 @@ class VariableTest(unittest.TestCase):
     def tearDown(self):
         crypto._fernet = None
 
-    @conf_vars({('core', 'FERNET_KEY'): ''})
+    @conf_vars({('core', 'fernet_key'): ''})
     def test_variable_no_encryption(self):
         """
         Test variables without encryption
@@ -44,7 +44,7 @@ class VariableTest(unittest.TestCase):
         self.assertFalse(test_var.is_encrypted)
         self.assertEqual(test_var.val, 'value')
 
-    @conf_vars({('core', 'FERNET_KEY'): Fernet.generate_key().decode()})
+    @conf_vars({('core', 'fernet_key'): Fernet.generate_key().decode()})
     def test_variable_with_encryption(self):
         """
         Test variables with encryption
@@ -62,7 +62,7 @@ class VariableTest(unittest.TestCase):
         key1 = Fernet.generate_key()
         key2 = Fernet.generate_key()
 
-        with conf_vars({('core', 'FERNET_KEY'): key1.decode()}):
+        with conf_vars({('core', 'fernet_key'): key1.decode()}):
             Variable.set('key', 'value')
             session = settings.Session()
             test_var = session.query(Variable).filter(Variable.key == 'key').one()
@@ -71,7 +71,7 @@ class VariableTest(unittest.TestCase):
             self.assertEqual(Fernet(key1).decrypt(test_var._val.encode()), b'value')
 
         # Test decrypt of old value with new key
-        with conf_vars({('core', 'FERNET_KEY'): ','.join([key2.decode(), key1.decode()])}):
+        with conf_vars({('core', 'fernet_key'): ','.join([key2.decode(), key1.decode()])}):
             crypto._fernet = None
             self.assertEqual(test_var.val, 'value')
 

--- a/tests/operators/test_email_operator.py
+++ b/tests/operators/test_email_operator.py
@@ -57,6 +57,6 @@ class TestEmailOperator(unittest.TestCase):
         task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
     def test_execute(self):
-        with conf_vars({('email', 'EMAIL_BACKEND'): 'tests.operators.test_email_operator.send_email_test'}):
+        with conf_vars({('email', 'email_backend'): 'tests.operators.test_email_operator.send_email_test'}):
             self._run_as_operator()
         assert send_email_test.call_count == 1

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -51,7 +51,6 @@ class ConfTest(unittest.TestCase):
     def setUpClass(cls):
         os.environ['AIRFLOW__TESTSECTION__TESTKEY'] = 'testvalue'
         os.environ['AIRFLOW__TESTSECTION__TESTPERCENT'] = 'with%percent'
-        os.environ['AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW__TESTSECTION__TESTKEY'] = 'nested'
         conf.set('core', 'percent', 'with%%inside')
 
     @classmethod
@@ -83,6 +82,13 @@ class ConfTest(unittest.TestCase):
                 configuration.get_airflow_config('/home//airflow'),
                 '/path/to/airflow/airflow.cfg')
 
+    def test_case_sensitivity(self):
+        # section and key are case insensitive for get method
+        # note: this is not the case for as_dict method
+        self.assertEqual(conf.get("core", "percent"), "with%inside")
+        self.assertEqual(conf.get("core", "PERCENT"), "with%inside")
+        self.assertEqual(conf.get("CORE", "PERCENT"), "with%inside")
+
     def test_env_var_config(self):
         opt = conf.get('testsection', 'testkey')
         self.assertEqual(opt, 'testvalue')
@@ -92,10 +98,13 @@ class ConfTest(unittest.TestCase):
 
         self.assertTrue(conf.has_option('testsection', 'testkey'))
 
+        os.environ['AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW__TESTSECTION__TESTKEY'] = 'nested'
         opt = conf.get('kubernetes_environment_variables', 'AIRFLOW__TESTSECTION__TESTKEY')
         self.assertEqual(opt, 'nested')
+        del os.environ['AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW__TESTSECTION__TESTKEY']
 
     def test_conf_as_dict(self):
+        os.environ['AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW__TESTSECTION__TESTKEY'] = 'nested'
         cfg_dict = conf.as_dict()
 
         # test that configs are picked up
@@ -106,8 +115,9 @@ class ConfTest(unittest.TestCase):
         # test env vars
         self.assertEqual(cfg_dict['testsection']['testkey'], '< hidden >')
         self.assertEqual(
-            cfg_dict['kubernetes_environment_variables']['airflow__testsection__testkey'],
+            cfg_dict['kubernetes_environment_variables']['AIRFLOW__TESTSECTION__TESTKEY'],
             '< hidden >')
+        del os.environ['AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW__TESTSECTION__TESTKEY']
 
     def test_conf_as_dict_source(self):
         # test display_source
@@ -316,6 +326,24 @@ key3 = value3
                 ('testkey', 'testvalue'),
                 ('testpercent', 'with%percent')]),
             test_conf.getsection('testsection')
+        )
+
+    def test_kubernetes_environment_variables_section(self):
+        TEST_CONFIG = '''
+[kubernetes_environment_variables]
+key1 = hello
+AIRFLOW_HOME = /root/airflow
+'''
+        TEST_CONFIG_DEFAULT = '''
+[kubernetes_environment_variables]
+'''
+        test_conf = AirflowConfigParser(
+            default_config=parameterized_config(TEST_CONFIG_DEFAULT))
+        test_conf.read_string(TEST_CONFIG)
+
+        self.assertEqual(
+            OrderedDict([('key1', 'hello'), ('AIRFLOW_HOME', '/root/airflow')]),
+            test_conf.getsection('kubernetes_environment_variables')
         )
 
     def test_broker_transport_options(self):


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apahe.org/jira/browse/AIRFLOW-5055) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5055

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

When `AIRFLOW_KUBERNETES_ENVIRONMENT_VARIABLES__AIRFLOW_HOME` is set in
the scheduler, `AIRFLOW_HOME` should be set for workers, not airflow_home. This means `kubernetes_environment_variables` section's keys need to be parsed with case sensitivity.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Updated test in `test_env_var_config` to capture the requirement.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
