### PR TITLE
[AIRFLOW-4462] Use datetime2 column types when using MSSQL backend

### DIFF
--- a/airflow/migrations/versions/74effc47d867_change_datetime_to_datetime2_6_on_mssql_.py
+++ b/airflow/migrations/versions/74effc47d867_change_datetime_to_datetime2_6_on_mssql_.py
@@ -151,7 +151,6 @@ def downgrade():
             task_reschedule_batch_op.alter_column(column_name='end_date', type_=mssql.DATETIME)
             task_reschedule_batch_op.alter_column(column_name='reschedule_date', type_=mssql.DATETIME)
 
-
         with op.batch_alter_table('task_instance') as task_instance_batch_op:
             task_instance_batch_op.drop_index('ti_state_lkp')
             task_instance_batch_op.drop_index('ti_dag_date')

--- a/airflow/migrations/versions/74effc47d867_change_datetime_to_datetime2_6_on_mssql_.py
+++ b/airflow/migrations/versions/74effc47d867_change_datetime_to_datetime2_6_on_mssql_.py
@@ -1,0 +1,367 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""change datetime to datetime2(6) on MSSQL tables
+
+Revision ID: 74effc47d867
+Revises: 6e96a59344a4
+Create Date: 2019-08-01 15:19:57.585620
+
+"""
+
+from collections import defaultdict
+from alembic import op
+from sqlalchemy.dialects import mssql
+
+# revision identifiers, used by Alembic.
+revision = '74effc47d867'
+down_revision = '6e96a59344a4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Change datetime to datetime2(6) when using MSSQL as backend
+    """
+    conn = op.get_bind()
+    if conn.dialect.name == "mssql":
+        result = conn.execute(
+            """SELECT CASE WHEN CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion'))
+            like '8%' THEN '2000' WHEN CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion'))
+            like '9%' THEN '2005' ELSE '2005Plus' END AS MajorVersion""").fetchone()
+        mssql_version = result[0]
+        if mssql_version in ("2000", "2005"):
+            return
+
+        with op.batch_alter_table('task_reschedule') as task_reschedule_batch_op:
+            task_reschedule_batch_op.drop_index('idx_task_reschedule_dag_task_date')
+
+            task_reschedule_batch_op.drop_constraint(
+                'task_reschedule_dag_task_date_fkey',
+                type_='foreignkey'
+            )
+            task_reschedule_batch_op.alter_column(
+                column_name="execution_date",
+                type_=mssql.DATETIME2(precision=6),
+                nullable=False,
+            )
+
+        with op.batch_alter_table('task_instance') as task_instance_batch_op:
+            task_instance_batch_op.drop_index('ti_state_lkp')
+            task_instance_batch_op.drop_index('ti_dag_date')
+
+            modify_execution_date_with_constraint(conn, task_instance_batch_op, 'task_instance',
+                                                  mssql.DATETIME2(precision=6), False)
+
+            task_instance_batch_op.alter_column(column_name='start_date', type_=mssql.DATETIME2(precision=6))
+            task_instance_batch_op.alter_column(column_name='end_date', type_=mssql.DATETIME2(precision=6))
+            task_instance_batch_op.alter_column(column_name='queued_dttm', type_=mssql.DATETIME2(precision=6))
+
+            task_instance_batch_op.create_index('ti_state_lkp',
+                                                ['dag_id', 'task_id', 'execution_date'], unique=False)
+            task_instance_batch_op.create_index('ti_dag_date',
+                                                ['dag_id', 'execution_date'], unique=False)
+
+        with op.batch_alter_table('dag_run') as dag_run_batch_op:
+            modify_execution_date_with_constraint(conn, dag_run_batch_op, 'dag_run',
+                                                  mssql.DATETIME2(precision=6), None)
+            dag_run_batch_op.alter_column(column_name='start_date', type_=mssql.DATETIME2(precision=6))
+            dag_run_batch_op.alter_column(column_name='end_date', type_=mssql.DATETIME2(precision=6))
+
+        with op.batch_alter_table('task_reschedule') as task_reschedule_batch_op:
+            task_reschedule_batch_op.create_foreign_key(
+                'task_reschedule_dag_task_date_fkey',
+                'task_instance',
+                ['task_id', 'dag_id', 'execution_date'],
+                ['task_id', 'dag_id', 'execution_date'],
+                ondelete='CASCADE'
+            )
+            task_reschedule_batch_op.create_index('idx_task_reschedule_dag_task_date',
+                                                  ['dag_id', 'task_id', 'execution_date'], unique=False)
+
+        op.alter_column(
+            table_name="log", column_name="execution_date", type_=mssql.DATETIME2(precision=6)
+        )
+
+        op.alter_column(table_name='log', column_name='dttm', type_=mssql.DATETIME2(precision=6))
+
+        with op.batch_alter_table('sla_miss') as sla_miss_batch_op:
+            modify_execution_date_with_constraint(conn, sla_miss_batch_op, 'sla_miss',
+                                                  mssql.DATETIME2(precision=6), False)
+            sla_miss_batch_op.alter_column(column_name='timestamp', type_=mssql.DATETIME2(precision=6))
+
+        op.drop_index('idx_task_fail_dag_task_date', table_name='task_fail')
+        op.alter_column(
+            table_name="task_fail",
+            column_name="execution_date",
+            type_=mssql.DATETIME2(precision=6),
+        )
+        op.create_index('idx_task_fail_dag_task_date',
+                        'task_fail',
+                        ['dag_id', 'task_id', 'execution_date'], unique=False)
+
+        op.drop_index('idx_xcom_dag_task_date', table_name='xcom')
+        op.alter_column(
+            table_name="xcom",
+            column_name="execution_date",
+            type_=mssql.DATETIME2(precision=6),
+        )
+        op.alter_column(table_name='xcom', column_name='timestamp', type_=mssql.DATETIME2(precision=6))
+        op.create_index('idx_xcom_dag_task_date',
+                        'xcom',
+                        ['dag_id', 'task_id', 'execution_date'], unique=False)
+
+        op.alter_column(table_name='dag', column_name='last_scheduler_run',
+                        type_=mssql.DATETIME2(precision=6))
+        op.alter_column(table_name='dag', column_name='last_pickled', type_=mssql.DATETIME2(precision=6))
+        op.alter_column(table_name='dag', column_name='last_expired', type_=mssql.DATETIME2(precision=6))
+
+        op.alter_column(table_name='dag_pickle', column_name='created_dttm',
+                        type_=mssql.DATETIME2(precision=6))
+
+        op.alter_column(table_name='import_error', column_name='timestamp',
+                        type_=mssql.DATETIME2(precision=6))
+
+        op.drop_index('job_type_heart', table_name='job')
+        op.drop_index('idx_job_state_heartbeat', table_name='job')
+        op.alter_column(table_name='job', column_name='start_date', type_=mssql.DATETIME2(precision=6))
+        op.alter_column(table_name='job', column_name='end_date', type_=mssql.DATETIME2(precision=6))
+        op.alter_column(table_name='job', column_name='latest_heartbeat', type_=mssql.DATETIME2(precision=6))
+        op.create_index('idx_job_state_heartbeat', 'job', ['state', 'latest_heartbeat'], unique=False)
+        op.create_index('job_type_heart', 'job', ['job_type', 'latest_heartbeat'], unique=False)
+
+
+def downgrade():
+    """
+    Change datetime2(6) back to datetime
+    """
+    conn = op.get_bind()
+    if conn.dialect.name == "mssql":
+        result = conn.execute(
+            """SELECT CASE WHEN CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion'))
+            like '8%' THEN '2000' WHEN CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion'))
+            like '9%' THEN '2005' ELSE '2005Plus' END AS MajorVersion""").fetchone()
+        mssql_version = result[0]
+        if mssql_version in ("2000", "2005"):
+            return
+
+        with op.batch_alter_table('task_reschedule') as task_reschedule_batch_op:
+            task_reschedule_batch_op.drop_index('idx_task_reschedule_dag_task_date')
+
+            task_reschedule_batch_op.drop_constraint(
+                'task_reschedule_dag_task_date_fkey',
+                type_='foreignkey'
+            )
+            task_reschedule_batch_op.alter_column(
+                column_name="execution_date",
+                type_=mssql.DATETIME,
+                nullable=False,
+            )
+
+        with op.batch_alter_table('task_instance') as task_instance_batch_op:
+            task_instance_batch_op.drop_index('ti_state_lkp')
+            task_instance_batch_op.drop_index('ti_dag_date')
+
+            modify_execution_date_with_constraint(conn, task_instance_batch_op, 'task_instance',
+                                                  mssql.DATETIME, False)
+
+            task_instance_batch_op.alter_column(column_name='start_date', type_=mssql.DATETIME)
+            task_instance_batch_op.alter_column(column_name='end_date', type_=mssql.DATETIME)
+            task_instance_batch_op.alter_column(column_name='queued_dttm', type_=mssql.DATETIME)
+
+            task_instance_batch_op.create_index('ti_state_lkp',
+                                                ['dag_id', 'task_id', 'execution_date'], unique=False)
+            task_instance_batch_op.create_index('ti_dag_date',
+                                                ['dag_id', 'execution_date'], unique=False)
+
+        with op.batch_alter_table('dag_run') as dag_run_batch_op:
+            modify_execution_date_with_constraint(conn, dag_run_batch_op, 'dag_run',
+                                                  mssql.DATETIME, None)
+            dag_run_batch_op.alter_column(column_name='start_date', type_=mssql.DATETIME)
+            dag_run_batch_op.alter_column(column_name='end_date', type_=mssql.DATETIME)
+
+        with op.batch_alter_table('task_reschedule') as task_reschedule_batch_op:
+            task_reschedule_batch_op.create_foreign_key(
+                'task_reschedule_dag_task_date_fkey',
+                'task_instance',
+                ['task_id', 'dag_id', 'execution_date'],
+                ['task_id', 'dag_id', 'execution_date'],
+                ondelete='CASCADE'
+            )
+            task_reschedule_batch_op.create_index('idx_task_reschedule_dag_task_date',
+                                                  ['dag_id', 'task_id', 'execution_date'], unique=False)
+
+        op.alter_column(
+            table_name="log", column_name="execution_date", type_=mssql.DATETIME
+        )
+
+        op.alter_column(table_name='log', column_name='dttm', type_=mssql.DATETIME)
+
+        with op.batch_alter_table('sla_miss') as sla_miss_batch_op:
+            modify_execution_date_with_constraint(conn, sla_miss_batch_op, 'sla_miss',
+                                                  mssql.DATETIME, False)
+            sla_miss_batch_op.alter_column(column_name='timestamp', type_=mssql.DATETIME)
+
+        op.drop_index('idx_task_fail_dag_task_date', table_name='task_fail')
+        op.alter_column(
+            table_name="task_fail",
+            column_name="execution_date",
+            type_=mssql.DATETIME,
+        )
+        op.alter_column(table_name='task_fail', column_name='start_date', type_=mssql.DATETIME2(precision=6))
+        op.alter_column(table_name='task_fail', column_name='end_date', type_=mssql.DATETIME2(precision=6))
+        op.create_index('idx_task_fail_dag_task_date',
+                        'task_fail',
+                        ['dag_id', 'task_id', 'execution_date'], unique=False)
+
+        op.drop_index('idx_xcom_dag_task_date', table_name='xcom')
+        op.alter_column(
+            table_name="xcom",
+            column_name="execution_date",
+            type_=mssql.DATETIME,
+        )
+        op.alter_column(table_name='xcom', column_name='timestamp', type_=mssql.DATETIME)
+        op.create_index('idx_xcom_dag_task_date',
+                        'xcom',
+                        ['dag_id', 'task_ild', 'execution_date'], unique=False)
+
+        op.alter_column(table_name='dag', column_name='last_scheduler_run', type_=mssql.DATETIME)
+        op.alter_column(table_name='dag', column_name='last_pickled', type_=mssql.DATETIME)
+        op.alter_column(table_name='dag', column_name='last_expired', type_=mssql.DATETIME)
+
+        op.alter_column(table_name='dag_pickle', column_name='created_dttm', type_=mssql.DATETIME)
+
+        op.alter_column(table_name='import_error', column_name='timestamp', type_=mssql.DATETIME)
+
+        op.drop_index('job_type_heart', table_name='job')
+        op.drop_index('idx_job_state_heartbeat', table_name='job')
+        op.alter_column(table_name='job', column_name='start_date', type_=mssql.DATETIME)
+        op.alter_column(table_name='job', column_name='end_date', type_=mssql.DATETIME)
+        op.alter_column(table_name='job', column_name='latest_heartbeat', type_=mssql.DATETIME)
+        op.create_index('idx_job_state_heartbeat', 'job', ['state', 'latest_heartbeat'], unique=False)
+        op.create_index('job_type_heart', 'job', ['job_type', 'latest_heartbeat'], unique=False)
+
+
+def get_table_constraints(conn, table_name):
+    """
+     This function return primary and unique constraint
+     along with column name. some tables like task_instance
+     is missing primary key constraint name and the name is
+     auto-generated by sql server. so this function helps to
+     retrieve any primary or unique constraint name.
+
+     :param conn: sql connection object
+     :param table_name: table name
+     :return: a dictionary of ((constraint name, constraint type), column name) of table
+     :rtype: defaultdict(list)
+     """
+    query = """SELECT tc.CONSTRAINT_NAME , tc.CONSTRAINT_TYPE, ccu.COLUMN_NAME
+     FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc
+     JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE AS ccu ON ccu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+     WHERE tc.TABLE_NAME = '{table_name}' AND
+     (tc.CONSTRAINT_TYPE = 'PRIMARY KEY' or tc.CONSTRAINT_TYPE = 'Unique')
+    """.format(table_name=table_name)
+    result = conn.execute(query).fetchall()
+    constraint_dict = defaultdict(list)
+    for constraint, constraint_type, column in result:
+        constraint_dict[(constraint, constraint_type)].append(column)
+    return constraint_dict
+
+
+def reorder_columns(columns):
+    """
+    Reorder the columns for creating constraint, preserve primary key ordering
+    ['task_id', 'dag_id', 'execution_date']
+    :param columns: columns retrieved from DB related to constraint
+    :return: ordered column
+    """
+    ordered_columns = list()
+    for column in ['task_id', 'dag_id', 'execution_date']:
+        if column in columns:
+            ordered_columns.append(column)
+
+    for column in columns:
+        if column not in ['task_id', 'dag_id', 'execution_date']:
+            ordered_columns.append(column)
+
+    return ordered_columns
+
+
+def drop_constraint(operator, constraint_dict):
+    """
+    Drop a primary key or unique constraint
+    :param operator: batch_alter_table for the table
+    :param constraint_dict: a dictionary of ((constraint name, constraint type), column name) of table
+    """
+    for constraint, columns in constraint_dict.items():
+        if 'execution_date' in columns:
+            if constraint[1].lower().startswith("primary"):
+                operator.drop_constraint(
+                    constraint[0],
+                    type_='primary'
+                )
+            elif constraint[1].lower().startswith("unique"):
+                operator.drop_constraint(
+                    constraint[0],
+                    type_='unique'
+                )
+
+
+def create_constraint(operator, constraint_dict):
+    """
+    Create a primary key or unique constraint
+    :param operator: batch_alter_table for the table
+    :param constraint_dict: a dictionary of ((constraint name, constraint type), column name) of table
+    """
+    for constraint, columns in constraint_dict.items():
+        if 'execution_date' in columns:
+            if constraint[1].lower().startswith("primary"):
+                operator.create_primary_key(
+                    constraint_name=constraint[0],
+                    columns=reorder_columns(columns)
+                )
+            elif constraint[1].lower().startswith("unique"):
+                operator.create_unique_constraint(
+                    constraint_name=constraint[0],
+                    columns=reorder_columns(columns)
+                )
+
+
+def modify_execution_date_with_constraint(conn, batch_operator, table_name, type_, nullable):
+    """
+         Helper function changes type of column execution_date by
+         dropping and recreating any primary/unique constraint associated with
+         the column
+
+         :param conn: sql connection object
+         :param batch_operator: batch_alter_table for the table
+         :param table_name: table name
+         :param type_: DB column type
+         :param nullable: nullable (boolean)
+         :return: a dictionary of ((constraint name, constraint type), column name) of table
+         :rtype: defaultdict(list)
+         """
+    constraint_dict = get_table_constraints(conn, table_name)
+    drop_constraint(batch_operator, constraint_dict)
+    batch_operator.alter_column(
+        column_name="execution_date",
+        type_=type_,
+        nullable=nullable,
+    )
+    create_constraint(batch_operator, constraint_dict)

--- a/pylintrc
+++ b/pylintrc
@@ -289,7 +289,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=alembic.op
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.


### PR DESCRIPTION
Co-authored-by: mattinbits <3765307+mattinbits@users.noreply.github.com>
Co-authored-by: sirVir <sirVir@users.noreply.github.com>

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4462
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This change address the fact that we need to use datetime2 when using MSSQL server as a backend. pyodbc uses microseconds which datetime doesn't support. One of the sideeffects of this is that trigger dag does not work. Details in JIRA.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Please note that pylint fails for this since it has poor support for alembic. One way to solve this is to ignore the alembic.op module in pylintrc.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
