### PR TITLE
[AIRFLOW-5292] Allow ECSOperator to tag tasks

### DIFF
--- a/airflow/contrib/operators/ecs_operator.py
+++ b/airflow/contrib/operators/ecs_operator.py
@@ -73,6 +73,8 @@ class ECSOperator(BaseOperator):
     :type platform_version: str
     :param network_configuration: the network configuration for the task
     :type network_configuration: dict
+    :param tags: a dictionary of tags in the form of {'tagKey': 'tagValue'}.
+    :type tags: dict
     :param awslogs_group: the CloudWatch group where your ECS container logs are stored.
         Only required if you want logs to be shown in the Airflow UI after your job has
         finished.
@@ -97,7 +99,7 @@ class ECSOperator(BaseOperator):
     def __init__(self, task_definition, cluster, overrides,
                  aws_conn_id=None, region_name=None, launch_type='EC2',
                  group=None, placement_constraints=None, platform_version='LATEST',
-                 network_configuration=None, awslogs_group=None,
+                 network_configuration=None, tags=None, awslogs_group=None,
                  awslogs_region=None, awslogs_stream_prefix=None, **kwargs):
         super().__init__(**kwargs)
 
@@ -112,6 +114,7 @@ class ECSOperator(BaseOperator):
         self.platform_version = platform_version
         self.network_configuration = network_configuration
 
+        self.tags = tags
         self.awslogs_group = awslogs_group
         self.awslogs_stream_prefix = awslogs_stream_prefix
         self.awslogs_region = awslogs_region
@@ -149,6 +152,9 @@ class ECSOperator(BaseOperator):
             run_opts['placementConstraints'] = self.placement_constraints
         if self.network_configuration is not None:
             run_opts['networkConfiguration'] = self.network_configuration
+        if self.tags is not None:
+            run_opts['tags'] = [{'key': k, 'value': v} for (k, v) in self.tags.items()]
+
         response = self.client.run_task(**run_opts)
 
         failures = response['failures']


### PR DESCRIPTION
This commit introduces a parameter for the `ECSOperator` in order to
pass along tags to any tasks it is running.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
