### PR TITLE
[AIRFLOW-5298] Move FileToGcs to core

### DIFF
--- a/airflow/contrib/operators/file_to_gcs.py
+++ b/airflow/contrib/operators/file_to_gcs.py
@@ -16,79 +16,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
+"""
+This module is deprecated. Please use `airflow.operators.local_to_gcs`.
+"""
+
 import warnings
 
-from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
-from airflow.models import BaseOperator
-from airflow.utils.decorators import apply_defaults
+# pylint: disable=unused-import
+from airflow.operators.local_to_gcs import FileToGoogleCloudStorageOperator  # noqa
 
-
-class FileToGoogleCloudStorageOperator(BaseOperator):
-    """
-    Uploads a file to Google Cloud Storage.
-    Optionally can compress the file for upload.
-
-    :param src: Path to the local file. (templated)
-    :type src: str
-    :param dst: Destination path within the specified bucket. (templated)
-    :type dst: str
-    :param bucket: The bucket to upload to. (templated)
-    :type bucket: str
-    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
-    :type gcp_conn_id: str
-    :param google_cloud_storage_conn_id: (Deprecated) The connection ID used to connect to Google Cloud
-        Platform. This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
-    :type google_cloud_storage_conn_id: str
-    :param mime_type: The mime-type string
-    :type mime_type: str
-    :param delegate_to: The account to impersonate, if any
-    :type delegate_to: str
-    :param gzip: Allows for file to be compressed and uploaded as gzip
-    :type gzip: bool
-    """
-    template_fields = ('src', 'dst', 'bucket')
-
-    @apply_defaults
-    def __init__(self,
-                 src,
-                 dst,
-                 bucket,
-                 gcp_conn_id='google_cloud_default',
-                 google_cloud_storage_conn_id=None,
-                 mime_type='application/octet-stream',
-                 delegate_to=None,
-                 gzip=False,
-                 *args,
-                 **kwargs):
-        super().__init__(*args, **kwargs)
-
-        if google_cloud_storage_conn_id:
-            warnings.warn(
-                "The google_cloud_storage_conn_id parameter has been deprecated. You should pass "
-                "the gcp_conn_id parameter.", DeprecationWarning, stacklevel=3)
-            gcp_conn_id = google_cloud_storage_conn_id
-
-        self.src = src
-        self.dst = dst
-        self.bucket = bucket
-        self.gcp_conn_id = gcp_conn_id
-        self.mime_type = mime_type
-        self.delegate_to = delegate_to
-        self.gzip = gzip
-
-    def execute(self, context):
-        """
-        Uploads the file to Google cloud storage
-        """
-        hook = GoogleCloudStorageHook(
-            google_cloud_storage_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to)
-
-        hook.upload(
-            bucket_name=self.bucket,
-            object_name=self.dst,
-            mime_type=self.mime_type,
-            filename=self.src,
-            gzip=self.gzip,
-        )
+warnings.warn(
+    "This module is deprecated. Please use `airflow.operators.local_to_gcs`,",
+    DeprecationWarning,
+)

