### PR TITLE
[AIRFLOW-5147] extended character set for for k8s worker pods annotations

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -40,6 +40,24 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Changes to propagating Kubernetes worker annotations
+
+`kubernetes_annotations` configuration section has been removed. 
+A new key `worker_annotations` has been added to existing `kubernetes` section instead. 
+That is to remove restriction on the character set for k8s annotation keys.
+All key/value pairs from `kubernetes_annotations` should now go to `worker_annotations` as a json. I.e. instead of e.g.
+```
+[kubernetes_annotations]
+annotation_key = annotation_value
+annotation_key2 = annotation_value2
+```
+it should be rewritten to
+```
+[kubernetes]
+worker_annotations = { "annotation_key" : "annotation_value", "annotation_key2" : "annotation_value2" }
+```
+
+
 ### Changes to import paths and names of GCP operators and hooks
 
 According to [AIP-21](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21%3A+Changes+in+import+paths) 

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -767,13 +767,15 @@ run_as_user =
 # that allows for the key to be read, e.g. 65533
 fs_group =
 
+# Annotations configuration as a single line formatted JSON object.
+# See the naming convention in:
+#   https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+worker_annotations =
+
+
 [kubernetes_node_selectors]
 # The Key-value pairs to be given to worker pods.
 # The worker pods will be scheduled to the nodes of the specified key-value pairs.
-# Should be supplied in the format: key = value
-
-[kubernetes_annotations]
-# The Key-value annotations pairs to be given to worker pods.
 # Should be supplied in the format: key = value
 
 [kubernetes_environment_variables]

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -51,7 +51,7 @@ class KubeConfig:  # pylint: disable=too-many-instance-attributes
     core_section = 'core'
     kubernetes_section = 'kubernetes'
 
-    def __init__(self):
+    def __init__(self):  # pylint: disable=too-many-statements
         configuration_dict = conf.as_dict(display_sensitive=True)
         self.core_configuration = configuration_dict['core']
         self.kube_secrets = configuration_dict.get('kubernetes_secrets', {})

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -73,7 +73,13 @@ class KubeConfig:  # pylint: disable=too-many-instance-attributes
             self.kubernetes_section, "worker_container_image_pull_policy"
         )
         self.kube_node_selectors = configuration_dict.get('kubernetes_node_selectors', {})
-        self.kube_annotations = configuration_dict.get('kubernetes_annotations', {})
+
+        kube_worker_annotations = conf.get(self.kubernetes_section, 'worker_annotations')
+        if kube_worker_annotations:
+            self.kube_annotations = json.loads(kube_worker_annotations)
+        else:
+            self.kube_annotations = None
+
         self.kube_labels = configuration_dict.get('kubernetes_labels', {})
         self.delete_worker_pods = conf.getboolean(
             self.kubernetes_section, 'delete_worker_pods')

--- a/scripts/ci/kubernetes/kube/templates/configmaps.template.yaml
+++ b/scripts/ci/kubernetes/kube/templates/configmaps.template.yaml
@@ -183,6 +183,9 @@ data:
     affinity = {"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"NotIn","values":["4e5e6a99-e28a-450b-bba9-e0124853de9b"]}]}]}}}
     tolerations = [{ "key": "dedicated", "operator": "Equal", "value": "airflow", "effect": "NoSchedule" }, { "key": "prod", "operator": "Exists" }]
 
+    # Example kubertenes worker pods annotations declaration.
+    worker_annotations = { "iam.amazonaws.com/role" : "role-arn", "iam.amazonaws.com/external-id" : "external-id" }
+
     # For cloning DAGs from git repositories into volumes: https://github.com/kubernetes/git-sync
     git_sync_container_repository = gcr.io/google-containers/git-sync-amd64
     git_sync_container_tag = v2.0.5
@@ -191,10 +194,6 @@ data:
     [kubernetes_node_selectors]
     # The Key-value pairs to be given to worker pods.
     # The worker pods will be scheduled to the nodes of the specified key-value pairs.
-    # Should be supplied in the format: key = value
-
-    [kubernetes_annotations]
-    # The Key-value annotations pairs to be given to worker pods.
     # Should be supplied in the format: key = value
 
     [kubernetes_secrets]

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -24,10 +24,12 @@ import random
 from urllib3 import HTTPResponse
 
 from tests.compat import mock
+from tests.test_utils.config import conf_vars
 try:
     from kubernetes.client.rest import ApiException
     from airflow.executors.kubernetes_executor import AirflowKubernetesScheduler
     from airflow.executors.kubernetes_executor import KubernetesExecutor
+    from airflow.executors.kubernetes_executor import KubeConfig
     from airflow.utils.state import State
 except ImportError:
     AirflowKubernetesScheduler = None  # type: ignore
@@ -109,6 +111,29 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
             serialized_datetime)
 
         self.assertEqual(datetime_obj, new_datetime_obj)
