### PR TITLE
[AIRFLOW-5318] Option to specify location of the new BQ dataset

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -1615,7 +1615,7 @@ class BigQueryBaseCursor(LoggingMixin):
             return source_dataset_resource
 
     def create_empty_dataset(self, dataset_id="", project_id="",
-                             dataset_reference=None):
+                             location=None, dataset_reference=None):
         """
         Create a new empty dataset:
         https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/insert
@@ -1626,6 +1626,9 @@ class BigQueryBaseCursor(LoggingMixin):
         :param dataset_id: The id of dataset. Don't need to provide,
             if datasetId in dataset_reference.
         :type dataset_id: str
+        :param location: (Optional) The geographic location where the dataset should reside.
+            There is no default value but the dataset will be created in US if nothing is provided.
+        :type location: str
         :param dataset_reference: Dataset reference that could be provided
             with request body. More info:
             https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets#resource
@@ -1661,6 +1664,14 @@ class BigQueryBaseCursor(LoggingMixin):
                 _api_resource_configs_duplication_check(
                     param_name, param,
                     dataset_reference['datasetReference'], 'dataset_reference')
+
+        if location:
+            if 'location' not in dataset_reference:
+                dataset_reference.update({'location': location})
+            else:
+                _api_resource_configs_duplication_check(
+                    'location', location,
+                    dataset_reference, 'dataset_reference')
 
         dataset_id = dataset_reference.get("datasetReference").get("datasetId")
         dataset_project_id = dataset_reference.get("datasetReference").get(

--- a/airflow/contrib/operators/bigquery_operator.py
+++ b/airflow/contrib/operators/bigquery_operator.py
@@ -725,6 +725,9 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
     :param dataset_id: The id of dataset. Don't need to provide,
         if datasetId in dataset_reference.
     :type dataset_id: str
+    :param location: (Optional) The geographic location where the dataset should reside.
+        There is no default value but the dataset will be created in US if nothing is provided.
+    :type location: str
     :param dataset_reference: Dataset reference that could be provided with request body.
         More info:
         https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets#resource
@@ -754,6 +757,7 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
                  dataset_id,
                  project_id=None,
                  dataset_reference=None,
+                 location=None,
                  gcp_conn_id='google_cloud_default',
                  bigquery_conn_id=None,
                  delegate_to=None,
@@ -767,6 +771,7 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
 
         self.dataset_id = dataset_id
         self.project_id = project_id
+        self.location = location
         self.gcp_conn_id = gcp_conn_id
         self.dataset_reference = dataset_reference if dataset_reference else {}
         self.delegate_to = delegate_to
@@ -786,7 +791,8 @@ class BigQueryCreateEmptyDatasetOperator(BaseOperator):
         cursor.create_empty_dataset(
             project_id=self.project_id,
             dataset_id=self.dataset_id,
-            dataset_reference=self.dataset_reference)
+            dataset_reference=self.dataset_reference,
+            location=self.location)
 
 
 class BigQueryGetDatasetOperator(BaseOperator):

--- a/tests/contrib/hooks/test_bigquery_hook.py
+++ b/tests/contrib/hooks/test_bigquery_hook.py
@@ -629,7 +629,6 @@ class TestLabelsInRunJob(unittest.TestCase):
 class TestDatasetsOperations(unittest.TestCase):
 
     def test_create_empty_dataset_no_dataset_id_err(self):
-
         with self.assertRaises(ValueError):
             hook.BigQueryBaseCursor(
                 mock.Mock(), "test_create_empty_dataset").create_empty_dataset(
@@ -644,6 +643,59 @@ class TestDatasetsOperations(unittest.TestCase):
                     "datasetReference":
                         {"datasetId": "test_dataset",
                          "projectId": "project_test2"}})
+
+    def test_create_empty_dataset_with_location_duplicates_call_err(self):
+        with self.assertRaises(ValueError):
+            hook.BigQueryBaseCursor(
+                mock.Mock(), "test_create_empty_dataset").create_empty_dataset(
+                dataset_id="", project_id="project_test", location="EU",
+                dataset_reference={
+                    "location": "US",
+                    "datasetReference":
+                        {"datasetId": "test_dataset",
+                         "projectId": "project_test"}})
+
+    def test_create_empty_dataset_with_location(self):
+        project_id = 'bq-project'
+        dataset_id = 'bq_dataset'
+        location = 'EU'
+
+        mock_service = mock.Mock()
+        method = mock_service.datasets.return_value.insert
+        cursor = hook.BigQueryBaseCursor(mock_service, project_id)
+        cursor.create_empty_dataset(project_id=project_id, dataset_id=dataset_id, location=location)
+
+        expected_body = {
+            "location": "EU",
+            "datasetReference": {
+                "datasetId": "bq_dataset",
+                "projectId": "bq-project"
+            }
+        }
+
+        method.assert_called_once_with(projectId=project_id, body=expected_body)
+
+    def test_create_empty_dataset_with_location_duplicates_call_no_err(self):
+        project_id = 'bq-project'
+        dataset_id = 'bq_dataset'
+        location = 'EU'
+        dataset_reference = {"location": "EU"}
+
+        mock_service = mock.Mock()
+        method = mock_service.datasets.return_value.insert
+        cursor = hook.BigQueryBaseCursor(mock_service, project_id)
+        cursor.create_empty_dataset(project_id=project_id, dataset_id=dataset_id, location=location,
+                                    dataset_reference=dataset_reference)
+
+        expected_body = {
+            "location": "EU",
+            "datasetReference": {
+                "datasetId": "bq_dataset",
+                "projectId": "bq-project"
+            }
+        }
+
+        method.assert_called_once_with(projectId=project_id, body=expected_body)
 
     def test_get_dataset_without_dataset_id(self):
         with mock.patch.object(hook.BigQueryHook, 'get_service'):

--- a/tests/contrib/operators/test_bigquery_operator.py
+++ b/tests/contrib/operators/test_bigquery_operator.py
@@ -42,6 +42,7 @@ from tests.compat import mock
 
 TASK_ID = 'test-bq-create-table-operator'
 TEST_DATASET = 'test-dataset'
+TEST_DATASET_LOCATION = 'EU'
 TEST_GCP_PROJECT_ID = 'test-project'
 TEST_DELETE_CONTENTS = True
 TEST_TABLE_ID = 'test-table-id'
@@ -146,7 +147,8 @@ class TestBigQueryCreateEmptyDatasetOperator(unittest.TestCase):
         operator = BigQueryCreateEmptyDatasetOperator(
             task_id=TASK_ID,
             dataset_id=TEST_DATASET,
-            project_id=TEST_GCP_PROJECT_ID
+            project_id=TEST_GCP_PROJECT_ID,
+            location=TEST_DATASET_LOCATION
         )
 
         operator.execute(None)
@@ -157,6 +159,7 @@ class TestBigQueryCreateEmptyDatasetOperator(unittest.TestCase):
             .assert_called_once_with(
                 dataset_id=TEST_DATASET,
                 project_id=TEST_GCP_PROJECT_ID,
+                location=TEST_DATASET_LOCATION,
                 dataset_reference={}
             )
 


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW-5318) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-5318

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The extra `str` argument gives the option to easily specify the location where the user wants the new BQ dataset to reside. The location will be `US` if nothing is provided.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [x] Passes `flake8`
