### PR TITLE
[AIRFLOW-5080] Added npm to apt-get install in compile.sh for docker

### DIFF
--- a/scripts/ci/kubernetes/docker/compile.sh
+++ b/scripts/ci/kubernetes/docker/compile.sh
@@ -27,6 +27,6 @@ apt-get install -y --no-install-recommends curl gnupg2
 curl -sL https://deb.nodesource.com/setup_8.x | bash -
 
 apt-get update
-apt-get install -y --no-install-recommends git nodejs
+apt-get install -y --no-install-recommends git nodejs npm
 pip install GitPython
 python setup.py compile_assets sdist -q


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira
- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5080

### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:

When I run [scripts/ci/kubernetes/docker/build.sh](https://github.com/apache/airflow/blob/1.10.3/scripts/ci/kubernetes/docker/build.sh#L45) to build Docker Image, I encountered the following error.

```
running compile_assets
./airflow/www_rbac/compile_assets.sh: 26: ./airflow/www_rbac/compile_assets.sh: npm: not found
```

So, http://YOUR_HOSTNAME/static didn't create. I got `500 Internal Server Error` with it on a browser(Chrome).

I think it needs to install npm in [scripts/ci/kubernetes/docker/compile.sh](https://github.com/apache/airflow/blob/1.10.3/scripts/ci/kubernetes/docker/compile.sh#L30).

```diff
-apt-get install -y --no-install-recommends git nodejs
+apt-get install -y --no-install-recommends git nodejs npm
```

It works for me.

### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I could see the top page without `500 Internal Server Error` by /static dir that doesn't exist.
I didn't encounter any error with running [scripts/ci/kubernetes/docker/build.sh](https://github.com/apache/airflow/blob/1.10.3/scripts/ci/kubernetes/docker/build.sh#L45).

### Commits
- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
