### PR TITLE
[AIRFLOW-5282] Add default timeout on kubeclient & catch HTTPError

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -778,11 +778,11 @@ tolerations =
 #   https://raw.githubusercontent.com/kubernetes-client/python/master/kubernetes/client/apis/core_v1_api.py
 # Note that if no _request_timeout is specified, the kubernetes client will wait indefinitely for kubernetes
 # api responses, which will cause the scheduler to hang. The timeout is specified as [connect timeout, read timeout]
+kube_client_request_args = {"_request_timeout" : [60,60] }
 
 # Worker pods security context options
 # See:
 #   https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-kube_client_request_args = {"_request_timeout" : [60,60] }
 
 # Specifies the uid to run the first process of the worker pods containers as
 run_as_user =

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -776,11 +776,13 @@ tolerations =
 # List of supported params in **kwargs are similar for all core_v1_apis, hence a single config variable for all apis
 # See:
 #   https://raw.githubusercontent.com/kubernetes-client/python/master/kubernetes/client/apis/core_v1_api.py
-kube_client_request_args =
+# Note that if no _request_timeout is specified, the kubernetes client will wait indefinitely for kubernetes
+# api responses, which will cause the scheduler to hang. The timeout is specified as [connect timeout, read timeout]
 
 # Worker pods security context options
 # See:
 #   https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+kube_client_request_args = {"_request_timeout" : [60,60] }
 
 # Specifies the uid to run the first process of the worker pods containers as
 run_as_user =

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -778,7 +778,7 @@ tolerations =
 #   https://raw.githubusercontent.com/kubernetes-client/python/master/kubernetes/client/apis/core_v1_api.py
 # Note that if no _request_timeout is specified, the kubernetes client will wait indefinitely for kubernetes
 # api responses, which will cause the scheduler to hang. The timeout is specified as [connect timeout, read timeout]
-kube_client_request_args = {"_request_timeout" : [60,60] }
+kube_client_request_args = {{"_request_timeout" : [60,60] }}
 
 # Worker pods security context options
 # See:

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -337,7 +337,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin, object):
         if resource_version:
             kwargs['resource_version'] = resource_version
         if kube_config.kube_client_request_args:
-            for key, value in kube_config.kube_client_request_args.iteritems():
+            for key, value in kube_config.kube_client_request_args.items():
                 kwargs[key] = value
 
         last_resource_version = None
@@ -684,7 +684,7 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
             )
             kwargs = dict(label_selector=dict_string)
             if self.kube_config.kube_client_request_args:
-                for key, value in self.kube_config.kube_client_request_args.iteritems():
+                for key, value in self.kube_config.kube_client_request_args.items():
                     kwargs[key] = value
             pod_list = self.kube_client.list_namespaced_pod(
                 self.kube_config.kube_namespace, **kwargs)

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -801,7 +801,7 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
                     self.task_queue.put(task)
                 except HTTPError as e:
                     self.log.warning('HTTPError when attempting to run task, re-queueing. '
-                                     'Exception: %s' + str(e))
+                                     'Exception: %s', str(e))
                     self.task_queue.put(task)
                 finally:
                     self.task_queue.task_done()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues:
  - https://issues.apache.org/jira/browse/AIRFLOW-5282

### Description

This PR:
* Adds a default _request_timeout in airflow.cfg, so that default installations will not hang indefinitely
* Catches the errors in the scheduler, and retries scheduling the task, in a similar fashion to how ApiExcptions are caught. (https://github.com/apache/airflow/blob/46885ccdbc8618f295b8f986da95c1abbb85bb02/airflow/executors/kubernetes_executor.py#L800-L803)
* Fixes a bug in the parsing of airflow.cfg. The notes state that a json dict is expected. This is parsed with `json.loads`, which returns a dict. But in the code, .iteritems() is called on this dict, which cannot work. .items() should be used instead.


### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
