### PR TITLE
[AIRFLOW-5172] Add choice of interval edge scheduling

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -523,6 +523,10 @@ scheduler_zombie_task_threshold = 300
 # DAG definition (catchup)
 catchup_by_default = True
 
+# Should DAGs be scheduled to execute at the 'start' or 'end'
+# of their schedule interval.
+schedule_at_interval_end = True
+
 # This changes the batch size of queries in the scheduling main loop.
 # If this is too high, SQL query performance may be impacted by one
 # or more of the following:

--- a/airflow/sensors/time_delta_sensor.py
+++ b/airflow/sensors/time_delta_sensor.py
@@ -24,7 +24,8 @@ from airflow.utils.decorators import apply_defaults
 
 class TimeDeltaSensor(BaseSensorOperator):
     """
-    Waits for a timedelta after the task's execution_date + schedule_interval.
+    Waits for a timedelta after the task's execution_date + schedule_interval
+    (if schedule_at_interval_end is True, otherwise just execution_date).
     In Airflow, the daily task stamped with ``execution_date``
     2016-01-01 can only start running on 2016-01-02. The timedelta here
     represents the time after the execution period has closed.
@@ -40,7 +41,7 @@ class TimeDeltaSensor(BaseSensorOperator):
 
     def poke(self, context):
         dag = context['dag']
-        target_dttm = dag.following_schedule(context['execution_date'])
+        target_dttm = dag.period_end(context['execution_date'])
         target_dttm += self.delta
         self.log.info('Checking if the time (%s) has come', target_dttm)
         return timezone.utcnow() > target_dttm

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -890,3 +890,11 @@ class TestDag(unittest.TestCase):
             self.assertIn('t1', stdout_lines[0])
             self.assertIn('t2', stdout_lines[1])
             self.assertIn('t3', stdout_lines[2])
+
+    def test_period_end(self):
+        """Verify period_end calculation."""
+        from datetime import timedelta
+        with DAG("test_dag", start_date=DEFAULT_DATE, schedule_at_interval_end=True) as dag:
+            self.assertEqual(dag.period_end(DEFAULT_DATE), DEFAULT_DATE + timedelta(days=1))
+        with DAG("test_dag", start_date=DEFAULT_DATE, schedule_at_interval_end=False) as dag:
+            self.assertEqual(dag.period_end(DEFAULT_DATE), DEFAULT_DATE)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5172

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes:

This change introduces the attribute `schedule_interval_edge`, a string containing either 'start' or 'end', to DAGs. The scheduler uses the value to determining if a DAG should be scheduled at the start or the end of the schedule interval.

A parameter with the same name was also added to the default_airflow.cfg in the [scheduler] section. 

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

tests.jobs.test_scheduler_job:SchedulerJobTest.test_schedule_interval_edge

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
