### PR TITLE
[AIRFLOW-5057] Provide bucket name to functions in S3 Hook when none is specified

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -23,6 +23,11 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Changes to S3Hook
+
+Note: The order of arguments has changed for `check_for_prefix`. 
+The `bucket_name` is now optional. It falls back to the `connection schema` attribute.
+
 ### `pool` config option in Celery section to support different Celery pool implementation
 
 The new `pool` config option allows users to choose different pool

--- a/airflow/hooks/S3_hook.py
+++ b/airflow/hooks/S3_hook.py
@@ -16,15 +16,46 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from botocore.exceptions import ClientError
 
-from airflow.exceptions import AirflowException
-from airflow.contrib.hooks.aws_hook import AwsHook
-
-from six import BytesIO
-from urllib.parse import urlparse
-import re
+# pylint: disable=invalid-name
+"""
+Interact with AWS S3, using the boto3 library.
+"""
 import fnmatch
+import re
+from functools import wraps
+from urllib.parse import urlparse
+
+from botocore.exceptions import ClientError
+from six import BytesIO
+
+from airflow.contrib.hooks.aws_hook import AwsHook
+from airflow.exceptions import AirflowException
+
+
+def provide_bucket_name(func):
+    """
+    Function decorator that provides a bucket name taken from the connection
+    in case no bucket name has been passed to the function and, if available, also no key has been passed.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        func_params = func.__code__.co_varnames
+
+        def has_arg(name):
+            name_in_args = name in func_params and func_params.index(name) < len(args)
+            name_in_kwargs = name in kwargs
+            return name_in_args or name_in_kwargs
+
+        if not has_arg('bucket_name') and not (has_arg('key') or has_arg('wildcard_key')):
+            self = args[0]
+            connection = self.get_connection(self.aws_conn_id)
+            kwargs['bucket_name'] = connection.schema
+
+        return func(*args, **kwargs)
+
+    return wrapper
 
 
 class S3Hook(AwsHook):
@@ -37,20 +68,33 @@ class S3Hook(AwsHook):
 
     @staticmethod
     def parse_s3_url(s3url):
-        parsed_url = urlparse(s3url)
-        if not parsed_url.netloc:
-            raise AirflowException('Please provide a bucket_name instead of "%s"' % s3url)
-        else:
-            bucket_name = parsed_url.netloc
-            key = parsed_url.path.strip('/')
-            return bucket_name, key
+        """
+        Parses the S3 Url into a bucket name and key.
 
-    def check_for_bucket(self, bucket_name):
+        :param s3url: The S3 Url to parse.
+        :rtype s3url: str
+        :return: the parsed bucket name and key
+        :rtype: tuple of str
+        """
+        parsed_url = urlparse(s3url)
+
+        if not parsed_url.netloc:
+            raise AirflowException('Please provide a bucket_name instead of "{s3url}"'.format(s3url=s3url))
+
+        bucket_name = parsed_url.netloc
+        key = parsed_url.path.strip('/')
+
+        return bucket_name, key
+
+    @provide_bucket_name
+    def check_for_bucket(self, bucket_name=None):
         """
         Check if bucket_name exists.
 
         :param bucket_name: the name of the bucket
         :type bucket_name: str
+        :return: True if it exists and False if not.
+        :rtype: bool
         """
         try:
             self.get_conn().head_bucket(Bucket=bucket_name)
@@ -59,17 +103,21 @@ class S3Hook(AwsHook):
             self.log.info(e.response["Error"]["Message"])
             return False
 
-    def get_bucket(self, bucket_name):
+    @provide_bucket_name
+    def get_bucket(self, bucket_name=None):
         """
         Returns a boto3.S3.Bucket object
 
         :param bucket_name: the name of the bucket
         :type bucket_name: str
+        :return: the bucket object to the bucket name.
+        :rtype: boto3.S3.Bucket
         """
-        s3 = self.get_resource_type('s3')
-        return s3.Bucket(bucket_name)
+        s3_resource = self.get_resource_type('s3')
+        return s3_resource.Bucket(bucket_name)
 
-    def create_bucket(self, bucket_name, region_name=None):
+    @provide_bucket_name
+    def create_bucket(self, bucket_name=None, region_name=None):
         """
         Creates an Amazon S3 bucket.
 
