### PR TITLE
[AIRFLOW-5123] Normalize *_conn_id parameter in GCS operators

### DIFF
--- a/airflow/contrib/operators/adls_to_gcs.py
+++ b/airflow/contrib/operators/adls_to_gcs.py
@@ -18,6 +18,7 @@
 # under the License.
 
 import os
+import warnings
 from tempfile import NamedTemporaryFile
 
 from airflow.contrib.hooks.azure_data_lake_hook import AzureDataLakeHook
@@ -42,8 +43,10 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
     :param azure_data_lake_conn_id: The connection ID to use when
         connecting to Azure Data Lake Storage.
     :type azure_data_lake_conn_id: str
-    :param google_cloud_storage_conn_id: The connection ID to use when
-        connecting to Google Cloud Storage.
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param google_cloud_storage_conn_id: (Deprecated) The connection ID used to connect to Google Cloud
+        Platform. This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
     :type google_cloud_storage_conn_id: str
     :param delegate_to: The account to impersonate, if any.
         For this to work, the service account making the request must have
@@ -61,7 +64,7 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
                 dest_gcs='gs://mybucket',
                 replace=False,
                 azure_data_lake_conn_id='azure_data_lake_default',
-                google_cloud_storage_conn_id='google_cloud_default'
+                gcp_conn_id='google_cloud_default'
             )
 
         The following Operator would copy all parquet files from ADLS
@@ -73,7 +76,7 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
                 dest_gcs='gs://mybucket',
                 replace=False,
                 azure_data_lake_conn_id='azure_data_lake_default',
-                google_cloud_storage_conn_id='google_cloud_default'
+                gcp_conn_id='google_cloud_default'
             )
 
          The following Operator would copy all parquet files from ADLS
@@ -85,7 +88,7 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
                 dest_gcs='gs://mybucket',
                 replace=False,
                 azure_data_lake_conn_id='azure_data_lake_default',
