### PR TITLE
[AIRFLOW-5251] add missing typing-extensions dep for py37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ jobs:
       env: BACKEND=sqlite ENV=docker
       python: "3.5"
       stage: test
-    - name: "Tests mysql python 3.6"
+    - name: "Tests mysql python 3.7"
       env: BACKEND=mysql ENV=docker
-      python: "3.6"
+      python: "3.7"
       stage: test
     - name: "Tests postgres kubernetes python 3.6 (persistent)"
       env: BACKEND=postgres ENV=kubernetes KUBERNETES_VERSION=v1.13.0 KUBERNETES_MODE=persistent_mode

--- a/airflow/contrib/operators/awsbatch_operator.py
+++ b/airflow/contrib/operators/awsbatch_operator.py
@@ -18,7 +18,7 @@
 # under the License.
 #
 from typing import Optional
-from typing_extensions import Protocol
+from airflow.typing import Protocol
 import sys
 
 from math import pow

--- a/airflow/contrib/operators/ecs_operator.py
+++ b/airflow/contrib/operators/ecs_operator.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from typing import Optional
-from typing_extensions import Protocol
+from airflow.typing import Protocol
 import sys
 import re
 

--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -18,7 +18,7 @@
 # under the License.
 
 from typing import Optional
-from typing_extensions import Protocol
+from airflow.typing import Protocol
 from datetime import datetime
 from contextlib import closing
 

--- a/airflow/models/crypto.py
+++ b/airflow/models/crypto.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing_extensions import Protocol
+from airflow.typing import Protocol
 from typing import Optional
 from airflow import configuration
 from airflow.exceptions import AirflowException

--- a/airflow/typing.py
+++ b/airflow/typing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -16,34 +15,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Default authentication backend - everything is allowed"""
-from typing import Optional
-from functools import wraps
-from airflow.typing import Protocol
 
+"""
+This module provides helper code to make type annotation within Airflow
+codebase easier.
+"""
 
-class ClientAuthProtocol(Protocol):
-    """
-    Protocol type for CLIENT_AUTH
-    """
-    def handle_response(self, _):
-        """
-        CLIENT_AUTH.handle_response method
-        """
-        ...
-
-
-CLIENT_AUTH = None  # type: Optional[ClientAuthProtocol]
-
-
-def init_app(_):
-    """Initializes authentication backend"""
-
-
-def requires_authentication(function):
-    """Decorator for functions that require authentication"""
-    @wraps(function)
-    def decorated(*args, **kwargs):
-        return function(*args, **kwargs)
-
-    return decorated
+try:
+    # Protocol is only added to typing module starting from python 3.8
+    # we can safely remove this shim import after Airflow drops support for
+    # <3.8
+    from typing import Protocol  # noqa # pylint: disable=unused-import
+except ImportError:
+    from typing_extensions import Protocol  # type: ignore # noqa

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 import errno
 
 import psutil

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -16,7 +16,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 import errno
 
 import psutil

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,6 +188,7 @@ exclude_patterns = [
     '_api/airflow/index.rst',
     '_api/airflow/jobs',
     '_api/airflow/lineage',
+    '_api/airflow/typing',
     '_api/airflow/logging_config',
     '_api/airflow/macros',
     '_api/airflow/migrations',

--- a/setup.py
+++ b/setup.py
@@ -361,7 +361,7 @@ def do_setup():
             'tzlocal>=1.4,<2.0.0',
             'unicodecsv>=0.14.1',
             'zope.deprecation>=4.0, <5.0',
-            'typing-extensions>=3.7.4;python_version<"3.7"',
+            'typing-extensions>=3.7.4;python_version<"3.8"',
         ],
         setup_requires=[
             'docutils>=0.14, <1.0',

--- a/tests/gcp/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/gcp/hooks/test_cloud_storage_transfer_service.py
@@ -233,7 +233,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
             {FILTER_PROJECT_ID: TEST_PROJECT_ID, FILTER_JOB_NAMES: ["transferJobs/test-job"]},
         )
 
-        mock_sleep.assert_called_once_with(TIME_TO_SLEEP_IN_SECONDS)
+        mock_sleep.assert_called_with(TIME_TO_SLEEP_IN_SECONDS)
 
     @mock.patch('time.sleep')
     @mock.patch('airflow.gcp.hooks.cloud_storage_transfer_service.GCPTransferServiceHook.get_conn')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Turns out Protocol is still experimental and not available in python 3.7's typing module. So typing-extensions is still required for py3.7.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
