### PR TITLE
[AIRFLOW-XXX] Add doc on specifying SSH Key in SSH connection

### DIFF
--- a/docs/howto/connection/ssh.rst
+++ b/docs/howto/connection/ssh.rst
@@ -49,7 +49,7 @@ Extra (optional)
     .. code-block:: json
 
        {
-          "key_file": "/home/airflow/.ssh/id_rsa"
+          "key_file": "/home/airflow/.ssh/id_rsa",
           "timeout": "10",
           "compress": "false",
           "no_host_key_check": "false",

--- a/docs/howto/connection/ssh.rst
+++ b/docs/howto/connection/ssh.rst
@@ -38,6 +38,7 @@ Extra (optional)
     connection. The following parameters out of the standard python parameters
     are supported:
 
+    * **key_file** - Full Path of the private SSH Key file that will be used to connect to the remote_host.
     * **timeout** - An optional timeout (in seconds) for the TCP connect. Default is ``10``.
     * **compress** - ``true`` to ask the remote client/server to compress traffic; `false` to refuse compression. Default is ``true``.
     * **no_host_key_check** - Set to ``false`` to restrict connecting to hosts with no entries in ``~/.ssh/known_hosts`` (Hosts file). This provides maximum protection against trojan horse attacks, but can be troublesome when the ``/etc/ssh/ssh_known_hosts`` file is poorly maintained or connections to new hosts are frequently made. This option forces the user to manually add all new hosts. Default is ``true``, ssh will automatically add new host keys to the user known hosts files.
@@ -48,6 +49,7 @@ Extra (optional)
     .. code-block:: json
 
        {
+          "key_file": "/home/airflow/.ssh/id_rsa"
           "timeout": "10",
           "compress": "false",
           "no_host_key_check": "false",
@@ -62,4 +64,4 @@ Extra (optional)
 
     .. code-block:: bash
 
-        ssh://user:pass@localhost:22?timeout=10&compress=false&no_host_key_check=false&allow_host_key_change=true
+        ssh://user:pass@localhost:22?timeout=10&compress=false&no_host_key_check=false&allow_host_key_change=true&key_file=%2Fhome%2Fairflow%2F.ssh%2Fid_rsa


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
