### PR TITLE
[AIRFLOW-5312] Fix timeout issue in pod launcher / KubernetesPodOperator

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -795,7 +795,9 @@ tolerations =
 # List of supported params in **kwargs are similar for all core_v1_apis, hence a single config variable for all apis
 # See:
 #   https://raw.githubusercontent.com/kubernetes-client/python/master/kubernetes/client/apis/core_v1_api.py
-kube_client_request_args =
+# Note that if no _request_timeout is specified, the kubernetes client will wait indefinitely for kubernetes
+# api responses, which will cause the scheduler to hang. The timeout is specified as [connect timeout, read timeout]
+kube_client_request_args = {{"_request_timeout" : [60,60] }}
 
 # Worker pods security context options
 # See:

--- a/airflow/contrib/kubernetes/pod_launcher.py
+++ b/airflow/contrib/kubernetes/pod_launcher.py
@@ -159,7 +159,7 @@ class PodLauncher(LoggingMixin):
                 follow=True,
                 tail_lines=10,
                 _preload_content=False,
-                _request_timeout=20
+                _request_timeout=self.kube_api_timeout_seconds
             )
         except BaseHTTPError as e:
             raise AirflowException(

--- a/airflow/contrib/kubernetes/pod_launcher.py
+++ b/airflow/contrib/kubernetes/pod_launcher.py
@@ -70,7 +70,8 @@ class PodLauncher(LoggingMixin):
     def delete_pod(self, pod):
         try:
             self._client.delete_namespaced_pod(
-                pod.name, pod.namespace, body=client.V1DeleteOptions(), _request_timeout=self.kube_api_timeout_seconds)
+                pod.name, pod.namespace, body=client.V1DeleteOptions(),
+                _request_timeout=self.kube_api_timeout_seconds)
         except ApiException as e:
             # If the pod is already deleted
             if e.status != 404:
@@ -172,7 +173,8 @@ class PodLauncher(LoggingMixin):
     )
     def read_pod(self, pod):
         try:
-            return self._client.read_namespaced_pod(pod.name, pod.namespace, _request_timeout=self.kube_api_timeout_seconds)
+            return self._client.read_namespaced_pod(pod.name, pod.namespace,
+                                                    _request_timeout=self.kube_api_timeout_seconds)
         except BaseHTTPError as e:
             raise AirflowException(
                 'There was an error reading the kubernetes API: {}'.format(e)

--- a/tests/kubernetes/test_pod_launcher.py
+++ b/tests/kubernetes/test_pod_launcher.py
@@ -49,7 +49,8 @@ class TestPodLauncher(unittest.TestCase):
                 follow=True,
                 name=mock.sentinel.name,
                 namespace=mock.sentinel.namespace,
-                tail_lines=10
+                tail_lines=10,
+                _request_timeout=20
             ),
             mock.call(
                 _preload_content=False,
@@ -57,7 +58,8 @@ class TestPodLauncher(unittest.TestCase):
                 follow=True,
                 name=mock.sentinel.name,
                 namespace=mock.sentinel.namespace,
-                tail_lines=10
+                tail_lines=10,
+                _request_timeout=20
             )
         ])
 
@@ -86,8 +88,8 @@ class TestPodLauncher(unittest.TestCase):
         pod_info = self.pod_launcher.read_pod(mock.sentinel)
         self.assertEqual(mock.sentinel.pod_info, pod_info)
         self.mock_kube_client.read_namespaced_pod.assert_has_calls([
-            mock.call(mock.sentinel.name, mock.sentinel.namespace),
-            mock.call(mock.sentinel.name, mock.sentinel.namespace)
+            mock.call(mock.sentinel.name, mock.sentinel.namespace, _request_timeout=20),
+            mock.call(mock.sentinel.name, mock.sentinel.namespace, _request_timeout=20)
         ])
 
     def test_read_pod_retries_fails(self):


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issue:
  - https://issues.apache.org/jira/browse/AIRFLOW-5312

### Description

- Adds `_request_timeout` on calls to Kubernetes API
- Adds retry via `tenacity` so `pod_launcher` will not die

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
