### PR TITLE
[AIRFLOW-4412] PodLauncher drops log lines printed by the pod

### DIFF
--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -103,6 +103,10 @@ class PodLauncher(LoggingMixin):
         if get_logs:
             logs = self.read_pod_logs(pod)
             for line in logs:
+                try:
+                    line = line.decode('utf-8').rstrip()
+                except:
+                    pass
                 self.log.info(line)
         result = None
         if self.extract_xcom:
@@ -151,7 +155,6 @@ class PodLauncher(LoggingMixin):
                 namespace=pod.namespace,
                 container='base',
                 follow=True,
-                tail_lines=10,
                 _preload_content=False
             )
         except BaseHTTPError as e:

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -105,7 +105,7 @@ class PodLauncher(LoggingMixin):
             for line in logs:
                 try:
                     line = line.decode('utf-8').rstrip()
-                except:
+                except Exception:
                     pass
                 self.log.info(line)
         result = None

--- a/tests/kubernetes/test_pod_launcher.py
+++ b/tests/kubernetes/test_pod_launcher.py
@@ -48,16 +48,14 @@ class TestPodLauncher(unittest.TestCase):
                 container='base',
                 follow=True,
                 name=mock.sentinel.name,
-                namespace=mock.sentinel.namespace,
-                tail_lines=10
+                namespace=mock.sentinel.namespace
             ),
             mock.call(
                 _preload_content=False,
                 container='base',
                 follow=True,
                 name=mock.sentinel.name,
-                namespace=mock.sentinel.namespace,
-                tail_lines=10
+                namespace=mock.sentinel.namespace
             )
         ])
 

--- a/tests/minikube/test_kubernetes_pod_operator.py
+++ b/tests/minikube/test_kubernetes_pod_operator.py
@@ -266,7 +266,7 @@ class KubernetesPodOperatorTest(unittest.TestCase):
                 get_logs=True
             )
             k.execute(None)
-            mock_logger.info.assert_any_call(b"+ echo 10\n")
+            mock_logger.info.assert_any_call(b"+ echo 10")
 
     @staticmethod
     def test_port():
@@ -311,7 +311,7 @@ class KubernetesPodOperatorTest(unittest.TestCase):
                 task_id="task"
             )
             k.execute(None)
-            mock_logger.info.assert_any_call(b"retrieved from mount\n")
+            mock_logger.info.assert_any_call(b"retrieved from mount")
 
     @staticmethod
     def test_run_as_user_root():


### PR DESCRIPTION
### Jira

https://issues.apache.org/jira/browse/AIRFLOW-4412

### Description

- tails entire log instead of just last 10 lines
- right-trims all the log lines read from kubernetes to remove annoying '\n' character
