### PR TITLE
[AIRFLOW-5103] Pass matching objects in GCSPrefixSensor along via XCom

### DIFF
--- a/airflow/contrib/sensors/gcs_sensor.py
+++ b/airflow/contrib/sensors/gcs_sensor.py
@@ -130,7 +130,11 @@ class GoogleCloudStorageObjectUpdatedSensor(BaseSensorOperator):
 
 class GoogleCloudStoragePrefixSensor(BaseSensorOperator):
     """
-    Checks for the existence of a objects at prefix in Google Cloud Storage bucket.
+    Checks for the existence of GCS objects at a given prefix, passing matches via XCom.
+
+    When files matching the given prefix are found, the poke method's criteria will be
+    fulfilled and the matching objects will be returned from the operator and passed
+    through XCom for downstream tasks.
 
     :param bucket: The Google cloud storage bucket where the object is.
     :type bucket: str
@@ -160,6 +164,7 @@ class GoogleCloudStoragePrefixSensor(BaseSensorOperator):
         self.prefix = prefix
         self.google_cloud_conn_id = google_cloud_conn_id
         self.delegate_to = delegate_to
+        self._matches = []
 
     def poke(self, context):
         self.log.info('Sensor checks existence of objects: %s, %s',
@@ -167,7 +172,13 @@ class GoogleCloudStoragePrefixSensor(BaseSensorOperator):
         hook = GoogleCloudStorageHook(
             google_cloud_storage_conn_id=self.google_cloud_conn_id,
             delegate_to=self.delegate_to)
-        return bool(hook.list(self.bucket, prefix=self.prefix))
+        self._matches = hook.list(self.bucket, prefix=self.prefix)
+        return bool(self._matches)
+
+    def execute(self, context):
+        """Overridden to allow matches to be passed"""
+        super(GoogleCloudStoragePrefixSensor, self).execute(context)
+        return self._matches
 
 
 def get_time():


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5103
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Matching the style of the [PubSubSensor|https://airflow.readthedocs.io/en/stable/_modules/airflow/contrib/sensors/pubsub_sensor.html], we should make the GoogleCloudStoragePrefixSensor return the list of matches so that downstream tasks don't have to duplicate the Sensor's logic and can instead grab matching GCS objets via XCom.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- test_gcs_sensor.py

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
