### PR TITLE
[AIRFLOW-5275] Add support for template parameters in DataprocWorkflowTemplateInstantiateOperator

### DIFF
--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -1104,7 +1104,7 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocOperationBaseOperator)
         Example: { "date_from": "2019-08-01", "date_to": "2019-08-02"}.
         Values may not exceed 100 characters. Please refer to:
         https://cloud.google.com/dataproc/docs/concepts/workflows/workflow-parameters
-    :type parameters: map   
+    :type parameters: Dict[str, str]  
     """
 
     template_fields = ['template_id']

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -1099,6 +1099,12 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocOperationBaseOperator)
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
     :type delegate_to: str
+    :param parameters: a map of parameters for Dataproc Template in key-value format: 
+        map (key: string, value: string)
+        Example: { "date_from": "2019-08-01", "date_to": "2019-08-02"}.
+        Values may not exceed 100 characters. Please refer to:
+        https://cloud.google.com/dataproc/docs/concepts/workflows/workflow-parameters
+    :type parameters: map   
     """
 
     template_fields = ['template_id']
@@ -1108,9 +1114,9 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocOperationBaseOperator)
         super().__init__(*args, **kwargs)
         self.template_id = template_id
 
-    def start(self):
+    def start(self, parameters):
         """
-        Instantiate a WorkflowTemplate on Google Cloud Dataproc.
+        Instantiate a WorkflowTemplate on Google Cloud Dataproc with given parameters.
         """
         self.log.info('Instantiating Template: %s', self.template_id)
         return (
@@ -1118,7 +1124,7 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocOperationBaseOperator)
             .instantiate(
                 name=('projects/%s/regions/%s/workflowTemplates/%s' %
                       (self.project_id, self.region, self.template_id)),
-                body={'requestId': str(uuid.uuid4())})
+                body={'requestId': str(uuid.uuid4()), 'parameters': parameters})
             .execute())
 
 

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -1099,23 +1099,23 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocOperationBaseOperator)
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
     :type delegate_to: str
-    :param parameters: a map of parameters for Dataproc Template in key-value format: 
+    :param parameters: a map of parameters for Dataproc Template in key-value format:
         map (key: string, value: string)
         Example: { "date_from": "2019-08-01", "date_to": "2019-08-02"}.
-        Values may not exceed 100 characters.
-        Please refer to:
+        Values may not exceed 100 characters. Please refer to:
         https://cloud.google.com/dataproc/docs/concepts/workflows/workflow-parameters
-    :type parameters: map    
+    :type parameters: Dict[str, str]
     """
 
     template_fields = ['template_id']
 
     @apply_defaults
-    def __init__(self, template_id, *args, **kwargs):
+    def __init__(self, template_id, parameters, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.template_id = template_id
+        self.parameters = parameters
 
-    def start(self, parameters):
+    def start(self):
         """
         Instantiate a WorkflowTemplate on Google Cloud Dataproc with given parameters.
         """
@@ -1125,7 +1125,7 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocOperationBaseOperator)
             .instantiate(
                 name=('projects/%s/regions/%s/workflowTemplates/%s' %
                       (self.project_id, self.region, self.template_id)),
-                body={'requestId': str(uuid.uuid4()), 'parameters': parameters})
+                body={'requestId': str(uuid.uuid4()), 'parameters': self.parameters})
             .execute())
 
 

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -1099,6 +1099,13 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocOperationBaseOperator)
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
     :type delegate_to: str
+    :param parameters: a map of parameters for Dataproc Template in key-value format: 
+        map (key: string, value: string)
+        Example: { "date_from": "2019-08-01", "date_to": "2019-08-02"}.
+        Values may not exceed 100 characters.
+        Please refer to:
+        https://cloud.google.com/dataproc/docs/concepts/workflows/workflow-parameters
+    :type parameters: map    
     """
 
     template_fields = ['template_id']
@@ -1108,9 +1115,9 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocOperationBaseOperator)
         super().__init__(*args, **kwargs)
         self.template_id = template_id
 
