### PR TITLE
[AIRFLOW-5107] Fix template_fields in GCS ACL operator

### DIFF
--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -479,7 +479,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
 
         self.log.info('A new ACL entry created in bucket: %s', bucket_name)
 
-    def insert_object_acl(self, bucket_name, object_name, entity, role, user_project=None):
+    def insert_object_acl(self, bucket_name, object_name, entity, role, generation=None, user_project=None):
         """
         Creates a new ACL entry on the specified object.
         See: https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls/insert
@@ -498,6 +498,8 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         :param role: The access permission for the entity.
             Acceptable values are: "OWNER", "READER".
         :type role: str
+        :param generation: Optional. If present, selects a specific revision of this object.
+        :type generation: long
         :param user_project: (Optional) The project to be billed for this request.
             Required for Requester Pays buckets.
         :type user_project: str
@@ -506,7 +508,7 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
                       object_name, bucket_name)
         client = self.get_conn()
         bucket = client.bucket(bucket_name=bucket_name)
-        blob = bucket.blob(object_name)
+        blob = bucket.blob(blob_name=object_name, generation=generation)
         # Reload fetches the current ACL from Cloud Storage.
         blob.acl.reload()
         blob.acl.entity_from_dict(entity_dict={"entity": entity, "role": role})

--- a/airflow/contrib/operators/gcs_acl_operator.py
+++ b/airflow/contrib/operators/gcs_acl_operator.py
@@ -93,6 +93,8 @@ class GoogleCloudStorageObjectCreateAclEntryOperator(BaseOperator):
     :param role: The access permission for the entity.
         Acceptable values are: "OWNER", "READER".
     :type role: str
+    :param generation: Optional. If present, selects a specific revision of this object.
+    :type generation: long
     :param user_project: (Optional) The project to be billed for this request.
         Required for Requester Pays buckets.
     :type user_project: str
@@ -101,8 +103,7 @@ class GoogleCloudStorageObjectCreateAclEntryOperator(BaseOperator):
     :type google_cloud_storage_conn_id: str
     """
     # [START gcs_object_create_acl_template_fields]
-    template_fields = ('bucket', 'object_name', 'entity', 'role', 'generation',
-                       'user_project')
+    template_fields = ('bucket', 'object_name', 'entity', 'generation', 'role', 'user_project')
     # [END gcs_object_create_acl_template_fields]
 
     @apply_defaults
@@ -111,6 +112,7 @@ class GoogleCloudStorageObjectCreateAclEntryOperator(BaseOperator):
                  object_name,
                  entity,
                  role,
+                 generation=None,
                  user_project=None,
                  google_cloud_storage_conn_id='google_cloud_default',
                  *args, **kwargs):
@@ -120,6 +122,7 @@ class GoogleCloudStorageObjectCreateAclEntryOperator(BaseOperator):
         self.object_name = object_name
         self.entity = entity
         self.role = role
+        self.generation = generation
         self.user_project = user_project
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
 
@@ -127,5 +130,9 @@ class GoogleCloudStorageObjectCreateAclEntryOperator(BaseOperator):
         hook = GoogleCloudStorageHook(
             google_cloud_storage_conn_id=self.google_cloud_storage_conn_id
         )
-        hook.insert_object_acl(bucket_name=self.bucket, object_name=self.object_name,
-                               entity=self.entity, role=self.role, user_project=self.user_project)
+        hook.insert_object_acl(bucket_name=self.bucket,
+                               object_name=self.object_name,
+                               entity=self.entity,
+                               role=self.role,
+                               generation=self.generation,
+                               user_project=self.user_project)

--- a/tests/contrib/operators/test_gcs_acl_operator.py
+++ b/tests/contrib/operators/test_gcs_acl_operator.py
@@ -49,6 +49,7 @@ class GoogleCloudStorageAclTest(unittest.TestCase):
             bucket="test-bucket",
             object_name="test-object",
             entity="test-entity",
+            generation=42,
             role="test-role",
             user_project="test-user-project",
             task_id="id"
@@ -58,6 +59,7 @@ class GoogleCloudStorageAclTest(unittest.TestCase):
             bucket_name="test-bucket",
             object_name="test-object",
             entity="test-entity",
+            generation=42,
             role="test-role",
             user_project="test-user-project"
         )


### PR DESCRIPTION
Fixes generation field in GoogleCloudStorageObjectCreateAclEntryOperator

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title
  - https://issues.apache.org/jira/browse/AIRFLOW-5107

### Description

- [ ] Fixes generation field in GoogleCloudStorageObjectCreateAclEntryOperator

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`