### PR TITLE
AIRFLOW-5262 Update timeout exception

### DIFF
--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -113,11 +113,11 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                     self._do_skip_downstream_tasks(context)
                     raise AirflowSkipException(
                         "Snap. Time is OUT for dag: {dag}"
-                        .format(dag=self.dag.dag_id))
+                        .format(dag=str(context['dag_run']) if context['dag_run'] else ""))
                 else:
                     raise AirflowSensorTimeout(
                         "Snap. Time is OUT for dag: {dag}"
-                        .format(dag=self.dag.dag_id))
+                        .format(dag=str(context['dag_run']) if context['dag_run'] else ""))
             if self.reschedule:
                 reschedule_date = timezone.utcnow() + timedelta(
                     seconds=self.poke_interval)

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -111,13 +111,9 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                 # This gives the ability to set up non-blocking AND soft-fail sensors.
                 if self.soft_fail and not context['ti'].is_eligible_to_retry():
                     self._do_skip_downstream_tasks(context)
-                    raise AirflowSkipException(
-                        "Snap. Time is OUT for dag: {dag}"
-                        .format(dag=str(context['dag_run']) if context['dag_run'] else ""))
+                    raise AirflowSkipException("Snap. Time is OUT for dag: {dag}")
                 else:
-                    raise AirflowSensorTimeout(
-                        "Snap. Time is OUT for dag: {dag}"
-                        .format(dag=str(context['dag_run']) if context['dag_run'] else ""))
+                    raise AirflowSensorTimeout("Snap. Time is OUT for dag: {dag}")
             if self.reschedule:
                 reschedule_date = timezone.utcnow() + timedelta(
                     seconds=self.poke_interval)

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -111,9 +111,13 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                 # This gives the ability to set up non-blocking AND soft-fail sensors.
                 if self.soft_fail and not context['ti'].is_eligible_to_retry():
                     self._do_skip_downstream_tasks(context)
-                    raise AirflowSkipException('Snap. Time is OUT.')
+                    raise AirflowSkipException(
+                        "Snap. Time is OUT for dag: {dag}"
+                        .format(dag=self.dag.dag_id))
                 else:
-                    raise AirflowSensorTimeout('Snap. Time is OUT.')
+                    raise AirflowSensorTimeout(
+                        "Snap. Time is OUT for dag: {dag}"
+                        .format(dag=self.dag.dag_id))
             if self.reschedule:
                 reschedule_date = timezone.utcnow() + timedelta(
                     seconds=self.poke_interval)


### PR DESCRIPTION
### Jira
My PR addresses the following [AIRFLOW-5262](https://issues.apache.org/jira/browse/AIRFLOW-5262). 

### Description
The following exception could be made clearer for cursory log investigation (especially in third party paging systems) by including the DAG name with this timeout error message.

https://github.com/apache/airflow/blob/f06ae8fbe9a5c786f0299872abc85d9960b05886/airflow/sensors/base_sensor_operator.py#L114-L116

### Code Quality

- [ ] Passes `flake8`
