### PR TITLE
[AIRFLOW-5313] Add params support for awsbatch_operator

### DIFF
--- a/airflow/contrib/operators/awsbatch_operator.py
+++ b/airflow/contrib/operators/awsbatch_operator.py
@@ -58,13 +58,17 @@ class AWSBatchOperator(BaseOperator):
     :param job_queue: the queue name on AWS Batch
     :type job_queue: str
     :param overrides: the same parameter that boto3 will receive on
-        containerOverrides (templated):
-        http://boto3.readthedocs.io/en/latest/reference/services/batch.html#submit_job
+        containerOverrides (templated)
+        http://boto3.readthedocs.io/en/latest/reference/services/batch.html#Batch.Client.submit_job
     :type overrides: dict
     :param array_properties: the same parameter that boto3 will receive on
-        arrayProperties:
-        http://boto3.readthedocs.io/en/latest/reference/services/batch.html#submit_job
+        arrayProperties
+        http://boto3.readthedocs.io/en/latest/reference/services/batch.html#Batch.Client.submit_job
     :type array_properties: dict
+    :param parameters: the same parameter that boto3 will receive on
+        parameters (templated)
+        http://boto3.readthedocs.io/en/latest/reference/services/batch.html#Batch.Client.submit_job
+    :type parameters: dict
     :param max_retries: exponential backoff retries while waiter is not
         merged, 4200 = 48 hours
     :type max_retries: int
@@ -80,11 +84,11 @@ class AWSBatchOperator(BaseOperator):
     ui_color = '#c3dae0'
     client = None  # type: Optional[BatchProtocol]
     arn = None  # type: Optional[str]
-    template_fields = ('job_name', 'overrides',)
+    template_fields = ('job_name', 'overrides', 'parameters',)
 
     @apply_defaults
     def __init__(self, job_name, job_definition, job_queue, overrides, array_properties=None,
-                 max_retries=4200, aws_conn_id=None, region_name=None, **kwargs):
+                 parameters=None, max_retries=4200, aws_conn_id=None, region_name=None, **kwargs):
         super().__init__(**kwargs)
 
         self.job_name = job_name
@@ -94,6 +98,7 @@ class AWSBatchOperator(BaseOperator):
         self.job_queue = job_queue
         self.overrides = overrides
         self.array_properties = array_properties or {}
+        self.parameters = parameters
         self.max_retries = max_retries
 
         self.jobId = None  # pylint: disable=invalid-name
@@ -119,6 +124,7 @@ class AWSBatchOperator(BaseOperator):
                 jobQueue=self.job_queue,
                 jobDefinition=self.job_definition,
                 arrayProperties=self.array_properties,
+                parameters=self.parameters,
                 containerOverrides=self.overrides)
 
             self.log.info('AWS Batch Job started: %s', response)

--- a/tests/contrib/operators/test_awsbatch_operator.py
+++ b/tests/contrib/operators/test_awsbatch_operator.py
@@ -42,6 +42,7 @@ class TestAWSBatchOperator(unittest.TestCase):
             job_queue='queue',
             job_definition='hello-world',
             max_retries=5,
+            parameters=None,
             overrides={},
             array_properties=None,
             aws_conn_id=None,
@@ -52,6 +53,7 @@ class TestAWSBatchOperator(unittest.TestCase):
         self.assertEqual(self.batch.job_queue, 'queue')
         self.assertEqual(self.batch.job_definition, 'hello-world')
         self.assertEqual(self.batch.max_retries, 5)
+        self.assertEqual(self.batch.parameters, None)
         self.assertEqual(self.batch.overrides, {})
         self.assertEqual(self.batch.array_properties, {})
         self.assertEqual(self.batch.region_name, 'eu-west-1')
@@ -61,7 +63,7 @@ class TestAWSBatchOperator(unittest.TestCase):
         self.aws_hook_mock.assert_called_once_with(aws_conn_id=None)
 
     def test_template_fields_overrides(self):
-        self.assertEqual(self.batch.template_fields, ('job_name', 'overrides',))
+        self.assertEqual(self.batch.template_fields, ('job_name', 'overrides', 'parameters',))
 
     @mock.patch.object(AWSBatchOperator, '_wait_for_task_ended')
     @mock.patch.object(AWSBatchOperator, '_check_success_task')
@@ -78,7 +80,8 @@ class TestAWSBatchOperator(unittest.TestCase):
             jobName='51455483-c62c-48ac-9b88-53a6a725baa3',
             containerOverrides={},
             jobDefinition='hello-world',
-            arrayProperties={}
+            arrayProperties={},
+            parameters=None
         )
 
         wait_mock.assert_called_once_with()
@@ -99,7 +102,8 @@ class TestAWSBatchOperator(unittest.TestCase):
             jobName='51455483-c62c-48ac-9b88-53a6a725baa3',
             containerOverrides={},
             jobDefinition='hello-world',
-            arrayProperties={}
+            arrayProperties={},
+            parameters=None
         )
 
     def test_wait_end_tasks(self):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

AWS Batch supports [passing parameters to jobs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html#Batch.Client.submit_job), and this update enables that functionality in the `AWSBatchOperator`.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

`tests/contrib/operators/test_awsbatch_operator.py` has been updated to include `parameters`.

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
