### PR TITLE
[AIRFLOW-5075] Let HttpHook handle connections with empty host fields

### DIFF
--- a/airflow/hooks/http_hook.py
+++ b/airflow/hooks/http_hook.py
@@ -59,12 +59,13 @@ class HttpHook(BaseHook):
         if self.http_conn_id:
             conn = self.get_connection(self.http_conn_id)
 
-            if "://" in conn.host:
+            if conn.host and "://" in conn.host:
                 self.base_url = conn.host
             else:
                 # schema defaults to HTTP
                 schema = conn.schema if conn.schema else "http"
-                self.base_url = schema + "://" + conn.host
+                host = conn.host if conn.host else ""
+                self.base_url = schema + "://" + host
 
             if conn.port:
                 self.base_url = self.base_url + ":" + str(conn.port)

--- a/tests/hooks/test_http_hook.py
+++ b/tests/hooks/test_http_hook.py
@@ -325,5 +325,14 @@ class TestHttpHook(unittest.TestCase):
     def test_method_converted_to_uppercase_when_created_in_lowercase(self):
         self.assertEqual(self.get_lowercase_hook.method, 'GET')
 
+    @mock.patch('airflow.hooks.http_hook.HttpHook.get_connection')
+    def test_connection_without_host(self, mock_get_connection):
+        c = Connection(conn_id='http_default', conn_type='http')
+        mock_get_connection.return_value = c
+
+        hook = HttpHook()
+        hook.get_conn({})
+        self.assertEqual(hook.base_url, 'http://')
+
 
 send_email_test = mock.Mock()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

Let HttpHook handle connections with empty host fields, which would throw an exception previously:

```
  File "/home/ubuntu/.local/lib/python3.6/site-packages/airflow/hooks/http_hook.py", line 63, in get_conn
    if "://" in conn.host:
TypeError: argument of type 'NoneType' is not iterable
```

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- `test_connection_without_host`

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

No docs; trivial change

### Code Quality
Let HttpHook handle connections with empty host fields
- [X] Passes `flake8`
