### PR TITLE
[AIRFLOW-5230] Refactor template file loading functionality

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -227,7 +227,7 @@ class DAG(BaseDag, LoggingMixin):
         self._description = description
         # set file location to caller source path
         self.fileloc = sys._getframe().f_back.f_code.co_filename
-        self.task_dict = dict()  # type: Dict[str, TaskInstance]
+        self.task_dict = dict()  # type: Dict[str, BaseOperator]
 
         # set timezone from start_date
         if start_date and start_date.tzinfo:
@@ -695,9 +695,9 @@ class DAG(BaseDag, LoggingMixin):
                 subdag_lst += task.subdag.subdags
         return subdag_lst
 
-    def resolve_template_files(self):
+    def load_template_files(self):
         for t in self.tasks:
-            t.resolve_template_files()
+            t.load_template_files()
 
     def get_template_env(self) -> jinja2.Environment:
         """Build a Jinja2 environment."""

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -319,7 +319,7 @@ class DagBag(BaseDagBag, LoggingMixin):
 
         dag.test_cycle()  # throws if a task cycle is found
 
-        dag.resolve_template_files()
+        dag.load_template_files()
         dag.last_loaded = timezone.utcnow()
 
         for task in dag.tasks:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -689,7 +689,7 @@ class Airflow(AirflowBaseView):
                 "error")
             return redirect(url_for('Airflow.index'))
         task = copy.copy(dag.get_task(task_id))
-        task.resolve_template_files()
+        task.load_template_files()
         ti = TI(task=task, execution_date=dttm)
         ti.refresh_from_db()
 

--- a/tests/core.py
+++ b/tests/core.py
@@ -649,24 +649,6 @@ class CoreTest(unittest.TestCase):
         t.execute = verify_templated_field
         t.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
-    def test_template_non_bool(self):
-        """
-        Test templates can handle objects with no sense of truthiness
-        """
-
-        class NonBoolObject:
-            def __len__(self):
-                return NotImplemented
-
-            def __bool__(self):
-                return NotImplemented
-
-        t = OperatorSubclass(
-            task_id='test_bad_template_obj',
-            some_templated_field=NonBoolObject(),
-            dag=self.dag)
-        t.resolve_template_files()
-
     def test_task_get_template(self):
         TI = TaskInstance
         ti = TI(

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -19,10 +19,8 @@
 
 import datetime
 import logging
-import os
 import re
 import unittest
-from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 
 import pendulum
@@ -439,43 +437,6 @@ class DagTest(unittest.TestCase):
 
         self.assertIn('hello', jinja_env.filters)
         self.assertEqual(jinja_env.filters['hello'], jinja_udf)
-
-    def test_resolve_template_files_value(self):
-
-        with NamedTemporaryFile(suffix='.template') as f:
-            f.write(b'{{ ds }}')
-            f.flush()
-            template_dir = os.path.dirname(f.name)
-            template_file = os.path.basename(f.name)
-
-            with DAG('test-dag', start_date=DEFAULT_DATE, template_searchpath=template_dir):
-                task = DummyOperator(task_id='op1')
-
-            task.test_field = template_file
-            task.template_fields = ('test_field',)
-            task.template_ext = ('.template',)
-            task.resolve_template_files()
-
-        self.assertEqual(task.test_field, '{{ ds }}')
-
-    def test_resolve_template_files_list(self):
-
-        with NamedTemporaryFile(suffix='.template') as f:
-            f = NamedTemporaryFile(suffix='.template')
-            f.write(b'{{ ds }}')
-            f.flush()
-            template_dir = os.path.dirname(f.name)
-            template_file = os.path.basename(f.name)
-
-            with DAG('test-dag', start_date=DEFAULT_DATE, template_searchpath=template_dir):
-                task = DummyOperator(task_id='op1')
-
-            task.test_field = [template_file, 'some_string']
-            task.template_fields = ('test_field',)
-            task.template_ext = ('.template',)
-            task.resolve_template_files()
-
-        self.assertEqual(task.test_field, ['{{ ds }}', 'some_string'])
 
     def test_cycle(self):
         # test empty


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5230
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Following https://issues.apache.org/jira/browse/AIRFLOW-4835, I've also refactored the template file loading functionality to:

- Avoid building multiple Jinja environments
- Avoid code duplication around `env.loader.get_source`
- Rename `resolve_template_files` to `load_template_files` which follows the Jinja naming
- Support other collection types for storing template file paths (tuple, namedtuple, dict and set)
- Add tests for all types
- Move related tests from `test_dag.py` and `core.py` to `test_baseoperator.py`
- Adhere to 110 char line length
- Add Pydoc
- Add typing

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Moved tests from `test_dag.py` and `core.py` to their correct location in `test_baseoperator.py`. Also added few tests in `test_baseoperator.py` to test providing template filepaths in various data structures (dict, list, str, etc...).

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
