### PR TITLE
[AIRFLOW-5302] Fix bug in none_skipped Trigger Rule

### DIFF
--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -104,15 +104,15 @@ class TriggerRuleDep(BaseTIDep):
         :param ti: the task instance to evaluate the trigger rule of
         :type ti: airflow.models.TaskInstance
         :param successes: Number of successful upstream tasks
-        :type successes: bool
+        :type successes: int
         :param skipped: Number of skipped upstream tasks
-        :type skipped: bool
+        :type skipped: int
         :param failed: Number of failed upstream tasks
-        :type failed: bool
+        :type failed: int
         :param upstream_failed: Number of upstream_failed upstream tasks
-        :type upstream_failed: bool
+        :type upstream_failed: int
         :param done: Number of completed upstream tasks
-        :type done: bool
+        :type done: int
         :param flag_upstream_failed: This is a hack to generate
             the upstream_failed state creation while checking to see
             whether the task instance is runnable. It was the shortest
@@ -211,7 +211,7 @@ class TriggerRuleDep(BaseTIDep):
                     .format(tr, num_failures, upstream_tasks_state,
                             task.upstream_task_ids))
         elif tr == TR.NONE_SKIPPED:
-            if skipped > 0:
+            if not upstream_done or (skipped > 0):
                 yield self._failing_status(
                     reason="Task's trigger rule '{0}' requires all upstream "
                     "tasks to not have been skipped, but found {1} task(s) skipped. "

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -343,6 +343,19 @@ class TestTriggerRuleDep(unittest.TestCase):
             self.assertEqual(len(dep_statuses), 1)
             self.assertFalse(dep_statuses[0].passed)
 
+            # Fail until all upstream tasks have completed execution
+            dep_statuses = tuple(TriggerRuleDep()._evaluate_trigger_rule(
+                ti=ti,
+                successes=0,
+                skipped=0,
+                failed=0,
+                upstream_failed=0,
+                done=0,
+                flag_upstream_failed=False,
+                session=session))
+            self.assertEqual(len(dep_statuses), 1)
+            self.assertFalse(dep_statuses[0].passed)
+
     def test_unknown_tr(self):
         """
         Unknown trigger rules should cause this dep to fail


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5302

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
The task been set none_skipped run immediately even before upstream tasks complete execution.
**Bug**:
![none_skipped_trigger_rule](https://user-images.githubusercontent.com/8811558/63619984-152f0b80-c5e8-11e9-9aa6-85fc856f873f.gif)

**After Fix**:
Waits till upstream tasks are complete / skipped and **skips** if all upstream tasks have skipped
![fixed_none_skipped](https://user-images.githubusercontent.com/8811558/63620073-43ace680-c5e8-11e9-884b-962f23f1320a.gif)


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added

### Commits

- [z] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
