### PR TITLE
[AIRFLOW-2891] Make DockerOperator container_name be templateable

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -51,8 +51,8 @@ class DockerOperator(BaseOperator):
     :type api_version: str
     :param command: Command to be run in the container. (templated)
     :type command: str or list
-    :param container_name: Name of the container.
-    :type container_name: str
+    :param container_name: Name of the container. Optional (templated)
+    :type container_name: str or None
     :param cpus: Number of CPUs to assign to the container.
         This value gets multiplied with 1024. See
         https://docs.docker.com/engine/reference/run/#cpu-share-constraint
@@ -116,7 +116,7 @@ class DockerOperator(BaseOperator):
         greater than 0. If omitted uses system default.
     :type shm_size: int
     """
-    template_fields = ('command', 'environment',)
+    template_fields = ('command', 'environment', 'container_name')
     template_ext = ('.sh', '.bash',)
 
     @apply_defaults


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] https://issues.apache.org/jira/browse/AIRFLOW-2891

### Description

- [x] Further to #5689, but lets also allow the docker container name to be templated so that it can be changed per task intances.

### Tests

- [x] templates in generally are well tested.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`