### PR TITLE
[AIRFLOW-5138] Don't override user's warning settings in airflow.configuration

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -36,12 +36,6 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 log = LoggingMixin().log
 
-# show Airflow's deprecation warnings
-warnings.filterwarnings(
-    action='default', category=DeprecationWarning, module='airflow')
-warnings.filterwarnings(
-    action='default', category=PendingDeprecationWarning, module='airflow')
-
 
 def generate_fernet_key():
     try:


### PR DESCRIPTION
### Jira

Partly addresses https://issues.apache.org/jira/browse/AIRFLOW-5138 by allowing users to silence the spurious warnings.

It's very uncommon for Python libraries to override warning settings in this way. By doing so, tools like pytest filterwarnings or even `python -W` won't suppress the warnings, which means the warnings just become background noise, rather than a meaningful message from one person to another.

### Tests

My PR doesn't need automated tests because it's reverting warnings behaviour to the Python default, which is fine for practically everyone else.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

None required. No behaviour changes.

### Code Quality

- [x] Passes `flake8` — your CI doesn't catch this?!
