### PR TITLE
[AIRFLOW-XXX] Make string type uniform in docstrings

### DIFF
--- a/airflow/contrib/hooks/ftp_hook.py
+++ b/airflow/contrib/hooks/ftp_hook.py
@@ -276,7 +276,7 @@ class FTPHook(BaseHook):
         Returns a datetime object representing the last time the file was modified
 
         :param path: remote file path
-        :type path: string
+        :type path: str
         """
         conn = self.get_conn()
         ftp_mdtm = conn.sendcmd('MDTM ' + path)
@@ -292,7 +292,7 @@ class FTPHook(BaseHook):
         Returns the size of a file (in bytes)
 
         :param path: remote file path
-        :type path: string
+        :type path: str
         """
         conn = self.get_conn()
         return conn.size(path)

--- a/airflow/contrib/hooks/sagemaker_hook.py
+++ b/airflow/contrib/hooks/sagemaker_hook.py
@@ -575,7 +575,7 @@ class SageMakerHook(AwsHook):
         Return the tuning job info associated with the name
 
         :param name: the name of the tuning job
-        :type name: string
+        :type name: str
         :return: A dict contains all the tuning job info
         """
 
@@ -586,7 +586,7 @@ class SageMakerHook(AwsHook):
         Return the SageMaker model info associated with the name
 
         :param name: the name of the SageMaker model
-        :type name: string
+        :type name: str
         :return: A dict contains all the model info
         """
 
@@ -597,7 +597,7 @@ class SageMakerHook(AwsHook):
         Return the transform job info associated with the name
 
         :param name: the name of the transform job
-        :type name: string
+        :type name: str
         :return: A dict contains all the transform job info
         """
 
@@ -608,7 +608,7 @@ class SageMakerHook(AwsHook):
         Return the endpoint config info associated with the name
 
         :param name: the name of the endpoint config
-        :type name: string
+        :type name: str
         :return: A dict contains all the endpoint config info
         """
 
@@ -617,7 +617,7 @@ class SageMakerHook(AwsHook):
     def describe_endpoint(self, name):
         """
         :param name: the name of the endpoint
-        :type name: string
+        :type name: str
         :return: A dict contains all the endpoint info
         """
 

--- a/airflow/contrib/operators/bigquery_to_mysql_operator.py
+++ b/airflow/contrib/operators/bigquery_to_mysql_operator.py
@@ -54,20 +54,20 @@ class BigQueryToMySqlOperator(BaseOperator):
     :type dataset_table: str
     :param max_results: The maximum number of records (rows) to be fetched
         from the table. (templated)
-    :type max_results: string
+    :type max_results: str
     :param selected_fields: List of fields to return (comma-separated). If
         unspecified, all fields are returned.
-    :type selected_fields: string
+    :type selected_fields: str
     :param gcp_conn_id: reference to a specific GCP hook.
-    :type gcp_conn_id: string
+    :type gcp_conn_id: str
     :param delegate_to: The account to impersonate, if any.
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
-    :type delegate_to: string
+    :type delegate_to: str
     :param mysql_conn_id: reference to a specific mysql hook
-    :type mysql_conn_id: string
+    :type mysql_conn_id: str
     :param database: name of database which overwrite defined one in connection
-    :type database: string
+    :type database: str
     :param replace: Whether to replace instead of insert
     :type replace: bool
     :param batch_size: The number of rows to take in each batch

--- a/airflow/contrib/operators/s3_to_sftp_operator.py
+++ b/airflow/contrib/operators/s3_to_sftp_operator.py
@@ -31,19 +31,19 @@ class S3ToSFTPOperator(BaseOperator):
 
     :param sftp_conn_id: The sftp connection id. The name or identifier for
         establishing a connection to the SFTP server.
-    :type sftp_conn_id: string
+    :type sftp_conn_id: str
     :param sftp_path: The sftp remote path. This is the specified file path for
         uploading file to the SFTP server.
