### PR TITLE
Revert "[AIRFLOW-4797] Improve performance and behaviour of zombie de…

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -62,18 +62,21 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
     :type pickle_dags: bool
     :param dag_id_white_list: If specified, only look at these DAG ID's
     :type dag_id_white_list: list[unicode]
+    :param zombies: zombie task instances to kill
+    :type zombies: list[airflow.utils.dag_processing.SimpleTaskInstance]
     """
 
     # Counter that increments every time an instance of this class is created
     class_creation_counter = 0
 
-    def __init__(self, file_path, pickle_dags, dag_id_white_list):
+    def __init__(self, file_path, pickle_dags, dag_id_white_list, zombies):
         self._file_path = file_path
 
         # The process that was launched to process the given .
         self._process = None
         self._dag_id_white_list = dag_id_white_list
         self._pickle_dags = pickle_dags
+        self._zombies = zombies
         # The result of Scheduler.process_file(file_path).
         self._result = None
         # Whether the process is done running.
@@ -94,7 +97,8 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
                             file_path,
                             pickle_dags,
                             dag_id_white_list,
-                            thread_name):
+                            thread_name,
+                            zombies):
         """
         Process the given file.
 
@@ -112,6 +116,8 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
         :type thread_name: unicode
         :return: the process that was launched
         :rtype: multiprocessing.Process
+        :param zombies: zombie task instances to kill
+        :type zombies: list[airflow.utils.dag_processing.SimpleTaskInstance]
         """
         # This helper runs in the newly created process
         log = logging.getLogger("airflow.processor")
@@ -139,7 +145,9 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
             log.info("Started process (PID=%s) to work on %s",
                      os.getpid(), file_path)
             scheduler_job = SchedulerJob(dag_ids=dag_id_white_list, log=log)
-            result = scheduler_job.process_file(file_path, pickle_dags)
+            result = scheduler_job.process_file(file_path,
+                                                zombies,
+                                                pickle_dags)
             result_channel.send(result)
             end_time = time.time()
             log.info(
@@ -170,6 +178,7 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin):
                 self._pickle_dags,
                 self._dag_id_white_list,
                 "DagFileProcessor{}".format(self._instance_id),
+                self._zombies
             ),
             name="DagFileProcessor{}-Process".format(self._instance_id)
         )
@@ -1285,10 +1294,11 @@ class SchedulerJob(BaseJob):
         known_file_paths = list_py_file_paths(self.subdir)
         self.log.info("There are %s files in %s", len(known_file_paths), self.subdir)
 
-        def processor_factory(file_path):
+        def processor_factory(file_path, zombies):
             return DagFileProcessor(file_path,
                                     pickle_dags,
-                                    self.dag_ids)
+                                    self.dag_ids,
+                                    zombies)
 
         # When using sqlite, we do not use async_mode
         # so the scheduler job and DAG parser don't access the DB at the same time.
@@ -1465,7 +1475,7 @@ class SchedulerJob(BaseJob):
         return dags
 
     @provide_session
-    def process_file(self, file_path, pickle_dags=False, session=None):
+    def process_file(self, file_path, zombies, pickle_dags=False, session=None):
         """
         Process a Python file containing Airflow DAGs.
 
@@ -1484,6 +1494,8 @@ class SchedulerJob(BaseJob):
 
         :param file_path: the path to the Python file that should be executed
         :type file_path: unicode
+        :param zombies: zombie task instances to kill.
+        :type zombies: list[airflow.utils.dag_processing.SimpleTaskInstance]
         :param pickle_dags: whether serialize the DAGs found in the file and
             save them to the db
         :type pickle_dags: bool
@@ -1567,7 +1579,7 @@ class SchedulerJob(BaseJob):
         except Exception:
             self.log.exception("Error logging import errors!")
         try:
-            dagbag.kill_zombies()
+            dagbag.kill_zombies(zombies)
         except Exception:
             self.log.exception("Error killing zombies!")
 

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -28,7 +28,6 @@ from collections import namedtuple
 from datetime import datetime
 
 from croniter import CroniterBadCronError, CroniterBadDateError, CroniterNotAlphaError, croniter
