### PR TITLE
[AIRFLOW-5303] Use project_id from GCP credentials

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -63,10 +63,9 @@ class BigQueryHook(GoogleCloudBaseHook, DbApiHook):
         Returns a BigQuery PEP 249 connection object.
         """
         service = self.get_service()
-        project = self._get_field('project')
         return BigQueryConnection(
             service=service,
-            project_id=project,
+            project_id=self.project_id,
             use_legacy_sql=self.use_legacy_sql,
             location=self.location,
             num_retries=self.num_retries
@@ -112,7 +111,7 @@ class BigQueryHook(GoogleCloudBaseHook, DbApiHook):
             dialect = 'legacy' if self.use_legacy_sql else 'standard'
 
         return read_gbq(sql,
-                        project_id=self._get_field('project'),
+                        project_id=self.project_id,
                         dialect=dialect,
                         verbose=False,
                         private_key=private_key)

--- a/airflow/contrib/hooks/gcp_api_base_hook.py
+++ b/airflow/contrib/hooks/gcp_api_base_hook.py
@@ -86,17 +86,16 @@ class GoogleCloudBaseHook(BaseHook):
         self.delegate_to = delegate_to
         self.extras = self.get_connection(self.gcp_conn_id).extra_dejson  # type: Dict
 
-    def _get_credentials(self) -> google.auth.credentials.Credentials:
+    def _get_credentials_and_project_id(self) -> google.auth.credentials.Credentials:
         """
-        Returns the Credentials object for Google API
+        Returns the Credentials object for Google API and the associated project_id
         """
         key_path = self._get_field('key_path', None)  # type: Optional[str]
         keyfile_dict = self._get_field('keyfile_dict', None)  # type: Optional[str]
-
         if not key_path and not keyfile_dict:
             self.log.info('Getting connection using `google.auth.default()` '
                           'since no key file is defined for hook.')
-            credentials, _ = google.auth.default(scopes=self.scopes)
+            credentials, project_id = google.auth.default(scopes=self.scopes)
         elif key_path:
             # Get credentials from a JSON file.
             if key_path.endswith('.json'):
@@ -105,6 +104,7 @@ class GoogleCloudBaseHook(BaseHook):
                     google.oauth2.service_account.Credentials.from_service_account_file(
                         key_path, scopes=self.scopes)
                 )
+                project_id = credentials.project_id
             elif key_path.endswith('.p12'):
                 raise AirflowException('Legacy P12 key file are not supported, '
                                        'use a JSON key file.')
@@ -125,11 +125,25 @@ class GoogleCloudBaseHook(BaseHook):
                     google.oauth2.service_account.Credentials.from_service_account_info(
                         keyfile_dict_json, scopes=self.scopes)
                 )
+                project_id = credentials.project_id
             except json.decoder.JSONDecodeError:
                 raise AirflowException('Invalid key JSON.')
 
-        return credentials.with_subject(self.delegate_to) \
-            if self.delegate_to else credentials
+        if self.delegate_to:
+            credentials = credentials.with_subject(self.delegate_to)
+
+        overridden_project_id = self._get_field('project')
+        if overridden_project_id:
+            project_id = overridden_project_id
+
+        return credentials, project_id
+
+    def _get_credentials(self) -> google.auth.credentials.Credentials:
+        """
+        Returns the Credentials object for Google API
+        """
+        credentials, _ = self._get_credentials_and_project_id()
+        return credentials
 
     def _get_access_token(self) -> str:
         """
