### PR TITLE
[AIRFLOW-5316] Skip running check-apache-license without --all-files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,8 +32,8 @@ repos:
         name: Check if licences are OK for Apache
         entry: ./scripts/ci/ci_check_license.sh
         language: system
-        always_run: true
-        pass_filenames: false
+        files: ^\.pre-commit-config\.yaml$
+        pass_filenames: true
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.6
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -696,6 +696,7 @@ In airflow we have the following checks:
 
 ```text
 check-hooks-apply                Check hooks apply to the repository
+check-apache-license             Checks compatibility with Apache License requirements
 check-merge-conflict             Checks if merge conflict is being committed
 check-executables-have-shebangs  Check that executables have shebang
 check-xml                        Check XML files with xmllint
@@ -712,6 +713,13 @@ pylint                           Run pylint
 shellcheck                       Check shell files with shellcheck
 yamllint                         Check yaml files with yamllint
 ```
+
+The check-apache-licence check is normally skipped for commits unless `.pre-commit-config.yaml` file
+is changed. This check always run for the full set of files and if you want to run it locally you need to
+specify `--all-files` flag of pre-commit. For example:
+
+`pre-commit run check-apache-licenses --all-files`
+
 ## Using pre-commit hooks
 
 After installing pre-commit hooks are run automatically when you commit the code, but you can


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5316

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
