### PR TITLE
[AIRFLOW-5125] Add gzip support for AdlsToGoogleCloudStorageOperator

### DIFF
--- a/airflow/contrib/operators/adls_to_gcs.py
+++ b/airflow/contrib/operators/adls_to_gcs.py
@@ -37,6 +37,8 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
     :type dest_gcs: str
     :param replace: If true, replaces same-named files in GCS
     :type replace: bool
+    :param gzip: Option to compress file for upload
+    :type gzip: bool
     :param azure_data_lake_conn_id: The connection ID to use when
         connecting to Azure Data Lake Storage.
     :type azure_data_lake_conn_id: str
@@ -97,6 +99,7 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
                  google_cloud_storage_conn_id,
                  delegate_to=None,
                  replace=False,
+                 gzip=False,
                  *args,
                  **kwargs):
 
@@ -111,6 +114,7 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
         self.replace = replace
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
         self.delegate_to = delegate_to
+        self.gzip = gzip
 
     def execute(self, context):
         # use the super to list all files in an Azure Data Lake path
@@ -140,8 +144,12 @@ class AdlsToGoogleCloudStorageOperator(AzureDataLakeStorageListOperator):
                     dest_path = os.path.join(dest_gcs_prefix, obj)
                     self.log.info("Saving file to %s", dest_path)
 
-                    g_hook.upload(bucket_name=dest_gcs_bucket,
-                                  object_name=dest_path, filename=f.name)
+                    g_hook.upload(
+                        bucket_name=dest_gcs_bucket,
+                        object_name=dest_path,
+                        filename=f.name,
+                        gzip=self.gzip
+                    )
 
             self.log.info("All done, uploaded %d files to GCS", len(files))
         else:


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
