### PR TITLE
[AIRFLOW-5257] ElasticSearch log handler errors when attemping to close it

### DIFF
--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -252,7 +252,6 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
         self.handler.emit(logging.makeLogRecord({'msg': self.end_of_log_mark}))
 
         if self.write_stdout:
-            self.writer.close()
             self.handler.close()
             sys.stdout = sys.__stdout__
 

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -255,7 +255,6 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.es_task_handler.formatter = mock.MagicMock()
         self.es_task_handler.formatter._fmt = mock.MagicMock()
         self.es_task_handler.formatter._fmt.find = mock.MagicMock(return_value=1)
-        self.es_task_handler.writer = mock.MagicMock()
         self.es_task_handler.write_stdout = True
         self.es_task_handler.json_format = True
         self.es_task_handler.set_context(self.ti)


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-5257\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5257
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-5257\], code changes always need a Jira issue.

### Description

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
