### PR TITLE
[AIRFLOW-YYY] Add Cloud Memorystore integration

### DIFF
--- a/airflow/example_dags/cloud_memorystore.py
+++ b/airflow/example_dags/cloud_memorystore.py
@@ -1,0 +1,1 @@
+/opt/airflow/airflow/gcp/example_dags/cloud_memorystore.py

--- a/airflow/gcp/example_dags/cloud_memorystore.py
+++ b/airflow/gcp/example_dags/cloud_memorystore.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+
+from google.cloud.redis_v1.gapic.enums import Instance, FailoverInstanceRequest
+
+from airflow import models
+from airflow.contrib.operators.gcs_acl_operator import GoogleCloudStorageBucketCreateAclEntryOperator
+from airflow.gcp.operators.cloud_memorystore import (CloudMemorystoreCreateInstanceOperator,
+                                                     CloudMemorystoreDeleteInstanceOperator,
+                                                     CloudMemorystoreExportInstanceOperator,
+                                                     CloudMemorystoreFailoverInstanceOperator,
+                                                     CloudMemorystoreGetInstanceOperator,
+                                                     CloudMemorystoreImportInstanceOperator,
+                                                     CloudMemorystoreListInstancesOperator,
+                                                     CloudMemorystoreUpdateInstanceOperator)
+from airflow.operators.bash_operator import BashOperator
+from airflow.utils import dates
+
+
+GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
+
+INSTANCE_NAME = os.environ.get('GCP_MEMORYSTORE_INSTANCE_NAME', 'test-memorystore-1')
+INSTANCE_NAME_2 = os.environ.get('GCP_MEMORYSTORE_INSTANCE_NAME2', 'test-memorystore-2')
+
+BUCKET_NAME = os.environ.get('GCP_MEMORYSTORE_BUCKET_NAME', 'test-memorystore-2')
+
+FIRST_INSTANCE = {
+    'tier': Instance.Tier.BASIC,
+    'memory_size_gb': 1
+}
+
+SECOND_INSTANCE = {
+    'tier': Instance.Tier.STANDARD_HA,
+    'memory_size_gb': 3
+}
+
+
+default_args = {
+    'start_date': dates.days_ago(1)
+}
+
+with models.DAG(
+    'gcp_cloud_memorystore',
+    default_args=default_args,
+    schedule_interval=None  # Override to match your needs
+) as dag:
+    create_instance = CloudMemorystoreCreateInstanceOperator(
+        task_id='create-instance',
+        location='europe-north1',
+        instance_id=INSTANCE_NAME,
+        instance=FIRST_INSTANCE,
+        project_id=GCP_PROJECT_ID,
+    )
+
+    create_instance_2 = CloudMemorystoreCreateInstanceOperator(
+        task_id='create-instance-2',
+        location='europe-north1',
+        instance_id=INSTANCE_NAME_2,
+        instance=SECOND_INSTANCE,
+        project_id=GCP_PROJECT_ID,
+    )
+
+    delete_instance = CloudMemorystoreDeleteInstanceOperator(
+        task_id='delete-instance',
+        location='europe-north1',
+        instance=INSTANCE_NAME,
+        project_id=GCP_PROJECT_ID,
+    )
+
+    get_instance = CloudMemorystoreGetInstanceOperator(
+        task_id='get-instance',
+        location='europe-north1',
+        instance=INSTANCE_NAME,
+        project_id=GCP_PROJECT_ID,
+    )
+
+    get_instance_result = BashOperator(
+        task_id="get-instance-result",
+        bash_command="echo \"{{ task_instance.xcom_pull('get-instance') }}\"",
+    )
+
+    failover_instance = CloudMemorystoreFailoverInstanceOperator(
+        task_id='failover-instance',
+        location='europe-north1',
+        instance=INSTANCE_NAME_2,
+        data_protection_mode=FailoverInstanceRequest.DataProtectionMode.LIMITED_DATA_LOSS,
+        project_id=GCP_PROJECT_ID,
+    )
+
+    list_instance = CloudMemorystoreListInstancesOperator(
+        task_id='list-instances',
+        location='-',
+        page_size=100,
+        project_id=GCP_PROJECT_ID,
+    )
+
+    list_instance_result = BashOperator(
+        task_id="get-instance-result",
+        bash_command="echo \"{{ task_instance.xcom_pull('list-instances') }}\"",
+    )
+
+    # update_instance = CloudMemorystoreUpdateInstanceOperator(
+    #     task_id='update-instance',
+    #     update_mask={
+    #         'paths': ['memory_size_gb']
+    #     },
+    #     instance={'memory_size_gb': 2},
+    # )
+
+    set_acl_permission = GoogleCloudStorageBucketCreateAclEntryOperator(
+        bucket=BUCKET_NAME,
+        # entity="{{ task_instance.xcom_pull('get-instance')['persistenceIamIdentity'] }}",
+        entity="33987476006-compute@developer.gserviceaccount.com",
+        role='OWNER',
+        task_id="gcs-set-acl-permission"
+    )
+
+    export_instance = CloudMemorystoreExportInstanceOperator(
+        task_id='export-instance',
+        location='europe-north1',
+        instance=INSTANCE_NAME,
+        output_config={
+            'gcs_destination': {
+                'uri': "gs://{}/my_export.rdb".format(BUCKET_NAME)
+            },
+        },
+        project_id=GCP_PROJECT_ID,
+    )
+
+    # import_instance = CloudMemorystoreImportInstanceOperator(
+    #     task_id='import-instance',
+    #     location=TEST_LOCATION,
+    #     instance=TEST_INSTANCE_NAME,
+    #     input_config=TEST_INPUT_CONFIG,
+    #     project_id=GCP_PROJECT_ID,
+    #     retry=TEST_RETRY,
+    #     timeout=TEST_TIMEOUT,
+    #     metadata=TEST_METADATA,
+    #     gcp_conn_id=TEST_GCP_CONN_ID,
+    # )