@@ -89,7 +137,8 @@ class S3Hook(AwsHook):
                                               'LocationConstraint': region_name
                                           })
 
-    def check_for_prefix(self, bucket_name, prefix, delimiter):
+    @provide_bucket_name
+    def check_for_prefix(self, prefix, delimiter, bucket_name=None):
         """
         Checks that a prefix exists in a bucket
 
@@ -99,6 +148,8 @@ class S3Hook(AwsHook):
         :type prefix: str
         :param delimiter: the delimiter marks key hierarchy.
         :type delimiter: str
+        :return: False if the prefix does not exist in the bucket and True if it does.
+        :rtype: bool
         """
         prefix = prefix + delimiter if prefix[-1] != delimiter else prefix
         prefix_split = re.split(r'(\w+[{d}])$'.format(d=delimiter), prefix, 1)
@@ -106,7 +157,8 @@ class S3Hook(AwsHook):
         plist = self.list_prefixes(bucket_name, previous_level, delimiter)
         return False if plist is None else prefix in plist
 
-    def list_prefixes(self, bucket_name, prefix='', delimiter='',
+    @provide_bucket_name
+    def list_prefixes(self, bucket_name=None, prefix='', delimiter='',
                       page_size=None, max_items=None):
         """
         Lists prefixes in a bucket under prefix
@@ -121,6 +173,8 @@ class S3Hook(AwsHook):
         :type page_size: int
         :param max_items: maximum items to return
         :type max_items: int
+        :return: a list of matched prefixes and None if there are none.
+        :rtype: list
         """
         config = {
             'PageSize': page_size,
@@ -138,13 +192,15 @@ class S3Hook(AwsHook):
         for page in response:
             if 'CommonPrefixes' in page:
                 has_results = True
-                for p in page['CommonPrefixes']:
-                    prefixes.append(p['Prefix'])
+                for common_prefix in page['CommonPrefixes']:
+                    prefixes.append(common_prefix['Prefix'])
 
         if has_results:
             return prefixes
+        return None
 
-    def list_keys(self, bucket_name, prefix='', delimiter='',
+    @provide_bucket_name
+    def list_keys(self, bucket_name=None, prefix='', delimiter='',
                   page_size=None, max_items=None):
         """
         Lists keys in a bucket under prefix and not containing delimiter
@@ -159,6 +215,8 @@ class S3Hook(AwsHook):
         :type page_size: int
         :param max_items: maximum items to return
         :type max_items: int
+        :return: a list of matched keys and None if there are none.
+        :rtype: list
         """
         config = {
             'PageSize': page_size,
@@ -181,7 +239,9 @@ class S3Hook(AwsHook):
 
         if has_results:
             return keys
+        return None
 
+    @provide_bucket_name
     def check_for_key(self, key, bucket_name=None):
         """
         Checks if a key exists in a bucket
@@ -190,6 +250,8 @@ class S3Hook(AwsHook):
         :type key: str
         :param bucket_name: Name of the bucket in which the file is stored
         :type bucket_name: str
+        :return: True if the key exists and False if not.
+        :rtype: bool
         """
         if not bucket_name:
             (bucket_name, key) = self.parse_s3_url(key)
@@ -201,6 +263,7 @@ class S3Hook(AwsHook):
             self.log.info(e.response["Error"]["Message"])
             return False
 
+    @provide_bucket_name
     def get_key(self, key, bucket_name=None):
         """
         Returns a boto3.s3.Object
@@ -209,6 +272,8 @@ class S3Hook(AwsHook):
         :type key: str
         :param bucket_name: the name of the bucket
         :type bucket_name: str
+        :return: the key object from the bucket
+        :rtype: boto3.s3.Object
         """
         if not bucket_name:
             (bucket_name, key) = self.parse_s3_url(key)
@@ -217,6 +282,7 @@ class S3Hook(AwsHook):
         obj.load()
         return obj
 
+    @provide_bucket_name
     def read_key(self, key, bucket_name=None):
         """
         Reads a key from S3
@@ -225,11 +291,14 @@ class S3Hook(AwsHook):
         :type key: str
         :param bucket_name: Name of the bucket in which the file is stored
         :type bucket_name: str
+        :return: the content of the key
+        :rtype: boto3.s3.Object
         """
 
         obj = self.get_key(key, bucket_name)
         return obj.get()['Body'].read().decode('utf-8')
 
+    @provide_bucket_name
     def select_key(self, key, bucket_name=None,
                    expression='SELECT * FROM S3Object',
                    expression_type='SQL',
@@ -276,6 +345,7 @@ class S3Hook(AwsHook):
                        for event in response['Payload']
                        if 'Records' in event)
 
+    @provide_bucket_name
     def check_for_wildcard_key(self,
                                wildcard_key, bucket_name=None, delimiter=''):
         """
@@ -287,11 +357,14 @@ class S3Hook(AwsHook):
         :type bucket_name: str
         :param delimiter: the delimiter marks key hierarchy
         :type delimiter: str
+        :return: True if a key exists and False if not.
+        :rtype: bool
         """
         return self.get_wildcard_key(wildcard_key=wildcard_key,
                                      bucket_name=bucket_name,
                                      delimiter=delimiter) is not None
 
+    @provide_bucket_name
     def get_wildcard_key(self, wildcard_key, bucket_name=None, delimiter=''):
         """
         Returns a boto3.s3.Object object matching the wildcard expression
@@ -302,17 +375,21 @@ class S3Hook(AwsHook):
         :type bucket_name: str
         :param delimiter: the delimiter marks key hierarchy
         :type delimiter: str
+        :return: the key object from the bucket or None if none has been found.
+        :rtype: boto3.s3.Object
         """
         if not bucket_name:
             (bucket_name, wildcard_key) = self.parse_s3_url(wildcard_key)
 
         prefix = re.split(r'[*]', wildcard_key, 1)[0]
-        klist = self.list_keys(bucket_name, prefix=prefix, delimiter=delimiter)
-        if klist:
-            key_matches = [k for k in klist if fnmatch.fnmatch(k, wildcard_key)]
+        key_list = self.list_keys(bucket_name, prefix=prefix, delimiter=delimiter)
+        if key_list:
+            key_matches = [k for k in key_list if fnmatch.fnmatch(k, wildcard_key)]
             if key_matches:
                 return self.get_key(key_matches[0], bucket_name)
+        return None
 
+    @provide_bucket_name
     def load_file(self,
                   filename,
                   key,
@@ -349,6 +426,7 @@ class S3Hook(AwsHook):
         client = self.get_conn()
         client.upload_file(filename, bucket_name, key, ExtraArgs=extra_args)
 
+    @provide_bucket_name
     def load_string(self,
                     string_data,
                     key,
@@ -374,6 +452,8 @@ class S3Hook(AwsHook):
         :param encrypt: If True, the file will be encrypted on the server-side
             by S3 and will be stored in an encrypted form while at rest in S3.
         :type encrypt: bool
+        :param encoding: The string to byte encoding
+        :type encoding: str
         """
         self.load_bytes(string_data.encode(encoding),
                         key=key,
@@ -381,6 +461,7 @@ class S3Hook(AwsHook):
                         replace=replace,
                         encrypt=encrypt)
 
+    @provide_bucket_name
     def load_bytes(self,
                    bytes_data,
                    key,
@@ -421,6 +502,7 @@ class S3Hook(AwsHook):
         client = self.get_conn()
         client.upload_fileobj(filelike_buffer, bucket_name, key, ExtraArgs=extra_args)
 
+    @provide_bucket_name
     def load_file_obj(self,
                       file_obj,
                       key,
@@ -509,18 +591,18 @@ class S3Hook(AwsHook):
                                        'source_bucket_key should be relative path ' +
                                        'from root level, rather than a full s3:// url')
 
-        CopySource = {'Bucket': source_bucket_name,
-                      'Key': source_bucket_key,
-                      'VersionId': source_version_id}
+        copy_source = {'Bucket': source_bucket_name,
+                       'Key': source_bucket_key,
+                       'VersionId': source_version_id}
         response = self.get_conn().copy_object(Bucket=dest_bucket_name,
                                                Key=dest_bucket_key,
-                                               CopySource=CopySource)
+                                               CopySource=copy_source)
         return response
 
-    def delete_objects(self,
-                       bucket,
-                       keys):
+    def delete_objects(self, bucket, keys):
         """
+        Delete keys from the bucket.
+
         :param bucket: Name of the bucket in which you are going to delete object(s)
         :type bucket: str
         :param keys: The key(s) to delete from S3 bucket.
@@ -538,6 +620,6 @@ class S3Hook(AwsHook):
             keys = [keys]
 
         delete_dict = {"Objects": [{"Key": k} for k in keys]}
-        response = self.get_conn().delete_objects(Bucket=bucket,
-                                                  Delete=delete_dict)
+        response = self.get_conn().delete_objects(Bucket=bucket, Delete=delete_dict)
+
         return response

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -198,7 +198,6 @@
 ./airflow/hooks/pig_hook.py
 ./airflow/hooks/postgres_hook.py
 ./airflow/hooks/presto_hook.py
-./airflow/hooks/S3_hook.py
 ./airflow/hooks/samba_hook.py
 ./airflow/hooks/slack_hook.py
 ./airflow/hooks/sqlite_hook.py
@@ -509,7 +508,6 @@
 ./tests/hooks/test_oracle_hook.py
 ./tests/hooks/test_pig_hook.py
 ./tests/hooks/test_postgres_hook.py
-./tests/hooks/test_s3_hook.py
 ./tests/hooks/test_webhdfs_hook.py
 ./tests/jobs/test_backfill_job.py
 ./tests/jobs/test_base_job.py

--- a/tests/hooks/test_s3_hook.py
+++ b/tests/hooks/test_s3_hook.py
@@ -17,11 +17,14 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+import tempfile
 import unittest
 from unittest import mock
-import tempfile
 
 from botocore.exceptions import NoCredentialsError
+
+from airflow.hooks.S3_hook import provide_bucket_name
+from airflow.models import Connection
 
 try:
     from airflow.hooks.S3_hook import S3Hook
@@ -53,8 +56,8 @@ class TestS3Hook(unittest.TestCase):
     @mock_s3
     def test_check_for_bucket(self):
         hook = S3Hook(aws_conn_id=None)
-        b = hook.get_bucket('bucket')
-        b.create()
+        bucket = hook.get_bucket('bucket')
+        bucket.create()
 
         self.assertTrue(hook.check_for_bucket('bucket'))
         self.assertFalse(hook.check_for_bucket('not-a-bucket'))
@@ -68,52 +71,52 @@ class TestS3Hook(unittest.TestCase):
     @mock_s3
     def test_get_bucket(self):
         hook = S3Hook(aws_conn_id=None)
-        b = hook.get_bucket('bucket')
-        self.assertIsNotNone(b)
+        bucket = hook.get_bucket('bucket')
+        self.assertIsNotNone(bucket)
 
     @mock_s3
     def test_create_bucket_default_region(self):
         hook = S3Hook(aws_conn_id=None)
         hook.create_bucket(bucket_name='new_bucket')
-        b = hook.get_bucket('new_bucket')
-        self.assertIsNotNone(b)
+        bucket = hook.get_bucket('new_bucket')
+        self.assertIsNotNone(bucket)
 
     @mock_s3
     def test_create_bucket_us_standard_region(self):
         hook = S3Hook(aws_conn_id=None)
         hook.create_bucket(bucket_name='new_bucket', region_name='us-east-1')
-        b = hook.get_bucket('new_bucket')
-        self.assertIsNotNone(b)
-        region = b.meta.client.get_bucket_location(Bucket=b.name).get('LocationConstraint', None)
+        bucket = hook.get_bucket('new_bucket')
+        self.assertIsNotNone(bucket)
+        region = bucket.meta.client.get_bucket_location(Bucket=bucket.name).get('LocationConstraint', None)
         self.assertEqual(region, 'us-east-1')
 
     @mock_s3
     def test_create_bucket_other_region(self):
         hook = S3Hook(aws_conn_id=None)
         hook.create_bucket(bucket_name='new_bucket', region_name='us-east-2')
-        b = hook.get_bucket('new_bucket')
-        self.assertIsNotNone(b)
-        region = b.meta.client.get_bucket_location(Bucket=b.name).get('LocationConstraint', None)
+        bucket = hook.get_bucket('new_bucket')
+        self.assertIsNotNone(bucket)
+        region = bucket.meta.client.get_bucket_location(Bucket=bucket.name).get('LocationConstraint', None)
         self.assertEqual(region, 'us-east-2')
 
     @mock_s3
     def test_check_for_prefix(self):
         hook = S3Hook(aws_conn_id=None)
-        b = hook.get_bucket('bucket')
-        b.create()
-        b.put_object(Key='a', Body=b'a')
-        b.put_object(Key='dir/b', Body=b'b')
+        bucket = hook.get_bucket('bucket')
+        bucket.create()
+        bucket.put_object(Key='a', Body=b'a')
+        bucket.put_object(Key='dir/b', Body=b'b')
 
-        self.assertTrue(hook.check_for_prefix('bucket', prefix='dir/', delimiter='/'))
-        self.assertFalse(hook.check_for_prefix('bucket', prefix='a', delimiter='/'))
+        self.assertTrue(hook.check_for_prefix(bucket_name='bucket', prefix='dir/', delimiter='/'))
+        self.assertFalse(hook.check_for_prefix(bucket_name='bucket', prefix='a', delimiter='/'))
 
     @mock_s3
     def test_list_prefixes(self):
         hook = S3Hook(aws_conn_id=None)
-        b = hook.get_bucket('bucket')
-        b.create()
-        b.put_object(Key='a', Body=b'a')
-        b.put_object(Key='dir/b', Body=b'b')
+        bucket = hook.get_bucket('bucket')
+        bucket.create()
+        bucket.put_object(Key='a', Body=b'a')
+        bucket.put_object(Key='dir/b', Body=b'b')
 
         self.assertIsNone(hook.list_prefixes('bucket', prefix='non-existent/'))
         self.assertListEqual(['dir/'], hook.list_prefixes('bucket', delimiter='/'))
@@ -123,15 +126,15 @@ class TestS3Hook(unittest.TestCase):
     @mock_s3
     def test_list_prefixes_paged(self):
         hook = S3Hook(aws_conn_id=None)
-        b = hook.get_bucket('bucket')
-        b.create()
+        bucket = hook.get_bucket('bucket')
+        bucket.create()
 
         # we dont need to test the paginator
         # that's covered by boto tests
         keys = ["%s/b" % i for i in range(2)]
         dirs = ["%s/" % i for i in range(2)]
         for key in keys:
-            b.put_object(Key=key, Body=b'a')
+            bucket.put_object(Key=key, Body=b'a')
 
         self.assertListEqual(sorted(dirs),
                              sorted(hook.list_prefixes('bucket', delimiter='/',
@@ -140,10 +143,10 @@ class TestS3Hook(unittest.TestCase):
     @mock_s3
     def test_list_keys(self):
         hook = S3Hook(aws_conn_id=None)
-        b = hook.get_bucket('bucket')
-        b.create()
-        b.put_object(Key='a', Body=b'a')
-        b.put_object(Key='dir/b', Body=b'b')
+        bucket = hook.get_bucket('bucket')
+        bucket.create()
+        bucket.put_object(Key='a', Body=b'a')
+        bucket.put_object(Key='dir/b', Body=b'b')
 
         self.assertIsNone(hook.list_keys('bucket', prefix='non-existent/'))
         self.assertListEqual(['a', 'dir/b'], hook.list_keys('bucket'))
@@ -153,12 +156,12 @@ class TestS3Hook(unittest.TestCase):
     @mock_s3
     def test_list_keys_paged(self):
         hook = S3Hook(aws_conn_id=None)
-        b = hook.get_bucket('bucket')
-        b.create()
+        bucket = hook.get_bucket('bucket')
+        bucket.create()
 
         keys = [str(i) for i in range(2)]
         for key in keys:
-            b.put_object(Key=key, Body=b'a')
+            bucket.put_object(Key=key, Body=b'a')
 
         self.assertListEqual(sorted(keys),
                              sorted(hook.list_keys('bucket', delimiter='/',
@@ -167,9 +170,9 @@ class TestS3Hook(unittest.TestCase):
     @mock_s3
     def test_check_for_key(self):
         hook = S3Hook(aws_conn_id=None)
-        b = hook.get_bucket('bucket')
-        b.create()
-        b.put_object(Key='a', Body=b'a')
+        bucket = hook.get_bucket('bucket')
+        bucket.create()
+        bucket.put_object(Key='a', Body=b'a')
 
         self.assertTrue(hook.check_for_key('a', 'bucket'))
         self.assertTrue(hook.check_for_key('s3://bucket//a'))
@@ -185,9 +188,9 @@ class TestS3Hook(unittest.TestCase):
     @mock_s3
     def test_get_key(self):
         hook = S3Hook(aws_conn_id=None)
-        b = hook.get_bucket('bucket')
-        b.create()
-        b.put_object(Key='a', Body=b'a')
+        bucket = hook.get_bucket('bucket')
+        bucket.create()
+        bucket.put_object(Key='a', Body=b'a')
 
         self.assertEqual(hook.get_key('a', 'bucket').key, 'a')
         self.assertEqual(hook.get_key('s3://bucket/a').key, 'a')
@@ -214,10 +217,10 @@ class TestS3Hook(unittest.TestCase):
     @mock_s3
     def test_check_for_wildcard_key(self):
         hook = S3Hook(aws_conn_id=None)
-        b = hook.get_bucket('bucket')
-        b.create()
-        b.put_object(Key='abc', Body=b'a')
-        b.put_object(Key='a/b', Body=b'a')
+        bucket = hook.get_bucket('bucket')
+        bucket.create()
+        bucket.put_object(Key='abc', Body=b'a')
+        bucket.put_object(Key='a/b', Body=b'a')
 
         self.assertTrue(hook.check_for_wildcard_key('a*', 'bucket'))
         self.assertTrue(hook.check_for_wildcard_key('s3://bucket//a*'))
@@ -231,10 +234,10 @@ class TestS3Hook(unittest.TestCase):
     @mock_s3
     def test_get_wildcard_key(self):
         hook = S3Hook(aws_conn_id=None)
-        b = hook.get_bucket('bucket')
-        b.create()
-        b.put_object(Key='abc', Body=b'a')
-        b.put_object(Key='a/b', Body=b'a')
+        bucket = hook.get_bucket('bucket')
+        bucket.create()
+        bucket.put_object(Key='abc', Body=b'a')
+        bucket.put_object(Key='a/b', Body=b'a')
 
         # The boto3 Class API is _odd_, and we can't do an isinstance check as
         # each instance is a different class, so lets just check one property
@@ -291,6 +294,34 @@ class TestS3Hook(unittest.TestCase):
             body = boto3.resource('s3').Object('mybucket', 'my_key').get()['Body'].read()
 
             self.assertEqual(body, b'Content')
+
+    @mock.patch.object(S3Hook, 'get_connection', return_value=Connection(schema='test_bucket'))
+    def test_provide_bucket_name(self, mock_get_connection):
+
+        class FakeS3Hook(S3Hook):
+
+            @provide_bucket_name
+            def test_function(self, bucket_name=None):
+                return bucket_name
+
+            # pylint: disable=unused-argument
+            @provide_bucket_name
+            def test_function_with_key(self, key, bucket_name=None):
+                return bucket_name
+
+            # pylint: disable=unused-argument
+            @provide_bucket_name
+            def test_function_with_wildcard_key(self, wildcard_key, bucket_name=None):
+                return bucket_name
+
+        fake_s3_hook = FakeS3Hook()
+        test_bucket_name = fake_s3_hook.test_function()
+        test_bucket_name_with_key = fake_s3_hook.test_function_with_key('test_key')
+        test_bucket_name_with_wildcard_key = fake_s3_hook.test_function_with_wildcard_key('test_*_key')
+
+        self.assertEqual(test_bucket_name, mock_get_connection.return_value.schema)
+        self.assertIsNone(test_bucket_name_with_key)
+        self.assertIsNone(test_bucket_name_with_wildcard_key)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5057
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Provide bucket name to functions in S3 Hook when none is specified.

Note: The order of arguments has changed for `check_for_prefix`.
The `bucket_name` is now optional. It falls back to the `connection schema` attribute.
- refactor code
- complete docs
- fix pylint issues

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
