### PR TITLE
[AIRFLOW-5209] Bump Sphinx version to fix doc build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ doc = [
     'sphinx-argparse>=0.1.13',
     'sphinx-autoapi==1.0.0',
     'sphinx-rtd-theme>=0.1.6',
-    'sphinx>=1.2.3',
+    'sphinx>=2.1.2',
     'sphinxcontrib-httpdomain>=1.7.0',
 ]
 docker = ['docker~=3.0']


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following Airflow Jira issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5209
 
### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Currently, if you try to build on master or 1.10.4 it fails with the following error:

```
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/docutils/statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 2753, in underline
    self.section(title, source, style, lineno - 1, messages)
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 327, in section
    self.new_subsection(title, lineno, messages)
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 395, in new_subsection
    node=section_node, match_titles=True)
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 282, in nested_parse
    node=node, match_titles=match_titles)
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 196, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/docutils/statemachine.py", line 239, in run
    context, state, transitions)
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/docutils/statemachine.py", line 460, in check_line
    return method(match, context, next_state)
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 2326, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 2338, in explicit_construct
    return method(self, expmatch)
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 2081, in directive
    directive_class, match, type_name, option_presets)
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 2130, in run_directive
    result = directive_instance.run()
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/sphinx/ext/autodoc/directive.py", line 121, in run
    documenter_options = process_documenter_options(doccls, self.config, self.options)
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/sphinx/ext/autodoc/directive.py", line 73, in process_documenter_options
    return Options(assemble_option_dict(options.items(), documenter.option_spec))
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/docutils/utils/__init__.py", line 328, in assemble_option_dict
    options[name] = convertor(value)
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/sphinx/ext/autodoc/__init__.py", line 82, in members_option
    return [x.strip() for x in arg.split(',')]
AttributeError: 'bool' object has no attribute 'split'

Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/airflow/envs/latest/lib/python3.7/site-packages/sphinx/ext/autodoc/__init__.py", line 82, in members_option
    return [x.strip() for x in arg.split(',')]
AttributeError: 'bool' object has no attribute 'split'
```

Our doc build on RTD also fails with the same error: https://readthedocs.org/projects/airflow/builds/9511663/

This is caused where the version of Sphinx < 2

Using the latest Sphinx version solves this for us.


Issue causing this: https://github.com/sphinx-doc/sphinx/issues/5459
Solved by https://github.com/sphinx-doc/sphinx/pull/6053/files

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
N/a

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality
- [x] Passes `flake8`