+
+
+class TestKubeConfig(unittest.TestCase):
+    def setUp(self):
+        if AirflowKubernetesScheduler is None:
+            self.skipTest("kubernetes python package is not installed")
+
+    @conf_vars({
+        ('kubernetes', 'git_ssh_known_hosts_configmap_name'): 'airflow-configmap',
+        ('kubernetes', 'git_ssh_key_secret_name'): 'airflow-secrets',
+        ('kubernetes', 'worker_annotations'): '{ "iam.com/role" : "role-arn", "other/annotation" : "value" }'
+    })
+    def test_kube_config_worker_annotations_properly_parsed(self):
+        annotations = KubeConfig().kube_annotations
+        self.assertEqual({'iam.com/role': 'role-arn', 'other/annotation': 'value'}, annotations)
+
+    @conf_vars({
+        ('kubernetes', 'git_ssh_known_hosts_configmap_name'): 'airflow-configmap',
+        ('kubernetes', 'git_ssh_key_secret_name'): 'airflow-secrets'
+    })
+    def test_kube_config_no_worker_annotations(self):
+        annotations = KubeConfig().kube_annotations
+        self.assertIsNone(annotations)
 
 
 class TestKubernetesExecutor(unittest.TestCase):

--- a/tests/kubernetes/test_worker_configuration.py
+++ b/tests/kubernetes/test_worker_configuration.py
@@ -71,6 +71,11 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
         }
     ]
 
+    worker_annotations_config = {
+        'iam.amazonaws.com/role': 'role-arn',
+        'other/annotation': 'value'
+    }
+
     def setUp(self):
         if AirflowKubernetesScheduler is None:
             self.skipTest("kubernetes python package is not installed")
@@ -425,6 +430,7 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
     def test_make_pod_with_empty_executor_config(self):
         self.kube_config.kube_affinity = self.affinity_config
         self.kube_config.kube_tolerations = self.tolerations_config
+        self.kube_config.kube_annotations = self.worker_annotations_config
         self.kube_config.dags_folder = 'dags'
         worker_config = WorkerConfiguration(self.kube_config)
 
@@ -441,6 +447,8 @@ class TestKubernetesWorkerConfiguration(unittest.TestCase):
 
         self.assertEqual(2, len(pod.spec.tolerations))
         self.assertEqual('prod', pod.spec.tolerations[1]['key'])
+        self.assertEqual('role-arn', pod.metadata.annotations['iam.amazonaws.com/role'])
+        self.assertEqual('value', pod.metadata.annotations['other/annotation'])
 
     def test_make_pod_with_executor_config(self):
         self.kube_config.dags_folder = 'dags'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-5147

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
This PR fixes the previous solution (https://github.com/apache/airflow/pull/4589) of providing k8s annotations to workers created by k8s executor. Previously each annotation key had to be declared as part of the airflow config key which implied having some limitations on it (like it could not contatin `/` character). 

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
 ```
executors.TestKubeConfig.test_kube_config_worker_annotations_properly_parsed
executors.TestKubeConfig.test_kube_config_no_worker_annotations
```
and updates
```
kubernetes.TestKubernetesWorkerConfiguration.test_make_pod_with_empty_executor_config
```

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