-from sqlalchemy import or_
 
 from airflow import settings
 from airflow.configuration import conf

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -28,14 +28,13 @@ import sys
 import time
 import zipfile
 from abc import ABCMeta, abstractmethod
-from collections import defaultdict
-from collections import namedtuple
 from datetime import datetime, timedelta
 from importlib import import_module
 from typing import Iterable, NamedTuple, Optional
 
 import psutil
 from setproctitle import setproctitle
+from sqlalchemy import or_
 from tabulate import tabulate
 
 # To avoid circular imports
@@ -50,7 +49,6 @@ from airflow.utils.db import provide_session
 from airflow.utils.helpers import reap_process_group
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
-from sqlalchemy import or_
 
 
 class SimpleDag(BaseDag):
@@ -766,13 +764,14 @@ class DagFileProcessorManager(LoggingMixin):
         # Map from file path to stats about the file
         self._file_stats = {}  # type: dict(str, DagFileStat)
 
-        self._last_zombie_query_time = timezone.utcnow()
+        self._last_zombie_query_time = None
         # Last time that the DAG dir was traversed to look for files
         self.last_dag_dir_refresh_time = timezone.utcnow()
         # Last time stats were printed
         self.last_stat_print_time = timezone.datetime(2000, 1, 1)
         # TODO: Remove magic number
         self._zombie_query_interval = 10
+        self._zombies = []
         # How long to wait before timing out a process to parse a DAG file
         self._processor_timeout = processor_timeout
 
@@ -842,6 +841,7 @@ class DagFileProcessorManager(LoggingMixin):
                 continue
 
             self._refresh_dag_dir()
+            self._find_zombies()
 
             simple_dags = self.heartbeat()
             for simple_dag in simple_dags:
@@ -1237,13 +1237,11 @@ class DagFileProcessorManager(LoggingMixin):
 
             self._file_path_queue.extend(files_paths_to_queue)
 
-        zombies = self._find_zombies()
-
         # Start more processors if we have enough slots and files to process
         while (self._parallelism - len(self._processors) > 0 and
                len(self._file_path_queue) > 0):
             file_path = self._file_path_queue.pop(0)
-            processor = self._processor_factory(file_path, zombies)
+            processor = self._processor_factory(file_path, self._zombies)
             Stats.incr('dag_processing.processes')
 
             processor.start()
@@ -1261,13 +1259,13 @@ class DagFileProcessorManager(LoggingMixin):
     @provide_session
     def _find_zombies(self, session):
         """
-        Find zombie task instances, which are tasks haven't heartbeated for too long.
-        :return: Zombie task instances in SimpleTaskInstance format.
+        Find zombie task instances, which are tasks haven't heartbeated for too long
+        and update the current zombie list.
         """
         now = timezone.utcnow()
         zombies = []
-        if (now - self._last_zombie_query_time).total_seconds() \
-                > self._zombie_query_interval:
+        if not self._last_zombie_query_time or \
+                (now - self._last_zombie_query_time).total_seconds() > self._zombie_query_interval:
             # to avoid circular imports
             from airflow.jobs import LocalTaskJob as LJ
             self.log.info("Finding 'running' jobs without a recent heartbeat")
@@ -1295,7 +1293,7 @@ class DagFileProcessorManager(LoggingMixin):
                     sti.dag_id, sti.task_id, sti.execution_date.isoformat())
                 zombies.append(sti)
 
