### PR TITLE
[AIRFLOW-5056] Add argument to filter mails in ImapHook and related operators

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,21 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Changes to ImapHook, ImapAttachmentSensor and ImapAttachmentToS3Operator
+
+ImapHook:
+* The order of arguments has changed for `has_mail_attachment`, 
+`retrieve_mail_attachments` and `download_mail_attachments`.
+* A new `mail_filter` argument has been added to each of those.
+
+ImapAttachmentSensor:
+* The order of arguments has changed for `__init__`.
+* A new `mail_filter` argument has been added to `__init__`. 
+
+ImapAttachmentToS3Operator:
+* The order of arguments has changed for `__init__`.
+* A new `imap_mail_filter` argument has been added to `__init__`. 
+
 ### Changes to `SubDagOperator`
 
 `SubDagOperator` is changed to use Airflow scheduler instead of backfill

--- a/airflow/contrib/operators/imap_attachment_to_s3_operator.py
+++ b/airflow/contrib/operators/imap_attachment_to_s3_operator.py
@@ -16,7 +16,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+"""
+This module allows you to transfer mail attachments from a mail server into s3 bucket.
+"""
 from airflow.contrib.hooks.imap_hook import ImapHook
 from airflow.hooks.S3_hook import S3Hook
 from airflow.models import BaseOperator
@@ -31,10 +33,13 @@ class ImapAttachmentToS3Operator(BaseOperator):
     :type imap_attachment_name: str
     :param s3_key: The destination file name in the s3 bucket for the attachment.
     :type s3_key: str
-    :param imap_mail_folder: The folder on the mail server to look for the attachment.
-    :type imap_mail_folder: str
     :param imap_check_regex: If set checks the `imap_attachment_name` for a regular expression.
     :type imap_check_regex: bool
+    :param imap_mail_folder: The folder on the mail server to look for the attachment.
+    :type imap_mail_folder: str
+    :param imap_mail_filter: If set other than 'All' only specific mails will be checked.
+        See :py:meth:`imaplib.IMAP4.search` for details.
+    :type imap_mail_filter: str
     :param s3_overwrite: If set overwrites the s3 key if already exists.
     :type s3_overwrite: bool
     :param imap_conn_id: The reference to the connection details of the mail server.