-                google_cloud_storage_conn_id='google_cloud_default'
+                gcp_conn_id='google_cloud_default'
             )
     """
     template_fields = ('src_adls', 'dest_gcs')
@@ -96,7 +99,8 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
                  src_adls,
                  dest_gcs,
                  azure_data_lake_conn_id,
-                 google_cloud_storage_conn_id,
+                 gcp_conn_id='google_cloud_default',
+                 google_cloud_storage_conn_id=None,
                  delegate_to=None,
                  replace=False,
                  gzip=False,
@@ -109,10 +113,17 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
             *args,
             **kwargs
         )
+
+        if google_cloud_storage_conn_id:
+            warnings.warn(
+                "The google_cloud_storage_conn_id parameter has been deprecated. You should pass "
+                "the gcp_conn_id parameter.", DeprecationWarning, stacklevel=3)
+            gcp_conn_id = google_cloud_storage_conn_id
+
         self.src_adls = src_adls
         self.dest_gcs = dest_gcs
         self.replace = replace
-        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.gzip = gzip
 
@@ -120,7 +131,7 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
         # use the super to list all files in an Azure Data Lake path
         files = super().execute(context)
         g_hook = GoogleCloudStorageHook(
-            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+            google_cloud_storage_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to)
 
         if not self.replace:

--- a/airflow/contrib/operators/file_to_gcs.py
+++ b/airflow/contrib/operators/file_to_gcs.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+import warnings
 
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.models import BaseOperator
@@ -34,7 +35,10 @@ class FileToGoogleCloudStorageOperator(BaseOperator):
     :type dst: str
     :param bucket: The bucket to upload to. (templated)
     :type bucket: str
-    :param google_cloud_storage_conn_id: The Airflow connection ID to upload with
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param google_cloud_storage_conn_id: (Deprecated) The connection ID used to connect to Google Cloud
+        Platform. This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
     :type google_cloud_storage_conn_id: str
     :param mime_type: The mime-type string
     :type mime_type: str
@@ -50,17 +54,25 @@ class FileToGoogleCloudStorageOperator(BaseOperator):
                  src,
                  dst,
                  bucket,
-                 google_cloud_storage_conn_id='google_cloud_default',
+                 gcp_conn_id='google_cloud_default',
+                 google_cloud_storage_conn_id=None,
                  mime_type='application/octet-stream',
                  delegate_to=None,
                  gzip=False,
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
+
+        if google_cloud_storage_conn_id:
+            warnings.warn(
+                "The google_cloud_storage_conn_id parameter has been deprecated. You should pass "
+                "the gcp_conn_id parameter.", DeprecationWarning, stacklevel=3)
+            gcp_conn_id = google_cloud_storage_conn_id
+
         self.src = src
         self.dst = dst
         self.bucket = bucket
-        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.gcp_conn_id = gcp_conn_id
         self.mime_type = mime_type
         self.delegate_to = delegate_to
         self.gzip = gzip
@@ -70,7 +82,7 @@ class FileToGoogleCloudStorageOperator(BaseOperator):
         Uploads the file to Google cloud storage
         """
         hook = GoogleCloudStorageHook(
-            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+            google_cloud_storage_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to)
 
         hook.upload(

--- a/airflow/contrib/operators/gcs_acl_operator.py
+++ b/airflow/contrib/operators/gcs_acl_operator.py
@@ -19,6 +19,7 @@
 """
 This module contains Google Cloud Storage ACL entry operator.
 """
+import warnings
 
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.models import BaseOperator
@@ -45,8 +46,10 @@ class GoogleCloudStorageBucketCreateAclEntryOperator(BaseOperator):
     :param user_project: (Optional) The project to be billed for this request.
         Required for Requester Pays buckets.
     :type user_project: str
-    :param google_cloud_storage_conn_id: The connection ID to use when
-        connecting to Google Cloud Storage.
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param google_cloud_storage_conn_id: (Deprecated) The connection ID used to connect to Google Cloud
+        Platform. This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
     :type google_cloud_storage_conn_id: str
     """
     # [START gcs_bucket_create_acl_template_fields]
@@ -54,19 +57,35 @@ class GoogleCloudStorageBucketCreateAclEntryOperator(BaseOperator):
     # [END gcs_bucket_create_acl_template_fields]
 
     @apply_defaults
-    def __init__(self, bucket, entity, role, user_project=None,
-                 google_cloud_storage_conn_id='google_cloud_default', *args, **kwargs):
+    def __init__(
+        self,
+        bucket,
+        entity,
+        role,
+        user_project=None,
+        gcp_conn_id='google_cloud_default',
+        google_cloud_storage_conn_id=None,
+        *args,
+        **kwargs
+    ):
         super().__init__(*args,
                          **kwargs)
+
+        if google_cloud_storage_conn_id:
+            warnings.warn(
+                "The google_cloud_storage_conn_id parameter has been deprecated. You should pass "
+                "the gcp_conn_id parameter.", DeprecationWarning, stacklevel=3)
+            gcp_conn_id = google_cloud_storage_conn_id
+
         self.bucket = bucket
         self.entity = entity
         self.role = role
         self.user_project = user_project
-        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
         hook = GoogleCloudStorageHook(
-            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id
+            google_cloud_storage_conn_id=self.gcp_conn_id
         )
         hook.insert_bucket_acl(bucket_name=self.bucket, entity=self.entity, role=self.role,
                                user_project=self.user_project)
@@ -98,8 +117,10 @@ class GoogleCloudStorageObjectCreateAclEntryOperator(BaseOperator):
     :param user_project: (Optional) The project to be billed for this request.
         Required for Requester Pays buckets.
     :type user_project: str
-    :param google_cloud_storage_conn_id: The connection ID to use when
-        connecting to Google Cloud Storage.
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param google_cloud_storage_conn_id: (Deprecated) The connection ID used to connect to Google Cloud
+        Platform. This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
     :type google_cloud_storage_conn_id: str
     """
     # [START gcs_object_create_acl_template_fields]
@@ -114,21 +135,29 @@ class GoogleCloudStorageObjectCreateAclEntryOperator(BaseOperator):
                  role,
                  generation=None,
                  user_project=None,
-                 google_cloud_storage_conn_id='google_cloud_default',
+                 gcp_conn_id='google_cloud_default',
+                 google_cloud_storage_conn_id=None,
                  *args, **kwargs):
         super().__init__(*args,
                          **kwargs)
+
+        if google_cloud_storage_conn_id:
+            warnings.warn(
+                "The google_cloud_storage_conn_id parameter has been deprecated. You should pass "
+                "the gcp_conn_id parameter.", DeprecationWarning, stacklevel=3)
+            gcp_conn_id = google_cloud_storage_conn_id
+
         self.bucket = bucket
         self.object_name = object_name
         self.entity = entity
         self.role = role
         self.generation = generation
         self.user_project = user_project
