### PR TITLE
[AIRFLOW-5118] Add ability to specify optional components in Dataproc…

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -121,6 +121,9 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
         config files (e.g. spark-defaults.conf), see
         https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#SoftwareConfig
     :type properties: dict
+    :param optionalComponents: List of optional cluster components, for more info see
+        https://cloud.google.com/dataproc/docs/reference/rest/v1/ClusterConfig#Component
+    :type optionalComponents: list[str]
     :param num_masters: The # of master nodes to spin up
     :type num_masters: int
     :param master_machine_type: Compute engine machine type to use for the master node
@@ -208,6 +211,7 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
                  image_version=None,
                  autoscaling_policy=None,
                  properties=None,
+                 optionalComponents=None,
                  num_masters=1,
                  master_machine_type='n1-standard-4',
                  master_disk_type='pd-standard',
@@ -240,6 +244,7 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
         self.custom_image_project_id = custom_image_project_id
         self.image_version = image_version
         self.properties = properties or dict()
+        self.optionalComponents = optionalComponents,
         self.master_machine_type = master_machine_type
         self.master_disk_type = master_disk_type
         self.master_disk_size = master_disk_size
@@ -416,6 +421,9 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
 
         if self.properties:
             cluster_data['config']['softwareConfig']['properties'] = self.properties
+
+        if self.optionalComponents:
+            cluster_data['config']['softwareConfig']['optionalComponents'] = self.optionalComponents
 
         cluster_data = self._build_lifecycle_config(cluster_data)
 

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -121,9 +121,9 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
         config files (e.g. spark-defaults.conf), see
         https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#SoftwareConfig
     :type properties: dict
-    :param optionalComponents: List of optional cluster components, for more info see
+    :param optional_components: List of optional cluster components, for more info see
         https://cloud.google.com/dataproc/docs/reference/rest/v1/ClusterConfig#Component
-    :type optionalComponents: list[str]
+    :type optional_components: list[str]
     :param num_masters: The # of master nodes to spin up
     :type num_masters: int
     :param master_machine_type: Compute engine machine type to use for the master node
@@ -211,7 +211,7 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
                  image_version=None,
                  autoscaling_policy=None,
                  properties=None,
-                 optionalComponents=None,
+                 optional_components=None,
                  num_masters=1,
                  master_machine_type='n1-standard-4',
                  master_disk_type='pd-standard',
@@ -244,7 +244,7 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
         self.custom_image_project_id = custom_image_project_id
         self.image_version = image_version
         self.properties = properties or dict()
-        self.optionalComponents = optionalComponents,
+        self.optional_components = optional_components
         self.master_machine_type = master_machine_type
         self.master_disk_type = master_disk_type
         self.master_disk_size = master_disk_size
@@ -422,8 +422,8 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
         if self.properties:
             cluster_data['config']['softwareConfig']['properties'] = self.properties
 
-        if self.optionalComponents:
-            cluster_data['config']['softwareConfig']['optionalComponents'] = self.optionalComponents
+        if self.optional_components:
+            cluster_data['config']['softwareConfig']['optionalComponents'] = self.optional_components
 
         cluster_data = self._build_lifecycle_config(cluster_data)
 

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -63,6 +63,7 @@ STORAGE_BUCKET = 'gs://airflow-test-bucket/'
 IMAGE_VERSION = '1.1'
 CUSTOM_IMAGE = 'test-custom-image'
 CUSTOM_IMAGE_PROJECT_ID = 'test-custom-image-project-id'
+OPTIONAL_COMPONENTS = ['COMPONENT1', 'COMPONENT2']
 MASTER_MACHINE_TYPE = 'n1-standard-2'
 MASTER_DISK_SIZE = 100
 MASTER_DISK_TYPE = 'pd-standard'
@@ -346,6 +347,16 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
                          expected_custom_image_url)
         self.assertEqual(cluster_data['config']['workerConfig']['imageUri'],
                          expected_custom_image_url)
+
+    def test_build_cluster_data_with_optional_components(self):
+        dataproc_operator = DataprocClusterCreateOperator(
+            task_id=TASK_ID,
+            cluster_name=CLUSTER_NAME,
+            project_id=GCP_PROJECT_ID,
+            optionalComponents=OPTIONAL_COMPONENTS,
+        )
+        cluster_data = dataproc_operator._build_cluster_data()
+        self.assertEqual(cluster_data['config']['softwareConfig']['optionalComponents'], OPTIONAL_COMPONENTS)
 
     def test_build_single_node_cluster(self):
         dataproc_operator = DataprocClusterCreateOperator(

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -354,7 +354,7 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
             cluster_name=CLUSTER_NAME,
             project_id=GCP_PROJECT_ID,
             num_workers=NUM_WORKERS,
-            optionalComponents=OPTIONAL_COMPONENTS,
+            optional_components=OPTIONAL_COMPONENTS,
         )
         cluster_data = dataproc_operator._build_cluster_data()
         self.assertEqual(cluster_data['config']['softwareConfig']['optionalComponents'], OPTIONAL_COMPONENTS)

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -353,6 +353,7 @@ class DataprocClusterCreateOperatorTest(unittest.TestCase):
             task_id=TASK_ID,
             cluster_name=CLUSTER_NAME,
             project_id=GCP_PROJECT_ID,
+            num_workers=NUM_WORKERS,
             optionalComponents=OPTIONAL_COMPONENTS,
         )
         cluster_data = dataproc_operator._build_cluster_data()


### PR DESCRIPTION
…ClusterCreateOperator

### Jira

https://issues.apache.org/jira/browse/AIRFLOW-5118

### Description

This PR adds ability to specify optional components in DataprocClusterCreateOperator

For more info see https://cloud.google.com/dataproc/docs/reference/rest/v1/ClusterConfig#Component

### Tests

One test added: it checks whether the optional components were set correctly

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