-    :type sftp_path: string
+    :type sftp_path: str
     :param s3_conn_id: The s3 connection id. The name or identifier for
         establishing a connection to S3
-    :type s3_conn_id: string
+    :type s3_conn_id: str
     :param s3_bucket: The targeted s3 bucket. This is the S3 bucket from
         where the file is downloaded.
-    :type s3_bucket: string
+    :type s3_bucket: str
     :param s3_key: The targeted s3 key. This is the specified file path for
         downloading the file from S3.
-    :type s3_key: string
+    :type s3_key: str
     """
 
     template_fields = ('s3_key', 'sftp_path')

--- a/airflow/contrib/operators/sagemaker_transform_operator.py
+++ b/airflow/contrib/operators/sagemaker_transform_operator.py
@@ -50,7 +50,7 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
 
     :type config: dict
     :param aws_conn_id: The AWS connection ID to use.
-    :type aws_conn_id: string
+    :type aws_conn_id: str
     :param wait_for_completion: Set to True to wait until the transform job finishes.
     :type wait_for_completion: bool
     :param check_interval: If wait is set to True, the time interval, in seconds,

--- a/airflow/contrib/operators/sftp_to_s3_operator.py
+++ b/airflow/contrib/operators/sftp_to_s3_operator.py
@@ -32,19 +32,19 @@ class SFTPToS3Operator(BaseOperator):
 
     :param sftp_conn_id: The sftp connection id. The name or identifier for
         establishing a connection to the SFTP server.
-    :type sftp_conn_id: string
+    :type sftp_conn_id: str
     :param sftp_path: The sftp remote path. This is the specified file path
         for downloading the file from the SFTP server.
-    :type sftp_path: string
+    :type sftp_path: str
     :param s3_conn_id: The s3 connection id. The name or identifier for
         establishing a connection to S3
-    :type s3_conn_id: string
+    :type s3_conn_id: str
     :param s3_bucket: The targeted s3 bucket. This is the S3 bucket to where
         the file is uploaded.
-    :type s3_bucket: string
+    :type s3_bucket: str
     :param s3_key: The targeted s3 key. This is the specified path for
         uploading the file to S3.
-    :type s3_key: string
+    :type s3_key: str
     """
 
     template_fields = ('s3_key', 'sftp_path')

--- a/airflow/contrib/operators/spark_submit_operator.py
+++ b/airflow/contrib/operators/spark_submit_operator.py
@@ -82,7 +82,7 @@ class SparkSubmitOperator(BaseOperator):
     :type verbose: bool
     :param spark_binary: The command to use for spark submit.
                          Some distros may use spark2-submit.
-    :type spark_binary: string
+    :type spark_binary: str
     """
     template_fields = ('_application', '_conf', '_files', '_py_files', '_jars', '_driver_class_path',
                        '_packages', '_exclude_packages', '_keytab', '_principal', '_name',

--- a/airflow/contrib/sensors/sagemaker_transform_sensor.py
+++ b/airflow/contrib/sensors/sagemaker_transform_sensor.py
@@ -29,7 +29,7 @@ class SageMakerTransformSensor(SageMakerBaseSensor):
     containing the failure reason.
 
     :param job_name: job_name of the transform job instance to check the state of
-    :type job_name: string
+    :type job_name: str
     """
 
     template_fields = ['job_name']

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -496,7 +496,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         as only / refresh button or cli.sync_perm will call this function
 
         :param dag_id: the ID of the DAG whose permissions should be updated
-        :type dag_id: string
+        :type dag_id: str
         :param access_control: a dict where each key is a rolename and
             each value is a set() of permission names (e.g.,
             {'can_dag_read'}
@@ -515,7 +515,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         """Set the access policy on the given DAG's ViewModel.
 
         :param dag_id: the ID of the DAG whose permissions should be updated
-        :type dag_id: string
+        :type dag_id: str
         :param access_control: a dict where each key is a rolename and
             each value is a set() of permission names (e.g.,
             {'can_dag_read'}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
