### PR TITLE
[AIRFLOW-5208] Passed **kwargs to push_by_returning

### DIFF
--- a/airflow/example_dags/example_xcom.py
+++ b/airflow/example_dags/example_xcom.py
@@ -40,7 +40,7 @@ def push(**kwargs):
     kwargs['ti'].xcom_push(key='value from pusher 1', value=value_1)
 
 
-def push_by_returning():
+def push_by_returning(**kwargs):
     """Pushes an XCom without a specific target, just by returning it"""
     return value_2
 


### PR DESCRIPTION
Without **kwargs push_by_returning was giving error, so added that parameter.

![Screen Shot 2019-08-13 at 11 20 14 AM](https://user-images.githubusercontent.com/10989521/62966801-a5857900-bdbc-11e9-9319-ca610e826922.png)

