### PR TITLE
[AIRFLOW-YYY] Mock connection in GCP's tests

### DIFF
--- a/tests/contrib/hooks/test_gcp_compute_hook.py
+++ b/tests/contrib/hooks/test_gcp_compute_hook.py
@@ -18,11 +18,9 @@
 # under the License.
 
 # pylint: disable=too-many-lines
-
 import unittest
 
-from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id, \
-    mock_base_gcp_hook_default_project_id, GCP_PROJECT_ID_HOOK_UNIT_TEST
+from tests.contrib.utils.base_gcp_mock import GCP_PROJECT_ID_HOOK_UNIT_TEST
 from tests.compat import mock
 
 from airflow import AirflowException
@@ -38,9 +36,17 @@ GCE_INSTANCE_GROUP_MANAGER = 'instance_group_manager'
 class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
 
     def setUp(self):
-        with mock.patch('airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
-                        new=mock_base_gcp_hook_no_default_project_id):
-            self.gce_hook_no_project_id = GceHook(gcp_conn_id='test')
+        self.patcher_get_connections = mock.patch(
+            "airflow.hooks.base_hook.BaseHook.get_connections",
+            return_value=[
+
+            ]
+        )
+        self.patcher_get_connections.start()
+        self.gce_hook_no_project_id = GceHook(gcp_conn_id='test')
+
+    def tearDown(self) -> None:
+        self.patcher_get_connections.stop()
 
     @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook.get_conn')
     @mock.patch('airflow.contrib.hooks.gcp_compute_hook.GceHook._wait_for_operation_to_complete')

--- a/tests/contrib/utils/base_gcp_mock.py
+++ b/tests/contrib/utils/base_gcp_mock.py
@@ -16,25 +16,23 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import json
 from unittest import mock
+
+from airflow.models import Connection
 
 GCP_PROJECT_ID_HOOK_UNIT_TEST = 'example-project'
 
 
-def mock_base_gcp_hook_default_project_id(self, gcp_conn_id, delegate_to=None):
-    self.extras = {
+GCP_CONNECTION_WITH_PROJECT_ID = Connection(
+    extra=json.dumps({
         'extra__google_cloud_platform__project': GCP_PROJECT_ID_HOOK_UNIT_TEST
-    }
-    self._conn = gcp_conn_id
-    self.delegate_to = delegate_to
+    })
+)
 
-
-def mock_base_gcp_hook_no_default_project_id(self, gcp_conn_id, delegate_to=None):
-    self.extras = {
-    }
-    self._conn = gcp_conn_id
-    self.delegate_to = delegate_to
+GCP_CONNECTION_WITHOUT_PROJECT_ID = Connection(
+    extra=json.dumps({})
+)
 
 
 def get_open_mock():


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