-        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
         hook = GoogleCloudStorageHook(
-            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id
+            google_cloud_storage_conn_id=self.gcp_conn_id
         )
         hook.insert_object_acl(bucket_name=self.bucket,
                                object_name=self.object_name,

--- a/airflow/contrib/operators/gcs_delete_operator.py
+++ b/airflow/contrib/operators/gcs_delete_operator.py
@@ -19,7 +19,7 @@
 """
 This module contains Google Cloud Storage delete operator.
 """
-
+import warnings
 from typing import Optional, Iterable
 
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
@@ -40,8 +40,10 @@ class GoogleCloudStorageDeleteOperator(BaseOperator):
     :type objects: Iterable[str]
     :param prefix: Prefix of objects to delete. All objects matching this
         prefix in the bucket will be deleted.
-    :param google_cloud_storage_conn_id: The connection ID to use for
-        Google Cloud Storage
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param google_cloud_storage_conn_id: (Deprecated) The connection ID used to connect to Google Cloud
+        Platform. This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
     :type google_cloud_storage_conn_id: str
     :param delegate_to: The account to impersonate, if any.
         For this to work, the service account making the request must have
@@ -56,13 +58,21 @@ class GoogleCloudStorageDeleteOperator(BaseOperator):
                  bucket_name: str,
                  objects: Optional[Iterable[str]] = None,
                  prefix: Optional[str] = None,
-                 google_cloud_storage_conn_id: str = 'google_cloud_default',
+                 gcp_conn_id: str = 'google_cloud_default',
+                 google_cloud_storage_conn_id: Optional[str] = None,
                  delegate_to: Optional[str] = None,
                  *args, **kwargs):
+
+        if google_cloud_storage_conn_id:
+            warnings.warn(
+                "The google_cloud_storage_conn_id parameter has been deprecated. You should pass "
+                "the gcp_conn_id parameter.", DeprecationWarning, stacklevel=3)
+            gcp_conn_id = google_cloud_storage_conn_id
+
         self.bucket_name = bucket_name
         self.objects = objects
         self.prefix = prefix
-        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
 
         assert objects is not None or prefix is not None
@@ -71,7 +81,7 @@ class GoogleCloudStorageDeleteOperator(BaseOperator):
 
     def execute(self, context):
         hook = GoogleCloudStorageHook(
-            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+            google_cloud_storage_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to
         )
 

--- a/airflow/contrib/operators/gcs_list_operator.py
+++ b/airflow/contrib/operators/gcs_list_operator.py
@@ -19,7 +19,7 @@
 """
 This module contains a Google Cloud Storage list operator.
 """
-
+import warnings
 from typing import Iterable
 
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
@@ -43,9 +43,11 @@ class GoogleCloudStorageListOperator(BaseOperator):
         For e.g to lists the CSV files from in a directory in GCS you would use
         delimiter='.csv'.
     :type delimiter: str
-    :param google_cloud_storage_conn_id: The connection ID to use when
-        connecting to Google cloud storage.
-    :type google_cloud_storage_conn_id: str
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param google_cloud_storage_conn_id: (Deprecated) The connection ID used to connect to Google Cloud
+        Platform. This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
+    :type google_cloud_storage_conn_id:
     :param delegate_to: The account to impersonate, if any.
         For this to work, the service account making the request must have
         domain-wide delegation enabled.
@@ -60,7 +62,7 @@ class GoogleCloudStorageListOperator(BaseOperator):
                 bucket='data',
                 prefix='sales/sales-2017/',
                 delimiter='.avro',
