### PR TITLE
[AIRFLOW-4301] Fix KubernetesPodOperator secret volume mapping

### DIFF
--- a/tests/kubernetes/kubernetes_request_factory/test_kubernetes_request_factory.py
+++ b/tests/kubernetes/kubernetes_request_factory/test_kubernetes_request_factory.py
@@ -151,29 +151,47 @@ class TestKubernetesRequestFactory(unittest.TestCase):
     def test_extract_volume_secrets(self):
         # Test when secrets is not empty
         secrets = [
-            Secret('volume', 'KEY1', 's1', 'key-1'),
+            Secret('volume', '/key1', 's1', 'key-1'),
             Secret('env', 'KEY2', 's2'),
-            Secret('volume', 'KEY3', 's3', 'key-2')
+            Secret('volume', '/var/key3', 's3', 'key-3'),
+            Secret('volume', '/var/secrets', 's4')
         ]
         pod = Pod('v3.14', {}, [], secrets=secrets)
         self.expected['spec']['containers'][0]['volumeMounts'] = [{
-            'mountPath': 'KEY1',
+            'mountPath': '/',
             'name': 'secretvol0',
             'readOnly': True
         }, {
-            'mountPath': 'KEY3',
+            'mountPath': '/var',
             'name': 'secretvol1',
+            'readOnly': True
+        }, {
+            'mountPath': '/var/secrets',
+            'name': 'secretvol2',
             'readOnly': True
         }]
         self.expected['spec']['volumes'] = [{
             'name': 'secretvol0',
             'secret': {
-                'secretName': 's1'
+                'secretName': 's1',
+                'items': [{
+                    'key': 'key-1',
+                    'path': 'key1'
+                }]
             }
         }, {
             'name': 'secretvol1',
             'secret': {
-                'secretName': 's3'
+                'secretName': 's3',
+                'items': [{
+                    'key': 'key-3',
+                    'path': 'key3'
+                }]
+            }
+        }, {
+            'name': 'secretvol2',
+            'secret': {
+                'secretName': 's4'
             }
         }]
         KubernetesRequestFactory.extract_volume_secrets(pod, self.input_req)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
