### PR TITLE
[AIRFLOW-2891] Option to set container_name for DockerOperator

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -51,6 +51,8 @@ class DockerOperator(BaseOperator):
     :type api_version: str
     :param command: Command to be run in the container. (templated)
     :type command: str or list
+    :param container_name: Name of the container.
+    :type container_name: str
     :param cpus: Number of CPUs to assign to the container.
         This value gets multiplied with 1024. See
         https://docs.docker.com/engine/reference/run/#cpu-share-constraint
@@ -123,6 +125,7 @@ class DockerOperator(BaseOperator):
             image: str,
             api_version: str = None,
             command: Union[str, List[str]] = None,
+            container_name: str = None,
             cpus: float = 1.0,
             docker_url: str = 'unix://var/run/docker.sock',
             environment: Dict = None,
@@ -152,6 +155,7 @@ class DockerOperator(BaseOperator):
         self.api_version = api_version
         self.auto_remove = auto_remove
         self.command = command
+        self.container_name = container_name
         self.cpus = cpus
         self.dns = dns
         self.dns_search = dns_search
@@ -215,6 +219,7 @@ class DockerOperator(BaseOperator):
 
             self.container = self.cli.create_container(
                 command=self.get_command(),
+                name=self.container_name,
                 environment=self.environment,
                 host_config=self.cli.create_host_config(
                     auto_remove=self.auto_remove,

--- a/tests/operators/test_docker_operator.py
+++ b/tests/operators/test_docker_operator.py
@@ -53,13 +53,14 @@ class DockerOperatorTestCase(unittest.TestCase):
                                   image='ubuntu:latest', network_mode='bridge', owner='unittest',
                                   task_id='unittest', volumes=['/host/path:/container/path'],
                                   working_dir='/container/path', shm_size=1000,
-                                  host_tmp_dir='/host/airflow')
+                                  host_tmp_dir='/host/airflow', container_name='test_container')
         operator.execute(None)
 
         client_class_mock.assert_called_with(base_url='unix://var/run/docker.sock', tls=None,
                                              version='1.19')
 
         client_mock.create_container.assert_called_with(command='env',
+                                                        name='test_container',
                                                         environment={
                                                             'AIRFLOW_TMP_DIR': '/tmp/airflow',
                                                             'UNIT': 'TEST'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following:
  - https://issues.apache.org/jira/browse/AIRFLOW-2891

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
  - allows specification of docker container name for containers spawned by DockerOperators

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - I have added to existing tests

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
