### PR TITLE
[AIRFLOW-5100] Use safe_mode configuration setting by default

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -288,7 +288,7 @@ def correct_maybe_zipped(fileloc):
 COMMENT_PATTERN = re.compile(r"\s*#.*")
 
 
-def list_py_file_paths(directory, safe_mode=None,
+def list_py_file_paths(directory, safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE', fallback=True),
                        include_examples=None):
     """
     Traverse a directory and look for Python files.
@@ -297,12 +297,11 @@ def list_py_file_paths(directory, safe_mode=None,
     :type directory: unicode
     :param safe_mode: whether to use a heuristic to determine whether a file
         contains Airflow DAG definitions. If not provided, use the
-        core.DAG_DISCOVERY_SAFE_MODE configuration setting.
+        core.DAG_DISCOVERY_SAFE_MODE configuration setting. If not set, default
+        to safe.
     :return: a list of paths to Python files in the specified directory
     :rtype: list[unicode]
     """
-    if safe_mode is None:
-        safe_mode = conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE')
     if include_examples is None:
         include_examples = conf.getboolean('core', 'LOAD_EXAMPLES')
     file_paths = []

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -288,7 +288,7 @@ def correct_maybe_zipped(fileloc):
 COMMENT_PATTERN = re.compile(r"\s*#.*")
 
 
-def list_py_file_paths(directory, safe_mode=True,
+def list_py_file_paths(directory, safe_mode=None,
                        include_examples=None):
     """
     Traverse a directory and look for Python files.
@@ -296,10 +296,13 @@ def list_py_file_paths(directory, safe_mode=True,
     :param directory: the directory to traverse
     :type directory: unicode
     :param safe_mode: whether to use a heuristic to determine whether a file
-        contains Airflow DAG definitions
+        contains Airflow DAG definitions. If not provided, use the
+        core.DAG_DISCOVERY_SAFE_MODE configuration setting.
     :return: a list of paths to Python files in the specified directory
     :rtype: list[unicode]
     """
+    if safe_mode is None:
+        safe_mode = conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE')
     if include_examples is None:
         include_examples = conf.getboolean('core', 'LOAD_EXAMPLES')
     file_paths = []


### PR DESCRIPTION
The scheduler calls `list_py_file_paths` to find DAGs to schedule. It does so
without passing any parameters other than the directory. This means that
it *won't* discover DAGs that are missing the words "airflow" and "DAG" even
if DAG_DISCOVERY_SAFE_MODE is disabled.

Since `list_py_file_paths` will refer to the configuration if
`include_examples` is not provided, it makes sense to have the same behaviour
for `safe_mode`.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"

### Description

See above. There are no UI changes.

### Tests

I stared at the code a long time and couldn't figure out a good place to test.

- `list_py_file_paths` doesn't have direct tests
  - adding a test for this particular branch might be OK, but feels a bit like a [change detector test](https://testing.googleblog.com/2015/01/testing-on-toilet-change-detector-tests.html)
  - If you can point me to a context manager to temporarily override a configuration setting, I could probably write some direct tests that use `tests/dags/` as the source of DAGs
- `SchedulerJob` is actually exhibiting the bug, and is where the behaviour needs to be correct
  - There's no obvious API to exercise that would let me test this
  - I could theoretically extract a `_make_processor_agent` from `_execute`, and assert things about its return value, but I don't want spend time on that without a core contributor approving it first
  - I would still need a context manager to temporarily override configuration settings 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