-                google_cloud_storage_conn_id=google_cloud_conn_id
+                gcp_conn_id=google_cloud_conn_id
             )
     """
     template_fields = ('bucket', 'prefix', 'delimiter')  # type: Iterable[str]
@@ -72,21 +74,29 @@ class GoogleCloudStorageListOperator(BaseOperator):
                  bucket,
                  prefix=None,
                  delimiter=None,
-                 google_cloud_storage_conn_id='google_cloud_default',
+                 gcp_conn_id='google_cloud_default',
+                 google_cloud_storage_conn_id=None,
                  delegate_to=None,
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
+
+        if google_cloud_storage_conn_id:
+            warnings.warn(
+                "The google_cloud_storage_conn_id parameter has been deprecated. You should pass "
+                "the gcp_conn_id parameter.", DeprecationWarning, stacklevel=3)
+            gcp_conn_id = google_cloud_storage_conn_id
+
         self.bucket = bucket
         self.prefix = prefix
         self.delimiter = delimiter
-        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
 
     def execute(self, context):
 
         hook = GoogleCloudStorageHook(
-            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+            google_cloud_storage_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to
         )
 

--- a/airflow/contrib/operators/gcs_operator.py
+++ b/airflow/contrib/operators/gcs_operator.py
@@ -19,6 +19,7 @@
 """
 This module contains a Google Cloud Storage Bucket operator.
 """
+import warnings
 
 from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
 from airflow.models import BaseOperator
@@ -64,8 +65,10 @@ class GoogleCloudStorageCreateBucketOperator(BaseOperator):
     :type project_id: str
     :param labels: User-provided labels, in key/value pairs.
     :type labels: dict
-    :param google_cloud_storage_conn_id: The connection ID to use when
-        connecting to Google cloud storage.
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param google_cloud_storage_conn_id: (Deprecated) The connection ID used to connect to Google Cloud
+        Platform. This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
     :type google_cloud_storage_conn_id: str
     :param delegate_to: The account to impersonate, if any.
         For this to work, the service account making the request must
@@ -83,7 +86,7 @@ class GoogleCloudStorageCreateBucketOperator(BaseOperator):
             storage_class='MULTI_REGIONAL',
             location='EU',
             labels={'env': 'dev', 'team': 'airflow'},
-            google_cloud_storage_conn_id='airflow-conn-id'
+            gcp_conn_id='airflow-conn-id'
         )
 
     """
@@ -99,19 +102,26 @@ class GoogleCloudStorageCreateBucketOperator(BaseOperator):
                  location='US',
                  project_id=None,
                  labels=None,
-                 google_cloud_storage_conn_id='google_cloud_default',
+                 gcp_conn_id='google_cloud_default',
+                 google_cloud_storage_conn_id=None,
                  delegate_to=None,
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
+
+        if google_cloud_storage_conn_id:
+            warnings.warn(
+                "The google_cloud_storage_conn_id parameter has been deprecated. You should pass "
+                "the gcp_conn_id parameter.", DeprecationWarning, stacklevel=3)
+            gcp_conn_id = google_cloud_storage_conn_id
+
         self.bucket_name = bucket_name
         self.resource = resource
         self.storage_class = storage_class
         self.location = location
         self.project_id = project_id
         self.labels = labels
-
-        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
 
     def execute(self, context):
@@ -121,7 +131,7 @@ class GoogleCloudStorageCreateBucketOperator(BaseOperator):
             )
 
         hook = GoogleCloudStorageHook(
-            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+            google_cloud_storage_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to
         )
 

--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -104,10 +104,11 @@ class GoogleCloudStorageToBigQueryOperator(BaseOperator):
         operators to use. This can be helpful with incremental loads--during
         future executions, you can pick up from the max ID.
     :type max_id_key: str
-    :param bigquery_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :param bigquery_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform and
+        interact with the BigQuery service.
     :type bigquery_conn_id: str
-    :param google_cloud_storage_conn_id: Reference to a specific Google
-        cloud storage hook.
+    :param google_cloud_storage_conn_id: (Optional) The connection ID used to connect to Google Cloud
+        Platform and interact with the Google Cloud Storage service.
     :type google_cloud_storage_conn_id: str
     :param delegate_to: The account to impersonate, if any. For this to
         work, the service account making the request must have domain-wide

--- a/airflow/contrib/operators/sql_to_gcs.py
+++ b/airflow/contrib/operators/sql_to_gcs.py
@@ -22,6 +22,7 @@ Base operator for SQL to GCS operators.
 
 import abc
 import json
+import warnings
 from tempfile import NamedTemporaryFile
 
 import unicodecsv as csv
@@ -62,8 +63,10 @@ class BaseSQLToGoogleCloudStorageOperator(BaseOperator, metaclass=abc.ABCMeta):
         dict. Examples could be seen: https://cloud.google.com/bigquery/docs
         /schemas#specifying_a_json_schema_file
     :type schema: str or list
