### PR TITLE
[AIRFLOW-4768] Add timeout parameter to Cloud Video Intelligence operators

### DIFF
--- a/airflow/gcp/operators/video_intelligence.py
+++ b/airflow/gcp/operators/video_intelligence.py
@@ -55,6 +55,9 @@ class CloudVideoIntelligenceDetectVideoLabelsOperator(BaseOperator):
     :param retry: Retry object used to determine when/if to retry requests.
         If None is specified, requests will not be retried.
     :type retry: google.api_core.retry.Retry
+    :param timeout: Optional, The amount of time, in seconds, to wait for the request to complete.
+        Note that if retry is specified, the timeout applies to each individual attempt.
+    :type timeout: float
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to ``google_cloud_default``.
     :type gcp_conn_id: str
@@ -71,6 +74,7 @@ class CloudVideoIntelligenceDetectVideoLabelsOperator(BaseOperator):
         video_context=None,
         location=None,
         retry=None,
+        timeout=None,
         gcp_conn_id="google_cloud_default",
         *args,
         **kwargs
@@ -83,6 +87,7 @@ class CloudVideoIntelligenceDetectVideoLabelsOperator(BaseOperator):
         self.location = location
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.timeout = timeout
 
     def execute(self, context):
         hook = CloudVideoIntelligenceHook(gcp_conn_id=self.gcp_conn_id)
@@ -93,6 +98,7 @@ class CloudVideoIntelligenceDetectVideoLabelsOperator(BaseOperator):
             location=self.location,
             retry=self.retry,
             features=[enums.Feature.LABEL_DETECTION],
+            timeout=self.timeout
         )
         self.log.info("Processing video for label annotations")
         result = MessageToDict(operation.result())
@@ -128,6 +134,9 @@ class CloudVideoIntelligenceDetectVideoExplicitContentOperator(BaseOperator):
     :param retry: Retry object used to determine when/if to retry requests.
         If None is specified, requests will not be retried.
     :type retry: google.api_core.retry.Retry
+    :param timeout: Optional, The amount of time, in seconds, to wait for the request to complete.
+        Note that if retry is specified, the timeout applies to each individual attempt.
+    :type timeout: float
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to ``google_cloud_default``.
     :type gcp_conn_id: str
@@ -144,6 +153,7 @@ class CloudVideoIntelligenceDetectVideoExplicitContentOperator(BaseOperator):
         video_context=None,
         location=None,
         retry=None,
+        timeout=None,
         gcp_conn_id="google_cloud_default",
         *args,
         **kwargs
@@ -156,6 +166,7 @@ class CloudVideoIntelligenceDetectVideoExplicitContentOperator(BaseOperator):
         self.location = location
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.timeout = timeout
 
     def execute(self, context):
         hook = CloudVideoIntelligenceHook(gcp_conn_id=self.gcp_conn_id)
@@ -166,6 +177,7 @@ class CloudVideoIntelligenceDetectVideoExplicitContentOperator(BaseOperator):
             location=self.location,
             retry=self.retry,
             features=[enums.Feature.EXPLICIT_CONTENT_DETECTION],
+            timeout=self.timeout
         )
         self.log.info("Processing video for explicit content annotations")
         result = MessageToDict(operation.result())
@@ -201,6 +213,9 @@ class CloudVideoIntelligenceDetectVideoShotsOperator(BaseOperator):
     :param retry: Retry object used to determine when/if to retry requests.
         If None is specified, requests will not be retried.
     :type retry: google.api_core.retry.Retry
+    :param timeout: Optional, The amount of time, in seconds, to wait for the request to complete.
+        Note that if retry is specified, the timeout applies to each individual attempt.
+    :type timeout: float
     :param gcp_conn_id: Optional, The connection ID used to connect to Google Cloud
         Platform. Defaults to ``google_cloud_default``.
     :type gcp_conn_id: str
@@ -217,6 +232,7 @@ class CloudVideoIntelligenceDetectVideoShotsOperator(BaseOperator):
         video_context=None,
         location=None,
         retry=None,
+        timeout=None,
         gcp_conn_id="google_cloud_default",
         *args,
         **kwargs
@@ -229,6 +245,7 @@ class CloudVideoIntelligenceDetectVideoShotsOperator(BaseOperator):
         self.location = location
         self.retry = retry
         self.gcp_conn_id = gcp_conn_id
+        self.timeout = timeout
 
     def execute(self, context):
         hook = CloudVideoIntelligenceHook(gcp_conn_id=self.gcp_conn_id)
@@ -239,6 +256,7 @@ class CloudVideoIntelligenceDetectVideoShotsOperator(BaseOperator):
             location=self.location,
             retry=self.retry,
             features=[enums.Feature.SHOT_CHANGE_DETECTION],
+            timeout=self.timeout
         )
         self.log.info("Processing video for video shots annotations")
         result = MessageToDict(operation.result())

--- a/tests/gcp/operators/test_video_intelligence.py
+++ b/tests/gcp/operators/test_video_intelligence.py
@@ -56,6 +56,7 @@ class CloudVideoIntelligenceOperatorsTestCase(unittest.TestCase):
             video_context=None,
             location=None,
             retry=None,
+            timeout=None
         )
 
     @mock.patch("airflow.gcp.operators.video_intelligence.CloudVideoIntelligenceHook")
@@ -76,6 +77,7 @@ class CloudVideoIntelligenceOperatorsTestCase(unittest.TestCase):
             video_context=None,
             location=None,
             retry=None,
+            timeout=None
         )
 
     @mock.patch("airflow.gcp.operators.video_intelligence.CloudVideoIntelligenceHook")
@@ -96,4 +98,5 @@ class CloudVideoIntelligenceOperatorsTestCase(unittest.TestCase):
             video_context=None,
             location=None,
             retry=None,
+            timeout=None
         )


### PR DESCRIPTION
This commit adds timeout parameter to GCP Video Intelligence operators

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/AIRFLOW-4768

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
This PR adds timeout parameter to GCP Video Intelligence operators

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
