### PR TITLE
[AIRFLOW-4449] updated default permission for custom roles to 'Viewer'

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -65,6 +65,7 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
     app.config['SESSION_COOKIE_HTTPONLY'] = True
     app.config['SESSION_COOKIE_SECURE'] = conf.getboolean('webserver', 'COOKIE_SECURE')
     app.config['SESSION_COOKIE_SAMESITE'] = conf.get('webserver', 'COOKIE_SAMESITE')
+    app.config['BASE_ROLE'] = conf.get('webserver', 'BASE_ROLE', default='Viewer')
 
     if config:
         app.config.from_mapping(config)

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -65,7 +65,7 @@ def create_app(config=None, session=None, testing=False, app_name="Airflow"):
     app.config['SESSION_COOKIE_HTTPONLY'] = True
     app.config['SESSION_COOKIE_SECURE'] = conf.getboolean('webserver', 'COOKIE_SECURE')
     app.config['SESSION_COOKIE_SAMESITE'] = conf.get('webserver', 'COOKIE_SAMESITE')
-    app.config['BASE_ROLE'] = conf.get('webserver', 'BASE_ROLE', default='Viewer')
+    app.config['BASE_ROLE'] = conf.get('webserver', 'BASE_ROLE', fallback='Viewer')
 
     if config:
         app.config.from_mapping(config)

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -412,10 +412,11 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
             for perm in self.DAG_PERMS:
                 merge_pv(perm, dag.dag_id)
 
-        # for all the dag-level role, add the permission of viewer
+        # for all the dag-level role, add the permission of the configurable BASE_ROLE
         # with the dag view to ab_permission_view
         all_roles = self.get_all_roles()
-        viewer_role = self.find_role('Viewer')
+        base_role_name = appbuilder.config.get('BASE_ROLE')
+        base_role = self.find_role(base_role_name)
 
         dag_role = [role for role in all_roles if role.name not in EXISTING_ROLES]
         update_perm_views = []
@@ -429,7 +430,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         all_perm_view_by_user = session.query(ab_perm_view_role)\
             .join(perm_view, perm_view.id == ab_perm_view_role
                   .columns.permission_view_id)\
-            .filter(ab_perm_view_role.columns.role_id == viewer_role.id)\
+            .filter(ab_perm_view_role.columns.role_id == base_role.id)\
             .join(view_menu)\
             .filter(perm_view.view_menu_id != dag_vm.id)
         all_perm_views = {role.permission_view_id for role in all_perm_view_by_user}

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -415,7 +415,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         # for all the dag-level role, add the permission of viewer
         # with the dag view to ab_permission_view
         all_roles = self.get_all_roles()
-        user_role = self.find_role('User')
+        viewer_role = self.find_role('Viewer')
 
         dag_role = [role for role in all_roles if role.name not in EXISTING_ROLES]
         update_perm_views = []
@@ -429,7 +429,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         all_perm_view_by_user = session.query(ab_perm_view_role)\
             .join(perm_view, perm_view.id == ab_perm_view_role
                   .columns.permission_view_id)\
-            .filter(ab_perm_view_role.columns.role_id == user_role.id)\
+            .filter(ab_perm_view_role.columns.role_id == viewer_role.id)\
             .join(view_menu)\
             .filter(perm_view.view_menu_id != dag_vm.id)
         all_perm_views = {role.permission_view_id for role in all_perm_view_by_user}

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -27,7 +27,7 @@ from airflow import models
 from airflow.exceptions import AirflowException
 from airflow.utils.db import provide_session
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.www.app import appbuilder
+from airflow.www.app import app, appbuilder
 
 EXISTING_ROLES = {
     'Admin',
@@ -415,7 +415,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         # for all the dag-level role, add the permission of the configurable BASE_ROLE
         # with the dag view to ab_permission_view
         all_roles = self.get_all_roles()
-        base_role_name = appbuilder.config.get('BASE_ROLE')
+        base_role_name = app.config.get('BASE_ROLE')
         base_role = self.find_role(base_role_name)
 
         dag_role = [role for role in all_roles if role.name not in EXISTING_ROLES]


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
- https://issues.apache.org/jira/browse/AIRFLOW-4449

### Description


- [x] Here are some details about my PR, including screenshots of any UI changes:

Previously, it was impossible to create a custom role with permissions
less than viewer. This was suboptimal if, for example, we wanted to
create a user without the `set_success` permission

This also makes the behavior of the mode match the associated comment.\

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: it's a pretty trivial change and is already covered by `test_init_role_baseview`

![manually tested that the web interface behaved as expected](https://user-images.githubusercontent.com/3322724/62976495-b8af3d80-bdea-11e9-836e-8ffdf548274a.png)

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
