### PR TITLE
[AIRFLOW-5145] take false is_encrypted choice away from user

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2198,7 +2198,7 @@ class VariableModelView(AirflowModelView):
     base_permissions = ['can_add', 'can_list', 'can_edit', 'can_delete', 'can_varimport']
 
     list_columns = ['key', 'val', 'is_encrypted']
-    add_columns = ['key', 'val', 'is_encrypted']
+    add_columns = ['key', 'val']
     edit_columns = ['key', 'val']
     search_columns = ['key', 'val']
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5145
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Don't display the *Is Encrypted* checkbox in the Variable add UI; the user's decision (explicit or implicit) here can incorrectly override the correct setting of this value when the model is saved.

In other words, this attempts to prevent this scenario from occurring
when the airflow instance has a fernet key set up and user forgets or decides not to check **Is Encrypted**:

* Database value is ciphertext, while is_encrypted is false.
* Variable.get does not attempt to decrypt the ciphertext and therefore does not return the correct value.
* Instead, the ciphertext, which looks like `gAAAAABdS1d_Mw<SNIP>D-O9SIg==`, is treated as the actual value ... so json deserialization and any other intended usage of the value fails.

**UI Changes**:

Is Encrypted checkbox is removed from the variable create screen.

Current `/variable/add` in my local 1.10.3 instance:

<img width="369" alt="current-with-is-enc-cb" src="https://user-images.githubusercontent.com/617540/62714062-71c4e080-b9c3-11e9-8562-84c20742c10a.png">

After change in that instance:

<img width="331" alt="no-is-encrypted-cb" src="https://user-images.githubusercontent.com/617540/62714074-7b4e4880-b9c3-11e9-9319-deeabf640ede.png">


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

* No tests added yet as this is a minor config change ... but I'm new to this to so willing to stand corrected :)

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
