### PR TITLE
[AIRFLOW-4771] Avoid initialization of hook in the GCP operator constructors

### DIFF
--- a/airflow/gcp/operators/bigtable.py
+++ b/airflow/gcp/operators/bigtable.py
@@ -122,12 +122,13 @@ class BigtableInstanceCreateOperator(BaseOperator, BigtableValidationMixin):
         self.cluster_storage_type = cluster_storage_type
         self.timeout = timeout
         self._validate_inputs()
-        self.hook = BigtableHook(gcp_conn_id=gcp_conn_id)
+        self.gcp_conn_id = gcp_conn_id
         super().__init__(*args, **kwargs)
 
     def execute(self, context):
-        instance = self.hook.get_instance(project_id=self.project_id,
-                                          instance_id=self.instance_id)
+        hook = BigtableHook(gcp_conn_id=self.gcp_conn_id)
+        instance = hook.get_instance(project_id=self.project_id,
+                                     instance_id=self.instance_id)
         if instance:
             # Based on Instance.__eq__ instance with the same ID and client is
             # considered as equal.
@@ -138,7 +139,7 @@ class BigtableInstanceCreateOperator(BaseOperator, BigtableValidationMixin):
             )
             return
         try:
-            self.hook.create_instance(
+            hook.create_instance(
                 project_id=self.project_id,
                 instance_id=self.instance_id,
                 main_cluster_id=self.main_cluster_id,
@@ -186,13 +187,14 @@ class BigtableInstanceDeleteOperator(BaseOperator, BigtableValidationMixin):
         self.project_id = project_id
         self.instance_id = instance_id
         self._validate_inputs()
-        self.hook = BigtableHook(gcp_conn_id=gcp_conn_id)
+        self.gcp_conn_id = gcp_conn_id
         super().__init__(*args, **kwargs)
 
     def execute(self, context):
+        hook = BigtableHook(gcp_conn_id=self.gcp_conn_id)
         try:
-            self.hook.delete_instance(project_id=self.project_id,
-                                      instance_id=self.instance_id)
+            hook.delete_instance(project_id=self.project_id,
+                                 instance_id=self.instance_id)
         except google.api_core.exceptions.NotFound:
             self.log.info(
                 "The instance '%s' does not exist in project '%s'. "
@@ -249,13 +251,11 @@ class BigtableTableCreateOperator(BaseOperator, BigtableValidationMixin):
         self.initial_split_keys = initial_split_keys or list()
         self.column_families = column_families or dict()
         self._validate_inputs()
-        self.hook = BigtableHook(gcp_conn_id=gcp_conn_id)
-        self.instance = None
+        self.gcp_conn_id = gcp_conn_id
         super().__init__(*args, **kwargs)
 
-    def _compare_column_families(self):
-        table_column_families = self.hook.get_column_families_for_table(self.instance,
-                                                                        self.table_id)
+    def _compare_column_families(self, hook, instance):
+        table_column_families = hook.get_column_families_for_table(instance, self.table_id)
         if set(table_column_families.keys()) != set(self.column_families.keys()):
             self.log.error("Table '%s' has different set of Column Families",
                            self.table_id)
@@ -278,21 +278,21 @@ class BigtableTableCreateOperator(BaseOperator, BigtableValidationMixin):
         return True
 
     def execute(self, context):
-        self.instance = self.hook.get_instance(project_id=self.project_id,
-                                               instance_id=self.instance_id)
-        if not self.instance:
+        hook = BigtableHook(gcp_conn_id=self.gcp_conn_id)
+        instance = hook.get_instance(project_id=self.project_id, instance_id=self.instance_id)
+        if not instance:
             raise AirflowException(
                 "Dependency: instance '{}' does not exist in project '{}'.".
                 format(self.instance_id, self.project_id))
         try:
-            self.hook.create_table(
-                instance=self.instance,
+            hook.create_table(
+                instance=instance,
                 table_id=self.table_id,
                 initial_split_keys=self.initial_split_keys,
                 column_families=self.column_families
             )
         except google.api_core.exceptions.AlreadyExists:
-            if not self._compare_column_families():
+            if not self._compare_column_families(hook, instance):
                 raise AirflowException(
                     "Table '{}' already exists with different Column Families.".
                     format(self.table_id))
@@ -337,18 +337,19 @@ class BigtableTableDeleteOperator(BaseOperator, BigtableValidationMixin):
         self.table_id = table_id
         self.app_profile_id = app_profile_id
         self._validate_inputs()
-        self.hook = BigtableHook(gcp_conn_id=gcp_conn_id)
+        self.gcp_conn_id = gcp_conn_id
         super().__init__(*args, **kwargs)
 
     def execute(self, context):
-        instance = self.hook.get_instance(project_id=self.project_id,
-                                          instance_id=self.instance_id)
+        hook = BigtableHook(gcp_conn_id=self.gcp_conn_id)
+        instance = hook.get_instance(project_id=self.project_id,
+                                     instance_id=self.instance_id)
         if not instance:
             raise AirflowException("Dependency: instance '{}' does not exist.".format(
                 self.instance_id))
 
         try:
-            self.hook.delete_table(
+            hook.delete_table(
                 project_id=self.project_id,
                 instance_id=self.instance_id,
                 table_id=self.table_id,
@@ -399,18 +400,19 @@ class BigtableClusterUpdateOperator(BaseOperator, BigtableValidationMixin):
         self.cluster_id = cluster_id
         self.nodes = nodes
         self._validate_inputs()
-        self.hook = BigtableHook(gcp_conn_id=gcp_conn_id)
+        self.gcp_conn_id = gcp_conn_id
         super().__init__(*args, **kwargs)
 
     def execute(self, context):
-        instance = self.hook.get_instance(project_id=self.project_id,
-                                          instance_id=self.instance_id)
+        hook = BigtableHook(gcp_conn_id=self.gcp_conn_id)
+        instance = hook.get_instance(project_id=self.project_id,
+                                     instance_id=self.instance_id)
         if not instance:
             raise AirflowException("Dependency: instance '{}' does not exist.".format(
                 self.instance_id))
 
         try:
-            self.hook.update_cluster(
+            hook.update_cluster(
                 instance=instance,
                 cluster_id=self.cluster_id,
                 nodes=self.nodes

--- a/airflow/gcp/operators/speech_to_text.py
+++ b/airflow/gcp/operators/speech_to_text.py
@@ -86,7 +86,7 @@ class GcpSpeechToTextRecognizeSpeechOperator(BaseOperator):
             raise AirflowException("The required parameter 'config' is empty")
 
     def execute(self, context):
-        _hook = GCPSpeechToTextHook(gcp_conn_id=self.gcp_conn_id)
-        return _hook.recognize_speech(
+        hook = GCPSpeechToTextHook(gcp_conn_id=self.gcp_conn_id)
+        return hook.recognize_speech(
             config=self.config, audio=self.audio, retry=self.retry, timeout=self.timeout
         )

--- a/airflow/gcp/operators/text_to_speech.py
+++ b/airflow/gcp/operators/text_to_speech.py
@@ -115,8 +115,8 @@ class GcpTextToSpeechSynthesizeOperator(BaseOperator):
                 raise AirflowException("The required parameter '{}' is empty".format(parameter))
 
     def execute(self, context):
-        gcp_text_to_speech_hook = GCPTextToSpeechHook(gcp_conn_id=self.gcp_conn_id)
-        result = gcp_text_to_speech_hook.synthesize_speech(
+        hook = GCPTextToSpeechHook(gcp_conn_id=self.gcp_conn_id)
+        result = hook.synthesize_speech(
             input_data=self.input_data,
             voice=self.voice,
             audio_config=self.audio_config,

--- a/airflow/gcp/operators/translate.py
+++ b/airflow/gcp/operators/translate.py
@@ -98,9 +98,9 @@ class CloudTranslateTextOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        _hook = CloudTranslateHook(gcp_conn_id=self.gcp_conn_id)
+        hook = CloudTranslateHook(gcp_conn_id=self.gcp_conn_id)
         try:
-            translation = _hook.translate(
+            translation = hook.translate(
                 values=self.values,
                 target_language=self.target_language,
                 format_=self.format_,

--- a/airflow/gcp/operators/translate_speech.py
+++ b/airflow/gcp/operators/translate_speech.py
@@ -124,10 +124,10 @@ class GcpTranslateSpeechOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
 
     def execute(self, context):
-        _speech_to_text_hook = GCPSpeechToTextHook(gcp_conn_id=self.gcp_conn_id)
-        _translate_hook = CloudTranslateHook(gcp_conn_id=self.gcp_conn_id)
+        speech_to_text_hook = GCPSpeechToTextHook(gcp_conn_id=self.gcp_conn_id)
+        translate_hook = CloudTranslateHook(gcp_conn_id=self.gcp_conn_id)
 
-        recognize_result = _speech_to_text_hook.recognize_speech(
+        recognize_result = speech_to_text_hook.recognize_speech(
             config=self.config, audio=self.audio
         )
         recognize_dict = MessageToDict(recognize_result)
@@ -146,7 +146,7 @@ class GcpTranslateSpeechOperator(BaseOperator):
                                    .format(recognize_dict, key))
 
         try:
-            translation = _translate_hook.translate(
+            translation = translate_hook.translate(
                 values=transcript,
                 target_language=self.target_language,
                 format_=self.format_,

--- a/airflow/gcp/operators/vision.py
+++ b/airflow/gcp/operators/vision.py
@@ -102,11 +102,11 @@ class CloudVisionProductSetCreateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        self._hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
 
     def execute(self, context):
+        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
         try:
-            return self._hook.create_product_set(
+            return hook.create_product_set(
                 location=self.location,
                 project_id=self.project_id,
                 product_set=self.product_set,
@@ -176,10 +176,10 @@ class CloudVisionProductSetGetOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        self._hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
 
     def execute(self, context):
-        return self._hook.get_product_set(
+        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        return hook.get_product_set(
             location=self.location,
             product_set_id=self.product_set_id,
             project_id=self.project_id,
@@ -265,10 +265,10 @@ class CloudVisionProductSetUpdateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        self._hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
 
     def execute(self, context):
-        return self._hook.update_product_set(
+        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        return hook.update_product_set(
             location=self.location,
             product_set_id=self.product_set_id,
             project_id=self.project_id,
@@ -335,10 +335,10 @@ class CloudVisionProductSetDeleteOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        self._hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
 
     def execute(self, context):
-        self._hook.delete_product_set(
+        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook.delete_product_set(
             location=self.location,
             product_set_id=self.product_set_id,
             project_id=self.project_id,
@@ -415,11 +415,11 @@ class CloudVisionProductCreateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        self._hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
 
     def execute(self, context):
+        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
         try:
-            return self._hook.create_product(
+            return hook.create_product(
                 location=self.location,
                 product=self.product,
                 project_id=self.project_id,
@@ -492,10 +492,10 @@ class CloudVisionProductGetOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        self._hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
 
     def execute(self, context):
-        return self._hook.get_product(
+        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        return hook.get_product(
             location=self.location,
             product_id=self.product_id,
             project_id=self.project_id,
@@ -592,10 +592,10 @@ class CloudVisionProductUpdateOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        self._hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
 
     def execute(self, context):
-        return self._hook.update_product(
+        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        return hook.update_product(
             product=self.product,
             location=self.location,
             product_id=self.product_id,
@@ -667,10 +667,10 @@ class CloudVisionProductDeleteOperator(BaseOperator):
         self.timeout = timeout
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
-        self._hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
 
     def execute(self, context):
-        self._hook.delete_product(
+        hook = CloudVisionHook(gcp_conn_id=self.gcp_conn_id)
+        hook.delete_product(
             location=self.location,
             product_id=self.product_id,
             project_id=self.project_id,


### PR DESCRIPTION
Hook should be initalized in execute method not in operator's constructor.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-4771

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