@@ -42,14 +47,15 @@ class ImapAttachmentToS3Operator(BaseOperator):
     :param s3_conn_id: The reference to the s3 connection details.
     :type s3_conn_id: str
     """
-    template_fields = ('imap_attachment_name', 's3_key')
+    template_fields = ('imap_attachment_name', 's3_key', 'imap_mail_filter')
 
     @apply_defaults
     def __init__(self,
                  imap_attachment_name,
                  s3_key,
-                 imap_mail_folder='INBOX',
                  imap_check_regex=False,
+                 imap_mail_folder='INBOX',
+                 imap_mail_filter='All',
                  s3_overwrite=False,
                  imap_conn_id='imap_default',
                  s3_conn_id='aws_default',
@@ -58,8 +64,9 @@ class ImapAttachmentToS3Operator(BaseOperator):
         super().__init__(*args, **kwargs)
         self.imap_attachment_name = imap_attachment_name
         self.s3_key = s3_key
-        self.imap_mail_folder = imap_mail_folder
         self.imap_check_regex = imap_check_regex
+        self.imap_mail_folder = imap_mail_folder
+        self.imap_mail_filter = imap_mail_filter
         self.s3_overwrite = s3_overwrite
         self.imap_conn_id = imap_conn_id
         self.s3_conn_id = s3_conn_id
@@ -79,9 +86,10 @@ class ImapAttachmentToS3Operator(BaseOperator):
         with ImapHook(imap_conn_id=self.imap_conn_id) as imap_hook:
             imap_mail_attachments = imap_hook.retrieve_mail_attachments(
                 name=self.imap_attachment_name,
-                mail_folder=self.imap_mail_folder,
                 check_regex=self.imap_check_regex,
-                latest_only=True
+                latest_only=True,
+                mail_folder=self.imap_mail_folder,
+                mail_filter=self.imap_mail_filter,
             )
 
         s3_hook = S3Hook(aws_conn_id=self.s3_conn_id)

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -38,7 +38,6 @@
 ./airflow/contrib/hooks/fs_hook.py
 ./airflow/contrib/hooks/ftp_hook.py
 ./airflow/contrib/hooks/grpc_hook.py
-./airflow/contrib/hooks/imap_hook.py
 ./airflow/contrib/hooks/jenkins_hook.py
 ./airflow/contrib/hooks/jira_hook.py
 ./airflow/contrib/hooks/mongo_hook.py
@@ -85,7 +84,6 @@
 ./airflow/contrib/operators/grpc_operator.py
 ./airflow/contrib/operators/hipchat_operator.py
 ./airflow/contrib/operators/hive_to_dynamodb.py
-./airflow/contrib/operators/imap_attachment_to_s3_operator.py
 ./airflow/contrib/operators/jenkins_job_trigger_operator.py
 ./airflow/contrib/operators/jira_operator.py
 ./airflow/contrib/operators/kubernetes_pod_operator.py
@@ -144,7 +142,6 @@
 ./airflow/contrib/sensors/file_sensor.py
 ./airflow/contrib/sensors/ftp_sensor.py
 ./airflow/contrib/sensors/hdfs_sensor.py
-./airflow/contrib/sensors/imap_attachment_sensor.py
 ./airflow/contrib/sensors/jira_sensor.py
 ./airflow/contrib/sensors/mongo_sensor.py
 ./airflow/contrib/sensors/python_sensor.py
@@ -421,7 +418,6 @@
 ./tests/contrib/hooks/test_datastore_hook.py
 ./tests/contrib/hooks/test_discord_webhook_hook.py
 ./tests/contrib/hooks/test_ftp_hook.py
-./tests/contrib/hooks/test_imap_hook.py
 ./tests/contrib/hooks/test_jira_hook.py
 ./tests/contrib/hooks/test_mongo_hook.py
 ./tests/contrib/hooks/test_openfaas_hook.py

--- a/tests/contrib/hooks/test_imap_hook.py
+++ b/tests/contrib/hooks/test_imap_hook.py
@@ -75,7 +75,7 @@ class TestImapHook(unittest.TestCase):
         assert mock_conn.logout.call_count == 1
 
     @patch(imaplib_string)
-    def test_has_mail_attachments_found(self, mock_imaplib):
+    def test_has_mail_attachment_found(self, mock_imaplib):
         _create_fake_imap(mock_imaplib, with_mail=True)
 
         with ImapHook() as imap_hook:
@@ -84,7 +84,7 @@ class TestImapHook(unittest.TestCase):
         self.assertTrue(has_attachment_in_inbox)
 
     @patch(imaplib_string)
-    def test_has_mail_attachments_not_found(self, mock_imaplib):
+    def test_has_mail_attachment_not_found(self, mock_imaplib):
         _create_fake_imap(mock_imaplib, with_mail=True)
 
         with ImapHook() as imap_hook:
@@ -93,7 +93,7 @@ class TestImapHook(unittest.TestCase):
         self.assertFalse(has_attachment_in_inbox)
 
     @patch(imaplib_string)
-    def test_has_mail_attachments_with_regex_found(self, mock_imaplib):
+    def test_has_mail_attachment_with_regex_found(self, mock_imaplib):
         _create_fake_imap(mock_imaplib, with_mail=True)
 
         with ImapHook() as imap_hook:
@@ -105,7 +105,7 @@ class TestImapHook(unittest.TestCase):
         self.assertTrue(has_attachment_in_inbox)
 
     @patch(imaplib_string)
-    def test_has_mail_attachments_with_regex_not_found(self, mock_imaplib):
+    def test_has_mail_attachment_with_regex_not_found(self, mock_imaplib):
         _create_fake_imap(mock_imaplib, with_mail=True)
 
         with ImapHook() as imap_hook:
@@ -115,6 +115,19 @@ class TestImapHook(unittest.TestCase):
             )
 
         self.assertFalse(has_attachment_in_inbox)
+
+    @patch(imaplib_string)
+    def test_has_mail_attachment_with_mail_filter(self, mock_imaplib):
+        _create_fake_imap(mock_imaplib, with_mail=True)
+        mail_filter = '(SINCE "01-Jan-2019")'
+
+        with ImapHook() as imap_hook:
+            imap_hook.has_mail_attachment(
+                name='test1.csv',
+                mail_filter=mail_filter
+            )
+
+        mock_imaplib.IMAP4_SSL.return_value.search.assert_called_once_with(None, mail_filter)
 
     @patch(imaplib_string)
     def test_retrieve_mail_attachments_found(self, mock_imaplib):
@@ -165,6 +178,19 @@ class TestImapHook(unittest.TestCase):
             )
 
         self.assertEqual(attachments_in_inbox, [('test1.csv', b'SWQsTmFtZQoxLEZlbGl4')])
+
+    @patch(imaplib_string)
+    def test_retrieve_mail_attachments_with_mail_filter(self, mock_imaplib):
+        _create_fake_imap(mock_imaplib, with_mail=True)
+        mail_filter = '(SINCE "01-Jan-2019")'
+
+        with ImapHook() as imap_hook:
+            imap_hook.retrieve_mail_attachments(
+                name='test1.csv',
+                mail_filter=mail_filter
+            )
+
+        mock_imaplib.IMAP4_SSL.return_value.search.assert_called_once_with(None, mail_filter)
 
     @patch(open_string, new_callable=mock_open)
     @patch(imaplib_string)
@@ -263,6 +289,22 @@ class TestImapHook(unittest.TestCase):
         assert mock_is_symlink.call_count == 1
         mock_open_method.assert_not_called()
         mock_open_method.return_value.write.assert_not_called()
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    def test_download_mail_attachments_with_mail_filter(self, mock_imaplib, mock_open_method):
+        _create_fake_imap(mock_imaplib, with_mail=True)
+        mail_filter = '(SINCE "01-Jan-2019")'
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments(
+                name='test1.csv',
+                local_output_directory='test_directory',
+                mail_filter=mail_filter
+            )
+
+        mock_imaplib.IMAP4_SSL.return_value.search.assert_called_once_with(None, mail_filter)
+        assert mock_open_method.call_count == 1
 
 
 if __name__ == '__main__':

--- a/tests/contrib/operators/test_imap_attachment_to_s3_operator.py
+++ b/tests/contrib/operators/test_imap_attachment_to_s3_operator.py
@@ -30,8 +30,9 @@ class TestImapAttachmentToS3Operator(unittest.TestCase):
         self.kwargs = dict(
             imap_attachment_name='test_file',
             s3_key='test_file',
-            imap_mail_folder='INBOX',
             imap_check_regex=False,
+            imap_mail_folder='INBOX',
+            imap_mail_filter='All',
             s3_overwrite=False,
             task_id='test_task',
             dag=None
@@ -47,9 +48,10 @@ class TestImapAttachmentToS3Operator(unittest.TestCase):
 
         mock_imap_hook.return_value.retrieve_mail_attachments.assert_called_once_with(
             name=self.kwargs['imap_attachment_name'],
-            mail_folder=self.kwargs['imap_mail_folder'],
             check_regex=self.kwargs['imap_check_regex'],
-            latest_only=True
+            latest_only=True,
+            mail_folder=self.kwargs['imap_mail_folder'],
+            mail_filter=self.kwargs['imap_mail_filter']
         )
         mock_s3_hook.return_value.load_bytes.assert_called_once_with(
             bytes_data=mock_imap_hook.return_value.retrieve_mail_attachments.return_value[0][1],


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5056
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

With these changes this hook now provides a way to retrieve attachments of specific mails by exposing the `mail_filter`. This filter gets passed to the [search](https://docs.python.org/3.6/library/imaplib.html#imaplib.IMAP4.search) function. For example you can now pass a filter like this: 
```
mail_filter = '(SINCE "{{ macros.ds_format(ds, "%Y-%m-%d", "%d-%b-%Y") }}" ' \
              'BEFORE "{{ macros.ds_format(macros.ds_add(ds, 3), "%Y-%m-%d", "%d-%b-%Y") }}")'
```
to search only in mails that are between a specific start and end date during a dag run.

These changes also includes:
- changes the order of arguments for `has_mail_attachment`, `retrieve_mail_attachments` and `download_mail_attachments`
- add `get_conn` function
- refactor code
- fix pylint issues
- add imap_mail_filter arg to ImapAttachmentToS3Operator
- add mail_filter arg to ImapAttachmentSensor
- remove superfluous tests
- changes the order of arguments in the sensors + operators __init__

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