-    :param google_cloud_storage_conn_id: Reference to a specific Google
-        cloud storage hook.
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param google_cloud_storage_conn_id: (Deprecated) The connection ID used to connect to Google Cloud
+        Platform. This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
     :type google_cloud_storage_conn_id: str
     :param delegate_to: The account to impersonate, if any. For this to
         work, the service account making the request must have domain-wide
@@ -86,11 +89,19 @@ class BaseSQLToGoogleCloudStorageOperator(BaseOperator, metaclass=abc.ABCMeta):
                  gzip=False,
                  schema=None,
                  parameters=None,
-                 google_cloud_storage_conn_id='google_cloud_default',
+                 gcp_conn_id='google_cloud_default',
+                 google_cloud_storage_conn_id=None,
                  delegate_to=None,
                  *args,
                  **kwargs):
         super(BaseSQLToGoogleCloudStorageOperator, self).__init__(*args, **kwargs)
+
+        if google_cloud_storage_conn_id:
+            warnings.warn(
+                "The google_cloud_storage_conn_id parameter has been deprecated. You should pass "
+                "the gcp_conn_id parameter.", DeprecationWarning, stacklevel=3)
+            gcp_conn_id = google_cloud_storage_conn_id
+
         self.sql = sql
         self.bucket = bucket
         self.filename = filename
@@ -101,7 +112,7 @@ class BaseSQLToGoogleCloudStorageOperator(BaseOperator, metaclass=abc.ABCMeta):
         self.gzip = gzip
         self.schema = schema
         self.parameters = parameters
-        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.parameters = parameters
 
@@ -256,7 +267,7 @@ class BaseSQLToGoogleCloudStorageOperator(BaseOperator, metaclass=abc.ABCMeta):
         Google cloud storage.
         """
         hook = GoogleCloudStorageHook(
-            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+            google_cloud_storage_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to)
         for tmp_file in files_to_upload:
             hook.upload(self.bucket, tmp_file.get('file_name'),

--- a/tests/contrib/operators/test_adls_to_gcs_operator.py
+++ b/tests/contrib/operators/test_adls_to_gcs_operator.py
@@ -42,14 +42,14 @@ class AdlsToGoogleCloudStorageOperatorTest(unittest.TestCase):
             dest_gcs=GCS_PATH,
             replace=False,
             azure_data_lake_conn_id=AZURE_CONN_ID,
-            google_cloud_storage_conn_id=GCS_CONN_ID
+            gcp_conn_id=GCS_CONN_ID
         )
 
         self.assertEqual(operator.task_id, TASK_ID)
         self.assertEqual(operator.src_adls, ADLS_PATH_1)
         self.assertEqual(operator.dest_gcs, GCS_PATH)
         self.assertEqual(operator.replace, False)
-        self.assertEqual(operator.google_cloud_storage_conn_id, GCS_CONN_ID)
+        self.assertEqual(operator.gcp_conn_id, GCS_CONN_ID)
         self.assertEqual(operator.azure_data_lake_conn_id, AZURE_CONN_ID)
 
     @mock.patch('airflow.contrib.operators.adls_to_gcs.AzureDataLakeHook')

--- a/tests/contrib/operators/test_s3_to_gcs_operator.py
+++ b/tests/contrib/operators/test_s3_to_gcs_operator.py
@@ -43,14 +43,14 @@ class S3ToGoogleCloudStorageOperatorTest(unittest.TestCase):
             bucket=S3_BUCKET,
             prefix=S3_PREFIX,
             delimiter=S3_DELIMITER,
-            dest_gcs_conn_id=GCS_CONN_ID,
+            gcp_conn_id=GCS_CONN_ID,
             dest_gcs=GCS_PATH_PREFIX)
 
         self.assertEqual(operator.task_id, TASK_ID)
         self.assertEqual(operator.bucket, S3_BUCKET)
         self.assertEqual(operator.prefix, S3_PREFIX)
         self.assertEqual(operator.delimiter, S3_DELIMITER)
-        self.assertEqual(operator.dest_gcs_conn_id, GCS_CONN_ID)
+        self.assertEqual(operator.gcp_conn_id, GCS_CONN_ID)
         self.assertEqual(operator.dest_gcs, GCS_PATH_PREFIX)
 
     @mock.patch('airflow.contrib.operators.s3_to_gcs_operator.S3Hook')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
