### PR TITLE
[AIRFLOW-4526] KubernetesPodOperator gets stuck in Running state when get_logs is set to True and there is a long gap without logs from pod

### DIFF
--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -54,6 +54,12 @@ class KubernetesPodOperator(BaseOperator):
     :type labels: dict
     :param startup_timeout_seconds: timeout in seconds to startup the pod
     :type startup_timeout_seconds: int
+    :param logs_connection_timeout_seconds: timeout in seconds for the connection
+                                            to the k8s logs API endpoint. If one
+                                            number provided, it will be total request
+                                            timeout. It can also be a pair (tuple)
+                                            of (connection, read) timeouts.
+    :type logs_connection_timeout_seconds: int or tuple(int, int)
     :param name: name of the task you want to run,
         will be used to generate a pod id
     :type name: str
@@ -150,6 +156,7 @@ class KubernetesPodOperator(BaseOperator):
                 (final_state, result) = launcher.run_pod(
                     pod,
                     startup_timeout=self.startup_timeout_seconds,
+                    logs_connection_timeout=self.logs_connection_timeout_seconds,
                     get_logs=self.get_logs)
             finally:
                 if self.is_delete_operator_pod:
@@ -187,6 +194,7 @@ class KubernetesPodOperator(BaseOperator):
                  cluster_context=None,
                  labels=None,
                  startup_timeout_seconds=120,
+                 logs_connection_timeout_seconds=600,
                  get_logs=True,
                  image_pull_policy='IfNotPresent',
                  annotations=None,
@@ -213,6 +221,7 @@ class KubernetesPodOperator(BaseOperator):
         self.arguments = arguments or []
         self.labels = labels or {}
         self.startup_timeout_seconds = startup_timeout_seconds
+        self.logs_connection_timeout_seconds = logs_connection_timeout_seconds
         self.name = name
         self.env_vars = env_vars or {}
         self.ports = ports or []

--- a/tests/kubernetes/test_pod_launcher.py
+++ b/tests/kubernetes/test_pod_launcher.py
@@ -45,6 +45,7 @@ class TestPodLauncher(unittest.TestCase):
         self.mock_kube_client.read_namespaced_pod_log.assert_has_calls([
             mock.call(
                 _preload_content=False,
+                _request_timeout=600,
                 container='base',
                 follow=True,
                 name=mock.sentinel.name,
@@ -53,6 +54,7 @@ class TestPodLauncher(unittest.TestCase):
             ),
             mock.call(
                 _preload_content=False,
+                _request_timeout=600,
                 container='base',
                 follow=True,
                 name=mock.sentinel.name,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-4526) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-4526

### Description

- I delved through the airflow/k8s python code, and it looks as if we can alleviate the above referenced JIRA issue by adding the ability for users to supply a timeout for the connection to the logs of the image running in the KubernetesPodOperator. From what I can glean of the codebase, the `pod_launcher` calls [`read_namespaced_pod_log`](https://github.com/apache/airflow/blob/5899cec01e0ea69a54e650a9e1abdbcd5370e120/airflow/kubernetes/pod_launcher.py#L149), which then calls the k8s API via a `GET` request to `/api/v1/namespaces/{namespace}/pods/{name}/log`. This `GET` request is fulfilled by the API client through a [`request`](https://github.com/kubernetes-client/python/blob/master/kubernetes/client/api_client.py#L354). Every request has the option to provide several options, one of which is `_preload_content`, which is used in Airflow currently another of which is `_request_timeout`, which this PR uses. This `_request_timeout` is fulfilled by the `RESTClientObject` which is implemented [here](https://github.com/kubernetes-client/python/blob/master/kubernetes/client/rest.py#L57). Within the REST client, the `_request_timeout` is taken care of [here](https://github.com/kubernetes-client/python/blob/master/kubernetes/client/rest.py#L142) by `urllib3` using a [`Timeout`](https://urllib3.readthedocs.io/en/latest/user-guide.html#using-timeouts). 

- A `urllib3` Timeout allows you to "to control how long (in seconds) requests are allowed to run before being aborted." This means that when logs are not received within 10 minutes, this call will properly be aborted and the retry logic recently implemented in [PR-5284](https://github.com/apache/airflow/pull/5284) will then kick in. After three retries, as far as I can tell, the pod operator task would then be marked as a failure.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: this is an extremely hard to reproduce failure case...we have been unable to reproduce it in a reliable manner during testing, but it does occur on long running tasks (> 1hr). Any task that runs for a long period of time and has connection issues is not easy to test. 

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
