### PR TITLE
[AIRFLOW-5258] ElasticSearch log handler, has 2 times of hours (%H and %I) in _clean_execution_date instead of %H and %M

### DIFF
--- a/airflow/utils/log/es_task_handler.py
+++ b/airflow/utils/log/es_task_handler.py
@@ -101,7 +101,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
         # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters
         :param execution_date: execution date of the dag run.
         """
-        return execution_date.strftime("%Y_%m_%dT%H_%I_%S_%f")
+        return execution_date.strftime("%Y_%m_%dT%H_%M_%S_%f")
 
     def _read(self, ti, try_number, metadata=None):
         """

--- a/tests/utils/log/test_es_task_handler.py
+++ b/tests/utils/log/test_es_task_handler.py
@@ -337,5 +337,5 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.assertEqual(expected_log_id, log_id)
 
     def test_clean_execution_date(self):
-        clean_execution_date = self.es_task_handler._clean_execution_date(self.EXECUTION_DATE)
-        self.assertEqual('2016_01_01T00_12_00_000000', clean_execution_date)
+        clean_execution_date = self.es_task_handler._clean_execution_date(datetime(2016, 7, 8, 9, 10, 11, 12))
+        self.assertEqual('2016_07_08T09_10_11_000012', clean_execution_date)


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-5258\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5258
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-5258\], code changes always need a Jira issue.


### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
