### PR TITLE
[AIRFLOW-5082] Add subject in AwsSnsHook

### DIFF
--- a/airflow/contrib/hooks/aws_sns_hook.py
+++ b/airflow/contrib/hooks/aws_sns_hook.py
@@ -41,7 +41,7 @@ class AwsSnsHook(AwsHook):
         self.conn = self.get_client_type('sns')
         return self.conn
 
-    def publish_to_target(self, target_arn, message):
+    def publish_to_target(self, target_arn, message, subject=None):
         """
         Publish a message to a topic or an endpoint.
 
@@ -49,6 +49,8 @@ class AwsSnsHook(AwsHook):
         :type target_arn: str
         :param message: the default message you want to send
         :param message: str
+        :param subject: subject of message
+        :type subject: str
         """
 
         conn = self.get_conn()
@@ -57,8 +59,16 @@ class AwsSnsHook(AwsHook):
             'default': message
         }
 
+        if subject is None:
+            return conn.publish(
+                TargetArn=target_arn,
+                Message=json.dumps(messages),
+                MessageStructure='json'
+            )
+
         return conn.publish(
             TargetArn=target_arn,
             Message=json.dumps(messages),
-            MessageStructure='json'
+            MessageStructure='json',
+            Subject = subject
         )

--- a/airflow/contrib/hooks/aws_sns_hook.py
+++ b/airflow/contrib/hooks/aws_sns_hook.py
@@ -54,10 +54,11 @@ class AwsSnsHook(AwsHook):
         """
 
         conn = self.get_conn()
+
         messages = {
             'default': message
         }
-        
+
         if subject is None:
             return conn.publish(
                 TargetArn=target_arn,

--- a/airflow/contrib/hooks/aws_sns_hook.py
+++ b/airflow/contrib/hooks/aws_sns_hook.py
@@ -70,5 +70,5 @@ class AwsSnsHook(AwsHook):
             TargetArn=target_arn,
             Message=json.dumps(messages),
             MessageStructure='json',
-            Subject = subject
+            Subject=subject
         )

--- a/airflow/contrib/hooks/aws_sns_hook.py
+++ b/airflow/contrib/hooks/aws_sns_hook.py
@@ -54,11 +54,10 @@ class AwsSnsHook(AwsHook):
         """
 
         conn = self.get_conn()
-
         messages = {
             'default': message
         }
-
+        
         if subject is None:
             return conn.publish(
                 TargetArn=target_arn,

--- a/tests/contrib/hooks/test_aws_sns_hook.py
+++ b/tests/contrib/hooks/test_aws_sns_hook.py
@@ -54,7 +54,7 @@ class TestAwsLambdaHook(unittest.TestCase):
         hook = AwsSnsHook(aws_conn_id='aws_default')
 
         message = "Hello world"
-        topic_name = "test-topic"
+        topic_name = "test-topic-without-subject"
         target = hook.get_conn().create_topic(Name=topic_name).get('TopicArn')
 
         response = hook.publish_to_target(target, message)

--- a/tests/contrib/hooks/test_aws_sns_hook.py
+++ b/tests/contrib/hooks/test_aws_sns_hook.py
@@ -54,7 +54,7 @@ class TestAwsLambdaHook(unittest.TestCase):
         hook = AwsSnsHook(aws_conn_id='aws_default')
 
         message = "Hello world"
-        topic_name = "test-topic-without-subject"
+        topic_name = "test-topic"
         target = hook.get_conn().create_topic(Name=topic_name).get('TopicArn')
 
         response = hook.publish_to_target(target, message)

--- a/tests/contrib/hooks/test_aws_sns_hook.py
+++ b/tests/contrib/hooks/test_aws_sns_hook.py
@@ -42,9 +42,10 @@ class TestAwsLambdaHook(unittest.TestCase):
 
         message = "Hello world"
         topic_name = "test-topic"
+        subject = "test-subject"
         target = hook.get_conn().create_topic(Name=topic_name).get('TopicArn')
 
-        response = hook.publish_to_target(target, message)
+        response = hook.publish_to_target(target, message, subject)
 
         self.assertTrue('MessageId' in response)
 

--- a/tests/contrib/hooks/test_aws_sns_hook.py
+++ b/tests/contrib/hooks/test_aws_sns_hook.py
@@ -49,6 +49,18 @@ class TestAwsLambdaHook(unittest.TestCase):
 
         self.assertTrue('MessageId' in response)
 
+    @mock_sns
+    def test_publish_to_target_without_subject(self):
+        hook = AwsSnsHook(aws_conn_id='aws_default')
+
+        message = "Hello world"
+        topic_name = "test-topic"
+        target = hook.get_conn().create_topic(Name=topic_name).get('TopicArn')
+
+        response = hook.publish_to_target(target, message)
+
+        self.assertTrue('MessageId' in response)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5082/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5082
  - In case you are fixing a typo in the documentation, you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