@@ -169,7 +183,8 @@ class GoogleCloudBaseHook(BaseHook):
         :return: id of the project
         :rtype: str
         """
-        return self._get_field('project')
+        _, project_id = self._get_credentials_and_project_id()
+        return project_id
 
     @property
     def client_info(self) -> ClientInfo:

--- a/tests/contrib/hooks/test_gcp_api_base_hook.py
+++ b/tests/contrib/hooks/test_gcp_api_base_hook.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
+import json
 import os
 import unittest
 from io import StringIO
@@ -43,6 +43,8 @@ try:
     _, default_project = google.auth.default(scopes=hook._DEFAULT_SCOPES)
 except GoogleAuthError:
     default_creds_available = False
+
+MODULE_NAME = "airflow.contrib.hooks.gcp_api_base_hook"
 
 
 class TestCatchHttpException(unittest.TestCase):
@@ -138,7 +140,7 @@ ENV_VALUE = "/tmp/a"
 class TestProvideGcpCredentialFile(unittest.TestCase):
     def setUp(self):
         with mock.patch(
-            'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.__init__',
+            MODULE_NAME + '.GoogleCloudBaseHook.__init__',
             new=mock_base_gcp_hook_default_project_id,
         ):
             self.instance = hook.GoogleCloudBaseHook(gcp_conn_id="google-cloud-default")
@@ -226,6 +228,86 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
 class TestGoogleCloudBaseHook(unittest.TestCase):
     def setUp(self):
         self.instance = hook.GoogleCloudBaseHook()
+
+    @mock.patch(MODULE_NAME + '.google.auth.default', return_value=("CREDENTIALS", "PROJECT_ID"))
+    def test_get_credentials_and_project_id_with_default_auth(self, mock_auth_default):
+        self.instance.extras = {}
+        result = self.instance._get_credentials_and_project_id()
+        mock_auth_default.assert_called_once_with(scopes=self.instance.scopes)
+        self.assertEqual(('CREDENTIALS', 'PROJECT_ID'), result)
+
+    @mock.patch(  # type: ignore
+        MODULE_NAME + '.google.oauth2.service_account.Credentials.from_service_account_file',
+        **{'reutnr_value.project_id': "PROJECT_ID"}
+    )
+    def test_get_credentials_and_project_id_with_service_account_file(self, mock_from_service_account_file):
+        self.instance.extras = {
+            'extra__google_cloud_platform__key_path': "KEY_PATH.json"
+        }
+        self.instance._get_credentials_and_project_id()
+        mock_from_service_account_file.assert_called_once_with('KEY_PATH.json', scopes=self.instance.scopes)
+
+    @mock.patch(MODULE_NAME + '.google.oauth2.service_account.Credentials.from_service_account_file')
+    def test_get_credentials_and_project_id_with_service_account_file_and_p12_key(
+        self,
+        mock_from_service_account_file
+    ):
+        self.instance.extras = {
+            'extra__google_cloud_platform__key_path': "KEY_PATH.p12"
+        }
+        with self.assertRaises(AirflowException):
+            self.instance._get_credentials_and_project_id()
+
+    @mock.patch(MODULE_NAME + '.google.oauth2.service_account.Credentials.from_service_account_file')
+    def test_get_credentials_and_project_id_with_service_account_file_and_unknown_key(
+        self,
+        mock_from_service_account_file
+    ):
+        self.instance.extras = {
+            'extra__google_cloud_platform__key_path': "KEY_PATH.unknown"
+        }
+        with self.assertRaises(AirflowException):
+            self.instance._get_credentials_and_project_id()
+
+    @mock.patch(  # type: ignore
+        MODULE_NAME + '.google.oauth2.service_account.Credentials.from_service_account_info',
+        **{'return_value.project_id': "PROJECT_ID"}
+    )
+    def test_get_credentials_and_project_id_with_service_account_info(self, mock_from_service_account_file):
+        service_account = {
+            'private_key': "PRIVATE_KEY"
+        }
+        self.instance.extras = {
+            'extra__google_cloud_platform__keyfile_dict': json.dumps(service_account)
+        }
+        self.instance._get_credentials_and_project_id()
+        mock_from_service_account_file.assert_called_once_with(service_account, scopes=self.instance.scopes)
+
+    @mock.patch(MODULE_NAME + '.google.auth.default')
+    def test_get_credentials_and_project_id_with_default_auth_and_delegate(self, mock_auth_default):
+        mock_credentials = mock.MagicMock()
+        mock_auth_default.return_value = (mock_credentials, "PROJECT_ID")
+        self.instance.extras = {}
+        self.instance.delegate_to = "USER"
+        result = self.instance._get_credentials_and_project_id()
+        mock_auth_default.assert_called_once_with(scopes=self.instance.scopes)
+        mock_credentials.with_subject.assert_called_once_with("USER")
+        self.assertEqual((mock_credentials.with_subject.return_value, "PROJECT_ID"), result)
+
+    @mock.patch(  # type: ignore
+        MODULE_NAME + '.google.auth.default',
+        return_value=("CREDENTIALS", "PROJECT_ID")
+    )
+    def test_get_credentials_and_project_id_with_default_auth_and_overridden_project_id(
+        self,
+        mock_auth_default
+    ):
+        self.instance.extras = {
+            'extra__google_cloud_platform__project': "SECOND_PROJECT_ID"
+        }
+        result = self.instance._get_credentials_and_project_id()
+        mock_auth_default.assert_called_once_with(scopes=self.instance.scopes)
+        self.assertEqual(("CREDENTIALS", 'SECOND_PROJECT_ID'), result)
 
     @unittest.skipIf(not default_creds_available, 'Default GCP credentials not available to run tests')
     def test_default_creds_with_scopes(self):

--- a/tests/contrib/hooks/test_gcp_api_base_hook.py
+++ b/tests/contrib/hooks/test_gcp_api_base_hook.py
@@ -238,14 +238,15 @@ class TestGoogleCloudBaseHook(unittest.TestCase):
 
     @mock.patch(  # type: ignore
         MODULE_NAME + '.google.oauth2.service_account.Credentials.from_service_account_file',
-        **{'reutnr_value.project_id': "PROJECT_ID"}
+        **{'return_value.project_id': "PROJECT_ID"}
     )
     def test_get_credentials_and_project_id_with_service_account_file(self, mock_from_service_account_file):
         self.instance.extras = {
             'extra__google_cloud_platform__key_path': "KEY_PATH.json"
         }
-        self.instance._get_credentials_and_project_id()
+        result = self.instance._get_credentials_and_project_id()
         mock_from_service_account_file.assert_called_once_with('KEY_PATH.json', scopes=self.instance.scopes)
+        self.assertEqual((mock_from_service_account_file.return_value, 'PROJECT_ID'), result)
 
     @mock.patch(MODULE_NAME + '.google.oauth2.service_account.Credentials.from_service_account_file')
     def test_get_credentials_and_project_id_with_service_account_file_and_p12_key(
@@ -280,8 +281,9 @@ class TestGoogleCloudBaseHook(unittest.TestCase):
         self.instance.extras = {
             'extra__google_cloud_platform__keyfile_dict': json.dumps(service_account)
         }
-        self.instance._get_credentials_and_project_id()
+        result = self.instance._get_credentials_and_project_id()
         mock_from_service_account_file.assert_called_once_with(service_account, scopes=self.instance.scopes)
+        self.assertEqual((mock_from_service_account_file.return_value, 'PROJECT_ID'), result)
 
     @mock.patch(MODULE_NAME + '.google.auth.default')
     def test_get_credentials_and_project_id_with_default_auth_and_delegate(self, mock_auth_default):

--- a/tests/gcp/hooks/test_bigtable.py
+++ b/tests/gcp/hooks/test_bigtable.py
@@ -26,7 +26,7 @@ from google.cloud.bigtable.instance import Instance
 
 from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id, \
     mock_base_gcp_hook_default_project_id, GCP_PROJECT_ID_HOOK_UNIT_TEST
-from tests.compat import mock
+from tests.compat import mock, PropertyMock
 
 from airflow import AirflowException
 from airflow.gcp.hooks.bigtable import BigtableHook
@@ -44,8 +44,13 @@ class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
                         new=mock_base_gcp_hook_no_default_project_id):
             self.bigtable_hook_no_default_project_id = BigtableHook(gcp_conn_id='test')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.bigtable.BigtableHook._get_client')
-    def test_get_instance_missing_project_id(self, get_client):
+    def test_get_instance_missing_project_id(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -69,8 +74,13 @@ class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
         get_client.assert_called_once_with(project_id='example-project')
         self.assertIsNotNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.bigtable.BigtableHook._get_client')
-    def test_delete_instance_missing_project_id(self, get_client):
+    def test_delete_instance_missing_project_id(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         delete_method = instance_method.return_value.delete
@@ -97,9 +107,14 @@ class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
         get_client.assert_called_once_with(project_id='example-project')
         self.assertIsNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('google.cloud.bigtable.instance.Instance.create')
     @mock.patch('airflow.gcp.hooks.bigtable.BigtableHook._get_client')
-    def test_create_instance_missing_project_id(self, get_client, instance_create):
+    def test_create_instance_missing_project_id(self, get_client, instance_create, mock_project_id):
         operation = mock.Mock()
         operation.result_return_value = Instance(instance_id=CBT_INSTANCE, client=get_client)
         instance_create.return_value = operation
@@ -128,8 +143,13 @@ class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
         instance_create.assert_called_once_with(clusters=mock.ANY)
         self.assertEqual(res.instance_id, 'instance')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.bigtable.BigtableHook._get_client')
-    def test_delete_table_missing_project_id(self, get_client):
+    def test_delete_table_missing_project_id(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         table_delete_method = instance_method.return_value.table.return_value.delete

--- a/tests/gcp/hooks/test_cloud_build.py
+++ b/tests/gcp/hooks/test_cloud_build.py
@@ -25,6 +25,7 @@ from unittest import mock
 
 from airflow import AirflowException
 from airflow.gcp.hooks.cloud_build import CloudBuildHook
+from tests.compat import PropertyMock
 from tests.contrib.utils.base_gcp_mock import (
     mock_base_gcp_hook_default_project_id,
     mock_base_gcp_hook_no_default_project_id,
@@ -198,8 +199,13 @@ class TestCloudBuildHookWithoutProjectId(unittest.TestCase):
         ):
             self.hook = CloudBuildHook(gcp_conn_id="test")
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch("airflow.gcp.hooks.cloud_build.CloudBuildHook.get_conn")
-    def test_create_build(self, _):
+    def test_create_build(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException) as e:
             self.hook.create_build(body={})
 

--- a/tests/gcp/hooks/test_cloud_sql.py
+++ b/tests/gcp/hooks/test_cloud_sql.py
@@ -31,7 +31,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id, \
     mock_base_gcp_hook_no_default_project_id
-from tests.compat import mock
+from tests.compat import mock, PropertyMock
 
 
 class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
@@ -424,9 +424,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
                         new=mock_base_gcp_hook_no_default_project_id):
             self.cloudsql_hook_no_default_project_id = CloudSqlHook(api_version='v1', gcp_conn_id='test')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_instance_import_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_instance_import_overridden_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         import_method = get_conn.return_value.instances.return_value.import_
         execute_method = import_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -441,9 +448,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
                                                                operation_name='operation_id')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_instance_import_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_instance_import_missing_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         import_method = get_conn.return_value.instances.return_value.import_
         execute_method = import_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -458,9 +472,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         self.assertIn("The project id must be passed", str(err))
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_instance_export_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_instance_export_overridden_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         export_method = get_conn.return_value.instances.return_value.export
         execute_method = export_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -475,9 +496,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
                                                                operation_name='operation_id')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_instance_export_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_instance_export_missing_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         export_method = get_conn.return_value.instances.return_value.export
         execute_method = export_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -492,9 +520,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         self.assertIn("The project id must be passed", str(err))
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_get_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_get_instance_overridden_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         get_method = get_conn.return_value.instances.return_value.get
         execute_method = get_method.return_value.execute
         execute_method.return_value = {"name": "instance"}
@@ -508,9 +543,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_get_instance_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_get_instance_missing_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         get_method = get_conn.return_value.instances.return_value.get
         execute_method = get_method.return_value.execute
         execute_method.return_value = {"name": "instance"}
@@ -524,9 +566,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         self.assertIn("The project id must be passed", str(err))
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_create_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_create_instance_overridden_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         insert_method = get_conn.return_value.instances.return_value.insert
         execute_method = insert_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -541,9 +590,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
             operation_name='operation_id', project_id='example-project'
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_create_instance_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_create_instance_missing_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         insert_method = get_conn.return_value.instances.return_value.insert
         execute_method = insert_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -557,9 +613,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         self.assertIn("The project id must be passed", str(err))
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_patch_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_patch_instance_overridden_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         patch_method = get_conn.return_value.instances.return_value.patch
         execute_method = patch_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -575,9 +638,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
             operation_name='operation_id', project_id='example-project'
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_patch_instance_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_patch_instance_missing_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         patch_method = get_conn.return_value.instances.return_value.patch
         execute_method = patch_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -592,9 +662,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         self.assertIn("The project id must be passed", str(err))
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_delete_instance_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_delete_instance_overridden_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         delete_method = get_conn.return_value.instances.return_value.delete
         execute_method = delete_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -609,9 +686,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
             operation_name='operation_id', project_id='example-project'
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_delete_instance_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_delete_instance_missing_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         delete_method = get_conn.return_value.instances.return_value.delete
         execute_method = delete_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -625,9 +709,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         self.assertIn("The project id must be passed", str(err))
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_get_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_get_database_overridden_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         get_method = get_conn.return_value.databases.return_value.get
         execute_method = get_method.return_value.execute
         execute_method.return_value = {"name": "database"}
@@ -644,9 +735,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_get_database_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_get_database_missing_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         get_method = get_conn.return_value.databases.return_value.get
         execute_method = get_method.return_value.execute
         execute_method.return_value = {"name": "database"}
@@ -661,9 +759,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         self.assertIn("The project id must be passed", str(err))
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_create_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_create_database_overridden_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         insert_method = get_conn.return_value.databases.return_value.insert
         execute_method = insert_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -679,9 +784,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
             operation_name='operation_id', project_id='example-project'
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_create_database_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_create_database_missing_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         insert_method = get_conn.return_value.databases.return_value.insert
         execute_method = insert_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -696,9 +808,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         self.assertIn("The project id must be passed", str(err))
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_patch_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_patch_database_overridden_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         patch_method = get_conn.return_value.databases.return_value.patch
         execute_method = patch_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -718,9 +837,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
             operation_name='operation_id', project_id='example-project'
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_patch_database_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_patch_database_missing_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         patch_method = get_conn.return_value.databases.return_value.patch
         execute_method = patch_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -736,9 +862,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         self.assertIn("The project id must be passed", str(err))
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_delete_database_overridden_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_delete_database_overridden_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         delete_method = get_conn.return_value.databases.return_value.delete
         execute_method = delete_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -756,9 +889,16 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
             operation_name='operation_id', project_id='example-project'
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook.get_conn')
     @mock.patch('airflow.gcp.hooks.cloud_sql.CloudSqlHook._wait_for_operation_to_complete')
-    def test_delete_database_missing_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_delete_database_missing_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         delete_method = get_conn.return_value.databases.return_value.delete
         execute_method = delete_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}

--- a/tests/gcp/hooks/test_dlp.py
+++ b/tests/gcp/hooks/test_dlp.py
@@ -29,7 +29,7 @@ from google.cloud.dlp_v2.types import DlpJob
 
 from airflow import AirflowException
 from airflow.gcp.hooks.dlp import CloudDLPHook
-from tests.compat import mock
+from tests.compat import mock, PropertyMock
 from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id
 
 API_RESPONSE = {}  # type: Dict[Any, Any]
@@ -88,20 +88,30 @@ class TestCloudDLPHook(unittest.TestCase):
         with self.assertRaises(AirflowException):
             self.hook.cancel_dlp_job(dlp_job_id=None, project_id=PROJECT_ID)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_cancel_dlp_job_without_parent(self, _):
+    def test_cancel_dlp_job_without_parent(self, _, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.cancel_dlp_job(dlp_job_id=DLP_JOB_ID)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
         **{
             "return_value.create_deidentify_template.return_value": API_RESPONSE
         },  # type: ignore
     )
-    def test_create_deidentify_template_with_org_id(self, get_conn):
+    def test_create_deidentify_template_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.create_deidentify_template(organization_id=ORGANIZATION_ID)
 
         self.assertIs(result, API_RESPONSE)
@@ -133,10 +143,15 @@ class TestCloudDLPHook(unittest.TestCase):
             metadata=None,
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_create_deidentify_template_without_parent(self, _):
+    def test_create_deidentify_template_without_parent(self, _, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.create_deidentify_template()
 
@@ -160,10 +175,15 @@ class TestCloudDLPHook(unittest.TestCase):
             metadata=None,
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_create_dlp_job_without_project_id(self, _):
+    def test_create_dlp_job_without_project_id(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.create_dlp_job()
 
@@ -182,13 +202,18 @@ class TestCloudDLPHook(unittest.TestCase):
             name=DLP_JOB_PATH, retry=None, timeout=None, metadata=None
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
         **{
             "return_value.create_inspect_template.return_value": API_RESPONSE
         },  # type: ignore
     )
-    def test_create_inspect_template_with_org_id(self, get_conn):
+    def test_create_inspect_template_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.create_inspect_template(organization_id=ORGANIZATION_ID)
 
         self.assertIs(result, API_RESPONSE)
@@ -220,10 +245,15 @@ class TestCloudDLPHook(unittest.TestCase):
             metadata=None,
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_create_inspect_template_without_parent(self, _):
+    def test_create_inspect_template_without_parent(self, _, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.create_inspect_template()
 
@@ -246,20 +276,30 @@ class TestCloudDLPHook(unittest.TestCase):
             metadata=None,
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_create_job_trigger_without_parent(self, _):
+    def test_create_job_trigger_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.create_job_trigger()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
         **{
             "return_value.create_stored_info_type.return_value": API_RESPONSE
         },  # type: ignore
     )
-    def test_create_stored_info_type_with_org_id(self, get_conn):
+    def test_create_stored_info_type_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.create_stored_info_type(organization_id=ORGANIZATION_ID)
 
         self.assertIs(result, API_RESPONSE)
@@ -291,10 +331,15 @@ class TestCloudDLPHook(unittest.TestCase):
             metadata=None,
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_create_stored_info_type_without_parent(self, _):
+    def test_create_stored_info_type_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.create_stored_info_type()
 
@@ -320,17 +365,27 @@ class TestCloudDLPHook(unittest.TestCase):
             metadata=None,
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_deidentify_content_without_parent(self, _):
+    def test_deidentify_content_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.deidentify_content()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_delete_deidentify_template_with_org_id(self, get_conn):
+    def test_delete_deidentify_template_with_org_id(self, get_conn, mock_project_id):
         self.hook.delete_deidentify_template(
             template_id=TEMPLATE_ID, organization_id=ORGANIZATION_ID
         )
@@ -364,10 +419,15 @@ class TestCloudDLPHook(unittest.TestCase):
         with self.assertRaises(AirflowException):
             self.hook.delete_deidentify_template(template_id=None)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_delete_deidentify_template_without_parent(self, _):
+    def test_delete_deidentify_template_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.delete_deidentify_template(template_id=TEMPLATE_ID)
 
@@ -388,17 +448,27 @@ class TestCloudDLPHook(unittest.TestCase):
         with self.assertRaises(AirflowException):
             self.hook.delete_dlp_job(dlp_job_id=None, project_id=PROJECT_ID)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_delete_dlp_job_without_parent(self, _):
+    def test_delete_dlp_job_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.delete_dlp_job(dlp_job_id=DLP_JOB_ID)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_delete_inspect_template_with_org_id(self, get_conn):
+    def test_delete_inspect_template_with_org_id(self, get_conn, mock_project_id):
         self.hook.delete_inspect_template(
             template_id=TEMPLATE_ID, organization_id=ORGANIZATION_ID
         )
@@ -432,10 +502,15 @@ class TestCloudDLPHook(unittest.TestCase):
         with self.assertRaises(AirflowException):
             self.hook.delete_inspect_template(template_id=None)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_delete_inspect_template_without_parent(self, _):
+    def test_delete_inspect_template_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.delete_inspect_template(template_id=TEMPLATE_ID)
 
@@ -456,17 +531,27 @@ class TestCloudDLPHook(unittest.TestCase):
         with self.assertRaises(AirflowException):
             self.hook.delete_job_trigger(job_trigger_id=None, project_id=PROJECT_ID)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_delete_job_trigger_without_parent(self, _):
+    def test_delete_job_trigger_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.delete_job_trigger(job_trigger_id=TRIGGER_ID)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_delete_stored_info_type_with_org_id(self, get_conn):
+    def test_delete_stored_info_type_with_org_id(self, get_conn, mock_project_id):
         self.hook.delete_stored_info_type(
             stored_info_type_id=STORED_INFO_TYPE_ID, organization_id=ORGANIZATION_ID
         )
@@ -500,20 +585,30 @@ class TestCloudDLPHook(unittest.TestCase):
         with self.assertRaises(AirflowException):
             self.hook.delete_stored_info_type(stored_info_type_id=None)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_delete_stored_info_type_without_parent(self, _):
+    def test_delete_stored_info_type_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.delete_stored_info_type(stored_info_type_id=STORED_INFO_TYPE_ID)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
         **{
             "return_value.get_deidentify_template.return_value": API_RESPONSE
         },  # type: ignore
     )
-    def test_get_deidentify_template_with_org_id(self, get_conn):
+    def test_get_deidentify_template_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.get_deidentify_template(
             template_id=TEMPLATE_ID, organization_id=ORGANIZATION_ID
         )
@@ -552,10 +647,15 @@ class TestCloudDLPHook(unittest.TestCase):
         with self.assertRaises(AirflowException):
             self.hook.get_deidentify_template(template_id=None)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_get_deidentify_template_without_parent(self, _):
+    def test_get_deidentify_template_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.get_deidentify_template(template_id=TEMPLATE_ID)
 
@@ -578,20 +678,30 @@ class TestCloudDLPHook(unittest.TestCase):
         with self.assertRaises(AirflowException):
             self.hook.get_dlp_job(dlp_job_id=None, project_id=PROJECT_ID)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_get_dlp_job_without_parent(self, _):
+    def test_get_dlp_job_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.get_dlp_job(dlp_job_id=DLP_JOB_ID)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
         **{
             "return_value.get_inspect_template.return_value": API_RESPONSE
         },  # type: ignore
     )
-    def test_get_inspect_template_with_org_id(self, get_conn):
+    def test_get_inspect_template_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.get_inspect_template(
             template_id=TEMPLATE_ID, organization_id=ORGANIZATION_ID
         )
@@ -630,10 +740,15 @@ class TestCloudDLPHook(unittest.TestCase):
         with self.assertRaises(AirflowException):
             self.hook.get_inspect_template(template_id=None)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_get_inspect_template_without_parent(self, _):
+    def test_get_inspect_template_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.get_inspect_template(template_id=TEMPLATE_ID)
 
@@ -658,20 +773,30 @@ class TestCloudDLPHook(unittest.TestCase):
         with self.assertRaises(AirflowException):
             self.hook.get_job_trigger(job_trigger_id=None, project_id=PROJECT_ID)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_get_job_trigger_without_parent(self, _):
+    def test_get_job_trigger_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.get_job_trigger(job_trigger_id=TRIGGER_ID)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
         **{
             "return_value.get_stored_info_type.return_value": API_RESPONSE
         },  # type: ignore
     )
-    def test_get_stored_info_type_with_org_id(self, get_conn):
+    def test_get_stored_info_type_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.get_stored_info_type(
             stored_info_type_id=STORED_INFO_TYPE_ID, organization_id=ORGANIZATION_ID
         )
@@ -710,10 +835,15 @@ class TestCloudDLPHook(unittest.TestCase):
         with self.assertRaises(AirflowException):
             self.hook.get_stored_info_type(stored_info_type_id=None)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_get_stored_info_type_without_parent(self, _):
+    def test_get_stored_info_type_without_parent(self, mock_get_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.get_stored_info_type(stored_info_type_id=STORED_INFO_TYPE_ID)
 
@@ -735,17 +865,27 @@ class TestCloudDLPHook(unittest.TestCase):
             metadata=None,
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_inspect_content_without_parent(self, _):
+    def test_inspect_content_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.inspect_content()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_list_deidentify_templates_with_org_id(self, get_conn):
+    def test_list_deidentify_templates_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.list_deidentify_templates(organization_id=ORGANIZATION_ID)
 
         self.assertIsInstance(result, list)
@@ -774,10 +914,15 @@ class TestCloudDLPHook(unittest.TestCase):
             metadata=None,
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_list_deidentify_templates_without_parent(self, _):
+    def test_list_deidentify_templates_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.list_deidentify_templates()
 
@@ -799,10 +944,15 @@ class TestCloudDLPHook(unittest.TestCase):
             metadata=None,
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_list_dlp_jobs_without_parent(self, _):
+    def test_list_dlp_jobs_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.list_dlp_jobs()
 
@@ -818,10 +968,15 @@ class TestCloudDLPHook(unittest.TestCase):
             language_code=None, filter_=None, retry=None, timeout=None, metadata=None
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_list_inspect_templates_with_org_id(self, get_conn):
+    def test_list_inspect_templates_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.list_inspect_templates(organization_id=ORGANIZATION_ID)
 
         self.assertIsInstance(result, list)
@@ -850,10 +1005,15 @@ class TestCloudDLPHook(unittest.TestCase):
             metadata=None,
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_list_inspect_templates_without_parent(self, _):
+    def test_list_inspect_templates_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.list_inspect_templates()
 
@@ -874,17 +1034,27 @@ class TestCloudDLPHook(unittest.TestCase):
             metadata=None,
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_list_job_triggers_without_parent(self, _):
+    def test_list_job_triggers_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.list_job_triggers()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_list_stored_info_types_with_org_id(self, get_conn):
+    def test_list_stored_info_types_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.list_stored_info_types(organization_id=ORGANIZATION_ID)
 
         self.assertIsInstance(result, list)
@@ -913,10 +1083,15 @@ class TestCloudDLPHook(unittest.TestCase):
             metadata=None,
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_list_stored_info_types_without_parent(self, _):
+    def test_list_stored_info_types_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.list_stored_info_types()
 
@@ -939,10 +1114,15 @@ class TestCloudDLPHook(unittest.TestCase):
             metadata=None,
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_redact_image_without_parent(self, _):
+    def test_redact_image_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.redact_image()
 
@@ -968,20 +1148,30 @@ class TestCloudDLPHook(unittest.TestCase):
             metadata=None,
         )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_reidentify_content_without_parent(self, _):
+    def test_reidentify_content_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.reidentify_content()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
         **{
             "return_value.update_deidentify_template.return_value": API_RESPONSE
         },  # type: ignore
     )
-    def test_update_deidentify_template_with_org_id(self, get_conn):
+    def test_update_deidentify_template_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.update_deidentify_template(
             template_id=TEMPLATE_ID, organization_id=ORGANIZATION_ID
         )
@@ -1026,20 +1216,30 @@ class TestCloudDLPHook(unittest.TestCase):
                 template_id=None, organization_id=ORGANIZATION_ID
             )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_update_deidentify_template_without_parent(self, _):
+    def test_update_deidentify_template_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.update_deidentify_template(template_id=TEMPLATE_ID)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
         **{
             "return_value.update_inspect_template.return_value": API_RESPONSE
         },  # type: ignore
     )
-    def test_update_inspect_template_with_org_id(self, get_conn):
+    def test_update_inspect_template_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.update_inspect_template(
             template_id=TEMPLATE_ID, organization_id=ORGANIZATION_ID
         )
@@ -1084,10 +1284,15 @@ class TestCloudDLPHook(unittest.TestCase):
                 template_id=None, organization_id=ORGANIZATION_ID
             )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_update_inspect_template_without_parent(self, _):
+    def test_update_inspect_template_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.update_inspect_template(template_id=TEMPLATE_ID)
 
@@ -1119,20 +1324,30 @@ class TestCloudDLPHook(unittest.TestCase):
         with self.assertRaises(AirflowException):
             self.hook.update_job_trigger(job_trigger_id=None, project_id=PROJECT_ID)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_update_job_trigger_without_parent(self, _):
+    def test_update_job_trigger_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.update_job_trigger(job_trigger_id=TRIGGER_ID)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn",
         **{
             "return_value.update_stored_info_type.return_value": API_RESPONSE
         },  # type: ignore
     )
-    def test_update_stored_info_type_with_org_id(self, get_conn):
+    def test_update_stored_info_type_with_org_id(self, get_conn, mock_project_id):
         result = self.hook.update_stored_info_type(
             stored_info_type_id=STORED_INFO_TYPE_ID, organization_id=ORGANIZATION_ID
         )
@@ -1177,9 +1392,14 @@ class TestCloudDLPHook(unittest.TestCase):
                 stored_info_type_id=None, organization_id=ORGANIZATION_ID
             )
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch(  # type: ignore
         "airflow.gcp.hooks.dlp.CloudDLPHook.get_conn"
     )
-    def test_update_stored_info_type_without_parent(self, _):
+    def test_update_stored_info_type_without_parent(self, mock_get_conn, mock_project_id):
         with self.assertRaises(AirflowException):
             self.hook.update_stored_info_type(stored_info_type_id=STORED_INFO_TYPE_ID)

--- a/tests/gcp/hooks/test_gcp_compute_hook.py
+++ b/tests/gcp/hooks/test_gcp_compute_hook.py
@@ -23,7 +23,7 @@ import unittest
 
 from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id, \
     mock_base_gcp_hook_default_project_id, GCP_PROJECT_ID_HOOK_UNIT_TEST
-from tests.compat import mock
+from tests.compat import mock, PropertyMock
 
 from airflow import AirflowException
 from airflow.gcp.hooks.compute import GceHook, GceOperationStatus
@@ -60,9 +60,14 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
                                                                operation_name='operation_id',
                                                                zone='zone')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
-    def test_start_instance_no_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_start_instance_no_project_id(self, wait_for_operation_to_complete, get_conn, mock_project_id):
         start_method = get_conn.return_value.instances.return_value.start
         execute_method = start_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -95,9 +100,14 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
                                                                operation_name='operation_id',
                                                                zone='zone')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
-    def test_stop_instance_no_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_stop_instance_no_project_id(self, wait_for_operation_to_complete, get_conn, mock_project_id):
         stop_method = get_conn.return_value.instances.return_value.stop
         execute_method = stop_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -132,9 +142,14 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
                                                                operation_name='operation_id',
                                                                zone='zone')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
-    def test_set_machine_type_no_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_set_machine_type_no_project_id(self, wait_for_operation_to_complete, get_conn, mock_project_id):
         set_machine_type_method = get_conn.return_value.instances.return_value.setMachineType
         execute_method = set_machine_type_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -166,9 +181,16 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
-    def test_get_instance_template_no_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_get_instance_template_no_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         get_method = get_conn.return_value.instanceTemplates.return_value.get
         execute_method = get_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -201,9 +223,16 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
         wait_for_operation_to_complete.assert_called_once_with(project_id='example-project',
                                                                operation_name='operation_id')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
-    def test_insert_instance_template_no_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_insert_instance_template_no_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         insert_method = get_conn.return_value.instanceTemplates.return_value.insert
         execute_method = insert_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -238,9 +267,16 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
         execute_method.assert_called_once_with(num_retries=5)
         wait_for_operation_to_complete.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
-    def test_get_instance_group_manager_no_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_get_instance_group_manager_no_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         get_method = get_conn.return_value.instanceGroupManagers.return_value.get
         execute_method = get_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}
@@ -284,9 +320,16 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
                                                                project_id='example-project',
                                                                zone='zone')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.compute.GceHook.get_conn')
     @mock.patch('airflow.gcp.hooks.compute.GceHook._wait_for_operation_to_complete')
-    def test_patch_instance_group_manager_no_project_id(self, wait_for_operation_to_complete, get_conn):
+    def test_patch_instance_group_manager_no_project_id(
+        self, wait_for_operation_to_complete, get_conn, mock_project_id
+    ):
         patch_method = get_conn.return_value.instanceGroupManagers.return_value.patch
         execute_method = patch_method.return_value.execute
         execute_method.return_value = {"name": "operation_id"}

--- a/tests/gcp/hooks/test_kubernetes_engine.py
+++ b/tests/gcp/hooks/test_kubernetes_engine.py
@@ -21,8 +21,7 @@ import unittest
 
 from airflow import AirflowException
 from airflow.gcp.hooks.kubernetes_engine import GKEClusterHook
-from tests.compat import mock
-
+from tests.compat import mock, PropertyMock
 
 TASK_ID = 'test-gke-cluster-operator'
 CLUSTER_NAME = 'test-cluster'
@@ -35,10 +34,15 @@ class TestGKEClusterHookDelete(unittest.TestCase):
         self.gke_hook = GKEClusterHook(location=GKE_ZONE)
         self.gke_hook._client = mock.Mock()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch("airflow.gcp.hooks.kubernetes_engine.GKEClusterHook._dict_to_proto")
     @mock.patch(
         "airflow.gcp.hooks.kubernetes_engine.GKEClusterHook.wait_for_operation")
-    def test_delete_cluster(self, wait_mock, convert_mock):
+    def test_delete_cluster(self, wait_mock, convert_mock, mock_project_id):
         retry_mock, timeout_mock = mock.Mock(), mock.Mock()
 
         client_delete = self.gke_hook._client.delete_cluster = mock.Mock()
@@ -56,11 +60,16 @@ class TestGKEClusterHookDelete(unittest.TestCase):
         convert_mock.assert_not_called()
 
     @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
+    @mock.patch(
         "airflow.gcp.hooks.kubernetes_engine.GKEClusterHook.log")
     @mock.patch("airflow.gcp.hooks.kubernetes_engine.GKEClusterHook._dict_to_proto")
     @mock.patch(
         "airflow.gcp.hooks.kubernetes_engine.GKEClusterHook.wait_for_operation")
-    def test_delete_cluster_not_found(self, wait_mock, convert_mock, log_mock):
+    def test_delete_cluster_not_found(self, wait_mock, convert_mock, log_mock, mock_project_id):
         from google.api_core.exceptions import NotFound
         # To force an error
         message = 'Not Found'
@@ -71,10 +80,15 @@ class TestGKEClusterHookDelete(unittest.TestCase):
         convert_mock.assert_not_called()
         log_mock.info.assert_any_call("Assuming Success: %s", message)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch("airflow.gcp.hooks.kubernetes_engine.GKEClusterHook._dict_to_proto")
     @mock.patch(
         "airflow.gcp.hooks.kubernetes_engine.GKEClusterHook.wait_for_operation")
-    def test_delete_cluster_error(self, wait_mock, convert_mock):
+    def test_delete_cluster_error(self, wait_mock, convert_mock, mock_project_id):
         # To force an error
         self.gke_hook._client.delete_cluster.side_effect = AirflowException('400')
 
@@ -89,10 +103,15 @@ class TestGKEClusterHookCreate(unittest.TestCase):
         self.gke_hook = GKEClusterHook(location=GKE_ZONE)
         self.gke_hook._client = mock.Mock()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch("airflow.gcp.hooks.kubernetes_engine.GKEClusterHook._dict_to_proto")
     @mock.patch(
         "airflow.gcp.hooks.kubernetes_engine.GKEClusterHook.wait_for_operation")
-    def test_create_cluster_proto(self, wait_mock, convert_mock):
+    def test_create_cluster_proto(self, wait_mock, convert_mock, mock_project_id):
         from google.cloud.container_v1.proto.cluster_service_pb2 import Cluster
 
         mock_cluster_proto = Cluster()
@@ -114,10 +133,15 @@ class TestGKEClusterHookCreate(unittest.TestCase):
         wait_mock.assert_called_once_with(client_create.return_value)
         convert_mock.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch("airflow.gcp.hooks.kubernetes_engine.GKEClusterHook._dict_to_proto")
     @mock.patch(
         "airflow.gcp.hooks.kubernetes_engine.GKEClusterHook.wait_for_operation")
-    def test_create_cluster_dict(self, wait_mock, convert_mock):
+    def test_create_cluster_dict(self, wait_mock, convert_mock, mock_project_id):
         mock_cluster_dict = {'name': CLUSTER_NAME}
         retry_mock, timeout_mock = mock.Mock(), mock.Mock()
 
@@ -149,11 +173,16 @@ class TestGKEClusterHookCreate(unittest.TestCase):
             convert_mock.assert_not_called()
 
     @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
+    @mock.patch(
         "airflow.gcp.hooks.kubernetes_engine.GKEClusterHook.log")
     @mock.patch("airflow.gcp.hooks.kubernetes_engine.GKEClusterHook._dict_to_proto")
     @mock.patch(
         "airflow.gcp.hooks.kubernetes_engine.GKEClusterHook.wait_for_operation")
-    def test_create_cluster_already_exists(self, wait_mock, convert_mock, log_mock):
+    def test_create_cluster_already_exists(self, wait_mock, convert_mock, log_mock, mock_project_id):
         from google.api_core.exceptions import AlreadyExists
         # To force an error
         message = 'Already Exists'

--- a/tests/gcp/hooks/test_spanner.py
+++ b/tests/gcp/hooks/test_spanner.py
@@ -23,7 +23,7 @@ from airflow import AirflowException
 from airflow.gcp.hooks.spanner import CloudSpannerHook
 from tests.contrib.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id, \
     GCP_PROJECT_ID_HOOK_UNIT_TEST, mock_base_gcp_hook_default_project_id
-from tests.compat import mock
+from tests.compat import mock, PropertyMock
 
 SPANNER_INSTANCE = 'instance'
 SPANNER_CONFIGURATION = 'configuration'
@@ -353,8 +353,13 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
                         new=mock_base_gcp_hook_no_default_project_id):
             self.spanner_hook_no_default_project_id = CloudSpannerHook(gcp_conn_id='test')
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_get_existing_instance_missing_project_id(self, get_client):
+    def test_get_existing_instance_missing_project_id(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -388,8 +393,13 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         instance_method.assert_called_once_with(instance_id='instance')
         self.assertIsNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_create_instance_missing_project_id(self, get_client):
+    def test_create_instance_missing_project_id(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         create_method = instance_method.return_value.create
         create_method.return_value = False
@@ -425,8 +435,13 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
             node_count=1)
         self.assertIsNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_update_instance_missing_project_id(self, get_client):
+    def test_update_instance_missing_project_id(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -464,8 +479,13 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         update_method.assert_called_once_with()
         self.assertIsNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_delete_instance_missing_project_id(self, get_client):
+    def test_delete_instance_missing_project_id(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -496,8 +516,13 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         delete_method.assert_called_once_with()
         self.assertIsNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_get_database_missing_project_id(self, get_client):
+    def test_get_database_missing_project_id(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -532,8 +557,13 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         database_exists_method.assert_called_once_with()
         self.assertIsNotNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_create_database_missing_project_id(self, get_client):
+    def test_create_database_missing_project_id(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -569,8 +599,13 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         database_create_method.assert_called_once_with()
         self.assertIsNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_update_database_missing_project_id(self, get_client):
+    def test_update_database_missing_project_id(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -625,8 +660,13 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         database_update_ddl_method.assert_called_once_with(ddl_statements=[], operation_id="operation")
         self.assertIsNone(res)
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_delete_database_missing_project_id(self, get_client):
+    def test_delete_database_missing_project_id(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True
@@ -685,8 +725,13 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
         database_exists_method.assert_called_once_with()
         database_drop_method.assert_not_called()
 
+    @mock.patch(
+        'airflow.contrib.hooks.gcp_api_base_hook.GoogleCloudBaseHook.project_id',
+        new_callable=PropertyMock,
+        return_value=None
+    )
     @mock.patch('airflow.gcp.hooks.spanner.CloudSpannerHook._get_client')
-    def test_execute_dml_missing_project_id(self, get_client):
+    def test_execute_dml_missing_project_id(self, get_client, mock_project_id):
         instance_method = get_client.return_value.instance
         instance_exists_method = instance_method.return_value.exists
         instance_exists_method.return_value = True


### PR DESCRIPTION
Currently project_id is read correctly only if project_id is configured in extra.

However, the default project_id can also be configured in other place.:
* Application Default Credentials  - It not only provides credentials, but also tries to find a project id.  More: https://cloud.google.com/docs/authentication/production
* service account - It may contain information about the project id

It makes much easier to configure the connection during development
Currently, I need to setup connection using following command:
```
export AIRFLOW_CONN_google_cloud_default='google-cloud-platform://?extra__google_cloud_platform__key_path=%2Fkeys%2Fsa.json&extra__google_cloud_platform__project=polidea-airflow'
```
but I would like to be able to configure the connection using the following command:
```
gcloud auth application-default login
```
or when I use a service account:
```
export GOOGLE_APPLICATION_CREDENTIALS=/keys/sa.json
```
CC: @ryanyuan 

----

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5303
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description


### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
