### PR TITLE
[AIRFLOW-5085] we always pass the default branch name to the build

### DIFF
--- a/scripts/ci/kubernetes/kube/deploy.sh
+++ b/scripts/ci/kubernetes/kube/deploy.sh
@@ -25,6 +25,9 @@ DIRNAME=$(cd "$(dirname "$0")"; pwd)
 TEMPLATE_DIRNAME="${DIRNAME}/templates"
 BUILD_DIRNAME="${DIRNAME}/build"
 
+# shellcheck source=../../../../hooks/_default_branch.sh
+. "${DIRNAME}/../../../../hooks/_default_branch.sh"
+
 usage() {
     cat << EOF
   usage: $0 options
@@ -82,7 +85,7 @@ else
     CONFIGMAP_DAGS_VOLUME_CLAIM=
 fi
 CONFIGMAP_GIT_REPO=${TRAVIS_REPO_SLUG:-apache/airflow}
-CONFIGMAP_BRANCH=${TRAVIS_BRANCH:-master}
+CONFIGMAP_BRANCH=${DEFAULT_BRANCH:=master}
 
 _UNAME_OUT=$(uname -s)
 case "${_UNAME_OUT}" in


### PR DESCRIPTION
TRAVIS_BRANCH is set to TAG when TAG build runs. We should alwayss
use branch and we already have our current branch in
hooks/_default_branch.sh and we can use it from there.

This seems to be the only way as TRAVIS does not pass the branch
in any variable - mainly because we do not know what branch we
are in when building a TAG build

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