-        return zombies
+            self._zombies = zombies
 
     def _kill_timed_out_processors(self):
         """

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -28,7 +28,9 @@ import sys
 import time
 import zipfile
 from abc import ABCMeta, abstractmethod
-from datetime import datetime
+from collections import defaultdict
+from collections import namedtuple
+from datetime import datetime, timedelta
 from importlib import import_module
 from typing import Iterable, NamedTuple, Optional
 
@@ -47,6 +49,8 @@ from airflow.utils import timezone
 from airflow.utils.db import provide_session
 from airflow.utils.helpers import reap_process_group
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.state import State
+from sqlalchemy import or_
 
 
 class SimpleDag(BaseDag):
@@ -751,6 +755,9 @@ class DagFileProcessorManager(LoggingMixin):
         # 30 seconds.
         self.print_stats_interval = conf.getint('scheduler',
                                                 'print_stats_interval')
+        # How many seconds do we wait for tasks to heartbeat before mark them as zombies.
+        self._zombie_threshold_secs = (
+            conf.getint('scheduler', 'scheduler_zombie_task_threshold'))
         # Map from file path to the processor
         self._processors = {}
 
@@ -1230,11 +1237,13 @@ class DagFileProcessorManager(LoggingMixin):
 
             self._file_path_queue.extend(files_paths_to_queue)
 
+        zombies = self._find_zombies()
+
         # Start more processors if we have enough slots and files to process
         while (self._parallelism - len(self._processors) > 0 and
                len(self._file_path_queue) > 0):
             file_path = self._file_path_queue.pop(0)
-            processor = self._processor_factory(file_path)
+            processor = self._processor_factory(file_path, zombies)
             Stats.incr('dag_processing.processes')
 
             processor.start()
@@ -1248,6 +1257,45 @@ class DagFileProcessorManager(LoggingMixin):
         self._heartbeat_count += 1
 
         return simple_dags
+
+    @provide_session
+    def _find_zombies(self, session):
+        """
+        Find zombie task instances, which are tasks haven't heartbeated for too long.
+        :return: Zombie task instances in SimpleTaskInstance format.
+        """
+        now = timezone.utcnow()
+        zombies = []
+        if (now - self._last_zombie_query_time).total_seconds() \
+                > self._zombie_query_interval:
+            # to avoid circular imports
+            from airflow.jobs import LocalTaskJob as LJ
+            self.log.info("Finding 'running' jobs without a recent heartbeat")
+            TI = airflow.models.TaskInstance
+            limit_dttm = timezone.utcnow() - timedelta(
+                seconds=self._zombie_threshold_secs)
+            self.log.info("Failing jobs without heartbeat after %s", limit_dttm)
+
+            tis = (
+                session.query(TI)
+                .join(LJ, TI.job_id == LJ.id)
+                .filter(TI.state == State.RUNNING)
+                .filter(
+                    or_(
+                        LJ.state != State.RUNNING,
+                        LJ.latest_heartbeat < limit_dttm,
+                    )
+                ).all()
+            )
+            self._last_zombie_query_time = timezone.utcnow()
+            for ti in tis:
+                sti = SimpleTaskInstance(ti)
+                self.log.info(
+                    "Detected zombie job with dag_id %s, task_id %s, and execution date %s",
+                    sti.dag_id, sti.task_id, sti.execution_date.isoformat())
+                zombies.append(sti)
+
+        return zombies
 
     def _kill_timed_out_processors(self):
         """

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from datetime import datetime, timezone
 import inspect
 import os
 import shutil
@@ -29,6 +30,7 @@ from unittest.mock import ANY, patch
 import airflow.example_dags
 from airflow import models
 from airflow.configuration import conf
+from airflow.utils.dag_processing import SimpleTaskInstance
 from airflow.jobs import LocalTaskJob as LJ
 from airflow.models import DagBag, DagModel, TaskInstance as TI
 from airflow.utils.db import create_session
@@ -605,91 +607,28 @@ class TestDagBag(unittest.TestCase):
         self.assertEqual([], dagbag.process_file(None))
 
     @patch.object(TI, 'handle_failure')
-    def test_kill_zombies_when_job_state_is_not_running(self, mock_ti_handle_failure):
+    def test_kill_zombies(self, mock_ti_handle_failure):
         """
-        Test that kill zombies calls TI's failure handler with proper context
+        Test that kill zombies call TIs failure handler with proper context
         """
         dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=True)
         with create_session() as session:
             session.query(TI).delete()
-            session.query(LJ).delete()
             dag = dagbag.get_dag('example_branch_operator')
             task = dag.get_task(task_id='run_this_first')
 
             ti = TI(task, DEFAULT_DATE, State.RUNNING)
-            lj = LJ(ti)
-            lj.state = State.SHUTDOWN
-            lj.id = 1
-            ti.job_id = lj.id
 
-            session.add(lj)
             session.add(ti)
             session.commit()
 
