### PR TITLE
[AIRFLOW-5270] JSONDecodeError in DockerOperator when force_pull

### DIFF
--- a/airflow/operators/docker_operator.py
+++ b/airflow/operators/docker_operator.py
@@ -256,7 +256,7 @@ class DockerOperator(BaseOperator):
         if self.force_pull or len(self.cli.images(name=self.image)) == 0:
             self.log.info('Pulling docker image %s', self.image)
             for l in self.cli.pull(self.image, stream=True):
-                output = json.loads(l.decode('utf-8').strip())
+                output = json.loads(l.decode('utf-8').replace('\r\n', '\n').strip())
                 if 'status' in output:
                     self.log.info("%s", output['status'])
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Airflow Jira]

https://issues.apache.org/jira/browse/AIRFLOW-5270

### Description

- [X] Here are some details about my PR, including screenshots of any UI changes

The DockerAPI often returns multiple JSONs within the same line, joined by `\r\n`. If we replace `\r\n` with `\n`, then the response is decoded as expected; otherwise we get "JSONDecodeError"

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason

Happy to add tests if necessary.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines.

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
