### PR TITLE
[AIRFLOW-5262] Update timeout exception to include dag

### DIFF
--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -111,9 +111,9 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                 # This gives the ability to set up non-blocking AND soft-fail sensors.
                 if self.soft_fail and not context['ti'].is_eligible_to_retry():
                     self._do_skip_downstream_tasks(context)
-                    raise AirflowSkipException('Snap. Time is OUT.')
+                    raise AirflowSkipException(f"Snap. Time is OUT for dag: {context['dag_run']}")
                 else:
-                    raise AirflowSensorTimeout('Snap. Time is OUT.')
+                    raise AirflowSensorTimeout(f"Snap. Time is OUT for dag: {context['dag_run']}")
             if self.reschedule:
                 reschedule_date = timezone.utcnow() + timedelta(
                     seconds=self.poke_interval)

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -111,9 +111,9 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                 # This gives the ability to set up non-blocking AND soft-fail sensors.
                 if self.soft_fail and not context['ti'].is_eligible_to_retry():
                     self._do_skip_downstream_tasks(context)
-                    raise AirflowSkipException(f"Snap. Time is OUT for dag: {context['dag_run']}")
+                    raise AirflowSkipException("Snap. Time is OUT for dag: %s", context['dag_run'])
                 else:
-                    raise AirflowSensorTimeout(f"Snap. Time is OUT for dag: {context['dag_run']}")
+                    raise AirflowSensorTimeout("Snap. Time is OUT for dag: %s", context['dag_run'])
             if self.reschedule:
                 reschedule_date = timezone.utcnow() + timedelta(
                     seconds=self.poke_interval)

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -111,9 +111,9 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                 # This gives the ability to set up non-blocking AND soft-fail sensors.
                 if self.soft_fail and not context['ti'].is_eligible_to_retry():
                     self._do_skip_downstream_tasks(context)
-                    raise AirflowSkipException("Snap. Time is OUT for dag: %s", context['dag_run'])
+                    raise AirflowSkipException("Snap. Time is OUT for dag: %s", self.dag.dag_id)
                 else:
-                    raise AirflowSensorTimeout("Snap. Time is OUT for dag: %s", context['dag_run'])
+                    raise AirflowSensorTimeout("Snap. Time is OUT for dag: %s", self.dag.dag_id)
             if self.reschedule:
                 reschedule_date = timezone.utcnow() + timedelta(
                     seconds=self.poke_interval)


### PR DESCRIPTION
### Jira
- My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5262) 

### Description

- This change will help expedite log investigation in third party logging services, making the dag's name visible in the top-level exception message.

### Tests

- My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: does not need testing

### Code Quality

- [ ] Passes `flake8`