--- a/airflow/operators/local_to_gcs.py
+++ b/airflow/operators/local_to_gcs.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+This module contains operator for uploading local file to GCS.
+"""
+import warnings
+
+from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class FileToGoogleCloudStorageOperator(BaseOperator):
+    """
+    Uploads a file to Google Cloud Storage.
+    Optionally can compress the file for upload.
+
+    :param src: Path to the local file. (templated)
+    :type src: str
+    :param dst: Destination path within the specified bucket. (templated)
+    :type dst: str
+    :param bucket: The bucket to upload to. (templated)
+    :type bucket: str
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param google_cloud_storage_conn_id: (Deprecated) The connection ID used to connect to Google Cloud
+        Platform. This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
+    :type google_cloud_storage_conn_id: str
+    :param mime_type: The mime-type string
+    :type mime_type: str
+    :param delegate_to: The account to impersonate, if any
+    :type delegate_to: str
+    :param gzip: Allows for file to be compressed and uploaded as gzip
+    :type gzip: bool
+    """
+    template_fields = ('src', 'dst', 'bucket')
+
+    @apply_defaults
+    def __init__(self,
+                 src,
+                 dst,
+                 bucket,
+                 gcp_conn_id='google_cloud_default',
+                 google_cloud_storage_conn_id=None,
+                 mime_type='application/octet-stream',
+                 delegate_to=None,
+                 gzip=False,
+                 *args,
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if google_cloud_storage_conn_id:
+            warnings.warn(
+                "The google_cloud_storage_conn_id parameter has been deprecated. You should pass "
+                "the gcp_conn_id parameter.", DeprecationWarning, stacklevel=3)
+            gcp_conn_id = google_cloud_storage_conn_id
+
+        self.src = src
+        self.dst = dst
+        self.bucket = bucket
+        self.gcp_conn_id = gcp_conn_id
+        self.mime_type = mime_type
+        self.delegate_to = delegate_to
+        self.gzip = gzip
+
+    def execute(self, context):
+        """
+        Uploads the file to Google cloud storage
+        """
+        hook = GoogleCloudStorageHook(
+            google_cloud_storage_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to)
+
+        hook.upload(
+            bucket_name=self.bucket,
+            object_name=self.dst,
+            mime_type=self.mime_type,
+            filename=self.src,
+            gzip=self.gzip,
+        )

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -579,7 +579,7 @@ They also use :class:`airflow.gcp.hooks.mlengine.MLEngineHook` to communicate wi
 Cloud Storage
 '''''''''''''
 
-:class:`airflow.contrib.operators.file_to_gcs.FileToGoogleCloudStorageOperator`
+:class:`airflow.operators.local_to_gcs.FileToGoogleCloudStorageOperator`
     Uploads a file to Google Cloud Storage.
 
 :class:`airflow.contrib.operators.gcs_acl_operator.GoogleCloudStorageBucketCreateAclEntryOperator`

--- a/scripts/ci/pylint_todo.txt
+++ b/scripts/ci/pylint_todo.txt
@@ -58,7 +58,6 @@
 ./airflow/contrib/operators/emr_add_steps_operator.py
 ./airflow/contrib/operators/emr_create_job_flow_operator.py
 ./airflow/contrib/operators/emr_terminate_job_flow_operator.py
-./airflow/contrib/operators/file_to_gcs.py
 ./airflow/contrib/operators/file_to_wasb.py
 ./airflow/contrib/operators/grpc_operator.py
 ./airflow/contrib/operators/hipchat_operator.py

--- a/tests/operators/test_local_to_gcs.py
+++ b/tests/operators/test_local_to_gcs.py
@@ -22,7 +22,7 @@ import datetime
 import unittest
 
 from airflow import DAG
-from airflow.contrib.operators.file_to_gcs import FileToGoogleCloudStorageOperator
+from airflow.operators.local_to_gcs import FileToGoogleCloudStorageOperator
 from tests.compat import mock
 
 
@@ -55,7 +55,7 @@ class TestFileToGcsOperator(unittest.TestCase):
         self.assertEqual(operator.mime_type, self._config['mime_type'])
         self.assertEqual(operator.gzip, self._config['gzip'])
 
-    @mock.patch('airflow.contrib.operators.file_to_gcs.GoogleCloudStorageHook',
+    @mock.patch('airflow.operators.local_to_gcs.GoogleCloudStorageHook',
                 autospec=True)
     def test_execute(self, mock_hook):
         mock_instance = mock_hook.return_value


### PR DESCRIPTION
For more information check AIP-21.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title.
  - https://issues.apache.org/jira/browse/AIRFLOW-5298

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
The PR moves `FileToGoogleCloudStorageOperator` from contrib to core.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
