### PR TITLE
[AIRFLOW-5169] Pass Project ID explicitly to StorageClient in GCS Hook

### DIFF
--- a/airflow/contrib/hooks/gcs_hook.py
+++ b/airflow/contrib/hooks/gcs_hook.py
@@ -51,7 +51,9 @@ class GoogleCloudStorageHook(GoogleCloudBaseHook):
         Returns a Google Cloud Storage service object.
         """
         if not self._conn:
-            self._conn = storage.Client(credentials=self._get_credentials(), client_info=self.client_info)
+            self._conn = storage.Client(credentials=self._get_credentials(),
+                                        client_info=self.client_info,
+                                        project=self.project_id)
 
         return self._conn
 


### PR DESCRIPTION
…Hook

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5169

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

If Project_id is not passed to the StorageClient it tries to infer the Project_ID from the environment variables or Cloud SDK.

If neither env variables is set nor Cloud SDK is configured it will error with the following message:

```
google.auth.exceptions.DefaultCredentialsError: Could not automatically determine credentials. Please set GOOGLE_APPLICATION_CREDENTIALS or explicitly create credentials and re-run the application. For more information, please see https://cloud.google.com/docs/authentication/getting-started
```

### Tests

- [] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
I need some help on adding a test to check that project_id exists when storage client is created @mik-laj 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
