### PR TITLE
[AIRFLOW-4451] Allow templated named tuples

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -646,10 +646,13 @@ class BaseOperator(LoggingMixin):
         rt = self.render_template
         if isinstance(content, str):
             result = jinja_env.from_string(content).render(**context)
-        # Special case for named tuples
-        elif isinstance(content, tuple) and type(content) is not tuple:
-            result = content.__class__(*(rt(attr, e, context) for e in content))
-        elif isinstance(content, (list, tuple)):
+        elif isinstance(content, tuple):
+            if type(content) is not tuple:
+                # Special case for named tuples
+                result = content.__class__(*(rt(attr, e, context) for e in content))
+            else:
+                result = (rt(attr, e, context) for e in content)
+        elif isinstance(content, list):
             result = [rt(attr, e, context) for e in content]
         elif isinstance(content, dict):
             result = {

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -651,7 +651,7 @@ class BaseOperator(LoggingMixin):
                 # Special case for named tuples
                 result = content.__class__(*(rt(attr, e, context) for e in content))
             else:
-                result = (rt(attr, e, context) for e in content)
+                result = tuple(rt(attr, e, context) for e in content)
         elif isinstance(content, list):
             result = [rt(attr, e, context) for e in content]
         elif isinstance(content, dict):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -646,6 +646,9 @@ class BaseOperator(LoggingMixin):
         rt = self.render_template
         if isinstance(content, str):
             result = jinja_env.from_string(content).render(**context)
+        # Special case for named tuples
+        elif isinstance(content, tuple) and type(content) is not tuple:
+            result = content.__class__(*(rt(attr, e, context) for e in content))
         elif isinstance(content, (list, tuple)):
             result = [rt(attr, e, context) for e in content]
         elif isinstance(content, dict):

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import unittest
+from collections import namedtuple
 from unittest.mock import patch
 import uuid
 from tempfile import NamedTemporaryFile
@@ -447,10 +448,37 @@ class DagTest(unittest.TestCase):
         with dag:
             task = DummyOperator(task_id='op1')
 
-        # tuple is replaced by a list
+        # tuple is returned
         self.assertListEqual(
             task.render_template('', ('{{ foo }}_1', '{{ foo }}_2'), {'foo': 'bar'}),
-            ['bar_1', 'bar_2']
+            ('bar_1', 'bar_2')
+        )
+
+    def test_render_template_named_tuple_field(self):
+        """Tests if render_template from a named tuple field works"""
+
+        Named = namedtuple('Named', ['var1', 'var2'])
+
+        dag = DAG('test-dag',
+                  start_date=DEFAULT_DATE)
+
+        with dag:
+            task = DummyOperator(task_id='op1')
+
+        expected = Named('bar_1', 'bar_2')
+        actual = task.render_template('', Named('{{ foo }}_1', '{{ foo }}_2'), {'foo': 'bar'})
+
+        # Named tuple's field access is preserved but are still rendered
+        self.assertListEqual(expected, actual)
+        self.assertEqual(
+            expected.var1,
+            actual.var1,
+            msg="Named tuples may not have been preserved in rendering"
+        )
+        self.assertEqual(
+            expected.var2,
+            actual.var2,
+            msg="Named tuples may not have been preserved in rendering"
         )
 
     def test_render_template_dict_field(self):

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -449,7 +449,7 @@ class DagTest(unittest.TestCase):
             task = DummyOperator(task_id='op1')
 
         # tuple is returned
-        self.assertListEqual(
+        self.assertTupleEqual(
             task.render_template('', ('{{ foo }}_1', '{{ foo }}_2'), {'foo': 'bar'}),
             ('bar_1', 'bar_2')
         )
@@ -469,7 +469,7 @@ class DagTest(unittest.TestCase):
         actual = task.render_template('', Named('{{ foo }}_1', '{{ foo }}_2'), {'foo': 'bar'})
 
         # Named tuple's field access is preserved but are still rendered
-        self.assertListEqual(expected, actual)
+        self.assertTupleEqual(expected, actual)
         self.assertEqual(
             expected.var1,
             actual.var1,

--- a/tests/operators/test_python_operator.py
+++ b/tests/operators/test_python_operator.py
@@ -21,6 +21,7 @@ import copy
 import logging
 import os
 import unittest
+from collections import namedtuple
 from datetime import timedelta, date
 
 from airflow.exceptions import AirflowException
@@ -138,6 +139,11 @@ class PythonOperatorTest(unittest.TestCase):
         """Test PythonOperator op_args are templatized"""
         recorded_calls = []
 
+        # Create a named tuple and ensure it is still preserved
+        # after the rendering is done
+        Named = namedtuple('Named', ['var'])
+        named_tuple = Named('foo')
+
         task = PythonOperator(
             task_id='python_operator',
             # a Mock instance cannot be used as a callable function or test fails with a
@@ -146,7 +152,8 @@ class PythonOperatorTest(unittest.TestCase):
             op_args=[
                 4,
                 date(2019, 1, 1),
-                "dag {{dag.dag_id}} ran on {{ds}}."
+                "dag {{dag.dag_id}} ran on {{ds}}.",
+                named_tuple
             ],
             dag=self.dag)
 
@@ -163,7 +170,8 @@ class PythonOperatorTest(unittest.TestCase):
             recorded_calls[0],
             Call(4,
                  date(2019, 1, 1),
-                 "dag {} ran on {}.".format(self.dag.dag_id, DEFAULT_DATE.date().isoformat()))
+                 "dag {} ran on {}.".format(self.dag.dag_id, DEFAULT_DATE.date().isoformat()),
+                 Named('foo'))
         )
 
     def test_python_callable_keyword_arguments_are_templatized(self):

--- a/tests/operators/test_python_operator.py
+++ b/tests/operators/test_python_operator.py
@@ -141,8 +141,8 @@ class PythonOperatorTest(unittest.TestCase):
 
         # Create a named tuple and ensure it is still preserved
         # after the rendering is done
-        Named = namedtuple('Named', ['var'])
-        named_tuple = Named('foo')
+        Named = namedtuple('Named', ['var1', 'var2'])
+        named_tuple = Named('{{ ds }}', 'unchanged')
 
         task = PythonOperator(
             task_id='python_operator',
@@ -165,13 +165,14 @@ class PythonOperatorTest(unittest.TestCase):
         )
         task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
+        ds_templated = DEFAULT_DATE.date().isoformat()
         self.assertEqual(1, len(recorded_calls))
         self._assertCallsEqual(
             recorded_calls[0],
             Call(4,
                  date(2019, 1, 1),
-                 "dag {} ran on {}.".format(self.dag.dag_id, DEFAULT_DATE.date().isoformat()),
-                 Named('foo'))
+                 "dag {} ran on {}.".format(self.dag.dag_id, ds_templated),
+                 Named(ds_templated, 'unchanged'))
         )
 
     def test_python_callable_keyword_arguments_are_templatized(self):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4451
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

PR #4691 introduced an issue where named tuples were inadvertently converted to a list of rendered entities. This then made subsequent attribute access on what was assumed to be a named tuple fail, since the object was actually a list.

Example:
```python
from collections import namedtuple

Test = namedtuple('Test', ['foo', 'bar'])
t = Test(1, 2)

t = render_template(t)  # `t` is now a list of [1, 2]
print(t.foo)  # This fails after rendering
```

This PR adds an additional clause in the base render function to catch named tuples, and re-instantiate them as the proper class after variable rendering.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This adds another clause to the python operator tests to ensure that rendered `op_args` that are named tuples are still preserved.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
