### PR TITLE
[AIRFLOW-5072] gcs_hook's download() method should download only once

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -687,6 +687,10 @@ Dataflow job labeling is now supported in Dataflow{Java,Python}Operator with a d
 "airflow-version" label, please upgrade your google-cloud-dataflow or apache-beam version
 to 2.2.0 or greater.
 
+### Google Cloud Storage Hook
+
+The `GoogleCloudStorageDownloadOperator` can either write to a supplied `filename` or return the content of a file via xcom through `store_to_xcom_key` - both options are mutually exclusive.
+
 ### BigQuery Hooks and Operator
 
 The `bql` parameter passed to `BigQueryOperator` and `BigQueryBaseCursor.run_query` has been deprecated and renamed to `sql` for consistency purposes. Using `bql` will still work (and raise a `DeprecationWarning`), but is no longer

--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -159,7 +159,12 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
 
     def download(self, bucket_name, object_name, filename=None):
         """
-        Get a file from Google Cloud Storage.
+        Downloads a file from Google Cloud Storage.
+
+        When no filename is supplied, the operator loads the file into memory and returns its
+        content. When a filename is supplied, it writes the file to the specified location and
+        returns the location. For file sizes that exceed the available memory it is recommended
+        to write to a file.
 
         :param bucket_name: The bucket to fetch from.
         :type bucket_name: str
@@ -175,8 +180,9 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         if filename:
             blob.download_to_filename(filename)
             self.log.info('File downloaded to %s', filename)
-
-        return blob.download_as_string()
+            return filename
+        else:
+            return blob.download_as_string()
 
     def upload(self, bucket_name, object_name, filename,
                mime_type='application/octet-stream', gzip=False):

--- a/tests/contrib/hooks/test_gcs_hook.py
+++ b/tests/contrib/hooks/test_gcs_hook.py
@@ -553,12 +553,11 @@ class TestGoogleCloudStorageHook(unittest.TestCase):
         download_as_a_string_method = mock_service.return_value.bucket.return_value \
             .blob.return_value.download_as_string
         download_as_a_string_method.return_value = test_object_bytes
-
         response = self.gcs_hook.download(bucket_name=test_bucket,
                                           object_name=test_object,
                                           filename=test_file)
 
-        self.assertEqual(response, test_object_bytes)
+        self.assertEqual(response, test_file)
         download_filename_method.assert_called_once_with(test_file)
 
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://jira.apache.org/jira/browse/AIRFLOW-5072) issues and references them in the PR title.
  - https://jira.apache.org/jira/browse/AIRFLOW-5072
### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: missing else inserted

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`