### PR TITLE
[AIRFLOW-4883] Bug-fix to killing hung file processes

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -185,7 +185,6 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
         # The queue will likely get corrupted, so remove the reference
         self._result_queue = None
         self._kill_process()
-        self._manager.shutdown()
 
     def terminate(self, sigkill=False):
         """


### PR DESCRIPTION
PRs #5615 and #5605 and fought a bit over this change, and this is
hard (but not impossible) to test so we didn't notice.

I have tested this change works locally and we know(again) successfully kill timed out processors.