### PR TITLE
[AIRFLOW-5091] Build epoch is fixed now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -303,10 +303,9 @@ RUN echo "Installing with extras: ${AIRFLOW_EXTRAS}."
 ARG AIRFLOW_CONTAINER_CI_OPTIMISED_BUILD="false"
 ENV AIRFLOW_CONTAINER_CI_OPTIMISED_BUILD=${AIRFLOW_CONTAINER_CI_OPTIMISED_BUILD}
 
-# By changing the CI build epoch we can force reinstalling Arflow from the current master -
-# in case of CI optimized builds (next step). Our build scripts will change the EPOCH every month normally
-# But it can also be overwritten manually by setting the AIRFLOW_CI_BUILD_EPOCH environment variable.
-ARG AIRFLOW_CI_BUILD_EPOCH=""
+# By changing the CI build epoch we can force reinstalling Arflow from the current master
+# It can also be overwritten manually by setting the AIRFLOW_CI_BUILD_EPOCH environment variable.
+ARG AIRFLOW_CI_BUILD_EPOCH="1"
 ENV AIRFLOW_CI_BUILD_EPOCH=${AIRFLOW_CI_BUILD_EPOCH}
 
 # In case of CI-optimised builds we want to pre-install master version of airflow dependencies so that

--- a/hooks/build
+++ b/hooks/build
@@ -46,7 +46,6 @@ LAST_STEP_NAME=""
 STEP_STARTED="false"
 PYTHON_VERSION_FOR_DEFAULT_IMAGE=3.6
 AIRFLOW_CI_VERBOSE=${AIRFLOW_CI_VERBOSE:="false"}
-AIRFLOW_CI_BUILD_EPOCH=${AIRFLOW_CI_BUILD_EPOCH:=$(date +"%Y%m")}
 
 function end_step {
     if [[ "${STEP_STARTED}" != "true" ]]; then
@@ -126,7 +125,6 @@ function build_image {
         --build-arg AIRFLOW_USER="${AIRFLOW_USER}" \
         --build-arg AIRFLOW_BRANCH="${AIRFLOW_CONTAINER_BRANCH_NAME}" \
         --build-arg BUILD_NPM="${AIRFLOW_CONTAINER_BUILD_NPM}" \
-        --build-arg AIRFLOW_CI_BUILD_EPOCH="${AIRFLOW_CI_BUILD_EPOCH}" \
         --build-arg AIRFLOW_CONTAINER_CI_OPTIMISED_BUILD="${AIRFLOW_CONTAINER_CI_OPTIMISED_BUILD}" \
         --build-arg HOME="${HOME}" \
         "${DOCKER_CACHE_DIRECTIVE[@]}" \


### PR DESCRIPTION
We do not need monthly build epoch as we rebuild from the scratch
anyway every time new python patchlevel is released.

This happens every 1-2 months.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5091
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