-            dagbag.kill_zombies()
+            zombies = [SimpleTaskInstance(ti)]
+            dagbag.kill_zombies(zombies)
             mock_ti_handle_failure.assert_called_once_with(
                 ANY,
                 conf.getboolean('core', 'unit_test_mode'),
                 ANY
             )
-
-    @patch.object(TI, 'handle_failure')
-    def test_kill_zombie_when_job_received_no_heartbeat(self, mock_ti_handle_failure):
-        """
-        Test that kill zombies calls TI's failure handler with proper context
-        """
-        zombie_threshold_secs = (
-            conf.getint('scheduler', 'scheduler_zombie_task_threshold'))
-        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=True)
-        with create_session() as session:
-            session.query(TI).delete()
-            session.query(LJ).delete()
-            dag = dagbag.get_dag('example_branch_operator')
-            task = dag.get_task(task_id='run_this_first')
-
-            ti = TI(task, DEFAULT_DATE, State.RUNNING)
-            lj = LJ(ti)
-            lj.latest_heartbeat = utcnow() - timedelta(seconds=zombie_threshold_secs)
-            lj.state = State.RUNNING
-            lj.id = 1
-            ti.job_id = lj.id
-
-            session.add(lj)
-            session.add(ti)
-            session.commit()
-
-            dagbag.kill_zombies()
-            mock_ti_handle_failure.assert_called_once_with(
-                ANY,
-                conf.getboolean('core', 'unit_test_mode'),
-                ANY
-            )
-
-    @patch.object(TI, 'handle_failure')
-    def test_kill_zombies_doesn_nothing(self, mock_ti_handle_failure):
-        """
-        Test that kill zombies does nothing when job is running and received heartbeat
-        """
-        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=True)
-        with create_session() as session:
-            session.query(TI).delete()
-            session.query(LJ).delete()
-            dag = dagbag.get_dag('example_branch_operator')
-            task = dag.get_task(task_id='run_this_first')
-
-            ti = TI(task, DEFAULT_DATE, State.RUNNING)
-            lj = LJ(ti)
-            lj.latest_heartbeat = utcnow()
-            lj.state = State.RUNNING
-            lj.id = 1
-            ti.job_id = lj.id
-
-            session.add(lj)
-            session.add(ti)
-            session.commit()
-
-            dagbag.kill_zombies()
-            mock_ti_handle_failure.assert_not_called()
 
     def test_deactivate_unknown_dags(self):
         """

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -17,25 +17,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from datetime import datetime, timezone
 import inspect
 import os
 import shutil
 import textwrap
 import unittest
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from tempfile import NamedTemporaryFile, mkdtemp
 from unittest.mock import ANY, patch
 
 import airflow.example_dags
 from airflow import models
 from airflow.configuration import conf
-from airflow.utils.dag_processing import SimpleTaskInstance
-from airflow.jobs import LocalTaskJob as LJ
 from airflow.models import DagBag, DagModel, TaskInstance as TI
+from airflow.utils.dag_processing import SimpleTaskInstance
 from airflow.utils.db import create_session
 from airflow.utils.state import State
-from airflow.utils.timezone import utcnow
 from tests.models import DEFAULT_DATE, TEST_DAGS_FOLDER
 from tests.test_utils.config import conf_vars
 


### PR DESCRIPTION
### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
Original reason stated in the PR why zombie detection was moved 
```Zombie tasks will be calculate by DAG parsing manager and send to DAG parsing processor to kill. This is to reduce DB CPU load( identified to produce 80% of CPU load during stress test, CPU usage went down from 80%+ to ~40% after this change).``` 
from https://github.com/apache/airflow/pull/3873.

I see no point sending a query joining two biggest tables in every DAG parsing. Establishing new connections is much more expensive than sending an aggregated query. It doesn't seem to deliver any immediate value: the DB load in a smaller cluster was not changing. And if we want to compare the running time diff we compare the aggregated query running time on all DAG file processors vs. the old query running time instead of compare the individual query. We parse a couple thoudsand files in 2 mins and it will generate heavy load to the DB, which I believe is the biggest bottelneck of Airflow scalibility.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Reverting PR

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
