### PR TITLE
[AIRFLOW-5114] Fix gcp_transfer_hook behavior with default operator arguments

### DIFF
--- a/airflow/contrib/hooks/gcp_transfer_hook.py
+++ b/airflow/contrib/hooks/gcp_transfer_hook.py
@@ -21,12 +21,11 @@ This module contains a Google Storage Transfer Service Hook.
 """
 
 import json
-import numbers
 import time
 import warnings
 from copy import deepcopy
 from datetime import timedelta
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Union, Optional
 
 from googleapiclient.discovery import build
 
@@ -372,7 +371,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
         self,
         job: Dict,
         expected_statuses: Tuple[str] = (GcpTransferOperationStatus.SUCCESS,),
-        timeout: Union[numbers.Real, timedelta, None] = None
+        timeout: Optional[Union[float, timedelta]] = None
     ) -> None:
         """
         Waits until the job reaches the expected state.
@@ -387,7 +386,7 @@ class GCPTransferServiceHook(GoogleCloudBaseHook):
         :type expected_statuses: set[str]
         :param timeout: Time in which the operation must end in seconds. If not specified, defaults to 60
             seconds.
-        :type timeout: Union[Real, timedelta, None]
+        :type timeout: Optional[Union[float, timedelta]]
         :rtype: None
         """
         if timeout is None:

--- a/airflow/contrib/operators/gcp_transfer_operator.py
+++ b/airflow/contrib/operators/gcp_transfer_operator.py
@@ -607,7 +607,7 @@ class S3ToGoogleCloudStorageTransferOperator(BaseOperator):
     :param wait: Wait for transfer to finish
     :type wait: bool
     :param timeout: Time to wait for the operation to end in seconds. Defaults to 60 seconds if not specified.
-    :type timeout: Union[Real, timedelta, None]
+    :type timeout: Optional[Union[float, timedelta]]
     """
 
     template_fields = ('gcp_conn_id', 's3_bucket', 'gcs_bucket', 'description', 'object_conditions')
@@ -740,7 +740,7 @@ class GoogleCloudStorageToGoogleCloudStorageTransferOperator(BaseOperator):
     :param wait: Wait for transfer to finish; defaults to `True`
     :type wait: bool
     :param timeout: Time to wait for the operation to end in seconds. Defaults to 60 seconds if not specified.
-    :type timeout: Union[Real, timedelta, None]
+    :type timeout: Optional[Union[float, timedelta]]
     """
 
     template_fields = (

--- a/airflow/contrib/operators/gcp_transfer_operator.py
+++ b/airflow/contrib/operators/gcp_transfer_operator.py
@@ -606,8 +606,8 @@ class S3ToGoogleCloudStorageTransferOperator(BaseOperator):
     :type transfer_options: dict
     :param wait: Wait for transfer to finish
     :type wait: bool
-    :param timeout: Time to wait for the operation to end in seconds
-    :type timeout: int
+    :param timeout: Time to wait for the operation to end in seconds. Defaults to 60 seconds if not specified.
+    :type timeout: Union[Real, timedelta, None]
     """
 
     template_fields = ('gcp_conn_id', 's3_bucket', 'gcs_bucket', 'description', 'object_conditions')
@@ -739,8 +739,8 @@ class GoogleCloudStorageToGoogleCloudStorageTransferOperator(BaseOperator):
     :type transfer_options: dict
     :param wait: Wait for transfer to finish; defaults to `True`
     :type wait: bool
-    :param timeout: Time to wait for the operation to end in seconds
-    :type timeout: int
+    :param timeout: Time to wait for the operation to end in seconds. Defaults to 60 seconds if not specified.
+    :type timeout: Union[Real, timedelta, None]
     """
 
     template_fields = (


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ X ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5114
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ X ] Here are some details about my PR, including screenshots of any UI changes:

`GCPTransferServiceHook.wait_for_transfer_job` defeaults its `timeout`
parameter to 60 and assumes it is an integer or at least comparable to
one. This is a problem as some of the built-in operators that use it
like `S3ToGoogleCloudStorageTransferOperator` and
`GoogleCloudStorageToGoogleCloudStorageTransferOperator` default their
`timeout` param to `None`, and when they call this method with their
default value, it causes an error. Fix this by allowing
`wait_for_transfer_job` to accept a timeout of `None` and fill in
appropriate defaults. This also adds functionality to allow it to take
a `timedelta` instead of an integer, allows seconds to be any real, as
there is really no need for them to actually be an integer, and fixes
the counting of time for determining timeout to be a bit more accurate.

### Tests

- [ X ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
From the point of view of `GCPTransferServiceHook`, this is a purely internal change that doesn't affect any default behavior except allowing a parameter to be `None`. Since `None` is now the default, that particular case is already covered by the existing unit tests. In principle this could be tested from `S3ToGoogleCloudStorageTransferOperator` or `GoogleCloudStorageToGoogleCloudStorageTransferOperator`, but that would require giving them an actual `GCPTransferServiceHook` instead of a Mock. I have tested this by running it on a Cloud Composer cluster and using it to transfer files from S3 to GCS using `S3ToGoogleCloudStorageTransferOperator`. I have not tested `GoogleCloudStorageToGoogleCloudStorageTransferOperator` in a similar way, so maybe someone should do that as I don't think anyone ever actually tested it before releasing it. This combined with #5726 allows `S3ToGoogleCloudStorageTransferOperator` to actually run correctly with default arguments for scheduling and timeout.

### Commits

- [ X ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ X ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
I have updated the docstrings of `GCPTransferServiceHook`, `S3ToGoogleCloudStorageTransferOperator` and
`GoogleCloudStorageToGoogleCloudStorageTransferOperator` to document their previously undocumented default behaviors and to reflect the relaxed type requirements.

### Code Quality

- [ X ] Passes `flake8`
