### PR TITLE
[AIRFLOW-5104] Set default schedule for GCP Transfer operators

### DIFF
--- a/tests/contrib/operators/test_gcp_transfer_operator.py
+++ b/tests/contrib/operators/test_gcp_transfer_operator.py
@@ -22,6 +22,7 @@ from copy import deepcopy
 from datetime import date, time
 from typing import Dict
 
+from freezegun import freeze_time
 from parameterized import parameterized
 from botocore.credentials import Credentials
 
@@ -183,6 +184,17 @@ class TransferJobPreprocessorTest(unittest.TestCase):
         body = {SCHEDULE: {START_TIME_OF_DAY: DICT_TIME}}
         TransferJobPreprocessor(body=body).process_body()
         self.assertEqual(body[SCHEDULE][START_TIME_OF_DAY], DICT_TIME)
+
+    @freeze_time("2018-10-15")
+    def test_should_set_default_schedule(self):
+        body = {}
+        TransferJobPreprocessor(body=body, default_schedule=True).process_body()
+        self.assertEqual(body, {
+            SCHEDULE: {
+                SCHEDULE_END_DATE: {'day': 15, 'month': 10, 'year': 2018},
+                SCHEDULE_START_DATE: {'day': 15, 'month': 10, 'year': 2018}
+            }
+        })
 
 
 class TransferJobValidatorTest(unittest.TestCase):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5104
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:

The GCS Transfer Service REST API requires that a schedule be set, even for
one-time immediate runs. This adds code to
`S3ToGoogleCloudStorageTransferOperator` and
`GoogleCloudStorageToGoogleCloudStorageTransferOperator` to set a default
one-time immediate run schedule when no `schedule` argument is passed.

### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
This should just be fixing existing behavior, and is hard to test as it only produces an error when actually sent to the GCP API. I have tested it by running it on a Cloud Composer cluster and using it to transfer files from S3 to GCS using `S3ToGoogleCloudStorageTransferOperator`. I have not tested `GoogleCloudStorageToGoogleCloudStorageTransferOperator` in a similar way, so maybe someone should do that as I don't think anyone ever actually tested it before releasing it. This combined with #5727 allows `S3ToGoogleCloudStorageTransferOperator` to run correctly with default arguments for scheduling and timeout.

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ X ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ X ] Passes `flake8`
