### PR TITLE
[AIRFLOW-5142] Fixed flaky cassandra test

### DIFF
--- a/tests/contrib/operators/test_cassandra_to_gcs_operator.py
+++ b/tests/contrib/operators/test_cassandra_to_gcs_operator.py
@@ -19,6 +19,8 @@
 
 import unittest
 from unittest import mock
+from mock import call
+
 from airflow.contrib.operators.cassandra_to_gcs import (
     CassandraToGoogleCloudStorageOperator,
 )
@@ -49,9 +51,10 @@ class CassandraToGCSTest(unittest.TestCase):
         )
         operator.execute(None)
         mock_hook.return_value.get_conn.assert_called_once_with()
-        mock_upload.assert_called_with(
-            test_bucket, schema, TMP_FILE_NAME, "application/json", gzip
-        )
+
+        call_schema = call(test_bucket, schema, TMP_FILE_NAME, "application/json", gzip)
+        call_data = call(test_bucket, filename, TMP_FILE_NAME, "application/json", gzip)
+        mock_upload.assert_has_calls([call_schema, call_data], any_order=True)
 
     def test_convert_value(self):
         op = CassandraToGoogleCloudStorageOperator


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5142

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