--- a/airflow/gcp/hooks/cloud_memorystore.py
+++ b/airflow/gcp/hooks/cloud_memorystore.py
@@ -1,0 +1,374 @@
+from typing import Dict, Sequence, Tuple, Union, Optional
+
+from google.api_core.retry import Retry
+from google.cloud.redis_v1 import CloudRedisClient
+from google.cloud.redis_v1.gapic.enums import FailoverInstanceRequest
+from google.cloud.redis_v1.types import FieldMask, InputConfig, Instance, OutputConfig
+from google.cloud.redis_v1beta1 import CloudRedisClient
+
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+
+
+class CloudMemorystoreHook(GoogleCloudBaseHook):
+    """
+    Hook for Google Cloud Memorystore APIs.
+
+    All the methods in the hook where project_id is used must be called with
+    keyword arguments rather than positional.
+
+    :param gcp_conn_id: The connection ID to use when fetching connection info.
+    :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    """
+
+    def __init__(self, gcp_conn_id: str = "google_cloud_default", delegate_to: str = None):
+        super().__init__(gcp_conn_id, delegate_to)
+        self._client: Optional[CloudRedisClient] = None
+
+    def get_conn(self,):
+        """
+        Retrieves client library object that allow access to Cloud Memorystore service.
+
+        """
+        if not self._client:
+            self._client = CloudRedisClient(credentials=self._get_credentials())
+        return self._client
+
+    def create_instance(
+        self,
+        location: str,
+        instance_id: str,
+        instance: Union[Dict, Instance],
+        project_id: str = None,
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+    ):
+        """
+        Creates a Redis instance based on the specified tier and memory size.
+
+        By default, the instance is accessible from the project's `default network
+        <https://cloud.google.com/compute/docs/networks-and-firewalls#networks>`__.
+
+        :param location: The location of the Cloud Memorystore instance (for example europe-west1)
+        :type location: str
+        :param instance_id: Required. The logical name of the Redis instance in the customer project with the
+            following restrictions:
+
+            -  Must contain only lowercase letters, numbers, and hyphens.
+            -  Must start with a letter.
+            -  Must be between 1-40 characters.
+            -  Must end with a number or a letter.
+            -  Must be unique within the customer project / location
+        :type instance_id: str
+        :param instance: Required. A Redis [Instance] resource
+
+            If a dict is provided, it must be of the same form as the protobuf message
+            :class:`~google.cloud.redis_v1.types.Instance`
+        :type instance: Union[Dict, google.cloud.redis_v1.types.Instance]
+        :param project_id: Project ID of the project that contains the instance. If set
+            to None or missing, the default project_id from the GCP connection is used.
+        :type project_id: str
+        :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            ``retry`` is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: Sequence[Tuple[str, str]]
+        """
+        client = self.get_conn()
+        parent = CloudRedisClient.location_path(project_id, location)
+        result = client.create_instance(
+            parent=parent,
+            instance_id=instance_id,
+            instance=instance,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+        return result
+
+    def delete_instance(
+        self,
+        location: str,
+        instance: str,
+        project_id: str = None,
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+    ):
+        """
+        Deletes a specific Redis instance.  Instance stops serving and data is deleted.
+
+        :param location: The location of the Cloud Memorystore instance (for example europe-west1)
+        :type location: str
+        :param instance: The logical name of the Redis instance in the customer project.
+        :type instance: str
+        :param project_id:  Project ID of the project that contains the instance. If set
+            to None or missing, the default project_id from the GCP connection is used.
+        :type project_id: str
+        :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            ``retry`` is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: Sequence[Tuple[str, str]]
+        """
+        client = self.get_conn()
+        name = CloudRedisClient.instance_path(project_id, location, instance)
+        result = client.delete_instance(name=name, retry=retry, timeout=timeout, metadata=metadata)
+        return result
+
+    def export_instance(
+        self,
+        location: str,
+        instance: str,
+        output_config: Union[Dict, OutputConfig],
+        project_id: str = None,
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+    ):
+        """
+        Export Redis instance data into a Redis RDB format file in Cloud Storage.
+
+        Redis will continue serving during this operation.
+
+        :param location: The location of the Cloud Memorystore instance (for example europe-west1)
+        :type location: str
+        :param instance: The logical name of the Redis instance in the customer project.
+        :type instance: str
+        :param output_config: Required. Specify data to be exported.
+
+            If a dict is provided, it must be of the same form as the protobuf message
+            :class:`~google.cloud.redis_v1.types.OutputConfig`
+        :type output_config: Union[Dict, google.cloud.redis_v1.types.OutputConfig]
+        :param project_id: Project ID of the project that contains the instance. If set
+            to None or missing, the default project_id from the GCP connection is used.
+        :type project_id: str
+        :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            ``retry`` is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: Sequence[Tuple[str, str]]
+        """
+        client = self.get_conn()
+        name = CloudRedisClient.instance_path(project_id, location, instance)
+        result = client.export_instance(
+            name=name, output_config=output_config, retry=retry, timeout=timeout, metadata=metadata
+        )
+        return result
+
+    def failover_instance(
+        self,
+        location: str,
+        instance: str,
+        data_protection_mode: FailoverInstanceRequest.DataProtectionMode,
+        project_id: str = None,
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+    ):
+        """
+        Initiates a failover of the master node to current replica node for a specific STANDARD tier Cloud
+        Memorystore for Redis instance.
+
+        :param location: The location of the Cloud Memorystore instance (for example europe-west1)
+        :type location: str
+        :param instance: The logical name of the Redis instance in the customer project.
+        :type instance: str
+        :param data_protection_mode: Optional. Available data protection modes that the user can choose. If
+            it's unspecified, data protection mode will be LIMITED\_DATA\_LOSS by default.
+        :type data_protection_mode: google.cloud.redis_v1.gapic.enums.FailoverInstanceRequest.DataProtectionMode
+        :param project_id: Project ID of the project that contains the instance. If set
+            to None or missing, the default project_id from the GCP connection is used.
+        :type project_id: str
+        :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            ``retry`` is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: Sequence[Tuple[str, str]]
+        """
+        client = self.get_conn()
+        name = CloudRedisClient.instance_path(project_id, location, instance)
+        result = client.failover_instance(
+            name=name,
+            data_protection_mode=data_protection_mode,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+        return result
+
+    def get_instance(
+        self,
+        location: str,
+        instance: str,
+        project_id: str = None,
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+    ):
+        """
+        Gets the details of a specific Redis instance.
+
+        :param location: The location of the Cloud Memorystore instance (for example europe-west1)
+        :type location: str
+        :param instance: The logical name of the Redis instance in the customer project.
+        :type instance: str
+        :param project_id:  Project ID of the project that contains the instance. If set
+            to None or missing, the default project_id from the GCP connection is used.
+        :type project_id: str
+        :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            ``retry`` is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: Sequence[Tuple[str, str]]
+        """
+        client = self.get_conn()
+        name = CloudRedisClient.instance_path(project_id, location, instance)
+        result = client.get_instance(name=name, retry=retry, timeout=timeout, metadata=metadata)
+        return result
+
+    def import_instance(
+        self,
+        location: str,
+        instance: str,
+        input_config: Union[Dict, InputConfig],
+        project_id: str = None,
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+    ):
+        """
+        Import a Redis RDB snapshot file from Cloud Storage into a Redis instance.
+
+        Redis may stop serving during this operation. Instance state will be IMPORTING for entire operation.
+        When complete, the instance will contain only data from the imported file.
+
+        :param location: The location of the Cloud Memorystore instance (for example europe-west1)
+        :type location: str
+        :param instance: The logical name of the Redis instance in the customer project.
+        :type instance: str
+        :param input_config: Required. Specify data to be imported.
+
+            If a dict is provided, it must be of the same form as the protobuf message
+            :class:`~google.cloud.redis_v1.types.InputConfig`
+        :type input_config: Union[Dict, google.cloud.redis_v1.types.InputConfig]
+        :param project_id: Project ID of the project that contains the instance. If set
+            to None or missing, the default project_id from the GCP connection is used.
+        :type project_id: str
+        :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            ``retry`` is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: Sequence[Tuple[str, str]]
+        """
+        client = self.get_conn()
+        name = CloudRedisClient.instance_path(project_id, location, instance)
+        result = client.import_instance(
+            name=name, input_config=input_config, retry=retry, timeout=timeout, metadata=metadata
+        )
+        return result
+
+    def list_instances(
+        self,
+        location: str,
+        page_size: int,
+        project_id: str = None,
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+    ):
+        """
+        Lists all Redis instances owned by a project in either the specified location (region) or all
+        locations.
+
+        :param location: The location of the Cloud Memorystore instance (for example europe-west1)
+
+                If it is specified as ``-`` (wildcard), then all regions available to the project are
+                queried, and the results are aggregated.
+        :type location: str
+        :param page_size: The maximum number of resources contained in the underlying API response. If page
+            streaming is performed per- resource, this parameter does not affect the return value. If page
+            streaming is performed per-page, this determines the maximum number of resources in a page.
+        :type page_size: int
+        :param project_id: Project ID of the project that contains the instance. If set
+            to None or missing, the default project_id from the GCP connection is used.
+        :type project_id: str
+        :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            ``retry`` is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: Sequence[Tuple[str, str]]
+        """
+        client = self.get_conn()
+        parent = CloudRedisClient.location_path(project_id, location)
+        result = client.list_instances(
+            parent=parent, page_size=page_size, retry=retry, timeout=timeout, metadata=metadata
+        )
+        return result
+
+    def update_instance(
+        self,
+        update_mask: Union[Dict, FieldMask],
+        instance: Union[Dict, Instance],
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+    ):
+        """
+        Updates the metadata and configuration of a specific Redis instance.
+
+        :param update_mask: Required. Mask of fields to update. At least one path must be supplied in this
+            field. The elements of the repeated paths field may only include these fields from ``Instance``:
+
+            -  ``displayName``
+            -  ``labels``
+            -  ``memorySizeGb``
+            -  ``redisConfig``
+
+            If a dict is provided, it must be of the same form as the protobuf message
+            :class:`~google.cloud.redis_v1.types.FieldMask`
+        :type update_mask: Union[Dict, google.cloud.redis_v1.types.FieldMask]
+        :param instance: Required. Update description. Only fields specified in ``update_mask`` are updated.
+
+            If a dict is provided, it must be of the same form as the protobuf message
+            :class:`~google.cloud.redis_v1.types.Instance`
+        :type instance: Union[Dict, google.cloud.redis_v1.types.Instance]
+        :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+            retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+            ``retry`` is specified, the timeout applies to each individual attempt.
+        :type timeout: float
+        :param metadata: Additional metadata that is provided to the method.
+        :type metadata: Sequence[Tuple[str, str]]
+        """
+        client = self.get_conn()
+        result = client.update_instance(
+            update_mask=update_mask, instance=instance, retry=retry, timeout=timeout, metadata=metadata
+        )
+        return result

--- a/airflow/gcp/operators/cloud_memorystore.py
+++ b/airflow/gcp/operators/cloud_memorystore.py
@@ -1,0 +1,531 @@
+from typing import Dict, Sequence, Tuple, Union
+
+from google.api_core.retry import Retry
+from google.cloud.redis_v1.gapic.enums import FailoverInstanceRequest
+from google.cloud.redis_v1.types import FieldMask, InputConfig, Instance, OutputConfig
+from google.protobuf.json_format import MessageToDict
+
+from tests.contrib.utils.base_gcp_mock import (GCP_PROJECT_ID_HOOK_UNIT_TEST,
+                                               mock_base_gcp_hook_default_project_id,
+                                               mock_base_gcp_hook_no_default_project_id)
+
+from airflow.gcp.hooks.cloud_memorystore import CloudMemorystoreHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class CloudMemorystoreCreateInstanceOperator(BaseOperator):
+    """
+    Creates a Redis instance based on the specified tier and memory size.
+
+    By default, the instance is accessible from the project's `default network
+    <https://cloud.google.com/compute/docs/networks-and-firewalls#networks>`__.
+
+    :param location: The location of the Cloud Memorystore instance (for example europe-west1)
+    :type location: str
+    :param instance_id: Required. The logical name of the Redis instance in the customer project with the
+        following restrictions:
+
+        -  Must contain only lowercase letters, numbers, and hyphens.
+        -  Must start with a letter.
+        -  Must be between 1-40 characters.
+        -  Must end with a number or a letter.
+        -  Must be unique within the customer project / location
+    :type instance_id: str
+    :param instance: Required. A Redis [Instance] resource
+
+        If a dict is provided, it must be of the same form as the protobuf message
+        :class:`~google.cloud.redis_v1.types.Instance`
+    :type instance: Union[Dict, google.cloud.redis_v1.types.Instance]
+    :param project_id: Project ID of the project that contains the instance. If set
+        to None or missing, the default project_id from the GCP connection is used.
+    :type project_id: str
+    :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+        retried.
+    :type retry: google.api_core.retry.Retry
+    :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+        ``retry`` is specified, the timeout applies to each individual attempt.
+    :type timeout: float
+    :param metadata: Additional metadata that is provided to the method.
+    :type metadata: Sequence[Tuple[str, str]]
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
+    :type gcp_conn_id: str
+    """
+
+    @apply_defaults
+    def __init__(
+        self,
+        location: str,
+        instance_id: str,
+        instance: Union[Dict, Instance],
+        project_id: str = None,
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+        gcp_conn_id: str = "google_cloud_default",
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.location = location
+        self.instance_id = instance_id
+        self.instance = instance
+        self.project_id = project_id
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+
+    def execute(self, context: Dict):
+        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        result = hook.create_instance(
+            location=self.location,
+            instance_id=self.instance_id,
+            instance=self.instance,
+            project_id=self.project_id,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )
+        return MessageToDict(result.result())
+
+
+class CloudMemorystoreDeleteInstanceOperator(BaseOperator):
+    """
+    Deletes a specific Redis instance. Instance stops serving and data is deleted.
+
+    :param location: The location of the Cloud Memorystore instance (for example europe-west1)
+    :type location: str
+    :param instance: The logical name of the Redis instance in the customer project.
+    :type instance: str
+    :param project_id: Project ID of the project that contains the instance. If set
+        to None or missing, the default project_id from the GCP connection is used.
+    :type project_id: str
+    :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+        retried.
+    :type retry: google.api_core.retry.Retry
+    :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+        ``retry`` is specified, the timeout applies to each individual attempt.
+    :type timeout: float
+    :param metadata: Additional metadata that is provided to the method.
+    :type metadata: Sequence[Tuple[str, str]]
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
+    :type gcp_conn_id: str
+    """
+
+    @apply_defaults
+    def __init__(
+        self,
+        location: str,
+        instance: str,
+        project_id: str = None,
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+        gcp_conn_id: str = "google_cloud_default",
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.location = location
+        self.instance = instance
+        self.project_id = project_id
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+
+    def execute(self, context: Dict):
+        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        result = hook.delete_instance(
+            location=self.location,
+            instance=self.instance,
+            project_id=self.project_id,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )
+        return MessageToDict(result.result())
+
+
+class CloudMemorystoreExportInstanceOperator(BaseOperator):
+    """
+    Export Redis instance data into a Redis RDB format file in Cloud Storage.
+
+    Redis will continue serving during this operation.
+
+    :param location: The location of the Cloud Memorystore instance (for example europe-west1)
+    :type location: str
+    :param instance: The logical name of the Redis instance in the customer project.
+    :type instance: str
+    :param output_config: Required. Specify data to be exported.
+
+        If a dict is provided, it must be of the same form as the protobuf message
+        :class:`~google.cloud.redis_v1.types.OutputConfig`
+    :type output_config: Union[Dict, google.cloud.redis_v1.types.OutputConfig]
+    :param project_id: Project ID of the project that contains the instance. If set
+        to None or missing, the default project_id from the GCP connection is used.
+    :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+        retried.
+    :type retry: google.api_core.retry.Retry
+    :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+        ``retry`` is specified, the timeout applies to each individual attempt.
+    :type timeout: float
+    :param metadata: Additional metadata that is provided to the method.
+    :type metadata: Sequence[Tuple[str, str]]
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
+    :type gcp_conn_id: str
+    """
+
+    @apply_defaults
+    def __init__(
+        self,
+        location: str,
+        instance: str,
+        output_config: Union[Dict, OutputConfig],
+        project_id: str = None,
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+        gcp_conn_id: str = "google_cloud_default",
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.location = location
+        self.instance = instance
+        self.output_config = output_config
+        self.project_id = project_id
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+
+    def execute(self, context: Dict):
+        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        result = hook.export_instance(
+            location=self.location,
+            instance=self.instance,
+            output_config=self.output_config,
+            project_id=self.project_id,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )
+        return MessageToDict(result.result())
+
+
+class CloudMemorystoreFailoverInstanceOperator(BaseOperator):
+    """
+    Initiates a failover of the master node to current replica node for a specific STANDARD tier Cloud
+    Memorystore for Redis instance.
+
+    :param location: The location of the Cloud Memorystore instance (for example europe-west1)
+    :type location: str
+
+    :param instance: The logical name of the Redis instance in the customer project.
+    :type instance: str
+    :param data_protection_mode: Optional. Available data protection modes that the user can choose. If it's
+        unspecified, data protection mode will be LIMITED\_DATA\_LOSS by default.
+    :type data_protection_mode: google.cloud.redis_v1.gapic.enums.FailoverInstanceRequest.DataProtectionMode
+    :param project_id: Project ID of the project that contains the instance. If set
+        to None or missing, the default project_id from the GCP connection is used.
+    :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+        retried.
+    :type retry: google.api_core.retry.Retry
+    :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+        ``retry`` is specified, the timeout applies to each individual attempt.
+    :type timeout: float
+    :param metadata: Additional metadata that is provided to the method.
+    :type metadata: Sequence[Tuple[str, str]]
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
+    :type gcp_conn_id: str
+    """
+
+    @apply_defaults
+    def __init__(
+        self,
+        location: str,
+        instance: str,
+        data_protection_mode: FailoverInstanceRequest.DataProtectionMode,
+        project_id: str = None,
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+        gcp_conn_id: str = "google_cloud_default",
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.location = location
+        self.instance = instance
+        self.data_protection_mode = data_protection_mode
+        self.project_id = project_id
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+
+    def execute(self, context: Dict):
+        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        result = hook.failover_instance(
+            location=self.location,
+            instance=self.instance,
+            data_protection_mode=self.data_protection_mode,
+            project_id=self.project_id,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )
+
+        return MessageToDict(result.result())
+
+
+class CloudMemorystoreGetInstanceOperator(BaseOperator):
+    """
+    Gets the details of a specific Redis instance.
+
+    :param location: The location of the Cloud Memorystore instance (for example europe-west1)
+    :type location: str
+    :param instance: The logical name of the Redis instance in the customer project.
+    :type instance: str
+    :param project_id: Project ID of the project that contains the instance. If set
+        to None or missing, the default project_id from the GCP connection is used.
+    :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+        retried.
+    :type retry: google.api_core.retry.Retry
+    :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+        ``retry`` is specified, the timeout applies to each individual attempt.
+    :type timeout: float
+    :param metadata: Additional metadata that is provided to the method.
+    :type metadata: Sequence[Tuple[str, str]]
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
+    :type gcp_conn_id: str
+    """
+
+    @apply_defaults
+    def __init__(
+        self,
+        location: str,
+        instance: str,
+        project_id: str = None,
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+        gcp_conn_id: str = "google_cloud_default",
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.location = location
+        self.instance = instance
+        self.project_id = project_id
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+
+    def execute(self, context: Dict):
+        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        result = hook.get_instance(
+            location=self.location,
+            instance=self.instance,
+            project_id=self.project_id,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )
+        return MessageToDict(result)
+
+
+class CloudMemorystoreImportInstanceOperator(BaseOperator):
+    """
+    Import a Redis RDB snapshot file from Cloud Storage into a Redis instance.
+
+    Redis may stop serving during this operation. Instance state will be IMPORTING for entire operation. When
+    complete, the instance will contain only data from the imported file.
+
+    :param location: The location of the Cloud Memorystore instance (for example europe-west1)
+    :type location: str
+    :param instance: The logical name of the Redis instance in the customer project.
+    :type instance: str
+    :param input_config: Required. Specify data to be imported.
+
+        If a dict is provided, it must be of the same form as the protobuf message
+        :class:`~google.cloud.redis_v1.types.InputConfig`
+    :type input_config: Union[Dict, google.cloud.redis_v1.types.InputConfig]
+    :param project_id: Project ID of the project that contains the instance. If set
+        to None or missing, the default project_id from the GCP connection is used.
+    :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+        retried.
+    :type retry: google.api_core.retry.Retry
+    :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+        ``retry`` is specified, the timeout applies to each individual attempt.
+    :type timeout: float
+    :param metadata: Additional metadata that is provided to the method.
+    :type metadata: Sequence[Tuple[str, str]]
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
+    :type gcp_conn_id: str
+    """
+
+    @apply_defaults
+    def __init__(
+        self,
+        location: str,
+        instance: str,
+        input_config: Union[Dict, InputConfig],
+        project_id: str = None,
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+        gcp_conn_id: str = "google_cloud_default",
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.location = location
+        self.instance = instance
+        self.input_config = input_config
+        self.project_id = project_id
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+
+    def execute(self, context: Dict):
+        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook.import_instance(
+            location=self.location,
+            instance=self.instance,
+            input_config=self.input_config,
+            project_id=self.project_id,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )
+
+
+class CloudMemorystoreListInstancesOperator(BaseOperator):
+    """
+    Lists all Redis instances owned by a project in either the specified location (region) or all locations.
+
+    :param location: The location of the Cloud Memorystore instance (for example europe-west1)
+        If it is specified as ``-`` (wildcard), then all regions available to the project are
+        queried, and the results are aggregated.
+    :type location: str
+    :param page_size: The maximum number of resources contained in the underlying API response. If page
+        streaming is performed per- resource, this parameter does not affect the return value. If page
+        streaming is performed per-page, this determines the maximum number of resources in a page.
+    :type page_size: int
+    :param project_id: Project ID of the project that contains the instance. If set
+        to None or missing, the default project_id from the GCP connection is used.
+    :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+        retried.
+    :type retry: google.api_core.retry.Retry
+    :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+        ``retry`` is specified, the timeout applies to each individual attempt.
+    :type timeout: float
+    :param metadata: Additional metadata that is provided to the method.
+    :type metadata: Sequence[Tuple[str, str]]
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
+    :type gcp_conn_id: str
+    """
+
+    @apply_defaults
+    def __init__(
+        self,
+        location: str,
+        page_size: int,
+        project_id: str = None,
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+        gcp_conn_id: str = "google_cloud_default",
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.location = location
+        self.page_size = page_size
+        self.project_id = project_id
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+
+    def execute(self, context: Dict):
+        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        result = hook.list_instances(
+            location=self.location,
+            page_size=self.page_size,
+            project_id=self.project_id,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )
+        instances = [MessageToDict(a) for a in result]
+        print(instances)
+        return instances
+
+
+class CloudMemorystoreUpdateInstanceOperator(BaseOperator):
+    """
+    Updates the metadata and configuration of a specific Redis instance.
+
+    :param update_mask: Required. Mask of fields to update. At least one path must be supplied in this field.
+        The elements of the repeated paths field may only include these fields from ``Instance``:
+
+        -  ``displayName``
+        -  ``labels``
+        -  ``memorySizeGb``
+        -  ``redisConfig``
+
+        If a dict is provided, it must be of the same form as the protobuf message
+        :class:`~google.cloud.redis_v1.types.FieldMask`
+    :type update_mask: Union[Dict, google.cloud.redis_v1.types.FieldMask]
+    :param instance: Required. Update description. Only fields specified in update\_mask are updated.
+
+        If a dict is provided, it must be of the same form as the protobuf message
+        :class:`~google.cloud.redis_v1.types.Instance`
+    :type instance: Union[Dict, google.cloud.redis_v1.types.Instance]
+    :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
+        retried.
+    :type retry: google.api_core.retry.Retry
+    :param timeout: The amount of time, in seconds, to wait for the request to complete. Note that if
+        ``retry`` is specified, the timeout applies to each individual attempt.
+    :type timeout: float
+    :param metadata: Additional metadata that is provided to the method.
+    :type metadata: Sequence[Tuple[str, str]]
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
+    :type gcp_conn_id: str
+    """
+
+    @apply_defaults
+    def __init__(
+        self,
+        update_mask: Union[Dict, FieldMask],
+        instance: Union[Dict, Instance],
+        retry: Retry = None,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = None,
+        gcp_conn_id: str = "google_cloud_default",
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.update_mask = update_mask
+        self.instance = instance
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+
+    def execute(self, context: Dict):
+        hook = CloudMemorystoreHook(gcp_conn_id=self.gcp_conn_id)
+        hook.update_instance(
+            update_mask=self.update_mask,
+            instance=self.instance,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )

--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,7 @@ elasticsearch = [
     'elasticsearch-dsl>=5.0.0,<6.0.0'
 ]
 gcp = [
+    # Please keep the list in alphabetical order
     'google-api-python-client>=1.6.0, <2.0.0dev',
     'google-auth-httplib2>=0.0.1',
     'google-auth>=1.0.0, <2.0.0dev',
@@ -195,14 +196,15 @@ gcp = [
     'google-cloud-container>=0.1.1',
     'google-cloud-dlp>=0.11.0',
     'google-cloud-language>=1.1.1',
+    'google-cloud-redis>=0.3.0',
     'google-cloud-spanner>=1.9.0, <1.10.0',
+    'google-cloud-speech>=0.36.3',
     'google-cloud-storage~=1.16',
+    'google-cloud-tasks==1.1.0',
+    'google-cloud-texttospeech>=0.4.0',
     'google-cloud-translate>=1.5.0',
     'google-cloud-videointelligence>=1.7.0',
     'google-cloud-vision>=0.35.2',
-    'google-cloud-tasks==1.1.0',
-    'google-cloud-texttospeech>=0.4.0',
-    'google-cloud-speech>=0.36.3',
     'grpcio-gcp>=0.2.2',
     'httplib2~=0.9.2',
     'pandas-gbq',

--- a/tests/gcp/hooks/test_gcp_cloud_memorystore_hook.py
+++ b/tests/gcp/hooks/test_gcp_cloud_memorystore_hook.py
@@ -1,0 +1,286 @@
+from typing import Dict, Sequence, Tuple
+from unittest import TestCase, mock
+
+from google.api_core.retry import Retry
+
+from tests.contrib.utils.base_gcp_mock import (GCP_PROJECT_ID_HOOK_UNIT_TEST,
+                                               mock_base_gcp_hook_default_project_id,
+                                               mock_base_gcp_hook_no_default_project_id)
+
+from airflow import AirflowException
+from airflow.contrib.hooks.gcp_cloud_memorystore_hook import CloudMemorystoreHook
+
+TEST_GCP_CONN_ID: str = "test-gcp-conn-id"
+TEST_DELEGATE_TO: str = "test-delegate-to"
+TEST_LOCATION: str = "test-location"
+TEST_INSTANCE_ID: str = "test-instance-id"
+TEST_INSTANCE: Dict = None  # TODO: Fill missing value
+TEST_PROJECT_ID: str = "test-project-id"
+TEST_RETRY: Retry = None  # TODO: Fill missing value
+TEST_TIMEOUT: float = None  # TODO: Fill missing value
+TEST_METADATA: Sequence[Tuple[str, str]] = None  # TODO: Fill missing value
+TEST_PAGE_SIZE: int = None  # TODO: Fill missing value
+TEST_UPDATE_MASK: Dict = None  # TODO: Fill missing value
+TEST_PARENT: str = "test-parent"
+TEST_NAME: str = "test-name"
+
+
+class TestCloudMemorystoreWithDefaultProjectIdHook(TestCase):
+    def setUp(self,):
+        with mock.patch(
+            "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.__init__",
+            new=mock_base_gcp_hook_default_project_id,
+        ):
+            self.hook = CloudMemorystoreHook(gcp_conn_id="test")
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.get_conn"
+    )
+    def test_create_instance(self, mock_get_conn):
+        self.hook.create_instance(
+            location=TEST_LOCATION,
+            instance_id=TEST_INSTANCE_ID,
+            instance=TEST_INSTANCE,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+        mock_get_conn.create_instance.assert_called_once_with(
+            parent=TEST_PARENT,
+            instance_id=TEST_INSTANCE_ID,
+            instance=TEST_INSTANCE,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.get_conn"
+    )
+    def test_delete_instance(self, mock_get_conn):
+        self.hook.delete_instance(
+            location=TEST_LOCATION,
+            instance=TEST_INSTANCE,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+        mock_get_conn.delete_instance.assert_called_once_with(
+            name=TEST_NAME, retry=TEST_RETRY, timeout=TEST_TIMEOUT, metadata=TEST_METADATA
+        )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.get_conn"
+    )
+    def test_get_instance(self, mock_get_conn):
+        self.hook.get_instance(
+            location=TEST_LOCATION,
+            instance=TEST_INSTANCE,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+        mock_get_conn.get_instance.assert_called_once_with(
+            name=TEST_NAME, retry=TEST_RETRY, timeout=TEST_TIMEOUT, metadata=TEST_METADATA
+        )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.get_conn"
+    )
+    def test_list_instances(self, mock_get_conn):
+        self.hook.list_instances(
+            location=TEST_LOCATION,
+            page_size=TEST_PAGE_SIZE,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+        mock_get_conn.list_instances.assert_called_once_with(
+            parent=TEST_PARENT,
+            page_size=TEST_PAGE_SIZE,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.get_conn"
+    )
+    def test_update_instance(self, mock_get_conn):
+        self.hook.update_instance(
+            update_mask=TEST_UPDATE_MASK,
+            instance=TEST_INSTANCE,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+        mock_get_conn.update_instance.assert_called_once_with(
+            update_mask=TEST_UPDATE_MASK,
+            instance=TEST_INSTANCE,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+
+
+class TestCloudMemorystoreWithoutDefaultProjectIdHook(TestCase):
+    def setUp(self,):
+        with mock.patch(
+            "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.__init__",
+            new=mock_base_gcp_hook_no_default_project_id,
+        ):
+            self.hook = CloudMemorystoreHook(gcp_conn_id="test")
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.get_conn"
+    )
+    def test_create_instance(self, mock_get_conn):
+        self.hook.create_instance(
+            location=TEST_LOCATION,
+            instance_id=TEST_INSTANCE_ID,
+            instance=TEST_INSTANCE,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+        mock_get_conn.create_instance.assert_called_once_with(
+            parent=TEST_PARENT,
+            instance_id=TEST_INSTANCE_ID,
+            instance=TEST_INSTANCE,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.get_conn"
+    )
+    def test_create_instance_without_project_id(self, mock_get_conn):
+        with self.assertRaises(AirflowException):
+            self.hook.create_instance(
+                location=TEST_LOCATION,
+                instance_id=TEST_INSTANCE_ID,
+                instance=TEST_INSTANCE,
+                project_id=None,
+                retry=TEST_RETRY,
+                timeout=TEST_TIMEOUT,
+                metadata=TEST_METADATA,
+            )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.get_conn"
+    )
+    def test_delete_instance(self, mock_get_conn):
+        self.hook.delete_instance(
+            location=TEST_LOCATION,
+            instance=TEST_INSTANCE,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+        mock_get_conn.delete_instance.assert_called_once_with(
+            name=TEST_NAME, retry=TEST_RETRY, timeout=TEST_TIMEOUT, metadata=TEST_METADATA
+        )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.get_conn"
+    )
+    def test_delete_instance_without_project_id(self, mock_get_conn):
+        with self.assertRaises(AirflowException):
+            self.hook.delete_instance(
+                location=TEST_LOCATION,
+                instance=TEST_INSTANCE,
+                project_id=None,
+                retry=TEST_RETRY,
+                timeout=TEST_TIMEOUT,
+                metadata=TEST_METADATA,
+            )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.get_conn"
+    )
+    def test_get_instance(self, mock_get_conn):
+        self.hook.get_instance(
+            location=TEST_LOCATION,
+            instance=TEST_INSTANCE,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+        mock_get_conn.get_instance.assert_called_once_with(
+            name=TEST_NAME, retry=TEST_RETRY, timeout=TEST_TIMEOUT, metadata=TEST_METADATA
+        )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.get_conn"
+    )
+    def test_get_instance_without_project_id(self, mock_get_conn):
+        with self.assertRaises(AirflowException):
+            self.hook.get_instance(
+                location=TEST_LOCATION,
+                instance=TEST_INSTANCE,
+                project_id=None,
+                retry=TEST_RETRY,
+                timeout=TEST_TIMEOUT,
+                metadata=TEST_METADATA,
+            )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.get_conn"
+    )
+    def test_list_instances(self, mock_get_conn):
+        self.hook.list_instances(
+            location=TEST_LOCATION,
+            page_size=TEST_PAGE_SIZE,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+        mock_get_conn.list_instances.assert_called_once_with(
+            parent=TEST_PARENT,
+            page_size=TEST_PAGE_SIZE,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.get_conn"
+    )
+    def test_list_instances_without_project_id(self, mock_get_conn):
+        with self.assertRaises(AirflowException):
+            self.hook.list_instances(
+                location=TEST_LOCATION,
+                page_size=TEST_PAGE_SIZE,
+                project_id=None,
+                retry=TEST_RETRY,
+                timeout=TEST_TIMEOUT,
+                metadata=TEST_METADATA,
+            )
+
+    @mock.patch(  # type: ignore
+        "airflow.contrib.hooks.gcp_cloud_memorystore_hook.CloudMemorystoreHook.get_conn"
+    )
+    def test_update_instance(self, mock_get_conn):
+        self.hook.update_instance(
+            update_mask=TEST_UPDATE_MASK,
+            instance=TEST_INSTANCE,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+        mock_get_conn.update_instance.assert_called_once_with(
+            update_mask=TEST_UPDATE_MASK,
+            instance=TEST_INSTANCE,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )

--- a/tests/gcp/operators/test_gcp_cloud_memorystore_operator.py
+++ b/tests/gcp/operators/test_gcp_cloud_memorystore_operator.py
@@ -1,0 +1,239 @@
+from typing import Dict, Sequence, Tuple
+from unittest import TestCase, mock
+
+from google.api_core.retry import Retry
+from google.cloud.redis_v1.types import DataProtectionMode, FieldMask, InputConfig, Instance, OutputConfig
+
+from airflow.gcp.operators.cloud_memorystore import (CloudMemorystoreCreateInstanceOperator,
+                                                     CloudMemorystoreDeleteInstanceOperator,
+                                                     CloudMemorystoreExportInstanceOperator,
+                                                     CloudMemorystoreFailoverInstanceOperator,
+                                                     CloudMemorystoreGetInstanceOperator,
+                                                     CloudMemorystoreImportInstanceOperator,
+                                                     CloudMemorystoreListInstancesOperator,
+                                                     CloudMemorystoreUpdateInstanceOperator)
+
+
+TEST_GCP_CONN_ID: str = "test-gcp-conn-id"
+TEST_TASK_ID: str = 'task-id'
+TEST_LOCATION: str = "test-location"
+TEST_INSTANCE_ID: str = "test-instance-id"
+TEST_INSTANCE: Dict = None  # TODO: Fill missing value
+TEST_INSTANCE_NAME: str = "test-instance-name"
+TEST_PROJECT_ID: str = "test-project-id"
+TEST_RETRY: Retry = None  # TODO: Fill missing value
+TEST_TIMEOUT: float = None  # TODO: Fill missing value
+TEST_METADATA: Sequence[Tuple[str, str]] = None  # TODO: Fill missing value
+TEST_OUTPUT_CONFIG: Dict = None  # TODO: Fill missing value
+TEST_DATA_PROTECTION_MODE: DataProtectionMode = None  # TODO: Fill missing value
+TEST_INPUT_CONFIG: Dict = None  # TODO: Fill missing value
+TEST_PAGE_SIZE: int = None  # TODO: Fill missing value
+TEST_UPDATE_MASK: Dict = None  # TODO: Fill missing value
+TEST_PARENT: str = "test-parent"
+TEST_NAME: str = "test-name"
+
+
+class TestCloudMemorystoreCreateInstanceOperator(TestCase):
+    @mock.patch("airflow.gcp.operators.cloud_memorystore.CloudMemorystoreHook")
+    def test_assert_valid_hook_call(self, mock_hook):
+        task = CloudMemorystoreCreateInstanceOperator(
+            task_id=TEST_TASK_ID,
+            location=TEST_LOCATION,
+            instance_id=TEST_INSTANCE_ID,
+            instance=TEST_INSTANCE,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+        )
+        task.execute(mock.MagicMock())
+        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.return_value.create_instance.assert_called_once_with(
+            location=TEST_LOCATION,
+            instance_id=TEST_INSTANCE_ID,
+            instance=TEST_INSTANCE,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+
+
+class TestCloudMemorystoreDeleteInstanceOperator(TestCase):
+    @mock.patch("airflow.gcp.operators.cloud_memorystore.CloudMemorystoreHook")
+    def test_assert_valid_hook_call(self, mock_hook):
+        task = CloudMemorystoreDeleteInstanceOperator(
+            task_id=TEST_TASK_ID,
+            location=TEST_LOCATION,
+            instance=TEST_INSTANCE_NAME,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+        )
+        task.execute(mock.MagicMock())
+        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.return_value.delete_instance.assert_called_once_with(
+            location=TEST_LOCATION,
+            instance=TEST_INSTANCE_NAME,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+
+
+class TestCloudMemorystoreExportInstanceOperator(TestCase):
+    @mock.patch("airflow.contrib.operator.gcp_cloud_memorystore_operator.CloudMemorystoreHook")
+    def test_assert_valid_hook_call(self, mock_hook):
+        task = CloudMemorystoreExportInstanceOperator(
+            task_id=TEST_TASK_ID,
+            location=TEST_LOCATION,
+            instance=TEST_INSTANCE_NAME,
+            output_config=TEST_OUTPUT_CONFIG,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+        )
+        task.execute(context=mock.MagicMock())
+        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.return_value.export_instance.assert_called_once_with(
+            location=TEST_LOCATION,
+            instance=TEST_INSTANCE,
+            output_config=TEST_OUTPUT_CONFIG,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+
+
+class TestCloudMemorystoreFailoverInstanceOperator(TestCase):
+    @mock.patch("airflow.contrib.operator.gcp_cloud_memorystore_operator.CloudMemorystoreHook")
+    def test_assert_valid_hook_call(self, mock_hook):
+        task = CloudMemorystoreFailoverInstanceOperator(
+            task_id=TEST_TASK_ID,
+            location=TEST_LOCATION,
+            instance=TEST_INSTANCE_NAME,
+            data_protection_mode=TEST_DATA_PROTECTION_MODE,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+        )
+        task.execute(context=mock.MagicMock())
+        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.return_value.failover_instance.assert_called_once_with(
+            location=TEST_LOCATION,
+            instance=TEST_INSTANCE,
+            data_protection_mode=TEST_DATA_PROTECTION_MODE,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+
+
+class TestCloudMemorystoreGetInstanceOperator(TestCase):
+    @mock.patch("airflow.gcp.operators.cloud_memorystore.CloudMemorystoreHook")
+    def test_assert_valid_hook_call(self, mock_hook):
+        task = CloudMemorystoreGetInstanceOperator(
+            task_id=TEST_TASK_ID,
+            location=TEST_LOCATION,
+            instance=TEST_INSTANCE_NAME,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+        )
+        task.execute(mock.MagicMock())
+        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.return_value.get_instance.assert_called_once_with(
+            location=TEST_LOCATION,
+            instance=TEST_INSTANCE_NAME,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+
+
+class TestCloudMemorystoreImportInstanceOperator(TestCase):
+    @mock.patch("airflow.contrib.operator.gcp_cloud_memorystore_operator.CloudMemorystoreHook")
+    def test_assert_valid_hook_call(self, mock_hook):
+        task = CloudMemorystoreImportInstanceOperator(
+            task_id=TEST_TASK_ID,
+            location=TEST_LOCATION,
+            instance=TEST_INSTANCE_NAME,
+            input_config=TEST_INPUT_CONFIG,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+        )
+        task.execute(context=mock.MagicMock())
+        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.return_value.import_instance.assert_called_once_with(
+            location=TEST_LOCATION,
+            instance=TEST_INSTANCE,
+            input_config=TEST_INPUT_CONFIG,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+
+
+class TestCloudMemorystoreListInstancesOperator(TestCase):
+    @mock.patch("airflow.gcp.operators.cloud_memorystore.CloudMemorystoreHook")
+    def test_assert_valid_hook_call(self, mock_hook):
+        task = CloudMemorystoreListInstancesOperator(
+            task_id=TEST_TASK_ID,
+            location=TEST_LOCATION,
+            page_size=TEST_PAGE_SIZE,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+        )
+        task.execute(mock.MagicMock())
+        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.return_value.list_instances.assert_called_once_with(
+            location=TEST_LOCATION,
+            page_size=TEST_PAGE_SIZE,
+            project_id=TEST_PROJECT_ID,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )
+
+
+class TestCloudMemorystoreUpdateInstanceOperator(TestCase):
+    @mock.patch("airflow.gcp.operators.cloud_memorystore.CloudMemorystoreHook")
+    def test_assert_valid_hook_call(self, mock_hook):
+        task = CloudMemorystoreUpdateInstanceOperator(
+            task_id=TEST_TASK_ID,
+            update_mask=TEST_UPDATE_MASK,
+            instance=TEST_INSTANCE,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+        )
+        task.execute(mock.MagicMock())
+        mock_hook.assert_called_once_with(gcp_conn_id=TEST_GCP_CONN_ID)
+        mock_hook.return_value.update_instance.assert_called_once_with(
+            update_mask=TEST_UPDATE_MASK,
+            instance=TEST_INSTANCE,
+            retry=TEST_RETRY,
+            timeout=TEST_TIMEOUT,
+            metadata=TEST_METADATA,
+        )


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
