### PR TITLE
[AIRFLOW-5289] Add body to templated fields for gcp operators.

### DIFF
--- a/airflow/gcp/operators/cloud_sql.py
+++ b/airflow/gcp/operators/cloud_sql.py
@@ -230,7 +230,7 @@ class CloudSqlInstanceCreateOperator(CloudSqlBaseOperator):
     :type validate_body: bool
     """
     # [START gcp_sql_create_template_fields]
-    template_fields = ('project_id', 'instance', 'gcp_conn_id', 'api_version')
+    template_fields = ('project_id', 'instance', 'body', 'gcp_conn_id', 'api_version')
     # [END gcp_sql_create_template_fields]
 
     @apply_defaults
@@ -304,7 +304,7 @@ class CloudSqlInstancePatchOperator(CloudSqlBaseOperator):
     :type api_version: str
     """
     # [START gcp_sql_patch_template_fields]
-    template_fields = ('project_id', 'instance', 'gcp_conn_id', 'api_version')
+    template_fields = ('project_id', 'instance', 'body', 'gcp_conn_id', 'api_version')
     # [END gcp_sql_patch_template_fields]
 
     @apply_defaults
@@ -405,7 +405,7 @@ class CloudSqlInstanceDatabaseCreateOperator(CloudSqlBaseOperator):
     :type validate_body: bool
     """
     # [START gcp_sql_db_create_template_fields]
-    template_fields = ('project_id', 'instance', 'gcp_conn_id', 'api_version')
+    template_fields = ('project_id', 'instance', 'body', 'gcp_conn_id', 'api_version')
     # [END gcp_sql_db_create_template_fields]
 
     @apply_defaults
@@ -477,7 +477,7 @@ class CloudSqlInstanceDatabasePatchOperator(CloudSqlBaseOperator):
     :type validate_body: bool
     """
     # [START gcp_sql_db_patch_template_fields]
-    template_fields = ('project_id', 'instance', 'database', 'gcp_conn_id',
+    template_fields = ('project_id', 'instance', 'body', 'database', 'gcp_conn_id',
                        'api_version')
     # [END gcp_sql_db_patch_template_fields]
 
@@ -609,7 +609,7 @@ class CloudSqlInstanceExportOperator(CloudSqlBaseOperator):
     :type validate_body: bool
     """
     # [START gcp_sql_export_template_fields]
-    template_fields = ('project_id', 'instance', 'gcp_conn_id', 'api_version')
+    template_fields = ('project_id', 'instance', 'body', 'gcp_conn_id', 'api_version')
     # [END gcp_sql_export_template_fields]
 
     @apply_defaults
@@ -685,7 +685,7 @@ class CloudSqlInstanceImportOperator(CloudSqlBaseOperator):
     :type validate_body: bool
     """
     # [START gcp_sql_import_template_fields]
-    template_fields = ('project_id', 'instance', 'gcp_conn_id', 'api_version')
+    template_fields = ('project_id', 'instance', 'body', 'gcp_conn_id', 'api_version')
     # [END gcp_sql_import_template_fields]
 
     @apply_defaults

--- a/airflow/gcp/operators/compute.py
+++ b/airflow/gcp/operators/compute.py
@@ -198,7 +198,7 @@ class GceSetMachineTypeOperator(GceBaseOperator):
     :type validate_body: bool
     """
     # [START gce_instance_set_machine_type_template_fields]
-    template_fields = ('project_id', 'zone', 'resource_id', 'gcp_conn_id', 'api_version')
+    template_fields = ('project_id', 'zone', 'resource_id', 'body', 'gcp_conn_id', 'api_version')
     # [END gce_instance_set_machine_type_template_fields]
 
     @apply_defaults

--- a/airflow/gcp/operators/functions.py
+++ b/airflow/gcp/operators/functions.py
@@ -118,7 +118,7 @@ class GcfFunctionDeployOperator(BaseOperator):
     :type validate_body: bool
     """
     # [START gcf_function_deploy_template_fields]
-    template_fields = ('project_id', 'location', 'gcp_conn_id', 'api_version')
+    template_fields = ('body', 'project_id', 'location', 'gcp_conn_id', 'api_version')
     # [END gcf_function_deploy_template_fields]
 
     @apply_defaults


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5289
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
