### PR TITLE
[AIRFLOW-5250] fix all dmypy error for gcp hooks

### DIFF
--- a/airflow/gcp/hooks/cloud_build.py
+++ b/airflow/gcp/hooks/cloud_build.py
@@ -19,7 +19,7 @@
 """Hook for Google Cloud Build service"""
 
 import time
-from typing import Dict
+from typing import Dict, Any, Optional
 
 from googleapiclient.discovery import build
 
@@ -48,7 +48,7 @@ class CloudBuildHook(GoogleCloudBaseHook):
     :type delegate_to: str
     """
 
-    _conn = None
+    _conn = None  # type: Optional[Any]
 
     def __init__(
         self,

--- a/airflow/gcp/hooks/cloud_sql.py
+++ b/airflow/gcp/hooks/cloud_sql.py
@@ -736,7 +736,7 @@ class CloudSqlDatabaseHook(BaseHook):
            in the connection URL
     :type default_gcp_project_id: str
     """
-    _conn = None
+    _conn = None  # type: Optional[Any]
 
     def __init__(
         self,

--- a/airflow/gcp/hooks/compute.py
+++ b/airflow/gcp/hooks/compute.py
@@ -21,7 +21,7 @@ This module contains a Google Compute Engine Hook.
 """
 
 import time
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from googleapiclient.discovery import build
 
@@ -49,7 +49,7 @@ class GceHook(GoogleCloudBaseHook):
     All the methods in the hook where project_id is used must be called with
     keyword arguments rather than positional.
     """
-    _conn = None
+    _conn = None  # type: Optional[Any]
 
     def __init__(
         self,

--- a/airflow/gcp/hooks/functions.py
+++ b/airflow/gcp/hooks/functions.py
@@ -20,7 +20,7 @@
 This module contains a Google Cloud Functions Hook.
 """
 import time
-from typing import Dict, List
+from typing import Dict, List, Optional, Any
 
 import requests
 from googleapiclient.discovery import build
@@ -40,7 +40,7 @@ class GcfHook(GoogleCloudBaseHook):
     All the methods in the hook where project_id is used must be called with
     keyword arguments rather than positional.
     """
-    _conn = None
+    _conn = None  # type: Optional[Any]
 
     def __init__(
         self,

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -273,7 +273,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         # return a set of all dags that the user could access
         return {view for perm, view in user_perms_views if perm in self.DAG_PERMS}
 
-    def has_access(self, permission, view_name, user=None):
+    def has_access(self, permission, view_name, user=None) -> bool:
         """
         Verify whether a given user could perform certain permission
         (e.g can_read, can_write) on the given dag_id.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

This commit fixes all the remaining error reported by dmypy:

```bash
airflow/contrib/hooks/gcp_cloud_build_hook.py:51: error: Need type annotation for '_conn'
airflow/contrib/hooks/gcp_compute_hook.py:52: error: Need type annotation for '_conn'
airflow/contrib/hooks/gcp_sql_hook.py:739: error: Need type annotation for '_conn'
airflow/gcp/hooks/functions.py:43: error: Need type annotation for '_conn'
```

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
