### PR TITLE
[AIRFLOW-5194] Add error handler to action log

### DIFF
--- a/airflow/cli/commands/version_command.py
+++ b/airflow/cli/commands/version_command.py
@@ -17,10 +17,8 @@
 """Version command"""
 import airflow
 from airflow import settings
-from airflow.utils import cli as cli_utils
 
 
-@cli_utils.action_logging
 def version(args):
     """Displays Airflow version at the command line"""
     print(settings.HEADER + "  v" + airflow.__version__)

--- a/airflow/utils/cli_action_loggers.py
+++ b/airflow/utils/cli_action_loggers.py
@@ -99,8 +99,11 @@ def default_action_log(log, **_):
     :param **_: other keyword arguments that is not being used by this function
     :return: None
     """
-    with create_session() as session:
-        session.add(log)
+    try:
+        with create_session() as session:
+            session.add(log)
+    except Exception as error:
+        logging.warning("Failed to log action with %s", error)
 
 
 __pre_exec_callbacks = []  # type: List[Callable]


### PR DESCRIPTION
### Jira

- [X] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5194) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-5194

### Description

Added try/except with logging.warning on action log error, quite less scary than having a wall of red text pop up from the unhandled error.

Also removed action logging from the CLI version command which doesn't do
anything worth logging.

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: no functional changes.

### Commits

- [X] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [X] Passes `flake8`
