### PR TITLE
[AIRFLOW-5077] Skip force pulling latest python in CI environment

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -156,6 +156,7 @@ export DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow"}
 export PYTHON_VERSION=\
 ${PYTHON_VERSION:=$(python -c 'import sys;print("%s.%s" % (sys.version_info.major, sys.version_info.minor))')}
 
+# shellcheck source=./_default_branch.sh
 . ${MY_DIR}/_default_branch.sh
 
 # Source brnnch will be set in DockerHub
@@ -254,7 +255,7 @@ export AIRFLOW_VERSION
 # Check if we are running in the CI environment
 CI=${CI:="false"}
 
-if [[ "${CI}" == "true" ]]; then
+if [[ ${CI} == "true" ]]; then
     NON_CI="false"
 else
     NON_CI="true"
@@ -279,6 +280,9 @@ export AIRFLOW_CONTAINER_PUSH_IMAGES=${AIRFLOW_CONTAINER_PUSH_IMAGES:=${NON_CI}}
 
 # Whether to force pull images to populate cache
 export AIRFLOW_CONTAINER_FORCE_PULL_IMAGES=${AIRFLOW_CONTAINER_FORCE_PULL_IMAGES:="false"}
+
+# In CI environment (and local force) we skip pulling latest python image
+export AIRFLOW_CONTAINER_SKIP_LATEST_PYTHON_PULL=${AIRFLOW_CONTAINER_SKIP_LATEST_PYTHON_PULL:=${CI}}
 
 # Skips downloading and building the slim image of airflow
 # This is set to true by default in CI test environment (we only need full CI image then)
@@ -365,12 +369,19 @@ if [[ "${AIRFLOW_CONTAINER_USE_PULLED_IMAGES_CACHE}" == "true" ]]; then
     echo
     echo
     if [[ "${AIRFLOW_CONTAINER_FORCE_PULL_IMAGES}" == "true" ]]; then
-        echo "Force-pull base python image. This forces to get the most recent versions from the repository."
-        echo
-        set -x
-        docker pull "${PYTHON_BASE_IMAGE}"
-        set +x
-        echo
+        if [[ ${AIRFLOW_CONTAINER_SKIP_LATEST_PYTHON_PULL} == "true" ]]; then
+            echo
+            echo "Skip force-pulling the base python image."
+            echo
+        else
+            echo
+            echo "Force-pull base python image. This forces to get the most recent versions from DockerHub."
+            echo
+            set -x
+            docker pull "${PYTHON_BASE_IMAGE}"
+            set +x
+            echo
+        fi
     fi
     IMAGES_TO_PULL=""
     if [[ "${AIRFLOW_CONTAINER_SKIP_CI_IMAGE}" == "true" ]]; then

--- a/scripts/ci/local_ci_pull_and_build.sh
+++ b/scripts/ci/local_ci_pull_and_build.sh
@@ -32,6 +32,7 @@ basic_sanity_checks
 script_start
 
 export AIRFLOW_CONTAINER_FORCE_PULL_IMAGES="true"
+export AIRFLOW_CONTAINER_SKIP_LATEST_PYTHON_PULL="true"
 
 rebuild_image_if_needed_for_tests
 


### PR DESCRIPTION
The latest python will only be pulled by DockerHub when building
master/v1-10-test - which means that it will eventually catch
up with the latest python security releases but it will not
slow down the CI builds.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5077

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
