### PR TITLE
[AIRFLOW-5078] User is asked if an image needs to be rebuild

### DIFF
--- a/confirm
+++ b/confirm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,6 +15,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+set -euo pipefail
+
+if [[ "${ASSUME_YES:=false}" == "true" ]]; then
+    exit 0
+fi
+
 read -r -p "${1}. Are you sure? [y/N] " response
 case "$response" in
     [yY][eE][sS]|[yY])

--- a/scripts/ci/_utils.sh
+++ b/scripts/ci/_utils.sh
@@ -18,7 +18,7 @@
 
 # Assume all the scripts are sourcing the _utils.sh from the scripts/ci directory
 # and MY_DIR variable is set to this directory
-AIRFLOW_SOURCES=$(cd ${MY_DIR}/../../ && pwd)
+AIRFLOW_SOURCES=$(cd "${MY_DIR}/../../" && pwd)
 export AIRFLOW_SOURCES
 
 BUILD_CACHE_DIR="${AIRFLOW_SOURCES}/.build"
@@ -32,16 +32,17 @@ Dockerfile \
 airflow/version.py
 "
 
-mkdir -p ${AIRFLOW_SOURCES}/.mypy_cache
-mkdir -p ${AIRFLOW_SOURCES}/logs
-mkdir -p ${AIRFLOW_SOURCES}/tmp
+mkdir -p "${AIRFLOW_SOURCES}/.mypy_cache"
+mkdir -p "${AIRFLOW_SOURCES}/logs"
+mkdir -p "${AIRFLOW_SOURCES}/tmp"
 
 # Disable writing .pyc files - slightly slower imports but not messing around when switching
 # Python version and avoids problems with root-owned .pyc files in host
 export PYTHONDONTWRITEBYTECODE="true"
 
 # Read default branch name
-. ${AIRFLOW_SOURCES}/hooks/_default_branch.sh
+# shellcheck source=../../hooks/_default_branch.sh
+. "${AIRFLOW_SOURCES}/hooks/_default_branch.sh"
 
 # Default branch name for triggered builds is the one configured in hooks/_default_branch.sh
 export AIRFLOW_CONTAINER_BRANCH_NAME=${AIRFLOW_CONTAINER_BRANCH_NAME:=${DEFAULT_BRANCH}}
@@ -327,11 +328,10 @@ EOF
     check_if_docker_build_is_needed
 
     if [[ "${AIRFLOW_CONTAINER_DOCKER_BUILD_NEEDED}" == "true" ]]; then
-        SKIP_REBUILD="false"
+        local SKIP_REBUILD="false"
         if [[ ${CI:=} != "true" ]]; then
             set +e
-            ${MY_DIR}/../../confirm "The image might need to be rebuild. This will take short time"
-            if [[ $? != "0" ]]; then
+            if ! "${MY_DIR}/../../confirm" "The image might need to be rebuild."; then
                SKIP_REBUILD="true"
             fi
             set -e
@@ -398,15 +398,25 @@ EOF
     check_if_docker_build_is_needed
 
     if [[ "${AIRFLOW_CONTAINER_DOCKER_BUILD_NEEDED}" == "true" ]]; then
-        echo
-        echo "Rebuilding image"
-        echo
-        # shellcheck source=../../hooks/build
-        ./hooks/build | tee -a "${OUTPUT_LOG}"
-        update_all_md5_files
-        echo
-        echo "Image rebuilt"
-        echo
+        local SKIP_REBUILD="false"
+        if [[ ${CI:=} != "true" ]]; then
+            set +e
+            if ! "${MY_DIR}/../../confirm" "The image might need to be rebuild."; then
+               SKIP_REBUILD="true"
+            fi
+            set -e
+        fi
+        if [[ ${SKIP_REBUILD} != "true" ]]; then
+            echo
+            echo "Rebuilding image"
+            echo
+            # shellcheck source=../../hooks/build
+            ./hooks/build | tee -a "${OUTPUT_LOG}"
+            update_all_md5_files
+            echo
+            echo "Image rebuilt"
+            echo
+        fi
     else
         echo
         echo "No need to rebuild the image as none of the sensitive files changed: ${FILES_FOR_REBUILD_CHECK}"

--- a/scripts/ci/local_ci_build.sh
+++ b/scripts/ci/local_ci_build.sh
@@ -31,6 +31,8 @@ basic_sanity_checks
 
 script_start
 
+export ASSUME_YES="true"
+
 rebuild_image_if_needed_for_tests
 
 rebuild_image_if_needed_for_static_checks

--- a/scripts/ci/local_ci_pull_and_build.sh
+++ b/scripts/ci/local_ci_pull_and_build.sh
@@ -32,6 +32,7 @@ basic_sanity_checks
 script_start
 
 export AIRFLOW_CONTAINER_FORCE_PULL_IMAGES="true"
+export ASSUME_YES="true"
 
 rebuild_image_if_needed_for_tests
 


### PR DESCRIPTION
This is not happening when the user explicitely wants to build image
or in CI environment (DockerHub always builds the image via
hooks/build script.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5078
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
