### PR TITLE
[AIRFLOW-5317] Remove invalid arguments in tests

### DIFF
--- a/tests/gcp/sensors/test_cloud_storage_transfer_service.py
+++ b/tests/gcp/sensors/test_cloud_storage_transfer_service.py
@@ -34,7 +34,6 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
 
         op = GCPTransferServiceWaitForJobStatusSensor(
             task_id='task-id',
-            operation_name='operation-name',
             job_name='job-name',
             project_id='project-id',
             expected_statuses=GcpTransferOperationStatus.SUCCESS,
@@ -56,7 +55,6 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
 
         op = GCPTransferServiceWaitForJobStatusSensor(
             task_id='task-id',
-            operation_name='operation-name',
             job_name='job-name',
             project_id='project-id',
             expected_statuses=GcpTransferOperationStatus.SUCCESS,
@@ -83,7 +81,6 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
 
         op = GCPTransferServiceWaitForJobStatusSensor(
             task_id='task-id',
-            operation_name='operation-name',
             job_name='job-name',
             project_id='project-id',
             expected_statuses=GcpTransferOperationStatus.SUCCESS,
@@ -125,7 +122,6 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
 
         op = GCPTransferServiceWaitForJobStatusSensor(
             task_id='task-id',
-            operation_name='operation-name',
             job_name='job-name',
             project_id='project-id',
             expected_statuses=expected_status,


### PR DESCRIPTION
This commit removes unused  in tests for GCPTransferServiceWaitForJobStatusSensor.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5317

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
This commit removes unused  in tests for GCPTransferServiceWaitForJobStatusSensor.

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
