### PR TITLE
[AIRFLOW-5130] Use GOOGLE_APPLICATION_CREDENTIALS constant from library

### DIFF
--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -33,6 +33,7 @@ import google.auth
 import google.oauth2.service_account
 from google.api_core.client_info import ClientInfo
 from google.api_core.exceptions import GoogleAPICallError, AlreadyExists, RetryError
+from google.auth.environment_vars import CREDENTIALS
 
 import google_auth_httplib2
 from googleapiclient.errors import HttpError
@@ -43,10 +44,6 @@ from airflow.hooks.base_hook import BaseHook
 
 
 _DEFAULT_SCOPES = ('https://www.googleapis.com/auth/cloud-platform',)  # type: Sequence[str]
-# The name of the environment variable that Google Authentication library uses
-# to get service account key location. Read more:
-# https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable
-_G_APP_CRED_ENV_VAR = "GOOGLE_APPLICATION_CREDENTIALS"
 
 
 RT = TypeVar('RT')  # pylint: disable=invalid-name
@@ -263,10 +260,10 @@ class GoogleCloudBaseHook(BaseHook):
                 if key_path:
                     if key_path.endswith('.p12'):
                         raise AirflowException('Legacy P12 key file are not supported, use a JSON key file.')
-                    os.environ[_G_APP_CRED_ENV_VAR] = key_path
+                    os.environ[CREDENTIALS] = key_path
                 elif keyfile_dict:
                     conf_file.write(keyfile_dict)
                     conf_file.flush()
-                    os.environ[_G_APP_CRED_ENV_VAR] = conf_file.name
+                    os.environ[CREDENTIALS] = conf_file.name
                 return func(self, *args, **kwargs)
         return wrapper

--- a/airflow/contrib/operators/gcp_container_operator.py
+++ b/airflow/contrib/operators/gcp_container_operator.py
@@ -25,6 +25,8 @@ import os
 import subprocess
 import tempfile
 
+from google.auth.environment_vars import CREDENTIALS
+
 from airflow import AirflowException
 from airflow.contrib.hooks.gcp_container_hook import GKEClusterHook
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
@@ -183,7 +185,6 @@ class GKEClusterCreateOperator(BaseOperator):
 
 
 KUBE_CONFIG_ENV_VAR = "KUBECONFIG"
-G_APP_CRED = "GOOGLE_APPLICATION_CREDENTIALS"
 
 
 class GKEPodOperator(KubernetesPodOperator):
@@ -302,13 +303,13 @@ class GKEPodOperator(KubernetesPodOperator):
             self.log.info('Using gcloud with application default credentials.')
             return None
         elif key_path:
-            os.environ[G_APP_CRED] = key_path
+            os.environ[CREDENTIALS] = key_path
             return None
         else:
             # Write service account JSON to secure file for gcloud to reference
             service_key = tempfile.NamedTemporaryFile(delete=False)
             service_key.write(keyfile_json_str.encode('utf-8'))
-            os.environ[G_APP_CRED] = service_key.name
+            os.environ[CREDENTIALS] = service_key.name
             # Return file object to have a pointer to close after use,
             # thus deleting from file system.
             return service_key

--- a/tests/contrib/hooks/test_gcp_api_base_hook.py
+++ b/tests/contrib/hooks/test_gcp_api_base_hook.py
@@ -25,6 +25,7 @@ from io import StringIO
 from parameterized import parameterized
 
 import google.auth
+from google.auth.environment_vars import CREDENTIALS
 from google.auth.exceptions import GoogleAuthError
 from google.api_core.exceptions import RetryError, AlreadyExists
 from google.cloud.exceptions import MovedPermanently
@@ -136,7 +137,7 @@ class TestGoogleCloudBaseHook(unittest.TestCase):
 
         @hook.GoogleCloudBaseHook.provide_gcp_credential_file
         def assert_gcp_credential_file_in_env(hook_instance):  # pylint:disable=unused-argument
