### PR TITLE
[AIRFLOW-5239] Fix listing of pylint test scripts for Docker container

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ other development environments that you have on your local machine.
 Another disadvantage is that you you cannot run tests that require
 external components - mysql, postgres database, hadoop, mongo, cassandra, redis etc..
 The tests in Airflow are a mixture of unit and integration tests and some of them
-require those components to be setup. Only real unit tests can be run bu default in local environment.
+require those components to be setup. Only real unit tests can be run by default in local environment.
 
 If you want to run integration tests, you need to configure and install the dependencies on your own.
 
@@ -392,7 +392,8 @@ If you are already in the [Docker Compose Environment](#entering-bash-shell-in-d
 you can also run the same static checks from within container:
 
 * Mypy: `./scripts/ci/in_container/run_mypy.sh airflow tests`
-* Pylint: `./scripts/ci/in_container/run_pylint.sh`
+* Pylint for main files: `./scripts/ci/in_container/run_pylint_main.sh`
+* Pylint for test files: `./scripts/ci/in_container/run_pylint_tests.sh`
 * Flake8: `./scripts/ci/in_container/run_flake8.sh`
 * Licence check: `./scripts/ci/in_container/run_check_licence.sh`
 * Documentation: `./scripts/ci/in_container/run_docs_build.sh`


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5239) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5239

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

  1. List the two separate `pylint` scripts for use inside the Docker containers in CONTRIBUTING.md, not a single one that appears to no longer exist.
  1. Fix a small typo in another spot of `CONTRIBUTING.md`

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - These are only docs changes

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`