-    def start(self):
+    def start(self, parameters):
         """
-        Instantiate a WorkflowTemplate on Google Cloud Dataproc.
+        Instantiate a WorkflowTemplate on Google Cloud Dataproc with given parameters.
         """
         self.log.info('Instantiating Template: %s', self.template_id)
         return (
@@ -1118,7 +1125,7 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocOperationBaseOperator)
             .instantiate(
                 name=('projects/%s/regions/%s/workflowTemplates/%s' %
                       (self.project_id, self.region, self.template_id)),
-                body={'requestId': str(uuid.uuid4())})
+                body={'requestId': str(uuid.uuid4()), 'parameters': parameters})
             .execute())
 
 

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -1099,7 +1099,8 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocOperationBaseOperator)
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
     :type delegate_to: str
-    :param parameters: a map of parameters for Dataproc Template in key-value format: map (key: string, value: string)
+    :param parameters: a map of parameters for Dataproc Template in key-value format: 
+        map (key: string, value: string)
         Example: { "date_from": "2019-08-01", "date_to": "2019-08-02"}.
         Values may not exceed 100 characters.
         Please refer to:

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -1099,6 +1099,12 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocOperationBaseOperator)
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
     :type delegate_to: str
+    :param parameters: a map of parameters for Dataproc Template in key-value format: map (key: string, value: string)
+        Example: { "date_from": "2019-08-01", "date_to": "2019-08-02"}.
+        Values may not exceed 100 characters.
+        Please refer to:
+        https://cloud.google.com/dataproc/docs/concepts/workflows/workflow-parameters
+    :type parameters: map    
     """
 
     template_fields = ['template_id']
@@ -1108,9 +1114,9 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocOperationBaseOperator)
         super().__init__(*args, **kwargs)
         self.template_id = template_id
 
-    def start(self):
+    def start(self, parameters):
         """
-        Instantiate a WorkflowTemplate on Google Cloud Dataproc.
+        Instantiate a WorkflowTemplate on Google Cloud Dataproc with given parameters.
         """
         self.log.info('Instantiating Template: %s', self.template_id)
         return (
@@ -1118,7 +1124,7 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocOperationBaseOperator)
             .instantiate(
                 name=('projects/%s/regions/%s/workflowTemplates/%s' %
                       (self.project_id, self.region, self.template_id)),
-                body={'requestId': str(uuid.uuid4())})
+                body={'requestId': str(uuid.uuid4()), 'parameters': parameters})
             .execute())
 
 

--- a/airflow/contrib/operators/dataproc_operator.py
+++ b/airflow/contrib/operators/dataproc_operator.py
@@ -1099,12 +1099,12 @@ class DataprocWorkflowTemplateInstantiateOperator(DataprocOperationBaseOperator)
         For this to work, the service account making the request must have domain-wide
         delegation enabled.
     :type delegate_to: str
-    :param parameters: a map of parameters for Dataproc Template in key-value format: 
+    :param parameters: a map of parameters for Dataproc Template in key-value format:
         map (key: string, value: string)
         Example: { "date_from": "2019-08-01", "date_to": "2019-08-02"}.
         Values may not exceed 100 characters. Please refer to:
         https://cloud.google.com/dataproc/docs/concepts/workflows/workflow-parameters
-    :type parameters: Dict[str, str]  
+    :type parameters: Dict[str, str]
     """
 
     template_fields = ['template_id']

--- a/tests/contrib/operators/test_dataproc_operator.py
+++ b/tests/contrib/operators/test_dataproc_operator.py
@@ -84,6 +84,7 @@ DEFAULT_DATE = datetime.datetime(2017, 6, 6)
 GCP_REGION = 'test-region'
 MAIN_URI = 'test-uri'
 TEMPLATE_ID = 'template-id'
+WORKFLOW_PARAMETERS = '{"parameter": "value"}'
 
 LABELS = {
     'label_a': 'value_a',
@@ -968,6 +969,7 @@ class DataprocWorkflowTemplateInstantiateOperatorTest(unittest.TestCase):
                 project_id=GCP_PROJECT_ID,
                 region=GCP_REGION,
                 template_id=TEMPLATE_ID,
+                parameters=WORKFLOW_PARAMETERS,
                 dag=self.dag
             )
 


### PR DESCRIPTION
Added passing parameter values to Dataproc workflow template.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

Adding support for parameters in Dataprc API https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.locations.workflowTemplates/instantiate

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