-            self.assertEqual(os.environ[hook._G_APP_CRED_ENV_VAR],
+            self.assertEqual(os.environ[CREDENTIALS],
                              key_path)
 
         assert_gcp_credential_file_in_env(self.instance)
@@ -155,7 +156,7 @@ class TestGoogleCloudBaseHook(unittest.TestCase):
 
         @hook.GoogleCloudBaseHook.provide_gcp_credential_file
         def assert_gcp_credential_file_in_env(hook_instance):  # pylint:disable=unused-argument
-            self.assertEqual(os.environ[hook._G_APP_CRED_ENV_VAR],
+            self.assertEqual(os.environ[CREDENTIALS],
                              file_name)
             self.assertEqual(file_content, string_file.getvalue())
 

--- a/tests/contrib/operators/test_gcp_container_operator.py
+++ b/tests/contrib/operators/test_gcp_container_operator.py
@@ -20,6 +20,8 @@
 import os
 import unittest
 
+from google.auth.environment_vars import CREDENTIALS
+
 from airflow import AirflowException
 from airflow.contrib.operators.gcp_container_operator import GKEClusterCreateOperator, \
     GKEClusterDeleteOperator, GKEPodOperator
@@ -40,7 +42,6 @@ IMAGE = 'bash'
 
 GCLOUD_COMMAND = "gcloud container clusters get-credentials {} --zone {} --project {}"
 KUBE_ENV_VAR = 'KUBECONFIG'
-GAC_ENV_VAR = 'GOOGLE_APPLICATION_CREDENTIALS'
 FILE_NAME = '/tmp/mock_name'
 
 
@@ -143,8 +144,8 @@ class GKEPodOperatorTest(unittest.TestCase):
                                      name=TASK_NAME,
                                      namespace=NAMESPACE,
                                      image=IMAGE)
-        if GAC_ENV_VAR in os.environ:
-            del os.environ[GAC_ENV_VAR]
+        if CREDENTIALS in os.environ:
+            del os.environ[CREDENTIALS]
 
     def test_template_fields(self):
         self.assertTrue(set(KubernetesPodOperator.template_fields).issubset(
@@ -193,9 +194,9 @@ class GKEPodOperatorTest(unittest.TestCase):
         self.assertIn(KUBE_ENV_VAR, os.environ)
         self.assertEqual(os.environ[KUBE_ENV_VAR], FILE_NAME)
 
-        self.assertIn(GAC_ENV_VAR, os.environ)
+        self.assertIn(CREDENTIALS, os.environ)
         # since we passed in keyfile_path we should get a file
-        self.assertEqual(os.environ[GAC_ENV_VAR], file_path)
+        self.assertEqual(os.environ[CREDENTIALS], file_path)
 
         # Assert the gcloud command being called correctly
         proc_mock.assert_called_with(
@@ -229,9 +230,9 @@ class GKEPodOperatorTest(unittest.TestCase):
         self.assertIn(KUBE_ENV_VAR, os.environ)
         self.assertEqual(os.environ[KUBE_ENV_VAR], FILE_NAME)
 
-        self.assertIn(GAC_ENV_VAR, os.environ)
+        self.assertIn(CREDENTIALS, os.environ)
         # since we passed in keyfile_path we should get a file
-        self.assertEqual(os.environ[GAC_ENV_VAR], file_path)
+        self.assertEqual(os.environ[CREDENTIALS], file_path)
 
         # Assert the gcloud command being called correctly
         proc_mock.assert_called_with(
@@ -244,7 +245,7 @@ class GKEPodOperatorTest(unittest.TestCase):
         extras = {}
         self.gke_op._set_env_from_extras(extras)
         # _set_env_from_extras should not edit os.environ if extras does not specify
-        self.assertNotIn(GAC_ENV_VAR, os.environ)
+        self.assertNotIn(CREDENTIALS, os.environ)
 
     @mock.patch.dict(os.environ, {})
     @mock.patch('tempfile.NamedTemporaryFile')
@@ -262,7 +263,7 @@ class GKEPodOperatorTest(unittest.TestCase):
         file_mock.return_value.name = FILE_NAME
 
         key_file = self.gke_op._set_env_from_extras(extras)
-        self.assertEqual(os.environ[GAC_ENV_VAR], FILE_NAME)
+        self.assertEqual(os.environ[CREDENTIALS], FILE_NAME)
         self.assertIsInstance(key_file, mock.MagicMock)
 
     @mock.patch.dict(os.environ, {})
@@ -274,7 +275,7 @@ class GKEPodOperatorTest(unittest.TestCase):
         }
 
         self.gke_op._set_env_from_extras(extras)
-        self.assertEqual(os.environ[GAC_ENV_VAR], test_path)
+        self.assertEqual(os.environ[CREDENTIALS], test_path)
 
     def test_get_field(self):
         field_name = 'test_field'


### PR DESCRIPTION
Constant GOOGLE_APPLICATION_CREDENTIALS is used in many places in inconsistent way. I try to organize this small piece of code.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
