### PR TITLE
[AIRFLOW-5210] Make finding template files more efficient

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -717,26 +717,27 @@ class BaseOperator(LoggingMixin):
 
     def resolve_template_files(self):
         # Getting the content of files for template_field / template_ext
-        for attr in self.template_fields:
-            content = getattr(self, attr, None)
-            if content is None:
-                continue
-            elif isinstance(content, str) and \
-                    any([content.endswith(ext) for ext in self.template_ext]):
-                env = self.get_template_env()
-                try:
-                    setattr(self, attr, env.loader.get_source(env, content)[0])
-                except Exception as e:
-                    self.log.exception(e)
-            elif isinstance(content, list):
-                env = self.dag.get_template_env()
-                for i in range(len(content)):
-                    if isinstance(content[i], str) and \
-                            any([content[i].endswith(ext) for ext in self.template_ext]):
-                        try:
-                            content[i] = env.loader.get_source(env, content[i])[0]
-                        except Exception as e:
-                            self.log.exception(e)
+        if self.template_ext:
+            for attr in self.template_fields:
+                content = getattr(self, attr, None)
+                if content is None:
+                    continue
+                elif isinstance(content, str) and \
+                        any([content.endswith(ext) for ext in self.template_ext]):
+                    env = self.get_template_env()
+                    try:
+                        setattr(self, attr, env.loader.get_source(env, content)[0])
+                    except Exception as e:
+                        self.log.exception(e)
+                elif isinstance(content, list):
+                    env = self.dag.get_template_env()
+                    for i in range(len(content)):
+                        if isinstance(content[i], str) and \
+                                any([content[i].endswith(ext) for ext in self.template_ext]):
+                            try:
+                                content[i] = env.loader.get_source(env, content[i])[0]
+                            except Exception as e:
+                                self.log.exception(e)
         self.prepare_template()
 
     @property


### PR DESCRIPTION

### Jira

https://issues.apache.org/jira/browse/AIRFLOW-5210

### Description

For large DAGs (1000s of tasks) iterating over template_fields adds significant time to task execution and is not necessary for tasks that do not specify template_ext 

### Tests

I can add tests if you think necessary, but this is a _very_ simple change 

### Code Quality

- [ ] Passes `flake8`
