### PR TITLE
[AIRFLOW-3705] Fix PostgresHook get_conn to use conn_name_attr

### DIFF
--- a/airflow/hooks/postgres_hook.py
+++ b/airflow/hooks/postgres_hook.py
@@ -53,7 +53,8 @@ class PostgresHook(DbApiHook):
         self.schema = kwargs.pop("schema", None)
 
     def get_conn(self):
-        conn = self.get_connection(self.postgres_conn_id)
+        conn_id = getattr(self, self.conn_name_attr)
+        conn = self.get_connection(conn_id)
 
         # check for authentication via AWS IAM
         if conn.extra_dejson.get('iam', False):

--- a/tests/hooks/test_postgres_hook.py
+++ b/tests/hooks/test_postgres_hook.py
@@ -39,9 +39,21 @@ class TestPostgresHookConn(unittest.TestCase):
             schema='schema'
         )
 
-        self.db_hook = PostgresHook()
+        class UnitTestPostgresHook(PostgresHook):
+            conn_name_attr = 'test_conn_id'
+
+        self.db_hook = UnitTestPostgresHook()
         self.db_hook.get_connection = mock.Mock()
         self.db_hook.get_connection.return_value = self.connection
+
+    @mock.patch('airflow.hooks.postgres_hook.psycopg2.connect')
+    def test_get_conn_non_default_id(self, mock_connect):
+        self.db_hook.test_conn_id = 'non_default'
+        self.db_hook.get_conn()
+        mock_connect.assert_called_once_with(user='login', password='password',
+                                             host='host', dbname='schema',
+                                             port=None)
+        self.db_hook.get_connection.assert_called_once_with('non_default')
 
     @mock.patch('airflow.hooks.postgres_hook.psycopg2.connect')
     def test_get_conn(self, mock_connect):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-3705) issue and references it in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-3705

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Update the `get_conn` method of `PostgresHook` to ensure that the `conn_name_attr` specified is used to establish the connection via `psycopg2`.

This is an issue when subclassing `PostgresHook`. The `postgres_conn_id` attribute must be overridden since it is explicitly used in establishing the connection. Now any given `conn_name_attr` set when subclassing will be used when connecting.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - Adds a small subclass of `PostgresHook` with a new `conn_name_attr` which is used in `TestPostgresHookConn`. This illustrates the problem with the default behavior for `get_conn` with three test failures that say:

```bash
AttributeError: 'UnitTestPostgresHook' object has no attribute 'postgres_conn_id'
```

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- [x] Passes `flake8`
